### PR TITLE
feat(command): hide unimplemented commands from command bar and OS menu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,41 @@
 
 - Do not add comments to code.
 - Do not use mod.rs files. Use the filename-based module pattern (e.g. `layout.rs` + `layout/` directory).
+- **Never make changes directly on `main`.** Always use a worktree branch.
+
+## Mandatory: Lint and Test Before Every Commit
+
+**You MUST run these commands and confirm they pass before every `git commit` or `git push`.** Do not skip this step. CI will reject PRs that fail these checks.
+
+```sh
+make lint      # cargo fmt --check + clippy -D warnings (excludes vendored patches)
+make test      # cargo test --workspace --exclude bevy_cef_core
+make lint-fix  # auto-fix: cargo fmt + clippy --fix
+```
+
+### What CI checks
+
+| CI Job         | What it runs                                                   |
+|----------------|----------------------------------------------------------------|
+| **Lint**       | `cargo fmt --check` + `cargo clippy --all-targets -D warnings` per non-patch crate |
+| **Test**       | `cargo test --workspace --exclude bevy_cef_core`               |
+| **Website**    | `dx build --platform web --release` in `website/`              |
+
+### Fixing failures
+
+- **Auto-fix:** run `make lint-fix` to auto-format and apply clippy suggestions.
+- **Manual fix:** if `make lint-fix` can't resolve a clippy warning, fix it by hand.
+- **If `make lint` takes too long**, you can target a single crate: `cargo clippy -p <crate> --all-targets -- -D warnings`
+
+### Workflow
+
+1. Make your changes.
+2. Run `make lint-fix` — auto-fix formatting and clippy issues.
+3. Run `make lint` — confirm everything passes.
+4. Run `make test` — fix any failures.
+5. Only then `git commit` / `git push`.
+
+**Never commit with known lint or test failures.** If you are unsure whether your changes compile cleanly, run `make lint` again.
 
 ## Worktrees
 
@@ -13,12 +48,3 @@ When working on a Linear issue, always use a git worktree for isolation:
 4. Remember: if the worktree is deleted while your shell is inside it, `cd` back to the repo root — `../..` won't work.
 
 Worktree directory: `.worktrees/` (already in `.gitignore`).
-
-## Before Pushing
-
-Always run lint and test before pushing to catch CI failures locally:
-
-```sh
-make lint  # runs fmt --check + clippy -D warnings
-make test  # runs cargo test --workspace
-```

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run-mac run-mac-local run-doctor build-mac-debug build build-local-mac package-mac setup-cef install-debug-render-process doctor-mac ensure-run-mac-deps run-website build-website lint fmt clippy test
+.PHONY: run-mac run-mac-local run-doctor build-mac-debug build build-local-mac package-mac setup-cef install-debug-render-process doctor-mac ensure-run-mac-deps run-website build-website lint lint-fix fmt clippy test
 
 CARGO_BIN := $(or $(shell command -v cargo 2>/dev/null),$(HOME)/.cargo/bin/cargo)
 RUSTUP_BIN := $(or $(shell command -v rustup 2>/dev/null),$(HOME)/.cargo/bin/rustup)
@@ -49,6 +49,14 @@ install-debug-render-process:
 PKGS = $(shell "$(CARGO_BIN)" metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.manifest_path | test("patches") | not) | .name')
 
 lint: fmt clippy
+
+lint-fix:
+	@for pkg in $(PKGS); do \
+		"$(CARGO_BIN)" fmt -p "$$pkg" || exit 1; \
+	done
+	@for pkg in $(PKGS); do \
+		env -u CEF_PATH "$(CARGO_BIN)" clippy -p "$$pkg" --all-targets --fix --allow-dirty --allow-staged -- -D warnings || exit 1; \
+	done
 
 fmt:
 	@for pkg in $(PKGS); do \

