### PR TITLE
fix(macos): declare TCC usage descriptions to unblock passkey/WebAuthn

### DIFF
--- a/packaging/macos/Info.plist
+++ b/packaging/macos/Info.plist
@@ -30,5 +30,13 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright 2024-2025 Junichi Sugiura. MIT License.</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Vmux uses Bluetooth so websites can complete passkey sign-in with a phone or hardware security key.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Vmux uses the camera so websites can scan QR codes for cross-device passkey sign-in and access video conferencing.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Vmux uses the microphone so websites can use voice input and video conferencing.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Vmux shares your location with websites that request it (for example, maps and local search).</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

Clicking a passkey button on github.com (and any other WebAuthn flow) crashes Vmux instantly with `EXC_CRASH/SIGABRT`. Crash log says it all:

> This app has crashed because it attempted to access privacy-sensitive data without a usage description. The app's Info.plist must contain an `NSBluetoothAlwaysUsageDescription` key…

Chromium opens CoreBluetooth for the hybrid CTAP transport (phone-as-authenticator) and macOS TCC kills the process because `packaging/macos/Info.plist` declares zero `NS*UsageDescription` keys.

This PR adds the four usage descriptions Chromium routinely hits at runtime, so the system shows a permission prompt instead of aborting the app:

- `NSBluetoothAlwaysUsageDescription` — passkey / security key (the actual crash trigger).
- `NSCameraUsageDescription` — cross-device passkey QR scan, WebRTC video.
- `NSMicrophoneUsageDescription` — WebRTC audio.
- `NSLocationWhenInUseUsageDescription` — geolocation API.

Closes VMX-114.

## Test plan

- [ ] `plutil -lint packaging/macos/Info.plist` passes (already verified locally).
- [ ] Build a local `.app` (`make build-mac-local` or equivalent), install it, open `https://github.com/login`, click "Sign in with a passkey". Expect: macOS permission prompt for Bluetooth, no crash. Verify no new `vmux_desktop-*.ips` lands under `~/Library/Logs/DiagnosticReports/`.
- [ ] Smoke-check that other browser flows still work (regular page load, plain password sign-in).
