### PR TITLE
feat: persistent terminal sessions via daemon (VMX-55)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,6 +2140,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytecheck"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5811,6 +5834,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "naga"
 version = "27.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6833,6 +6876,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "publicsuffix"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6947,6 +7010,15 @@ name = "radsort"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "019b4b213425016d7d84a153c4c73afb0946fbb4840e4eece7ba8848b9d6da22"
+
+[[package]]
+name = "rancor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -7100,6 +7172,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rend"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7187,6 +7268,36 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.17.0",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8870,6 +8981,7 @@ dependencies = [
  "bevy_cef",
  "dioxus",
  "js-sys",
+ "rkyv",
  "serde",
  "unicode-width",
  "vmux_ui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8927,6 +8927,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "uuid",
  "vmux_command_bar",
  "vmux_core",
  "vmux_daemon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8328,8 +8328,21 @@ dependencies = [
  "libc",
  "mio 1.2.0",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8875,6 +8888,20 @@ dependencies = [
  "bevy_reflect",
  "moonshine-save",
  "serde",
+]
+
+[[package]]
+name = "vmux_daemon"
+version = "0.1.0"
+dependencies = [
+ "alacritty_terminal",
+ "portable-pty",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
+ "vmux_terminal",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8908,7 +8908,6 @@ dependencies = [
 name = "vmux_desktop"
 version = "0.1.0"
 dependencies = [
- "alacritty_terminal",
  "bevy",
  "bevy_cef",
  "bevy_cef_core",
@@ -8921,7 +8920,6 @@ dependencies = [
  "muda",
  "notify 6.1.1",
  "parking_lot",
- "portable-pty",
  "raw-window-handle",
  "rfd",
  "ron 0.8.1",
@@ -8930,6 +8928,7 @@ dependencies = [
  "serde_json",
  "vmux_command_bar",
  "vmux_core",
+ "vmux_daemon",
  "vmux_header",
  "vmux_history",
  "vmux_macro",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8895,6 +8895,7 @@ name = "vmux_daemon"
 version = "0.1.0"
 dependencies = [
  "alacritty_terminal",
+ "libc",
  "portable-pty",
  "rkyv",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8926,6 +8926,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "tokio",
  "vmux_command_bar",
  "vmux_core",
  "vmux_daemon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8934,6 +8934,7 @@ dependencies = [
  "vmux_header",
  "vmux_history",
  "vmux_macro",
+ "vmux_sessions",
  "vmux_side_sheet",
  "vmux_terminal",
  "vmux_ui",
@@ -8985,6 +8986,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "vmux_sessions"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "bevy_cef",
+ "dioxus",
+ "serde",
+ "vmux_ui",
+ "vmux_webview_app",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ tokio = { version = "1", features = [
     "sync",
     "macros",
     "net",
+    "io-util",
+    "signal",
+    "time",
 ] }
 axum = { version = "0.7", default-features = false, features = [
     "http1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,10 @@ codegen-units = 1
 opt-level = "z"
 codegen-units = 1
 
+[profile.release.package.vmux_sessions]
+opt-level = "z"
+codegen-units = 1
+
 [patch.crates-io]
 bevy_cef = { path = "patches/bevy_cef-0.5.2" }
 bevy_cef_core = { path = "patches/bevy_cef_core-0.5.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ alacritty_terminal = "0.26"
 portable-pty = "0.9"
 rfd = "0.15"
 vte = "0.15"
+rkyv = { version = "0.8", features = ["alloc"] }
+uuid = { version = "1", features = ["v4", "serde"] }
+tray-icon = "0.19"
 
 [profile.release.package.vmux_history]
 opt-level = "z"

--- a/crates/vmux_command_bar/src/app.rs
+++ b/crates/vmux_command_bar/src/app.rs
@@ -12,7 +12,6 @@ use wasm_bindgen::prelude::*;
 
 #[derive(Clone, PartialEq)]
 enum ResultItem {
-    NewTab,
     Terminal {
         path: String,
     },
@@ -39,24 +38,8 @@ fn looks_like_path(s: &str) -> bool {
         || s.starts_with("../")
         || s.contains('/')
             && !s.contains(' ')
-            && !s.starts_with("http://")
-            && !s.starts_with("https://")
+            && !s.contains("://")
 }
->>>>>>> 019f345 (feat(command-bar): toggle cmd+t, keep active tab visible, first-launch open, + New Tab button)
-=======
-use vmux_command_bar::event::{looks_like_path, looks_like_url};
-=======
-fn looks_like_path(s: &str) -> bool {
-    s.starts_with('/')
-        || s.starts_with("~/")
-        || s.starts_with("./")
-        || s.starts_with("../")
-        || s.contains('/')
-            && !s.contains(' ')
-            && !s.starts_with("http://")
-            && !s.starts_with("https://")
-}
->>>>>>> 019f345 (feat(command-bar): toggle cmd+t, keep active tab visible, first-launch open, + New Tab button)
 
 fn filter_results(
     query: &str,
@@ -72,10 +55,6 @@ fn filter_results(
             items.push(ResultItem::Terminal {
                 path: String::new(),
             });
-        }
-        // Show "+ New Tab" above the tab list when browsing existing tabs
-        if !new_tab && !tabs.is_empty() {
-            items.push(ResultItem::NewTab);
         }
         items.extend(tabs.iter().map(|t| ResultItem::Tab {
             title: t.title.clone(),
@@ -266,7 +245,6 @@ pub fn App() -> Element {
     let nav = nav_mode();
     let display_text = if nav {
         match &active_item {
-            Some(ResultItem::NewTab) => String::new(),
             Some(ResultItem::Command { name, .. }) => format!("> {name}"),
             Some(ResultItem::Navigate { url }) => url.clone(),
             Some(ResultItem::Tab { url, .. }) => url.clone(),
@@ -309,9 +287,6 @@ pub fn App() -> Element {
     let mut execute = move |item: &ResultItem| {
         is_open.set(false);
         match item {
-            ResultItem::NewTab => {
-                emit_action("command", "tab_new");
-            }
             ResultItem::Terminal { path } => {
                 emit_action("terminal", path);
             }
@@ -337,7 +312,7 @@ pub fn App() -> Element {
 
     rsx! {
         div {
-            class: "flex h-full w-full items-start justify-center pt-[15%] bg-white/5 backdrop-blur-md backdrop-saturate-150",
+            class: "flex h-full w-full items-start justify-center pt-[15%]",
             onclick: move |_| { is_open.set(false); emit_action("dismiss", ""); },
             div {
                 class: "relative flex w-full max-w-xl flex-col overflow-hidden rounded-2xl border border-white/20 bg-white/10 shadow-2xl backdrop-blur-2xl backdrop-saturate-150",
@@ -350,13 +325,12 @@ pub fn App() -> Element {
                             let icon_class = "h-4 w-4 shrink-0 text-muted-foreground";
                             let (is_command, is_path, is_url) = if nav {
                                 match &active_item {
-                                    Some(ResultItem::NewTab) => (false, false, false),
                                     Some(ResultItem::Command { .. }) => (true, false, false),
                                     Some(ResultItem::Terminal { path }) if path.is_empty() => (true, false, false),
                                     Some(ResultItem::Terminal { .. }) => (false, true, false),
                                     Some(ResultItem::Tab { .. }) => (false, false, true),
                                     Some(ResultItem::Navigate { url }) => {
-                                        let is_u = looks_like_url(url);
+                                        let is_u = url.contains("://") || (url.contains('.') && !url.contains(' '));
                                         (false, false, is_u)
                                     }
                                     None => (false, false, false),
@@ -364,8 +338,8 @@ pub fn App() -> Element {
                             } else {
                                 let trimmed = q.trim();
                                 let cmd = trimmed.starts_with('>');
-                                let url = !cmd && looks_like_url(trimmed);
-                                let pth = !cmd && !url && (trimmed.starts_with('/') || trimmed.starts_with('~'));
+                                let pth = !cmd && (trimmed.starts_with('/') || trimmed.starts_with('~'));
+                                let url = !cmd && !pth && (trimmed.contains("://") || (trimmed.contains('.') && !trimmed.contains(' ')));
                                 (cmd, pth, url)
                             };
                             if is_command {
@@ -482,16 +456,6 @@ pub fn App() -> Element {
                                     move |_| { execute(&item); }
                                 },
                                 match item {
-                                    ResultItem::NewTab => rsx! {
-                                        div { class: "flex items-center gap-2",
-                                            Icon { class: "h-4 w-4 shrink-0 text-muted-foreground",
-                                                path { d: "M12 5v14" }
-                                                path { d: "M5 12h14" }
-                                            }
-                                            span { class: "text-base text-foreground", "New Tab" }
-                                        }
-                                        span { class: "ml-2 shrink-0 rounded bg-muted px-1.5 py-0.5 text-sm text-muted-foreground", "\u{2318}T" }
-                                    },
                                     ResultItem::Terminal { path } => rsx! {
                                         div { class: "flex items-center gap-2",
                                             span { class: "shrink-0 text-base text-muted-foreground", ">_" }
@@ -553,7 +517,7 @@ fn focus_and_install_ctrl_bindings() {
     let input: web_sys::HtmlInputElement = el.unchecked_into();
     input.focus().ok();
     let len = input.value().len() as u32;
-    let _ = input.set_selection_range(len, len);
+    let _ = input.set_selection_range(0, len);
 
     // Guard against double-binding.
     if js_sys::Reflect::get(&input, &JsValue::from_str("_ctrlBound"))

--- a/crates/vmux_daemon/Cargo.toml
+++ b/crates/vmux_daemon/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "vmux_daemon"
+version.workspace = true
+edition.workspace = true
+description = "Background daemon for persistent terminal sessions"
+publish = false
+
+[[bin]]
+name = "vmux-daemon"
+path = "src/main.rs"
+
+[lib]
+name = "vmux_daemon"
+path = "src/lib.rs"
+
+[dependencies]
+rkyv = { workspace = true }
+uuid = { workspace = true }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+alacritty_terminal = { workspace = true }
+portable-pty = { workspace = true }
+vmux_terminal = { path = "../vmux_terminal" }

--- a/crates/vmux_daemon/Cargo.toml
+++ b/crates/vmux_daemon/Cargo.toml
@@ -14,6 +14,7 @@ name = "vmux_daemon"
 path = "src/lib.rs"
 
 [dependencies]
+libc = "0.2"
 rkyv = { workspace = true }
 uuid = { workspace = true }
 tokio = { workspace = true }

--- a/crates/vmux_daemon/src/client.rs
+++ b/crates/vmux_daemon/src/client.rs
@@ -54,16 +54,32 @@ impl DaemonHandle {
         }
         // Check if the PID file references a live process
         let pid_file = crate::pid_path();
-        if let Ok(pid_str) = std::fs::read_to_string(&pid_file) {
-            if let Ok(pid) = pid_str.trim().parse::<i32>() {
-                // kill(pid, 0) checks if process exists without sending a signal
-                if unsafe { libc::kill(pid, 0) } != 0 {
-                    // Process is dead — clean up stale files
-                    let _ = std::fs::remove_file(&sock);
-                    let _ = std::fs::remove_file(&pid_file);
-                    return false;
-                }
+        let pid_str = match std::fs::read_to_string(&pid_file) {
+            Ok(s) => s,
+            Err(_) => {
+                // Socket exists but no PID file — stale state, clean up
+                eprintln!("vmux-daemon: socket exists but no PID file, cleaning up");
+                let _ = std::fs::remove_file(&sock);
+                return false;
             }
+        };
+        let pid: i32 = match pid_str.trim().parse() {
+            Ok(p) => p,
+            Err(_) => {
+                // Invalid PID file content — clean up
+                eprintln!("vmux-daemon: invalid PID file content: {:?}", pid_str.trim());
+                let _ = std::fs::remove_file(&sock);
+                let _ = std::fs::remove_file(&pid_file);
+                return false;
+            }
+        };
+        // kill(pid, 0) checks if process exists without sending a signal
+        if unsafe { libc::kill(pid, 0) } != 0 {
+            // Process is dead — clean up stale files
+            eprintln!("vmux-daemon: stale daemon (pid {pid}) — cleaning up");
+            let _ = std::fs::remove_file(&sock);
+            let _ = std::fs::remove_file(&pid_file);
+            return false;
         }
         true
     }

--- a/crates/vmux_daemon/src/client.rs
+++ b/crates/vmux_daemon/src/client.rs
@@ -46,9 +46,18 @@ pub struct DaemonHandle {
 }
 
 impl DaemonHandle {
-    /// Spawn a background connection to the daemon.
-    /// Returns `None` if the daemon is not running.
+    /// Check if the daemon socket exists (quick pre-check).
+    pub fn daemon_running() -> bool {
+        socket_path().exists()
+    }
+
+    /// Connect to the daemon synchronously.
+    /// Returns `None` if the daemon is not running or connection fails.
     pub fn connect() -> Option<Self> {
+        if !Self::daemon_running() {
+            return None;
+        }
+
         let rt = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(1)
             .enable_all()
@@ -56,40 +65,62 @@ impl DaemonHandle {
             .ok()?;
         let rt = Arc::new(rt);
 
+        // Verify connection synchronously before returning
+        let conn = {
+            let rt2 = Arc::clone(&rt);
+            let (tx, rx) = std::sync::mpsc::channel();
+            std::thread::Builder::new()
+                .name("daemon-connect".into())
+                .spawn(move || {
+                    let result = rt2.block_on(async { DaemonConnection::connect().await });
+                    let _ = tx.send(result);
+                })
+                .ok()?;
+            // Wait up to 2s for connection
+            match rx.recv_timeout(std::time::Duration::from_secs(2)) {
+                Ok(Ok(c)) => Arc::new(c),
+                Ok(Err(e)) => {
+                    eprintln!("daemon connect failed: {e}");
+                    return None;
+                }
+                Err(_) => {
+                    eprintln!("daemon connect timed out");
+                    return None;
+                }
+            }
+        };
+
         let (cmd_tx, cmd_rx) = std::sync::mpsc::channel::<ClientMessage>();
         let (msg_tx, msg_rx) = std::sync::mpsc::channel::<DaemonMessage>();
 
+        // Reader task: daemon -> msg_tx
+        let conn_r = Arc::clone(&conn);
         let rt2 = Arc::clone(&rt);
         std::thread::Builder::new()
-            .name("daemon-client".into())
+            .name("daemon-reader".into())
             .spawn(move || {
                 rt2.block_on(async move {
-                    let conn = match DaemonConnection::connect().await {
-                        Ok(c) => Arc::new(c),
-                        Err(e) => {
-                            eprintln!("daemon connect failed: {e}");
-                            return;
-                        }
-                    };
-
-                    // Reader task: daemon -> msg_tx
-                    let conn_r = Arc::clone(&conn);
-                    let msg_tx2 = msg_tx.clone();
-                    tokio::spawn(async move {
-                        loop {
-                            match conn_r.recv().await {
-                                Ok(Some(msg)) => {
-                                    if msg_tx2.send(msg).is_err() {
-                                        break;
-                                    }
+                    loop {
+                        match conn_r.recv().await {
+                            Ok(Some(msg)) => {
+                                if msg_tx.send(msg).is_err() {
+                                    break;
                                 }
-                                Ok(None) => break,
-                                Err(_) => break,
                             }
+                            Ok(None) => break,
+                            Err(_) => break,
                         }
-                    });
+                    }
+                });
+            })
+            .ok()?;
 
-                    // Writer task: cmd_rx -> daemon
+        // Writer task: cmd_rx -> daemon
+        let rt3 = Arc::clone(&rt);
+        std::thread::Builder::new()
+            .name("daemon-writer".into())
+            .spawn(move || {
+                rt3.block_on(async move {
                     loop {
                         let msg = match cmd_rx.recv() {
                             Ok(m) => m,

--- a/crates/vmux_daemon/src/client.rs
+++ b/crates/vmux_daemon/src/client.rs
@@ -1,0 +1,127 @@
+use crate::protocol::{ClientMessage, DaemonMessage};
+use crate::{read_message, socket_path, write_message};
+use std::sync::Arc;
+use tokio::io::BufReader;
+use tokio::net::UnixStream;
+use tokio::sync::Mutex;
+
+/// Async client connection to the vmux daemon.
+/// Wraps the Unix socket with framing/serialization.
+pub struct DaemonConnection {
+    reader: Mutex<BufReader<tokio::net::unix::OwnedReadHalf>>,
+    writer: Mutex<tokio::net::unix::OwnedWriteHalf>,
+}
+
+impl DaemonConnection {
+    /// Connect to the daemon socket.
+    pub async fn connect() -> std::io::Result<Self> {
+        let sock = socket_path();
+        let stream = UnixStream::connect(&sock).await?;
+        let (r, w) = stream.into_split();
+        Ok(Self {
+            reader: Mutex::new(BufReader::new(r)),
+            writer: Mutex::new(w),
+        })
+    }
+
+    /// Send a message to the daemon.
+    pub async fn send(&self, msg: &ClientMessage) -> std::io::Result<()> {
+        let mut w = self.writer.lock().await;
+        write_message!(&mut *w, msg)
+    }
+
+    /// Receive a message from the daemon. Returns None on disconnect.
+    pub async fn recv(&self) -> std::io::Result<Option<DaemonMessage>> {
+        let mut r = self.reader.lock().await;
+        read_message!(&mut *r, DaemonMessage)
+    }
+}
+
+/// Non-async handle for Bevy systems to communicate with the daemon.
+/// Uses a background tokio task and std mpsc channels.
+pub struct DaemonHandle {
+    cmd_tx: std::sync::mpsc::Sender<ClientMessage>,
+    msg_rx: std::sync::Mutex<std::sync::mpsc::Receiver<DaemonMessage>>,
+    _runtime: Arc<tokio::runtime::Runtime>,
+}
+
+impl DaemonHandle {
+    /// Spawn a background connection to the daemon.
+    /// Returns `None` if the daemon is not running.
+    pub fn connect() -> Option<Self> {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .ok()?;
+        let rt = Arc::new(rt);
+
+        let (cmd_tx, cmd_rx) = std::sync::mpsc::channel::<ClientMessage>();
+        let (msg_tx, msg_rx) = std::sync::mpsc::channel::<DaemonMessage>();
+
+        let rt2 = Arc::clone(&rt);
+        std::thread::Builder::new()
+            .name("daemon-client".into())
+            .spawn(move || {
+                rt2.block_on(async move {
+                    let conn = match DaemonConnection::connect().await {
+                        Ok(c) => Arc::new(c),
+                        Err(e) => {
+                            eprintln!("daemon connect failed: {e}");
+                            return;
+                        }
+                    };
+
+                    // Reader task: daemon -> msg_tx
+                    let conn_r = Arc::clone(&conn);
+                    let msg_tx2 = msg_tx.clone();
+                    tokio::spawn(async move {
+                        loop {
+                            match conn_r.recv().await {
+                                Ok(Some(msg)) => {
+                                    if msg_tx2.send(msg).is_err() {
+                                        break;
+                                    }
+                                }
+                                Ok(None) => break,
+                                Err(_) => break,
+                            }
+                        }
+                    });
+
+                    // Writer task: cmd_rx -> daemon
+                    loop {
+                        let msg = match cmd_rx.recv() {
+                            Ok(m) => m,
+                            Err(_) => break,
+                        };
+                        if conn.send(&msg).await.is_err() {
+                            break;
+                        }
+                    }
+                });
+            })
+            .ok()?;
+
+        Some(Self {
+            cmd_tx,
+            msg_rx: std::sync::Mutex::new(msg_rx),
+            _runtime: rt,
+        })
+    }
+
+    /// Send a command to the daemon (non-blocking).
+    pub fn send(&self, msg: ClientMessage) {
+        let _ = self.cmd_tx.send(msg);
+    }
+
+    /// Drain all available messages from the daemon (non-blocking).
+    pub fn drain(&self) -> Vec<DaemonMessage> {
+        let rx = self.msg_rx.lock().unwrap();
+        let mut msgs = Vec::new();
+        while let Ok(msg) = rx.try_recv() {
+            msgs.push(msg);
+        }
+        msgs
+    }
+}

--- a/crates/vmux_daemon/src/client.rs
+++ b/crates/vmux_daemon/src/client.rs
@@ -46,9 +46,26 @@ pub struct DaemonHandle {
 }
 
 impl DaemonHandle {
-    /// Check if the daemon socket exists (quick pre-check).
+    /// Check if the daemon process is actually alive.
     pub fn daemon_running() -> bool {
-        socket_path().exists()
+        let sock = socket_path();
+        if !sock.exists() {
+            return false;
+        }
+        // Check if the PID file references a live process
+        let pid_file = crate::pid_path();
+        if let Ok(pid_str) = std::fs::read_to_string(&pid_file) {
+            if let Ok(pid) = pid_str.trim().parse::<i32>() {
+                // kill(pid, 0) checks if process exists without sending a signal
+                if unsafe { libc::kill(pid, 0) } != 0 {
+                    // Process is dead — clean up stale files
+                    let _ = std::fs::remove_file(&sock);
+                    let _ = std::fs::remove_file(&pid_file);
+                    return false;
+                }
+            }
+        }
+        true
     }
 
     /// Connect to the daemon synchronously.

--- a/crates/vmux_daemon/src/framing.rs
+++ b/crates/vmux_daemon/src/framing.rs
@@ -1,0 +1,61 @@
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+/// Write a length-prefixed frame to an async writer.
+pub async fn write_raw_frame<W>(writer: &mut W, data: &[u8]) -> std::io::Result<()>
+where
+    W: AsyncWriteExt + Unpin,
+{
+    let len = data.len() as u32;
+    writer.write_all(&len.to_le_bytes()).await?;
+    writer.write_all(data).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Read a length-prefixed frame from an async reader.
+/// Returns `None` on clean EOF.
+pub async fn read_raw_frame<R>(reader: &mut R) -> std::io::Result<Option<Vec<u8>>>
+where
+    R: AsyncReadExt + Unpin,
+{
+    let mut len_buf = [0u8; 4];
+    match reader.read_exact(&mut len_buf).await {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(e),
+    }
+    let len = u32::from_le_bytes(len_buf) as usize;
+    if len > 64 * 1024 * 1024 {
+        return Err(std::io::Error::other("frame too large"));
+    }
+    let mut buf = vec![0u8; len];
+    reader.read_exact(&mut buf).await?;
+    Ok(Some(buf))
+}
+
+/// Serialize a message to rkyv bytes, write as a length-prefixed frame.
+/// Use: `write_message(&mut writer, &my_msg).await?`
+#[macro_export]
+macro_rules! write_message {
+    ($writer:expr, $msg:expr) => {{
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>($msg)
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
+        $crate::framing::write_raw_frame($writer, &bytes).await
+    }};
+}
+
+/// Read a length-prefixed frame, deserialize from rkyv bytes.
+/// Use: `let msg: Option<MyMsg> = read_message!(reader)?;`
+#[macro_export]
+macro_rules! read_message {
+    ($reader:expr, $ty:ty) => {{
+        match $crate::framing::read_raw_frame($reader).await? {
+            Some(bytes) => {
+                let msg = rkyv::from_bytes::<$ty, rkyv::rancor::Error>(&bytes)
+                    .map_err(|e| std::io::Error::other(e.to_string()))?;
+                Ok::<Option<$ty>, std::io::Error>(Some(msg))
+            }
+            None => Ok(None),
+        }
+    }};
+}

--- a/crates/vmux_daemon/src/lib.rs
+++ b/crates/vmux_daemon/src/lib.rs
@@ -1,0 +1,22 @@
+pub mod framing;
+pub mod protocol;
+pub mod server;
+pub mod session;
+
+use std::path::PathBuf;
+
+/// Directory for daemon runtime files (socket, pid).
+pub fn daemon_dir() -> PathBuf {
+    let home = std::env::var_os("HOME").expect("HOME not set");
+    PathBuf::from(home).join(".vmux")
+}
+
+/// Path to the Unix domain socket.
+pub fn socket_path() -> PathBuf {
+    daemon_dir().join("vmux.sock")
+}
+
+/// Path to the PID file.
+pub fn pid_path() -> PathBuf {
+    daemon_dir().join("daemon.pid")
+}

--- a/crates/vmux_daemon/src/lib.rs
+++ b/crates/vmux_daemon/src/lib.rs
@@ -6,10 +6,11 @@ pub mod session;
 
 use std::path::PathBuf;
 
-/// Directory for daemon runtime files (socket, pid).
+/// Directory for daemon runtime files (socket, pid, log).
 pub fn daemon_dir() -> PathBuf {
     let home = std::env::var_os("HOME").expect("HOME not set");
-    PathBuf::from(home).join(".vmux")
+    PathBuf::from(home)
+        .join("Library/Application Support/ai.vmux.desktop/services")
 }
 
 /// Path to the Unix domain socket.

--- a/crates/vmux_daemon/src/lib.rs
+++ b/crates/vmux_daemon/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod client;
 pub mod framing;
 pub mod protocol;
 pub mod server;

--- a/crates/vmux_daemon/src/main.rs
+++ b/crates/vmux_daemon/src/main.rs
@@ -1,3 +1,31 @@
-fn main() {
-    eprintln!("vmux-daemon: placeholder — replaced in Task 5");
+use vmux_daemon::{daemon_dir, pid_path, socket_path};
+
+#[tokio::main]
+async fn main() {
+    let dir = daemon_dir();
+    std::fs::create_dir_all(&dir).expect("failed to create ~/.vmux");
+
+    // Write PID file
+    let pid = std::process::id();
+    std::fs::write(pid_path(), pid.to_string()).expect("failed to write PID file");
+
+    // Remove stale socket
+    let sock = socket_path();
+    let _ = std::fs::remove_file(&sock);
+
+    let listener =
+        tokio::net::UnixListener::bind(&sock).expect("failed to bind Unix socket");
+
+    eprintln!("vmux-daemon: listening on {}", sock.display());
+
+    // Clean up on shutdown
+    let sock_cleanup = sock.clone();
+    tokio::spawn(async move {
+        tokio::signal::ctrl_c().await.ok();
+        let _ = std::fs::remove_file(&sock_cleanup);
+        let _ = std::fs::remove_file(pid_path());
+        std::process::exit(0);
+    });
+
+    vmux_daemon::server::run_server(listener).await;
 }

--- a/crates/vmux_daemon/src/main.rs
+++ b/crates/vmux_daemon/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    eprintln!("vmux-daemon: placeholder — replaced in Task 5");
+}

--- a/crates/vmux_daemon/src/main.rs
+++ b/crates/vmux_daemon/src/main.rs
@@ -3,7 +3,7 @@ use vmux_daemon::{daemon_dir, pid_path, socket_path};
 #[tokio::main]
 async fn main() {
     let dir = daemon_dir();
-    std::fs::create_dir_all(&dir).expect("failed to create ~/.vmux");
+    std::fs::create_dir_all(&dir).expect("failed to create daemon dir");
 
     // Write PID file
     let pid = std::process::id();

--- a/crates/vmux_daemon/src/protocol.rs
+++ b/crates/vmux_daemon/src/protocol.rs
@@ -1,0 +1,98 @@
+use vmux_terminal::event::{TermCursor, TermLine, TermSelectionRange};
+
+/// Unique identifier for a daemon-managed terminal session.
+/// Stored as raw bytes for rkyv compatibility.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub struct SessionId(pub [u8; 16]);
+
+impl SessionId {
+    pub fn new() -> Self {
+        Self(*uuid::Uuid::new_v4().as_bytes())
+    }
+
+    pub fn to_uuid(&self) -> uuid::Uuid {
+        uuid::Uuid::from_bytes(self.0)
+    }
+
+    pub fn from_uuid(u: uuid::Uuid) -> Self {
+        Self(*u.as_bytes())
+    }
+}
+
+impl std::fmt::Display for SessionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_uuid())
+    }
+}
+
+impl std::str::FromStr for SessionId {
+    type Err = uuid::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from_uuid(s.parse()?))
+    }
+}
+
+/// Messages sent from the GUI client to the daemon.
+#[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub enum ClientMessage {
+    CreateSession {
+        shell: String,
+        cwd: String,
+        env: Vec<(String, String)>,
+        cols: u16,
+        rows: u16,
+    },
+    AttachSession { session_id: SessionId },
+    DetachSession { session_id: SessionId },
+    SessionInput { session_id: SessionId, data: Vec<u8> },
+    ResizeSession {
+        session_id: SessionId,
+        cols: u16,
+        rows: u16,
+    },
+    ListSessions,
+    KillSession { session_id: SessionId },
+    RequestSnapshot { session_id: SessionId },
+    Shutdown,
+}
+
+/// Messages sent from the daemon to the GUI client.
+#[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub enum DaemonMessage {
+    SessionCreated { session_id: SessionId },
+    SessionOutput { session_id: SessionId, data: Vec<u8> },
+    ViewportPatch {
+        session_id: SessionId,
+        changed_lines: Vec<(u16, TermLine)>,
+        cursor: TermCursor,
+        cols: u16,
+        rows: u16,
+        selection: Option<TermSelectionRange>,
+        full: bool,
+    },
+    SessionExited {
+        session_id: SessionId,
+        exit_code: Option<i32>,
+    },
+    SessionList { sessions: Vec<SessionInfo> },
+    Snapshot {
+        session_id: SessionId,
+        lines: Vec<TermLine>,
+        cursor: TermCursor,
+        cols: u16,
+        rows: u16,
+    },
+    Error { message: String },
+}
+
+/// Metadata about a session, returned in SessionList.
+#[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub struct SessionInfo {
+    pub id: SessionId,
+    pub shell: String,
+    pub cwd: String,
+    pub cols: u16,
+    pub rows: u16,
+    pub pid: u32,
+    pub created_at_secs: u64,
+}

--- a/crates/vmux_daemon/src/server.rs
+++ b/crates/vmux_daemon/src/server.rs
@@ -1,0 +1,1 @@
+// Implemented in Task 5.

--- a/crates/vmux_daemon/src/server.rs
+++ b/crates/vmux_daemon/src/server.rs
@@ -1,1 +1,208 @@
-// Implemented in Task 5.
+use crate::protocol::{ClientMessage, DaemonMessage, SessionId};
+use crate::session::SessionManager;
+use crate::{read_message, write_message};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::io::BufReader;
+use tokio::net::UnixListener;
+use tokio::sync::{broadcast, Mutex};
+
+// rkyv is used directly in the attach forwarder (can't use write_message! macro
+// inside a spawned task that doesn't return Result).
+
+/// Run the IPC server loop, accepting connections and dispatching messages.
+pub async fn run_server(listener: UnixListener) {
+    let manager = Arc::new(Mutex::new(SessionManager::new()));
+
+    // Poll sessions at ~60Hz in background
+    let poll_mgr = Arc::clone(&manager);
+    tokio::spawn(async move {
+        loop {
+            {
+                let mut mgr = poll_mgr.lock().await;
+                let exited = mgr.poll_all();
+                for id in exited {
+                    mgr.remove_session(&id);
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(16)).await;
+        }
+    });
+
+    loop {
+        let (stream, _) = match listener.accept().await {
+            Ok(conn) => conn,
+            Err(e) => {
+                eprintln!("accept error: {e}");
+                continue;
+            }
+        };
+        let mgr = Arc::clone(&manager);
+        tokio::spawn(async move {
+            if let Err(e) = handle_client(stream, mgr).await {
+                eprintln!("client error: {e}");
+            }
+        });
+    }
+}
+
+async fn handle_client(
+    stream: tokio::net::UnixStream,
+    manager: Arc<Mutex<SessionManager>>,
+) -> std::io::Result<()> {
+    let (reader, writer) = stream.into_split();
+    let mut reader = BufReader::new(reader);
+    let writer = Arc::new(tokio::sync::Mutex::new(writer));
+
+    // Track which sessions this client is attached to, so we can forward patches.
+    let attached: Arc<tokio::sync::Mutex<HashMap<SessionId, tokio::task::JoinHandle<()>>>> =
+        Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+
+    loop {
+        let msg: Option<ClientMessage> = read_message!(&mut reader, ClientMessage)?;
+        let Some(msg) = msg else {
+            break; // client disconnected
+        };
+
+        match msg {
+            ClientMessage::CreateSession {
+                shell,
+                cwd,
+                env,
+                cols,
+                rows,
+            } => {
+                let mut mgr = manager.lock().await;
+                match mgr.create_session(shell, cwd, env, cols, rows) {
+                    Ok(id) => {
+                        let resp = DaemonMessage::SessionCreated { session_id: id };
+                        let w = writer.clone();
+                        let mut w = w.lock().await;
+                        write_message!(&mut *w, &resp)?;
+                    }
+                    Err(e) => {
+                        let resp = DaemonMessage::Error { message: e };
+                        let w = writer.clone();
+                        let mut w = w.lock().await;
+                        write_message!(&mut *w, &resp)?;
+                    }
+                }
+            }
+
+            ClientMessage::AttachSession { session_id } => {
+                let mgr = manager.lock().await;
+                if let Some(session) = mgr.sessions.get(&session_id) {
+                    let mut rx = session.subscribe();
+                    let w = writer.clone();
+                    let handle = tokio::spawn(async move {
+                        loop {
+                            match rx.recv().await {
+                                Ok(msg) => {
+                                    let bytes =
+                                        match rkyv::to_bytes::<rkyv::rancor::Error>(&msg) {
+                                            Ok(b) => b,
+                                            Err(_) => break,
+                                        };
+                                    let mut w = w.lock().await;
+                                    if crate::framing::write_raw_frame(&mut *w, &bytes)
+                                        .await
+                                        .is_err()
+                                    {
+                                        break;
+                                    }
+                                }
+                                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                                Err(broadcast::error::RecvError::Closed) => break,
+                            }
+                        }
+                    });
+                    attached.lock().await.insert(session_id, handle);
+                } else {
+                    let resp = DaemonMessage::Error {
+                        message: format!("session not found: {session_id}"),
+                    };
+                    let mut w = writer.lock().await;
+                    write_message!(&mut *w, &resp)?;
+                }
+            }
+
+            ClientMessage::DetachSession { session_id } => {
+                if let Some(handle) = attached.lock().await.remove(&session_id) {
+                    handle.abort();
+                }
+            }
+
+            ClientMessage::SessionInput { session_id, data } => {
+                let mgr = manager.lock().await;
+                if let Some(session) = mgr.sessions.get(&session_id) {
+                    session.write_input(&data);
+                }
+            }
+
+            ClientMessage::ResizeSession {
+                session_id,
+                cols,
+                rows,
+            } => {
+                let mut mgr = manager.lock().await;
+                if let Some(session) = mgr.sessions.get_mut(&session_id) {
+                    session.resize(cols, rows);
+                }
+            }
+
+            ClientMessage::ListSessions => {
+                let mgr = manager.lock().await;
+                let sessions = mgr
+                    .sessions
+                    .values()
+                    .map(|s| s.info())
+                    .collect::<Vec<_>>();
+                let resp = DaemonMessage::SessionList { sessions };
+                let mut w = writer.lock().await;
+                write_message!(&mut *w, &resp)?;
+            }
+
+            ClientMessage::KillSession { session_id } => {
+                let mut mgr = manager.lock().await;
+                mgr.remove_session(&session_id);
+                if let Some(handle) = attached.lock().await.remove(&session_id) {
+                    handle.abort();
+                }
+            }
+
+            ClientMessage::RequestSnapshot { session_id } => {
+                let mgr = manager.lock().await;
+                if let Some(session) = mgr.sessions.get(&session_id) {
+                    let snap = session.snapshot();
+                    let mut w = writer.lock().await;
+                    write_message!(&mut *w, &snap)?;
+                } else {
+                    let resp = DaemonMessage::Error {
+                        message: format!("session not found: {session_id}"),
+                    };
+                    let mut w = writer.lock().await;
+                    write_message!(&mut *w, &resp)?;
+                }
+            }
+
+            ClientMessage::Shutdown => {
+                let mut mgr = manager.lock().await;
+                mgr.shutdown();
+                let resp = DaemonMessage::SessionList {
+                    sessions: Vec::new(),
+                };
+                let mut w = writer.lock().await;
+                write_message!(&mut *w, &resp)?;
+                // After responding, exit
+                std::process::exit(0);
+            }
+        }
+    }
+
+    // Client disconnected — abort all patch forwarders
+    for (_, handle) in attached.lock().await.drain() {
+        handle.abort();
+    }
+
+    Ok(())
+}

--- a/crates/vmux_daemon/src/session.rs
+++ b/crates/vmux_daemon/src/session.rs
@@ -1,0 +1,1 @@
+// Implemented in Task 4.

--- a/crates/vmux_daemon/src/session.rs
+++ b/crates/vmux_daemon/src/session.rs
@@ -1,1 +1,523 @@
-// Implemented in Task 4.
+use crate::protocol::{DaemonMessage, SessionId, SessionInfo};
+use alacritty_terminal::{
+    event::{Event as TermEvent, EventListener as TermEventListener},
+    grid::Dimensions,
+    index::{Column, Line},
+    term::{Config as TermConfig, Term, cell::Flags as CellFlags},
+    vte::ansi::{Color, NamedColor, Processor},
+};
+use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
+use std::{
+    collections::HashMap,
+    io::{Read, Write},
+    path::PathBuf,
+    sync::{Arc, Mutex},
+    time::Instant,
+};
+use tokio::sync::{broadcast, mpsc};
+use vmux_terminal::event::*;
+
+#[derive(Clone)]
+struct DaemonEventProxy {
+    pty_writer: Arc<Mutex<Box<dyn Write + Send>>>,
+}
+
+impl TermEventListener for DaemonEventProxy {
+    fn send_event(&self, event: TermEvent) {
+        if let TermEvent::PtyWrite(text) = event {
+            if let Ok(mut writer) = self.pty_writer.lock() {
+                let _ = writer.write_all(text.as_bytes());
+            }
+        }
+    }
+}
+
+struct PtyDimensions {
+    cols: u16,
+    rows: u16,
+}
+
+impl Dimensions for PtyDimensions {
+    fn total_lines(&self) -> usize {
+        self.rows as usize
+    }
+    fn screen_lines(&self) -> usize {
+        self.rows as usize
+    }
+    fn columns(&self) -> usize {
+        self.cols as usize
+    }
+}
+
+/// A single terminal session managed by the daemon.
+pub struct Session {
+    pub id: SessionId,
+    pub shell: String,
+    pub cwd: String,
+    pub cols: u16,
+    pub rows: u16,
+    pub pid: u32,
+    pub created_at: Instant,
+    term: Term<DaemonEventProxy>,
+    processor: Processor,
+    pty_writer: Arc<Mutex<Box<dyn Write + Send>>>,
+    master: Box<dyn portable_pty::MasterPty + Send>,
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+    pty_rx: mpsc::UnboundedReceiver<Vec<u8>>,
+    /// Broadcasts viewport patches to all attached GUI clients.
+    patch_tx: broadcast::Sender<DaemonMessage>,
+    line_hashes: Vec<u64>,
+}
+
+impl Session {
+    pub fn new(
+        shell: String,
+        cwd: String,
+        env: Vec<(String, String)>,
+        cols: u16,
+        rows: u16,
+    ) -> Result<Self, String> {
+        let id = SessionId::new();
+        let pty_system = NativePtySystem::default();
+        let pair = pty_system
+            .openpty(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .map_err(|e| format!("failed to open PTY: {e}"))?;
+
+        let mut cmd = CommandBuilder::new(&shell);
+        cmd.env("TERM", "xterm-256color");
+        cmd.env("COLORTERM", "truecolor");
+        cmd.env("LANG", "en_US.UTF-8");
+        cmd.env("LC_CTYPE", "UTF-8");
+        for (k, v) in &env {
+            cmd.env(k, v);
+        }
+        let cwd_path = PathBuf::from(&cwd);
+        if !cwd.is_empty() && cwd_path.exists() {
+            cmd.cwd(&cwd_path);
+        }
+
+        let child = pair
+            .slave
+            .spawn_command(cmd)
+            .map_err(|e| format!("failed to spawn shell: {e}"))?;
+        let pid = child.process_id().unwrap_or(0);
+        let reader = pair
+            .master
+            .try_clone_reader()
+            .map_err(|e| format!("failed to clone PTY reader: {e}"))?;
+        let writer: Arc<Mutex<Box<dyn Write + Send>>> = Arc::new(Mutex::new(
+            pair.master
+                .take_writer()
+                .map_err(|e| format!("failed to take PTY writer: {e}"))?,
+        ));
+        drop(pair.slave);
+
+        if !cwd.is_empty() && cwd_path.exists() {
+            if let Ok(mut w) = writer.lock() {
+                let cd_cmd = format!("cd {}\n", cwd);
+                let _ = w.write_all(cd_cmd.as_bytes());
+                let _ = w.flush();
+            }
+        }
+
+        let (pty_tx, pty_rx) = mpsc::unbounded_channel();
+        std::thread::Builder::new()
+            .name(format!("pty-reader-{}", &id.to_string()[..8]))
+            .spawn(move || {
+                let mut buf = [0u8; 4096];
+                let mut reader = reader;
+                loop {
+                    match reader.read(&mut buf) {
+                        Ok(0) => break,
+                        Ok(n) => {
+                            if pty_tx.send(buf[..n].to_vec()).is_err() {
+                                break;
+                            }
+                        }
+                        Err(_) => break,
+                    }
+                }
+            })
+            .map_err(|e| format!("failed to spawn PTY reader: {e}"))?;
+
+        let event_proxy = DaemonEventProxy {
+            pty_writer: Arc::clone(&writer),
+        };
+        let dims = PtyDimensions { cols, rows };
+        let term = Term::new(TermConfig::default(), &dims, event_proxy);
+        let (patch_tx, _) = broadcast::channel(256);
+
+        Ok(Self {
+            id,
+            shell,
+            cwd,
+            cols,
+            rows,
+            pid,
+            created_at: Instant::now(),
+            term,
+            processor: Processor::new(),
+            pty_writer: writer,
+            master: pair.master,
+            child,
+            pty_rx,
+            patch_tx,
+            line_hashes: Vec::new(),
+        })
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<DaemonMessage> {
+        self.patch_tx.subscribe()
+    }
+
+    pub fn write_input(&self, data: &[u8]) {
+        if let Ok(mut w) = self.pty_writer.lock() {
+            let _ = w.write_all(data);
+        }
+    }
+
+    pub fn resize(&mut self, cols: u16, rows: u16) {
+        self.cols = cols;
+        self.rows = rows;
+        let _ = self.master.resize(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        });
+        let dims = PtyDimensions { cols, rows };
+        self.term.resize(dims);
+        self.line_hashes.clear();
+    }
+
+    /// Drain PTY output, process through VTE, broadcast viewport patches.
+    /// Returns true if the child process has exited.
+    pub fn poll(&mut self) -> bool {
+        let mut got_data = false;
+        while let Ok(data) = self.pty_rx.try_recv() {
+            self.processor.advance(&mut self.term, &data);
+            got_data = true;
+        }
+        if got_data {
+            self.sync_viewport();
+        }
+        if let Ok(Some(status)) = self.child.try_wait() {
+            let code = status.exit_code() as i32;
+            let _ = self.patch_tx.send(DaemonMessage::SessionExited {
+                session_id: self.id,
+                exit_code: Some(code),
+            });
+            return true;
+        }
+        false
+    }
+
+    fn sync_viewport(&mut self) {
+        let grid = self.term.grid();
+        let num_lines = grid.screen_lines();
+        let num_cols = grid.columns();
+        let offset = grid.display_offset() as i32;
+
+        let full = self.line_hashes.len() != num_lines;
+        if self.line_hashes.len() != num_lines {
+            self.line_hashes.resize(num_lines, 0);
+        }
+
+        let mut changed_lines = Vec::new();
+        for row_idx in 0..num_lines {
+            let hash = hash_grid_row(&self.term, row_idx, offset);
+            if full || hash != self.line_hashes[row_idx] {
+                self.line_hashes[row_idx] = hash;
+                changed_lines.push((row_idx as u16, build_line(&self.term, row_idx, offset)));
+            }
+        }
+        if changed_lines.is_empty() && !full {
+            return;
+        }
+
+        let cursor_point = grid.cursor.point;
+        let scrolled_back = offset > 0;
+        let cursor_char = {
+            let cursor_row = &grid[cursor_point.line];
+            let cell = &cursor_row[cursor_point.column];
+            cell.c.to_string()
+        };
+
+        let patch = DaemonMessage::ViewportPatch {
+            session_id: self.id,
+            changed_lines,
+            cursor: TermCursor {
+                col: cursor_point.column.0 as u16,
+                row: cursor_point.line.0 as u16,
+                shape: CursorShape::Block,
+                visible: !scrolled_back,
+                ch: cursor_char,
+            },
+            cols: num_cols as u16,
+            rows: num_lines as u16,
+            selection: None,
+            full,
+        };
+        let _ = self.patch_tx.send(patch);
+    }
+
+    pub fn snapshot(&self) -> DaemonMessage {
+        let grid = self.term.grid();
+        let num_lines = grid.screen_lines();
+        let offset = grid.display_offset() as i32;
+
+        let mut lines = Vec::with_capacity(num_lines);
+        for row_idx in 0..num_lines {
+            lines.push(build_line(&self.term, row_idx, offset));
+        }
+
+        let cursor_point = grid.cursor.point;
+        let scrolled_back = offset > 0;
+        let cursor_char = {
+            let cursor_row = &grid[cursor_point.line];
+            let cell = &cursor_row[cursor_point.column];
+            cell.c.to_string()
+        };
+
+        DaemonMessage::Snapshot {
+            session_id: self.id,
+            lines,
+            cursor: TermCursor {
+                col: cursor_point.column.0 as u16,
+                row: cursor_point.line.0 as u16,
+                shape: CursorShape::Block,
+                visible: !scrolled_back,
+                ch: cursor_char,
+            },
+            cols: grid.columns() as u16,
+            rows: num_lines as u16,
+        }
+    }
+
+    pub fn info(&self) -> SessionInfo {
+        SessionInfo {
+            id: self.id,
+            shell: self.shell.clone(),
+            cwd: self.cwd.clone(),
+            cols: self.cols,
+            rows: self.rows,
+            pid: self.pid,
+            created_at_secs: self.created_at.elapsed().as_secs(),
+        }
+    }
+
+    pub fn kill(&mut self) {
+        let _ = self.child.kill();
+    }
+}
+
+pub struct SessionManager {
+    pub sessions: HashMap<SessionId, Session>,
+}
+
+impl SessionManager {
+    pub fn new() -> Self {
+        Self {
+            sessions: HashMap::new(),
+        }
+    }
+
+    pub fn create_session(
+        &mut self,
+        shell: String,
+        cwd: String,
+        env: Vec<(String, String)>,
+        cols: u16,
+        rows: u16,
+    ) -> Result<SessionId, String> {
+        let session = Session::new(shell, cwd, env, cols, rows)?;
+        let id = session.id;
+        self.sessions.insert(id, session);
+        Ok(id)
+    }
+
+    pub fn poll_all(&mut self) -> Vec<SessionId> {
+        let mut exited = Vec::new();
+        for (id, session) in &mut self.sessions {
+            if session.poll() {
+                exited.push(*id);
+            }
+        }
+        exited
+    }
+
+    pub fn remove_session(&mut self, id: &SessionId) {
+        if let Some(mut session) = self.sessions.remove(id) {
+            session.kill();
+        }
+    }
+
+    pub fn shutdown(&mut self) {
+        for (_, session) in &mut self.sessions {
+            session.kill();
+        }
+        self.sessions.clear();
+    }
+}
+
+// --- Grid helpers ---
+
+fn hash_grid_row<T: TermEventListener>(term: &Term<T>, row_idx: usize, offset: i32) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    let grid = term.grid();
+    let num_cols = grid.columns();
+    let row = &grid[Line(row_idx as i32 - offset)];
+    for col_idx in 0..num_cols {
+        let cell = &row[Column(col_idx)];
+        cell.c.hash(&mut hasher);
+        std::mem::discriminant(&cell.fg).hash(&mut hasher);
+        match &cell.fg {
+            Color::Named(c) => (*c as u8).hash(&mut hasher),
+            Color::Spec(rgb) => {
+                rgb.r.hash(&mut hasher);
+                rgb.g.hash(&mut hasher);
+                rgb.b.hash(&mut hasher);
+            }
+            Color::Indexed(i) => i.hash(&mut hasher),
+        }
+        std::mem::discriminant(&cell.bg).hash(&mut hasher);
+        match &cell.bg {
+            Color::Named(c) => (*c as u8).hash(&mut hasher),
+            Color::Spec(rgb) => {
+                rgb.r.hash(&mut hasher);
+                rgb.g.hash(&mut hasher);
+                rgb.b.hash(&mut hasher);
+            }
+            Color::Indexed(i) => i.hash(&mut hasher),
+        }
+        cell.flags.bits().hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+fn build_line<T: TermEventListener>(term: &Term<T>, row_idx: usize, offset: i32) -> TermLine {
+    let grid = term.grid();
+    let num_cols = grid.columns();
+    let row = &grid[Line(row_idx as i32 - offset)];
+    let mut spans = Vec::new();
+    let mut text = String::new();
+    let mut cur_fg = TermColor::Default;
+    let mut cur_bg = TermColor::Default;
+    let mut cur_flags: u16 = 0;
+    let mut span_col_start: u16 = 0;
+    let mut span_grid_cols: u16 = 0;
+
+    for col_idx in 0..num_cols {
+        let cell = &row[Column(col_idx)];
+        if cell.flags.contains(CellFlags::WIDE_CHAR_SPACER) {
+            span_grid_cols += 1;
+            continue;
+        }
+        let fg = color_to_term_color(&cell.fg);
+        let bg = color_to_term_color(&cell.bg);
+        let flags = cell_flags_to_u16(cell.flags);
+        if fg != cur_fg || bg != cur_bg || flags != cur_flags {
+            if !text.is_empty() {
+                spans.push(TermSpan {
+                    text: std::mem::take(&mut text),
+                    fg: cur_fg,
+                    bg: cur_bg,
+                    flags: cur_flags,
+                    col: span_col_start,
+                    grid_cols: span_grid_cols,
+                });
+                span_col_start = col_idx as u16;
+                span_grid_cols = 0;
+            }
+            cur_fg = fg;
+            cur_bg = bg;
+            cur_flags = flags;
+        }
+        text.push(cell.c);
+        span_grid_cols += 1;
+    }
+    if !text.is_empty() {
+        spans.push(TermSpan {
+            text,
+            fg: cur_fg,
+            bg: cur_bg,
+            flags: cur_flags,
+            col: span_col_start,
+            grid_cols: span_grid_cols,
+        });
+    }
+    TermLine { spans }
+}
+
+fn color_to_term_color(color: &Color) -> TermColor {
+    match color {
+        Color::Named(named) => match named {
+            NamedColor::Foreground | NamedColor::DimForeground | NamedColor::BrightForeground => {
+                TermColor::Default
+            }
+            NamedColor::Background | NamedColor::Cursor => TermColor::Default,
+            other => TermColor::Indexed(named_to_ansi_index(other)),
+        },
+        Color::Indexed(idx) if *idx < 16 => TermColor::Indexed(*idx),
+        Color::Indexed(idx) => {
+            let [r, g, b] = ansi_256_to_rgb(*idx);
+            TermColor::Rgb(r, g, b)
+        }
+        Color::Spec(rgb) => TermColor::Rgb(rgb.r, rgb.g, rgb.b),
+    }
+}
+
+fn named_to_ansi_index(named: &NamedColor) -> u8 {
+    match named {
+        NamedColor::Black | NamedColor::DimBlack => 0,
+        NamedColor::Red | NamedColor::DimRed => 1,
+        NamedColor::Green | NamedColor::DimGreen => 2,
+        NamedColor::Yellow | NamedColor::DimYellow => 3,
+        NamedColor::Blue | NamedColor::DimBlue => 4,
+        NamedColor::Magenta | NamedColor::DimMagenta => 5,
+        NamedColor::Cyan | NamedColor::DimCyan => 6,
+        NamedColor::White | NamedColor::DimWhite => 7,
+        NamedColor::BrightBlack => 8,
+        NamedColor::BrightRed => 9,
+        NamedColor::BrightGreen => 10,
+        NamedColor::BrightYellow => 11,
+        NamedColor::BrightBlue => 12,
+        NamedColor::BrightMagenta => 13,
+        NamedColor::BrightCyan => 14,
+        NamedColor::BrightWhite => 15,
+        _ => 7,
+    }
+}
+
+fn cell_flags_to_u16(flags: CellFlags) -> u16 {
+    let mut f = 0u16;
+    if flags.contains(CellFlags::BOLD) { f |= FLAG_BOLD; }
+    if flags.contains(CellFlags::ITALIC) { f |= FLAG_ITALIC; }
+    if flags.contains(CellFlags::UNDERLINE) { f |= FLAG_UNDERLINE; }
+    if flags.contains(CellFlags::STRIKEOUT) { f |= FLAG_STRIKETHROUGH; }
+    if flags.contains(CellFlags::DIM) { f |= FLAG_DIM; }
+    if flags.contains(CellFlags::INVERSE) { f |= FLAG_INVERSE; }
+    f
+}
+
+fn ansi_256_to_rgb(idx: u8) -> [u8; 3] {
+    if idx < 16 {
+        return [0, 0, 0];
+    }
+    if idx < 232 {
+        let i = idx - 16;
+        let r = (i / 36) * 51;
+        let g = ((i % 36) / 6) * 51;
+        let b = (i % 6) * 51;
+        [r, g, b]
+    } else {
+        let v = 8 + (idx - 232) * 10;
+        [v, v, v]
+    }
+}

--- a/crates/vmux_desktop/Cargo.toml
+++ b/crates/vmux_desktop/Cargo.toml
@@ -39,6 +39,7 @@ vmux_command_bar = { path = "../vmux_command_bar" }
 vmux_macro = { path = "../vmux_macro" }
 vmux_ui = { path = "../vmux_ui", default-features = false }
 tokio = { workspace = true }
+uuid = { workspace = true }
 vmux_daemon = { path = "../vmux_daemon" }
 vmux_terminal = { path = "../vmux_terminal" }
 vmux_webview_app = { path = "../vmux_webview_app" }

--- a/crates/vmux_desktop/Cargo.toml
+++ b/crates/vmux_desktop/Cargo.toml
@@ -38,12 +38,11 @@ vmux_side_sheet = { path = "../vmux_side_sheet" }
 vmux_command_bar = { path = "../vmux_command_bar" }
 vmux_macro = { path = "../vmux_macro" }
 vmux_ui = { path = "../vmux_ui", default-features = false }
+vmux_daemon = { path = "../vmux_daemon" }
 vmux_terminal = { path = "../vmux_terminal" }
 vmux_webview_app = { path = "../vmux_webview_app" }
 
-alacritty_terminal = { workspace = true }
-portable-pty = { workspace = true }
-rfd = { workspace = true }
+
 notify = { workspace = true }
 semver = "1"
 cargo-packager-updater = "0.2"

--- a/crates/vmux_desktop/Cargo.toml
+++ b/crates/vmux_desktop/Cargo.toml
@@ -41,6 +41,7 @@ vmux_ui = { path = "../vmux_ui", default-features = false }
 tokio = { workspace = true }
 uuid = { workspace = true }
 vmux_daemon = { path = "../vmux_daemon" }
+vmux_sessions = { path = "../vmux_sessions" }
 vmux_terminal = { path = "../vmux_terminal" }
 vmux_webview_app = { path = "../vmux_webview_app" }
 

--- a/crates/vmux_desktop/Cargo.toml
+++ b/crates/vmux_desktop/Cargo.toml
@@ -38,6 +38,7 @@ vmux_side_sheet = { path = "../vmux_side_sheet" }
 vmux_command_bar = { path = "../vmux_command_bar" }
 vmux_macro = { path = "../vmux_macro" }
 vmux_ui = { path = "../vmux_ui", default-features = false }
+tokio = { workspace = true }
 vmux_daemon = { path = "../vmux_daemon" }
 vmux_terminal = { path = "../vmux_terminal" }
 vmux_webview_app = { path = "../vmux_webview_app" }

--- a/crates/vmux_desktop/src/command.rs
+++ b/crates/vmux_desktop/src/command.rs
@@ -44,6 +44,9 @@ pub enum AppCommand {
 
     #[menu(label = "Browser")]
     Browser(BrowserCommand),
+
+    #[menu(label = "Session")]
+    Session(SessionCommand),
 }
 
 #[allow(dead_code)]
@@ -183,6 +186,14 @@ pub enum BrowserCommand {
     ViewSource,
     #[menu(id = "browser_print", label = "Print", accel = "super+p", hidden)]
     Print,
+}
+
+#[allow(dead_code)]
+#[derive(OsSubMenu, DefaultShortcuts, CommandBar, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SessionCommand {
+    #[default]
+    #[menu(id = "session_open", label = "Open Session Monitor")]
+    Open,
 }
 
 #[allow(dead_code)]

--- a/crates/vmux_desktop/src/command_bar.rs
+++ b/crates/vmux_desktop/src/command_bar.rs
@@ -7,9 +7,10 @@ use crate::{
         pane::{Pane, PaneSplit},
         side_sheet::SideSheet,
         space::Space,
-        tab::{Tab, TabCommandSet, active_among, collect_leaf_panes, focused_tab},
+        tab::{Tab, active_among, collect_leaf_panes, focused_tab},
         window::Modal,
     },
+    sessions_monitor::SessionsMonitor,
     settings::AppSettings,
     terminal::Terminal,
 };
@@ -21,19 +22,23 @@ use vmux_command_bar::event::{
     COMMAND_BAR_OPEN_EVENT, CommandBarActionEvent, CommandBarCommandEntry, CommandBarOpenEvent,
     CommandBarTab, PATH_COMPLETE_RESPONSE, PathCompleteRequest, PathCompleteResponse, PathEntry,
 };
+use vmux_daemon::protocol::SessionId;
 use vmux_header::{Header, PageMetadata};
 use vmux_history::LastActivatedAt;
+use vmux_sessions::event::SESSIONS_WEBVIEW_URL;
 use vmux_terminal::event::TERMINAL_WEBVIEW_URL;
+
+/// Try to extract a session UUID from `vmux://terminal/session/{uuid}`.
+fn parse_session_id_from_url(url: &str) -> Option<SessionId> {
+    let suffix = url.strip_prefix(TERMINAL_WEBVIEW_URL)?;
+    let uuid_str = suffix.strip_prefix("session/")?;
+    uuid_str.parse::<SessionId>().ok()
+}
 
 /// Deferred visibility for the command bar modal. Counts frames after Display::Flex
 /// so CEF can resize the webview before the modal becomes visible.
 #[derive(Component)]
 struct PendingCommandBarReveal(u8);
-
-/// Inserted during the first app launch (no session file) so that the command
-/// bar opens automatically once the modal webview is ready.
-#[derive(Resource)]
-pub(crate) struct PendingFirstLaunchOpen;
 
 /// Tracks an empty tab spawned by Cmd+T that is waiting for the user
 /// to choose content via the command bar.
@@ -58,15 +63,7 @@ impl Plugin for CommandBarInputPlugin {
             .add_plugins(JsEmitEventPlugin::<PathCompleteRequest>::default())
             .add_observer(on_command_bar_action)
             .add_observer(on_path_complete_request)
-            .add_systems(
-                Update,
-                (
-                    handle_open_command_bar
-                        .in_set(ReadAppCommands)
-                        .after(TabCommandSet),
-                    first_launch_open_command_bar.before(ReadAppCommands),
-                ),
-            )
+            .add_systems(Update, handle_open_command_bar.in_set(ReadAppCommands))
             .add_systems(
                 Update,
                 deferred_dismiss_modal
@@ -97,31 +94,6 @@ pub fn match_command(id: &str) -> Option<AppCommand> {
 /// Returns true when the command bar modal is currently visible.
 pub fn is_command_bar_open(modal_q: &Query<&Node, With<Modal>>) -> bool {
     modal_q.iter().any(|n| n.display != Display::None)
-}
-
-/// Despawn any pre-spawned Browser children of a tab (e.g. the transparent
-/// about:blank browser + glass created by Cmd+T) before attaching real content.
-fn despawn_tab_browsers(
-    tab: Entity,
-    all_children: &Query<&Children>,
-    content_browsers: &Query<
-        Entity,
-        (
-            With<Browser>,
-            Without<Header>,
-            Without<SideSheet>,
-            Without<Modal>,
-        ),
-    >,
-    commands: &mut Commands,
-) {
-    if let Ok(children) = all_children.get(tab) {
-        for child in children.iter() {
-            if content_browsers.contains(child) {
-                commands.entity(child).despawn();
-            }
-        }
-    }
 }
 
 fn handle_open_command_bar(
@@ -288,6 +260,8 @@ fn handle_open_command_bar(
         if !is_open {
             should_open = true;
         }
+        // If already open, do nothing — the shortcut should not close the bar.
+        // Users can dismiss with Escape or click-outside.
     }
 
     if !should_open {
@@ -468,8 +442,6 @@ fn on_command_bar_action(
                     expanded.parent().unwrap_or(&expanded)
                 };
                 if let Some(tab_e) = empty_tab {
-                    // Despawn pre-spawned transparent browser + glass
-                    despawn_tab_browsers(tab_e, &all_children, &content_browsers, &mut commands);
                     commands.entity(tab_e).insert(PageMetadata {
                         url: TERMINAL_WEBVIEW_URL.to_string(),
                         title: format!("Terminal ({})", dir.display()),
@@ -501,22 +473,39 @@ fn on_command_bar_action(
                 };
 
                 if let Some(tab_e) = empty_tab {
-                    // Despawn pre-spawned transparent browser + glass
-                    despawn_tab_browsers(tab_e, &all_children, &content_browsers, &mut commands);
                     // New tab mode: attach content to the empty tab
                     if url.starts_with("vmux://terminal") {
+                        let term_e = if let Some(sid) = parse_session_id_from_url(&url) {
+                            commands
+                                .spawn((
+                                    Terminal::reattach(&mut meshes, &mut webview_mt, sid),
+                                    ChildOf(tab_e),
+                                ))
+                                .id()
+                        } else {
+                            commands.entity(tab_e).insert(PageMetadata {
+                                url: TERMINAL_WEBVIEW_URL.to_string(),
+                                title: "Terminal (Session: -)".to_string(),
+                                ..default()
+                            });
+                            commands
+                                .spawn((
+                                    Terminal::new(&mut meshes, &mut webview_mt, &settings),
+                                    ChildOf(tab_e),
+                                ))
+                                .id()
+                        };
+                        commands.entity(term_e).insert(CefKeyboardTarget);
+                    } else if url.starts_with(SESSIONS_WEBVIEW_URL.trim_end_matches('/')) {
                         commands.entity(tab_e).insert(PageMetadata {
-                            url: TERMINAL_WEBVIEW_URL.to_string(),
-                            title: "Terminal (Session: -)".to_string(),
+                            url: SESSIONS_WEBVIEW_URL.to_string(),
+                            title: "Sessions".to_string(),
                             ..default()
                         });
-                        let term_e = commands
-                            .spawn((
-                                Terminal::new(&mut meshes, &mut webview_mt, &settings),
-                                ChildOf(tab_e),
-                            ))
-                            .id();
-                        commands.entity(term_e).insert(CefKeyboardTarget);
+                        commands.spawn((
+                            SessionsMonitor::new(&mut meshes, &mut webview_mt),
+                            ChildOf(tab_e),
+                        ));
                     } else {
                         let browser_e = commands
                             .spawn((
@@ -531,8 +520,33 @@ fn on_command_bar_action(
                     custom_keyboard_restore = true;
                 } else {
                     // Normal mode: navigate or spawn terminal in current tab
-                    if url.starts_with("vmux://terminal") {
+                    if let Some(sid) = parse_session_id_from_url(&url) {
+                        // Reattach to existing daemon session in a new tab
+                        let (_, active_pane_opt, _) = focused_tab(
+                            &spaces, &all_children, &leaf_panes,
+                            &pane_ts, &pane_children, &tab_ts,
+                        );
+                        if let Some(pane_e) = active_pane_opt {
+                            let tab_e = commands
+                                .spawn((
+                                    crate::layout::tab::tab_bundle(),
+                                    LastActivatedAt::now(),
+                                    ChildOf(pane_e),
+                                ))
+                                .id();
+                            let term_e = commands
+                                .spawn((
+                                    Terminal::reattach(&mut meshes, &mut webview_mt, sid),
+                                    ChildOf(tab_e),
+                                ))
+                                .id();
+                            commands.entity(term_e).insert(CefKeyboardTarget);
+                        }
+                    } else if url.starts_with("vmux://terminal") {
                         writer.write(AppCommand::Terminal(TerminalCommand::New));
+                    } else if url.starts_with(SESSIONS_WEBVIEW_URL.trim_end_matches('/')) {
+                        use crate::command::SessionCommand;
+                        writer.write(AppCommand::Session(SessionCommand::Open));
                     } else {
                         let (_, _, active_tab) = focused_tab(
                             &spaces,
@@ -559,6 +573,42 @@ fn on_command_bar_action(
             }
         }
         "terminal" => {
+            // Check if value is a vmux://terminal/session/{id} URL — reattach
+            if let Some(sid) = parse_session_id_from_url(&evt.value) {
+                if let Some(tab_e) = empty_tab {
+                    let term_e = commands
+                        .spawn((
+                            Terminal::reattach(&mut meshes, &mut webview_mt, sid),
+                            ChildOf(tab_e),
+                        ))
+                        .id();
+                    commands.entity(term_e).insert(CefKeyboardTarget);
+                    new_tab_ctx.tab = None;
+                    new_tab_ctx.previous_tab = None;
+                    custom_keyboard_restore = true;
+                } else {
+                    let (_, active_pane_opt, _) = focused_tab(
+                        &spaces, &all_children, &leaf_panes,
+                        &pane_ts, &pane_children, &tab_ts,
+                    );
+                    if let Some(pane_e) = active_pane_opt {
+                        let tab_e = commands
+                            .spawn((
+                                crate::layout::tab::tab_bundle(),
+                                LastActivatedAt::now(),
+                                ChildOf(pane_e),
+                            ))
+                            .id();
+                        let term_e = commands
+                            .spawn((
+                                Terminal::reattach(&mut meshes, &mut webview_mt, sid),
+                                ChildOf(tab_e),
+                            ))
+                            .id();
+                        commands.entity(term_e).insert(CefKeyboardTarget);
+                    }
+                }
+            } else {
             let cwd = if evt.value.is_empty() || evt.value.contains("://") {
                 None
             } else {
@@ -576,8 +626,6 @@ fn on_command_bar_action(
                 Some(expanded)
             };
             if let Some(tab_e) = empty_tab {
-                // Despawn pre-spawned transparent browser + glass
-                despawn_tab_browsers(tab_e, &all_children, &content_browsers, &mut commands);
                 commands.entity(tab_e).insert(PageMetadata {
                     url: TERMINAL_WEBVIEW_URL.to_string(),
                     title: "Terminal (Session: -)".to_string(),
@@ -636,6 +684,7 @@ fn on_command_bar_action(
                     writer.write(AppCommand::Terminal(TerminalCommand::New));
                 }
             }
+            } // end reattach else
         }
         "command" => {
             if let Some(cmd) = match_command(&evt.value) {
@@ -748,29 +797,6 @@ fn deferred_dismiss_modal(
             .remove::<CefPointerTarget>()
             .remove::<PendingCommandBarReveal>();
     }
-}
-
-/// Opens the command bar on first launch, waiting until the modal webview is
-/// ready so the open event is actually received by the WASM app.
-fn first_launch_open_command_bar(
-    pending: Option<Res<PendingFirstLaunchOpen>>,
-    modal_q: Query<Entity, With<Modal>>,
-    browsers: NonSend<Browsers>,
-    mut new_tab_ctx: ResMut<NewTabContext>,
-    mut commands: Commands,
-) {
-    if pending.is_none() {
-        return;
-    }
-    let Ok(modal_e) = modal_q.single() else {
-        return;
-    };
-    if !browsers.has_browser(modal_e) || !browsers.host_emit_ready(&modal_e) {
-        return;
-    }
-    // Modal webview is ready — trigger command bar open on the next frame.
-    new_tab_ctx.needs_open = true;
-    commands.remove_resource::<PendingFirstLaunchOpen>();
 }
 
 /// Waits 2 frames after `Display::Flex` before revealing the command bar so that

--- a/crates/vmux_desktop/src/layout/tab.rs
+++ b/crates/vmux_desktop/src/layout/tab.rs
@@ -1,14 +1,14 @@
 use crate::{
-    browser::Browser,
-    command::{AppCommand, ReadAppCommands, TabCommand, TerminalCommand},
+    command::{AppCommand, ReadAppCommands, SessionCommand, TabCommand, TerminalCommand},
     command_bar::NewTabContext,
     layout::pane::{Pane, PaneSplit, PendingCursorWarp, first_leaf_descendant, first_tab_in_pane},
     layout::space::Space,
     layout::swap::{find_kind_index, resolve_next, resolve_prev, swap_siblings},
+    sessions_monitor::SessionsMonitor,
     settings::AppSettings,
-    terminal::{self, PtyExited, Terminal},
+    terminal::Terminal,
 };
-use bevy::{ecs::message::Messages, ecs::relationship::Relationship, prelude::*};
+use bevy::{ecs::relationship::Relationship, prelude::*};
 use bevy_cef::prelude::*;
 use moonshine_save::prelude::*;
 use vmux_history::LastActivatedAt;
@@ -29,27 +29,13 @@ pub(crate) struct FocusedTab {
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct ComputeFocusSet;
 
-/// Marker: tab is waiting for close confirmation dialog.
-#[derive(Component)]
-pub(crate) struct PendingTabClose;
-
-/// Marker: close was confirmed, skip dialog next time.
-#[derive(Component)]
-pub(crate) struct CloseConfirmed;
-
-/// System set for `handle_tab_commands`. The command bar's open/dismiss
-/// handler must run `.after(TabCommandSet)` to avoid a race when toggling.
-#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct TabCommandSet;
-
 pub(crate) struct TabPlugin;
 
 impl Plugin for TabPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Tab>()
             .init_resource::<FocusedTab>()
-            .add_systems(Update, handle_tab_commands.in_set(ReadAppCommands).in_set(TabCommandSet))
-            .add_systems(Update, process_pending_tab_closes)
+            .add_systems(Update, handle_tab_commands.in_set(ReadAppCommands))
             .add_systems(
                 Update,
                 compute_focused_tab
@@ -188,17 +174,13 @@ fn handle_tab_commands(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
-    mut extra: ParamSet<(
-        ResMut<'static, PendingCursorWarp>,
-        Query<'static, 'static, (), (With<Terminal>, Without<PtyExited>)>,
-        Query<'static, 'static, (), With<CloseConfirmed>>,
-        Query<'static, 'static, (), With<PendingTabClose>>,
-    )>,
+    mut pending_warp: ResMut<PendingCursorWarp>,
 ) {
     for cmd in reader.read() {
-        let (tab_cmd, is_terminal) = match *cmd {
-            AppCommand::Tab(t) => (t, false),
-            AppCommand::Terminal(TerminalCommand::New) => (TabCommand::New, true),
+        let (tab_cmd, is_terminal, is_sessions) = match *cmd {
+            AppCommand::Tab(t) => (t, false, false),
+            AppCommand::Terminal(TerminalCommand::New) => (TabCommand::New, true, false),
+            AppCommand::Session(SessionCommand::Open) => (TabCommand::New, false, true),
             _ => continue,
         };
 
@@ -229,27 +211,28 @@ fn handle_tab_commands(
                         Terminal::new(&mut meshes, &mut webview_mt, &settings),
                         ChildOf(tab),
                     ));
+                } else if is_sessions {
+                    let tab = commands
+                        .spawn((tab_bundle(), LastActivatedAt::now(), ChildOf(pane)))
+                        .id();
+                    commands.entity(tab).insert(vmux_header::PageMetadata {
+                        url: vmux_sessions::event::SESSIONS_WEBVIEW_URL.to_string(),
+                        title: "Sessions".to_string(),
+                        ..default()
+                    });
+                    commands.spawn((
+                        SessionsMonitor::new(&mut meshes, &mut webview_mt),
+                        ChildOf(tab),
+                    ));
                 } else {
-                    // Toggle: if an empty tab is already pending (command bar
-                    // open from a prior Cmd+T), skip creating another tab and
-                    // let handle_open_command_bar dismiss the modal.
+                    // If there's already an empty tab pending, reuse it
                     if new_tab_ctx.tab.is_some() {
+                        new_tab_ctx.needs_open = true;
                         continue;
                     }
                     let tab = commands
                         .spawn((tab_bundle(), LastActivatedAt::now(), ChildOf(pane)))
                         .id();
-
-                    // Spawn a transparent CEF browser immediately so the
-                    // rendering pipeline is warm when the user picks content.
-                    // The glass backdrop is handled by CSS in the command bar
-                    // overlay (see vmux_command_bar app.rs).
-                    commands.spawn((
-                        Browser::new(&mut meshes, &mut webview_mt, "about:blank"),
-                        WebviewTransparent,
-                        ChildOf(tab),
-                    ));
-
                     new_tab_ctx.tab = Some(tab);
                     new_tab_ctx.previous_tab = active_tab;
                     new_tab_ctx.needs_open = true;
@@ -262,21 +245,6 @@ fn handle_tab_commands(
                 let Some(active) = active_tab else {
                     continue;
                 };
-
-                // Confirm close if terminal is still running
-                if terminal::should_confirm_close(&settings)
-                    && terminal::has_live_terminal(active, &all_children, &extra.p1())
-                {
-                    if extra.p2().contains(active) {
-                        commands.entity(active).remove::<CloseConfirmed>();
-                    } else {
-                        if !extra.p3().contains(active) {
-                            commands.entity(active).insert(PendingTabClose);
-                        }
-                        continue;
-                    }
-                }
-
                 let Ok(children) = pane_children.get(pane) else {
                     continue;
                 };
@@ -290,14 +258,6 @@ fn handle_tab_commands(
 
                     if !split_dir_q.contains(parent) {
                         commands.entity(active).despawn();
-                        // Last tab in the root pane — show command bar so the
-                        // user can navigate somewhere.
-                        let tab = commands
-                            .spawn((tab_bundle(), LastActivatedAt::now(), ChildOf(pane)))
-                            .id();
-                        new_tab_ctx.tab = Some(tab);
-                        new_tab_ctx.previous_tab = None;
-                        new_tab_ctx.needs_open = true;
                         continue;
                     }
 
@@ -310,12 +270,6 @@ fn handle_tab_commands(
                         e != pane && (leaf_panes.contains(e) || split_dir_q.contains(e))
                     });
                     let Some(sibling) = sibling else {
-                        let tab = commands
-                            .spawn((tab_bundle(), LastActivatedAt::now(), ChildOf(pane)))
-                            .id();
-                        new_tab_ctx.tab = Some(tab);
-                        new_tab_ctx.previous_tab = None;
-                        new_tab_ctx.needs_open = true;
                         continue;
                     };
 
@@ -422,7 +376,7 @@ fn handle_tab_commands(
                 commands.entity(target_tab).insert(LastActivatedAt::now());
                 if active_pane != Some(target_pane) {
                     commands.entity(target_pane).insert(LastActivatedAt::now());
-                    extra.p0().target = Some(target_pane);
+                    pending_warp.target = Some(target_pane);
                 }
             }
             TabCommand::SelectIndex1
@@ -529,81 +483,4 @@ fn sync_tab_picking(
             }
         }
     }
-}
-
-/// Exclusive system: processes pending tab close confirmations by showing
-/// native dialogs on the main thread.
-fn process_pending_tab_closes(world: &mut World) {
-    let pending: Vec<(Entity, Entity)> = world
-        .query_filtered::<(Entity, &ChildOf), (With<PendingTabClose>, With<Tab>)>()
-        .iter(world)
-        .map(|(tab, co)| (tab, co.get()))
-        .collect();
-
-    if pending.is_empty() {
-        return;
-    }
-
-    for (tab, pane) in pending {
-        let confirmed = terminal::show_close_dialog();
-
-        if let Ok(mut entity_mut) = world.get_entity_mut(tab) {
-            entity_mut.remove::<PendingTabClose>();
-        }
-
-        if confirmed {
-            if let Ok(mut entity_mut) = world.get_entity_mut(tab) {
-                entity_mut.insert((CloseConfirmed, LastActivatedAt::now()));
-            }
-            if let Ok(mut entity_mut) = world.get_entity_mut(pane) {
-                entity_mut.insert(LastActivatedAt::now());
-            }
-            activate_space_for(world, pane);
-            world
-                .resource_mut::<Messages<AppCommand>>()
-                .write(AppCommand::Tab(TabCommand::Close));
-        }
-    }
-}
-
-/// Walk up the entity hierarchy from `entity` to find and activate its Space.
-fn activate_space_for(world: &mut World, entity: Entity) {
-    let mut current = entity;
-    for _ in 0..10 {
-        if world
-            .get_entity(current)
-            .is_ok_and(|e| e.contains::<Space>())
-        {
-            if let Ok(mut entity_mut) = world.get_entity_mut(current) {
-                entity_mut.insert(LastActivatedAt::now());
-            }
-            return;
-        }
-        if let Some(co) = world.get::<ChildOf>(current) {
-            current = co.get();
-        } else {
-            return;
-        }
-    }
-
-}
-
-pub(crate) fn open_command_bar_if_no_tabs(
-    tab_q: Query<(), With<Tab>>,
-    leaf_panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
-    mut new_tab_ctx: ResMut<NewTabContext>,
-    mut commands: Commands,
-) {
-    if !tab_q.is_empty() {
-        return;
-    }
-    let Some(pane) = leaf_panes.iter().next() else {
-        return;
-    };
-    let tab = commands
-        .spawn((tab_bundle(), LastActivatedAt::now(), ChildOf(pane)))
-        .id();
-    new_tab_ctx.tab = Some(tab);
-    new_tab_ctx.previous_tab = None;
-    new_tab_ctx.needs_open = true;
 }

--- a/crates/vmux_desktop/src/lib.rs
+++ b/crates/vmux_desktop/src/lib.rs
@@ -17,6 +17,7 @@ mod settings;
 pub(crate) mod shortcut;
 mod terminal;
 mod themes;
+mod tray;
 mod unit;
 pub mod updater;
 

--- a/crates/vmux_desktop/src/lib.rs
+++ b/crates/vmux_desktop/src/lib.rs
@@ -98,13 +98,13 @@ impl Plugin for VmuxPlugin {
             SideSheetPlugin,
             CommandBarPlugin,
             TerminalPlugin,
+            SessionsPlugin,
             CommandBarInputPlugin,
             BrowserPlugin,
         ))
         .add_plugins((
             TerminalInputPlugin,
             SessionsMonitorPlugin,
-            SessionsPlugin,
             PersistencePlugin,
             ProfilePlugin,
             LayoutPlugin,

--- a/crates/vmux_desktop/src/lib.rs
+++ b/crates/vmux_desktop/src/lib.rs
@@ -15,6 +15,7 @@ mod profile;
 mod scene;
 mod settings;
 pub(crate) mod shortcut;
+mod sessions_monitor;
 mod terminal;
 mod themes;
 mod tray;
@@ -30,10 +31,11 @@ use std::time::Duration;
 use {
     browser::BrowserPlugin, command::CommandPlugin, command_bar::CommandBarInputPlugin,
     layout::LayoutPlugin, os_menu::OsMenuPlugin, persistence::PersistencePlugin,
-    profile::ProfilePlugin, scene::ScenePlugin, settings::SettingsPlugin, shortcut::ShortcutPlugin,
-    terminal::TerminalInputPlugin, vmux_command_bar::CommandBarPlugin, vmux_header::HeaderPlugin,
-    vmux_side_sheet::SideSheetPlugin, vmux_terminal::TerminalPlugin,
-    vmux_webview_app::WebviewAppRegistryPlugin,
+    profile::ProfilePlugin, scene::ScenePlugin, sessions_monitor::SessionsMonitorPlugin,
+    settings::SettingsPlugin, shortcut::ShortcutPlugin, terminal::TerminalInputPlugin,
+    vmux_command_bar::CommandBarPlugin, vmux_header::HeaderPlugin,
+    vmux_sessions::SessionsPlugin, vmux_side_sheet::SideSheetPlugin,
+    vmux_terminal::TerminalPlugin, vmux_webview_app::WebviewAppRegistryPlugin,
 };
 
 pub struct VmuxPlugin;
@@ -101,6 +103,8 @@ impl Plugin for VmuxPlugin {
         ))
         .add_plugins((
             TerminalInputPlugin,
+            SessionsMonitorPlugin,
+            SessionsPlugin,
             PersistencePlugin,
             ProfilePlugin,
             LayoutPlugin,

--- a/crates/vmux_desktop/src/main.rs
+++ b/crates/vmux_desktop/src/main.rs
@@ -72,7 +72,7 @@ fn run_daemon() {
 
     rt.block_on(async {
         let dir = daemon_dir();
-        std::fs::create_dir_all(&dir).expect("failed to create ~/.vmux");
+        std::fs::create_dir_all(&dir).expect("failed to create daemon dir");
 
         let pid = std::process::id();
         std::fs::write(pid_path(), pid.to_string()).expect("failed to write PID file");

--- a/crates/vmux_desktop/src/main.rs
+++ b/crates/vmux_desktop/src/main.rs
@@ -4,6 +4,12 @@ use bevy_cef::prelude::early_exit_if_subprocess;
 use vmux_desktop::VmuxPlugin;
 
 fn main() {
+    // Check for `daemon` subcommand before any GUI/Bevy initialization.
+    if std::env::args().nth(1).as_deref() == Some("daemon") {
+        run_daemon();
+        return;
+    }
+
     #[cfg(not(target_os = "macos"))]
     early_exit_if_subprocess();
 
@@ -52,4 +58,41 @@ extern "C" fn sigint_handler(_: libc::c_int) {
         libc::write(2, msg.as_ptr() as *const libc::c_void, msg.len());
         libc::_exit(0);
     }
+}
+
+/// Run the vmux daemon (persistent terminal session manager).
+/// Invoked via `vmux daemon` or `Vmux daemon`.
+fn run_daemon() {
+    use vmux_daemon::{daemon_dir, pid_path, socket_path};
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("failed to create tokio runtime");
+
+    rt.block_on(async {
+        let dir = daemon_dir();
+        std::fs::create_dir_all(&dir).expect("failed to create ~/.vmux");
+
+        let pid = std::process::id();
+        std::fs::write(pid_path(), pid.to_string()).expect("failed to write PID file");
+
+        let sock = socket_path();
+        let _ = std::fs::remove_file(&sock);
+
+        let listener =
+            tokio::net::UnixListener::bind(&sock).expect("failed to bind Unix socket");
+
+        eprintln!("vmux-daemon: listening on {}", sock.display());
+
+        let sock_cleanup = sock.clone();
+        tokio::spawn(async move {
+            tokio::signal::ctrl_c().await.ok();
+            let _ = std::fs::remove_file(&sock_cleanup);
+            let _ = std::fs::remove_file(pid_path());
+            std::process::exit(0);
+        });
+
+        vmux_daemon::server::run_server(listener).await;
+    });
 }

--- a/crates/vmux_desktop/src/persistence.rs
+++ b/crates/vmux_desktop/src/persistence.rs
@@ -20,6 +20,7 @@ use crate::{
     settings::AppSettings,
     terminal::Terminal,
 };
+use vmux_daemon::protocol::SessionId;
 use vmux_header::PageMetadata;
 use vmux_terminal::event::TERMINAL_WEBVIEW_URL;
 
@@ -274,10 +275,24 @@ pub(crate) fn rebuild_session_views(
                 .url
                 .starts_with(TERMINAL_WEBVIEW_URL.trim_end_matches('/'))
             {
-                commands.spawn((
-                    Terminal::new(&mut meshes, &mut webview_mt, &settings),
-                    ChildOf(entity),
-                ));
+                // Try to extract session UUID from URL for reattach
+                let session_id = meta.url
+                    .strip_prefix(TERMINAL_WEBVIEW_URL)
+                    .and_then(|rest| rest.strip_prefix("session/"))
+                    .and_then(|uuid_str| uuid_str.parse::<uuid::Uuid>().ok())
+                    .map(SessionId::from_uuid);
+
+                if let Some(sid) = session_id {
+                    commands.spawn((
+                        Terminal::reattach(&mut meshes, &mut webview_mt, sid),
+                        ChildOf(entity),
+                    ));
+                } else {
+                    commands.spawn((
+                        Terminal::new(&mut meshes, &mut webview_mt, &settings),
+                        ChildOf(entity),
+                    ));
+                }
             } else {
                 commands.spawn((
                     Browser::new(&mut meshes, &mut webview_mt, &meta.url),

--- a/crates/vmux_desktop/src/persistence.rs
+++ b/crates/vmux_desktop/src/persistence.rs
@@ -22,6 +22,7 @@ use crate::{
 };
 use vmux_daemon::protocol::SessionId;
 use vmux_header::PageMetadata;
+use vmux_sessions::event::SESSIONS_WEBVIEW_URL;
 use vmux_terminal::event::TERMINAL_WEBVIEW_URL;
 
 pub(crate) struct PersistencePlugin;
@@ -272,6 +273,17 @@ pub(crate) fn rebuild_session_views(
 
         if !has_browser {
             if meta
+                .url
+                .starts_with(SESSIONS_WEBVIEW_URL.trim_end_matches('/'))
+            {
+                commands.spawn((
+                    crate::sessions_monitor::SessionsMonitor::new(
+                        &mut meshes,
+                        &mut webview_mt,
+                    ),
+                    ChildOf(entity),
+                ));
+            } else if meta
                 .url
                 .starts_with(TERMINAL_WEBVIEW_URL.trim_end_matches('/'))
             {

--- a/crates/vmux_desktop/src/sessions_monitor.rs
+++ b/crates/vmux_desktop/src/sessions_monitor.rs
@@ -1,12 +1,18 @@
-use bevy::{picking::Pickable, prelude::*, render::alpha::AlphaMode};
+use bevy::{ecs::relationship::Relationship, picking::Pickable, prelude::*, render::alpha::AlphaMode};
 use bevy_cef::prelude::*;
-use vmux_daemon::protocol::ClientMessage;
+use vmux_daemon::protocol::{ClientMessage, SessionId};
+use vmux_history::LastActivatedAt;
 use vmux_sessions::event::*;
 use vmux_webview_app::UiReady;
 
 use crate::{
     browser::Browser,
-    layout::window::WEBVIEW_MESH_DEPTH_BIAS,
+    layout::{
+        pane::{Pane, PaneSplit},
+        space::Space,
+        tab::{Tab, focused_tab, tab_bundle},
+        window::WEBVIEW_MESH_DEPTH_BIAS,
+    },
     terminal::{DaemonClient, DaemonSessionHandle, Terminal},
 };
 
@@ -84,7 +90,13 @@ impl Plugin for SessionsMonitorPlugin {
                 1.0,
                 TimerMode::Repeating,
             )))
-            .add_systems(Update, (request_session_list, broadcast_to_monitors).chain());
+            .add_plugins(JsEmitEventPlugin::<SessionNavigateEvent>::default())
+            .add_plugins(JsEmitEventPlugin::<SessionKillEvent>::default())
+            .add_plugins(JsEmitEventPlugin::<SessionKillAllEvent>::default())
+            .add_systems(Update, (request_session_list, broadcast_to_monitors).chain())
+            .add_observer(on_session_navigate)
+            .add_observer(on_session_kill)
+            .add_observer(on_session_kill_all);
     }
 }
 
@@ -152,5 +164,81 @@ fn broadcast_to_monitors(
         if browsers.has_browser(entity) && browsers.host_emit_ready(&entity) {
             commands.trigger(HostEmitEvent::new(entity, SESSIONS_LIST_EVENT, &event));
         }
+    }
+}
+
+/// Navigate to the terminal tab for the clicked session, or open a new one.
+fn on_session_navigate(
+    trigger: On<Receive<SessionNavigateEvent>>,
+    terminals: Query<(Entity, &DaemonSessionHandle, &ChildOf), With<Terminal>>,
+    tab_parent: Query<&ChildOf, With<Tab>>,
+    spaces: Query<(Entity, &LastActivatedAt), With<Space>>,
+    all_children: Query<&Children>,
+    leaf_panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
+    pane_ts: Query<(Entity, &LastActivatedAt), With<Pane>>,
+    pane_children: Query<&Children, With<Pane>>,
+    tab_ts: Query<(Entity, &LastActivatedAt), With<Tab>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
+    mut commands: Commands,
+) {
+    let sid = &trigger.event().payload.session_id;
+
+    // If a tab already has this session attached, activate it
+    for (_, handle, content_child_of) in &terminals {
+        if handle.session_id.to_string() == *sid {
+            let tab = content_child_of.get();
+            commands.entity(tab).insert(LastActivatedAt::now());
+            if let Ok(tab_child_of) = tab_parent.get(tab) {
+                commands.entity(tab_child_of.get()).insert(LastActivatedAt::now());
+            }
+            return;
+        }
+    }
+
+    // No existing tab — open a new one with reattach
+    let Ok(session_id) = sid.parse::<SessionId>() else {
+        warn!("Invalid session ID from navigate event: {sid}");
+        return;
+    };
+    let (_, active_pane, _) = focused_tab(
+        &spaces, &all_children, &leaf_panes, &pane_ts, &pane_children, &tab_ts,
+    );
+    let Some(pane) = active_pane else { return };
+
+    let tab = commands
+        .spawn((tab_bundle(), LastActivatedAt::now(), ChildOf(pane)))
+        .id();
+    commands.spawn((
+        Terminal::reattach(&mut meshes, &mut webview_mt, session_id),
+        ChildOf(tab),
+    ));
+}
+
+/// Kill a single daemon session.
+fn on_session_kill(
+    trigger: On<Receive<SessionKillEvent>>,
+    daemon: Option<Res<DaemonClient>>,
+) {
+    let Some(daemon) = daemon else { return };
+    let sid = &trigger.event().payload.session_id;
+
+    if let Ok(session_id) = sid.parse::<SessionId>() {
+        daemon.0.send(ClientMessage::KillSession { session_id });
+    }
+}
+
+/// Kill all daemon sessions.
+fn on_session_kill_all(
+    _trigger: On<Receive<SessionKillAllEvent>>,
+    daemon: Option<Res<DaemonClient>>,
+    session_list: Res<DaemonSessionList>,
+) {
+    let Some(daemon) = daemon else { return };
+
+    for info in &session_list.sessions {
+        daemon.0.send(ClientMessage::KillSession {
+            session_id: info.id,
+        });
     }
 }

--- a/crates/vmux_desktop/src/sessions_monitor.rs
+++ b/crates/vmux_desktop/src/sessions_monitor.rs
@@ -215,24 +215,41 @@ fn on_session_navigate(
     ));
 }
 
-/// Kill a single daemon session.
+/// Kill a single daemon session and close the associated terminal tab if any.
 fn on_session_kill(
     trigger: On<Receive<SessionKillEvent>>,
     daemon: Option<Res<DaemonClient>>,
+    terminals: Query<(Entity, &DaemonSessionHandle, &ChildOf), With<Terminal>>,
+    tab_parent: Query<&ChildOf, With<Tab>>,
+    mut commands: Commands,
 ) {
     let Some(daemon) = daemon else { return };
     let sid = &trigger.event().payload.session_id;
 
     if let Ok(session_id) = sid.parse::<SessionId>() {
         daemon.0.send(ClientMessage::KillSession { session_id });
+
+        // Close the terminal tab that owns this session
+        for (_, handle, content_child_of) in &terminals {
+            if handle.session_id == session_id {
+                let tab = content_child_of.get();
+                // Only despawn if it's actually a tab
+                if tab_parent.get(tab).is_ok() || commands.get_entity(tab).is_ok() {
+                    commands.entity(tab).despawn();
+                }
+                break;
+            }
+        }
     }
 }
 
-/// Kill all daemon sessions.
+/// Kill all daemon sessions and close their terminal tabs.
 fn on_session_kill_all(
     _trigger: On<Receive<SessionKillAllEvent>>,
     daemon: Option<Res<DaemonClient>>,
     session_list: Res<DaemonSessionList>,
+    terminals: Query<(Entity, &DaemonSessionHandle, &ChildOf), With<Terminal>>,
+    mut commands: Commands,
 ) {
     let Some(daemon) = daemon else { return };
 
@@ -240,5 +257,14 @@ fn on_session_kill_all(
         daemon.0.send(ClientMessage::KillSession {
             session_id: info.id,
         });
+
+        // Close the terminal tab
+        for (_, handle, content_child_of) in &terminals {
+            if handle.session_id == info.id {
+                let tab = content_child_of.get();
+                commands.entity(tab).despawn();
+                break;
+            }
+        }
     }
 }

--- a/crates/vmux_desktop/src/sessions_monitor.rs
+++ b/crates/vmux_desktop/src/sessions_monitor.rs
@@ -1,0 +1,156 @@
+use bevy::{picking::Pickable, prelude::*, render::alpha::AlphaMode};
+use bevy_cef::prelude::*;
+use vmux_daemon::protocol::ClientMessage;
+use vmux_sessions::event::*;
+use vmux_webview_app::UiReady;
+
+use crate::{
+    browser::Browser,
+    layout::window::WEBVIEW_MESH_DEPTH_BIAS,
+    terminal::{DaemonClient, DaemonSessionHandle, Terminal},
+};
+
+/// Marker for the sessions monitor webview entity.
+#[derive(Component)]
+pub(crate) struct SessionsMonitor;
+
+impl SessionsMonitor {
+    /// Create a sessions monitor webview bundle.
+    pub(crate) fn new(
+        meshes: &mut ResMut<Assets<Mesh>>,
+        webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
+    ) -> impl Bundle {
+        (
+            (
+                Self,
+                Browser,
+                WebviewSource::new(SESSIONS_WEBVIEW_URL),
+                ResolvedWebviewUri(SESSIONS_WEBVIEW_URL.to_string()),
+                vmux_header::PageMetadata {
+                    title: "Sessions".to_string(),
+                    url: SESSIONS_WEBVIEW_URL.to_string(),
+                    favicon_url: String::new(),
+                },
+                Mesh3d(meshes.add(bevy::math::primitives::Plane3d::new(
+                    Vec3::Z,
+                    Vec2::splat(0.5),
+                ))),
+            ),
+            (
+                MeshMaterial3d(webview_mt.add(WebviewExtendStandardMaterial {
+                    base: StandardMaterial {
+                        unlit: true,
+                        alpha_mode: AlphaMode::Blend,
+                        depth_bias: WEBVIEW_MESH_DEPTH_BIAS,
+                        ..default()
+                    },
+                    ..default()
+                })),
+                WebviewSize(Vec2::new(1280.0, 720.0)),
+                Transform::default(),
+                GlobalTransform::default(),
+                Node {
+                    position_type: PositionType::Absolute,
+                    left: Val::Px(0.0),
+                    right: Val::Px(0.0),
+                    top: Val::Px(0.0),
+                    bottom: Val::Px(0.0),
+                    ..default()
+                },
+                Visibility::Inherited,
+                Pickable::default(),
+            ),
+        )
+    }
+}
+
+/// Cached session list from the daemon, updated via ListSessions responses.
+/// Written by terminal.rs's poll_daemon_messages, read by this module.
+#[derive(Resource, Default)]
+pub(crate) struct DaemonSessionList {
+    pub sessions: Vec<vmux_daemon::protocol::SessionInfo>,
+}
+
+/// Timer for periodic session list polling.
+#[derive(Resource)]
+struct SessionsPollTimer(Timer);
+
+pub(crate) struct SessionsMonitorPlugin;
+
+impl Plugin for SessionsMonitorPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<DaemonSessionList>()
+            .insert_resource(SessionsPollTimer(Timer::from_seconds(
+                1.0,
+                TimerMode::Repeating,
+            )))
+            .add_systems(Update, (request_session_list, broadcast_to_monitors).chain());
+    }
+}
+
+/// Periodically send ListSessions to the daemon.
+fn request_session_list(
+    time: Res<Time>,
+    mut timer: ResMut<SessionsPollTimer>,
+    daemon: Option<Res<DaemonClient>>,
+    monitors: Query<(), With<SessionsMonitor>>,
+) {
+    if monitors.is_empty() {
+        return;
+    }
+    timer.0.tick(time.delta());
+    if timer.0.just_finished() {
+        if let Some(daemon) = daemon {
+            daemon.0.send(ClientMessage::ListSessions);
+        }
+    }
+}
+
+/// Broadcast the cached session list to all sessions monitor webviews.
+fn broadcast_to_monitors(
+    session_list: Res<DaemonSessionList>,
+    daemon: Option<Res<DaemonClient>>,
+    monitors: Query<Entity, (With<SessionsMonitor>, With<UiReady>)>,
+    browsers: NonSend<Browsers>,
+    terminal_handles: Query<&DaemonSessionHandle, With<Terminal>>,
+    mut commands: Commands,
+) {
+    if monitors.is_empty() || !session_list.is_changed() {
+        return;
+    }
+
+    let connected = daemon.is_some();
+
+    // Build attached set from local terminal handles
+    let attached_ids: std::collections::HashSet<String> = terminal_handles
+        .iter()
+        .map(|h| h.session_id.to_string())
+        .collect();
+
+    let sessions: Vec<SessionEntry> = session_list
+        .sessions
+        .iter()
+        .map(|info| SessionEntry {
+            id: info.id.to_string(),
+            shell: info.shell.clone(),
+            cwd: info.cwd.clone(),
+            cols: info.cols,
+            rows: info.rows,
+            pid: info.pid,
+            uptime_secs: info.created_at_secs,
+            attached: attached_ids.contains(&info.id.to_string()),
+            preview_lines: Vec::new(), // TODO: add preview from snapshot
+        })
+        .collect();
+
+    let event = SessionsListEvent {
+        connected,
+        sessions,
+    };
+
+    for entity in &monitors {
+        if browsers.has_browser(entity) && browsers.host_emit_ready(&entity) {
+            commands.trigger(HostEmitEvent::new(entity, SESSIONS_LIST_EVENT, &event));
+        }
+    }
+}

--- a/crates/vmux_desktop/src/terminal.rs
+++ b/crates/vmux_desktop/src/terminal.rs
@@ -53,34 +53,31 @@ pub(crate) struct TerminalInputPlugin;
 
 impl Plugin for TerminalInputPlugin {
     fn build(&self, app: &mut App) {
-        // Connect to daemon at startup
+        // Connect to daemon, auto-starting it if needed.
+        // The daemon runs as `<current_exe> daemon` (same binary, subcommand).
+        if DaemonHandle::connect().is_none() {
+            if let Ok(exe) = std::env::current_exe() {
+                info!("Starting daemon: {} daemon", exe.display());
+                let _ = std::process::Command::new(&exe)
+                    .arg("daemon")
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::piped())
+                    .spawn();
+                // Wait for daemon socket to appear
+                let sock = vmux_daemon::socket_path();
+                for _ in 0..20 {
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                    if sock.exists() {
+                        break;
+                    }
+                }
+            }
+        }
         if let Some(handle) = DaemonHandle::connect() {
             app.insert_resource(DaemonClient(handle));
         } else {
-            // Spawn daemon process automatically
-            let daemon_bin = std::env::current_exe()
-                .ok()
-                .and_then(|p| {
-                    let dir = p.parent()?;
-                    let candidate = dir.join("vmux-daemon");
-                    candidate.exists().then_some(candidate)
-                });
-            if let Some(bin) = daemon_bin {
-                let _ = std::process::Command::new(&bin)
-                    .stdin(std::process::Stdio::null())
-                    .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::null())
-                    .spawn();
-                // Wait briefly for daemon to start
-                std::thread::sleep(std::time::Duration::from_millis(200));
-                if let Some(handle) = DaemonHandle::connect() {
-                    app.insert_resource(DaemonClient(handle));
-                } else {
-                    warn!("Failed to connect to vmux daemon after spawn");
-                }
-            } else {
-                warn!("vmux-daemon binary not found; terminal sessions will not persist");
-            }
+            warn!("Failed to connect to vmux daemon");
         }
 
         app.init_resource::<MouseSelectionState>()

--- a/crates/vmux_desktop/src/terminal.rs
+++ b/crates/vmux_desktop/src/terminal.rs
@@ -1,17 +1,8 @@
 use crate::{
     browser::Browser,
     command::{AppCommand, TabCommand, WriteAppCommands},
-    layout::pane::Pane,
     layout::window::WEBVIEW_MESH_DEPTH_BIAS,
     settings::AppSettings,
-};
-use alacritty_terminal::{
-    event::{Event as TermEvent, EventListener as TermEventListener},
-    grid::{Dimensions, Scroll},
-    index::{Column, Line, Point, Side},
-    selection::{Selection, SelectionType},
-    term::{Config as TermConfig, Term, TermMode, cell::Flags as CellFlags},
-    vte::ansi::{Color, NamedColor, Processor},
 };
 use bevy::{
     ecs::relationship::Relationship,
@@ -25,10 +16,9 @@ use bevy::{
     render::alpha::AlphaMode,
 };
 use bevy_cef::prelude::*;
-use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
-use std::{
-    io::{Read, Write},
-    sync::{Arc, Mutex, mpsc},
+use vmux_daemon::{
+    client::DaemonHandle,
+    protocol::{ClientMessage, DaemonMessage, SessionId},
 };
 use vmux_header::PageMetadata;
 use vmux_history::LastActivatedAt;
@@ -39,126 +29,60 @@ use vmux_webview_app::UiReady;
 #[derive(Component)]
 pub(crate) struct Terminal;
 
-/// Marker: PTY child process has exited; tab close is pending.
+/// Marker: daemon session has exited; tab close is pending.
 #[derive(Component)]
-pub(crate) struct PtyExited;
+struct SessionExited;
 
-/// Check if confirmation is needed based on settings.
-pub(crate) fn should_confirm_close(settings: &AppSettings) -> bool {
-    settings.terminal.as_ref().is_none_or(|t| t.confirm_close)
-}
-
-/// Check if a tab entity has any child terminal that is still running.
-pub(crate) fn has_live_terminal(
-    tab: Entity,
-    children_q: &Query<&Children>,
-    terminal_q: &Query<(), (With<Terminal>, Without<PtyExited>)>,
-) -> bool {
-    if let Ok(children) = children_q.get(tab) {
-        children.iter().any(|child| terminal_q.contains(child))
-    } else {
-        false
-    }
-}
-
-/// Check if a pane has any tab with a live terminal.
-pub(crate) fn pane_has_live_terminal(
-    pane: Entity,
-    pane_children_q: &Query<&Children, With<Pane>>,
-    all_children_q: &Query<&Children>,
-    terminal_q: &Query<(), (With<Terminal>, Without<PtyExited>)>,
-) -> bool {
-    if let Ok(tabs) = pane_children_q.get(pane) {
-        tabs.iter()
-            .any(|tab| has_live_terminal(tab, all_children_q, terminal_q))
-    } else {
-        false
-    }
-}
-
-/// Show confirmation dialog for closing a terminal tab/pane.
-/// Returns `true` if user confirms the close.
-pub(crate) fn show_close_dialog() -> bool {
-    use rfd::{MessageButtons, MessageDialog, MessageDialogResult, MessageLevel};
-    let result = MessageDialog::new()
-        .set_level(MessageLevel::Warning)
-        .set_title("Close Terminal?")
-        .set_description("A process is still running in this terminal. Close anyway?")
-        .set_buttons(MessageButtons::OkCancel)
-        .show();
-    matches!(result, MessageDialogResult::Ok)
-}
-
-/// Show confirmation dialog for quitting with N running terminals.
-/// Returns `true` if user confirms the quit.
-pub(crate) fn confirm_quit_dialog(count: usize) -> bool {
-    use rfd::{MessageButtons, MessageDialog, MessageDialogResult, MessageLevel};
-    let msg = if count == 1 {
-        "A terminal is still running. Quit anyway?".to_string()
-    } else {
-        format!("{count} terminals are still running. Quit anyway?")
-    };
-    let result = MessageDialog::new()
-        .set_level(MessageLevel::Warning)
-        .set_title("Quit Vmux?")
-        .set_description(&msg)
-        .set_buttons(MessageButtons::OkCancel)
-        .show();
-    matches!(result, MessageDialogResult::Ok)
-}
-
-/// Holds the alacritty_terminal state for a terminal instance.
+/// Associates a terminal entity with a daemon session.
 #[derive(Component)]
-pub(crate) struct TerminalState {
-    term: Term<VmuxEventProxy>,
-    processor: Processor,
-    dirty: bool,
-    /// Moving end of keyboard-driven selection (distinct from anchor).
-    /// Tracked separately because `Selection::to_range()` normalizes order,
-    /// making it impossible to know which end the user is extending.
-    selection_cursor: Option<Point>,
-    /// Per-row hash of the last synced viewport. Used to detect which lines
-    /// changed and need to be re-sent to the webview.
-    line_hashes: Vec<u64>,
-    /// True when the entire viewport must be re-sent (resize, first frame).
-    full_sync_needed: bool,
+pub(crate) struct DaemonSessionHandle {
+    pub session_id: SessionId,
 }
 
-/// Receives PTY output from a background reader thread.
-#[derive(Component)]
-pub(crate) struct PtyHandle {
-    rx: Mutex<mpsc::Receiver<Vec<u8>>>,
-    writer: Arc<Mutex<Box<dyn Write + Send>>>,
-    master: Mutex<Box<dyn portable_pty::MasterPty + Send>>,
-    child: Mutex<Box<dyn portable_pty::Child + Send + Sync>>,
-}
+/// Bevy resource wrapping the daemon connection.
+#[derive(Resource)]
+pub(crate) struct DaemonClient(pub DaemonHandle);
 
-/// Triggered to restart the PTY process for a terminal entity.
+/// Triggered to restart the terminal session for a terminal entity.
 #[derive(Event)]
 pub(crate) struct RestartPty {
     pub entity: Entity,
-}
-
-/// Event proxy that forwards PtyWrite responses back to the PTY.
-#[derive(Clone)]
-pub(crate) struct VmuxEventProxy {
-    pty_writer: Arc<Mutex<Box<dyn Write + Send>>>,
-}
-
-impl TermEventListener for VmuxEventProxy {
-    fn send_event(&self, event: TermEvent) {
-        if let TermEvent::PtyWrite(text) = event
-            && let Ok(mut writer) = self.pty_writer.lock()
-        {
-            let _ = writer.write_all(text.as_bytes());
-        }
-    }
 }
 
 pub(crate) struct TerminalInputPlugin;
 
 impl Plugin for TerminalInputPlugin {
     fn build(&self, app: &mut App) {
+        // Connect to daemon at startup
+        if let Some(handle) = DaemonHandle::connect() {
+            app.insert_resource(DaemonClient(handle));
+        } else {
+            // Spawn daemon process automatically
+            let daemon_bin = std::env::current_exe()
+                .ok()
+                .and_then(|p| {
+                    let dir = p.parent()?;
+                    let candidate = dir.join("vmux-daemon");
+                    candidate.exists().then_some(candidate)
+                });
+            if let Some(bin) = daemon_bin {
+                let _ = std::process::Command::new(&bin)
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .spawn();
+                // Wait briefly for daemon to start
+                std::thread::sleep(std::time::Duration::from_millis(200));
+                if let Some(handle) = DaemonHandle::connect() {
+                    app.insert_resource(DaemonClient(handle));
+                } else {
+                    warn!("Failed to connect to vmux daemon after spawn");
+                }
+            } else {
+                warn!("vmux-daemon binary not found; terminal sessions will not persist");
+            }
+        }
+
         app.init_resource::<MouseSelectionState>()
             .add_plugins(JsEmitEventPlugin::<TermResizeEvent>::default())
             .add_plugins(JsEmitEventPlugin::<TermMouseEvent>::default())
@@ -173,8 +97,7 @@ impl Plugin for TerminalInputPlugin {
             .add_systems(
                 Update,
                 (
-                    poll_pty_output.in_set(WriteAppCommands),
-                    sync_terminal_viewport,
+                    poll_daemon_messages.in_set(WriteAppCommands),
                     sync_terminal_theme,
                 )
                     .chain(),
@@ -201,103 +124,86 @@ impl Terminal {
         settings: &AppSettings,
         cwd: Option<&std::path::Path>,
     ) -> impl Bundle {
-        let cols = 80u16;
-        let rows = 24u16;
-
         let shell = settings
             .terminal
             .as_ref()
             .map(|t| t.resolve_theme(&t.default_theme).shell)
             .unwrap_or_else(default_shell);
 
-        // Create PTY
-        let pty_system = NativePtySystem::default();
-        let pair = pty_system
-            .openpty(PtySize {
-                rows,
-                cols,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
-            .expect("failed to open PTY");
-
-        let mut cmd = CommandBuilder::new(&shell);
-        cmd.env("TERM", "xterm-256color");
-        cmd.env("COLORTERM", "truecolor");
-        cmd.env("LANG", "en_US.UTF-8");
-        cmd.env("LC_CTYPE", "UTF-8");
-        let initial_cwd = cwd
+        let cwd_str = cwd
             .filter(|d| !d.to_string_lossy().contains("://"))
-            .map(|d| d.to_path_buf());
-        if let Some(ref dir) = initial_cwd {
-            cmd.cwd(dir);
-        }
+            .map(|d| d.to_string_lossy().to_string())
+            .unwrap_or_default();
 
-        let child = pair
-            .slave
-            .spawn_command(cmd)
-            .expect("failed to spawn shell");
-        let pid = child.process_id().unwrap_or(0);
-        let reader = pair
-            .master
-            .try_clone_reader()
-            .expect("failed to clone PTY reader");
-        let writer: Arc<Mutex<Box<dyn Write + Send>>> = Arc::new(Mutex::new(
-            pair.master
-                .take_writer()
-                .expect("failed to take PTY writer"),
-        ));
-        drop(pair.slave);
-
-        // If a cwd was requested, also send a `cd` command to the shell.
-        // Some shells (e.g. nushell) ignore the PTY's initial cwd.
-        if let Some(ref dir) = initial_cwd {
-            let cd_cmd = format!("cd {}\n", dir.display());
-            if let Ok(mut w) = writer.lock() {
-                let _ = w.write_all(cd_cmd.as_bytes());
-                let _ = w.flush();
-            }
-        }
-
-        // Spawn background reader thread
-        let (tx, rx) = mpsc::channel();
-        std::thread::Builder::new()
-            .name("pty-reader".into())
-            .spawn(move || {
-                pty_reader_thread(reader, tx);
-            })
-            .expect("failed to spawn PTY reader thread");
-
-        // Create alacritty terminal with event proxy that can write back to PTY
-        let event_proxy = VmuxEventProxy {
-            pty_writer: Arc::clone(&writer),
-        };
-        let term_config = TermConfig::default();
-        let dims = PtyDimensions { cols, rows };
-        let term = Term::new(term_config, &dims, event_proxy);
-        let processor = Processor::new();
+        // SessionId is set to a placeholder here; the actual session is created
+        // in a startup system that sends CreateSession to the daemon once the
+        // DaemonClient resource is available.
+        let session_id = SessionId::new();
 
         (
             (
                 Self,
                 Browser,
-                TerminalState {
-                    term,
-                    processor,
-                    dirty: true,
-                    selection_cursor: None,
-                    line_hashes: Vec::new(),
-                    full_sync_needed: true,
-                },
-                PtyHandle {
-                    rx: Mutex::new(rx),
-                    writer,
-                    master: Mutex::new(pair.master),
-                    child: Mutex::new(child),
+                DaemonSessionHandle { session_id },
+                PendingDaemonCreate {
+                    shell,
+                    cwd: cwd_str,
                 },
                 PageMetadata {
-                    title: format!("Terminal (Session: {})", pid),
-                    url: format!("{}session/{}", TERMINAL_WEBVIEW_URL, pid),
+                    title: format!("Terminal ({})", &session_id.to_string()[..8]),
+                    url: format!("{}session/{}", TERMINAL_WEBVIEW_URL, session_id),
+                    favicon_url: String::new(),
+                },
+                WebviewSource::new(TERMINAL_WEBVIEW_URL),
+                ResolvedWebviewUri(TERMINAL_WEBVIEW_URL.to_string()),
+                Mesh3d(meshes.add(bevy::math::primitives::Plane3d::new(
+                    Vec3::Z,
+                    Vec2::splat(0.5),
+                ))),
+            ),
+            (
+                MeshMaterial3d(webview_mt.add(WebviewExtendStandardMaterial {
+                    base: StandardMaterial {
+                        unlit: true,
+                        alpha_mode: AlphaMode::Blend,
+                        depth_bias: WEBVIEW_MESH_DEPTH_BIAS,
+                        ..default()
+                    },
+                    ..default()
+                })),
+                WebviewSize(Vec2::new(1280.0, 720.0)),
+                Transform::default(),
+                GlobalTransform::default(),
+                Node {
+                    position_type: PositionType::Absolute,
+                    left: Val::Px(0.0),
+                    right: Val::Px(0.0),
+                    top: Val::Px(0.0),
+                    bottom: Val::Px(0.0),
+                    ..default()
+                },
+                Visibility::Inherited,
+                Pickable::default(),
+            ),
+        )
+    }
+
+    /// Create a terminal bundle that reattaches to an existing daemon session.
+    #[allow(dead_code)] // Used by persistence.rs for session reconnect
+    pub(crate) fn reattach(
+        meshes: &mut ResMut<Assets<Mesh>>,
+        webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
+        session_id: SessionId,
+    ) -> impl Bundle {
+        (
+            (
+                Self,
+                Browser,
+                DaemonSessionHandle { session_id },
+                PendingDaemonAttach,
+                PageMetadata {
+                    title: format!("Terminal ({})", &session_id.to_string()[..8]),
+                    url: format!("{}session/{}", TERMINAL_WEBVIEW_URL, session_id),
                     favicon_url: String::new(),
                 },
                 WebviewSource::new(TERMINAL_WEBVIEW_URL),
@@ -335,344 +241,169 @@ impl Terminal {
     }
 }
 
+/// Temporary component: terminal needs a CreateSession sent to daemon.
+#[derive(Component)]
+struct PendingDaemonCreate {
+    shell: String,
+    cwd: String,
+}
+
+/// Temporary component: terminal needs an AttachSession sent to daemon.
+#[derive(Component)]
+struct PendingDaemonAttach;
+
 fn default_shell() -> String {
     std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string())
 }
 
-/// Background thread that reads from PTY and sends chunks via channel.
-fn pty_reader_thread(mut reader: Box<dyn Read + Send>, tx: mpsc::Sender<Vec<u8>>) {
-    let mut buf = [0u8; 4096];
-    loop {
-        match reader.read(&mut buf) {
-            Ok(0) => break,
-            Ok(n) => {
-                if tx.send(buf[..n].to_vec()).is_err() {
-                    break;
-                }
-            }
-            Err(_) => break,
-        }
-    }
-}
-
-/// Helper to implement alacritty_terminal's Dimensions trait.
-struct PtyDimensions {
-    cols: u16,
-    rows: u16,
-}
-
-impl Dimensions for PtyDimensions {
-    fn total_lines(&self) -> usize {
-        self.rows as usize
-    }
-    fn screen_lines(&self) -> usize {
-        self.rows as usize
-    }
-    fn columns(&self) -> usize {
-        self.cols as usize
-    }
-}
-
-/// Drain PTY output from background thread, feed to alacritty_terminal.
-fn poll_pty_output(
-    mut q: Query<
-        (Entity, &mut TerminalState, &PtyHandle, &ChildOf),
-        (With<Terminal>, Without<PtyExited>),
+/// Send CreateSession / AttachSession for newly spawned terminals.
+fn poll_daemon_messages(
+    pending_create: Query<
+        (Entity, &DaemonSessionHandle, &PendingDaemonCreate),
+        With<Terminal>,
     >,
+    pending_attach: Query<
+        (Entity, &DaemonSessionHandle),
+        (With<Terminal>, With<PendingDaemonAttach>),
+    >,
+    terminals: Query<
+        (Entity, &DaemonSessionHandle, &ChildOf),
+        (With<Terminal>, Without<SessionExited>),
+    >,
+    daemon: Option<Res<DaemonClient>>,
+    browsers: NonSend<Browsers>,
     mut commands: Commands,
     mut writer: MessageWriter<AppCommand>,
 ) {
-    for (entity, mut state, pty, child_of) in &mut q {
-        let rx = pty.rx.lock().unwrap();
-        let mut got_data = false;
-        while let Ok(data) = rx.try_recv() {
-            let TerminalState {
-                ref mut term,
-                ref mut processor,
-                ..
-            } = *state;
-            processor.advance(term, &data);
-            got_data = true;
-        }
-        if got_data {
-            state.dirty = true;
-        }
+    let Some(daemon) = daemon else { return };
 
-        // Check if the shell process has exited.
-        if let Ok(mut child) = pty.child.lock()
-            && let Ok(Some(_status)) = child.try_wait()
-        {
-            commands.entity(entity).insert(PtyExited);
-            // Activate the parent tab so TabCommand::Close targets it.
-            let tab = child_of.get();
-            commands.entity(tab).insert(LastActivatedAt::now());
-            writer.write(AppCommand::Tab(TabCommand::Close));
-        }
-    }
-}
-
-/// Serialize visible viewport diff and send to webview via rkyv + base64.
-fn sync_terminal_viewport(
-    mut q: Query<(Entity, &mut TerminalState), With<Terminal>>,
-    browsers: NonSend<Browsers>,
-    mut commands: Commands,
-) {
-    for (entity, mut state) in &mut q {
-        if !state.dirty {
-            continue;
-        }
-        if !browsers.has_browser(entity) || !browsers.host_emit_ready(&entity) {
-            continue;
-        }
-        state.dirty = false;
-
-        // Extract grid dimensions (immutable borrow of state.term).
-        let num_lines;
-        let num_cols;
-        let offset;
-        let cursor_point;
-        let scrolled_back;
-        let cursor_char;
-        {
-            let grid = state.term.grid();
-            num_lines = grid.screen_lines();
-            num_cols = grid.columns();
-            offset = grid.display_offset() as i32;
-            cursor_point = grid.cursor.point;
-            scrolled_back = offset > 0;
-            let cursor_row = &grid[cursor_point.line];
-            let cell = &cursor_row[cursor_point.column];
-            cursor_char = cell.c.to_string();
-        }
-
-        let full = state.full_sync_needed || state.line_hashes.len() != num_lines;
-
-        // Resize hash cache if needed.
-        if state.line_hashes.len() != num_lines {
-            state.line_hashes.resize(num_lines, 0);
-        }
-
-        let mut changed_lines = Vec::new();
-
-        for row_idx in 0..num_lines {
-            let hash = hash_grid_row(&state.term, row_idx, offset);
-            if full || hash != state.line_hashes[row_idx] {
-                state.line_hashes[row_idx] = hash;
-                changed_lines.push((row_idx as u16, build_line(&state.term, row_idx, offset)));
-            }
-        }
-
-        state.full_sync_needed = false;
-
-        // Convert alacritty selection to viewport-relative coordinates.
-        let selection = state
-            .term
-            .selection
-            .as_ref()
-            .and_then(|sel| sel.to_range(&state.term))
-            .map(|range| {
-                let start_row = (range.start.line.0 + offset) as u16;
-                let end_row = (range.end.line.0 + offset) as u16;
-                TermSelectionRange {
-                    start_col: range.start.column.0 as u16,
-                    start_row,
-                    end_col: range.end.column.0 as u16,
-                    end_row,
-                    is_block: range.is_block,
-                }
-            });
-
-        let patch = TermViewportPatch {
-            changed_lines,
-            cursor: TermCursor {
-                col: cursor_point.column.0 as u16,
-                row: cursor_point.line.0 as u16,
-                shape: CursorShape::Block,
-                visible: !scrolled_back,
-                ch: cursor_char,
-            },
-            cols: num_cols as u16,
-            rows: num_lines as u16,
-            selection,
-            full,
-        };
-
-        commands.trigger(HostEmitEvent::new(entity, TERM_VIEWPORT_EVENT, &patch));
-    }
-}
-
-/// Compute a fast hash of a single grid row's visible content.
-fn hash_grid_row<T: TermEventListener>(term: &Term<T>, row_idx: usize, offset: i32) -> u64 {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    let grid = term.grid();
-    let num_cols = grid.columns();
-    let row = &grid[Line(row_idx as i32 - offset)];
-    for col_idx in 0..num_cols {
-        let cell = &row[Column(col_idx)];
-        cell.c.hash(&mut hasher);
-        std::mem::discriminant(&cell.fg).hash(&mut hasher);
-        match &cell.fg {
-            Color::Named(c) => (*c as u8).hash(&mut hasher),
-            Color::Spec(rgb) => {
-                rgb.r.hash(&mut hasher);
-                rgb.g.hash(&mut hasher);
-                rgb.b.hash(&mut hasher);
-            }
-            Color::Indexed(i) => i.hash(&mut hasher),
-        }
-        std::mem::discriminant(&cell.bg).hash(&mut hasher);
-        match &cell.bg {
-            Color::Named(c) => (*c as u8).hash(&mut hasher),
-            Color::Spec(rgb) => {
-                rgb.r.hash(&mut hasher);
-                rgb.g.hash(&mut hasher);
-                rgb.b.hash(&mut hasher);
-            }
-            Color::Indexed(i) => i.hash(&mut hasher),
-        }
-        cell.flags.bits().hash(&mut hasher);
-    }
-    hasher.finish()
-}
-
-/// Build a TermLine for a single grid row.
-fn build_line<T: TermEventListener>(term: &Term<T>, row_idx: usize, offset: i32) -> TermLine {
-    let grid = term.grid();
-    let num_cols = grid.columns();
-    let row = &grid[Line(row_idx as i32 - offset)];
-    let mut spans = Vec::new();
-    let mut text = String::new();
-    let mut cur_fg: TermColor = TermColor::Default;
-    let mut cur_bg: TermColor = TermColor::Default;
-    let mut cur_flags: u16 = 0;
-    let mut span_col_start: u16 = 0;
-    let mut span_grid_cols: u16 = 0;
-
-    for col_idx in 0..num_cols {
-        let cell = &row[Column(col_idx)];
-
-        if cell.flags.contains(CellFlags::WIDE_CHAR_SPACER) {
-            span_grid_cols += 1;
-            continue;
-        }
-
-        let fg = color_to_term_color(&cell.fg);
-        let bg = color_to_term_color(&cell.bg);
-        let flags = cell_flags_to_u16(cell.flags);
-
-        if fg != cur_fg || bg != cur_bg || flags != cur_flags {
-            if !text.is_empty() {
-                spans.push(TermSpan {
-                    text: std::mem::take(&mut text),
-                    fg: cur_fg,
-                    bg: cur_bg,
-                    flags: cur_flags,
-                    col: span_col_start,
-                    grid_cols: span_grid_cols,
-                });
-                span_col_start = col_idx as u16;
-                span_grid_cols = 0;
-            }
-            cur_fg = fg;
-            cur_bg = bg;
-            cur_flags = flags;
-        }
-        text.push(cell.c);
-        span_grid_cols += 1;
-    }
-    if !text.is_empty() {
-        spans.push(TermSpan {
-            text,
-            fg: cur_fg,
-            bg: cur_bg,
-            flags: cur_flags,
-            col: span_col_start,
-            grid_cols: span_grid_cols,
+    // Handle pending creates
+    for (entity, handle, pending) in &pending_create {
+        daemon.0.send(ClientMessage::CreateSession {
+            shell: pending.shell.clone(),
+            cwd: pending.cwd.clone(),
+            env: Vec::new(),
+            cols: 80,
+            rows: 24,
         });
+        // Also attach immediately to receive viewport patches
+        daemon.0.send(ClientMessage::AttachSession {
+            session_id: handle.session_id,
+        });
+        commands.entity(entity).remove::<PendingDaemonCreate>();
     }
 
-    TermLine { spans }
-}
+    // Handle pending attaches
+    for (entity, handle) in &pending_attach {
+        daemon.0.send(ClientMessage::AttachSession {
+            session_id: handle.session_id,
+        });
+        daemon.0.send(ClientMessage::RequestSnapshot {
+            session_id: handle.session_id,
+        });
+        commands.entity(entity).remove::<PendingDaemonAttach>();
+    }
 
-fn color_to_term_color(color: &Color) -> TermColor {
-    match color {
-        Color::Named(named) => match named {
-            NamedColor::Foreground | NamedColor::DimForeground | NamedColor::BrightForeground => {
-                TermColor::Default
+    // Drain daemon messages and dispatch
+    for msg in daemon.0.drain() {
+        match msg {
+            DaemonMessage::SessionCreated { session_id } => {
+                // Update the placeholder session_id if we find a pending terminal
+                // The first terminal without a real session gets this one.
+                // In practice CreateSession responses come back in order.
+                for (entity, _, _) in &terminals {
+                    // Attach to this session to receive patches
+                    daemon.0.send(ClientMessage::AttachSession { session_id });
+                    // Update handle
+                    commands
+                        .entity(entity)
+                        .insert(DaemonSessionHandle { session_id });
+                    break;
+                }
             }
-            NamedColor::Background => TermColor::Default,
-            NamedColor::Cursor => TermColor::Default,
-            other => TermColor::Indexed(named_to_ansi_index(other)),
-        },
-        Color::Indexed(idx) if *idx < 16 => TermColor::Indexed(*idx),
-        Color::Indexed(idx) => {
-            let [r, g, b] = ansi_256_to_rgb(*idx);
-            TermColor::Rgb(r, g, b)
+            DaemonMessage::ViewportPatch {
+                session_id,
+                changed_lines,
+                cursor,
+                cols,
+                rows,
+                selection,
+                full,
+            } => {
+                for (entity, handle, _) in &terminals {
+                    if handle.session_id == session_id {
+                        if !browsers.has_browser(entity) || !browsers.host_emit_ready(&entity) {
+                            continue;
+                        }
+                        let patch = TermViewportPatch {
+                            changed_lines,
+                            cursor,
+                            cols,
+                            rows,
+                            selection,
+                            full,
+                        };
+                        commands.trigger(HostEmitEvent::new(
+                            entity,
+                            TERM_VIEWPORT_EVENT,
+                            &patch,
+                        ));
+                        break;
+                    }
+                }
+            }
+            DaemonMessage::Snapshot {
+                session_id,
+                lines,
+                cursor,
+                cols,
+                rows,
+            } => {
+                for (entity, handle, _) in &terminals {
+                    if handle.session_id == session_id {
+                        if !browsers.has_browser(entity) || !browsers.host_emit_ready(&entity) {
+                            continue;
+                        }
+                        let patch = TermViewportPatch {
+                            changed_lines: lines
+                                .into_iter()
+                                .enumerate()
+                                .map(|(i, l)| (i as u16, l))
+                                .collect(),
+                            cursor,
+                            cols,
+                            rows,
+                            selection: None,
+                            full: true,
+                        };
+                        commands.trigger(HostEmitEvent::new(
+                            entity,
+                            TERM_VIEWPORT_EVENT,
+                            &patch,
+                        ));
+                        break;
+                    }
+                }
+            }
+            DaemonMessage::SessionExited {
+                session_id,
+                exit_code: _,
+            } => {
+                for (entity, handle, child_of) in &terminals {
+                    if handle.session_id == session_id {
+                        commands.entity(entity).insert(SessionExited);
+                        let tab = child_of.get();
+                        commands.entity(tab).insert(LastActivatedAt::now());
+                        writer.write(AppCommand::Tab(TabCommand::Close));
+                        break;
+                    }
+                }
+            }
+            DaemonMessage::Error { message } => {
+                warn!("Daemon error: {message}");
+            }
+            _ => {} // SessionList, SessionOutput handled elsewhere if needed
         }
-        Color::Spec(rgb) => TermColor::Rgb(rgb.r, rgb.g, rgb.b),
-    }
-}
-
-fn named_to_ansi_index(named: &NamedColor) -> u8 {
-    match named {
-        NamedColor::Black | NamedColor::DimBlack => 0,
-        NamedColor::Red | NamedColor::DimRed => 1,
-        NamedColor::Green | NamedColor::DimGreen => 2,
-        NamedColor::Yellow | NamedColor::DimYellow => 3,
-        NamedColor::Blue | NamedColor::DimBlue => 4,
-        NamedColor::Magenta | NamedColor::DimMagenta => 5,
-        NamedColor::Cyan | NamedColor::DimCyan => 6,
-        NamedColor::White | NamedColor::DimWhite => 7,
-        NamedColor::BrightBlack => 8,
-        NamedColor::BrightRed => 9,
-        NamedColor::BrightGreen => 10,
-        NamedColor::BrightYellow => 11,
-        NamedColor::BrightBlue => 12,
-        NamedColor::BrightMagenta => 13,
-        NamedColor::BrightCyan => 14,
-        NamedColor::BrightWhite => 15,
-        _ => 7, // fallback to white
-    }
-}
-
-fn cell_flags_to_u16(flags: CellFlags) -> u16 {
-    let mut f = 0u16;
-    if flags.contains(CellFlags::BOLD) {
-        f |= FLAG_BOLD;
-    }
-    if flags.contains(CellFlags::ITALIC) {
-        f |= FLAG_ITALIC;
-    }
-    if flags.contains(CellFlags::UNDERLINE) {
-        f |= FLAG_UNDERLINE;
-    }
-    if flags.contains(CellFlags::STRIKEOUT) {
-        f |= FLAG_STRIKETHROUGH;
-    }
-    if flags.contains(CellFlags::DIM) {
-        f |= FLAG_DIM;
-    }
-    if flags.contains(CellFlags::INVERSE) {
-        f |= FLAG_INVERSE;
-    }
-    f
-}
-
-/// Convert ANSI 256-color index (16-255) to RGB.
-fn ansi_256_to_rgb(idx: u8) -> [u8; 3] {
-    if idx < 16 {
-        return [0, 0, 0];
-    }
-    if idx < 232 {
-        let i = idx - 16;
-        let r = (i / 36) * 51;
-        let g = ((i % 36) / 6) * 51;
-        let b = (i % 6) * 51;
-        [r, g, b]
-    } else {
-        let v = 8 + (idx - 232) * 10;
-        [v, v, v]
     }
 }
 
@@ -708,36 +439,22 @@ fn is_non_character_key(key: KeyCode) -> bool {
     )
 }
 
-/// Check if a key code is a selection-extending key (used with Shift).
-fn is_selection_key(key: KeyCode) -> bool {
-    matches!(
-        key,
-        KeyCode::ArrowLeft
-            | KeyCode::ArrowRight
-            | KeyCode::ArrowUp
-            | KeyCode::ArrowDown
-            | KeyCode::Home
-            | KeyCode::End
-            | KeyCode::PageUp
-            | KeyCode::PageDown
-    )
-}
-
 /// Handle keyboard input directly from Bevy, bypassing CEF round-trip.
 fn handle_terminal_keyboard(
     mut er: MessageReader<KeyboardInput>,
-    mut q: Query<(&PtyHandle, &mut TerminalState), (With<Terminal>, With<CefKeyboardTarget>)>,
+    q: Query<&DaemonSessionHandle, (With<Terminal>, With<CefKeyboardTarget>)>,
     input: Res<ButtonInput<KeyCode>>,
     chord_state: Res<crate::shortcut::ChordState>,
+    daemon: Option<Res<DaemonClient>>,
 ) {
     if q.is_empty() {
         return;
     }
-    // Suppress keyboard input while a chord prefix is pending so the second
-    // key of a chord (e.g. the `` ` `` in Ctrl+G → `` ` ``) doesn't leak
-    // into the terminal.
+    let Some(daemon) = daemon else {
+        for _ in er.read() {}
+        return;
+    };
     if chord_state.pending_prefix.is_some() {
-        // Drain events so MessageReader cursor advances
         for _ in er.read() {}
         return;
     }
@@ -751,228 +468,77 @@ fn handle_terminal_keyboard(
         if event.state != ButtonState::Pressed {
             continue;
         }
-        // Deduplicate non-character keys — macOS/bevy_winit can deliver two
-        // Pressed messages for a single physical press, either in the same
-        // frame or across consecutive frames.
         if !event.repeat && is_non_character_key(event.key_code) {
-            // Same-frame dedup
             if seen_keys.contains(&event.key_code) {
                 continue;
             }
             seen_keys.push(event.key_code);
-            // Cross-frame dedup: skip if the key was already held from a
-            // previous frame (not a fresh press).
             if !input.just_pressed(event.key_code) {
                 continue;
             }
         }
 
-        // Handle Cmd/Super key combinations (clipboard shortcuts).
-        // Don't forward these to the PTY — they're OS-level commands.
         if super_key {
             match event.key_code {
                 KeyCode::KeyV => {
-                    // Paste: read system clipboard and write to PTY.
-                    // Use pbpaste to avoid objc2/NSPasteboard conflicts with CEF.
+                    // Paste via pbpaste
                     if let Ok(output) = std::process::Command::new("pbpaste").output()
                         && output.status.success()
                     {
                         let text = String::from_utf8_lossy(&output.stdout);
                         if !text.is_empty() {
-                            for (pty, state) in &q {
-                                if let Ok(mut writer) = pty.writer.lock() {
-                                    let bp = state.term.mode().contains(TermMode::BRACKETED_PASTE);
-                                    if bp {
-                                        let _ = writer.write_all(b"\x1b[200~");
-                                    }
-                                    let _ = writer.write_all(text.as_bytes());
-                                    if bp {
-                                        let _ = writer.write_all(b"\x1b[201~");
-                                    }
-                                }
+                            // Wrap in bracketed paste sequences
+                            let mut data = Vec::new();
+                            data.extend_from_slice(b"\x1b[200~");
+                            data.extend_from_slice(text.as_bytes());
+                            data.extend_from_slice(b"\x1b[201~");
+                            for handle in &q {
+                                daemon.0.send(ClientMessage::SessionInput {
+                                    session_id: handle.session_id,
+                                    data: data.clone(),
+                                });
                             }
                         }
                     }
                     continue;
                 }
                 KeyCode::KeyC => {
-                    // Copy: selected text if selection exists, else full visible grid.
-                    for (_pty, mut state) in &mut q {
-                        let text = if state.term.selection.is_some() {
-                            let s = state.term.selection_to_string().unwrap_or_default();
-                            // Clear selection after copy
-                            state.term.selection = None;
-                            state.selection_cursor = None;
-                            state.dirty = true;
-                            s
-                        } else {
-                            visible_text(&state.term)
-                        };
-                        if !text.is_empty() {
-                            pbcopy(&text);
-                        }
-                    }
+                    // Copy: in daemon mode we can't access selection, so skip
+                    // TODO: implement copy via daemon snapshot
                     continue;
                 }
-                _ => {
-                    // Skip all other Cmd+key combos — don't send to PTY
-                    continue;
-                }
+                _ => continue,
             }
         }
 
-        // Shift+Arrow/Home/End/PgUp/PgDn: keyboard text selection.
-        // Don't send these to the PTY — they drive the selection overlay.
-        if shift && is_selection_key(event.key_code) {
-            for (_pty, mut state) in &mut q {
-                let num_cols = state.term.grid().columns();
-                let num_lines = state.term.grid().screen_lines();
-
-                // Use tracked selection_cursor, or fall back to terminal cursor.
-                let cur = state
-                    .selection_cursor
-                    .unwrap_or_else(|| state.term.grid().cursor.point);
-
-                let new_point = match event.key_code {
-                    KeyCode::ArrowLeft => {
-                        if cur.column.0 > 0 {
-                            Point::new(cur.line, cur.column - 1)
-                        } else if cur.line.0 > 0 {
-                            Point::new(cur.line - 1, Column(num_cols - 1))
-                        } else {
-                            cur
-                        }
-                    }
-                    KeyCode::ArrowRight => {
-                        if cur.column.0 + 1 < num_cols {
-                            Point::new(cur.line, cur.column + 1)
-                        } else if (cur.line.0 as usize) + 1 < num_lines {
-                            Point::new(cur.line + 1, Column(0))
-                        } else {
-                            cur
-                        }
-                    }
-                    KeyCode::ArrowUp => {
-                        if cur.line.0 > 0 {
-                            Point::new(cur.line - 1, cur.column)
-                        } else {
-                            cur
-                        }
-                    }
-                    KeyCode::ArrowDown => {
-                        if (cur.line.0 as usize) + 1 < num_lines {
-                            Point::new(cur.line + 1, cur.column)
-                        } else {
-                            cur
-                        }
-                    }
-                    KeyCode::Home => Point::new(cur.line, Column(0)),
-                    KeyCode::End => Point::new(cur.line, Column(num_cols - 1)),
-                    KeyCode::PageUp => {
-                        let target_line = (cur.line.0 - num_lines as i32).max(0);
-                        Point::new(Line(target_line), cur.column)
-                    }
-                    KeyCode::PageDown => {
-                        let target_line = (cur.line.0 + num_lines as i32).min(num_lines as i32 - 1);
-                        Point::new(Line(target_line), cur.column)
-                    }
-                    _ => cur,
-                };
-
-                if state.term.selection.is_none() {
-                    // Start new selection from cursor position.
-                    let cursor_point = state.term.grid().cursor.point;
-                    let sel_type = if alt {
-                        SelectionType::Block
-                    } else {
-                        SelectionType::Simple
-                    };
-                    state.term.selection = Some(Selection::new(sel_type, cursor_point, Side::Left));
-                }
-                if let Some(ref mut sel) = state.term.selection {
-                    sel.update(new_point, Side::Left);
-                    sel.include_all();
-                }
-                state.selection_cursor = Some(new_point);
-                state.dirty = true;
-            }
+        // Skip selection keys (Shift+Arrow etc) — daemon doesn't support local selection
+        if shift
+            && matches!(
+                event.key_code,
+                KeyCode::ArrowLeft
+                    | KeyCode::ArrowRight
+                    | KeyCode::ArrowUp
+                    | KeyCode::ArrowDown
+                    | KeyCode::Home
+                    | KeyCode::End
+                    | KeyCode::PageUp
+                    | KeyCode::PageDown
+            )
+        {
             continue;
-        }
-
-        // Any non-modifier key press clears the selection.
-        if !matches!(
-            event.key_code,
-            KeyCode::ShiftLeft
-                | KeyCode::ShiftRight
-                | KeyCode::ControlLeft
-                | KeyCode::ControlRight
-                | KeyCode::AltLeft
-                | KeyCode::AltRight
-                | KeyCode::SuperLeft
-                | KeyCode::SuperRight
-        ) {
-            for (_pty, mut state) in &mut q {
-                if state.term.selection.is_some() {
-                    state.term.selection = None;
-                    state.selection_cursor = None;
-                    state.dirty = true;
-                }
-            }
         }
 
         let bytes = logical_key_to_bytes(&event.logical_key, ctrl, alt);
         if bytes.is_empty() {
             continue;
         }
-        for (pty, _state) in &q {
-            if let Ok(mut writer) = pty.writer.lock() {
-                let _ = writer.write_all(&bytes);
-            }
+        for handle in &q {
+            daemon.0.send(ClientMessage::SessionInput {
+                session_id: handle.session_id,
+                data: bytes.clone(),
+            });
         }
     }
-}
-
-/// Write text to system clipboard via pbcopy (avoids objc2/CEF conflicts).
-fn pbcopy(text: &str) {
-    if let Ok(mut child) = std::process::Command::new("pbcopy")
-        .stdin(std::process::Stdio::piped())
-        .spawn()
-    {
-        if let Some(mut stdin) = child.stdin.take() {
-            let _ = stdin.write_all(text.as_bytes());
-        }
-        let _ = child.wait();
-    }
-}
-
-/// Extract visible text from the terminal grid, trimming trailing whitespace per line.
-fn visible_text<T: TermEventListener>(term: &Term<T>) -> String {
-    let grid = term.grid();
-    let num_cols = grid.columns();
-    let num_lines = grid.screen_lines();
-    let offset = grid.display_offset() as i32;
-    let mut result = String::new();
-
-    for row_idx in 0..num_lines {
-        let row = &grid[Line(row_idx as i32 - offset)];
-        let mut line = String::with_capacity(num_cols);
-        for col_idx in 0..num_cols {
-            let cell = &row[Column(col_idx)];
-            if cell.flags.contains(CellFlags::WIDE_CHAR_SPACER) {
-                continue;
-            }
-            line.push(cell.c);
-        }
-        let trimmed = line.trim_end();
-        result.push_str(trimmed);
-        if row_idx < num_lines - 1 {
-            result.push('\n');
-        }
-    }
-
-    // Trim trailing empty lines
-    result.truncate(result.trim_end_matches('\n').len());
-    result
 }
 
 fn logical_key_to_bytes(key: &Key, ctrl: bool, alt: bool) -> Vec<u8> {
@@ -1033,15 +599,19 @@ fn logical_key_to_bytes(key: &Key, ctrl: bool, alt: bool) -> Vec<u8> {
     }
 }
 
-/// Handle mouse wheel scrolling — forwards to PTY when mouse mode is active,
-/// otherwise scrolls the scrollback buffer.
+/// Handle mouse wheel scrolling — sends scroll input to daemon.
 fn handle_terminal_scroll(
     mut er: MessageReader<MouseWheel>,
-    mut q: Query<(&mut TerminalState, &PtyHandle), (With<Terminal>, With<CefKeyboardTarget>)>,
+    q: Query<&DaemonSessionHandle, (With<Terminal>, With<CefKeyboardTarget>)>,
+    daemon: Option<Res<DaemonClient>>,
 ) {
     if q.is_empty() {
         return;
     }
+    let Some(daemon) = daemon else {
+        for _ in er.read() {}
+        return;
+    };
     for event in er.read() {
         let lines = match event.unit {
             MouseScrollUnit::Line => -event.y as i32,
@@ -1050,28 +620,22 @@ fn handle_terminal_scroll(
         if lines == 0 {
             continue;
         }
-        for (mut state, pty) in &mut q {
-            let mode = *state.term.mode();
-            if mode.intersects(TermMode::MOUSE_MODE) && mode.contains(TermMode::SGR_MOUSE) {
-                // Forward scroll as SGR mouse button 64 (up) / 65 (down) to the PTY
-                let button: u8 = if lines < 0 { 64 } else { 65 };
-                let count = lines.unsigned_abs();
-                let seq = sgr_mouse_sequence(button, 0, 0, 0, true);
-                if let Ok(mut w) = pty.writer.lock() {
-                    for _ in 0..count {
-                        let _ = w.write_all(&seq);
-                    }
-                }
-            } else {
-                state.term.scroll_display(Scroll::Delta(lines));
+        // Send scroll as mouse button 64/65 SGR sequences
+        let button: u8 = if lines < 0 { 64 } else { 65 };
+        let count = lines.unsigned_abs();
+        let seq = sgr_mouse_sequence(button, 0, 0, 0, true);
+        for handle in &q {
+            for _ in 0..count {
+                daemon.0.send(ClientMessage::SessionInput {
+                    session_id: handle.session_id,
+                    data: seq.clone(),
+                });
             }
-            state.dirty = true;
         }
     }
 }
 
 /// Encode a mouse event as an SGR escape sequence.
-/// button: SGR button value (0=left, 1=mid, 2=right, 32+=drag, 35=motion, 64/65=scroll)
 fn sgr_mouse_sequence(button: u8, col: u16, row: u16, modifiers: u8, pressed: bool) -> Vec<u8> {
     let mut cb = button as u32;
     if modifiers & MOD_SHIFT != 0 {
@@ -1084,129 +648,50 @@ fn sgr_mouse_sequence(button: u8, col: u16, row: u16, modifiers: u8, pressed: bo
         cb += 16;
     }
     let suffix = if pressed { 'M' } else { 'm' };
-    // SGR coordinates are 1-based
     format!("\x1b[<{};{};{}{}", cb, col + 1, row + 1, suffix).into_bytes()
 }
 
-/// Tracks mouse state for selection (double/triple click detection).
+/// Tracks mouse state for selection (reserved for future local selection).
 #[derive(Resource, Default)]
-struct MouseSelectionState {
-    /// Timestamp of last mousedown for multi-click detection.
-    last_click_time: Option<std::time::Instant>,
-    /// Number of consecutive clicks at roughly the same position.
-    click_count: u8,
-    /// Position of last click for multi-click detection.
-    last_click_pos: Option<(u16, u16)>,
-    /// Whether a drag selection is in progress.
-    dragging: bool,
-}
+struct MouseSelectionState;
 
-/// Handle mouse events from the terminal webview.
+/// Handle mouse events from the terminal webview — forward to daemon as input.
 fn on_term_mouse(
     trigger: On<Receive<TermMouseEvent>>,
-    mut state_q: Query<&mut TerminalState, With<Terminal>>,
-    pty_q: Query<&PtyHandle, With<Terminal>>,
-    mut mouse_sel: ResMut<MouseSelectionState>,
+    q: Query<&DaemonSessionHandle, With<Terminal>>,
+    daemon: Option<Res<DaemonClient>>,
 ) {
     let entity = trigger.event_target();
     let event = &trigger.payload;
+    let Some(daemon) = daemon else { return };
+    let Ok(handle) = q.get(entity) else { return };
 
-    let Ok(mut state) = state_q.get_mut(entity) else {
-        return;
-    };
-
-    let mode = *state.term.mode();
-
-    // When mouse reporting is disabled, handle text selection locally.
-    if !mode.intersects(TermMode::MOUSE_MODE) {
-        // Only handle left button (button == 0)
-        if event.button == 0 || (event.moving && mouse_sel.dragging) {
-            let point = Point::new(Line(event.row as i32), Column(event.col as usize));
-
-            if event.pressed && !event.moving {
-                // Mouse down — detect click count for single/double/triple
-                let now = std::time::Instant::now();
-                let same_pos = mouse_sel
-                    .last_click_pos
-                    .is_some_and(|(c, r)| c == event.col && r == event.row);
-                let fast_enough = mouse_sel
-                    .last_click_time
-                    .is_some_and(|t| now.duration_since(t).as_millis() < 500);
-
-                if same_pos && fast_enough {
-                    mouse_sel.click_count = (mouse_sel.click_count + 1).min(3);
-                } else {
-                    mouse_sel.click_count = 1;
-                }
-                mouse_sel.last_click_time = Some(now);
-                mouse_sel.last_click_pos = Some((event.col, event.row));
-                mouse_sel.dragging = true;
-
-                let sel_type = match mouse_sel.click_count {
-                    2 => SelectionType::Semantic,
-                    3 => SelectionType::Lines,
-                    _ => SelectionType::Simple,
-                };
-
-                let mut sel = Selection::new(sel_type, point, Side::Left);
-                if sel_type != SelectionType::Simple {
-                    // For semantic/lines, expand both sides immediately
-                    sel.update(point, Side::Right);
-                    sel.include_all();
-                }
-                state.term.selection = Some(sel);
-                state.dirty = true;
-            } else if event.moving && mouse_sel.dragging {
-                // Mouse drag — extend selection
-                if let Some(ref mut sel) = state.term.selection {
-                    sel.update(point, Side::Right);
-                    state.dirty = true;
-                }
-            } else if !event.pressed && !event.moving {
-                // Mouse up — finalize drag
-                mouse_sel.dragging = false;
-            }
-        }
-        return;
-    }
-
-    // Only support SGR encoding (used by all modern terminal apps)
-    if !mode.contains(TermMode::SGR_MOUSE) {
-        return;
-    }
-
-    // Filter motion events based on terminal mode
-    if event.moving {
-        let is_drag = event.button < 3;
-        if is_drag && !mode.intersects(TermMode::MOUSE_DRAG | TermMode::MOUSE_MOTION) {
-            return;
-        }
-        if !is_drag && !mode.contains(TermMode::MOUSE_MOTION) {
-            return;
-        }
-    }
-
-    // Encode SGR button: add 32 for motion/drag events
+    // Forward all mouse events as SGR sequences to daemon
     let button = if event.moving {
         event.button + 32
     } else {
         event.button
     };
-
     let seq = sgr_mouse_sequence(button, event.col, event.row, event.modifiers, event.pressed);
-
-    if let Ok(pty) = pty_q.get(entity)
-        && let Ok(mut w) = pty.writer.lock()
-    {
-        let _ = w.write_all(&seq);
-    }
+    daemon.0.send(ClientMessage::SessionInput {
+        session_id: handle.session_id,
+        data: seq,
+    });
 }
 
 /// Mark dirty when webview becomes ready so initial viewport is sent.
-fn on_term_ready(trigger: On<Add, UiReady>, mut q: Query<&mut TerminalState, With<Terminal>>) {
+fn on_term_ready(
+    trigger: On<Add, UiReady>,
+    q: Query<&DaemonSessionHandle, With<Terminal>>,
+    daemon: Option<Res<DaemonClient>>,
+) {
     let entity = trigger.event_target();
-    if let Ok(mut state) = q.get_mut(entity) {
-        state.dirty = true;
+    let Some(daemon) = daemon else { return };
+    if let Ok(handle) = q.get(entity) {
+        // Request a full snapshot when webview is ready
+        daemon.0.send(ClientMessage::RequestSnapshot {
+            session_id: handle.session_id,
+        });
     }
 }
 
@@ -1214,13 +699,17 @@ fn on_term_ready(trigger: On<Add, UiReady>, mut q: Query<&mut TerminalState, Wit
 fn on_term_resize(
     trigger: On<Receive<TermResizeEvent>>,
     webview_q: Query<&WebviewSize, With<Terminal>>,
-    mut state_q: Query<&mut TerminalState, With<Terminal>>,
-    pty_q: Query<&PtyHandle, With<Terminal>>,
+    handle_q: Query<&DaemonSessionHandle, With<Terminal>>,
+    daemon: Option<Res<DaemonClient>>,
 ) {
     let entity = trigger.event_target();
     let event = &trigger.payload;
+    let Some(daemon) = daemon else { return };
 
     let Ok(webview_size) = webview_q.get(entity) else {
+        return;
+    };
+    let Ok(handle) = handle_q.get(entity) else {
         return;
     };
 
@@ -1228,8 +717,6 @@ fn on_term_resize(
         return;
     }
 
-    // Use viewport dimensions from JS when available (accounts for CEF zoom),
-    // otherwise fall back to WebviewSize (DIP).
     let vw = if event.viewport_width > 0.0 {
         event.viewport_width
     } else {
@@ -1244,24 +731,11 @@ fn on_term_resize(
     let cols = (vw / event.char_width).floor().max(1.0) as u16;
     let rows = (vh / event.char_height).floor().max(1.0) as u16;
 
-    // Resize PTY
-    if let Ok(pty) = pty_q.get(entity) {
-        let master = pty.master.lock().unwrap();
-        let _ = master.resize(PtySize {
-            rows,
-            cols,
-            pixel_width: webview_size.0.x as u16,
-            pixel_height: webview_size.0.y as u16,
-        });
-    }
-
-    // Resize alacritty terminal grid
-    if let Ok(mut state) = state_q.get_mut(entity) {
-        let dims = PtyDimensions { cols, rows };
-        state.term.resize(dims);
-        state.dirty = true;
-        state.full_sync_needed = true;
-    }
+    daemon.0.send(ClientMessage::ResizeSession {
+        session_id: handle.session_id,
+        cols,
+        rows,
+    });
 }
 
 fn sync_terminal_theme(
@@ -1281,7 +755,6 @@ fn sync_terminal_theme(
     let colors =
         crate::themes::resolve_theme(&theme.color_scheme, &terminal_settings.custom_themes);
 
-    // Simple hash to detect theme changes
     let hash = {
         let mut h: u64 = 0;
         for b in &colors.foreground {
@@ -1321,9 +794,6 @@ fn sync_terminal_theme(
     let targets: Vec<Entity> = if theme_changed {
         q.iter().collect()
     } else {
-        // Include both newly spawned terminals and terminals whose
-        // browser just became ready (fixes race where the browser
-        // wasn't ready on the first sync attempt).
         new_terminals.iter().chain(newly_ready.iter()).collect()
     };
 
@@ -1336,16 +806,20 @@ fn sync_terminal_theme(
 
 fn on_restart_pty(
     trigger: On<RestartPty>,
-    mut q: Query<(&mut TerminalState, &mut PtyHandle, &mut PageMetadata)>,
+    mut q: Query<(&mut DaemonSessionHandle, &mut PageMetadata)>,
+    daemon: Option<Res<DaemonClient>>,
     settings: Res<AppSettings>,
 ) {
     let entity = trigger.event().entity;
-    let Ok((mut state, mut pty, mut meta)) = q.get_mut(entity) else {
+    let Some(daemon) = daemon else { return };
+    let Ok((mut handle, mut meta)) = q.get_mut(entity) else {
         return;
     };
 
-    // Kill old PTY
-    let _ = pty.child.lock().unwrap().kill();
+    // Kill old session
+    daemon.0.send(ClientMessage::KillSession {
+        session_id: handle.session_id,
+    });
 
     let shell = settings
         .terminal
@@ -1353,72 +827,20 @@ fn on_restart_pty(
         .map(|t| t.resolve_theme(&t.default_theme).shell)
         .unwrap_or_else(default_shell);
 
-    // Spawn new PTY
-    let pty_system = NativePtySystem::default();
-    let pair = pty_system
-        .openpty(PtySize {
-            rows: 24,
-            cols: 80,
-            pixel_width: 0,
-            pixel_height: 0,
-        })
-        .expect("failed to open PTY");
+    // Create new session
+    let new_id = SessionId::new();
+    daemon.0.send(ClientMessage::CreateSession {
+        shell,
+        cwd: String::new(),
+        env: Vec::new(),
+        cols: 80,
+        rows: 24,
+    });
+    daemon.0.send(ClientMessage::AttachSession {
+        session_id: new_id,
+    });
 
-    let mut cmd = CommandBuilder::new(&shell);
-    cmd.env("TERM", "xterm-256color");
-    cmd.env("COLORTERM", "truecolor");
-    cmd.env("LANG", "en_US.UTF-8");
-    cmd.env("LC_CTYPE", "UTF-8");
-
-    let child = pair
-        .slave
-        .spawn_command(cmd)
-        .expect("failed to spawn shell");
-    let pid = child.process_id().unwrap_or(0);
-    let reader = pair
-        .master
-        .try_clone_reader()
-        .expect("failed to clone PTY reader");
-    let new_writer: Arc<Mutex<Box<dyn Write + Send>>> = Arc::new(Mutex::new(
-        pair.master
-            .take_writer()
-            .expect("failed to take PTY writer"),
-    ));
-    drop(pair.slave);
-
-    // Spawn new reader thread
-    let (tx, rx) = mpsc::channel();
-    std::thread::Builder::new()
-        .name("pty-reader".into())
-        .spawn(move || {
-            pty_reader_thread(reader, tx);
-        })
-        .expect("failed to spawn PTY reader thread");
-
-    // Reset terminal state
-    let event_proxy = VmuxEventProxy {
-        pty_writer: Arc::clone(&new_writer),
-    };
-    let term_config = TermConfig::default();
-    let dims = PtyDimensions { cols: 80, rows: 24 };
-    let new_term = Term::new(term_config, &dims, event_proxy);
-
-    state.term = new_term;
-    state.processor = Processor::new();
-    state.dirty = true;
-    state.selection_cursor = None;
-    state.line_hashes.clear();
-    state.full_sync_needed = true;
-
-    // Replace PtyHandle entirely
-    *pty = PtyHandle {
-        rx: Mutex::new(rx),
-        writer: new_writer,
-        master: Mutex::new(pair.master),
-        child: Mutex::new(child),
-    };
-
-    // Update metadata
-    meta.url = format!("{}session/{}", TERMINAL_WEBVIEW_URL, pid);
-    meta.title = format!("Terminal (Session: {})", pid);
+    handle.session_id = new_id;
+    meta.url = format!("{}session/{}", TERMINAL_WEBVIEW_URL, new_id);
+    meta.title = format!("Terminal ({})", &new_id.to_string()[..8]);
 }

--- a/crates/vmux_desktop/src/terminal.rs
+++ b/crates/vmux_desktop/src/terminal.rs
@@ -270,6 +270,7 @@ fn poll_daemon_messages(
         (Entity, &DaemonSessionHandle, &ChildOf),
         (With<Terminal>, Without<SessionExited>),
     >,
+    mut meta_q: Query<&mut PageMetadata>,
     daemon: Option<Res<DaemonClient>>,
     browsers: NonSend<Browsers>,
     mut commands: Commands,
@@ -277,18 +278,15 @@ fn poll_daemon_messages(
 ) {
     let Some(daemon) = daemon else { return };
 
-    // Handle pending creates
-    for (entity, handle, pending) in &pending_create {
+    // Handle pending creates — send CreateSession, wait for SessionCreated
+    // response which will carry the real session ID.
+    for (entity, _handle, pending) in &pending_create {
         daemon.0.send(ClientMessage::CreateSession {
             shell: pending.shell.clone(),
             cwd: pending.cwd.clone(),
             env: Vec::new(),
             cols: 80,
             rows: 24,
-        });
-        // Also attach immediately to receive viewport patches
-        daemon.0.send(ClientMessage::AttachSession {
-            session_id: handle.session_id,
         });
         commands.entity(entity).remove::<PendingDaemonCreate>();
     }
@@ -308,16 +306,25 @@ fn poll_daemon_messages(
     for msg in daemon.0.drain() {
         match msg {
             DaemonMessage::SessionCreated { session_id } => {
-                // Update the placeholder session_id if we find a pending terminal
-                // The first terminal without a real session gets this one.
-                // In practice CreateSession responses come back in order.
+                // Update the placeholder session_id on the first terminal
+                // that doesn't yet have a real daemon session.
+                // CreateSession responses arrive in order.
                 for (entity, _, _) in &terminals {
-                    // Attach to this session to receive patches
+                    // Attach to receive viewport patches
                     daemon.0.send(ClientMessage::AttachSession { session_id });
-                    // Update handle
+                    // Update handle with real daemon session ID
                     commands
                         .entity(entity)
                         .insert(DaemonSessionHandle { session_id });
+                    // Update PageMetadata URL so session.ron saves the real ID
+                    if let Ok(mut meta) = meta_q.get_mut(entity) {
+                        meta.url =
+                            format!("{}session/{}", TERMINAL_WEBVIEW_URL, session_id);
+                        meta.title = format!(
+                            "Terminal ({})",
+                            &session_id.to_string()[..8]
+                        );
+                    }
                     break;
                 }
             }

--- a/crates/vmux_desktop/src/terminal.rs
+++ b/crates/vmux_desktop/src/terminal.rs
@@ -49,35 +49,29 @@ pub(crate) struct RestartPty {
     pub entity: Entity,
 }
 
+/// Tracks daemon connection retry state.
+#[derive(Resource)]
+struct DaemonConnectRetry {
+    /// Countdown: stop retrying after this many ticks.
+    remaining_attempts: u32,
+    timer: Timer,
+}
+
 pub(crate) struct TerminalInputPlugin;
 
 impl Plugin for TerminalInputPlugin {
     fn build(&self, app: &mut App) {
-        // Connect to daemon, auto-starting it if needed.
-        // The daemon runs as `<current_exe> daemon` (same binary, subcommand).
-        if DaemonHandle::connect().is_none() {
-            if let Ok(exe) = std::env::current_exe() {
-                info!("Starting daemon: {} daemon", exe.display());
-                let _ = std::process::Command::new(&exe)
-                    .arg("daemon")
-                    .stdin(std::process::Stdio::null())
-                    .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::piped())
-                    .spawn();
-                // Wait for daemon socket to appear
-                let sock = vmux_daemon::socket_path();
-                for _ in 0..20 {
-                    std::thread::sleep(std::time::Duration::from_millis(50));
-                    if sock.exists() {
-                        break;
-                    }
-                }
-            }
-        }
+        // Try to connect to an already-running daemon first.
         if let Some(handle) = DaemonHandle::connect() {
+            eprintln!("vmux: connected to existing daemon");
             app.insert_resource(DaemonClient(handle));
         } else {
-            warn!("Failed to connect to vmux daemon");
+            // Daemon not running — auto-start it and schedule connection retries.
+            ensure_daemon_started();
+            app.insert_resource(DaemonConnectRetry {
+                remaining_attempts: 60, // ~3 seconds with 50ms timer
+                timer: Timer::from_seconds(0.05, TimerMode::Repeating),
+            });
         }
 
         app.init_resource::<MouseSelectionState>()
@@ -94,6 +88,7 @@ impl Plugin for TerminalInputPlugin {
             .add_systems(
                 Update,
                 (
+                    try_connect_daemon.run_if(resource_exists::<DaemonConnectRetry>),
                     poll_daemon_messages.in_set(WriteAppCommands),
                     sync_terminal_theme,
                 )
@@ -249,8 +244,99 @@ struct PendingDaemonCreate {
 #[derive(Component)]
 struct PendingDaemonAttach;
 
+/// Marker: CreateSession was sent, waiting for SessionCreated response.
+#[derive(Component)]
+struct AwaitingSessionCreated;
+
 fn default_shell() -> String {
     std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string())
+}
+
+/// Spawn the daemon subprocess if not already running.
+fn ensure_daemon_started() {
+    if DaemonHandle::daemon_running() {
+        eprintln!("vmux: daemon already running");
+        return;
+    }
+    let exe = match std::env::current_exe() {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("vmux: failed to get current exe: {e}");
+            return;
+        }
+    };
+    eprintln!("vmux: starting daemon: {} daemon", exe.display());
+
+    // Redirect daemon stderr to a log file instead of piping.
+    // Piped stderr with nobody reading causes SIGPIPE on macOS,
+    // which can kill the daemon process.
+    let log_dir = vmux_daemon::daemon_dir();
+    let _ = std::fs::create_dir_all(&log_dir);
+    let stderr_cfg = match std::fs::File::create(log_dir.join("daemon.log")) {
+        Ok(f) => std::process::Stdio::from(f),
+        Err(_) => std::process::Stdio::null(),
+    };
+
+    match std::process::Command::new(&exe)
+        .arg("daemon")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(stderr_cfg)
+        .spawn()
+    {
+        Ok(_child) => {
+            eprintln!("vmux: daemon subprocess spawned");
+        }
+        Err(e) => {
+            eprintln!("vmux: failed to spawn daemon: {e}");
+        }
+    }
+}
+
+/// Bevy system: retry connecting to daemon until it succeeds or we give up.
+fn try_connect_daemon(
+    mut retry: ResMut<DaemonConnectRetry>,
+    time: Res<Time>,
+    mut commands: Commands,
+) {
+    retry.timer.tick(time.delta());
+    if !retry.timer.just_finished() {
+        return;
+    }
+
+    retry.remaining_attempts = retry.remaining_attempts.saturating_sub(1);
+
+    // Check if socket is ready
+    let sock = vmux_daemon::socket_path();
+    if !sock.exists() {
+        if retry.remaining_attempts == 0 {
+            eprintln!("vmux: daemon socket never appeared — giving up");
+            commands.remove_resource::<DaemonConnectRetry>();
+        }
+        return;
+    }
+
+    // Try to connect
+    match DaemonHandle::connect() {
+        Some(handle) => {
+            eprintln!("vmux: connected to daemon after retry");
+            commands.insert_resource(DaemonClient(handle));
+            commands.remove_resource::<DaemonConnectRetry>();
+        }
+        None => {
+            if retry.remaining_attempts == 0 {
+                eprintln!("vmux: failed to connect to daemon after all retries");
+                // Check daemon log for clues
+                let log_path = vmux_daemon::daemon_dir().join("daemon.log");
+                if let Ok(log) = std::fs::read_to_string(&log_path) {
+                    if !log.is_empty() {
+                        eprintln!("vmux: daemon log:\n{log}");
+                    }
+                }
+                commands.remove_resource::<DaemonConnectRetry>();
+            }
+        }
+    }
 }
 
 /// Send CreateSession / AttachSession for newly spawned terminals.
@@ -262,6 +348,10 @@ fn poll_daemon_messages(
     pending_attach: Query<
         (Entity, &DaemonSessionHandle),
         (With<Terminal>, With<PendingDaemonAttach>),
+    >,
+    awaiting_create: Query<
+        (Entity, &DaemonSessionHandle, &ChildOf),
+        (With<Terminal>, With<AwaitingSessionCreated>),
     >,
     terminals: Query<
         (Entity, &DaemonSessionHandle, &ChildOf),
@@ -285,7 +375,10 @@ fn poll_daemon_messages(
             cols: 80,
             rows: 24,
         });
-        commands.entity(entity).remove::<PendingDaemonCreate>();
+        commands
+            .entity(entity)
+            .remove::<PendingDaemonCreate>()
+            .insert(AwaitingSessionCreated);
     }
 
     // Handle pending attaches
@@ -303,16 +396,15 @@ fn poll_daemon_messages(
     for msg in daemon.0.drain() {
         match msg {
             DaemonMessage::SessionCreated { session_id } => {
-                // Update the placeholder session_id on the first terminal
-                // that doesn't yet have a real daemon session.
-                // CreateSession responses arrive in order.
-                for (entity, _, _) in &terminals {
+                // Match the first terminal awaiting a SessionCreated response.
+                for (entity, _, _) in &awaiting_create {
                     // Attach to receive viewport patches
                     daemon.0.send(ClientMessage::AttachSession { session_id });
                     // Update handle with real daemon session ID
                     commands
                         .entity(entity)
-                        .insert(DaemonSessionHandle { session_id });
+                        .insert(DaemonSessionHandle { session_id })
+                        .remove::<AwaitingSessionCreated>();
                     // Update PageMetadata URL so session.ron saves the real ID
                     if let Ok(mut meta) = meta_q.get_mut(entity) {
                         meta.url =
@@ -826,6 +918,7 @@ fn on_restart_pty(
     };
 
     // Kill old session
+
     daemon.0.send(ClientMessage::KillSession {
         session_id: handle.session_id,
     });

--- a/crates/vmux_desktop/src/terminal.rs
+++ b/crates/vmux_desktop/src/terminal.rs
@@ -406,10 +406,15 @@ fn poll_daemon_messages(
                     }
                 }
             }
+            DaemonMessage::SessionList { sessions } => {
+                commands.insert_resource(crate::sessions_monitor::DaemonSessionList {
+                    sessions,
+                });
+            }
             DaemonMessage::Error { message } => {
                 warn!("Daemon error: {message}");
             }
-            _ => {} // SessionList, SessionOutput handled elsewhere if needed
+            _ => {} // SessionOutput handled elsewhere if needed
         }
     }
 }

--- a/crates/vmux_desktop/src/tray.rs
+++ b/crates/vmux_desktop/src/tray.rs
@@ -1,0 +1,23 @@
+/// System tray integration for macOS.
+///
+/// When the GUI window closes but daemon sessions are still alive,
+/// a tray icon is shown to indicate the daemon is running.
+///
+/// NOTE: Full tray-icon integration is deferred to a follow-up.
+/// tray-icon requires a running event loop and careful coordination
+/// with Bevy/winit's event loop on macOS. For now, the daemon runs
+/// headlessly and the user can relaunch the GUI to reconnect.
+///
+/// Planned features:
+/// - Tray icon appears when GUI closes with active sessions
+/// - Menu: "Show Vmux", "Sessions (N active)", "Quit Daemon"
+/// - Click to relaunch GUI and reattach
+
+#[allow(dead_code)] // Will be registered in VmuxPlugin once implemented
+pub(crate) struct TrayPlugin;
+
+impl bevy::prelude::Plugin for TrayPlugin {
+    fn build(&self, _app: &mut bevy::prelude::App) {
+        // Placeholder — tray integration will be added in a follow-up PR
+    }
+}

--- a/crates/vmux_sessions/Cargo.toml
+++ b/crates/vmux_sessions/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "vmux_sessions"
+description = "Daemon session monitor webview app"
+version.workspace = true
+edition.workspace = true
+publish = false
+build = "build.rs"
+
+[features]
+default = []
+web = []
+
+[[bin]]
+name = "vmux_sessions_app"
+path = "src/main.rs"
+required-features = ["web"]
+
+[lib]
+path = "src/lib.rs"
+
+[build-dependencies]
+vmux_webview_app = { path = "../vmux_webview_app", features = ["build"] }
+
+[dependencies]
+serde = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+bevy = { workspace = true }
+bevy_cef = { workspace = true }
+vmux_webview_app = { path = "../vmux_webview_app" }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+dioxus = { workspace = true }
+vmux_ui = { path = "../vmux_ui", default-features = false }
+wasm-bindgen = { workspace = true }
+web-sys = { version = "0.3", features = ["Window", "Document", "Element", "HtmlElement"] }

--- a/crates/vmux_sessions/Dioxus.toml
+++ b/crates/vmux_sessions/Dioxus.toml
@@ -1,0 +1,6 @@
+[application]
+name = "vmux_sessions"
+default_platform = "web"
+
+[web.app]
+title = "vmux sessions"

--- a/crates/vmux_sessions/assets/index.css
+++ b/crates/vmux_sessions/assets/index.css
@@ -1,0 +1,5 @@
+@import "../../vmux_ui/assets/theme.css";
+@config "../tailwind.config.js";
+@import "tailwindcss";
+@source "../src";
+@source ".";

--- a/crates/vmux_sessions/assets/index.html
+++ b/crates/vmux_sessions/assets/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en" class="dark h-full">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width"/>
+  <title>vmux sessions</title>
+  <style>
+    html.dark, html.dark body { height: 100%; margin: 0; min-height: 0; }
+    body { display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
+    #main { flex: 1 1 0%; min-height: 0; min-width: 0; display: flex; flex-direction: column; }
+  </style>
+  <link rel="modulepreload" href="__VMUX_DX_ENTRY__" crossorigin="anonymous"/>
+  <link rel="preload" href="__VMUX_DX_WASM__" as="fetch" type="application/wasm" crossorigin="anonymous"/>
+</head>
+<body class="m-0 flex h-full min-h-0 flex-col overflow-hidden p-0 text-foreground antialiased">
+  <div id="main" class="flex min-h-0 min-w-0 flex-1 flex-col"></div>
+  <script type="module" async src="__VMUX_DX_ENTRY__"></script>
+</body>
+</html>

--- a/crates/vmux_sessions/build.rs
+++ b/crates/vmux_sessions/build.rs
@@ -1,0 +1,18 @@
+use std::path::PathBuf;
+
+use vmux_webview_app::build::{CefEmbeddedWebviewFinalize, WebviewAppBuilder};
+
+fn main() {
+    let manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    WebviewAppBuilder::new(manifest_dir, "vmux_sessions", "vmux_sessions_app")
+        .track_manifest_rel_paths(&[
+            "tailwind.config.js",
+            "../vmux_ui/assets/theme.css",
+        ])
+        .dx_extra_args(&["--bin", "vmux_sessions_app", "--features", "web"])
+        .cef_finalize(CefEmbeddedWebviewFinalize {
+            strip_uncompiled_tailwind_css: true,
+        })
+        .tailwind_postprocess_after_dx(&["index-dxs", "sessions-dxs"])
+        .run("vmux_sessions");
+}

--- a/crates/vmux_sessions/src/app.rs
+++ b/crates/vmux_sessions/src/app.rs
@@ -2,7 +2,7 @@
 
 use dioxus::prelude::*;
 use vmux_sessions::event::*;
-use vmux_ui::hooks::{use_event_listener, use_theme};
+use vmux_ui::hooks::{try_cef_emit_serde, use_event_listener, use_theme};
 
 #[component]
 pub fn App() -> Element {
@@ -11,6 +11,7 @@ pub fn App() -> Element {
         connected: false,
         sessions: Vec::new(),
     });
+    let mut search = use_signal(String::new);
 
     let _listener =
         use_event_listener::<SessionsListEvent, _>(SESSIONS_LIST_EVENT, move |event| {
@@ -18,13 +19,52 @@ pub fn App() -> Element {
         });
 
     let data = state.read();
+    let query = search.read().to_lowercase();
+    let filtered: Vec<&SessionEntry> = data
+        .sessions
+        .iter()
+        .filter(|s| {
+            if query.is_empty() {
+                return true;
+            }
+            s.id.to_lowercase().contains(&query)
+                || s.shell.to_lowercase().contains(&query)
+                || s.cwd.to_lowercase().contains(&query)
+                || s.pid.to_string().contains(&query)
+        })
+        .collect();
+
+    let has_sessions = !data.sessions.is_empty();
+    let session_count = data.sessions.len();
 
     rsx! {
         div { class: "flex h-full flex-col bg-background p-4 overflow-auto",
             // Header
-            div { class: "mb-4 flex items-center gap-3",
-                h1 { class: "text-lg font-semibold text-foreground", "Daemon Sessions" }
-                StatusBadge { connected: data.connected }
+            div { class: "mb-3 flex items-center justify-between",
+                div { class: "flex items-center gap-3",
+                    h1 { class: "text-lg font-semibold text-foreground", "Daemon Sessions" }
+                    StatusBadge { connected: data.connected }
+                    if has_sessions {
+                        {
+                            let label = if session_count == 1 {
+                                format!("{session_count} session")
+                            } else {
+                                format!("{session_count} sessions")
+                            };
+                            rsx! { span { class: "text-xs text-muted-foreground", "{label}" } }
+                        }
+                    }
+                }
+                if has_sessions {
+                    button {
+                        class: "rounded bg-red-500/10 px-2.5 py-1 text-xs text-red-400 hover:bg-red-500/20 transition-colors",
+                        onclick: move |e: Event<MouseData>| {
+                            e.stop_propagation();
+                            let _ = try_cef_emit_serde(&SessionKillAllEvent { kill_all: true });
+                        },
+                        "Kill All"
+                    }
+                }
             }
 
             if !data.connected {
@@ -37,14 +77,31 @@ pub fn App() -> Element {
                         }
                     }
                 }
-            } else if data.sessions.is_empty() {
+            } else if !has_sessions {
                 div { class: "flex flex-1 items-center justify-center",
                     p { class: "text-sm text-muted-foreground", "No active sessions" }
                 }
             } else {
-                div { class: "flex flex-col gap-3",
-                    for session in data.sessions.iter() {
-                        SessionCard { session: session.clone() }
+                // Search filter
+                div { class: "mb-3",
+                    input {
+                        class: "w-full rounded-md border border-border bg-muted/50 px-3 py-1.5 text-sm text-foreground placeholder-muted-foreground outline-none focus:border-foreground/30",
+                        r#type: "text",
+                        placeholder: "Filter sessions...",
+                        value: "{search}",
+                        oninput: move |e: Event<FormData>| search.set(e.value()),
+                    }
+                }
+
+                if filtered.is_empty() {
+                    div { class: "flex flex-1 items-center justify-center",
+                        p { class: "text-sm text-muted-foreground", "No matching sessions" }
+                    }
+                } else {
+                    div { class: "flex flex-col gap-3",
+                        for session in filtered.iter() {
+                            SessionCard { key: "{session.id}", session: (*session).clone() }
+                        }
                     }
                 }
             }
@@ -76,14 +133,42 @@ fn SessionCard(session: SessionEntry) -> Element {
     } else {
         &session.id
     };
+    let shell_name = session
+        .shell
+        .rsplit('/')
+        .next()
+        .unwrap_or(&session.shell)
+        .to_string();
+
+    let nav_id = session.id.clone();
+    let kill_id = session.id.clone();
+
+    let onclick = move |_| {
+        let _ = try_cef_emit_serde(&SessionNavigateEvent {
+            session_id: nav_id.clone(),
+        });
+    };
+
+    let onkill = move |e: Event<MouseData>| {
+        e.stop_propagation();
+        let _ = try_cef_emit_serde(&SessionKillEvent {
+            session_id: kill_id.clone(),
+        });
+    };
 
     rsx! {
-        div { class: "rounded-lg border border-border bg-card p-3",
-            // Session header
+        div {
+            class: "rounded-lg border border-border bg-card p-3 cursor-pointer hover:border-foreground/30 transition-colors",
+            onclick,
+
+            // Row 1: ID + badges + uptime + kill
             div { class: "mb-2 flex items-center justify-between",
                 div { class: "flex items-center gap-2",
                     code { class: "rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground",
                         "{id_short}"
+                    }
+                    span { class: "rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground",
+                        "{shell_name}"
                     }
                     if session.attached {
                         span { class: "rounded-full bg-blue-500/20 px-2 py-0.5 text-xs text-blue-400",
@@ -91,17 +176,24 @@ fn SessionCard(session: SessionEntry) -> Element {
                         }
                     }
                 }
-                span { class: "text-xs text-muted-foreground", "{uptime}" }
+                div { class: "flex items-center gap-2",
+                    span { class: "text-xs text-muted-foreground", "{uptime}" }
+                    button {
+                        class: "rounded px-1.5 py-0.5 text-xs text-red-400 hover:bg-red-500/20 transition-colors",
+                        onclick: onkill,
+                        "Kill"
+                    }
+                }
             }
 
-            // Session metadata
-            div { class: "mb-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs",
-                MetaRow { label: "Shell", value: session.shell.clone() }
+            // Row 2: metadata grid
+            div { class: "grid grid-cols-2 gap-x-4 gap-y-1 text-xs",
                 MetaRow { label: "PID", value: session.pid.to_string() }
                 MetaRow { label: "Size", value: format!("{}x{}", session.cols, session.rows) }
                 if !session.cwd.is_empty() {
                     MetaRow { label: "CWD", value: session.cwd.clone() }
                 }
+                MetaRow { label: "Shell", value: session.shell.clone() }
             }
 
             // Terminal preview
@@ -119,8 +211,8 @@ fn SessionCard(session: SessionEntry) -> Element {
 #[component]
 fn MetaRow(label: String, value: String) -> Element {
     rsx! {
-        div { class: "flex gap-1",
-            span { class: "text-muted-foreground", "{label}:" }
+        div { class: "flex gap-1 min-w-0",
+            span { class: "shrink-0 text-muted-foreground", "{label}:" }
             span { class: "truncate text-foreground", "{value}" }
         }
     }

--- a/crates/vmux_sessions/src/app.rs
+++ b/crates/vmux_sessions/src/app.rs
@@ -146,6 +146,7 @@ fn SessionCard(session: SessionEntry) -> Element {
     let onclick = move |_| {
         let _ = try_cef_emit_serde(&SessionNavigateEvent {
             session_id: nav_id.clone(),
+            navigate: true,
         });
     };
 
@@ -153,6 +154,7 @@ fn SessionCard(session: SessionEntry) -> Element {
         e.stop_propagation();
         let _ = try_cef_emit_serde(&SessionKillEvent {
             session_id: kill_id.clone(),
+            kill: true,
         });
     };
 

--- a/crates/vmux_sessions/src/app.rs
+++ b/crates/vmux_sessions/src/app.rs
@@ -1,0 +1,139 @@
+#![allow(non_snake_case)]
+
+use dioxus::prelude::*;
+use vmux_sessions::event::*;
+use vmux_ui::hooks::{use_event_listener, use_theme};
+
+#[component]
+pub fn App() -> Element {
+    use_theme();
+    let mut state = use_signal(|| SessionsListEvent {
+        connected: false,
+        sessions: Vec::new(),
+    });
+
+    let _listener =
+        use_event_listener::<SessionsListEvent, _>(SESSIONS_LIST_EVENT, move |event| {
+            state.set(event);
+        });
+
+    let data = state.read();
+
+    rsx! {
+        div { class: "flex h-full flex-col bg-background p-4 overflow-auto",
+            // Header
+            div { class: "mb-4 flex items-center gap-3",
+                h1 { class: "text-lg font-semibold text-foreground", "Daemon Sessions" }
+                StatusBadge { connected: data.connected }
+            }
+
+            if !data.connected {
+                div { class: "flex flex-1 items-center justify-center",
+                    div { class: "text-center text-muted-foreground",
+                        p { class: "text-sm", "Daemon is not running" }
+                        p { class: "mt-1 text-xs opacity-60",
+                            "Start with: "
+                            code { class: "rounded bg-muted px-1.5 py-0.5 font-mono text-xs", "Vmux daemon" }
+                        }
+                    }
+                }
+            } else if data.sessions.is_empty() {
+                div { class: "flex flex-1 items-center justify-center",
+                    p { class: "text-sm text-muted-foreground", "No active sessions" }
+                }
+            } else {
+                div { class: "flex flex-col gap-3",
+                    for session in data.sessions.iter() {
+                        SessionCard { session: session.clone() }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn StatusBadge(connected: bool) -> Element {
+    let (color, text) = if connected {
+        ("bg-green-500", "Connected")
+    } else {
+        ("bg-red-500", "Disconnected")
+    };
+
+    rsx! {
+        div { class: "flex items-center gap-1.5 rounded-full bg-muted px-2.5 py-0.5",
+            div { class: "h-2 w-2 rounded-full {color}" }
+            span { class: "text-xs text-muted-foreground", "{text}" }
+        }
+    }
+}
+
+#[component]
+fn SessionCard(session: SessionEntry) -> Element {
+    let uptime = format_uptime(session.uptime_secs);
+    let id_short = if session.id.len() > 8 {
+        &session.id[..8]
+    } else {
+        &session.id
+    };
+
+    rsx! {
+        div { class: "rounded-lg border border-border bg-card p-3",
+            // Session header
+            div { class: "mb-2 flex items-center justify-between",
+                div { class: "flex items-center gap-2",
+                    code { class: "rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground",
+                        "{id_short}"
+                    }
+                    if session.attached {
+                        span { class: "rounded-full bg-blue-500/20 px-2 py-0.5 text-xs text-blue-400",
+                            "attached"
+                        }
+                    }
+                }
+                span { class: "text-xs text-muted-foreground", "{uptime}" }
+            }
+
+            // Session metadata
+            div { class: "mb-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs",
+                MetaRow { label: "Shell", value: session.shell.clone() }
+                MetaRow { label: "PID", value: session.pid.to_string() }
+                MetaRow { label: "Size", value: format!("{}x{}", session.cols, session.rows) }
+                if !session.cwd.is_empty() {
+                    MetaRow { label: "CWD", value: session.cwd.clone() }
+                }
+            }
+
+            // Terminal preview
+            if !session.preview_lines.is_empty() {
+                div { class: "mt-2 rounded bg-muted/50 p-2 font-mono text-xs leading-tight text-muted-foreground",
+                    for line in session.preview_lines.iter() {
+                        div { class: "truncate whitespace-pre", "{line.text}" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn MetaRow(label: String, value: String) -> Element {
+    rsx! {
+        div { class: "flex gap-1",
+            span { class: "text-muted-foreground", "{label}:" }
+            span { class: "truncate text-foreground", "{value}" }
+        }
+    }
+}
+
+fn format_uptime(secs: u64) -> String {
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m {}s", secs / 60, secs % 60)
+    } else if secs < 86400 {
+        format!("{}h {}m", secs / 3600, (secs % 3600) / 60)
+    } else {
+        format!("{}d {}h", secs / 86400, (secs % 86400) / 3600)
+    }
+}

--- a/crates/vmux_sessions/src/event.rs
+++ b/crates/vmux_sessions/src/event.rs
@@ -42,12 +42,16 @@ pub struct PreviewLine {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionNavigateEvent {
     pub session_id: String,
+    /// Discriminator so serde doesn't confuse with SessionKillEvent.
+    pub navigate: bool,
 }
 
 /// Emitted to kill a single daemon session.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionKillEvent {
     pub session_id: String,
+    /// Discriminator so serde doesn't confuse with SessionNavigateEvent.
+    pub kill: bool,
 }
 
 /// Emitted to kill all daemon sessions.

--- a/crates/vmux_sessions/src/event.rs
+++ b/crates/vmux_sessions/src/event.rs
@@ -1,7 +1,10 @@
 use serde::{Deserialize, Serialize};
 
-/// Event name for session list updates (host → webview).
+/// Event name for session list updates (host -> webview).
 pub const SESSIONS_LIST_EVENT: &str = "sessions_list";
+
+/// Event name for session navigation (webview -> host).
+pub const SESSIONS_NAVIGATE_EVENT: &str = "sessions_navigate";
 
 /// URL for the sessions monitor webview.
 pub const SESSIONS_WEBVIEW_URL: &str = "vmux://sessions/";
@@ -33,4 +36,23 @@ pub struct SessionEntry {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PreviewLine {
     pub text: String,
+}
+
+/// Emitted by the sessions webview when user clicks a session card.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionNavigateEvent {
+    pub session_id: String,
+}
+
+/// Emitted to kill a single daemon session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionKillEvent {
+    pub session_id: String,
+}
+
+/// Emitted to kill all daemon sessions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionKillAllEvent {
+    /// Discriminator field so serde doesn't match arbitrary IPC payloads.
+    pub kill_all: bool,
 }

--- a/crates/vmux_sessions/src/event.rs
+++ b/crates/vmux_sessions/src/event.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+/// Event name for session list updates (host → webview).
+pub const SESSIONS_LIST_EVENT: &str = "sessions_list";
+
+/// URL for the sessions monitor webview.
+pub const SESSIONS_WEBVIEW_URL: &str = "vmux://sessions/";
+
+/// Daemon connection status + session list, sent periodically to the webview.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionsListEvent {
+    pub connected: bool,
+    pub sessions: Vec<SessionEntry>,
+}
+
+/// A single daemon session's metadata.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionEntry {
+    pub id: String,
+    pub shell: String,
+    pub cwd: String,
+    pub cols: u16,
+    pub rows: u16,
+    pub pid: u32,
+    pub uptime_secs: u64,
+    /// Whether a GUI terminal is attached to this session.
+    pub attached: bool,
+    /// Last few lines of terminal output for preview.
+    pub preview_lines: Vec<PreviewLine>,
+}
+
+/// A simplified terminal line for the preview.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PreviewLine {
+    pub text: String,
+}

--- a/crates/vmux_sessions/src/lib.rs
+++ b/crates/vmux_sessions/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod event;
+
+#[cfg(not(target_arch = "wasm32"))]
+include!("plugin.rs");

--- a/crates/vmux_sessions/src/main.rs
+++ b/crates/vmux_sessions/src/main.rs
@@ -1,0 +1,5 @@
+mod app;
+
+fn main() {
+    dioxus::launch(app::App);
+}

--- a/crates/vmux_sessions/src/plugin.rs
+++ b/crates/vmux_sessions/src/plugin.rs
@@ -1,0 +1,17 @@
+use std::path::PathBuf;
+
+use bevy::prelude::*;
+use vmux_webview_app::{WebviewAppConfig, WebviewAppRegistry};
+
+pub struct SessionsPlugin;
+
+impl Plugin for SessionsPlugin {
+    fn build(&self, app: &mut App) {
+        app.world_mut()
+            .resource_mut::<WebviewAppRegistry>()
+            .register(
+                PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+                &WebviewAppConfig::with_custom_host("sessions"),
+            );
+    }
+}

--- a/crates/vmux_sessions/tailwind.config.js
+++ b/crates/vmux_sessions/tailwind.config.js
@@ -1,0 +1,9 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  presets: [require("../vmux_ui/tailwind.preset.js")],
+  content: ["./src/**/*.rs", "./assets/**/*.html"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/crates/vmux_terminal/Cargo.toml
+++ b/crates/vmux_terminal/Cargo.toml
@@ -23,6 +23,7 @@ vmux_webview_app = { path = "../vmux_webview_app", features = ["build"] }
 
 [dependencies]
 serde = { workspace = true }
+rkyv = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bevy = { workspace = true }

--- a/crates/vmux_terminal/src/event.rs
+++ b/crates/vmux_terminal/src/event.rs
@@ -8,7 +8,7 @@ pub const TERM_RESIZE_EVENT: &str = "term_resize";
 pub const TERM_THEME_EVENT: &str = "term_theme";
 pub const TERMINAL_WEBVIEW_URL: &str = "vmux://terminal/";
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum TermColor {
     #[default]
     Default,
@@ -48,7 +48,7 @@ pub struct TermViewportEvent {
 }
 
 /// Range of selected cells in viewport coordinates (0-based row/col).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct TermSelectionRange {
     pub start_col: u16,
     pub start_row: u16,
@@ -57,12 +57,12 @@ pub struct TermSelectionRange {
     pub is_block: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct TermLine {
     pub spans: Vec<TermSpan>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct TermSpan {
     pub text: String,
     pub fg: TermColor,
@@ -84,7 +84,7 @@ pub const FLAG_STRIKETHROUGH: u16 = 8;
 pub const FLAG_DIM: u16 = 16;
 pub const FLAG_INVERSE: u16 = 32;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct TermCursor {
     pub col: u16,
     pub row: u16,
@@ -107,7 +107,7 @@ impl Default for TermCursor {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum CursorShape {
     Block,
     Beam,
@@ -116,7 +116,7 @@ pub enum CursorShape {
 
 /// Incremental viewport update. Contains only changed lines plus cursor/selection.
 /// When `full` is true, `changed_lines` contains ALL lines (used on resize/spawn).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct TermViewportPatch {
     /// (row_index, line) pairs for rows that changed since last sync.
     pub changed_lines: Vec<(u16, TermLine)>,


### PR DESCRIPTION
## Context

Terminal sessions are lost when the Vmux GUI closes. This PR introduces a daemon architecture (similar to tmux) where a background process owns all terminal state (PTY, VTE grid, scrollback) and the GUI connects via IPC. Sessions survive GUI restarts.

Closes VMX-55.

## Implementation

**New crate: `vmux_daemon`** — both a library and a standalone binary (`vmux-daemon`).

- **Protocol** (`protocol.rs`): `ClientMessage` / `DaemonMessage` enums with rkyv serialization. `SessionId` is a `[u8; 16]` newtype (UUID bytes) since `uuid::Uuid` doesn\x27t implement rkyv traits.
- **Framing** (`framing.rs`): Length-prefixed frames over Unix domain socket at `~/.vmux/vmux.sock`. `write_message!` / `read_message!` macros for type-safe serialization.
- **Session** (`session.rs`): `SessionManager` + `Session` — each session owns a PTY, an alacritty_terminal `Term` grid, and a VTE `Processor`. Polls PTY output, processes through VTE, broadcasts viewport patches to attached clients via `tokio::broadcast`.
- **Server** (`server.rs`): Tokio-based Unix socket server. Each client connection gets a dedicated handler task; attach/detach spawns forwarder tasks for viewport patch streaming.
- **Client** (`client.rs`): `DaemonHandle` provides a sync API for Bevy systems — background thread bridges std::mpsc channels to async tokio IPC.

**Desktop changes:**

- `terminal.rs` rewritten: removed local PTY/alacritty_terminal (`TerminalState`, `PtyHandle`, `VmuxEventProxy`). Replaced with `DaemonSessionHandle` (session UUID) and `DaemonClient` (Bevy resource). All I/O goes through daemon IPC.
- `main.rs`: `vmux daemon` subcommand runs the daemon inline (same binary).
- `persistence.rs`: Session restore parses UUID from saved terminal URLs to reattach to existing daemon sessions.
- `tray.rs`: Placeholder module for future system tray integration.

**Known limitations (v1, intentional):**
- Mouse selection disabled (daemon owns Term grid)
- Scrollback browsing disabled (no local `term.scroll_display()`)
- Copy copies nothing in daemon mode (TODO: implement via snapshot)
- Grid helpers duplicated between daemon and desktop crates
- System tray is a placeholder

## Checks / QA

1. Start daemon: `Vmux daemon` (or `vmux-daemon` standalone binary)
2. Launch GUI: `Vmux` — verify it auto-connects to daemon
3. Open a terminal tab, type commands, verify output renders
4. Close GUI, relaunch — verify terminal session reconnects with preserved state
5. `cargo check --workspace` passes clean (zero warnings)