--- a/crates/vmux_command_bar/src/app.rs
+++ b/crates/vmux_command_bar/src/app.rs
@@ -227,36 +227,12 @@ pub fn App() -> Element {
                 .cloned();
             r.retain(|item| !matches!(item, ResultItem::Terminal { path } if !path.is_empty()));
             let mut combined = Vec::new();
-            if let Some(ref entry) = typed_terminal {
-                if let ResultItem::Terminal { path: tp } = entry {
-                    if !path_items
-                        .iter()
-                        .any(|item| matches!(item, ResultItem::Terminal { path } if path == tp))
-                    {
-                        combined.push(entry.clone());
-                    }
-                }
->>>>>>> 2e4e40e (feat: hide unimplemented commands from command bar and OS menu)
-            }
-=======
             if let Some(ref entry @ ResultItem::Terminal { path: ref tp }) = typed_terminal
                 && !path_items
                     .iter()
                     .any(|item| matches!(item, ResultItem::Terminal { path } if path == tp))
             {
                 combined.push(entry.clone());
-            }
-=======
-            if let Some(ref entry) = typed_terminal {
-                if let ResultItem::Terminal { path: tp } = entry {
-                    if !path_items
-                        .iter()
-                        .any(|item| matches!(item, ResultItem::Terminal { path } if path == tp))
-                    {
-                        combined.push(entry.clone());
-                    }
-                }
->>>>>>> 2e4e40e (feat: hide unimplemented commands from command bar and OS menu)
             }
             combined.extend(path_items);
             combined.extend(r);

--- a/crates/vmux_command_bar/src/app.rs
+++ b/crates/vmux_command_bar/src/app.rs
@@ -227,12 +227,36 @@ pub fn App() -> Element {
                 .cloned();
             r.retain(|item| !matches!(item, ResultItem::Terminal { path } if !path.is_empty()));
             let mut combined = Vec::new();
+            if let Some(ref entry) = typed_terminal {
+                if let ResultItem::Terminal { path: tp } = entry {
+                    if !path_items
+                        .iter()
+                        .any(|item| matches!(item, ResultItem::Terminal { path } if path == tp))
+                    {
+                        combined.push(entry.clone());
+                    }
+                }
+>>>>>>> 2e4e40e (feat: hide unimplemented commands from command bar and OS menu)
+            }
+=======
             if let Some(ref entry @ ResultItem::Terminal { path: ref tp }) = typed_terminal
                 && !path_items
                     .iter()
                     .any(|item| matches!(item, ResultItem::Terminal { path } if path == tp))
             {
                 combined.push(entry.clone());
+            }
+=======
+            if let Some(ref entry) = typed_terminal {
+                if let ResultItem::Terminal { path: tp } = entry {
+                    if !path_items
+                        .iter()
+                        .any(|item| matches!(item, ResultItem::Terminal { path } if path == tp))
+                    {
+                        combined.push(entry.clone());
+                    }
+                }
+>>>>>>> 2e4e40e (feat: hide unimplemented commands from command bar and OS menu)
             }
             combined.extend(path_items);
             combined.extend(r);

--- a/crates/vmux_desktop/src/command.rs
+++ b/crates/vmux_desktop/src/command.rs
@@ -46,6 +46,7 @@ pub enum AppCommand {
     Browser(BrowserCommand),
 }
 
+#[allow(dead_code)]
 #[derive(OsSubMenu, DefaultShortcuts, CommandBar, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum TabCommand {
     #[default]
@@ -85,12 +86,12 @@ pub enum TabCommand {
     #[menu(id = "tab_duplicate", label = "Duplicate Tab\t<leader> d", hidden)]
     #[shortcut(chord = "Ctrl+g, d")]
     Duplicate,
-    #[menu(id = "tab_pin", label = "Pin Tab", hidden)]
-    Pin,
-    #[menu(id = "tab_mute", label = "Mute Tab\t<leader> m", hidden)]
-    #[shortcut(chord = "Ctrl+g, m")]
-    Mute,
-    #[menu(id = "tab_move_to_pane", label = "Move Tab to Pane\t<leader> !", hidden)]
+
+    #[menu(
+        id = "tab_move_to_pane",
+        label = "Move Tab to Pane\t<leader> !",
+        hidden
+    )]
     #[shortcut(chord = "Ctrl+g, !")]
     MoveToPane,
     #[menu(id = "tab_swap_prev", label = "Move Tab Left\t<leader> <")]
@@ -101,28 +102,19 @@ pub enum TabCommand {
     SwapNext,
 }
 
+#[allow(dead_code)]
 #[derive(OsSubMenu, DefaultShortcuts, CommandBar, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum TerminalCommand {
     #[default]
     #[menu(id = "terminal_new", label = "New Terminal", accel = "ctrl+`")]
     #[shortcut(direct = "Ctrl+`")]
     New,
-    #[menu(id = "terminal_close", label = "Close Terminal", hidden)]
-    Close,
-    #[menu(id = "terminal_next", label = "Next Terminal", hidden)]
-    Next,
-    #[menu(id = "terminal_prev", label = "Previous Terminal", hidden)]
-    Previous,
+
     #[menu(id = "terminal_clear", label = "Clear Terminal", hidden)]
     Clear,
-    #[menu(id = "terminal_reset", label = "Reset Terminal", hidden)]
-    Reset,
-    #[menu(id = "terminal_split_v", label = "Split Terminal Vertically", hidden)]
-    SplitV,
-    #[menu(id = "terminal_split_h", label = "Split Terminal Horizontally", hidden)]
-    SplitH,
 }
 
