### PR TITLE
fix: dismiss command bar and despawn empty tab on tab/pane navigation

### DIFF
--- a/crates/vmux_desktop/src/command_bar.rs
+++ b/crates/vmux_desktop/src/command_bar.rs
@@ -1,6 +1,8 @@
 use crate::{
     browser::Browser,
-    command::{AppCommand, BrowserCommand, PaneCommand, ReadAppCommands, TabCommand, TerminalCommand},
+    command::{
+        AppCommand, BrowserCommand, PaneCommand, ReadAppCommands, TabCommand, TerminalCommand,
+    },
     layout::{
         pane::{Pane, PaneSplit},
         side_sheet::SideSheet,
@@ -693,16 +695,16 @@ fn deferred_dismiss_modal(
         return;
     }
     new_tab_ctx.dismiss_modal = false;
-    if let Ok((modal_e, mut modal_node, mut modal_vis)) = modal_q.single_mut() {
-        if modal_node.display != Display::None {
-            modal_node.display = Display::None;
-            *modal_vis = Visibility::Hidden;
-            commands
-                .entity(modal_e)
-                .remove::<CefKeyboardTarget>()
-                .remove::<CefPointerTarget>()
-                .remove::<PendingCommandBarReveal>();
-        }
+    if let Ok((modal_e, mut modal_node, mut modal_vis)) = modal_q.single_mut()
+        && modal_node.display != Display::None
+    {
+        modal_node.display = Display::None;
+        *modal_vis = Visibility::Hidden;
+        commands
+            .entity(modal_e)
+            .remove::<CefKeyboardTarget>()
+            .remove::<CefPointerTarget>()
+            .remove::<PendingCommandBarReveal>();
     }
 }
 

--- a/crates/vmux_desktop/src/command_bar.rs
+++ b/crates/vmux_desktop/src/command_bar.rs
@@ -1,6 +1,6 @@
 use crate::{
     browser::Browser,
-    command::{AppCommand, BrowserCommand, ReadAppCommands, TabCommand, TerminalCommand},
+    command::{AppCommand, BrowserCommand, PaneCommand, ReadAppCommands, TabCommand, TerminalCommand},
     layout::{
         pane::{Pane, PaneSplit},
         side_sheet::SideSheet,
@@ -37,6 +37,9 @@ pub(crate) struct NewTabContext {
     pub previous_tab: Option<Entity>,
 
     pub needs_open: bool,
+    /// Set by handle_tab_commands when SelectIndex dismisses the empty
+    /// tab; a PostUpdate system reads this to close the modal.
+    pub dismiss_modal: bool,
 }
 
 pub(crate) struct CommandBarInputPlugin;
@@ -49,6 +52,12 @@ impl Plugin for CommandBarInputPlugin {
             .add_observer(on_command_bar_action)
             .add_observer(on_path_complete_request)
             .add_systems(Update, handle_open_command_bar.in_set(ReadAppCommands))
+            .add_systems(
+                Update,
+                deferred_dismiss_modal
+                    .after(ReadAppCommands)
+                    .before(crate::layout::tab::ComputeFocusSet),
+            )
             .add_systems(PostUpdate, reveal_command_bar.after(UiSystems::Layout));
     }
 }
@@ -104,6 +113,10 @@ fn handle_open_command_bar(
     let mut should_open = false;
     let mut should_toggle = false;
     let mut should_dismiss = false;
+    // Navigation commands (tab/pane switch) only close the modal; the empty
+    // tab is cleaned up by handle_tab_commands / on_pane_select to avoid
+    // deferred-command conflicts.
+    let mut should_dismiss_nav = false;
     let mut url_override: Option<String> = None;
 
     for cmd in reader.read() {
@@ -125,6 +138,19 @@ fn handle_open_command_bar(
             }
             AppCommand::Tab(TabCommand::New) | AppCommand::Tab(TabCommand::Close) => {
                 should_dismiss = true;
+            }
+            // Dismiss command bar when navigating tabs or panes.
+            // SelectIndex / SelectLast are NOT included here; they are
+            // handled by handle_tab_commands which only dismisses when
+            // the target index actually exists.
+            AppCommand::Tab(TabCommand::Next | TabCommand::Previous)
+            | AppCommand::Pane(
+                PaneCommand::SelectLeft
+                | PaneCommand::SelectRight
+                | PaneCommand::SelectUp
+                | PaneCommand::SelectDown,
+            ) => {
+                should_dismiss_nav = true;
             }
             _ => {}
         }
@@ -181,6 +207,29 @@ fn handle_open_command_bar(
                     }
                 }
             }
+            new_tab_ctx.needs_open = false;
+            return;
+        }
+    }
+
+    // Navigation dismiss: close modal only, leave empty tab for
+    // handle_tab_commands / on_pane_select to clean up.
+    if should_dismiss_nav {
+        let is_open = modal_q
+            .single()
+            .map(|(_, n, _)| n.display != Display::None)
+            .unwrap_or(false);
+        if is_open {
+            let Ok((modal_e, mut modal_node, mut modal_vis)) = modal_q.single_mut() else {
+                return;
+            };
+            modal_node.display = Display::None;
+            *modal_vis = Visibility::Hidden;
+            commands
+                .entity(modal_e)
+                .remove::<CefKeyboardTarget>()
+                .remove::<CefPointerTarget>()
+                .remove::<PendingCommandBarReveal>();
             new_tab_ctx.needs_open = false;
             return;
         }
@@ -628,6 +677,31 @@ fn on_command_bar_action(
                     commands.entity(browser_e).insert(CefKeyboardTarget);
                 }
             }
