### PR TITLE
feat: cmd+l navigates within current tab instead of opening new tab

### DIFF
--- a/crates/vmux_command_bar/src/app.rs
+++ b/crates/vmux_command_bar/src/app.rs
@@ -31,28 +31,22 @@ enum ResultItem {
     },
 }
 
-fn looks_like_path(s: &str) -> bool {
-    s.starts_with('/')
-        || s.starts_with("~/")
-        || s.starts_with("./")
-        || s.starts_with("../")
-        || s.contains('/')
-            && !s.contains(' ')
-            && !s.starts_with("http://")
-            && !s.starts_with("https://")
-}
+use vmux_command_bar::event::looks_like_path;
 
 fn filter_results(
     query: &str,
     tabs: &[CommandBarTab],
     commands: &[CommandBarCommandEntry],
     new_tab: bool,
+    current_url: &str,
 ) -> Vec<ResultItem> {
+    let current_is_terminal = current_url.starts_with("vmux://terminal");
+    let show_terminal = new_tab || !current_is_terminal;
     let q = query.trim();
     if q.is_empty() {
         let mut items: Vec<ResultItem> = Vec::new();
         items.push(ResultItem::Navigate { url: String::new() });
-        if new_tab {
+        if show_terminal {
             items.push(ResultItem::Terminal {
                 path: String::new(),
             });
@@ -85,7 +79,7 @@ fn filter_results(
         });
     }
 
-    if !starts_with_cmd && !is_path && new_tab && "terminal".contains(&search_lower) {
+    if !starts_with_cmd && !is_path && show_terminal && "terminal".contains(&search_lower) {
         items.push(ResultItem::Terminal {
             path: String::new(),
         });
@@ -147,10 +141,11 @@ fn filter_results(
     items
 }
 
-fn emit_action(action: &str, value: &str) {
+fn emit_action(action: &str, value: &str, new_tab: bool) {
     let _ = try_cef_emit_serde(&CommandBarActionEvent {
         action: action.to_string(),
         value: value.to_string(),
+        new_tab,
     });
 }
 
@@ -202,7 +197,7 @@ pub fn App() -> Element {
     });
 
     let CommandBarOpenEvent {
-        url: _,
+        url: current_url,
         tabs,
         commands,
         new_tab: _,
@@ -210,7 +205,7 @@ pub fn App() -> Element {
     let q = query();
     let is_new_tab = new_tab();
     let results = {
-        let mut r = filter_results(&q, &tabs, &commands, is_new_tab);
+        let mut r = filter_results(&q, &tabs, &commands, is_new_tab, &current_url);
         let completions = path_completions();
         if !completions.is_empty() {
             let path_items: Vec<ResultItem> = completions
@@ -287,21 +282,22 @@ pub fn App() -> Element {
 
     let mut execute = move |item: &ResultItem| {
         is_open.set(false);
+        let nt = new_tab();
         match item {
             ResultItem::Terminal { path } => {
-                emit_action("terminal", path);
+                emit_action("terminal", path, nt);
             }
             ResultItem::Tab {
                 pane_id, tab_index, ..
             } => {
-                emit_action("switch_tab", &format!("{pane_id}:{tab_index}"));
+                emit_action("switch_tab", &format!("{pane_id}:{tab_index}"), nt);
             }
             ResultItem::Command { id, .. } => {
-                emit_action("command", id);
+                emit_action("command", id, nt);
             }
             ResultItem::Navigate { url } => {
                 if !url.is_empty() {
-                    emit_action("navigate", url);
+                    emit_action("navigate", url, nt);
                 }
             }
         }
@@ -314,7 +310,7 @@ pub fn App() -> Element {
     rsx! {
         div {
             class: "flex h-full w-full items-start justify-center pt-[15%]",
-            onclick: move |_| { is_open.set(false); emit_action("dismiss", ""); },
+            onclick: move |_| { is_open.set(false); emit_action("dismiss", "", new_tab()); },
             div {
                 class: "relative flex w-full max-w-xl flex-col overflow-hidden rounded-2xl border border-white/20 bg-white/10 shadow-2xl backdrop-blur-2xl backdrop-saturate-150",
                 onclick: move |e| { e.stop_propagation(); },
@@ -428,12 +424,12 @@ pub fn App() -> Element {
                                         || (ctrl && e.code() == Code::KeyC)
                                     {
                                         is_open.set(false);
-                                        emit_action("dismiss", "");
+                                        emit_action("dismiss", "", new_tab());
                                     } else if e.key() == Key::Enter {
                                         if let Some(item) = results.get(sel) {
                                             execute(item);
                                         } else if !q.is_empty() {
-                                            emit_action("navigate", &q);
+                                            emit_action("navigate", &q, new_tab());
                                         }
                                     }
                                 },
@@ -461,7 +457,11 @@ pub fn App() -> Element {
                                         div { class: "flex items-center gap-2",
                                             span { class: "shrink-0 text-base text-muted-foreground", ">_" }
                                             if path.is_empty() {
-                                                span { class: "text-base text-foreground", "Terminal" }
+                                                if is_new_tab {
+                                                    span { class: "text-base text-foreground", "Open Terminal" }
+                                                } else {
+                                                    span { class: "text-base text-foreground", "Open Terminal in New Tab" }
+                                                }
                                             } else {
                                                 span { class: "text-base text-foreground", "Open in Terminal" }
                                                 span { class: "ml-1 text-sm text-muted-foreground", "{path}" }

--- a/crates/vmux_command_bar/src/event.rs
+++ b/crates/vmux_command_bar/src/event.rs
@@ -28,6 +28,7 @@ pub struct CommandBarCommandEntry {
 pub struct CommandBarActionEvent {
     pub action: String,
     pub value: String,
+    pub new_tab: bool,
 }
 
 pub const PATH_COMPLETE_REQUEST: &str = "path-complete-request";
@@ -48,4 +49,105 @@ pub struct PathEntry {
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct PathCompleteResponse {
     pub completions: Vec<PathEntry>,
+}
+
+pub fn looks_like_path(s: &str) -> bool {
+    s.starts_with('/')
+        || s.starts_with("~/")
+        || s.starts_with("./")
+        || s.starts_with("../")
+        || s.contains('/')
+            && !s.contains(' ')
+            && !s.starts_with("http://")
+            && !s.starts_with("https://")
+}
+
+pub fn looks_like_explicit_path(s: &str) -> bool {
+    s.starts_with('/') || s.starts_with('~') || s.starts_with("./") || s.starts_with("../")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn looks_like_path_absolute() {
+        assert!(looks_like_path("/usr/bin"));
+        assert!(looks_like_path("/"));
+    }
+
+    #[test]
+    fn looks_like_path_home() {
+        assert!(looks_like_path("~/projects"));
+        assert!(looks_like_path("~/"));
+    }
+
+    #[test]
+    fn looks_like_path_relative() {
+        assert!(looks_like_path("./src"));
+        assert!(looks_like_path("../parent"));
+    }
+
+    #[test]
+    fn looks_like_path_with_slash() {
+        assert!(looks_like_path("src/main.rs"));
+        assert!(looks_like_path("foo/bar"));
+    }
+
+    #[test]
+    fn looks_like_path_rejects_urls() {
+        assert!(!looks_like_path("http://example.com/path"));
+        assert!(!looks_like_path("https://example.com/path"));
+    }
+
+    #[test]
+    fn looks_like_path_rejects_bare_words() {
+        assert!(!looks_like_path("mistral"));
+        assert!(!looks_like_path("hello world"));
+        assert!(!looks_like_path("google.com"));
+    }
+
+    #[test]
+    fn looks_like_path_rejects_spaces_with_slash() {
+        assert!(!looks_like_path("some query / thing"));
+    }
+
+    #[test]
+    fn explicit_path_only_prefixed() {
+        assert!(looks_like_explicit_path("/usr"));
+        assert!(looks_like_explicit_path("~/foo"));
+        assert!(looks_like_explicit_path("./bar"));
+        assert!(looks_like_explicit_path("../baz"));
+    }
+
+    #[test]
+    fn explicit_path_rejects_bare_words() {
+        assert!(!looks_like_explicit_path("mistral"));
+        assert!(!looks_like_explicit_path("foo/bar"));
+        assert!(!looks_like_explicit_path("google.com"));
+        assert!(!looks_like_explicit_path("search query"));
+    }
+
+    #[test]
+    fn explicit_path_rejects_urls() {
+        assert!(!looks_like_explicit_path("http://example.com"));
+        assert!(!looks_like_explicit_path("https://example.com"));
+    }
+
+    #[test]
+    fn action_event_new_tab_field() {
+        let evt = CommandBarActionEvent {
+            action: "navigate".to_string(),
+            value: "google.com".to_string(),
+            new_tab: false,
+        };
+        assert!(!evt.new_tab);
+
+        let evt_new = CommandBarActionEvent {
+            action: "navigate".to_string(),
+            value: "google.com".to_string(),
+            new_tab: true,
+        };
+        assert!(evt_new.new_tab);
+    }
 }

--- a/crates/vmux_desktop/src/command.rs
+++ b/crates/vmux_desktop/src/command.rs
@@ -106,11 +106,18 @@ pub enum TabCommand {
 #[derive(OsSubMenu, DefaultShortcuts, CommandBar, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum TerminalCommand {
     #[default]
-    #[menu(id = "terminal_new", label = "New Terminal", accel = "ctrl+`")]
-    #[shortcut(direct = "Ctrl+`")]
+    #[menu(id = "terminal_new", label = "New Terminal")]
     New,
-
-    #[menu(id = "terminal_clear", label = "Clear Terminal", hidden)]
+    #[menu(id = "terminal_new_tab", label = "New Terminal Tab", accel = "ctrl+`")]
+    #[shortcut(direct = "Ctrl+`")]
+    NewTab,
+    #[menu(id = "terminal_close", label = "Close Terminal")]
+    Close,
+    #[menu(id = "terminal_next", label = "Next Terminal")]
+    Next,
+    #[menu(id = "terminal_prev", label = "Previous Terminal")]
+    Previous,
+    #[menu(id = "terminal_clear", label = "Clear Terminal")]
     Clear,
 }
 

--- a/crates/vmux_desktop/src/command_bar.rs
+++ b/crates/vmux_desktop/src/command_bar.rs
@@ -1,8 +1,6 @@
 use crate::{
     browser::Browser,
-    command::{
-        AppCommand, BrowserCommand, PaneCommand, ReadAppCommands, TabCommand, TerminalCommand,
-    },
+    command::{AppCommand, BrowserCommand, PaneCommand, ReadAppCommands, TabCommand},
     layout::{
         pane::{Pane, PaneSplit},
         side_sheet::SideSheet,
@@ -20,6 +18,7 @@ use bevy_cef::prelude::*;
 use vmux_command_bar::event::{
     COMMAND_BAR_OPEN_EVENT, CommandBarActionEvent, CommandBarCommandEntry, CommandBarOpenEvent,
     CommandBarTab, PATH_COMPLETE_RESPONSE, PathCompleteRequest, PathCompleteResponse, PathEntry,
+    looks_like_explicit_path,
 };
 use vmux_header::{Header, PageMetadata};
 use vmux_history::LastActivatedAt;
@@ -402,12 +401,39 @@ fn on_command_bar_action(
     let evt = &trigger.event().payload;
     let empty_tab = new_tab_ctx.tab;
     let previous_tab = new_tab_ctx.previous_tab;
-    // Track whether we handle keyboard restore ourselves
     let mut custom_keyboard_restore = false;
+
+    let current_tab = || {
+        focused_tab(
+            &spaces,
+            &all_children,
+            &leaf_panes,
+            &pane_ts,
+            &pane_children,
+            &tab_ts,
+        )
+    };
+
+    let current_tab_has_browser = |tab: Entity| -> Option<Entity> {
+        let children = all_children.get(tab).ok()?;
+        children.iter().find(|&e| content_browsers.contains(e))
+    };
+
+    let current_tab_has_terminal = |tab: Entity| -> bool {
+        all_children
+            .get(tab)
+            .ok()
+            .map(|children| {
+                let has_children = !children.is_empty();
+                let has_browser = children.iter().any(|e| content_browsers.contains(e));
+                has_children && !has_browser
+            })
+            .unwrap_or(false)
+    };
 
     match evt.action.as_str() {
         "navigate" => {
-            // Detect filesystem paths — open terminal with cwd instead of browser
+            let looks_like_path = looks_like_explicit_path(&evt.value);
             let expanded = if evt.value.starts_with('~') {
                 std::env::var("HOME")
                     .ok()
@@ -415,15 +441,10 @@ fn on_command_bar_action(
                         std::path::PathBuf::from(h).join(evt.value[1..].trim_start_matches('/'))
                     })
                     .unwrap_or_else(|| std::path::PathBuf::from(&evt.value))
-            } else if evt.value.starts_with('/') {
-                std::path::PathBuf::from(&evt.value)
             } else {
-                std::env::var("HOME")
-                    .ok()
-                    .map(|h| std::path::PathBuf::from(h).join(&evt.value))
-                    .unwrap_or_else(|| std::path::PathBuf::from(&evt.value))
+                std::path::PathBuf::from(&evt.value)
             };
-            let is_path = expanded.exists();
+            let is_path = looks_like_path && expanded.exists();
 
             if is_path {
                 let dir = if expanded.is_dir() {
@@ -431,27 +452,108 @@ fn on_command_bar_action(
                 } else {
                     expanded.parent().unwrap_or(&expanded)
                 };
-                if let Some(tab_e) = empty_tab {
-                    commands.entity(tab_e).insert(PageMetadata {
-                        url: TERMINAL_WEBVIEW_URL.to_string(),
-                        title: format!("Terminal ({})", dir.display()),
-                        ..default()
-                    });
-                    let term_e = commands
-                        .spawn((
-                            Terminal::new_with_cwd(
-                                &mut meshes,
-                                &mut webview_mt,
-                                &settings,
-                                Some(dir),
-                            ),
-                            ChildOf(tab_e),
-                        ))
-                        .id();
-                    commands.entity(term_e).insert(CefKeyboardTarget);
-                    new_tab_ctx.tab = None;
-                    new_tab_ctx.previous_tab = None;
-                    custom_keyboard_restore = true;
+                if evt.new_tab {
+                    if let Some(tab_e) = empty_tab {
+                        commands.entity(tab_e).insert(PageMetadata {
+                            url: TERMINAL_WEBVIEW_URL.to_string(),
+                            title: format!("Terminal ({})", dir.display()),
+                            ..default()
+                        });
+                        let term_e = commands
+                            .spawn((
+                                Terminal::new_with_cwd(
+                                    &mut meshes,
+                                    &mut webview_mt,
+                                    &settings,
+                                    Some(dir),
+                                ),
+                                ChildOf(tab_e),
+                            ))
+                            .id();
+                        commands.entity(term_e).insert(CefKeyboardTarget);
+                        new_tab_ctx.tab = None;
+                        new_tab_ctx.previous_tab = None;
+                        custom_keyboard_restore = true;
+                    }
+                } else {
+                    let (_, active_pane, active_tab) = current_tab();
+                    if let Some(tab) = active_tab {
+                        if let Some(browser_e) = current_tab_has_browser(tab) {
+                            commands.entity(browser_e).despawn();
+                            commands.entity(tab).insert(PageMetadata {
+                                url: TERMINAL_WEBVIEW_URL.to_string(),
+                                title: format!("Terminal ({})", dir.display()),
+                                ..default()
+                            });
+                            let term_e = commands
+                                .spawn((
+                                    Terminal::new_with_cwd(
+                                        &mut meshes,
+                                        &mut webview_mt,
+                                        &settings,
+                                        Some(dir),
+                                    ),
+                                    ChildOf(tab),
+                                ))
+                                .id();
+                            commands.entity(term_e).insert(CefKeyboardTarget);
+                            custom_keyboard_restore = true;
+                        } else if current_tab_has_terminal(tab)
+                            && let Some(pane_e) = active_pane
+                        {
+                            let new_tab_e = commands
+                                .spawn((
+                                    crate::layout::tab::tab_bundle(),
+                                    LastActivatedAt::now(),
+                                    ChildOf(pane_e),
+                                ))
+                                .id();
+                            commands.entity(new_tab_e).insert(PageMetadata {
+                                url: TERMINAL_WEBVIEW_URL.to_string(),
+                                title: format!("Terminal ({})", dir.display()),
+                                ..default()
+                            });
+                            let term_e = commands
+                                .spawn((
+                                    Terminal::new_with_cwd(
+                                        &mut meshes,
+                                        &mut webview_mt,
+                                        &settings,
+                                        Some(dir),
+                                    ),
+                                    ChildOf(new_tab_e),
+                                ))
+                                .id();
+                            commands.entity(term_e).insert(CefKeyboardTarget);
+                            custom_keyboard_restore = true;
+                        }
+                    } else if let Some(pane_e) = active_pane {
+                        let new_tab_e = commands
+                            .spawn((
+                                crate::layout::tab::tab_bundle(),
+                                LastActivatedAt::now(),
+                                ChildOf(pane_e),
+                            ))
+                            .id();
+                        commands.entity(new_tab_e).insert(PageMetadata {
+                            url: TERMINAL_WEBVIEW_URL.to_string(),
+                            title: format!("Terminal ({})", dir.display()),
+                            ..default()
+                        });
+                        let term_e = commands
+                            .spawn((
+                                Terminal::new_with_cwd(
+                                    &mut meshes,
+                                    &mut webview_mt,
+                                    &settings,
+                                    Some(dir),
+                                ),
+                                ChildOf(new_tab_e),
+                            ))
+                            .id();
+                        commands.entity(term_e).insert(CefKeyboardTarget);
+                        custom_keyboard_restore = true;
+                    }
                 }
             } else {
                 let url = if evt.value.contains("://") {
@@ -462,58 +564,139 @@ fn on_command_bar_action(
                     format!("https://www.google.com/search?q={}", evt.value)
                 };
 
-                if let Some(tab_e) = empty_tab {
-                    // New tab mode: attach content to the empty tab
-                    if url.starts_with("vmux://terminal") {
-                        commands.entity(tab_e).insert(PageMetadata {
-                            url: TERMINAL_WEBVIEW_URL.to_string(),
-                            title: "Terminal (Session: -)".to_string(),
-                            ..default()
-                        });
-                        let term_e = commands
-                            .spawn((
-                                Terminal::new(&mut meshes, &mut webview_mt, &settings),
-                                ChildOf(tab_e),
-                            ))
-                            .id();
-                        commands.entity(term_e).insert(CefKeyboardTarget);
-                    } else {
-                        let browser_e = commands
-                            .spawn((
-                                Browser::new(&mut meshes, &mut webview_mt, &url),
-                                ChildOf(tab_e),
-                            ))
-                            .id();
-                        commands.entity(browser_e).insert(CefKeyboardTarget);
-                    }
-                    new_tab_ctx.tab = None;
-                    new_tab_ctx.previous_tab = None;
-                    custom_keyboard_restore = true;
-                } else {
-                    // Normal mode: navigate or spawn terminal in current tab
-                    if url.starts_with("vmux://terminal") {
-                        writer.write(AppCommand::Terminal(TerminalCommand::New));
-                    } else {
-                        let (_, _, active_tab) = focused_tab(
-                            &spaces,
-                            &all_children,
-                            &leaf_panes,
-                            &pane_ts,
-                            &pane_children,
-                            &tab_ts,
-                        );
-                        if let Some(tab) = active_tab {
-                            for browser_e in &content_browsers {
-                                let is_child = child_of_q
-                                    .get(browser_e)
-                                    .ok()
-                                    .map(|co| co.get() == tab)
-                                    .unwrap_or(false);
-                                if is_child {
-                                    commands.entity(browser_e).insert(WebviewSource::new(&url));
-                                }
-                            }
+                if evt.new_tab {
+                    if let Some(tab_e) = empty_tab {
+                        if url.starts_with("vmux://terminal") {
+                            commands.entity(tab_e).insert(PageMetadata {
+                                url: TERMINAL_WEBVIEW_URL.to_string(),
+                                title: "Terminal (Session: -)".to_string(),
+                                ..default()
+                            });
+                            let term_e = commands
+                                .spawn((
+                                    Terminal::new(&mut meshes, &mut webview_mt, &settings),
+                                    ChildOf(tab_e),
+                                ))
+                                .id();
+                            commands.entity(term_e).insert(CefKeyboardTarget);
+                        } else {
+                            let browser_e = commands
+                                .spawn((
+                                    Browser::new(&mut meshes, &mut webview_mt, &url),
+                                    ChildOf(tab_e),
+                                ))
+                                .id();
+                            commands.entity(browser_e).insert(CefKeyboardTarget);
                         }
+                        new_tab_ctx.tab = None;
+                        new_tab_ctx.previous_tab = None;
+                        custom_keyboard_restore = true;
+                    }
+                } else {
+                    let (_, active_pane, active_tab) = current_tab();
+                    if let Some(tab) = active_tab {
+                        if url.starts_with("vmux://terminal") {
+                            if let Some(browser_e) = current_tab_has_browser(tab) {
+                                commands.entity(browser_e).despawn();
+                                commands.entity(tab).insert(PageMetadata {
+                                    url: TERMINAL_WEBVIEW_URL.to_string(),
+                                    title: "Terminal (Session: -)".to_string(),
+                                    ..default()
+                                });
+                                let term_e = commands
+                                    .spawn((
+                                        Terminal::new(&mut meshes, &mut webview_mt, &settings),
+                                        ChildOf(tab),
+                                    ))
+                                    .id();
+                                commands.entity(term_e).insert(CefKeyboardTarget);
+                                custom_keyboard_restore = true;
+                            } else if current_tab_has_terminal(tab)
+                                && let Some(pane_e) = active_pane
+                            {
+                                let new_tab_e = commands
+                                    .spawn((
+                                        crate::layout::tab::tab_bundle(),
+                                        LastActivatedAt::now(),
+                                        ChildOf(pane_e),
+                                    ))
+                                    .id();
+                                commands.entity(new_tab_e).insert(PageMetadata {
+                                    url: TERMINAL_WEBVIEW_URL.to_string(),
+                                    title: "Terminal (Session: -)".to_string(),
+                                    ..default()
+                                });
+                                let term_e = commands
+                                    .spawn((
+                                        Terminal::new(&mut meshes, &mut webview_mt, &settings),
+                                        ChildOf(new_tab_e),
+                                    ))
+                                    .id();
+                                commands.entity(term_e).insert(CefKeyboardTarget);
+                                custom_keyboard_restore = true;
+                            }
+                        } else if let Some(browser_e) = current_tab_has_browser(tab) {
+                            commands.entity(browser_e).insert(WebviewSource::new(&url));
+                        } else if current_tab_has_terminal(tab)
+                            && let Some(pane_e) = active_pane
+                        {
+                            let new_tab_e = commands
+                                .spawn((
+                                    crate::layout::tab::tab_bundle(),
+                                    LastActivatedAt::now(),
+                                    ChildOf(pane_e),
+                                ))
+                                .id();
+                            commands.entity(new_tab_e).insert(PageMetadata {
+                                url: url.clone(),
+                                title: url.clone(),
+                                ..default()
+                            });
+                            let browser_e = commands
+                                .spawn((
+                                    Browser::new(&mut meshes, &mut webview_mt, &url),
+                                    ChildOf(new_tab_e),
+                                ))
+                                .id();
+                            commands.entity(browser_e).insert(CefKeyboardTarget);
+                            custom_keyboard_restore = true;
+                        }
+                    } else if let Some(pane_e) = active_pane {
+                        let new_tab_e = commands
+                            .spawn((
+                                crate::layout::tab::tab_bundle(),
+                                LastActivatedAt::now(),
+                                ChildOf(pane_e),
+                            ))
+                            .id();
+                        if url.starts_with("vmux://terminal") {
+                            commands.entity(new_tab_e).insert(PageMetadata {
+                                url: TERMINAL_WEBVIEW_URL.to_string(),
+                                title: "Terminal (Session: -)".to_string(),
+                                ..default()
+                            });
+                            let term_e = commands
+                                .spawn((
+                                    Terminal::new(&mut meshes, &mut webview_mt, &settings),
+                                    ChildOf(new_tab_e),
+                                ))
+                                .id();
+                            commands.entity(term_e).insert(CefKeyboardTarget);
+                        } else {
+                            commands.entity(new_tab_e).insert(PageMetadata {
+                                url: url.clone(),
+                                title: url.clone(),
+                                ..default()
+                            });
+                            let browser_e = commands
+                                .spawn((
+                                    Browser::new(&mut meshes, &mut webview_mt, &url),
+                                    ChildOf(new_tab_e),
+                                ))
+                                .id();
+                            commands.entity(browser_e).insert(CefKeyboardTarget);
+                        }
+                        custom_keyboard_restore = true;
                     }
                 }
             }
@@ -535,44 +718,8 @@ fn on_command_bar_action(
                 };
                 Some(expanded)
             };
-            if let Some(tab_e) = empty_tab {
-                commands.entity(tab_e).insert(PageMetadata {
-                    url: TERMINAL_WEBVIEW_URL.to_string(),
-                    title: "Terminal (Session: -)".to_string(),
-                    ..default()
-                });
-                let term_e = commands
-                    .spawn((
-                        Terminal::new_with_cwd(
-                            &mut meshes,
-                            &mut webview_mt,
-                            &settings,
-                            cwd.as_deref(),
-                        ),
-                        ChildOf(tab_e),
-                    ))
-                    .id();
-                commands.entity(term_e).insert(CefKeyboardTarget);
-                new_tab_ctx.tab = None;
-                new_tab_ctx.previous_tab = None;
-                custom_keyboard_restore = true;
-            } else {
-                let (_, active_pane_opt, _) = focused_tab(
-                    &spaces,
-                    &all_children,
-                    &leaf_panes,
-                    &pane_ts,
-                    &pane_children,
-                    &tab_ts,
-                );
-                if let Some(pane_e) = active_pane_opt {
-                    let tab_e = commands
-                        .spawn((
-                            crate::layout::tab::tab_bundle(),
-                            LastActivatedAt::now(),
-                            ChildOf(pane_e),
-                        ))
-                        .id();
+            if evt.new_tab {
+                if let Some(tab_e) = empty_tab {
                     commands.entity(tab_e).insert(PageMetadata {
                         url: TERMINAL_WEBVIEW_URL.to_string(),
                         title: "Terminal (Session: -)".to_string(),
@@ -590,8 +737,88 @@ fn on_command_bar_action(
                         ))
                         .id();
                     commands.entity(term_e).insert(CefKeyboardTarget);
-                } else {
-                    writer.write(AppCommand::Terminal(TerminalCommand::New));
+                    new_tab_ctx.tab = None;
+                    new_tab_ctx.previous_tab = None;
+                    custom_keyboard_restore = true;
+                }
+            } else {
+                let (_, active_pane, active_tab) = current_tab();
+                if let Some(tab) = active_tab {
+                    if let Some(browser_e) = current_tab_has_browser(tab) {
+                        commands.entity(browser_e).despawn();
+                        commands.entity(tab).insert(PageMetadata {
+                            url: TERMINAL_WEBVIEW_URL.to_string(),
+                            title: "Terminal (Session: -)".to_string(),
+                            ..default()
+                        });
+                        let term_e = commands
+                            .spawn((
+                                Terminal::new_with_cwd(
+                                    &mut meshes,
+                                    &mut webview_mt,
+                                    &settings,
+                                    cwd.as_deref(),
+                                ),
+                                ChildOf(tab),
+                            ))
+                            .id();
+                        commands.entity(term_e).insert(CefKeyboardTarget);
+                        custom_keyboard_restore = true;
+                    } else if current_tab_has_terminal(tab)
+                        && let Some(pane_e) = active_pane
+                    {
+                        let new_tab_e = commands
+                            .spawn((
+                                crate::layout::tab::tab_bundle(),
+                                LastActivatedAt::now(),
+                                ChildOf(pane_e),
+                            ))
+                            .id();
+                        commands.entity(new_tab_e).insert(PageMetadata {
+                            url: TERMINAL_WEBVIEW_URL.to_string(),
+                            title: "Terminal (Session: -)".to_string(),
+                            ..default()
+                        });
+                        let term_e = commands
+                            .spawn((
+                                Terminal::new_with_cwd(
+                                    &mut meshes,
+                                    &mut webview_mt,
+                                    &settings,
+                                    cwd.as_deref(),
+                                ),
+                                ChildOf(new_tab_e),
+                            ))
+                            .id();
+                        commands.entity(term_e).insert(CefKeyboardTarget);
+                        custom_keyboard_restore = true;
+                    }
+                } else if let Some(pane_e) = active_pane {
+                    let new_tab_e = commands
+                        .spawn((
+                            crate::layout::tab::tab_bundle(),
+                            LastActivatedAt::now(),
+                            ChildOf(pane_e),
+                        ))
+                        .id();
+                    commands.entity(new_tab_e).insert(PageMetadata {
+                        url: TERMINAL_WEBVIEW_URL.to_string(),
+                        title: "Terminal (Session: -)".to_string(),
+                        ..default()
+                    });
+                    let term_e = commands
+                        .spawn((
+                            Terminal::new_with_cwd(
+                                &mut meshes,
+                                &mut webview_mt,
+                                &settings,
+                                cwd.as_deref(),
+                            ),
+                            ChildOf(new_tab_e),
+                        ))
+                        .id();
+                    commands.entity(term_e).insert(CefKeyboardTarget);
+                    custom_keyboard_restore = true;
                 }
             }
         }
@@ -599,7 +826,6 @@ fn on_command_bar_action(
             if let Some(cmd) = match_command(&evt.value) {
                 writer.write(cmd);
             }
-            // If in new-tab mode and a command was executed, clean up the empty tab
             if let Some(tab_e) = empty_tab {
                 commands.entity(tab_e).despawn();
                 new_tab_ctx.tab = None;
@@ -607,7 +833,6 @@ fn on_command_bar_action(
             }
         }
         "switch_tab" => {
-            // Despawn empty tab if in new-tab mode
             if let Some(tab_e) = empty_tab {
                 commands.entity(tab_e).despawn();
                 new_tab_ctx.tab = None;
@@ -629,11 +854,9 @@ fn on_command_bar_action(
             }
         }
         _ => {
-            // "dismiss" and unknown actions
             if let Some(tab_e) = empty_tab {
                 commands.entity(tab_e).despawn();
                 new_tab_ctx.tab = None;
-                // Restore keyboard to previous tab's browser
                 if let Some(prev) = previous_tab
                     && let Ok(children) = all_children.get(prev)
                 {
@@ -649,7 +872,6 @@ fn on_command_bar_action(
         }
     }
 
-    // Close command bar and restore keyboard
     if let Ok((modal_e, mut modal_node, mut modal_vis)) = modal_q.single_mut() {
         modal_node.display = Display::None;
         *modal_vis = Visibility::Hidden;

--- a/crates/vmux_desktop/src/layout/tab.rs
+++ b/crates/vmux_desktop/src/layout/tab.rs
@@ -176,9 +176,10 @@ fn handle_tab_commands(
     mut pending_warp: ResMut<PendingCursorWarp>,
 ) {
     for cmd in reader.read() {
-        let (tab_cmd, is_terminal) = match *cmd {
-            AppCommand::Tab(t) => (t, false),
-            AppCommand::Terminal(TerminalCommand::New) => (TabCommand::New, true),
+        let (tab_cmd, terminal_mode) = match *cmd {
+            AppCommand::Tab(t) => (t, None),
+            AppCommand::Terminal(TerminalCommand::New) => (TabCommand::New, Some(false)),
+            AppCommand::Terminal(TerminalCommand::NewTab) => (TabCommand::New, Some(true)),
             _ => continue,
         };
 
@@ -196,31 +197,45 @@ fn handle_tab_commands(
                 let Some(pane) = active_pane else {
                     continue;
                 };
-                if is_terminal {
-                    let tab = commands
-                        .spawn((tab_bundle(), LastActivatedAt::now(), ChildOf(pane)))
-                        .id();
-                    commands.entity(tab).insert(vmux_header::PageMetadata {
-                        url: TERMINAL_WEBVIEW_URL.to_string(),
-                        title: "Terminal (Session: -)".to_string(),
-                        ..default()
-                    });
-                    commands.spawn((
-                        Terminal::new(&mut meshes, &mut webview_mt, &settings),
-                        ChildOf(tab),
-                    ));
-                } else {
-                    // If there's already an empty tab pending, reuse it
-                    if new_tab_ctx.tab.is_some() {
-                        new_tab_ctx.needs_open = true;
-                        continue;
+                match terminal_mode {
+                    Some(new_tab) => {
+                        let tab = match (new_tab, active_tab) {
+                            (false, Some(existing)) => {
+                                if let Ok(children) = all_children.get(existing) {
+                                    for child in children.iter() {
+                                        if !tab_q.contains(child) {
+                                            commands.entity(child).despawn();
+                                        }
+                                    }
+                                }
+                                existing
+                            }
+                            _ => commands
+                                .spawn((tab_bundle(), LastActivatedAt::now(), ChildOf(pane)))
+                                .id(),
+                        };
+                        commands.entity(tab).insert(vmux_header::PageMetadata {
+                            url: TERMINAL_WEBVIEW_URL.to_string(),
+                            title: "Terminal (Session: -)".to_string(),
+                            ..default()
+                        });
+                        commands.spawn((
+                            Terminal::new(&mut meshes, &mut webview_mt, &settings),
+                            ChildOf(tab),
+                        ));
                     }
-                    let tab = commands
-                        .spawn((tab_bundle(), LastActivatedAt::now(), ChildOf(pane)))
-                        .id();
-                    new_tab_ctx.tab = Some(tab);
-                    new_tab_ctx.previous_tab = active_tab;
-                    new_tab_ctx.needs_open = true;
+                    None => {
+                        if new_tab_ctx.tab.is_some() {
+                            new_tab_ctx.needs_open = true;
+                            continue;
+                        }
+                        let tab = commands
+                            .spawn((tab_bundle(), LastActivatedAt::now(), ChildOf(pane)))
+                            .id();
+                        new_tab_ctx.tab = Some(tab);
+                        new_tab_ctx.previous_tab = active_tab;
+                        new_tab_ctx.needs_open = true;
+                    }
                 }
             }
             TabCommand::Close => {

--- a/docs/superpowers/specs/2025-07-26-cmdl-navigate-in-tab-design.md
+++ b/docs/superpowers/specs/2025-07-26-cmdl-navigate-in-tab-design.md
@@ -1,0 +1,110 @@
+# VMX-73: Cmd+L Navigate In-Tab Instead of New Tab
+
+## Problem
+
+When using Cmd+L (FocusAddressBar) and navigating to a terminal or filesystem path, the current behavior either does nothing or creates a new tab. Users expect Cmd+L to change content within the current tab, reserving new-tab creation for Cmd+T.
+
+### Current Behavior
+
+| Input | Cmd+L (normal mode) | Cmd+T (new tab mode) |
+|---|---|---|
+| URL | Changes `WebviewSource` on current browser | Spawns browser in empty tab |
+| Filesystem path | **Does nothing** (only handled in new-tab mode) | Spawns terminal in empty tab |
+| `vmux://terminal` | **Fires `TerminalCommand::New`** (creates new tab) | Spawns terminal in empty tab |
+| "terminal" action | **Creates new tab** with terminal | Spawns terminal in empty tab |
+
+### Desired Behavior
+
+Cmd+L replaces current tab content when the current tab is a browser. When the current tab is a terminal, Cmd+L creates a new tab (to preserve the running terminal session).
+
+## Design
+
+### Event Schema Change
+
+Add `new_tab: bool` to `CommandBarActionEvent` to make navigation intent explicit:
+
+```rust
+// crates/vmux_command_bar/src/event.rs
+pub struct CommandBarActionEvent {
+    pub action: String,
+    pub value: String,
+    pub new_tab: bool,  // true = Cmd+T mode, false = Cmd+L mode
+}
+```
+
+The WASM command bar already receives `new_tab` via `CommandBarOpenEvent`. The `emit_action` helper propagates this flag into every action event.
+
+Flow:
+- Cmd+L -> `CommandBarOpenEvent { new_tab: false }` -> user action -> `CommandBarActionEvent { new_tab: false }`
+- Cmd+T -> `CommandBarOpenEvent { new_tab: true }` -> user action -> `CommandBarActionEvent { new_tab: true }`
+
+### Rust Handler Logic
+
+`on_command_bar_action` in `command_bar.rs` uses `evt.new_tab` to determine behavior instead of checking `NewTabContext.tab`.
+
+#### `navigate` action
+
+| `new_tab` | Input type | Current tab | Behavior |
+|---|---|---|---|
+| `true` | URL | any | Spawn browser in empty tab (existing) |
+| `true` | Path | any | Spawn terminal in empty tab (existing) |
+| `true` | `vmux://terminal` | any | Spawn terminal in empty tab (existing) |
+| `false` | URL | Browser | Change `WebviewSource` (existing, works) |
+| `false` | URL | Terminal | Create new tab with browser |
+| `false` | Path | Browser | Despawn browser, spawn terminal in current tab |
+| `false` | Path | Terminal | Create new tab with terminal |
+| `false` | `vmux://terminal` | Browser | Despawn browser, spawn terminal in current tab |
+| `false` | `vmux://terminal` | Terminal | Create new tab with terminal |
+
+#### `terminal` action
+
+| `new_tab` | Current tab | Behavior |
+|---|---|---|
+| `true` | any | Spawn terminal in empty tab (existing) |
+| `false` | Browser | Despawn browser, spawn terminal in current tab |
+| `false` | Terminal | Create new tab with terminal |
+
+#### `dismiss` action
+
+When `new_tab: true`, despawn empty tab from `NewTabContext` and restore keyboard to previous tab (existing behavior). `NewTabContext` still tracks the empty tab entity for cleanup purposes.
+
+### Replace-in-Tab Procedure
+
+When replacing a browser tab's content with a terminal:
+
+1. Find the current active tab entity via `focused_tab()`
+2. Find the `Browser` child entity of that tab
+3. Despawn the browser entity
+4. Spawn new `Terminal` entity as child of the same tab
+5. Update `PageMetadata` on the tab entity
+6. Set `CefKeyboardTarget` on the new terminal entity
+
+When replacing with a new URL (browser -> browser), the existing `WebviewSource` change is sufficient.
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `crates/vmux_command_bar/src/event.rs` | Add `new_tab: bool` field to `CommandBarActionEvent` |
+| `crates/vmux_command_bar/src/app.rs` | Update `emit_action` to accept `new_tab` param, pass `new_tab()` signal at all call sites |
+| `crates/vmux_desktop/src/command_bar.rs` | Rewrite `on_command_bar_action` to branch on `evt.new_tab` + current tab type detection |
+
+### What Does NOT Change
+
+- Command bar UI/UX (no visual changes)
+- `CommandBarOpenEvent` (already has `new_tab` field)
+- Keybinding definitions
+- Tab/Pane/Space entity hierarchy
+- `NewTabContext` resource (still used for empty tab cleanup)
+
+## Testing
+
+Manual testing matrix:
+1. Cmd+L from browser tab -> type URL -> should navigate in current tab
+2. Cmd+L from browser tab -> type path -> should replace browser with terminal in current tab
+3. Cmd+L from browser tab -> select Terminal -> should replace browser with terminal in current tab
+4. Cmd+L from terminal tab -> type URL -> should create new tab with browser
+5. Cmd+L from terminal tab -> type path -> should create new tab with terminal
+6. Cmd+T -> type URL -> should create new tab with browser (unchanged)
+7. Cmd+T -> select Terminal -> should create new tab with terminal (unchanged)
+8. Cmd+T -> Escape -> should despawn empty tab (unchanged)


### PR DESCRIPTION
## Context

When using Cmd+L (FocusAddressBar) and navigating to a terminal or filesystem path, the app either did nothing or created a new tab. Users expect Cmd+L to change content within the current tab, reserving new-tab creation for Cmd+T.

## Implementation

- Added `new_tab: bool` field to `CommandBarActionEvent` to make navigation intent explicit at the event level rather than inferring from `NewTabContext` resource state
- Updated the WASM command bar `emit_action` helper to propagate the `new_tab` signal from `CommandBarOpenEvent` into every action event
- Rewrote `on_command_bar_action` to branch on `evt.new_tab` combined with current tab type detection:
  - **Browser tab + Cmd+L**: replaces content in-place (despawns browser, spawns terminal/new browser)
  - **Terminal tab + Cmd+L**: creates a new tab to preserve the running terminal session
  - **Cmd+T**: unchanged behavior (always creates new tab)
- Removed unused `TerminalCommand` import

## Checks / QA

-  Cmd+L from browser tab -> type URL -> navigates in current tab
-  Cmd+L from browser tab -> type path -> replaces browser with terminal in current tab
-  Cmd+L from browser tab -> select Terminal -> replaces browser with terminal
-  Cmd+L from terminal tab -> type URL -> creates new tab with browser
-  Cmd+L from terminal tab -> type path -> creates new tab with terminal
-  Cmd+T -> type URL -> creates new tab with browser (unchanged)
-  Cmd+T -> select Terminal -> creates new tab with terminal (unchanged)
-  Cmd+T -> Escape -> despawns empty tab (unchanged)

Closes VMX-73