+#[allow(dead_code)]
 #[derive(OsSubMenu, DefaultShortcuts, CommandBar, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum BrowserCommand {
     #[default]
@@ -186,6 +178,7 @@ pub enum BrowserCommand {
     Print,
 }
 
+#[allow(dead_code)]
 #[derive(OsSubMenu, DefaultShortcuts, CommandBar, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PaneCommand {
     #[default]
@@ -222,10 +215,18 @@ pub enum PaneCommand {
     #[menu(id = "swap_pane_next", label = "Swap Pane Next\t<leader> }")]
     #[shortcut(chord = "Ctrl+g, }")]
     SwapNext,
-    #[menu(id = "rotate_forward", label = "Rotate Forward\t<leader> ctrl+o", hidden)]
+    #[menu(
+        id = "rotate_forward",
+        label = "Rotate Forward\t<leader> ctrl+o",
+        hidden
+    )]
     #[shortcut(chord = "Ctrl+g, Ctrl+o")]
     RotateForward,
-    #[menu(id = "rotate_backward", label = "Rotate Backward\t<leader> alt+o", hidden)]
+    #[menu(
+        id = "rotate_backward",
+        label = "Rotate Backward\t<leader> alt+o",
+        hidden
+    )]
     #[shortcut(chord = "Ctrl+g, Alt+o")]
     RotateBackward,
     #[menu(id = "equalize_pane_size", label = "Equalize Pane Size\t<leader> =")]
@@ -248,6 +249,7 @@ pub enum PaneCommand {
     ResizeDown,
 }
 
+#[allow(dead_code)]
 #[derive(OsSubMenu, DefaultShortcuts, CommandBar, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SpaceCommand {
     #[default]
@@ -272,6 +274,7 @@ pub enum SpaceCommand {
     SwapNext,
 }
 
+#[allow(dead_code)]
 #[derive(OsSubMenu, DefaultShortcuts, CommandBar, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SideSheetCommand {
     #[default]
@@ -313,12 +316,18 @@ pub enum HeaderCommand {
     Toggle,
 }
 
+#[allow(dead_code)]
 #[derive(OsSubMenu, DefaultShortcuts, CommandBar, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum WindowCommand {
     #[default]
     #[menu(id = "new_window", label = "New Window", accel = "super+n", hidden)]
     NewWindow,
-    #[menu(id = "close_window", label = "Close Window", accel = "super+shift+w", hidden)]
+    #[menu(
+        id = "close_window",
+        label = "Close Window",
+        accel = "super+shift+w",
+        hidden
+    )]
     CloseWindow,
     #[menu(id = "minimize_window", label = "Minimize", accel = "super+m", hidden)]
     Minimize,

--- a/crates/vmux_desktop/src/command.rs
+++ b/crates/vmux_desktop/src/command.rs
@@ -78,18 +78,19 @@ pub enum TabCommand {
     #[menu(
         id = "tab_reopen",
         label = "Reopen Closed Tab",
-        accel = "super+shift+t"
+        accel = "super+shift+t",
+        hidden
     )]
     Reopen,
