### PR TITLE
Fix run-mac dependency bootstrap and pane typing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-.PHONY: run-mac run-doctor build-mac-debug build bundle-mac setup-cef install-debug-render-process doctor-mac
+.PHONY: run-mac run-doctor build-mac-debug build bundle-mac setup-cef install-debug-render-process doctor-mac ensure-run-mac-deps
 
 CARGO_BIN := $(or $(shell command -v cargo 2>/dev/null),$(HOME)/.cargo/bin/cargo)
 RUSTUP_BIN := $(or $(shell command -v rustup 2>/dev/null),$(HOME)/.cargo/bin/rustup)
 EXPORT_CEF_BIN := $(or $(shell command -v export-cef-dir 2>/dev/null),$(HOME)/.cargo/bin/export-cef-dir)
 DX_BIN := $(or $(shell command -v dx 2>/dev/null),$(HOME)/.cargo/bin/dx)
+DX_VERSION := 0.7.4
 CEF_FRAMEWORK_DIR := $(HOME)/.local/share/Chromium Embedded Framework.framework
 CEF_DEBUG_RENDER := $(CEF_FRAMEWORK_DIR)/Libraries/bevy_cef_debug_render_process
 
@@ -13,10 +14,10 @@ CEF_DEBUG_RENDER := $(CEF_FRAMEWORK_DIR)/Libraries/bevy_cef_debug_render_process
 run-mac: build-mac-debug
 	exec env -u CEF_PATH ./target/debug/vmux_desktop
 
-build-mac-debug:
+build-mac-debug: ensure-run-mac-deps
 	env -u CEF_PATH "$(CARGO_BIN)" build -p vmux_desktop --features debug
 
-build:
+build: ensure-run-mac-deps
 	env -u CEF_PATH "$(CARGO_BIN)" build -p vmux_desktop --release
 
 bundle-mac:
@@ -42,3 +43,24 @@ doctor-mac:
 	@CARGO_BIN="$(CARGO_BIN)" RUSTUP_BIN="$(RUSTUP_BIN)" EXPORT_CEF_BIN="$(EXPORT_CEF_BIN)" \
 		DX_BIN="$(DX_BIN)" CEF_FRAMEWORK_DIR="$(CEF_FRAMEWORK_DIR)" \
 		CEF_DEBUG_RENDER="$(CEF_DEBUG_RENDER)" ./scripts/doctor-mac.sh
+
+# Non-interactive bootstrap so `make run-mac` works even after dependency bumps.
+ensure-run-mac-deps:
+	@echo "Checking build dependencies for run-mac..."
+	@if [ ! -x "$(CARGO_BIN)" ]; then \
+		echo "cargo not found at $(CARGO_BIN). Install rustup first: https://rustup.rs/"; \
+		exit 1; \
+	fi
+	@if [ ! -x "$(RUSTUP_BIN)" ]; then \
+		echo "rustup not found at $(RUSTUP_BIN). Install rustup first: https://rustup.rs/"; \
+		exit 1; \
+	fi
+	@if ! "$(RUSTUP_BIN)" target list --installed 2>/dev/null | grep -qx "wasm32-unknown-unknown"; then \
+		echo "Installing rust target wasm32-unknown-unknown..."; \
+		"$(RUSTUP_BIN)" target add wasm32-unknown-unknown; \
+	fi
+	@dx_version="$$( ("$(DX_BIN)" --version 2>/dev/null || true) | awk '{print $$2}' )"; \
+	if [ "$$dx_version" != "$(DX_VERSION)" ]; then \
+		echo "Installing dioxus-cli $(DX_VERSION) (found: $${dx_version:-missing})..."; \
+		"$(CARGO_BIN)" install dioxus-cli --locked --version "$(DX_VERSION)"; \
+	fi

--- a/crates/vmux_input/src/cef_keyboard_target.rs
+++ b/crates/vmux_input/src/cef_keyboard_target.rs
@@ -70,7 +70,9 @@ pub fn sync_cef_pointer_suppression_for_prefix(
     let prefix_on = first_prefix || chord_continuation;
     let on = prefix_on || palette_on;
     pointer.0 = on;
-    keyboard.0 = on || palette_hotkey;
+    // Keep keyboard suppression focused on command-palette ownership.
+    // Prefix routing is handled in app logic; suppressing here can starve normal pane typing.
+    keyboard.0 = palette_on || palette_hotkey;
 }
 
 /// Match CEF OSR focus to the active pane so windowless browsers paint without waiting for a click.


### PR DESCRIPTION
## Summary
- add `ensure-run-mac-deps` and wire it into `build-mac-debug` / `build` so `make run-mac` auto-installs missing runtime build deps (`wasm32-unknown-unknown`, pinned `dioxus-cli`)
- keep doctor checks as guidance while making dependency setup non-interactive and resilient after project updates
- fix focused pane typing by limiting CEF keyboard suppression to command-palette ownership/hotkeys instead of prefix routing state

## Test plan
- [x] `make ensure-run-mac-deps`
- [x] `PATH="$HOME/.cargo/bin:$PATH" env -u CEF_PATH cargo check -p vmux_input -p vmux_desktop`
- [x] run app with `make run-mac` and verify typing works in focused pane
