### PR TITLE
Add make doctor-mac and robust macOS dev setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
-.PHONY: run-mac build-mac-debug build bundle-mac setup-cef install-debug-render-process
+.PHONY: run-mac build-mac-debug build bundle-mac setup-cef install-debug-render-process doctor-mac
+
+CARGO_BIN := $(or $(shell command -v cargo 2>/dev/null),$(HOME)/.cargo/bin/cargo)
+RUSTUP_BIN := $(or $(shell command -v rustup 2>/dev/null),$(HOME)/.cargo/bin/rustup)
+EXPORT_CEF_BIN := $(or $(shell command -v export-cef-dir 2>/dev/null),$(HOME)/.cargo/bin/export-cef-dir)
+WASM_BINDGEN_BIN := $(or $(shell command -v wasm-bindgen 2>/dev/null),$(HOME)/.cargo/bin/wasm-bindgen)
+CEF_FRAMEWORK_DIR := $(HOME)/.local/share/Chromium Embedded Framework.framework
+CEF_DEBUG_RENDER := $(CEF_FRAMEWORK_DIR)/Libraries/bevy_cef_debug_render_process
 
 # Status bar (`dist/`) and history UI (`web_dist/`) are built by each crate’s `build.rs` when you compile `vmux` or `vmux_status_bar` / `vmux_history`.
 
@@ -7,10 +14,10 @@ run-mac: build-mac-debug
 	exec env -u CEF_PATH ./target/debug/vmux
 
 build-mac-debug:
-	env -u CEF_PATH cargo build -p vmux --features debug
+	env -u CEF_PATH "$(CARGO_BIN)" build -p vmux --features debug
 
 build:
-	env -u CEF_PATH cargo build -p vmux --release
+	env -u CEF_PATH "$(CARGO_BIN)" build -p vmux --release
 
 bundle-mac:
 	chmod +x scripts/bundle-macos.sh
@@ -18,11 +25,109 @@ bundle-mac:
 
 # One-time CEF download (macOS paths; pin matches bevy_cef 0.5.x)
 setup-cef:
-	cargo install export-cef-dir@145.6.1+145.0.28 --force
-	export-cef-dir --force "$$HOME/.local/share"
+	"$(CARGO_BIN)" install export-cef-dir@145.6.1+145.0.28 --force
+	"$(EXPORT_CEF_BIN)" --force "$$HOME/.local/share"
 
 # After setup-cef: copy debug render helper for macOS dev (see README)
 install-debug-render-process:
-	cargo install bevy_cef_debug_render_process
+	"$(CARGO_BIN)" install bevy_cef_debug_render_process
 	cp "$$HOME/.cargo/bin/bevy_cef_debug_render_process" \
 	  "$$HOME/.local/share/Chromium Embedded Framework.framework/Libraries/bevy_cef_debug_render_process"