-    #[menu(id = "tab_duplicate", label = "Duplicate Tab\t<leader> d")]
+    #[menu(id = "tab_duplicate", label = "Duplicate Tab\t<leader> d", hidden)]
     #[shortcut(chord = "Ctrl+g, d")]
     Duplicate,
-    #[menu(id = "tab_pin", label = "Pin Tab")]
+    #[menu(id = "tab_pin", label = "Pin Tab", hidden)]
     Pin,
-    #[menu(id = "tab_mute", label = "Mute Tab\t<leader> m")]
+    #[menu(id = "tab_mute", label = "Mute Tab\t<leader> m", hidden)]
     #[shortcut(chord = "Ctrl+g, m")]
     Mute,
-    #[menu(id = "tab_move_to_pane", label = "Move Tab to Pane\t<leader> !")]
+    #[menu(id = "tab_move_to_pane", label = "Move Tab to Pane\t<leader> !", hidden)]
     #[shortcut(chord = "Ctrl+g, !")]
     MoveToPane,
     #[menu(id = "tab_swap_prev", label = "Move Tab Left\t<leader> <")]
@@ -106,19 +107,19 @@ pub enum TerminalCommand {
     #[menu(id = "terminal_new", label = "New Terminal", accel = "ctrl+`")]
     #[shortcut(direct = "Ctrl+`")]
     New,
-    #[menu(id = "terminal_close", label = "Close Terminal")]
+    #[menu(id = "terminal_close", label = "Close Terminal", hidden)]
     Close,
-    #[menu(id = "terminal_next", label = "Next Terminal")]
+    #[menu(id = "terminal_next", label = "Next Terminal", hidden)]
     Next,
-    #[menu(id = "terminal_prev", label = "Previous Terminal")]
+    #[menu(id = "terminal_prev", label = "Previous Terminal", hidden)]
     Previous,
-    #[menu(id = "terminal_clear", label = "Clear Terminal")]
+    #[menu(id = "terminal_clear", label = "Clear Terminal", hidden)]
     Clear,
-    #[menu(id = "terminal_reset", label = "Reset Terminal")]
+    #[menu(id = "terminal_reset", label = "Reset Terminal", hidden)]
     Reset,
-    #[menu(id = "terminal_split_v", label = "Split Terminal Vertically")]
+    #[menu(id = "terminal_split_v", label = "Split Terminal Vertically", hidden)]
     SplitV,
-    #[menu(id = "terminal_split_h", label = "Split Terminal Horizontally")]
+    #[menu(id = "terminal_split_h", label = "Split Terminal Horizontally", hidden)]
     SplitH,
 }
 
@@ -137,7 +138,7 @@ pub enum BrowserCommand {
         accel = "super+shift+r"
     )]
     HardReload,
-    #[menu(id = "browser_stop", label = "Stop Loading", accel = "super+.")]
+    #[menu(id = "browser_stop", label = "Stop Loading", accel = "super+.", hidden)]
     Stop,
     #[menu(
         id = "browser_focus_address_bar",
@@ -160,7 +161,7 @@ pub enum BrowserCommand {
     #[menu(id = "browser_open_commands", label = "Commands")]
     #[shortcut(direct = ">")]
     OpenCommands,
-    #[menu(id = "browser_find", label = "Find", accel = "super+f")]
+    #[menu(id = "browser_find", label = "Find", accel = "super+f", hidden)]
     Find,
     #[menu(id = "browser_zoom_in", label = "Zoom In", accel = "super+=")]
     ZoomIn,
@@ -177,10 +178,11 @@ pub enum BrowserCommand {
     #[menu(
         id = "browser_view_source",
         label = "View Source",
-        accel = "super+alt+u"
+        accel = "super+alt+u",
+        hidden
     )]
     ViewSource,
-    #[menu(id = "browser_print", label = "Print", accel = "super+p")]
+    #[menu(id = "browser_print", label = "Print", accel = "super+p", hidden)]
     Print,
 }
 