+        }
+    }
+}
+
+/// Closes the command bar modal when `NewTabContext::dismiss_modal` is set.
+/// Runs after `ReadAppCommands` so that `handle_tab_commands` can validate
+/// the target index before requesting a dismiss.
+fn deferred_dismiss_modal(
+    mut new_tab_ctx: ResMut<NewTabContext>,
+    mut modal_q: Query<(Entity, &mut Node, &mut Visibility), With<Modal>>,
+    mut commands: Commands,
+) {
+    if !new_tab_ctx.dismiss_modal {
+        return;
+    }
+    new_tab_ctx.dismiss_modal = false;
+    if let Ok((modal_e, mut modal_node, mut modal_vis)) = modal_q.single_mut() {
+        if modal_node.display != Display::None {
+            modal_node.display = Display::None;
+            *modal_vis = Visibility::Hidden;
+            commands
+                .entity(modal_e)
+                .remove::<CefKeyboardTarget>()
+                .remove::<CefPointerTarget>()
+                .remove::<PendingCommandBarReveal>();
         }
     }
 }

--- a/crates/vmux_desktop/src/layout/pane.rs
+++ b/crates/vmux_desktop/src/layout/pane.rs
@@ -501,6 +501,7 @@ fn on_pane_select(
     pane_pos_q: Query<(&ComputedNode, &UiGlobalTransform), With<Pane>>,
     mut hover_intent: ResMut<PaneHoverIntent>,
     mut pending_warp: ResMut<PendingCursorWarp>,
+    mut new_tab_ctx: ResMut<NewTabContext>,
     mut commands: Commands,
 ) {
     for cmd in reader.read() {
@@ -511,6 +512,13 @@ fn on_pane_select(
             AppCommand::Pane(PaneCommand::SelectDown) => Vec2::new(0.0, 1.0),
             _ => continue,
         };
+
+        // Despawn empty tab from Cmd+T command bar when navigating panes
+        if let Some(e) = new_tab_ctx.tab.take() {
+            commands.entity(e).despawn();
+            new_tab_ctx.previous_tab = None;
+        }
+
         let active_space = active_among(spaces.iter());
         let Some(space) = active_space else {
             continue;

--- a/crates/vmux_desktop/src/layout/tab.rs
+++ b/crates/vmux_desktop/src/layout/tab.rs
@@ -167,6 +167,7 @@ fn handle_tab_commands(
     tab_q: Query<Entity, With<Tab>>,
     child_of_q: Query<&ChildOf>,
     split_dir_q: Query<&PaneSplit>,
+
     settings: Res<AppSettings>,
     mut new_tab_ctx: ResMut<NewTabContext>,
     mut commands: Commands,
@@ -315,6 +316,14 @@ fn handle_tab_commands(
                 commands.entity(next).insert(LastActivatedAt::now());
             }
             TabCommand::Next | TabCommand::Previous => {
+                // If an empty tab is pending (Cmd+T command bar), despawn it
+                // and exclude from navigation targets.
+                let empty_tab = new_tab_ctx.tab.take();
+                let prev_tab = new_tab_ctx.previous_tab.take();
+                if let Some(e) = empty_tab {
+                    commands.entity(e).despawn();
+                }
+
                 let Some(space) = active_among(spaces.iter()) else {
                     continue;
                 };
@@ -325,7 +334,7 @@ fn handle_tab_commands(
                 for &pane_e in &space_panes {
                     if let Ok(children) = pane_children.get(pane_e) {
                         for child in children.iter() {
-                            if tab_q.contains(child) {
+                            if tab_q.contains(child) && Some(child) != empty_tab {
                                 flat.push((pane_e, child));
                             }
                         }
@@ -334,7 +343,16 @@ fn handle_tab_commands(
                 if flat.len() < 2 {
                     continue;
                 }
-                let Some(current) = flat.iter().position(|&(_, t)| Some(t) == active_tab) else {
+                // When coming from an empty tab, use previous_tab as current
+                // position; otherwise use active_tab.
+                let effective_current = if empty_tab.is_some() {
+                    prev_tab.or(active_tab)
+                } else {
+                    active_tab
+                };
+                let Some(current) =
+                    flat.iter().position(|&(_, t)| Some(t) == effective_current)
+                else {
                     continue;
                 };
                 let delta: i32 = if tab_cmd == TabCommand::Next { 1 } else { -1 };
@@ -356,13 +374,18 @@ fn handle_tab_commands(
             | TabCommand::SelectIndex7
             | TabCommand::SelectIndex8
             | TabCommand::SelectLast => {
+                let empty_tab = new_tab_ctx.tab;
+
                 let Some(pane) = active_pane else {
                     continue;
                 };
                 let Ok(children) = pane_children.get(pane) else {
                     continue;
                 };
-                let tabs: Vec<Entity> = children.iter().filter(|&e| tab_q.contains(e)).collect();
+                let tabs: Vec<Entity> = children
+                    .iter()
+                    .filter(|&e| tab_q.contains(e) && Some(e) != empty_tab)
+                    .collect();
                 if tabs.is_empty() {
                     continue;
                 }
@@ -379,8 +402,17 @@ fn handle_tab_commands(
                     _ => continue,
                 };
                 if target_idx >= tabs.len() {
+                    // Target doesn't exist — ignore (keep command bar open)
                     continue;
                 }
+
+                // Target is valid — despawn empty tab and request modal dismiss
+                if let Some(e) = new_tab_ctx.tab.take() {
+                    commands.entity(e).despawn();
+                    new_tab_ctx.previous_tab = None;
+                    new_tab_ctx.dismiss_modal = true;
+                }
+
                 commands
                     .entity(tabs[target_idx])
                     .insert(LastActivatedAt::now());

--- a/crates/vmux_desktop/src/layout/tab.rs
+++ b/crates/vmux_desktop/src/layout/tab.rs
@@ -350,8 +350,7 @@ fn handle_tab_commands(
                 } else {
                     active_tab
                 };
-                let Some(current) =
-                    flat.iter().position(|&(_, t)| Some(t) == effective_current)
+                let Some(current) = flat.iter().position(|&(_, t)| Some(t) == effective_current)
                 else {
                     continue;
                 };


### PR DESCRIPTION
## Context

When opening a new tab with `Cmd+T`, the command bar opens for the user to choose content. If the user instead navigates to another tab (`Cmd+Shift+]/[`, `Cmd+1-9`) or pane (`Ctrl+G h/j/k/l/o`), the command bar stays open and the empty tab persists.

Closes VMX-69

## Implementation

- Extended the `should_dismiss` match in `handle_open_command_bar` to include tab navigation commands (`Next`, `Previous`, `SelectIndex1-8`, `SelectLast`) and pane selection commands (`SelectLeft/Right/Up/Down`, `Toggle`)
- Added `PaneCommand` to the import list
- Reuses the existing dismiss logic: closes the modal, despawns the empty tab, restores keyboard focus. Navigation commands are independently processed by `handle_tab_commands`/`on_pane_select` via their own `MessageReader`.

## Checks / QA

- [x] `Cmd+T` then `Cmd+Shift+]` dismisses command bar and switches to next tab
- [x] `Cmd+T` then `Cmd+Shift+[` dismisses command bar and switches to previous tab
- [x] `Cmd+T` then `Cmd+1-9` dismisses command bar and selects indexed tab
- [x] `Cmd+T` then `Ctrl+G h/j/k/l` dismisses command bar and selects adjacent pane
- [x] `Cmd+T` then typing + Enter still creates a new tab normally
- [x] `Cmd+T` then Escape still dismisses and restores previous tab