### PR TITLE
Title: Refactor key bindings system with derive macro and configurable settings

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -22,7 +22,10 @@
       "Bash(git stash:*)",
       "Bash(git mv:*)",
       "Bash(~/.cargo/bin/cargo check:*)",
-      "Bash(ls crates/vmux_header/dist/wasm/vmux_header_app*)"
+      "Bash(ls crates/vmux_header/dist/wasm/vmux_header_app*)",
+      "Read(//Users/js/.cargo/bin/**)",
+      "Read(//opt/homebrew/bin/**)",
+      "Read(//usr/local/bin/**)"
     ]
   }
 }

--- a/crates/vmux_desktop/src/command.rs
+++ b/crates/vmux_desktop/src/command.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use vmux_macro::{OsMenu, OsSubMenu};
+use vmux_macro::{DefaultKeyBindings, OsMenu, OsSubMenu};
 
 #[derive(SystemSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct WriteAppCommands;
@@ -16,7 +16,7 @@ impl Plugin for CommandPlugin {
     }
 }
 
-#[derive(Message, OsMenu, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Message, OsMenu, DefaultKeyBindings, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AppCommand {
     #[menu(label = "Space")]
     Space(SpaceCommand),
@@ -31,37 +31,43 @@ pub enum AppCommand {
     Camera(CameraCommand),
 }
 
-#[derive(OsSubMenu, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(OsSubMenu, DefaultKeyBindings, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SpaceCommand {
     #[default]
     #[menu(id = "new_space", label = "New Space")]
     New,
 }
 
-#[derive(OsSubMenu, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(OsSubMenu, DefaultKeyBindings, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum TabCommand {
     #[default]
     #[menu(id = "tab_next", label = "Select Next Tab")]
+    #[bind(direct = "Ctrl+Tab")]
     Next,
 
     #[menu(id = "tab_previous", label = "Select Previous Tab")]
+    #[bind(direct = "Shift+Ctrl+Tab")]
     Previous,
 }
 
-#[derive(OsSubMenu, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(OsSubMenu, DefaultKeyBindings, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PaneCommand {
     #[default]
     #[menu(id = "split_v", label = "Split Vertically")]
+    #[bind(chord = "Ctrl+KeyB, Shift+Digit5")]
     SplitV,
     #[menu(id = "split_h", label = "Split Horizontally")]
+    #[bind(chord = "Ctrl+KeyB, Shift+Quote")]
     SplitH,
     #[menu(id = "toggle_pane", label = "Toggle Pane")]
+    #[bind(chord = "Ctrl+KeyB, KeyO")]
     Toggle,
     #[menu(id = "close_pane", label = "Close Pane")]
+    #[bind(chord = "Ctrl+KeyB, KeyX")]
     Close,
 }
 
-#[derive(OsSubMenu, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(OsSubMenu, DefaultKeyBindings, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CameraCommand {
     #[default]
     #[menu(id = "reset_camera", label = "Reset Camera")]

