### PR TITLE
fix(vmux_service): cfg-gate Path import for non-macos builds

### DIFF
--- a/crates/vmux_cli/src/commands/service.rs
+++ b/crates/vmux_cli/src/commands/service.rs
@@ -91,6 +91,7 @@ fn not_supported() -> std::io::Result<i32> {
     Ok(2)
 }
 
+#[cfg(target_os = "macos")]
 fn current_service_binary() -> std::io::Result<std::path::PathBuf> {
     vmux_service::daemon_binary_path()
 }

--- a/crates/vmux_service/src/cli.rs
+++ b/crates/vmux_service/src/cli.rs
@@ -1,5 +1,6 @@
 //! Implementation of `vmux service ...` subcommands.
 
+#[cfg(target_os = "macos")]
 use std::path::Path;
 use std::time::Duration;
 


### PR DESCRIPTION
## Summary
- Linux clippy on main fails with `unused import: \`std::path::Path\`` in `crates/vmux_service/src/cli.rs:3`. `Path` is only used by the macOS-gated `cmd_install` / `cmd_start` / `cmd_restart` helpers, so the import needs the same `#[cfg(target_os = \"macos\")]` gate.
- Failing run: https://github.com/vmux-ai/vmux/actions/runs/25786016378/job/75739504467

## Test plan
- [x] `cargo fmt -p vmux_service -- --check`
- [x] `env -u CEF_PATH cargo clippy -p vmux_service --all-targets -- -D warnings`
- [x] `env -u CEF_PATH cargo test -p vmux_service` (45 unit + 18 integration tests pass)