@@ -193,13 +195,13 @@ pub enum PaneCommand {
     #[menu(id = "split_h", label = "Split Horizontally\t<leader> \"")]
     #[shortcut(chord = "Ctrl+g, \"")]
     SplitH,
-    #[menu(id = "toggle_pane", label = "Next Pane\t<leader> o")]
+    #[menu(id = "toggle_pane", label = "Next Pane\t<leader> o", hidden)]
     #[shortcut(chord = "Ctrl+g, o")]
     Toggle,
     #[menu(id = "close_pane", label = "Close Pane\t<leader> x")]
     #[shortcut(chord = "Ctrl+g, x")]
     Close,
-    #[menu(id = "zoom_pane", label = "Zoom Pane\t<leader> z")]
+    #[menu(id = "zoom_pane", label = "Zoom Pane\t<leader> z", hidden)]
     #[shortcut(chord = "Ctrl+g, z")]
     Zoom,
     #[menu(id = "select_pane_left", label = "Select Left Pane\t<leader> h")]
@@ -220,10 +222,10 @@ pub enum PaneCommand {
     #[menu(id = "swap_pane_next", label = "Swap Pane Next\t<leader> }")]
     #[shortcut(chord = "Ctrl+g, }")]
     SwapNext,
-    #[menu(id = "rotate_forward", label = "Rotate Forward\t<leader> ctrl+o")]
+    #[menu(id = "rotate_forward", label = "Rotate Forward\t<leader> ctrl+o", hidden)]
     #[shortcut(chord = "Ctrl+g, Ctrl+o")]
     RotateForward,
-    #[menu(id = "rotate_backward", label = "Rotate Backward\t<leader> alt+o")]
+    #[menu(id = "rotate_backward", label = "Rotate Backward\t<leader> alt+o", hidden)]
     #[shortcut(chord = "Ctrl+g, Alt+o")]
     RotateBackward,
     #[menu(id = "equalize_pane_size", label = "Equalize Pane Size\t<leader> =")]
@@ -249,24 +251,24 @@ pub enum PaneCommand {
 #[derive(OsSubMenu, DefaultShortcuts, CommandBar, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SpaceCommand {
     #[default]
-    #[menu(id = "new_space", label = "New Space\t<leader> c")]
+    #[menu(id = "new_space", label = "New Space\t<leader> c", hidden)]
     #[shortcut(chord = "Ctrl+g, c")]
     New,
-    #[menu(id = "close_space", label = "Close Space\t<leader> &")]
+    #[menu(id = "close_space", label = "Close Space\t<leader> &", hidden)]
     #[shortcut(chord = "Ctrl+g, &")]
     Close,
-    #[menu(id = "next_space", label = "Next Space\t<leader> n")]
+    #[menu(id = "next_space", label = "Next Space\t<leader> n", hidden)]
     #[shortcut(chord = "Ctrl+g, n")]
     Next,
-    #[menu(id = "prev_space", label = "Previous Space\t<leader> p")]
+    #[menu(id = "prev_space", label = "Previous Space\t<leader> p", hidden)]
     #[shortcut(chord = "Ctrl+g, p")]
     Previous,
-    #[menu(id = "rename_space", label = "Rename Space\t<leader> ,")]
+    #[menu(id = "rename_space", label = "Rename Space\t<leader> ,", hidden)]
     #[shortcut(chord = "Ctrl+g, Comma")]
     Rename,
-    #[menu(id = "swap_space_prev", label = "Move Space Left")]
+    #[menu(id = "swap_space_prev", label = "Move Space Left", hidden)]
     SwapPrev,
-    #[menu(id = "swap_space_next", label = "Move Space Right")]
+    #[menu(id = "swap_space_next", label = "Move Space Right", hidden)]
     SwapNext,
 }
 
@@ -282,13 +284,15 @@ pub enum SideSheetCommand {
     Toggle,
     #[menu(
         id = "toggle_side_sheet_right",
-        label = "Toggle Right Sheet\t<leader> r"
+        label = "Toggle Right Sheet\t<leader> r",
+        hidden
     )]
     #[shortcut(chord = "Ctrl+g, r")]
     ToggleRight,
     #[menu(
         id = "toggle_side_sheet_bottom",
-        label = "Toggle Bottom Sheet\t<leader> b"
+        label = "Toggle Bottom Sheet\t<leader> b",
+        hidden
     )]
     #[shortcut(chord = "Ctrl+g, b")]
     ToggleBottom,
