### PR TITLE
fix(macos): show traffic light buttons when side sheet is open

### DIFF
--- a/crates/vmux_desktop/src/layout/side_sheet.rs
+++ b/crates/vmux_desktop/src/layout/side_sheet.rs
@@ -4,7 +4,7 @@ use crate::{
     layout::window::Main,
     settings::AppSettings,
 };
-use bevy::{prelude::*, ui::UiSystems, window::PrimaryWindow, winit::WinitWindows};
+use bevy::{ecs::system::NonSendMarker, prelude::*, ui::UiSystems, window::PrimaryWindow, winit::WINIT_WINDOWS};
 use vmux_header::Header;
 
 pub(crate) struct SideSheetLayoutPlugin;
@@ -236,73 +236,93 @@ fn sync_side_sheet_visibility(
 }
 
 /// Show/hide macOS traffic-light buttons to match the side-sheet state.
+///
+/// Uses `Local<Option<bool>>` to track the last-applied state instead of
+/// change-detection (`Added` / `RemovedComponents`) so we never miss a
+/// toggle – e.g. when the side-sheet is restored from persistence during
+/// startup.
 #[cfg(target_os = "macos")]
 fn sync_window_buttons_visibility(
     side_sheet_q: Query<(&SideSheetPosition, Has<Open>), With<SideSheet>>,
-    added: Query<Entity, (With<SideSheet>, Added<Open>)>,
-    mut removed: RemovedComponents<Open>,
-    winit_windows: Option<NonSend<WinitWindows>>,
     window_q: Query<Entity, With<PrimaryWindow>>,
+    mut last_open: Local<Option<bool>>,
+    _non_send: NonSendMarker,
 ) {
-    // Only react to left side sheet changes
-    let mut changed = false;
-    let mut is_open = false;
-    for entity in &added {
-        if let Ok((pos, _)) = side_sheet_q.get(entity)
-            && *pos == SideSheetPosition::Left
-        {
-            changed = true;
-            is_open = true;
-        }
-    }
-    if !changed {
-        for entity in removed.read() {
-            if let Ok((pos, _)) = side_sheet_q.get(entity)
-                && *pos == SideSheetPosition::Left
-            {
-                changed = true;
-            }
-        }
+    let is_open = side_sheet_q
+        .iter()
+        .any(|(pos, open)| *pos == SideSheetPosition::Left && open);
+
+    if *last_open == Some(is_open) {
+        return;
     }
 
-    if !changed {
-        return;
-    }
-    let Some(winit_windows) = winit_windows else {
-        return;
-    };
+    *last_open = Some(is_open);
+
     let Ok(entity) = window_q.single() else {
-        return;
-    };
-    let Some(winit_win) = winit_windows.get_window(entity) else {
-        return;
-    };
-
-    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
-    let Ok(handle) = winit_win.window_handle() else {
-        return;
-    };
-    let RawWindowHandle::AppKit(appkit) = handle.as_raw() else {
+        warn!("sync_window_buttons: no PrimaryWindow entity");
         return;
     };
 
-    // ns_view -> [view window] -> standardWindowButton: for each button type
-    let ns_view = appkit.ns_view.as_ptr();
-    unsafe {
-        use objc_ffi::{objc_msgSend, sel};
-        let ns_window = objc_msgSend(ns_view, sel("window"));
-        if ns_window.is_null() {
+    WINIT_WINDOWS.with_borrow(|winit_windows| {
+        let Some(winit_win) = winit_windows.get_window(entity) else {
+            // Window not yet created – reset so we retry next frame.
+            warn!("sync_window_buttons: winit window not found, will retry");
+            *last_open = None;
             return;
-        }
-        let hidden: libc::c_int = if is_open { 0 } else { 1 };
-        // NSWindowButton values: Close=0, Miniaturize=1, Zoom=2
-        for button_type in 0u64..=2 {
-            let button = objc_msgSend(ns_window, sel("standardWindowButton:"), button_type);
-            if !button.is_null() {
-                objc_msgSend(button, sel("setHidden:"), hidden);
+        };
+
+        use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+        let Ok(handle) = winit_win.window_handle() else {
+            warn!("sync_window_buttons: no window handle");
+            return;
+        };
+        let RawWindowHandle::AppKit(appkit) = handle.as_raw() else {
+            warn!("sync_window_buttons: not AppKit handle");
+            return;
+        };
+
+        let ns_view = appkit.ns_view.as_ptr();
+        unsafe {
+            use objc_ffi::sel;
+
+            // On ARM64 Apple, variadic arguments are passed on the stack,
+            // but objc_msgSend reads them from registers.  We must cast
+            // objc_msgSend to a properly-typed non-variadic function pointer
+            // for each call signature.
+            type MsgSendNoArgs =
+                unsafe extern "C" fn(*mut libc::c_void, *const libc::c_void) -> *mut libc::c_void;
+            type MsgSendU64 = unsafe extern "C" fn(
+                *mut libc::c_void,
+                *const libc::c_void,
+                u64,
+            ) -> *mut libc::c_void;
+            type MsgSendBool = unsafe extern "C" fn(
+                *mut libc::c_void,
+                *const libc::c_void,
+                libc::c_schar,
+            );
+
+            let send_no_args: MsgSendNoArgs =
+                std::mem::transmute(objc_ffi::objc_msgSend as *const ());
+            let send_u64: MsgSendU64 =
+                std::mem::transmute(objc_ffi::objc_msgSend as *const ());
+            let send_bool: MsgSendBool =
+                std::mem::transmute(objc_ffi::objc_msgSend as *const ());
+
+            let ns_window = send_no_args(ns_view, sel("window"));
+            if ns_window.is_null() {
+                return;
+            }
+            let hidden: libc::c_schar = if is_open { 0 } else { 1 };
+            // NSWindowButton values: Close=0, Miniaturize=1, Zoom=2
+            for button_type in 0u64..=2 {
+                let button = send_u64(ns_window, sel("standardWindowButton:"), button_type);
+                if !button.is_null() {
+                    send_bool(button, sel("setHidden:"), hidden);
+                }
             }
         }
-    }
+    });
 }
 
 #[cfg(not(target_os = "macos"))]

--- a/crates/vmux_desktop/src/layout/side_sheet.rs
+++ b/crates/vmux_desktop/src/layout/side_sheet.rs
@@ -4,7 +4,10 @@ use crate::{
     layout::window::Main,
     settings::AppSettings,
 };
-use bevy::{ecs::system::NonSendMarker, prelude::*, ui::UiSystems, window::PrimaryWindow, winit::WINIT_WINDOWS};
+use bevy::{
+    ecs::system::NonSendMarker, prelude::*, ui::UiSystems, window::PrimaryWindow,
+    winit::WINIT_WINDOWS,
+};
 use vmux_header::Header;
 
 pub(crate) struct SideSheetLayoutPlugin;
@@ -296,18 +299,13 @@ fn sync_window_buttons_visibility(
                 *const libc::c_void,
                 u64,
             ) -> *mut libc::c_void;
-            type MsgSendBool = unsafe extern "C" fn(
-                *mut libc::c_void,
-                *const libc::c_void,
-                libc::c_schar,
-            );
+            type MsgSendBool =
+                unsafe extern "C" fn(*mut libc::c_void, *const libc::c_void, libc::c_schar);
 
             let send_no_args: MsgSendNoArgs =
                 std::mem::transmute(objc_ffi::objc_msgSend as *const ());
-            let send_u64: MsgSendU64 =
-                std::mem::transmute(objc_ffi::objc_msgSend as *const ());
-            let send_bool: MsgSendBool =
-                std::mem::transmute(objc_ffi::objc_msgSend as *const ());
+            let send_u64: MsgSendU64 = std::mem::transmute(objc_ffi::objc_msgSend as *const ());
+            let send_bool: MsgSendBool = std::mem::transmute(objc_ffi::objc_msgSend as *const ());
 
             let ns_window = send_no_args(ns_view, sel("window"));
             if ns_window.is_null() {

--- a/crates/vmux_desktop/src/layout/window.rs
+++ b/crates/vmux_desktop/src/layout/window.rs
@@ -16,7 +16,7 @@ use bevy::{
     render::alpha::AlphaMode,
     ui::{FlexDirection, UiTargetCamera},
     window::PrimaryWindow,
-    winit::WinitWindows,
+    winit::WINIT_WINDOWS,
 };
 use bevy_cef::prelude::*;
 use vmux_command_bar::COMMAND_BAR_WEBVIEW_URL;
@@ -66,28 +66,26 @@ struct ScreenMaximized;
 
 /// Size the window to fill the current monitor (runs once at startup).
 fn maximize_window_to_screen(
-    winit_windows: Option<NonSend<WinitWindows>>,
     mut window_q: Query<(Entity, &mut Window), With<PrimaryWindow>>,
     mut commands: Commands,
 ) {
-    let Some(winit_windows) = winit_windows else {
-        return;
-    };
     let Ok((entity, mut window)) = window_q.single_mut() else {
         return;
     };
-    let Some(winit_win) = winit_windows.get_window(entity) else {
-        return;
-    };
-    let Some(monitor) = winit_win.current_monitor() else {
-        return;
-    };
-    let size = monitor.size();
-    let scale = monitor.scale_factor() as f32;
-    let logical_w = size.width as f32 / scale;
-    let logical_h = size.height as f32 / scale;
-    window.resolution.set(logical_w, logical_h);
-    commands.insert_resource(ScreenMaximized);
+    WINIT_WINDOWS.with_borrow(|winit_windows| {
+        let Some(winit_win) = winit_windows.get_window(entity) else {
+            return;
+        };
+        let Some(monitor) = winit_win.current_monitor() else {
+            return;
+        };
+        let size = monitor.size();
+        let scale = monitor.scale_factor() as f32;
+        let logical_w = size.width as f32 / scale;
+        let logical_h = size.height as f32 / scale;
+        window.resolution.set(logical_w, logical_h);
+        commands.insert_resource(ScreenMaximized);
+    });
 }
 
 #[derive(Bundle)]

--- a/crates/vmux_desktop/src/lib.rs
+++ b/crates/vmux_desktop/src/lib.rs
@@ -51,7 +51,10 @@ impl Plugin for VmuxPlugin {
             transparent: true,
             composite_alpha_mode: CompositeAlphaMode::PostMultiplied,
             decorations: true,
-            titlebar_shown: false,
+            titlebar_shown: true,
+            titlebar_transparent: true,
+            titlebar_show_title: false,
+            titlebar_show_buttons: false,
             movable_by_window_background: false,
             fullsize_content_view: true,
             ..default()

--- a/crates/vmux_side_sheet/src/app.rs
+++ b/crates/vmux_side_sheet/src/app.rs
@@ -36,7 +36,7 @@ pub fn App() -> Element {
     let PaneTreeEvent { panes } = tree_state();
 
     rsx! {
-        div { class: "flex h-full flex-col overflow-y-auto px-2 py-3 text-foreground",
+        div { class: "flex h-full flex-col overflow-y-auto px-2 pb-3 pt-10 text-foreground",
             if (listener.is_loading)() {
                 div { class: "flex items-center px-2 py-1",
                     span { class: "text-ui text-muted-foreground", "Connecting…" }


### PR DESCRIPTION
## Root Cause

`titlebar_shown: false` caused winit to set `NSWindowStyleMask::Borderless` instead of `NSWindowStyleMask::Titled`. With Borderless, `standardWindowButton:` returns nil, so the `setHidden:0` calls in `sync_window_buttons_visibility` were no-ops.

## Fix

Replace `titlebar_shown: false` with:
- `titlebar_shown: true` (keeps Titled style mask, buttons exist)
- `titlebar_transparent: true` (invisible titlebar background)
- `titlebar_show_title: false` (hide window title text)
- `titlebar_show_buttons: false` (hide buttons initially)

The existing `sync_window_buttons_visibility` system then works correctly — `setHidden:0` shows the buttons when the left side sheet opens.

Closes VMX-81