### PR TITLE
feat(command-bar): toggle cmd+t, keep active tab visible, first-launch open, + New Tab button

### DIFF
--- a/crates/vmux_command_bar/src/app.rs
+++ b/crates/vmux_command_bar/src/app.rs
@@ -12,6 +12,7 @@ use wasm_bindgen::prelude::*;
 
 #[derive(Clone, PartialEq)]
 enum ResultItem {
+    NewTab,
     Terminal {
         path: String,
     },
@@ -31,25 +32,50 @@ enum ResultItem {
     },
 }
 
+fn looks_like_path(s: &str) -> bool {
+    s.starts_with('/')
+        || s.starts_with("~/")
+        || s.starts_with("./")
+        || s.starts_with("../")
+        || s.contains('/')
+            && !s.contains(' ')
+            && !s.starts_with("http://")
+            && !s.starts_with("https://")
+}
+>>>>>>> 019f345 (feat(command-bar): toggle cmd+t, keep active tab visible, first-launch open, + New Tab button)
+=======
 use vmux_command_bar::event::{looks_like_path, looks_like_url};
+=======
+fn looks_like_path(s: &str) -> bool {
+    s.starts_with('/')
+        || s.starts_with("~/")
+        || s.starts_with("./")
+        || s.starts_with("../")
+        || s.contains('/')
+            && !s.contains(' ')
+            && !s.starts_with("http://")
+            && !s.starts_with("https://")
+}
+>>>>>>> 019f345 (feat(command-bar): toggle cmd+t, keep active tab visible, first-launch open, + New Tab button)
 
 fn filter_results(
     query: &str,
     tabs: &[CommandBarTab],
     commands: &[CommandBarCommandEntry],
     new_tab: bool,
-    current_url: &str,
 ) -> Vec<ResultItem> {
-    let current_is_terminal = current_url.starts_with("vmux://terminal");
-    let show_terminal = new_tab || !current_is_terminal;
     let q = query.trim();
     if q.is_empty() {
         let mut items: Vec<ResultItem> = Vec::new();
         items.push(ResultItem::Navigate { url: String::new() });
-        if show_terminal {
+        if new_tab {
             items.push(ResultItem::Terminal {
                 path: String::new(),
             });
+        }
+        // Show "+ New Tab" above the tab list when browsing existing tabs
+        if !new_tab && !tabs.is_empty() {
+            items.push(ResultItem::NewTab);
         }
         items.extend(tabs.iter().map(|t| ResultItem::Tab {
             title: t.title.clone(),
@@ -79,7 +105,7 @@ fn filter_results(
         });
     }
 
-    if !starts_with_cmd && !is_path && show_terminal && "terminal".contains(&search_lower) {
+    if !starts_with_cmd && !is_path && new_tab && "terminal".contains(&search_lower) {
         items.push(ResultItem::Terminal {
             path: String::new(),
         });
@@ -141,11 +167,10 @@ fn filter_results(
     items
 }
 
-fn emit_action(action: &str, value: &str, new_tab: bool) {
+fn emit_action(action: &str, value: &str) {
     let _ = try_cef_emit_serde(&CommandBarActionEvent {
         action: action.to_string(),
         value: value.to_string(),
-        new_tab,
     });
 }
 
@@ -160,7 +185,6 @@ pub fn App() -> Element {
     let mut nav_mode = use_signal(|| false);
 
     let mut path_completions = use_signal(Vec::<PathEntry>::new);
-    let mut path_query_is_dir = use_signal(|| false);
 
     let _listener =
         use_event_listener::<CommandBarOpenEvent, _>(COMMAND_BAR_OPEN_EVENT, move |data| {
@@ -175,14 +199,12 @@ pub fn App() -> Element {
     let _path_listener =
         use_event_listener::<PathCompleteResponse, _>(PATH_COMPLETE_RESPONSE, move |data| {
             path_completions.set(data.completions);
-            path_query_is_dir.set(data.query_is_dir);
         });
 
     use_effect(move || {
         let q = query();
         if !looks_like_path(q.trim()) {
             path_completions.set(Vec::new());
-            path_query_is_dir.set(false);
             return;
         }
         let _ = try_cef_emit_serde(&PathCompleteRequest {
@@ -200,7 +222,7 @@ pub fn App() -> Element {
     });
 
     let CommandBarOpenEvent {
-        url: current_url,
+        url: _,
         tabs,
         commands,
         new_tab: _,
@@ -208,9 +230,8 @@ pub fn App() -> Element {
     let q = query();
     let is_new_tab = new_tab();
     let results = {
-        let mut r = filter_results(&q, &tabs, &commands, is_new_tab, &current_url);
+        let mut r = filter_results(&q, &tabs, &commands, is_new_tab);
         let completions = path_completions();
-        let is_dir = path_query_is_dir();
         if !completions.is_empty() {
             let path_items: Vec<ResultItem> = completions
                 .iter()
@@ -226,8 +247,7 @@ pub fn App() -> Element {
                 .cloned();
             r.retain(|item| !matches!(item, ResultItem::Terminal { path } if !path.is_empty()));
             let mut combined = Vec::new();
-            if is_dir
-                && let Some(ref entry @ ResultItem::Terminal { path: ref tp }) = typed_terminal
+            if let Some(ref entry @ ResultItem::Terminal { path: ref tp }) = typed_terminal
                 && !path_items
                     .iter()
                     .any(|item| matches!(item, ResultItem::Terminal { path } if path == tp))
@@ -238,10 +258,6 @@ pub fn App() -> Element {
             combined.extend(r);
             combined
         } else {
-            // No completions — hide typed path item if the path doesn't exist
-            if !is_dir {
-                r.retain(|item| !matches!(item, ResultItem::Terminal { path } if !path.is_empty()));
-            }
             r
         }
     };
@@ -250,6 +266,7 @@ pub fn App() -> Element {
     let nav = nav_mode();
     let display_text = if nav {
         match &active_item {
+            Some(ResultItem::NewTab) => String::new(),
             Some(ResultItem::Command { name, .. }) => format!("> {name}"),
             Some(ResultItem::Navigate { url }) => url.clone(),
             Some(ResultItem::Tab { url, .. }) => url.clone(),
@@ -291,22 +308,24 @@ pub fn App() -> Element {
 
     let mut execute = move |item: &ResultItem| {
         is_open.set(false);
-        let nt = new_tab();
         match item {
+            ResultItem::NewTab => {
+                emit_action("command", "tab_new");
+            }
             ResultItem::Terminal { path } => {
-                emit_action("terminal", path, nt);
+                emit_action("terminal", path);
             }
             ResultItem::Tab {
                 pane_id, tab_index, ..
             } => {
-                emit_action("switch_tab", &format!("{pane_id}:{tab_index}"), nt);
+                emit_action("switch_tab", &format!("{pane_id}:{tab_index}"));
             }
             ResultItem::Command { id, .. } => {
-                emit_action("command", id, nt);
+                emit_action("command", id);
             }
             ResultItem::Navigate { url } => {
                 if !url.is_empty() {
-                    emit_action("navigate", url, nt);
+                    emit_action("navigate", url);
                 }
             }
         }
@@ -318,8 +337,8 @@ pub fn App() -> Element {
 
     rsx! {
         div {
-            class: "flex h-full w-full items-start justify-center pt-[15%]",
-            onclick: move |_| { is_open.set(false); emit_action("dismiss", "", new_tab()); },
+            class: "flex h-full w-full items-start justify-center pt-[15%] bg-white/5 backdrop-blur-md backdrop-saturate-150",
+            onclick: move |_| { is_open.set(false); emit_action("dismiss", ""); },
             div {
                 class: "relative flex w-full max-w-xl flex-col overflow-hidden rounded-2xl border border-white/20 bg-white/10 shadow-2xl backdrop-blur-2xl backdrop-saturate-150",
                 onclick: move |e| { e.stop_propagation(); },
@@ -331,6 +350,7 @@ pub fn App() -> Element {
                             let icon_class = "h-4 w-4 shrink-0 text-muted-foreground";
                             let (is_command, is_path, is_url) = if nav {
                                 match &active_item {
+                                    Some(ResultItem::NewTab) => (false, false, false),
                                     Some(ResultItem::Command { .. }) => (true, false, false),
                                     Some(ResultItem::Terminal { path }) if path.is_empty() => (true, false, false),
                                     Some(ResultItem::Terminal { .. }) => (false, true, false),
@@ -433,12 +453,12 @@ pub fn App() -> Element {
                                         || (ctrl && e.code() == Code::KeyC)
                                     {
                                         is_open.set(false);
-                                        emit_action("dismiss", "", new_tab());
+                                        emit_action("dismiss", "");
                                     } else if e.key() == Key::Enter {
                                         if let Some(item) = results.get(sel) {
                                             execute(item);
                                         } else if !q.is_empty() {
-                                            emit_action("navigate", &q, new_tab());
+                                            emit_action("navigate", &q);
                                         }
                                     }
                                 },
@@ -462,15 +482,21 @@ pub fn App() -> Element {
                                     move |_| { execute(&item); }
                                 },
                                 match item {
+                                    ResultItem::NewTab => rsx! {
+                                        div { class: "flex items-center gap-2",
+                                            Icon { class: "h-4 w-4 shrink-0 text-muted-foreground",
+                                                path { d: "M12 5v14" }
+                                                path { d: "M5 12h14" }
+                                            }
+                                            span { class: "text-base text-foreground", "New Tab" }
+                                        }
+                                        span { class: "ml-2 shrink-0 rounded bg-muted px-1.5 py-0.5 text-sm text-muted-foreground", "\u{2318}T" }
+                                    },
                                     ResultItem::Terminal { path } => rsx! {
                                         div { class: "flex items-center gap-2",
                                             span { class: "shrink-0 text-base text-muted-foreground", ">_" }
                                             if path.is_empty() {
-                                                if is_new_tab {
-                                                    span { class: "text-base text-foreground", "Open Terminal" }
-                                                } else {
-                                                    span { class: "text-base text-foreground", "Open Terminal in New Tab" }
-                                                }
+                                                span { class: "text-base text-foreground", "Terminal" }
                                             } else {
                                                 span { class: "text-base text-foreground", "Open in Terminal" }
                                                 span { class: "ml-1 text-sm text-muted-foreground", "{path}" }

--- a/crates/vmux_command_bar/src/event.rs
+++ b/crates/vmux_command_bar/src/event.rs
@@ -28,7 +28,6 @@ pub struct CommandBarCommandEntry {
 pub struct CommandBarActionEvent {
     pub action: String,
     pub value: String,
-    pub new_tab: bool,
 }
 
 pub const PATH_COMPLETE_REQUEST: &str = "path-complete-request";
@@ -49,9 +48,6 @@ pub struct PathEntry {
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct PathCompleteResponse {
     pub completions: Vec<PathEntry>,
-    /// Whether the exact queried path is an existing directory.
-    #[serde(default)]
-    pub query_is_dir: bool,
 }
 
 pub fn looks_like_url(s: &str) -> bool {
@@ -182,19 +178,12 @@ mod tests {
     }
 
     #[test]
-    fn action_event_new_tab_field() {
+    fn action_event_fields() {
         let evt = CommandBarActionEvent {
             action: "navigate".to_string(),
             value: "google.com".to_string(),
-            new_tab: false,
         };
-        assert!(!evt.new_tab);
-
-        let evt_new = CommandBarActionEvent {
-            action: "navigate".to_string(),
-            value: "google.com".to_string(),
-            new_tab: true,
-        };
-        assert!(evt_new.new_tab);
+        assert_eq!(evt.action, "navigate");
+        assert_eq!(evt.value, "google.com");
     }
 }

--- a/crates/vmux_desktop/src/browser.rs
+++ b/crates/vmux_desktop/src/browser.rs
@@ -586,7 +586,7 @@ fn push_tabs_host_emit(
     {
         rows.retain(|r| !r.is_active);
         rows.push(TabRow {
-            title: "+ New Tab".to_string(),
+            title: "New Tab".to_string(),
             url: String::new(),
             favicon_url: String::new(),
             is_active: true,
@@ -660,7 +660,7 @@ fn push_pane_tree_emit(
                             let is_new_tab = new_tab_ctx.tab == Some(child)
                                 && (meta.url.is_empty() || meta.url == "about:blank");
                             tabs.push(TabNode {
-                                title: if is_new_tab { "+ New Tab".to_string() } else { meta.title.clone() },
+                                title: if is_new_tab { "New Tab".to_string() } else { meta.title.clone() },
                                 url: if is_new_tab { String::new() } else { meta.url.clone() },
                                 favicon_url: if is_new_tab { String::new() } else { meta.favicon_url.clone() },
                                 is_active: tab_is_active,

--- a/crates/vmux_desktop/src/browser.rs
+++ b/crates/vmux_desktop/src/browser.rs
@@ -231,6 +231,7 @@ fn sync_children_to_ui(
     pane_rect: Query<(&ComputedNode, &UiGlobalTransform), With<Pane>>,
     pane_children: Query<&Children, With<Pane>>,
     tab_ts: Query<(Entity, &LastActivatedAt), With<Tab>>,
+    new_tab_ctx: Res<crate::command_bar::NewTabContext>,
     glass: Single<(Entity, &ComputedNode, &UiGlobalTransform), With<VmuxWindow>>,
 ) {
     let &(glass_entity, glass_node, glass_ui_gt) = &*glass;
@@ -271,8 +272,16 @@ fn sync_children_to_ui(
             true
         };
 
-        let is_inactive_tab =
-            parent != glass_entity && status.is_none() && side_sheet.is_none() && !is_active_tab;
+        // Keep rendering the previous tab behind while a new empty tab
+        // (without CEF content) is pending in the command bar flow.
+        let is_previous_tab = new_tab_ctx.tab.is_some()
+            && new_tab_ctx.previous_tab == Some(parent);
+
+        let is_inactive_tab = parent != glass_entity
+            && status.is_none()
+            && side_sheet.is_none()
+            && !is_active_tab
+            && !is_previous_tab;
 
         let sx = size_px.x / glass_size_px.x;
         let sy = size_px.y / glass_size_px.y;
@@ -400,6 +409,7 @@ fn sync_osr_webview_focus(
     browsers: NonSend<Browsers>,
     webviews: Query<Entity, With<WebviewSource>>,
     focus: Res<crate::layout::tab::FocusedTab>,
+    new_tab_ctx: Res<crate::command_bar::NewTabContext>,
     leaf_panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
     pane_children_q: Query<&Children, With<Pane>>,
     tab_ts: Query<(Entity, &LastActivatedAt), With<Tab>>,
@@ -453,7 +463,12 @@ fn sync_osr_webview_focus(
             browsers.set_osr_not_hidden(&e);
             continue;
         }
-        if active_tab_in_pane(pane, &pane_children_q, &tab_ts) == Some(parent) {
+        let is_active = active_tab_in_pane(pane, &pane_children_q, &tab_ts) == Some(parent);
+        // Keep previous tab's webview visible while an empty new tab is
+        // pending (user is picking content in the command bar).
+        let is_prev = new_tab_ctx.tab.is_some()
+            && new_tab_ctx.previous_tab == Some(parent);
+        if is_active || is_prev {
             browsers.set_osr_not_hidden(&e);
         } else {
             browsers.set_osr_hidden(&e);
@@ -564,11 +579,12 @@ fn push_tabs_host_emit(
             });
         }
     }
-    // If the active tab is an empty new-tab, add a placeholder row
+    // If the active tab is a new-tab (pending content selection),
+    // replace any pre-spawned browser row with a "New tab" placeholder.
     if let Some(empty_tab) = new_tab_ctx.tab
         && active_tab_opt == Some(empty_tab)
-        && !rows.iter().any(|r| r.is_active)
     {
+        rows.retain(|r| !r.is_active);
         rows.push(TabRow {
             title: "New tab".to_string(),
             url: String::new(),

--- a/crates/vmux_desktop/src/browser.rs
+++ b/crates/vmux_desktop/src/browser.rs
@@ -586,7 +586,7 @@ fn push_tabs_host_emit(
     {
         rows.retain(|r| !r.is_active);
         rows.push(TabRow {
-            title: "New tab".to_string(),
+            title: "+ New Tab".to_string(),
             url: String::new(),
             favicon_url: String::new(),
             is_active: true,
@@ -614,6 +614,7 @@ fn push_pane_tree_emit(
     mut commands: Commands,
     browsers: NonSend<Browsers>,
     side_sheet: Option<Single<Entity, (With<SideSheet>, With<UiReady>)>>,
+    new_tab_ctx: Res<crate::command_bar::NewTabContext>,
     focus: Res<crate::layout::tab::FocusedTab>,
     all_children: Query<&Children>,
     leaf_pane_q: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
@@ -656,10 +657,12 @@ fn push_pane_tree_emit(
                 if let Ok(tab_kids) = tab_children.get(child) {
                     for browser_e in tab_kids.iter() {
                         if let Ok((meta, loading)) = browser_meta.get(browser_e) {
+                            let is_new_tab = new_tab_ctx.tab == Some(child)
+                                && (meta.url.is_empty() || meta.url == "about:blank");
                             tabs.push(TabNode {
-                                title: meta.title.clone(),
-                                url: meta.url.clone(),
-                                favicon_url: meta.favicon_url.clone(),
+                                title: if is_new_tab { "+ New Tab".to_string() } else { meta.title.clone() },
+                                url: if is_new_tab { String::new() } else { meta.url.clone() },
+                                favicon_url: if is_new_tab { String::new() } else { meta.favicon_url.clone() },
                                 is_active: tab_is_active,
                                 tab_index,
                                 is_loading: loading,

--- a/crates/vmux_desktop/src/command_bar.rs
+++ b/crates/vmux_desktop/src/command_bar.rs
@@ -1,11 +1,13 @@
 use crate::{
     browser::Browser,
-    command::{AppCommand, BrowserCommand, PaneCommand, ReadAppCommands, TabCommand},
+    command::{
+        AppCommand, BrowserCommand, PaneCommand, ReadAppCommands, TabCommand, TerminalCommand,
+    },
     layout::{
         pane::{Pane, PaneSplit},
         side_sheet::SideSheet,
         space::Space,
-        tab::{Tab, active_among, collect_leaf_panes, focused_tab},
+        tab::{Tab, TabCommandSet, active_among, collect_leaf_panes, focused_tab},
         window::Modal,
     },
     settings::AppSettings,
@@ -18,7 +20,6 @@ use bevy_cef::prelude::*;
 use vmux_command_bar::event::{
     COMMAND_BAR_OPEN_EVENT, CommandBarActionEvent, CommandBarCommandEntry, CommandBarOpenEvent,
     CommandBarTab, PATH_COMPLETE_RESPONSE, PathCompleteRequest, PathCompleteResponse, PathEntry,
-    looks_like_explicit_path,
 };
 use vmux_header::{Header, PageMetadata};
 use vmux_history::LastActivatedAt;
@@ -28,6 +29,11 @@ use vmux_terminal::event::TERMINAL_WEBVIEW_URL;
 /// so CEF can resize the webview before the modal becomes visible.
 #[derive(Component)]
 struct PendingCommandBarReveal(u8);
+
+/// Inserted during the first app launch (no session file) so that the command
+/// bar opens automatically once the modal webview is ready.
+#[derive(Resource)]
+pub(crate) struct PendingFirstLaunchOpen;
 
 /// Tracks an empty tab spawned by Cmd+T that is waiting for the user
 /// to choose content via the command bar.
@@ -52,7 +58,15 @@ impl Plugin for CommandBarInputPlugin {
             .add_plugins(JsEmitEventPlugin::<PathCompleteRequest>::default())
             .add_observer(on_command_bar_action)
             .add_observer(on_path_complete_request)
-            .add_systems(Update, handle_open_command_bar.in_set(ReadAppCommands))
+            .add_systems(
+                Update,
+                (
+                    handle_open_command_bar
+                        .in_set(ReadAppCommands)
+                        .after(TabCommandSet),
+                    first_launch_open_command_bar.before(ReadAppCommands),
+                ),
+            )
             .add_systems(
                 Update,
                 deferred_dismiss_modal
@@ -83,6 +97,31 @@ pub fn match_command(id: &str) -> Option<AppCommand> {
 /// Returns true when the command bar modal is currently visible.
 pub fn is_command_bar_open(modal_q: &Query<&Node, With<Modal>>) -> bool {
     modal_q.iter().any(|n| n.display != Display::None)
+}
+
+/// Despawn any pre-spawned Browser children of a tab (e.g. the transparent
+/// about:blank browser + glass created by Cmd+T) before attaching real content.
+fn despawn_tab_browsers(
+    tab: Entity,
+    all_children: &Query<&Children>,
+    content_browsers: &Query<
+        Entity,
+        (
+            With<Browser>,
+            Without<Header>,
+            Without<SideSheet>,
+            Without<Modal>,
+        ),
+    >,
+    commands: &mut Commands,
+) {
+    if let Ok(children) = all_children.get(tab) {
+        for child in children.iter() {
+            if content_browsers.contains(child) {
+                commands.entity(child).despawn();
+            }
+        }
+    }
 }
 
 fn handle_open_command_bar(
@@ -401,39 +440,12 @@ fn on_command_bar_action(
     let evt = &trigger.event().payload;
     let empty_tab = new_tab_ctx.tab;
     let previous_tab = new_tab_ctx.previous_tab;
+    // Track whether we handle keyboard restore ourselves
     let mut custom_keyboard_restore = false;
-
-    let current_tab = || {
-        focused_tab(
-            &spaces,
-            &all_children,
-            &leaf_panes,
-            &pane_ts,
-            &pane_children,
-            &tab_ts,
-        )
-    };
-
-    let current_tab_has_browser = |tab: Entity| -> Option<Entity> {
-        let children = all_children.get(tab).ok()?;
-        children.iter().find(|&e| content_browsers.contains(e))
-    };
-
-    let current_tab_has_terminal = |tab: Entity| -> bool {
-        all_children
-            .get(tab)
-            .ok()
-            .map(|children| {
-                let has_children = !children.is_empty();
-                let has_browser = children.iter().any(|e| content_browsers.contains(e));
-                has_children && !has_browser
-            })
-            .unwrap_or(false)
-    };
 
     match evt.action.as_str() {
         "navigate" => {
-            let looks_like_path = looks_like_explicit_path(&evt.value);
+            // Detect filesystem paths — open terminal with cwd instead of browser
             let expanded = if evt.value.starts_with('~') {
                 std::env::var("HOME")
                     .ok()
@@ -441,10 +453,15 @@ fn on_command_bar_action(
                         std::path::PathBuf::from(h).join(evt.value[1..].trim_start_matches('/'))
                     })
                     .unwrap_or_else(|| std::path::PathBuf::from(&evt.value))
-            } else {
+            } else if evt.value.starts_with('/') {
                 std::path::PathBuf::from(&evt.value)
+            } else {
+                std::env::var("HOME")
+                    .ok()
+                    .map(|h| std::path::PathBuf::from(h).join(&evt.value))
+                    .unwrap_or_else(|| std::path::PathBuf::from(&evt.value))
             };
-            let is_path = looks_like_path && expanded.exists();
+            let is_path = expanded.exists();
 
             if is_path {
                 let dir = if expanded.is_dir() {
@@ -452,108 +469,29 @@ fn on_command_bar_action(
                 } else {
                     expanded.parent().unwrap_or(&expanded)
                 };
-                if evt.new_tab {
-                    if let Some(tab_e) = empty_tab {
-                        commands.entity(tab_e).insert(PageMetadata {
-                            url: TERMINAL_WEBVIEW_URL.to_string(),
-                            title: format!("Terminal ({})", dir.display()),
-                            ..default()
-                        });
-                        let term_e = commands
-                            .spawn((
-                                Terminal::new_with_cwd(
-                                    &mut meshes,
-                                    &mut webview_mt,
-                                    &settings,
-                                    Some(dir),
-                                ),
-                                ChildOf(tab_e),
-                            ))
-                            .id();
-                        commands.entity(term_e).insert(CefKeyboardTarget);
-                        new_tab_ctx.tab = None;
-                        new_tab_ctx.previous_tab = None;
-                        custom_keyboard_restore = true;
-                    }
-                } else {
-                    let (_, active_pane, active_tab) = current_tab();
-                    if let Some(tab) = active_tab {
-                        if let Some(browser_e) = current_tab_has_browser(tab) {
-                            commands.entity(browser_e).despawn();
-                            commands.entity(tab).insert(PageMetadata {
-                                url: TERMINAL_WEBVIEW_URL.to_string(),
-                                title: format!("Terminal ({})", dir.display()),
-                                ..default()
-                            });
-                            let term_e = commands
-                                .spawn((
-                                    Terminal::new_with_cwd(
-                                        &mut meshes,
-                                        &mut webview_mt,
-                                        &settings,
-                                        Some(dir),
-                                    ),
-                                    ChildOf(tab),
-                                ))
-                                .id();
-                            commands.entity(term_e).insert(CefKeyboardTarget);
-                            custom_keyboard_restore = true;
-                        } else if current_tab_has_terminal(tab)
-                            && let Some(pane_e) = active_pane
-                        {
-                            let new_tab_e = commands
-                                .spawn((
-                                    crate::layout::tab::tab_bundle(),
-                                    LastActivatedAt::now(),
-                                    ChildOf(pane_e),
-                                ))
-                                .id();
-                            commands.entity(new_tab_e).insert(PageMetadata {
-                                url: TERMINAL_WEBVIEW_URL.to_string(),
-                                title: format!("Terminal ({})", dir.display()),
-                                ..default()
-                            });
-                            let term_e = commands
-                                .spawn((
-                                    Terminal::new_with_cwd(
-                                        &mut meshes,
-                                        &mut webview_mt,
-                                        &settings,
-                                        Some(dir),
-                                    ),
-                                    ChildOf(new_tab_e),
-                                ))
-                                .id();
-                            commands.entity(term_e).insert(CefKeyboardTarget);
-                            custom_keyboard_restore = true;
-                        }
-                    } else if let Some(pane_e) = active_pane {
-                        let new_tab_e = commands
-                            .spawn((
-                                crate::layout::tab::tab_bundle(),
-                                LastActivatedAt::now(),
-                                ChildOf(pane_e),
-                            ))
-                            .id();
-                        commands.entity(new_tab_e).insert(PageMetadata {
-                            url: TERMINAL_WEBVIEW_URL.to_string(),
-                            title: format!("Terminal ({})", dir.display()),
-                            ..default()
-                        });
-                        let term_e = commands
-                            .spawn((
-                                Terminal::new_with_cwd(
-                                    &mut meshes,
-                                    &mut webview_mt,
-                                    &settings,
-                                    Some(dir),
-                                ),
-                                ChildOf(new_tab_e),
-                            ))
-                            .id();
-                        commands.entity(term_e).insert(CefKeyboardTarget);
-                        custom_keyboard_restore = true;
-                    }
+                if let Some(tab_e) = empty_tab {
+                    // Despawn pre-spawned transparent browser + glass
+                    despawn_tab_browsers(tab_e, &all_children, &content_browsers, &mut commands);
+                    commands.entity(tab_e).insert(PageMetadata {
+                        url: TERMINAL_WEBVIEW_URL.to_string(),
+                        title: format!("Terminal ({})", dir.display()),
+                        ..default()
+                    });
+                    let term_e = commands
+                        .spawn((
+                            Terminal::new_with_cwd(
+                                &mut meshes,
+                                &mut webview_mt,
+                                &settings,
+                                Some(dir),
+                            ),
+                            ChildOf(tab_e),
+                        ))
+                        .id();
+                    commands.entity(term_e).insert(CefKeyboardTarget);
+                    new_tab_ctx.tab = None;
+                    new_tab_ctx.previous_tab = None;
+                    custom_keyboard_restore = true;
                 }
             } else {
                 let url = if evt.value.contains("://") {
@@ -564,139 +502,60 @@ fn on_command_bar_action(
                     format!("https://www.google.com/search?q={}", evt.value)
                 };
 
-                if evt.new_tab {
-                    if let Some(tab_e) = empty_tab {
-                        if url.starts_with("vmux://terminal") {
-                            commands.entity(tab_e).insert(PageMetadata {
-                                url: TERMINAL_WEBVIEW_URL.to_string(),
-                                title: "Terminal (Session: -)".to_string(),
-                                ..default()
-                            });
-                            let term_e = commands
-                                .spawn((
-                                    Terminal::new(&mut meshes, &mut webview_mt, &settings),
-                                    ChildOf(tab_e),
-                                ))
-                                .id();
-                            commands.entity(term_e).insert(CefKeyboardTarget);
-                        } else {
-                            let browser_e = commands
-                                .spawn((
-                                    Browser::new(&mut meshes, &mut webview_mt, &url),
-                                    ChildOf(tab_e),
-                                ))
-                                .id();
-                            commands.entity(browser_e).insert(CefKeyboardTarget);
-                        }
-                        new_tab_ctx.tab = None;
-                        new_tab_ctx.previous_tab = None;
-                        custom_keyboard_restore = true;
-                    }
-                } else {
-                    let (_, active_pane, active_tab) = current_tab();
-                    if let Some(tab) = active_tab {
-                        if url.starts_with("vmux://terminal") {
-                            if let Some(browser_e) = current_tab_has_browser(tab) {
-                                commands.entity(browser_e).despawn();
-                                commands.entity(tab).insert(PageMetadata {
-                                    url: TERMINAL_WEBVIEW_URL.to_string(),
-                                    title: "Terminal (Session: -)".to_string(),
-                                    ..default()
-                                });
-                                let term_e = commands
-                                    .spawn((
-                                        Terminal::new(&mut meshes, &mut webview_mt, &settings),
-                                        ChildOf(tab),
-                                    ))
-                                    .id();
-                                commands.entity(term_e).insert(CefKeyboardTarget);
-                                custom_keyboard_restore = true;
-                            } else if current_tab_has_terminal(tab)
-                                && let Some(pane_e) = active_pane
-                            {
-                                let new_tab_e = commands
-                                    .spawn((
-                                        crate::layout::tab::tab_bundle(),
-                                        LastActivatedAt::now(),
-                                        ChildOf(pane_e),
-                                    ))
-                                    .id();
-                                commands.entity(new_tab_e).insert(PageMetadata {
-                                    url: TERMINAL_WEBVIEW_URL.to_string(),
-                                    title: "Terminal (Session: -)".to_string(),
-                                    ..default()
-                                });
-                                let term_e = commands
-                                    .spawn((
-                                        Terminal::new(&mut meshes, &mut webview_mt, &settings),
-                                        ChildOf(new_tab_e),
-                                    ))
-                                    .id();
-                                commands.entity(term_e).insert(CefKeyboardTarget);
-                                custom_keyboard_restore = true;
-                            }
-                        } else if let Some(browser_e) = current_tab_has_browser(tab) {
-                            commands.entity(browser_e).insert(WebviewSource::new(&url));
-                        } else if current_tab_has_terminal(tab)
-                            && let Some(pane_e) = active_pane
-                        {
-                            let new_tab_e = commands
-                                .spawn((
-                                    crate::layout::tab::tab_bundle(),
-                                    LastActivatedAt::now(),
-                                    ChildOf(pane_e),
-                                ))
-                                .id();
-                            commands.entity(new_tab_e).insert(PageMetadata {
-                                url: url.clone(),
-                                title: url.clone(),
-                                ..default()
-                            });
-                            let browser_e = commands
-                                .spawn((
-                                    Browser::new(&mut meshes, &mut webview_mt, &url),
-                                    ChildOf(new_tab_e),
-                                ))
-                                .id();
-                            commands.entity(browser_e).insert(CefKeyboardTarget);
-                            custom_keyboard_restore = true;
-                        }
-                    } else if let Some(pane_e) = active_pane {
-                        let new_tab_e = commands
+                if let Some(tab_e) = empty_tab {
+                    // Despawn pre-spawned transparent browser + glass
+                    despawn_tab_browsers(tab_e, &all_children, &content_browsers, &mut commands);
+                    // New tab mode: attach content to the empty tab
+                    if url.starts_with("vmux://terminal") {
+                        commands.entity(tab_e).insert(PageMetadata {
+                            url: TERMINAL_WEBVIEW_URL.to_string(),
+                            title: "Terminal (Session: -)".to_string(),
+                            ..default()
+                        });
+                        let term_e = commands
                             .spawn((
-                                crate::layout::tab::tab_bundle(),
-                                LastActivatedAt::now(),
-                                ChildOf(pane_e),
+                                Terminal::new(&mut meshes, &mut webview_mt, &settings),
+                                ChildOf(tab_e),
                             ))
                             .id();
-                        if url.starts_with("vmux://terminal") {
-                            commands.entity(new_tab_e).insert(PageMetadata {
-                                url: TERMINAL_WEBVIEW_URL.to_string(),
-                                title: "Terminal (Session: -)".to_string(),
-                                ..default()
-                            });
-                            let term_e = commands
-                                .spawn((
-                                    Terminal::new(&mut meshes, &mut webview_mt, &settings),
-                                    ChildOf(new_tab_e),
-                                ))
-                                .id();
-                            commands.entity(term_e).insert(CefKeyboardTarget);
-                        } else {
-                            commands.entity(new_tab_e).insert(PageMetadata {
-                                url: url.clone(),
-                                title: url.clone(),
-                                ..default()
-                            });
-                            let browser_e = commands
-                                .spawn((
-                                    Browser::new(&mut meshes, &mut webview_mt, &url),
-                                    ChildOf(new_tab_e),
-                                ))
-                                .id();
-                            commands.entity(browser_e).insert(CefKeyboardTarget);
+                        commands.entity(term_e).insert(CefKeyboardTarget);
+                    } else {
+                        let browser_e = commands
+                            .spawn((
+                                Browser::new(&mut meshes, &mut webview_mt, &url),
+                                ChildOf(tab_e),
+                            ))
+                            .id();
+                        commands.entity(browser_e).insert(CefKeyboardTarget);
+                    }
+                    new_tab_ctx.tab = None;
+                    new_tab_ctx.previous_tab = None;
+                    custom_keyboard_restore = true;
+                } else {
+                    // Normal mode: navigate or spawn terminal in current tab
+                    if url.starts_with("vmux://terminal") {
+                        writer.write(AppCommand::Terminal(TerminalCommand::New));
+                    } else {
+                        let (_, _, active_tab) = focused_tab(
+                            &spaces,
+                            &all_children,
+                            &leaf_panes,
+                            &pane_ts,
+                            &pane_children,
+                            &tab_ts,
+                        );
+                        if let Some(tab) = active_tab {
+                            for browser_e in &content_browsers {
+                                let is_child = child_of_q
+                                    .get(browser_e)
+                                    .ok()
+                                    .map(|co| co.get() == tab)
+                                    .unwrap_or(false);
+                                if is_child {
+                                    commands.entity(browser_e).insert(WebviewSource::new(&url));
+                                }
+                            }
                         }
-                        custom_keyboard_restore = true;
                     }
                 }
             }
@@ -718,8 +577,46 @@ fn on_command_bar_action(
                 };
                 Some(expanded)
             };
-            if evt.new_tab {
-                if let Some(tab_e) = empty_tab {
+            if let Some(tab_e) = empty_tab {
+                // Despawn pre-spawned transparent browser + glass
+                despawn_tab_browsers(tab_e, &all_children, &content_browsers, &mut commands);
+                commands.entity(tab_e).insert(PageMetadata {
+                    url: TERMINAL_WEBVIEW_URL.to_string(),
+                    title: "Terminal (Session: -)".to_string(),
+                    ..default()
+                });
+                let term_e = commands
+                    .spawn((
+                        Terminal::new_with_cwd(
+                            &mut meshes,
+                            &mut webview_mt,
+                            &settings,
+                            cwd.as_deref(),
+                        ),
+                        ChildOf(tab_e),
+                    ))
+                    .id();
+                commands.entity(term_e).insert(CefKeyboardTarget);
+                new_tab_ctx.tab = None;
+                new_tab_ctx.previous_tab = None;
+                custom_keyboard_restore = true;
+            } else {
+                let (_, active_pane_opt, _) = focused_tab(
+                    &spaces,
+                    &all_children,
+                    &leaf_panes,
+                    &pane_ts,
+                    &pane_children,
+                    &tab_ts,
+                );
+                if let Some(pane_e) = active_pane_opt {
+                    let tab_e = commands
+                        .spawn((
+                            crate::layout::tab::tab_bundle(),
+                            LastActivatedAt::now(),
+                            ChildOf(pane_e),
+                        ))
+                        .id();
                     commands.entity(tab_e).insert(PageMetadata {
                         url: TERMINAL_WEBVIEW_URL.to_string(),
                         title: "Terminal (Session: -)".to_string(),
@@ -737,88 +634,8 @@ fn on_command_bar_action(
                         ))
                         .id();
                     commands.entity(term_e).insert(CefKeyboardTarget);
-                    new_tab_ctx.tab = None;
-                    new_tab_ctx.previous_tab = None;
-                    custom_keyboard_restore = true;
-                }
-            } else {
-                let (_, active_pane, active_tab) = current_tab();
-                if let Some(tab) = active_tab {
-                    if let Some(browser_e) = current_tab_has_browser(tab) {
-                        commands.entity(browser_e).despawn();
-                        commands.entity(tab).insert(PageMetadata {
-                            url: TERMINAL_WEBVIEW_URL.to_string(),
-                            title: "Terminal (Session: -)".to_string(),
-                            ..default()
-                        });
-                        let term_e = commands
-                            .spawn((
-                                Terminal::new_with_cwd(
-                                    &mut meshes,
-                                    &mut webview_mt,
-                                    &settings,
-                                    cwd.as_deref(),
-                                ),
-                                ChildOf(tab),
-                            ))
-                            .id();
-                        commands.entity(term_e).insert(CefKeyboardTarget);
-                        custom_keyboard_restore = true;
-                    } else if current_tab_has_terminal(tab)
-                        && let Some(pane_e) = active_pane
-                    {
-                        let new_tab_e = commands
-                            .spawn((
-                                crate::layout::tab::tab_bundle(),
-                                LastActivatedAt::now(),
-                                ChildOf(pane_e),
-                            ))
-                            .id();
-                        commands.entity(new_tab_e).insert(PageMetadata {
-                            url: TERMINAL_WEBVIEW_URL.to_string(),
-                            title: "Terminal (Session: -)".to_string(),
-                            ..default()
-                        });
-                        let term_e = commands
-                            .spawn((
-                                Terminal::new_with_cwd(
-                                    &mut meshes,
-                                    &mut webview_mt,
-                                    &settings,
-                                    cwd.as_deref(),
-                                ),
-                                ChildOf(new_tab_e),
-                            ))
-                            .id();
-                        commands.entity(term_e).insert(CefKeyboardTarget);
-                        custom_keyboard_restore = true;
-                    }
-                } else if let Some(pane_e) = active_pane {
-                    let new_tab_e = commands
-                        .spawn((
-                            crate::layout::tab::tab_bundle(),
-                            LastActivatedAt::now(),
-                            ChildOf(pane_e),
-                        ))
-                        .id();
-                    commands.entity(new_tab_e).insert(PageMetadata {
-                        url: TERMINAL_WEBVIEW_URL.to_string(),
-                        title: "Terminal (Session: -)".to_string(),
-                        ..default()
-                    });
-                    let term_e = commands
-                        .spawn((
-                            Terminal::new_with_cwd(
-                                &mut meshes,
-                                &mut webview_mt,
-                                &settings,
-                                cwd.as_deref(),
-                            ),
-                            ChildOf(new_tab_e),
-                        ))
-                        .id();
-                    commands.entity(term_e).insert(CefKeyboardTarget);
-                    custom_keyboard_restore = true;
+                } else {
+                    writer.write(AppCommand::Terminal(TerminalCommand::New));
                 }
             }
         }
@@ -826,6 +643,7 @@ fn on_command_bar_action(
             if let Some(cmd) = match_command(&evt.value) {
                 writer.write(cmd);
             }
+            // If in new-tab mode and a command was executed, clean up the empty tab
             if let Some(tab_e) = empty_tab {
                 commands.entity(tab_e).despawn();
                 new_tab_ctx.tab = None;
@@ -833,6 +651,7 @@ fn on_command_bar_action(
             }
         }
         "switch_tab" => {
+            // Despawn empty tab if in new-tab mode
             if let Some(tab_e) = empty_tab {
                 commands.entity(tab_e).despawn();
                 new_tab_ctx.tab = None;
@@ -854,9 +673,11 @@ fn on_command_bar_action(
             }
         }
         _ => {
+            // "dismiss" and unknown actions
             if let Some(tab_e) = empty_tab {
                 commands.entity(tab_e).despawn();
                 new_tab_ctx.tab = None;
+                // Restore keyboard to previous tab's browser
                 if let Some(prev) = previous_tab
                     && let Ok(children) = all_children.get(prev)
                 {
@@ -872,6 +693,7 @@ fn on_command_bar_action(
         }
     }
 
+    // Close command bar and restore keyboard
     if let Ok((modal_e, mut modal_node, mut modal_vis)) = modal_q.single_mut() {
         modal_node.display = Display::None;
         *modal_vis = Visibility::Hidden;
@@ -930,6 +752,29 @@ fn deferred_dismiss_modal(
     }
 }
 
+/// Opens the command bar on first launch, waiting until the modal webview is
+/// ready so the open event is actually received by the WASM app.
+fn first_launch_open_command_bar(
+    pending: Option<Res<PendingFirstLaunchOpen>>,
+    modal_q: Query<Entity, With<Modal>>,
+    browsers: NonSend<Browsers>,
+    mut new_tab_ctx: ResMut<NewTabContext>,
+    mut commands: Commands,
+) {
+    if pending.is_none() {
+        return;
+    }
+    let Ok(modal_e) = modal_q.single() else {
+        return;
+    };
+    if !browsers.has_browser(modal_e) || !browsers.host_emit_ready(&modal_e) {
+        return;
+    }
+    // Modal webview is ready — trigger command bar open on the next frame.
+    new_tab_ctx.needs_open = true;
+    commands.remove_resource::<PendingFirstLaunchOpen>();
+}
+
 /// Waits 2 frames after `Display::Flex` before revealing the command bar so that
 /// Bevy UI layout + CEF resize can run while the webview is still invisible.
 fn reveal_command_bar(
@@ -961,21 +806,7 @@ fn on_path_complete_request(
     }
 
     let completions = complete_path(query);
-    let query_is_dir = {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/".to_string());
-        let resolved = if let Some(stripped) = query.strip_prefix("~/") {
-            std::path::PathBuf::from(&home).join(stripped)
-        } else if query.starts_with('/') {
-            std::path::PathBuf::from(query)
-        } else {
-            std::path::PathBuf::from(&home).join(query)
-        };
-        resolved.is_dir()
-    };
-    let payload = PathCompleteResponse {
-        completions,
-        query_is_dir,
-    };
+    let payload = PathCompleteResponse { completions };
     let ron_body = ron::ser::to_string(&payload).unwrap_or_default();
     commands.trigger(HostEmitEvent::new(
         modal_e,

--- a/crates/vmux_desktop/src/layout/tab.rs
+++ b/crates/vmux_desktop/src/layout/tab.rs
@@ -1,4 +1,5 @@
 use crate::{
+    browser::Browser,
     command::{AppCommand, ReadAppCommands, TabCommand, TerminalCommand},
     command_bar::NewTabContext,
     layout::pane::{Pane, PaneSplit, PendingCursorWarp, first_leaf_descendant, first_tab_in_pane},
@@ -36,13 +37,18 @@ pub(crate) struct PendingTabClose;
 #[derive(Component)]
 pub(crate) struct CloseConfirmed;
 
+/// System set for `handle_tab_commands`. The command bar's open/dismiss
+/// handler must run `.after(TabCommandSet)` to avoid a race when toggling.
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct TabCommandSet;
+
 pub(crate) struct TabPlugin;
 
 impl Plugin for TabPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Tab>()
             .init_resource::<FocusedTab>()
-            .add_systems(Update, handle_tab_commands.in_set(ReadAppCommands))
+            .add_systems(Update, handle_tab_commands.in_set(ReadAppCommands).in_set(TabCommandSet))
             .add_systems(Update, process_pending_tab_closes)
             .add_systems(
                 Update,
@@ -190,10 +196,9 @@ fn handle_tab_commands(
     )>,
 ) {
     for cmd in reader.read() {
-        let (tab_cmd, terminal_mode) = match *cmd {
-            AppCommand::Tab(t) => (t, None),
-            AppCommand::Terminal(TerminalCommand::New) => (TabCommand::New, Some(false)),
-            AppCommand::Terminal(TerminalCommand::NewTab) => (TabCommand::New, Some(true)),
+        let (tab_cmd, is_terminal) = match *cmd {
+            AppCommand::Tab(t) => (t, false),
+            AppCommand::Terminal(TerminalCommand::New) => (TabCommand::New, true),
             _ => continue,
         };
 
@@ -211,45 +216,43 @@ fn handle_tab_commands(
                 let Some(pane) = active_pane else {
                     continue;
                 };
-                match terminal_mode {
-                    Some(new_tab) => {
-                        let tab = match (new_tab, active_tab) {
-                            (false, Some(existing)) => {
-                                if let Ok(children) = all_children.get(existing) {
-                                    for child in children.iter() {
-                                        if !tab_q.contains(child) {
-                                            commands.entity(child).despawn();
-                                        }
-                                    }
-                                }
-                                existing
-                            }
-                            _ => commands
-                                .spawn((tab_bundle(), LastActivatedAt::now(), ChildOf(pane)))
-                                .id(),
-                        };
-                        commands.entity(tab).insert(vmux_header::PageMetadata {
-                            url: TERMINAL_WEBVIEW_URL.to_string(),
-                            title: "Terminal (Session: -)".to_string(),
-                            ..default()
-                        });
-                        commands.spawn((
-                            Terminal::new(&mut meshes, &mut webview_mt, &settings),
-                            ChildOf(tab),
-                        ));
+                if is_terminal {
+                    let tab = commands
+                        .spawn((tab_bundle(), LastActivatedAt::now(), ChildOf(pane)))
+                        .id();
+                    commands.entity(tab).insert(vmux_header::PageMetadata {
+                        url: TERMINAL_WEBVIEW_URL.to_string(),
+                        title: "Terminal (Session: -)".to_string(),
+                        ..default()
+                    });
+                    commands.spawn((
+                        Terminal::new(&mut meshes, &mut webview_mt, &settings),
+                        ChildOf(tab),
+                    ));
+                } else {
+                    // Toggle: if an empty tab is already pending (command bar
+                    // open from a prior Cmd+T), skip creating another tab and
+                    // let handle_open_command_bar dismiss the modal.
+                    if new_tab_ctx.tab.is_some() {
+                        continue;
                     }
-                    None => {
-                        if new_tab_ctx.tab.is_some() {
-                            new_tab_ctx.needs_open = true;
-                            continue;
-                        }
-                        let tab = commands
-                            .spawn((tab_bundle(), LastActivatedAt::now(), ChildOf(pane)))
-                            .id();
-                        new_tab_ctx.tab = Some(tab);
-                        new_tab_ctx.previous_tab = active_tab;
-                        new_tab_ctx.needs_open = true;
-                    }
+                    let tab = commands
+                        .spawn((tab_bundle(), LastActivatedAt::now(), ChildOf(pane)))
+                        .id();
+
+                    // Spawn a transparent CEF browser immediately so the
+                    // rendering pipeline is warm when the user picks content.
+                    // The glass backdrop is handled by CSS in the command bar
+                    // overlay (see vmux_command_bar app.rs).
+                    commands.spawn((
+                        Browser::new(&mut meshes, &mut webview_mt, "about:blank"),
+                        WebviewTransparent,
+                        ChildOf(tab),
+                    ));
+
+                    new_tab_ctx.tab = Some(tab);
+                    new_tab_ctx.previous_tab = active_tab;
+                    new_tab_ctx.needs_open = true;
                 }
             }
             TabCommand::Close => {

--- a/crates/vmux_desktop/src/layout/window.rs
+++ b/crates/vmux_desktop/src/layout/window.rs
@@ -316,9 +316,8 @@ fn spawn_default_session(
     profile_q: Query<(), With<Profile>>,
     primary_window: Single<Entity, With<PrimaryWindow>>,
     settings: Res<AppSettings>,
+    mut new_tab_ctx: ResMut<crate::command_bar::NewTabContext>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     // If profiles already exist (loaded from session.ron) or a session
     // file is present (entities may still be arriving from the load
@@ -329,7 +328,6 @@ fn spawn_default_session(
 
     let Ok(main) = main_q.single() else { return };
     let pw = *primary_window;
-    let startup_url = settings.browser.startup_url.as_str();
 
     // Spawn a Profile so that on next launch, this function is skipped
     // when session.ron is loaded (the guard checks profile_q.is_empty()).
@@ -373,6 +371,8 @@ fn spawn_default_session(
         ))
         .id();
 
+    // Create an empty tab (no browser content) and open the command bar
+    // so the user is immediately prompted instead of seeing an empty pane.
     let tab = commands
         .spawn((
             tab_bundle(),
@@ -381,11 +381,8 @@ fn spawn_default_session(
             ChildOf(leaf),
         ))
         .id();
-
-    commands.spawn((
-        Browser::new(&mut meshes, &mut webview_mt, startup_url),
-        ChildOf(tab),
-    ));
+    new_tab_ctx.tab = Some(tab);
+    commands.insert_resource(crate::command_bar::PendingFirstLaunchOpen);
 }
 
 fn spawn_glass_child(
@@ -446,7 +443,8 @@ fn spawn_glass_panes(
             spawn_glass_child(&mut commands, plane.clone(), &mut materials, r, entity);
         }
     }
-    // Modal and panes use CSS-based glass, not 3D meshes.
+    // Modal glass is handled per-tab (glass mesh spawned as child of
+    // the new tab's transparent browser in handle_tab_commands).
 }
 
 /// Keeps each Glass's GlassCorners clip in sync with its parent panel's computed size.

--- a/crates/vmux_side_sheet/src/app.rs
+++ b/crates/vmux_side_sheet/src/app.rs
@@ -136,6 +136,11 @@ fn TabRow(tab: TabNode, pane_id: u64) -> Element {
                         onerror: move |_| icon_error.set(true),
                     }
                 }
+            } else if tab.title == "New Tab" && tab.url.is_empty() {
+                Icon { class: "h-4 w-4 shrink-0 text-muted-foreground",
+                    line { x1: "12", y1: "5", x2: "12", y2: "19" }
+                    line { x1: "5", y1: "12", x2: "19", y2: "12" }
+                }
             } else {
                 Icon { class: "h-4 w-4 shrink-0 text-muted-foreground",
                     path { d: "M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Z" }


### PR DESCRIPTION
## Context

Addresses VMX-91: Command Bar refinement. The command bar experience had several rough edges -- cmd+t only opened (no toggle), new tabs showed a transparent flash instead of the previous tab content, first-time users saw an empty pane, and there was no quick way to open a new tab from the command bar.

## Implementation

**Toggle cmd+t**: When cmd+t fires while an empty tab is already pending (command bar open), `handle_tab_commands` skips creating another tab and `handle_open_command_bar` dismisses the modal -- effectively toggling. Previously, a race between these two systems caused the bar to immediately reopen.

**Keep active tab behind**: `sync_children_to_ui` and `sync_osr_webview_focus` now check `NewTabContext::previous_tab` -- if an empty new tab is pending, the previous tab's browser mesh and OSR texture stay visible instead of scaling to 1e-6 / marking hidden.

**First-launch open**: `spawn_default_session` no longer creates a browser child. Instead it inserts `PendingFirstLaunchOpen`, and a new system waits for the modal's CEF browser to be ready before triggering `needs_open`, ensuring the WASM app actually receives the open event.

**+ New Tab button**: Added a `NewTab` result variant in the command bar WASM app, shown above existing tabs when not already in new-tab mode. Emits `tab_new` command to trigger the standard new-tab flow.

## Checks / QA

- Launch with no session file -- command bar should appear automatically
- Press cmd+t to open command bar, then cmd+t again -- should dismiss
- Open command bar via cmd+t, verify previous tab content remains visible behind the modal
- Open command bar via cmd+l, verify "New Tab" entry appears above existing tabs with cmd+T shortcut badge
- Select "New Tab" from the list -- should open a fresh new-tab command bar flow
