### PR TITLE
feat(layout): show command bar when closing last tab

### DIFF
--- a/crates/vmux_desktop/src/command_bar.rs
+++ b/crates/vmux_desktop/src/command_bar.rs
@@ -237,6 +237,7 @@ fn handle_open_command_bar(
     }
 
     if new_tab_ctx.needs_open {
+        info!("[handle_open_command_bar] needs_open=true, will open");
         should_open = true;
         new_tab_ctx.needs_open = false;
     }
@@ -249,15 +250,15 @@ fn handle_open_command_bar(
         if !is_open {
             should_open = true;
         }
-        // If already open, do nothing — the shortcut should not close the bar.
-        // Users can dismiss with Escape or click-outside.
     }
 
     if !should_open {
         return;
     }
 
+    info!("[handle_open_command_bar] opening modal");
     let Ok((modal_e, mut modal_node, _)) = modal_q.single_mut() else {
+        info!("[handle_open_command_bar] no modal entity found!");
         return;
     };
 

--- a/crates/vmux_desktop/src/command_bar.rs
+++ b/crates/vmux_desktop/src/command_bar.rs
@@ -237,7 +237,6 @@ fn handle_open_command_bar(
     }
 
     if new_tab_ctx.needs_open {
-        info!("[handle_open_command_bar] needs_open=true, will open");
         should_open = true;
         new_tab_ctx.needs_open = false;
     }
@@ -256,9 +255,7 @@ fn handle_open_command_bar(
         return;
     }
 
-    info!("[handle_open_command_bar] opening modal");
     let Ok((modal_e, mut modal_node, _)) = modal_q.single_mut() else {
-        info!("[handle_open_command_bar] no modal entity found!");
         return;
     };
 

--- a/crates/vmux_desktop/src/layout/tab.rs
+++ b/crates/vmux_desktop/src/layout/tab.rs
@@ -308,6 +308,12 @@ fn handle_tab_commands(
                         e != pane && (leaf_panes.contains(e) || split_dir_q.contains(e))
                     });
                     let Some(sibling) = sibling else {
+                        let tab = commands
+                            .spawn((tab_bundle(), LastActivatedAt::now(), ChildOf(pane)))
+                            .id();
+                        new_tab_ctx.tab = Some(tab);
+                        new_tab_ctx.previous_tab = None;
+                        new_tab_ctx.needs_open = true;
                         continue;
                     };
 

--- a/crates/vmux_desktop/src/layout/tab.rs
+++ b/crates/vmux_desktop/src/layout/tab.rs
@@ -50,6 +50,7 @@ impl Plugin for TabPlugin {
                     .in_set(ComputeFocusSet)
                     .after(ReadAppCommands),
             )
+            .add_systems(Update, open_command_bar_if_no_tabs.run_if(run_once))
             .add_systems(PostUpdate, sync_tab_picking);
     }
 }
@@ -576,4 +577,23 @@ fn activate_space_for(world: &mut World, entity: Entity) {
             return;
         }
     }
+
+fn open_command_bar_if_no_tabs(
+    tab_q: Query<(), With<Tab>>,
+    leaf_panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
+    mut new_tab_ctx: ResMut<NewTabContext>,
+    mut commands: Commands,
+) {
+    if !tab_q.is_empty() {
+        return;
+    }
+    let Some(pane) = leaf_panes.iter().next() else {
+        return;
+    };
+    let tab = commands
+        .spawn((tab_bundle(), LastActivatedAt::now(), ChildOf(pane)))
+        .id();
+    new_tab_ctx.tab = Some(tab);
+    new_tab_ctx.previous_tab = None;
+    new_tab_ctx.needs_open = true;
 }

--- a/crates/vmux_desktop/src/layout/tab.rs
+++ b/crates/vmux_desktop/src/layout/tab.rs
@@ -50,7 +50,6 @@ impl Plugin for TabPlugin {
                     .in_set(ComputeFocusSet)
                     .after(ReadAppCommands),
             )
-
             .add_systems(PostUpdate, sync_tab_picking);
     }
 }