+
+doctor-mac:
+	@set -eu; \
+	fail=0; \
+	echo "Checking macOS dev dependencies for run-mac..."; \
+	if [ -x "$(EXPORT_CEF_BIN)" ]; then \
+		echo "[ok] export-cef-dir is installed at $(EXPORT_CEF_BIN)"; \
+	else \
+		echo "[precheck] export-cef-dir is not installed yet"; \
+		echo "  This is expected before CEF setup. Run: make setup-cef"; \
+	fi; \
+	if [ ! -d "$$HOME/.local/share" ]; then \
+		echo "[missing] CEF install base directory does not exist: $$HOME/.local/share"; \
+		echo "  Run: mkdir -p \"$$HOME/.local/share\""; \
+		fail=1; \
+	elif [ ! -w "$$HOME/.local/share" ]; then \
+		echo "[missing] CEF install base is not writable: $$HOME/.local/share"; \
+		echo "  Run: chmod u+rwx \"$$HOME/.local/share\""; \
+		fail=1; \
+	else \
+		echo "[ok] CEF install base is writable: $$HOME/.local/share"; \
+	fi; \
+	if [ -x "$(CARGO_BIN)" ]; then \
+		echo "[ok] cargo found at $(CARGO_BIN)"; \
+	else \
+		echo "[missing] cargo not found"; \
+		echo "  Install Rust toolchain: https://rustup.rs/"; \
+		echo "  Then reload shell PATH or run with: PATH=\"$$HOME/.cargo/bin:$$PATH\""; \
+		fail=1; \
+	fi; \
+	if [ -x "$(RUSTUP_BIN)" ]; then \
+		if "$(RUSTUP_BIN)" target list --installed | grep -qx "wasm32-unknown-unknown"; then \
+			echo "[ok] rust target installed: wasm32-unknown-unknown"; \
+		else \
+			echo "[missing] rust target not installed: wasm32-unknown-unknown"; \
+			echo "  Run: \"$(RUSTUP_BIN)\" target add wasm32-unknown-unknown"; \
+			fail=1; \
+		fi; \
+	else \
+		echo "[missing] rustup not found (required to install wasm target)"; \
+		echo "  Install Rust toolchain: https://rustup.rs/"; \
+		fail=1; \
+	fi; \
+	if command -v cmake >/dev/null 2>&1; then \
+		echo "[ok] cmake found"; \
+	else \
+		echo "[missing] cmake not found"; \
+		echo "  Install: brew install cmake"; \
+		fail=1; \
+	fi; \
+	if command -v ninja >/dev/null 2>&1; then \
+		echo "[ok] ninja found"; \
+	else \
+		echo "[missing] ninja not found"; \
+		echo "  Install: brew install ninja"; \
+		fail=1; \
+	fi; \
+	if command -v node >/dev/null 2>&1; then \
+		echo "[ok] node found"; \
+	else \
+		echo "[missing] node not found"; \
+		echo "  Install: brew install node"; \
+		fail=1; \
+	fi; \
+	if command -v npm >/dev/null 2>&1; then \
+		echo "[ok] npm found"; \
+	else \
+		echo "[missing] npm not found"; \
+		echo "  Install: brew install node"; \
+		fail=1; \
+	fi; \
+	if [ -x "$(WASM_BINDGEN_BIN)" ]; then \
+		echo "[ok] wasm-bindgen CLI found at $(WASM_BINDGEN_BIN)"; \
+	else \
+		echo "[missing] wasm-bindgen CLI not found"; \
+		echo "  Run: \"$(CARGO_BIN)\" install wasm-bindgen-cli"; \
+		fail=1; \
+	fi; \
+	if [ -d "$(CEF_FRAMEWORK_DIR)" ]; then \
+		echo "[ok] CEF framework found at $(CEF_FRAMEWORK_DIR)"; \
+	else \
+		echo "[missing] CEF framework not found at $(CEF_FRAMEWORK_DIR)"; \
+		echo "  Run: make setup-cef"; \
+		fail=1; \
+	fi; \
+	if [ -x "$(CEF_DEBUG_RENDER)" ]; then \
+		echo "[ok] bevy_cef_debug_render_process found"; \
+	else \
+		echo "[missing] bevy_cef_debug_render_process not found"; \
+		echo "  Run: make install-debug-render-process"; \
+		fail=1; \
+	fi; \
+	if [ "$$fail" -eq 0 ]; then \
+		echo "doctor-mac passed. You can run: make run-mac"; \
+	else \
+		echo "doctor-mac failed. Resolve the missing dependencies above."; \
+		exit 1; \
+	fi

--- a/README.md
+++ b/README.md
@@ -11,5 +11,8 @@
 See [Makefile](Makefile) for more targets.
 
 ```sh
+# Check prerequisites
+make run-doctor
+
 make run-mac
 ```

--- a/crates/vmux_history/package-lock.json
+++ b/crates/vmux_history/package-lock.json
@@ -370,7 +370,6 @@
       "version": "1.21.7",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -491,7 +490,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -533,7 +531,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",

--- a/crates/vmux_status_bar/package-lock.json
+++ b/crates/vmux_status_bar/package-lock.json
@@ -410,7 +410,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -587,7 +586,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -979,7 +977,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/crates/vmux_ui/package-lock.json
+++ b/crates/vmux_ui/package-lock.json
@@ -410,7 +410,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -587,7 +586,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -979,7 +977,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },


### PR DESCRIPTION
## Summary

This PR adds **`make doctor-mac`**, a dependency check target that validates everything needed for **`make run-mac`** on macOS, and tightens the Makefile so common setup steps work when `cargo`/`export-cef-dir` are only on `~/.cargo/bin`.

## Changes

- **`doctor-mac`**: Checks `export-cef-dir`, writable `~/.local/share` (with distinct messages for missing dir vs. not writable), `cargo`, `rustup` + **`wasm32-unknown-unknown`**, **`cmake`**, **`ninja`**, **`node`/`npm`**, **`wasm-bindgen`** CLI, CEF framework under `~/.local/share`, and **`bevy_cef_debug_render_process`** in the framework `Libraries` folder. Prints concrete fix commands for each failure.
- **Build/install targets**: Use **`$(CARGO_BIN)`** (PATH or `~/.cargo/bin/cargo`) for `build-mac-debug`, `build`, `setup-cef`, and `install-debug-render-process`.
- **`setup-cef`**: Invoke **`$(EXPORT_CEF_BIN)`** so the second step does not fail with `export-cef-dir: command not found` when `~/.cargo/bin` is not on `PATH`.

## Motivation

Fresh macOS setups were hitting opaque failures (`cargo` not on PATH, missing wasm target, missing cmake/ninja, missing `wasm-bindgen` after Dioxus wasm builds, and `setup-cef` finishing install but failing to run `export-cef-dir`). **`make doctor-mac`** surfaces these early with actionable hints.

## How to verify

```sh
make doctor-mac
make run-mac
```