--- a/crates/vmux_desktop/src/command.rs
+++ b/crates/vmux_desktop/src/command.rs
@@ -54,16 +54,16 @@ pub enum TabCommand {
 pub enum PaneCommand {
     #[default]
     #[menu(id = "split_v", label = "Split Vertically")]
-    #[bind(chord = "Ctrl+KeyB, Shift+Digit5")]
+    #[bind(chord = "Ctrl+b, %")]
     SplitV,
     #[menu(id = "split_h", label = "Split Horizontally")]
-    #[bind(chord = "Ctrl+KeyB, Shift+Quote")]
+    #[bind(chord = "Ctrl+b, \"")]
     SplitH,
     #[menu(id = "toggle_pane", label = "Toggle Pane")]
-    #[bind(chord = "Ctrl+KeyB, KeyO")]
+    #[bind(chord = "Ctrl+b, o")]
     Toggle,
     #[menu(id = "close_pane", label = "Close Pane")]
-    #[bind(chord = "Ctrl+KeyB, KeyX")]
+    #[bind(chord = "Ctrl+b, x")]
     Close,
 }
 

--- a/crates/vmux_desktop/src/keybinding.rs
+++ b/crates/vmux_desktop/src/keybinding.rs
@@ -1,0 +1,244 @@
+use crate::command::{AppCommand, WriteAppCommands};
+use crate::settings::AppSettings;
+use bevy::input::keyboard::KeyCode;
+use bevy::prelude::*;
+use std::time::Instant;
+
+pub struct KeyBindingPlugin;
+
+impl Plugin for KeyBindingPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Startup, init_keybindings)
+            .add_systems(Update, process_key_input.in_set(WriteAppCommands));
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct Modifiers {
+    pub ctrl: bool,
+    pub shift: bool,
+    pub alt: bool,
+    pub super_key: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct KeyCombo {
+    pub key: KeyCode,
+    pub modifiers: Modifiers,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum KeyBinding {
+    Direct(KeyCombo),
+    Chord(KeyCombo, KeyCombo),
+}
+
+#[derive(Resource, Debug, Clone)]
+pub struct KeyBindingMap {
+    pub bindings: Vec<(KeyBinding, String)>,
+    pub chord_timeout_ms: u64,
+}
+
+#[derive(Resource)]
+pub struct ChordState {
+    pub pending_prefix: Option<(KeyCombo, Instant)>,
+}
+
+impl Default for ChordState {
+    fn default() -> Self {
+        Self {
+            pending_prefix: None,
+        }
+    }
+}
+
+fn init_keybindings(mut commands: Commands, settings: Option<Res<AppSettings>>) {
+    let mut map = KeyBindingMap {
+        bindings: AppCommand::default_key_bindings(),
+        chord_timeout_ms: 1000,
+    };
+
+    if let Some(settings) = settings {
+        map.chord_timeout_ms = settings.keybindings.chord_timeout_ms;
+        for entry in &settings.keybindings.bindings {
+            if let Some(binding) = entry.binding.to_key_binding() {
+                if let Some(pos) = map.bindings.iter().position(|(_, id)| *id == entry.command) {
+                    map.bindings[pos] = (binding, entry.command.clone());
+                } else {
+                    map.bindings.push((binding, entry.command.clone()));
+                }
+            }
+        }
+    }
+
+    commands.insert_resource(map);
+    commands.insert_resource(ChordState::default());
+}
+
+fn process_key_input(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    bindings: Res<KeyBindingMap>,
+    mut chord_state: ResMut<ChordState>,
+    mut writer: MessageWriter<AppCommand>,
+) {
+    let current_modifiers = read_current_modifiers(&keyboard);
+
+    if let Some((_, instant)) = &chord_state.pending_prefix {
+        let timeout = std::time::Duration::from_millis(bindings.chord_timeout_ms);
+        if instant.elapsed() > timeout {
+            chord_state.pending_prefix = None;
+        }
+    }
+
+    for key in keyboard.get_just_pressed() {
+        if is_modifier_key(*key) {
+            continue;
+        }
+
+        let pressed = KeyCombo {
+            key: *key,
+            modifiers: current_modifiers,
+        };
+
+        if let Some((ref prefix, instant)) = chord_state.pending_prefix {
+            let timeout = std::time::Duration::from_millis(bindings.chord_timeout_ms);
+            if instant.elapsed() <= timeout {
+                for (binding, cmd_id) in &bindings.bindings {
+                    if let KeyBinding::Chord(b_prefix, b_second) = binding {
+                        if b_prefix == prefix && b_second == &pressed {
+                            if let Some(cmd) = AppCommand::from_menu_id(cmd_id.as_str()) {
+                                writer.write(cmd);
+                            }
+                            chord_state.pending_prefix = None;
+                            return;
+                        }
+                    }
+                }
+            }
+            chord_state.pending_prefix = None;
+        }
+
+        for (binding, cmd_id) in &bindings.bindings {
+            match binding {
+                KeyBinding::Direct(combo) if *combo == pressed => {
+                    if let Some(cmd) = AppCommand::from_menu_id(cmd_id.as_str()) {
+                        writer.write(cmd);
+                    }
+                    return;
+                }
+                KeyBinding::Chord(prefix, _) if *prefix == pressed => {
+                    chord_state.pending_prefix = Some((pressed, Instant::now()));
+                    return;
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn read_current_modifiers(keyboard: &ButtonInput<KeyCode>) -> Modifiers {
+    Modifiers {
+        ctrl: keyboard.pressed(KeyCode::ControlLeft) || keyboard.pressed(KeyCode::ControlRight),
+        shift: keyboard.pressed(KeyCode::ShiftLeft) || keyboard.pressed(KeyCode::ShiftRight),
+        alt: keyboard.pressed(KeyCode::AltLeft) || keyboard.pressed(KeyCode::AltRight),
+        super_key: keyboard.pressed(KeyCode::SuperLeft) || keyboard.pressed(KeyCode::SuperRight),
+    }
+}
+
+fn is_modifier_key(key: KeyCode) -> bool {
+    matches!(
+        key,
+        KeyCode::ControlLeft
+            | KeyCode::ControlRight
+            | KeyCode::ShiftLeft
+            | KeyCode::ShiftRight
+            | KeyCode::AltLeft
+            | KeyCode::AltRight
+            | KeyCode::SuperLeft
+            | KeyCode::SuperRight
+    )
+}
+
+pub fn key_code_from_str(s: &str) -> Option<KeyCode> {
+    match s {
+        "Backquote" => Some(KeyCode::Backquote),
+        "Backslash" => Some(KeyCode::Backslash),
+        "BracketLeft" => Some(KeyCode::BracketLeft),
+        "BracketRight" => Some(KeyCode::BracketRight),
+        "Comma" => Some(KeyCode::Comma),
+        "Digit0" => Some(KeyCode::Digit0),
+        "Digit1" => Some(KeyCode::Digit1),
+        "Digit2" => Some(KeyCode::Digit2),
+        "Digit3" => Some(KeyCode::Digit3),
+        "Digit4" => Some(KeyCode::Digit4),
+        "Digit5" => Some(KeyCode::Digit5),
+        "Digit6" => Some(KeyCode::Digit6),
+        "Digit7" => Some(KeyCode::Digit7),
+        "Digit8" => Some(KeyCode::Digit8),
+        "Digit9" => Some(KeyCode::Digit9),
+        "Equal" => Some(KeyCode::Equal),
+        "IntlBackslash" => Some(KeyCode::IntlBackslash),
+        "IntlRo" => Some(KeyCode::IntlRo),
+        "IntlYen" => Some(KeyCode::IntlYen),
+        "KeyA" => Some(KeyCode::KeyA),
+        "KeyB" => Some(KeyCode::KeyB),
+        "KeyC" => Some(KeyCode::KeyC),
+        "KeyD" => Some(KeyCode::KeyD),
+        "KeyE" => Some(KeyCode::KeyE),
+        "KeyF" => Some(KeyCode::KeyF),
+        "KeyG" => Some(KeyCode::KeyG),
+        "KeyH" => Some(KeyCode::KeyH),
+        "KeyI" => Some(KeyCode::KeyI),
+        "KeyJ" => Some(KeyCode::KeyJ),
+        "KeyK" => Some(KeyCode::KeyK),
+        "KeyL" => Some(KeyCode::KeyL),
+        "KeyM" => Some(KeyCode::KeyM),
+        "KeyN" => Some(KeyCode::KeyN),
+        "KeyO" => Some(KeyCode::KeyO),
+        "KeyP" => Some(KeyCode::KeyP),
+        "KeyQ" => Some(KeyCode::KeyQ),
+        "KeyR" => Some(KeyCode::KeyR),
+        "KeyS" => Some(KeyCode::KeyS),
+        "KeyT" => Some(KeyCode::KeyT),
+        "KeyU" => Some(KeyCode::KeyU),
+        "KeyV" => Some(KeyCode::KeyV),
+        "KeyW" => Some(KeyCode::KeyW),
+        "KeyX" => Some(KeyCode::KeyX),
+        "KeyY" => Some(KeyCode::KeyY),
+        "KeyZ" => Some(KeyCode::KeyZ),
+        "Minus" => Some(KeyCode::Minus),
+        "Period" => Some(KeyCode::Period),
+        "Quote" => Some(KeyCode::Quote),
+        "Semicolon" => Some(KeyCode::Semicolon),
+        "Slash" => Some(KeyCode::Slash),
+        "Backspace" => Some(KeyCode::Backspace),
+        "CapsLock" => Some(KeyCode::CapsLock),
+        "Enter" => Some(KeyCode::Enter),
+        "Space" => Some(KeyCode::Space),
+        "Tab" => Some(KeyCode::Tab),
+        "Delete" => Some(KeyCode::Delete),
+        "End" => Some(KeyCode::End),
+        "Home" => Some(KeyCode::Home),
+        "Insert" => Some(KeyCode::Insert),
+        "PageDown" => Some(KeyCode::PageDown),
+        "PageUp" => Some(KeyCode::PageUp),
+        "ArrowDown" => Some(KeyCode::ArrowDown),
+        "ArrowLeft" => Some(KeyCode::ArrowLeft),
+        "ArrowRight" => Some(KeyCode::ArrowRight),
+        "ArrowUp" => Some(KeyCode::ArrowUp),
+        "Escape" => Some(KeyCode::Escape),
+        "F1" => Some(KeyCode::F1),
+        "F2" => Some(KeyCode::F2),
+        "F3" => Some(KeyCode::F3),
+        "F4" => Some(KeyCode::F4),
+        "F5" => Some(KeyCode::F5),
+        "F6" => Some(KeyCode::F6),
+        "F7" => Some(KeyCode::F7),
+        "F8" => Some(KeyCode::F8),
+        "F9" => Some(KeyCode::F9),
+        "F10" => Some(KeyCode::F10),
+        "F11" => Some(KeyCode::F11),
+        "F12" => Some(KeyCode::F12),
+        _ => None,
+    }
+}

--- a/crates/vmux_desktop/src/keybinding.rs
+++ b/crates/vmux_desktop/src/keybinding.rs
@@ -159,7 +159,76 @@ fn is_modifier_key(key: KeyCode) -> bool {
     )
 }
 
-pub fn key_code_from_str(s: &str) -> Option<KeyCode> {
+pub struct ResolvedKey {
+    pub key: KeyCode,
+    pub implicit_shift: bool,
+}
+
+pub fn resolve_key(s: &str) -> Option<ResolvedKey> {
+    if let Some(key) = key_code_from_str(s) {
+        return Some(ResolvedKey {
+            key,
+            implicit_shift: false,
+        });
+    }
+
+    let chars: Vec<char> = s.chars().collect();
+    if chars.len() == 1 {
+        return resolve_char_literal(chars[0]);
+    }
+
+    None
+}
+
+fn resolve_char_literal(c: char) -> Option<ResolvedKey> {
+    let (key, shifted) = match c {
+        'a'..='z' => (
+            key_code_from_str(&format!("Key{}", c.to_ascii_uppercase()))?,
+            false,
+        ),
+        'A'..='Z' => (key_code_from_str(&format!("Key{}", c))?, true),
+        '0'..='9' => (key_code_from_str(&format!("Digit{}", c))?, false),
+        ')' => (KeyCode::Digit0, true),
+        '!' => (KeyCode::Digit1, true),
+        '@' => (KeyCode::Digit2, true),
+        '#' => (KeyCode::Digit3, true),
+        '$' => (KeyCode::Digit4, true),
+        '%' => (KeyCode::Digit5, true),
+        '^' => (KeyCode::Digit6, true),
+        '&' => (KeyCode::Digit7, true),
+        '*' => (KeyCode::Digit8, true),
+        '(' => (KeyCode::Digit9, true),
+        '-' => (KeyCode::Minus, false),
+        '_' => (KeyCode::Minus, true),
+        '=' => (KeyCode::Equal, false),
+        '/' => (KeyCode::Slash, false),
+        '?' => (KeyCode::Slash, true),
+        '.' => (KeyCode::Period, false),
+        '>' => (KeyCode::Period, true),
+        ',' => (KeyCode::Comma, false),
+        '<' => (KeyCode::Comma, true),
+        ';' => (KeyCode::Semicolon, false),
+        ':' => (KeyCode::Semicolon, true),
+        '\'' => (KeyCode::Quote, false),
+        '"' => (KeyCode::Quote, true),
+        '[' => (KeyCode::BracketLeft, false),
+        '{' => (KeyCode::BracketLeft, true),
+        ']' => (KeyCode::BracketRight, false),
+        '}' => (KeyCode::BracketRight, true),
+        '\\' => (KeyCode::Backslash, false),
+        '|' => (KeyCode::Backslash, true),
+        '`' => (KeyCode::Backquote, false),
+        '~' => (KeyCode::Backquote, true),
+        ' ' => (KeyCode::Space, false),
+        _ => return None,
+    };
+    Some(ResolvedKey {
+        key,
+        implicit_shift: shifted,
+    })
+}
+
+fn key_code_from_str(s: &str) -> Option<KeyCode> {
     match s {
         "Backquote" => Some(KeyCode::Backquote),
         "Backslash" => Some(KeyCode::Backslash),

--- a/crates/vmux_desktop/src/layout/tab.rs
+++ b/crates/vmux_desktop/src/layout/tab.rs
@@ -1,24 +1,7 @@
-use crate::command::{AppCommand, TabCommand, WriteAppCommands};
 use bevy::prelude::*;
 
 pub(crate) struct TabPlugin;
 
 impl Plugin for TabPlugin {
-    fn build(&self, app: &mut App) {
-        app.add_systems(Update, write_tab_hotkeys.in_set(WriteAppCommands));
-    }
-}
-
-fn write_tab_hotkeys(keyboard: Res<ButtonInput<KeyCode>>, mut writer: MessageWriter<AppCommand>) {
-    let ctrl = keyboard.pressed(KeyCode::ControlLeft) || keyboard.pressed(KeyCode::ControlRight);
-    let meta = keyboard.pressed(KeyCode::SuperLeft) || keyboard.pressed(KeyCode::SuperRight);
-    if !keyboard.just_pressed(KeyCode::Tab) || (!ctrl && !meta) {
-        return;
-    }
-    let shift = keyboard.pressed(KeyCode::ShiftLeft) || keyboard.pressed(KeyCode::ShiftRight);
-    if shift {
-        writer.write(AppCommand::Tab(TabCommand::Previous));
-    } else {
-        writer.write(AppCommand::Tab(TabCommand::Next));
-    }
+    fn build(&self, _app: &mut App) {}
 }

--- a/crates/vmux_desktop/src/lib.rs
+++ b/crates/vmux_desktop/src/lib.rs
@@ -1,5 +1,6 @@
 mod browser;
 mod command;
+pub(crate) mod keybinding;
 mod layout;
 mod os_menu;
 mod scene;
@@ -11,8 +12,9 @@ use bevy::prelude::*;
 use bevy::window::{CompositeAlphaMode, Window as NativeWindow, WindowPlugin};
 
 use {
-    browser::BrowserPlugin, command::CommandPlugin, layout::LayoutPlugin, os_menu::OsMenuPlugin,
-    scene::ScenePlugin, settings::SettingsPlugin, vmux_header::HeaderPlugin,
+    browser::BrowserPlugin, command::CommandPlugin, keybinding::KeyBindingPlugin,
+    layout::LayoutPlugin, os_menu::OsMenuPlugin, scene::ScenePlugin, settings::SettingsPlugin,
+    vmux_header::HeaderPlugin,
 };
 
 pub struct VmuxPlugin;
@@ -41,6 +43,7 @@ impl Plugin for VmuxPlugin {
                 .set(window_plugin),
             SettingsPlugin,
             CommandPlugin,
+            KeyBindingPlugin,
             ScenePlugin,
             OsMenuPlugin,
             LayoutPlugin,

--- a/crates/vmux_desktop/src/scene.rs
+++ b/crates/vmux_desktop/src/scene.rs
@@ -221,6 +221,8 @@ fn on_reset_camera(
     mut transform: Single<&mut Transform, With<MainCamera>>,
     projection: Single<&Projection, With<MainCamera>>,
     mut camera_state: Single<&mut FreeCameraState, With<MainCamera>>,
+    camera: Single<Entity, With<MainCamera>>,
+    mut commands: Commands,
 ) {
     for cmd in reader.read() {
         let AppCommand::Camera(CameraCommand::Reset) = *cmd else {
@@ -228,6 +230,7 @@ fn on_reset_camera(
         };
 
         camera_state.enabled = false;
+        commands.entity(*camera).remove::<Bloom>();
 
         let aspect = match &*projection {
             Projection::Perspective(p) => p.aspect_ratio,

--- a/crates/vmux_desktop/src/settings.ron
+++ b/crates/vmux_desktop/src/settings.ron
@@ -25,4 +25,15 @@
             ),
         ),
     ),
+    keybindings: (
+        chord_timeout_ms: 1000,
+        bindings: [
+            (command: "tab_next", binding: Direct((key: "Tab", ctrl: true))),
+            (command: "tab_previous", binding: Direct((key: "Tab", ctrl: true, shift: true))),
+            (command: "split_v", binding: Chord((key: "b", ctrl: true), (key: "%"))),
+            (command: "split_h", binding: Chord((key: "b", ctrl: true), (key: "\""))),
+            (command: "toggle_pane", binding: Chord((key: "b", ctrl: true), (key: "o"))),
+            (command: "close_pane", binding: Chord((key: "b", ctrl: true), (key: "x"))),
+        ],
+    ),
 )

--- a/crates/vmux_desktop/src/settings.rs
+++ b/crates/vmux_desktop/src/settings.rs
@@ -14,6 +14,83 @@ impl Plugin for SettingsPlugin {
 pub struct AppSettings {
     pub browser: BrowserSettings,
     pub layout: LayoutSettings,
+    #[serde(default)]
+    pub keybindings: KeyBindingSettings,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct KeyBindingSettings {
+    #[serde(default = "default_chord_timeout_ms")]
+    pub chord_timeout_ms: u64,
+    #[serde(default)]
+    pub bindings: Vec<KeyBindingEntry>,
+}
+
+impl Default for KeyBindingSettings {
+    fn default() -> Self {
+        Self {
+            chord_timeout_ms: default_chord_timeout_ms(),
+            bindings: Vec::new(),
+        }
+    }
+}
+
+fn default_chord_timeout_ms() -> u64 {
+    1000
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct KeyBindingEntry {
+    pub command: String,
+    pub binding: KeyBindingDef,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub enum KeyBindingDef {
+    Direct(KeyComboDef),
+    Chord(KeyComboDef, KeyComboDef),
+}
+
+impl KeyBindingDef {
+    pub fn to_key_binding(&self) -> Option<crate::keybinding::KeyBinding> {
+        match self {
+            KeyBindingDef::Direct(combo) => {
+                Some(crate::keybinding::KeyBinding::Direct(combo.to_key_combo()?))
+            }
+            KeyBindingDef::Chord(prefix, second) => Some(crate::keybinding::KeyBinding::Chord(
+                prefix.to_key_combo()?,
+                second.to_key_combo()?,
+            )),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct KeyComboDef {
+    pub key: String,
+    #[serde(default)]
+    pub ctrl: bool,
+    #[serde(default)]
+    pub shift: bool,
+    #[serde(default)]
+    pub alt: bool,
+    #[serde(default)]
+    pub super_key: bool,
+}
+
+impl KeyComboDef {
+    fn to_key_combo(&self) -> Option<crate::keybinding::KeyCombo> {
+        let key = crate::keybinding::key_code_from_str(&self.key)?;
+        Some(crate::keybinding::KeyCombo {
+            key,
+            modifiers: crate::keybinding::Modifiers {
+                ctrl: self.ctrl,
+                shift: self.shift,
+                alt: self.alt,
+                super_key: self.super_key,
+            },
+        })
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/crates/vmux_desktop/src/settings.rs
+++ b/crates/vmux_desktop/src/settings.rs
@@ -80,12 +80,12 @@ pub struct KeyComboDef {
 
 impl KeyComboDef {
     fn to_key_combo(&self) -> Option<crate::keybinding::KeyCombo> {
-        let key = crate::keybinding::key_code_from_str(&self.key)?;
+        let resolved = crate::keybinding::resolve_key(&self.key)?;
         Some(crate::keybinding::KeyCombo {
-            key,
+            key: resolved.key,
             modifiers: crate::keybinding::Modifiers {
                 ctrl: self.ctrl,
-                shift: self.shift,
+                shift: self.shift || resolved.implicit_shift,
                 alt: self.alt,
                 super_key: self.super_key,
             },

--- a/crates/vmux_macro/src/lib.rs
+++ b/crates/vmux_macro/src/lib.rs
@@ -2,6 +2,15 @@ use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{Attribute, Data, DeriveInput, Fields, LitStr, parse_macro_input};
 
+#[proc_macro_derive(DefaultKeyBindings, attributes(bind, menu))]
+pub fn derive_default_key_bindings(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match impl_default_key_bindings(input) {
+        Ok(tokens) => tokens.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
 #[proc_macro_derive(OsSubMenu, attributes(menu))]
 pub fn derive_os_sub_menu(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -204,4 +213,205 @@ fn heck_variant_snake_case(s: &str) -> String {
         out.push(ch.to_ascii_lowercase());
     }
     out
+}
+
+fn impl_default_key_bindings(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+    let ident = &input.ident;
+    let Data::Enum(data) = &input.data else {
+        return Err(syn::Error::new_spanned(
+            ident,
+            "DefaultKeyBindings only supports enums",
+        ));
+    };
+
+    let first_variant = data.variants.first();
+    let is_leaf = first_variant
+        .map(|v| matches!(v.fields, Fields::Unit))
+        .unwrap_or(true);
+
+    if is_leaf {
+        impl_leaf_key_bindings(ident, data)
+    } else {
+        impl_root_key_bindings(ident, data)
+    }
+}
+
+fn impl_leaf_key_bindings(
+    ident: &syn::Ident,
+    data: &syn::DataEnum,
+) -> syn::Result<proc_macro2::TokenStream> {
+    let mut binding_entries = Vec::new();
+
+    for variant in &data.variants {
+        let bind_props = BindProps::from_attrs(&variant.attrs)?;
+        let menu_props = MenuProps::from_attrs(&variant.attrs)?;
+
+        let binding_str = match (&bind_props.direct, &bind_props.chord) {
+            (Some(_), Some(_)) => {
+                return Err(syn::Error::new_spanned(
+                    variant,
+                    "cannot specify both direct and chord on the same variant",
+                ));
+            }
+            (None, None) => continue,
+            (Some(s), None) => s.clone(),
+            (None, Some(s)) => s.clone(),
+        };
+        let is_chord = bind_props.chord.is_some();
+
+        let Some(menu_id) = &menu_props.id else {
+            return Err(syn::Error::new_spanned(
+                variant,
+                "variant with #[bind(...)] must also have #[menu(id = \"...\")]",
+            ));
+        };
+
+        let binding_tokens = if is_chord {
+            let parts: Vec<&str> = binding_str.split(',').collect();
+            if parts.len() != 2 {
+                return Err(syn::Error::new_spanned(
+                    variant,
+                    "chord binding must have exactly two parts separated by comma",
+                ));
+            }
+            let prefix_tokens = parse_key_combo_tokens(parts[0].trim(), variant)?;
+            let second_tokens = parse_key_combo_tokens(parts[1].trim(), variant)?;
+            quote! {
+                crate::keybinding::KeyBinding::Chord(#prefix_tokens, #second_tokens)
+            }
+        } else {
+            let combo_tokens = parse_key_combo_tokens(&binding_str, variant)?;
+            quote! {
+                crate::keybinding::KeyBinding::Direct(#combo_tokens)
+            }
+        };
+
+        let menu_id_str = menu_id.as_str();
+        binding_entries.push(quote! {
+            (#binding_tokens, ::std::string::String::from(#menu_id_str))
+        });
+    }
+
+    Ok(quote! {
+        impl #ident {
+            pub fn default_key_bindings() -> ::std::vec::Vec<(crate::keybinding::KeyBinding, ::std::string::String)> {
+                ::std::vec![#(#binding_entries),*]
+            }
+        }
+    })
+}
+
+fn impl_root_key_bindings(
+    ident: &syn::Ident,
+    data: &syn::DataEnum,
+) -> syn::Result<proc_macro2::TokenStream> {
+    let mut extend_calls = Vec::new();
+
+    for variant in &data.variants {
+        let Fields::Unnamed(fields) = &variant.fields else {
+            return Err(syn::Error::new_spanned(
+                &variant.fields,
+                "DefaultKeyBindings root expects tuple variants",
+            ));
+        };
+        let Some(field) = fields.unnamed.first() else {
+            return Err(syn::Error::new_spanned(
+                variant,
+                "tuple variant needs one field",
+            ));
+        };
+        let inner_ty = &field.ty;
+        extend_calls.push(quote! {
+            bindings.extend(<#inner_ty>::default_key_bindings());
+        });
+    }
+
+    Ok(quote! {
+        impl #ident {
+            pub fn default_key_bindings() -> ::std::vec::Vec<(crate::keybinding::KeyBinding, ::std::string::String)> {
+                let mut bindings = ::std::vec::Vec::new();
+                #(#extend_calls)*
+                bindings
+            }
+        }
+    })
+}
+
+fn parse_key_combo_tokens(
+    s: &str,
+    spanned: &syn::Variant,
+) -> syn::Result<proc_macro2::TokenStream> {
+    let parts: Vec<&str> = s.split('+').map(|p| p.trim()).collect();
+    let mut ctrl = false;
+    let mut shift = false;
+    let mut alt = false;
+    let mut super_key = false;
+    let mut key_name: Option<&str> = None;
+
+    for part in &parts {
+        match *part {
+            "Ctrl" => ctrl = true,
+            "Shift" => shift = true,
+            "Alt" => alt = true,
+            "Super" => super_key = true,
+            other => {
+                if key_name.is_some() {
+                    return Err(syn::Error::new_spanned(
+                        spanned,
+                        format!("multiple non-modifier keys in binding: {s}"),
+                    ));
+                }
+                key_name = Some(other);
+            }
+        }
+    }
+
+    let Some(key_str) = key_name else {
+        return Err(syn::Error::new_spanned(
+            spanned,
+            format!("no key specified in binding: {s}"),
+        ));
+    };
+
+    let key_ident = format_ident!("{}", key_str);
+
+    Ok(quote! {
+        crate::keybinding::KeyCombo {
+            key: ::bevy::input::keyboard::KeyCode::#key_ident,
+            modifiers: crate::keybinding::Modifiers {
+                ctrl: #ctrl,
+                shift: #shift,
+                alt: #alt,
+                super_key: #super_key,
+            },
+        }
+    })
+}
+
+struct BindProps {
+    direct: Option<String>,
+    chord: Option<String>,
+}
+
+impl BindProps {
+    fn from_attrs(attrs: &[Attribute]) -> syn::Result<Self> {
+        let mut direct = None;
+        let mut chord = None;
+        for attr in attrs {
+            if !attr.path().is_ident("bind") {
+                continue;
+            }
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("direct") {
+                    let v: LitStr = meta.value()?.parse()?;
+                    direct = Some(v.value());
+                } else if meta.path.is_ident("chord") {
+                    let v: LitStr = meta.value()?.parse()?;
+                    chord = Some(v.value());
+                }
+                Ok(())
+            })?;
+        }
+        Ok(BindProps { direct, chord })
+    }
 }

--- a/crates/vmux_macro/src/lib.rs
+++ b/crates/vmux_macro/src/lib.rs
@@ -337,6 +337,56 @@ fn impl_root_key_bindings(
     })
 }
 
+struct ResolvedKey {
+    key_code: String,
+    implicit_shift: bool,
+}
+
+fn resolve_char_literal(c: char) -> Option<ResolvedKey> {
+    let (key_code, shifted) = match c {
+        'a'..='z' => (format!("Key{}", c.to_ascii_uppercase()), false),
+        'A'..='Z' => (format!("Key{}", c), true),
+        '0'..='9' => (format!("Digit{}", c), false),
+        ')' => ("Digit0".into(), true),
+        '!' => ("Digit1".into(), true),
+        '@' => ("Digit2".into(), true),
+        '#' => ("Digit3".into(), true),
+        '$' => ("Digit4".into(), true),
+        '%' => ("Digit5".into(), true),
+        '^' => ("Digit6".into(), true),
+        '&' => ("Digit7".into(), true),
+        '*' => ("Digit8".into(), true),
+        '(' => ("Digit9".into(), true),
+        '-' => ("Minus".into(), false),
+        '_' => ("Minus".into(), true),
+        '=' => ("Equal".into(), false),
+        '/' => ("Slash".into(), false),
+        '?' => ("Slash".into(), true),
+        '.' => ("Period".into(), false),
+        '>' => ("Period".into(), true),
+        ',' => ("Comma".into(), false),
+        '<' => ("Comma".into(), true),
+        ';' => ("Semicolon".into(), false),
+        ':' => ("Semicolon".into(), true),
+        '\'' => ("Quote".into(), false),
+        '"' => ("Quote".into(), true),
+        '[' => ("BracketLeft".into(), false),
+        '{' => ("BracketLeft".into(), true),
+        ']' => ("BracketRight".into(), false),
+        '}' => ("BracketRight".into(), true),
+        '\\' => ("Backslash".into(), false),
+        '|' => ("Backslash".into(), true),
+        '`' => ("Backquote".into(), false),
+        '~' => ("Backquote".into(), true),
+        ' ' => ("Space".into(), false),
+        _ => return None,
+    };
+    Some(ResolvedKey {
+        key_code,
+        implicit_shift: shifted,
+    })
+}
+
 fn parse_key_combo_tokens(
     s: &str,
     spanned: &syn::Variant,
@@ -346,7 +396,8 @@ fn parse_key_combo_tokens(
     let mut shift = false;
     let mut alt = false;
     let mut super_key = false;
-    let mut key_name: Option<&str> = None;
+    let mut key_name: Option<String> = None;
+    let mut implicit_shift = false;
 
     for part in &parts {
         match *part {
@@ -361,7 +412,20 @@ fn parse_key_combo_tokens(
                         format!("multiple non-modifier keys in binding: {s}"),
                     ));
                 }
-                key_name = Some(other);
+                let chars: Vec<char> = other.chars().collect();
+                if chars.len() == 1 {
+                    if let Some(resolved) = resolve_char_literal(chars[0]) {
+                        key_name = Some(resolved.key_code);
+                        implicit_shift = resolved.implicit_shift;
+                    } else {
+                        return Err(syn::Error::new_spanned(
+                            spanned,
+                            format!("unrecognized character literal '{}'", chars[0]),
+                        ));
+                    }
+                } else {
+                    key_name = Some(other.to_string());
+                }
             }
         }
     }
@@ -373,6 +437,7 @@ fn parse_key_combo_tokens(
         ));
     };
 
+    shift = shift || implicit_shift;
     let key_ident = format_ident!("{}", key_str);
 
     Ok(quote! {


### PR DESCRIPTION
## Summary

- New DefaultKeyBindings derive macro ([vmux_macro/src/lib.rs](vscode-webview://0he4tpk1jb0bk22l51r6fq0b7q9jn7e69cmugobsrjvp3bfmuk5f/crates/vmux_macro/src/lib.rs)) — generates default key binding maps from #[bind(direct = "...")] / #[bind(chord = "...")] attributes on command enum variants, supporting both direct keys and chord sequences (e.g. Ctrl+b, %)
- New KeyBindingPlugin ([keybinding.rs](vscode-webview://0he4tpk1jb0bk22l51r6fq0b7q9jn7e69cmugobsrjvp3bfmuk5f/crates/vmux_desktop/src/keybinding.rs)) — runtime key input processing with chord state machine, modifier detection, and configurable chord timeout
- User-configurable bindings ([settings.rs](vscode-webview://0he4tpk1jb0bk22l51r6fq0b7q9jn7e69cmugobsrjvp3bfmuk5f/crates/vmux_desktop/src/settings.rs), [settings.ron](vscode-webview://0he4tpk1jb0bk22l51r6fq0b7q9jn7e69cmugobsrjvp3bfmuk5f/crates/vmux_desktop/src/settings.ron)) — keybindings section in settings.ron allows overriding defaults at runtime via Direct or Chord definitions
#[bind] attributes on commands ([command.rs](vscode-webview://0he4tpk1jb0bk22l51r6fq0b7q9jn7e69cmugobsrjvp3bfmuk5f/crates/vmux_desktop/src/command.rs)) — TabCommand gets direct bindings (Ctrl+Tab, Shift+Ctrl+Tab), PaneCommand gets tmux-style chords (Ctrl+b, %, Ctrl+b, ", etc.)
- Remove bloom on camera reset ([scene.rs](vscode-webview://0he4tpk1jb0bk22l51r6fq0b7q9jn7e69cmugobsrjvp3bfmuk5f/crates/vmux_desktop/src/scene.rs)) — on_reset_camera now strips the Bloom component, matching the behavior in on_toggle_free_camera