@@ -312,18 +316,19 @@ pub enum HeaderCommand {
 #[derive(OsSubMenu, DefaultShortcuts, CommandBar, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum WindowCommand {
     #[default]
-    #[menu(id = "new_window", label = "New Window", accel = "super+n")]
+    #[menu(id = "new_window", label = "New Window", accel = "super+n", hidden)]
     NewWindow,
-    #[menu(id = "close_window", label = "Close Window", accel = "super+shift+w")]
+    #[menu(id = "close_window", label = "Close Window", accel = "super+shift+w", hidden)]
     CloseWindow,
-    #[menu(id = "minimize_window", label = "Minimize", accel = "super+m")]
+    #[menu(id = "minimize_window", label = "Minimize", accel = "super+m", hidden)]
     Minimize,
     #[menu(
         id = "toggle_fullscreen",
         label = "Toggle Fullscreen",
-        accel = "ctrl+super+f"
+        accel = "ctrl+super+f",
+        hidden
     )]
     ToggleFullscreen,
-    #[menu(id = "open_settings", label = "Settings", accel = "super+,")]
+    #[menu(id = "open_settings", label = "Settings", accel = "super+,", hidden)]
     Settings,
 }

--- a/crates/vmux_desktop/src/layout/tab.rs
+++ b/crates/vmux_desktop/src/layout/tab.rs
@@ -385,11 +385,7 @@ fn handle_tab_commands(
                     .entity(tabs[target_idx])
                     .insert(LastActivatedAt::now());
             }
-            TabCommand::Reopen
-            | TabCommand::Duplicate
-            | TabCommand::Pin
-            | TabCommand::Mute
-            | TabCommand::MoveToPane => {}
+            TabCommand::Reopen | TabCommand::Duplicate | TabCommand::MoveToPane => {}
             TabCommand::SwapPrev | TabCommand::SwapNext => {
                 let Some(pane) = active_pane else { continue };
                 let Some(tab) = active_tab else { continue };

--- a/crates/vmux_macro/src/lib.rs
+++ b/crates/vmux_macro/src/lib.rs
@@ -59,6 +59,9 @@ fn impl_os_sub_menu(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             ));
         };
         let props = MenuProps::from_attrs(&variant.attrs)?;