@@ -592,10 +591,17 @@ pub(crate) fn open_command_bar_if_no_tabs(
     mut new_tab_ctx: ResMut<NewTabContext>,
     mut commands: Commands,
 ) {
+    info!(
+        "[open_command_bar_if_no_tabs] tabs={} leaf_panes={}",
+        tab_q.iter().count(),
+        leaf_panes.iter().count(),
+    );
     if !tab_q.is_empty() {
+        info!("[open_command_bar_if_no_tabs] tabs exist, skipping");
         return;
     }
     let Some(pane) = leaf_panes.iter().next() else {
+        info!("[open_command_bar_if_no_tabs] no leaf panes, skipping");
         return;
     };
     let tab = commands
@@ -604,4 +610,8 @@ pub(crate) fn open_command_bar_if_no_tabs(
     new_tab_ctx.tab = Some(tab);
     new_tab_ctx.previous_tab = None;
     new_tab_ctx.needs_open = true;
+    info!(
+        "[open_command_bar_if_no_tabs] spawned empty tab {:?}, needs_open=true",
+        tab
+    );
 }

--- a/crates/vmux_desktop/src/layout/tab.rs
+++ b/crates/vmux_desktop/src/layout/tab.rs
@@ -287,6 +287,14 @@ fn handle_tab_commands(
 
                     if !split_dir_q.contains(parent) {
                         commands.entity(active).despawn();
+                        // Last tab in the root pane — show command bar so the
+                        // user can navigate somewhere.
+                        let tab = commands
+                            .spawn((tab_bundle(), LastActivatedAt::now(), ChildOf(pane)))
+                            .id();
+                        new_tab_ctx.tab = Some(tab);
+                        new_tab_ctx.previous_tab = None;
+                        new_tab_ctx.needs_open = true;
                         continue;
                     }
 

--- a/crates/vmux_desktop/src/layout/tab.rs
+++ b/crates/vmux_desktop/src/layout/tab.rs
@@ -591,17 +591,10 @@ pub(crate) fn open_command_bar_if_no_tabs(
     mut new_tab_ctx: ResMut<NewTabContext>,
     mut commands: Commands,
 ) {
-    info!(
-        "[open_command_bar_if_no_tabs] tabs={} leaf_panes={}",
-        tab_q.iter().count(),
-        leaf_panes.iter().count(),
-    );
     if !tab_q.is_empty() {
-        info!("[open_command_bar_if_no_tabs] tabs exist, skipping");
         return;
     }
     let Some(pane) = leaf_panes.iter().next() else {
-        info!("[open_command_bar_if_no_tabs] no leaf panes, skipping");
         return;
     };
     let tab = commands
@@ -610,8 +603,4 @@ pub(crate) fn open_command_bar_if_no_tabs(
     new_tab_ctx.tab = Some(tab);
     new_tab_ctx.previous_tab = None;
     new_tab_ctx.needs_open = true;
-    info!(
-        "[open_command_bar_if_no_tabs] spawned empty tab {:?}, needs_open=true",
-        tab
-    );
 }

--- a/crates/vmux_desktop/src/layout/tab.rs
+++ b/crates/vmux_desktop/src/layout/tab.rs
@@ -50,7 +50,7 @@ impl Plugin for TabPlugin {
                     .in_set(ComputeFocusSet)
                     .after(ReadAppCommands),
             )
-            .add_systems(Update, open_command_bar_if_no_tabs.run_if(run_once))
+            .add_systems(Update, open_command_bar_if_no_tabs)
             .add_systems(PostUpdate, sync_tab_picking);
     }
 }
@@ -582,8 +582,16 @@ fn open_command_bar_if_no_tabs(
     tab_q: Query<(), With<Tab>>,
     leaf_panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
     mut new_tab_ctx: ResMut<NewTabContext>,
+    mut fired: Local<bool>,
     mut commands: Commands,
 ) {
+    if *fired {
+        return;
+    }
+    if leaf_panes.is_empty() {
+        return;
+    }
+    *fired = true;
     if !tab_q.is_empty() {
         return;
     }

--- a/crates/vmux_desktop/src/layout/tab.rs
+++ b/crates/vmux_desktop/src/layout/tab.rs
@@ -50,7 +50,7 @@ impl Plugin for TabPlugin {
                     .in_set(ComputeFocusSet)
                     .after(ReadAppCommands),
             )
-            .add_systems(Update, open_command_bar_if_no_tabs)
+
             .add_systems(PostUpdate, sync_tab_picking);
     }
 }
@@ -584,20 +584,14 @@ fn activate_space_for(world: &mut World, entity: Entity) {
         }
     }
 
-fn open_command_bar_if_no_tabs(
+}
+
+pub(crate) fn open_command_bar_if_no_tabs(
     tab_q: Query<(), With<Tab>>,
     leaf_panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
     mut new_tab_ctx: ResMut<NewTabContext>,
-    mut fired: Local<bool>,
     mut commands: Commands,
 ) {
-    if *fired {
-        return;
-    }
-    if leaf_panes.is_empty() {
-        return;
-    }
-    *fired = true;
     if !tab_q.is_empty() {
         return;
     }

--- a/crates/vmux_desktop/src/layout/window.rs
+++ b/crates/vmux_desktop/src/layout/window.rs
@@ -45,6 +45,7 @@ impl Plugin for WindowPlugin {
                 crate::persistence::rebuild_session_views,
                 crate::persistence::ensure_layout_state_entities,
                 crate::persistence::apply_persisted_layout_state,
+                crate::layout::tab::open_command_bar_if_no_tabs,
                 fit_window_to_screen,
             )
                 .chain()

--- a/crates/vmux_header/src/app.rs
+++ b/crates/vmux_header/src/app.rs
@@ -104,7 +104,13 @@ pub fn App() -> Element {
                                     });
                                 },
                                 if let Some(tab) = active_row.as_ref() {
-                                    if !tab.url.is_empty() {
+                                    if tab.url.is_empty() {
+                                Icon { class: "h-4 w-4 shrink-0 text-muted-foreground",
+                                    path { d: "M5 12h14" }
+                                    path { d: "M12 5v14" }
+                                }
+                                span { class: "min-w-0 truncate text-sm text-muted-foreground", "New tab" }
+                            } else {
                                 if tab.url.starts_with("vmux://terminal") {
                                     Icon { class: "h-4 w-4 shrink-0 text-muted-foreground",
                                         path { d: "M4 17 10 11 4 5" }

--- a/crates/vmux_side_sheet/src/app.rs
+++ b/crates/vmux_side_sheet/src/app.rs
@@ -117,7 +117,12 @@ fn TabRow(tab: TabNode, pane_id: u64) -> Element {
                     tab_index,
                 });
             },
-            if tab.url.starts_with("vmux://terminal") {
+            if tab.url.is_empty() {
+                Icon { class: "h-4 w-4 shrink-0 text-muted-foreground",
+                    path { d: "M5 12h14" }
+                    path { d: "M12 5v14" }
+                }
+            } else if tab.url.starts_with("vmux://terminal") {
                 Icon { class: "h-4 w-4 shrink-0 text-muted-foreground",
                     path { d: "M4 17 10 11 4 5" }
                     path { d: "M12 19h8" }


### PR DESCRIPTION
When closing the last tab in the root pane, instead of leaving a blank screen, spawn an empty tab and open the command bar so the user can navigate somewhere.

Closes VMX-83