### PR TITLE
feat(layout): persist header and side sheet toggle state across restarts

### DIFF
--- a/crates/vmux_desktop/src/layout.rs
+++ b/crates/vmux_desktop/src/layout.rs
@@ -16,6 +16,7 @@ use bevy::prelude::*;
 use focus_ring::FocusRingPlugin;
 use glass::GlassMaterialPlugin;
 use header::HeaderLayoutPlugin;
+use moonshine_save::prelude::*;
 use pane::PanePlugin;
 use side_sheet::SideSheetLayoutPlugin;
 use space::SpacePlugin;
@@ -24,10 +25,31 @@ use vmux_webview_app::JsEmitUiReadyPlugin;
 use window::WindowPlugin;
 pub(crate) use window::fit_window_to_screen;
 
+/// Marker component indicating a panel (header, side-sheet) is open.
+/// Added/removed at runtime; persisted on state entities.
+#[derive(Component, Reflect, Default)]
+#[reflect(Component)]
+pub(crate) struct Open;
+
+/// Persisted entity that mirrors header open state.
+#[derive(Component, Reflect, Default)]
+#[reflect(Component)]
+#[require(Save)]
+pub(crate) struct HeaderState;
+
+/// Persisted entity that mirrors side-sheet open state.
+#[derive(Component, Reflect, Default)]
+#[reflect(Component)]
+#[require(Save)]
+pub(crate) struct SideSheetState;
+
 pub struct LayoutPlugin;
 
 impl Plugin for LayoutPlugin {
     fn build(&self, app: &mut App) {
+        app.register_type::<Open>()
+            .register_type::<HeaderState>()
+            .register_type::<SideSheetState>();
         app.add_plugins((
             JsEmitUiReadyPlugin,
             WindowPlugin,

--- a/crates/vmux_desktop/src/layout/header.rs
+++ b/crates/vmux_desktop/src/layout/header.rs
@@ -1,3 +1,4 @@
+use super::{HeaderState, Open};
 use crate::command::{AppCommand, HeaderCommand, ReadAppCommands};
 use bevy::prelude::*;
 use vmux_header::{HEADER_HEIGHT_PX, Header};
@@ -6,8 +7,7 @@ pub(crate) struct HeaderLayoutPlugin;
 
 impl Plugin for HeaderLayoutPlugin {
     fn build(&self, app: &mut App) {
-        app.insert_resource(HeaderOpen(false))
-            .add_systems(Update, handle_header_toggle.in_set(ReadAppCommands))
+        app.add_systems(Update, handle_header_toggle.in_set(ReadAppCommands))
             .add_systems(
                 PostUpdate,
                 sync_header_visibility.before(bevy::ui::UiSystems::Layout),
@@ -15,31 +15,47 @@ impl Plugin for HeaderLayoutPlugin {
     }
 }
 
-#[derive(Resource)]
-pub(crate) struct HeaderOpen(pub bool);
-
-fn handle_header_toggle(mut reader: MessageReader<AppCommand>, mut open: ResMut<HeaderOpen>) {
+fn handle_header_toggle(
+    mut reader: MessageReader<AppCommand>,
+    header_q: Query<(Entity, Has<Open>), With<Header>>,
+    state_q: Query<(Entity, Has<Open>), With<HeaderState>>,
+    mut commands: Commands,
+) {
     for cmd in reader.read() {
         if matches!(cmd, AppCommand::Header(HeaderCommand::Toggle)) {
-            open.0 = !open.0;
+            for (entity, is_open) in &header_q {
+                if is_open {
+                    commands.entity(entity).remove::<Open>();
+                } else {
+                    commands.entity(entity).insert(Open);
+                }
+            }
+            for (entity, is_open) in &state_q {
+                if is_open {
+                    commands.entity(entity).remove::<Open>();
+                } else {
+                    commands.entity(entity).insert(Open);
+                }
+            }
         }
     }
 }
 
 fn sync_header_visibility(
-    open: Res<HeaderOpen>,
     mut header_q: Query<(&mut Visibility, &mut Node), With<Header>>,
+    added: Query<Entity, (With<Header>, Added<Open>)>,
+    mut removed: RemovedComponents<Open>,
 ) {
-    if !open.is_changed() {
-        return;
-    }
-
-    for (mut vis, mut node) in &mut header_q {
-        if open.0 {
+    for entity in &added {
+        if let Ok((mut vis, mut node)) = header_q.get_mut(entity) {
             *vis = Visibility::Inherited;
             node.display = Display::Flex;
             node.height = Val::Px(HEADER_HEIGHT_PX);
-        } else {
+        }
+    }
+
+    for entity in removed.read() {
+        if let Ok((mut vis, mut node)) = header_q.get_mut(entity) {
             *vis = Visibility::Hidden;
             node.display = Display::None;
             node.height = Val::Px(0.0);

--- a/crates/vmux_desktop/src/layout/side_sheet.rs
+++ b/crates/vmux_desktop/src/layout/side_sheet.rs
@@ -86,7 +86,15 @@ fn side_sheet_drag_resize(
     windows: Query<&Window, With<PrimaryWindow>>,
 
     mut width_res: ResMut<SideSheetWidth>,
-    sheet_q: Query<(&SideSheetPosition, Has<Open>, &ComputedNode, &UiGlobalTransform), With<SideSheet>>,
+    sheet_q: Query<
+        (
+            &SideSheetPosition,
+            Has<Open>,
+            &ComputedNode,
+            &UiGlobalTransform,
+        ),
+        With<SideSheet>,
+    >,
     active_drags: Query<(Entity, &SideSheetDrag)>,
     mouse: Res<ButtonInput<MouseButton>>,
     mut side_sheet_q: Query<(&SideSheetPosition, &mut Node), With<SideSheet>>,
@@ -175,17 +183,17 @@ fn sync_side_sheet_visibility(
     // Determine if the left side sheet opened or closed
     let mut left_open: Option<bool> = None;
     for entity in &added {
-        if let Ok((_, pos, _, _)) = side_sheet_q.get(entity) {
-            if *pos == SideSheetPosition::Left {
-                left_open = Some(true);
-            }
+        if let Ok((_, pos, _, _)) = side_sheet_q.get(entity)
+            && *pos == SideSheetPosition::Left
+        {
+            left_open = Some(true);
         }
     }
     for entity in removed.read() {
-        if let Ok((_, pos, _, _)) = side_sheet_q.get(entity) {
-            if *pos == SideSheetPosition::Left {
-                left_open = Some(false);
-            }
+        if let Ok((_, pos, _, _)) = side_sheet_q.get(entity)
+            && *pos == SideSheetPosition::Left
+        {
+            left_open = Some(false);
         }
     }
 
@@ -240,19 +248,19 @@ fn sync_window_buttons_visibility(
     let mut changed = false;
     let mut is_open = false;
     for entity in &added {
-        if let Ok((pos, _)) = side_sheet_q.get(entity) {
-            if *pos == SideSheetPosition::Left {
-                changed = true;
-                is_open = true;
-            }
+        if let Ok((pos, _)) = side_sheet_q.get(entity)
+            && *pos == SideSheetPosition::Left
+        {
+            changed = true;
+            is_open = true;
         }
     }
     if !changed {
         for entity in removed.read() {
-            if let Ok((pos, _)) = side_sheet_q.get(entity) {
-                if *pos == SideSheetPosition::Left {
-                    changed = true;
-                }
+            if let Ok((pos, _)) = side_sheet_q.get(entity)
+                && *pos == SideSheetPosition::Left
+            {
+                changed = true;
             }
         }
     }

--- a/crates/vmux_desktop/src/layout/side_sheet.rs
+++ b/crates/vmux_desktop/src/layout/side_sheet.rs
@@ -1,3 +1,4 @@
+use super::{Open, SideSheetState};
 use crate::{
     command::{AppCommand, ReadAppCommands, SideSheetCommand},
     layout::window::Main,
@@ -10,8 +11,7 @@ pub(crate) struct SideSheetLayoutPlugin;
 
 impl Plugin for SideSheetLayoutPlugin {
     fn build(&self, app: &mut App) {
-        app.insert_resource(SideSheetOpen(false))
-            .insert_resource(SideSheetWidth(0.0)) // set from settings on first sync
+        app.insert_resource(SideSheetWidth(0.0)) // set from settings on first sync
             .add_systems(Update, handle_side_sheet_toggle.in_set(ReadAppCommands))
             .add_systems(Update, side_sheet_drag_resize)
             .add_systems(
@@ -34,9 +34,6 @@ pub(crate) enum SideSheetPosition {
     Bottom,
 }
 
-#[derive(Resource)]
-pub(crate) struct SideSheetOpen(pub bool);
-
 /// Current width of the left side sheet (mutable during drag).
 #[derive(Resource)]
 struct SideSheetWidth(f32);
@@ -54,12 +51,29 @@ const EDGE_HIT_ZONE: f32 = 6.0;
 
 fn handle_side_sheet_toggle(
     mut reader: MessageReader<AppCommand>,
-    mut open: ResMut<SideSheetOpen>,
+    side_sheet_q: Query<(Entity, &SideSheetPosition, Has<Open>), With<SideSheet>>,
+    state_q: Query<(Entity, Has<Open>), With<SideSheetState>>,
+    mut commands: Commands,
 ) {
     for cmd in reader.read() {
         match cmd {
             AppCommand::SideSheet(SideSheetCommand::Toggle) => {
-                open.0 = !open.0;
+                for (entity, pos, is_open) in &side_sheet_q {
+                    if *pos == SideSheetPosition::Left {
+                        if is_open {
+                            commands.entity(entity).remove::<Open>();
+                        } else {
+                            commands.entity(entity).insert(Open);
+                        }
+                    }
+                }
+                for (entity, is_open) in &state_q {
+                    if is_open {
+                        commands.entity(entity).remove::<Open>();
+                    } else {
+                        commands.entity(entity).insert(Open);
+                    }
+                }
             }
             AppCommand::SideSheet(SideSheetCommand::ToggleRight) => {}
             AppCommand::SideSheet(SideSheetCommand::ToggleBottom) => {}
@@ -71,9 +85,8 @@ fn handle_side_sheet_toggle(
 fn side_sheet_drag_resize(
     windows: Query<&Window, With<PrimaryWindow>>,
 
-    open: Res<SideSheetOpen>,
     mut width_res: ResMut<SideSheetWidth>,
-    sheet_q: Query<(&SideSheetPosition, &ComputedNode, &UiGlobalTransform), With<SideSheet>>,
+    sheet_q: Query<(&SideSheetPosition, Has<Open>, &ComputedNode, &UiGlobalTransform), With<SideSheet>>,
     active_drags: Query<(Entity, &SideSheetDrag)>,
     mouse: Res<ButtonInput<MouseButton>>,
     mut side_sheet_q: Query<(&SideSheetPosition, &mut Node), With<SideSheet>>,
@@ -82,7 +95,10 @@ fn side_sheet_drag_resize(
     settings: Res<AppSettings>,
     mut commands: Commands,
 ) {
-    if !open.0 {
+    let is_open = sheet_q
+        .iter()
+        .any(|(pos, open, _, _)| *pos == SideSheetPosition::Left && open);
+    if !is_open {
         return;
     }
 
@@ -120,7 +136,7 @@ fn side_sheet_drag_resize(
     }
 
     // Hover detection on right edge of left side sheet
-    for (pos, cn, gt) in &sheet_q {
+    for (pos, _, cn, gt) in &sheet_q {
         if *pos != SideSheetPosition::Left {
             continue;
         }
@@ -145,16 +161,35 @@ fn side_sheet_drag_resize(
 }
 
 fn sync_side_sheet_visibility(
-    open: Res<SideSheetOpen>,
     settings: Res<AppSettings>,
     mut width_res: ResMut<SideSheetWidth>,
-    mut side_sheet_q: Query<(&SideSheetPosition, &mut Visibility, &mut Node), With<SideSheet>>,
+    mut side_sheet_q: Query<
+        (Entity, &SideSheetPosition, &mut Visibility, &mut Node),
+        With<SideSheet>,
+    >,
     mut header_q: Query<&mut Node, (With<Header>, Without<SideSheet>, Without<Main>)>,
     mut main_q: Query<&mut Node, (With<Main>, Without<SideSheet>, Without<Header>)>,
+    added: Query<Entity, (With<SideSheet>, Added<Open>)>,
+    mut removed: RemovedComponents<Open>,
 ) {
-    if !open.is_changed() {
-        return;
+    // Determine if the left side sheet opened or closed
+    let mut left_open: Option<bool> = None;
+    for entity in &added {
+        if let Ok((_, pos, _, _)) = side_sheet_q.get(entity) {
+            if *pos == SideSheetPosition::Left {
+                left_open = Some(true);
+            }
+        }
     }
+    for entity in removed.read() {
+        if let Ok((_, pos, _, _)) = side_sheet_q.get(entity) {
+            if *pos == SideSheetPosition::Left {
+                left_open = Some(false);
+            }
+        }
+    }
+
+    let Some(is_open) = left_open else { return };
 
     // Initialize width from settings if not yet set
     if width_res.0 <= 0.0 {
@@ -163,11 +198,11 @@ fn sync_side_sheet_visibility(
 
     let width = width_res.0;
     let sheet_total = width + settings.layout.pane.gap;
-    for (pos, mut vis, mut node) in &mut side_sheet_q {
+    for (_, pos, mut vis, mut node) in &mut side_sheet_q {
         if *pos != SideSheetPosition::Left {
             continue;
         }
-        if open.0 {
+        if is_open {
             *vis = Visibility::Inherited;
             node.display = Display::Flex;
             node.width = Val::Px(width);
@@ -177,14 +212,14 @@ fn sync_side_sheet_visibility(
         }
     }
     for mut node in &mut header_q {
-        node.margin.left = if open.0 {
+        node.margin.left = if is_open {
             Val::Px(sheet_total)
         } else {
             Val::Px(0.0)
         };
     }
     for mut node in &mut main_q {
-        node.margin.left = if open.0 {
+        node.margin.left = if is_open {
             Val::Px(sheet_total)
         } else {
             Val::Px(0.0)
@@ -195,11 +230,34 @@ fn sync_side_sheet_visibility(
 /// Show/hide macOS traffic-light buttons to match the side-sheet state.
 #[cfg(target_os = "macos")]
 fn sync_window_buttons_visibility(
-    open: Res<SideSheetOpen>,
+    side_sheet_q: Query<(&SideSheetPosition, Has<Open>), With<SideSheet>>,
+    added: Query<Entity, (With<SideSheet>, Added<Open>)>,
+    mut removed: RemovedComponents<Open>,
     winit_windows: Option<NonSend<WinitWindows>>,
     window_q: Query<Entity, With<PrimaryWindow>>,
 ) {
-    if !open.is_changed() {
+    // Only react to left side sheet changes
+    let mut changed = false;
+    let mut is_open = false;
+    for entity in &added {
+        if let Ok((pos, _)) = side_sheet_q.get(entity) {
+            if *pos == SideSheetPosition::Left {
+                changed = true;
+                is_open = true;
+            }
+        }
+    }
+    if !changed {
+        for entity in removed.read() {
+            if let Ok((pos, _)) = side_sheet_q.get(entity) {
+                if *pos == SideSheetPosition::Left {
+                    changed = true;
+                }
+            }
+        }
+    }
+
+    if !changed {
         return;
     }
     let Some(winit_windows) = winit_windows else {
@@ -228,7 +286,7 @@ fn sync_window_buttons_visibility(
         if ns_window.is_null() {
             return;
         }
-        let hidden: libc::c_int = if open.0 { 0 } else { 1 };
+        let hidden: libc::c_int = if is_open { 0 } else { 1 };
         // NSWindowButton values: Close=0, Miniaturize=1, Zoom=2
         for button_type in 0u64..=2 {
             let button = objc_msgSend(ns_window, sel("standardWindowButton:"), button_type);

--- a/crates/vmux_desktop/src/layout/window.rs
+++ b/crates/vmux_desktop/src/layout/window.rs
@@ -43,6 +43,8 @@ impl Plugin for WindowPlugin {
                 crate::persistence::load_session_on_startup,
                 spawn_default_session,
                 crate::persistence::rebuild_session_views,
+                crate::persistence::ensure_layout_state_entities,
+                crate::persistence::apply_persisted_layout_state,
                 fit_window_to_screen,
             )
                 .chain()
@@ -208,9 +210,11 @@ fn setup(
                 HostWindow(pw),
                 Browser,
                 WebviewTransparent,
+                Visibility::Hidden,
                 Node {
-                    height: Val::Px(HEADER_HEIGHT_PX),
+                    height: Val::Px(0.0),
                     flex_shrink: 0.0,
+                    display: Display::None,
                     ..default()
                 },
                 HeaderBundle {

--- a/crates/vmux_desktop/src/persistence.rs
+++ b/crates/vmux_desktop/src/persistence.rs
@@ -9,12 +9,12 @@ use std::path::PathBuf;
 use crate::{
     browser::Browser,
     layout::{
+        HeaderState, Open, SideSheetState,
         pane::{Pane, PaneSize, PaneSplit, PaneSplitDirection},
         side_sheet::{SideSheet, SideSheetPosition},
         space::Space,
         tab::Tab,
         window::Main,
-        HeaderState, Open, SideSheetState,
     },
     profile::Profile,
     settings::AppSettings,
@@ -77,10 +77,8 @@ fn mark_dirty_on_change(
     mut removed_open: RemovedComponents<Open>,
     state_entities: Query<Entity, Or<(With<HeaderState>, With<SideSheetState>)>>,
 ) {
-    let open_state_changed = !open_on_state.is_empty()
-        || removed_open
-            .read()
-            .any(|e| state_entities.contains(e));
+    let open_state_changed =
+        !open_on_state.is_empty() || removed_open.read().any(|e| state_entities.contains(e));
 
     if !added_tabs.is_empty()
         || !added_panes.is_empty()

--- a/crates/vmux_desktop/src/persistence.rs
+++ b/crates/vmux_desktop/src/persistence.rs
@@ -10,9 +10,11 @@ use crate::{
     browser::Browser,
     layout::{
         pane::{Pane, PaneSize, PaneSplit, PaneSplitDirection},
+        side_sheet::{SideSheet, SideSheetPosition},
         space::Space,
         tab::Tab,
         window::Main,
+        HeaderState, Open, SideSheetState,
     },
     profile::Profile,
     settings::AppSettings,
@@ -65,7 +67,21 @@ fn mark_dirty_on_change(
     changed_meta: Query<(), (Changed<PageMetadata>, With<Tab>)>,
     changed_size: Query<(), Changed<PaneSize>>,
     changed_children: Query<(), Changed<Children>>,
+    open_on_state: Query<
+        (),
+        (
+            Or<(With<HeaderState>, With<SideSheetState>)>,
+            Or<(Added<Open>, Changed<Open>)>,
+        ),
+    >,
+    mut removed_open: RemovedComponents<Open>,
+    state_entities: Query<Entity, Or<(With<HeaderState>, With<SideSheetState>)>>,
 ) {
+    let open_state_changed = !open_on_state.is_empty()
+        || removed_open
+            .read()
+            .any(|e| state_entities.contains(e));
+
     if !added_tabs.is_empty()
         || !added_panes.is_empty()
         || !added_spaces.is_empty()
@@ -74,6 +90,7 @@ fn mark_dirty_on_change(
         || !changed_meta.is_empty()
         || !changed_size.is_empty()
         || !changed_children.is_empty()
+        || open_state_changed
     {
         auto_save.dirty = true;
         auto_save.debounce.reset();
@@ -115,6 +132,9 @@ fn do_save(commands: &mut Commands) {
         .allow::<PaneSplit>()
         .allow::<PaneSize>()
         .allow::<Profile>()
+        .allow::<Open>()
+        .allow::<HeaderState>()
+        .allow::<SideSheetState>()
         .allow::<PageMetadata>()
         .allow::<vmux_history::CreatedAt>()
         .allow::<vmux_history::LastActivatedAt>()
@@ -309,4 +329,45 @@ pub(crate) fn rebuild_session_views(
         panes_need_view.iter().count(),
         tabs_need_view.iter().count(),
     );
+}
+
+/// Spawn persisted layout-state entities if they don't already exist
+/// (handles first launch and migration from older sessions).
+pub(crate) fn ensure_layout_state_entities(
+    header_state_q: Query<(), With<HeaderState>>,
+    side_sheet_state_q: Query<(), With<SideSheetState>>,
+    mut commands: Commands,
+) {
+    if header_state_q.is_empty() {
+        commands.spawn(HeaderState);
+    }
+    if side_sheet_state_q.is_empty() {
+        commands.spawn(SideSheetState);
+    }
+}
+
+/// Apply persisted open state from state entities to UI entities after load.
+pub(crate) fn apply_persisted_layout_state(
+    header_state_q: Query<Has<Open>, With<HeaderState>>,
+    side_sheet_state_q: Query<Has<Open>, With<SideSheetState>>,
+    header_q: Query<Entity, With<vmux_header::Header>>,
+    side_sheet_q: Query<(Entity, &SideSheetPosition), With<SideSheet>>,
+    mut commands: Commands,
+) {
+    for is_open in &header_state_q {
+        if is_open {
+            for entity in &header_q {
+                commands.entity(entity).insert(Open);
+            }
+        }
+    }
+    for is_open in &side_sheet_state_q {
+        if is_open {
+            for (entity, pos) in &side_sheet_q {
+                if *pos == SideSheetPosition::Left {
+                    commands.entity(entity).insert(Open);
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Context

Header and side sheet visibility resets to hidden on every app restart. Users expect the layout to be restored from the previous session.

## Implementation

- Replaced `HeaderOpen`/`SideSheetOpen` resources with a shared `Open` marker component inserted/removed on the actual Header and SideSheet UI entities
- Introduced `HeaderState` and `SideSheetState` persisted entities (with `Save`) that mirror the `Open` state to `session.ron` via moonshine-save
- On toggle: `Open` is inserted/removed on both the UI entity and its corresponding state entity
- On startup: `ensure_layout_state_entities` spawns state entities if missing (first launch or migration); `apply_persisted_layout_state` syncs saved state to UI entities
- Header now spawns initially hidden in `window.rs` (previously relied on resource-driven first-frame sync)
- Added `Open` change detection on state entities to `mark_dirty_on_change` for auto-save

## Checks / QA

- [x] Toggle header (Cmd+Shift+H), restart app -- header should remain visible
- [x] Toggle side sheet (Cmd+S), restart app -- side sheet should remain visible
- [x] Close both panels, restart -- both should stay hidden
- [x] Delete `session.ron` and relaunch -- default hidden state, no crash

Closes VMX-87