+        if props.hidden {
+            continue;
+        }
         let (Some(id), Some(label)) = (&props.id, &props.label) else {
             return Err(syn::Error::new_spanned(
                 variant,
@@ -85,8 +88,12 @@ fn impl_os_sub_menu(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         });
     }
 
+    let has_visible = !items.is_empty();
+
     Ok(quote! {
         impl #ident {
+            pub(crate) const HAS_VISIBLE_ITEMS: bool = #has_visible;
+
             pub(crate) fn append_native_menu_leaf(
                 submenu: &mut ::muda::Submenu,
             ) -> Result<(), ::muda::Error> {
@@ -112,7 +119,6 @@ fn impl_os_menu(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     };
 
     let mut submenu_blocks = Vec::new();
-    let mut submenu_idents = Vec::new();
     let mut from_menu_clauses = Vec::new();
 
     for variant in &data.variants {
@@ -144,18 +150,18 @@ fn impl_os_menu(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
             ),
             variant.ident.span(),
         );
-        submenu_idents.push(submenu_ident.clone());
         submenu_blocks.push(quote! {
-            let mut #submenu_ident = ::muda::Submenu::new(#title, true);
-            <#inner_ty>::append_native_menu_leaf(&mut #submenu_ident)?;
+            if <#inner_ty>::HAS_VISIBLE_ITEMS {
+                let mut #submenu_ident = ::muda::Submenu::new(#title, true);
+                <#inner_ty>::append_native_menu_leaf(&mut #submenu_ident)?;
+                submenus.push(::std::boxed::Box::new(#submenu_ident) as ::std::boxed::Box<dyn ::muda::IsMenuItem>);
+            }
         });
 
         from_menu_clauses.push(quote! {
             <#inner_ty>::from_menu_id(id).map(#ident::#variant_ident)
         });
     }
-
-    let submenu_refs: Vec<_> = submenu_idents.iter().map(|i| quote! { &#i }).collect();
 
     let from_menu_body = if from_menu_clauses.is_empty() {
         quote! { ::core::option::Option::None }
@@ -176,11 +182,11 @@ fn impl_os_menu(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                     &::muda::PredefinedMenuItem::separator(),
                     &::muda::PredefinedMenuItem::quit(None),
                 ])?;
+                let mut submenus: ::std::vec::Vec<::std::boxed::Box<dyn ::muda::IsMenuItem>> = ::std::vec::Vec::new();
+                submenus.push(::std::boxed::Box::new(app_native_submenu));
                 #(#submenu_blocks)*
-                menu.append_items(&[
-                    &app_native_submenu,
-                    #(#submenu_refs),*
-                ])?;
+                let refs: ::std::vec::Vec<&dyn ::muda::IsMenuItem> = submenus.iter().map(|s| s.as_ref()).collect();
+                menu.append_items(&refs)?;
                 Ok(())
             }
 
@@ -195,6 +201,7 @@ struct MenuProps {
     id: Option<String>,
     label: Option<String>,
     accel: Option<String>,
+    hidden: bool,
 }
 
 impl MenuProps {
@@ -202,6 +209,7 @@ impl MenuProps {
         let mut id = None;
         let mut label = None;
         let mut accel = None;
+        let mut hidden = false;
         for attr in attrs {
             if !attr.path().is_ident("menu") {
                 continue;
@@ -216,11 +224,18 @@ impl MenuProps {
                 } else if meta.path.is_ident("accel") {
                     let v: LitStr = meta.value()?.parse()?;
                     accel = Some(v.value());
+                } else if meta.path.is_ident("hidden") {
+                    hidden = true;
                 }
                 Ok(())
             })?;
         }
-        Ok(MenuProps { id, label, accel })
+        Ok(MenuProps {
+            id,
+            label,
+            accel,
+            hidden,
+        })
     }
 }
 
@@ -265,6 +280,10 @@ fn impl_leaf_shortcuts(
     for variant in &data.variants {
         let bind_props = BindProps::from_attrs(&variant.attrs)?;
         let menu_props = MenuProps::from_attrs(&variant.attrs)?;
+
+        if menu_props.hidden {
+            continue;
+        }
 
         let binding_str = match (&bind_props.direct, &bind_props.chord) {
             (Some(_), Some(_)) => {
@@ -534,6 +553,9 @@ fn impl_command_bar_leaf(
 
     for variant in &data.variants {
         let props = MenuProps::from_attrs(&variant.attrs)?;
+        if props.hidden {
+            continue;
+        }
         let (Some(id), Some(label)) = (&props.id, &props.label) else {
             continue;
         };


### PR DESCRIPTION
## Context

The command bar and OS menu display all 75 commands, but 34 of them have no handler (empty match arms or no MessageReader). Users see commands that do nothing when selected.

## Implementation

- Added `hidden` flag to `#[menu()]` attribute in `vmux_macro`
- `hidden` skips variants from all three derive macros: `CommandBar`, `OsSubMenu`, and `DefaultShortcuts`
- OS submenus with zero visible items (Window, Terminal, Space) are automatically omitted via a generated `HAS_VISIBLE_ITEMS` const
- Marked 34 unimplemented command variants as hidden:
  - **Window**: all 5 (NewWindow, CloseWindow, Minimize, ToggleFullscreen, Settings)
  - **Terminal**: 7 of 8 (all except New)
  - **Space**: all 7
  - **Tab**: 5 (Reopen, Duplicate, Pin, Mute, MoveToPane)
  - **Pane**: 4 (Toggle, Zoom, RotateForward, RotateBackward)
  - **Browser**: 4 (Stop, Find, ViewSource, Print)
  - **SideSheet**: 2 (ToggleRight, ToggleBottom)

## Checks / QA

- [x] Open command bar (`Cmd+K` > `>`) and verify hidden commands do not appear
- [x] Verify OS menu bar does not show Window, Terminal, or Space submenus
- [x] Verify existing commands (tabs, panes, browser nav) still work
- [x] `cargo check -p vmux_desktop` passes

Closes VMX-82
