### PR TITLE
fix(macos): embed Info.plist into vmux_desktop binary so make run-mac honors TCC

### DIFF
--- a/crates/vmux_desktop/build.rs
+++ b/crates/vmux_desktop/build.rs
@@ -26,4 +26,16 @@ fn main() {
     println!("cargo::rerun-if-changed=../../.git/HEAD");
     println!("cargo::rerun-if-changed=../../.git/refs");
     println!("cargo::rerun-if-env-changed=VMUX_PROFILE");
+
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        let plist = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../packaging/macos/Info.plist")
+            .canonicalize()
+            .expect("packaging/macos/Info.plist not found");
+        println!("cargo::rerun-if-changed={}", plist.display());
+        println!(
+            "cargo::rustc-link-arg-bin=vmux_desktop=-Wl,-sectcreate,__TEXT,__info_plist,{}",
+            plist.display()
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`make run-mac` launches `target/debug/vmux_desktop` as a bare Mach-O binary — no `.app` wrapper, no adjacent `Info.plist`. macOS TCC has nothing to read, so the first time Chromium touches a privacy-sensitive API (Bluetooth for passkey hybrid transport, camera, mic, location) the process dies with `EXC_CRASH/SIGABRT`. The packaged `.app` (#29 / VMX-114) gets the right usage descriptions; the dev binary doesn't.

This PR embeds `packaging/macos/Info.plist` directly into the `vmux_desktop` binary as a Mach-O `__TEXT,__info_plist` section via a build-script linker arg. macOS reads embedded section plists for non-bundled executables, so dev builds now share the same TCC posture as the packaged build.

## Change

`crates/vmux_desktop/build.rs` gains a macOS-only block that:

- Resolves `packaging/macos/Info.plist` from `CARGO_MANIFEST_DIR`.
- Emits `cargo::rerun-if-changed=<plist>`.
- Emits `cargo::rustc-link-arg-bin=vmux_desktop=-Wl,-sectcreate,__TEXT,__info_plist,<plist>`.

No new deps. No effect on non-macOS targets. Packaged builds are unaffected because cargo-packager already places the same plist into `Contents/Info.plist` — both the bundle copy and the embedded section now come from the same source.

## Verification

```
$ otool -s __TEXT __info_plist target/debug/vmux_desktop
Contents of (__TEXT,__info_plist) section
…CFBundleDisplayName … Vmux …
```

Local checks:

- `cargo fmt -p vmux_desktop -- --check` — clean.
- `cargo clippy -p vmux_desktop --all-targets -- -D warnings` — exit 0.
- `cargo test -p vmux_desktop` — 7 passed, 0 failed.

## Depends on

VMX-114 (PR #29). The plist embedded by this PR has no effect on the passkey crash until VMX-114 adds `NSBluetoothAlwaysUsageDescription` to the source plist.

## Test plan

- [ ] Land #29 first.
- [ ] `make run-mac` (debug binary, not the `.app`).
- [ ] Open `https://github.com/login`, click "Sign in with a passkey".
- [ ] Expect: macOS Bluetooth permission prompt, no `vmux_desktop-*.ips` in `~/Library/Logs/DiagnosticReports/`.
- [ ] Sanity: `make run-mac-local` still launches `Vmux Local.app` correctly (no regression in packaged path).

Closes VMX-115.
