### PR TITLE
fix(command_bar): prioritize URL detection over path in command bar

### DIFF
--- a/crates/vmux_command_bar/src/app.rs
+++ b/crates/vmux_command_bar/src/app.rs
@@ -31,7 +31,7 @@ enum ResultItem {
     },
 }
 
-use vmux_command_bar::event::looks_like_path;
+use vmux_command_bar::event::{looks_like_path, looks_like_url};
 
 fn filter_results(
     query: &str,
@@ -336,7 +336,7 @@ pub fn App() -> Element {
                                     Some(ResultItem::Terminal { .. }) => (false, true, false),
                                     Some(ResultItem::Tab { .. }) => (false, false, true),
                                     Some(ResultItem::Navigate { url }) => {
-                                        let is_u = url.contains("://") || (url.contains('.') && !url.contains(' '));
+                                        let is_u = looks_like_url(url);
                                         (false, false, is_u)
                                     }
                                     None => (false, false, false),
@@ -344,8 +344,8 @@ pub fn App() -> Element {
                             } else {
                                 let trimmed = q.trim();
                                 let cmd = trimmed.starts_with('>');
-                                let pth = !cmd && (trimmed.starts_with('/') || trimmed.starts_with('~'));
-                                let url = !cmd && !pth && (trimmed.contains("://") || (trimmed.contains('.') && !trimmed.contains(' ')));
+                                let url = !cmd && looks_like_url(trimmed);
+                                let pth = !cmd && !url && (trimmed.starts_with('/') || trimmed.starts_with('~'));
                                 (cmd, pth, url)
                             };
                             if is_command {

--- a/crates/vmux_command_bar/src/event.rs
+++ b/crates/vmux_command_bar/src/event.rs
@@ -54,15 +54,31 @@ pub struct PathCompleteResponse {
     pub query_is_dir: bool,
 }
 
+pub fn looks_like_url(s: &str) -> bool {
+    if s.contains("://") {
+        return true;
+    }
+    if s.contains(' ')
+        || s.starts_with('/')
+        || s.starts_with("~/")
+        || s.starts_with("./")
+        || s.starts_with("../")
+    {
+        return false;
+    }
+    let before_slash = s.split('/').next().unwrap_or(s);
+    before_slash.contains('.')
+}
+
 pub fn looks_like_path(s: &str) -> bool {
+    if looks_like_url(s) {
+        return false;
+    }
     s.starts_with('/')
         || s.starts_with("~/")
         || s.starts_with("./")
         || s.starts_with("../")
-        || s.contains('/')
-            && !s.contains(' ')
-            && !s.starts_with("http://")
-            && !s.starts_with("https://")
+        || (s.contains('/') && !s.contains(' '))
 }
 
 pub fn looks_like_explicit_path(s: &str) -> bool {
@@ -101,6 +117,34 @@ mod tests {
     fn looks_like_path_rejects_urls() {
         assert!(!looks_like_path("http://example.com/path"));
         assert!(!looks_like_path("https://example.com/path"));
+        assert!(!looks_like_path("google.com/maps"));
+        assert!(!looks_like_path("example.com"));
+    }
+
+    #[test]
+    fn looks_like_url_protocols() {
+        assert!(looks_like_url("http://example.com"));
+        assert!(looks_like_url("https://example.com/path"));
+    }
+
+    #[test]
+    fn looks_like_url_domain_like() {
+        assert!(looks_like_url("google.com"));
+        assert!(looks_like_url("google.com/maps"));
+        assert!(looks_like_url("example.co.uk/page"));
+    }
+
+    #[test]
+    fn looks_like_url_rejects_file_paths() {
+        assert!(!looks_like_url("src/main.rs"));
+        assert!(!looks_like_url("/usr/bin"));
+        assert!(!looks_like_url("foo/bar"));
+    }
+
+    #[test]
+    fn looks_like_url_rejects_spaces() {
+        assert!(!looks_like_url("search query"));
+        assert!(!looks_like_url("hello world.txt"));
     }
 
     #[test]


### PR DESCRIPTION
## Context

When typing a URL like `google.com/maps` in the command bar, the `/` caused it to be classified as a filesystem path instead of a URL. This blocked users from navigating to URLs containing slashes. Fixes VMX-57.

## Implementation

Extracted URL detection into a `looks_like_url()` helper (checks for `://` or dot-containing strings without spaces). `looks_like_path()` now defers to this check first, so URL-like inputs are never treated as paths. The icon logic was also reordered to evaluate URL before path, preventing the file icon from showing on URL inputs.

## Checks / QA

- Type `google.com/maps` in the command bar — should show globe icon and Navigate action, not file icon / Terminal
- Type `/usr/local/bin` — should still show file icon and Terminal action
- Type `https://example.com/path` — should show globe icon
- Type `~/Documents` — should show file icon
- Type `example.com` (no slash) — should show globe icon