### PR TITLE
fix(command_bar): hide "Open in Terminal" when path does not exist

### DIFF
--- a/crates/vmux_command_bar/src/app.rs
+++ b/crates/vmux_command_bar/src/app.rs
@@ -231,14 +231,13 @@ pub fn App() -> Element {
                 .cloned();
             r.retain(|item| !matches!(item, ResultItem::Terminal { path } if !path.is_empty()));
             let mut combined = Vec::new();
-            if is_dir {
-                if let Some(ref entry @ ResultItem::Terminal { path: ref tp }) = typed_terminal
-                    && !path_items
-                        .iter()
-                        .any(|item| matches!(item, ResultItem::Terminal { path } if path == tp))
-                {
-                    combined.push(entry.clone());
-                }
+            if is_dir
+                && let Some(ref entry @ ResultItem::Terminal { path: ref tp }) = typed_terminal
+                && !path_items
+                    .iter()
+                    .any(|item| matches!(item, ResultItem::Terminal { path } if path == tp))
+            {
+                combined.push(entry.clone());
             }
             combined.extend(path_items);
             combined.extend(r);

--- a/crates/vmux_command_bar/src/app.rs
+++ b/crates/vmux_command_bar/src/app.rs
@@ -165,6 +165,7 @@ pub fn App() -> Element {
     let mut nav_mode = use_signal(|| false);
 
     let mut path_completions = use_signal(Vec::<PathEntry>::new);
+    let mut path_query_is_dir = use_signal(|| false);
 
     let _listener =
         use_event_listener::<CommandBarOpenEvent, _>(COMMAND_BAR_OPEN_EVENT, move |data| {
@@ -179,12 +180,14 @@ pub fn App() -> Element {
     let _path_listener =
         use_event_listener::<PathCompleteResponse, _>(PATH_COMPLETE_RESPONSE, move |data| {
             path_completions.set(data.completions);
+            path_query_is_dir.set(data.query_is_dir);
         });
 
     use_effect(move || {
         let q = query();
         if !looks_like_path(q.trim()) {
             path_completions.set(Vec::new());
+            path_query_is_dir.set(false);
             return;
         }
         let _ = try_cef_emit_serde(&PathCompleteRequest {
@@ -212,6 +215,7 @@ pub fn App() -> Element {
     let results = {
         let mut r = filter_results(&q, &tabs, &commands, is_new_tab);
         let completions = path_completions();
+        let is_dir = path_query_is_dir();
         if !completions.is_empty() {
             let path_items: Vec<ResultItem> = completions
                 .iter()
@@ -227,17 +231,23 @@ pub fn App() -> Element {
                 .cloned();
             r.retain(|item| !matches!(item, ResultItem::Terminal { path } if !path.is_empty()));
             let mut combined = Vec::new();
-            if let Some(ref entry @ ResultItem::Terminal { path: ref tp }) = typed_terminal
-                && !path_items
-                    .iter()
-                    .any(|item| matches!(item, ResultItem::Terminal { path } if path == tp))
-            {
-                combined.push(entry.clone());
+            if is_dir {
+                if let Some(ref entry @ ResultItem::Terminal { path: ref tp }) = typed_terminal
+                    && !path_items
+                        .iter()
+                        .any(|item| matches!(item, ResultItem::Terminal { path } if path == tp))
+                {
+                    combined.push(entry.clone());
+                }
             }
             combined.extend(path_items);
             combined.extend(r);
             combined
         } else {
+            // No completions — hide typed path item if the path doesn't exist
+            if !is_dir {
+                r.retain(|item| !matches!(item, ResultItem::Terminal { path } if !path.is_empty()));
+            }
             r
         }
     };

--- a/crates/vmux_command_bar/src/event.rs
+++ b/crates/vmux_command_bar/src/event.rs
@@ -48,4 +48,7 @@ pub struct PathEntry {
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct PathCompleteResponse {
     pub completions: Vec<PathEntry>,
+    /// Whether the exact queried path is an existing directory.
+    #[serde(default)]
+    pub query_is_dir: bool,
 }

--- a/crates/vmux_desktop/src/command_bar.rs
+++ b/crates/vmux_desktop/src/command_bar.rs
@@ -739,7 +739,21 @@ fn on_path_complete_request(
     }
 
     let completions = complete_path(query);
-    let payload = PathCompleteResponse { completions };
+    let query_is_dir = {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/".to_string());
+        let resolved = if let Some(stripped) = query.strip_prefix("~/") {
+            std::path::PathBuf::from(&home).join(stripped)
+        } else if query.starts_with('/') {
+            std::path::PathBuf::from(query)
+        } else {
+            std::path::PathBuf::from(&home).join(query)
+        };
+        resolved.is_dir()
+    };
+    let payload = PathCompleteResponse {
+        completions,
+        query_is_dir,
+    };
     let ron_body = ron::ser::to_string(&payload).unwrap_or_default();
     commands.trigger(HostEmitEvent::new(
         modal_e,


### PR DESCRIPTION
## Context

The command bar shows an "Open in Terminal" result for any input that looks like a path, even when the path does not exist on disk. This is misleading since selecting it would open a terminal at a nonexistent location.

## Implementation

Added a  boolean to . The desktop backend resolves the queried path (handling , absolute, and relative forms) and checks . The command bar frontend uses this flag to suppress the typed-path terminal item when the directory does not exist. Directory completions from the filesystem are unaffected and still appear normally.

## Checks / QA

1. Type a valid directory path (e.g. ) — "Open in Terminal" should appear with completions.
2. Type a nonexistent path (e.g. ) — no "Open in Terminal" item should appear.
3. Type a partial path that has completions (e.g. ) — directory completions should still show, but no exact-match terminal item unless the typed path itself is a directory.
4. Empty query with new-tab mode — plain "Terminal" item should still appear.