### PR TITLE
chore(ci): use rust-cache, run workspace lint as single cargo invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   TAILWINDCSS_VERSION: "4.2.4"
+  CEF_VERSION: "145.6.1+145.0.28"
 
 jobs:
   lint:
@@ -61,6 +62,23 @@ jobs:
           shared-key: lint
           cache-all-crates: true
 
+      - name: Cache CEF framework
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/Chromium Embedded Framework.framework
+          key: cef-${{ runner.os }}-${{ env.CEF_VERSION }}
+
+      - name: Cache tailwindcss
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/bin/tailwindcss
+          key: tailwindcss-${{ runner.os }}-${{ env.TAILWINDCSS_VERSION }}
+
+      - name: Add ~/.local/bin to PATH
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Compute workspace packages (excluding patches)
         id: pkgs
         run: |
@@ -74,14 +92,16 @@ jobs:
 
       - name: Install CEF framework
         run: |
-          command -v export-cef-dir >/dev/null 2>&1 || cargo install export-cef-dir@145.6.1+145.0.28
-          export-cef-dir --force "$HOME/.local/share"
+          if [ ! -d "$HOME/.local/share/Chromium Embedded Framework.framework" ]; then
+            command -v export-cef-dir >/dev/null 2>&1 || cargo install export-cef-dir@${{ env.CEF_VERSION }}
+            export-cef-dir "$HOME/.local/share"
+          fi
 
       - name: Install dioxus-cli
         run: command -v dx >/dev/null 2>&1 || cargo install dioxus-cli --locked --version 0.7.4
 
       - name: Install tailwindcss
-        run: ./scripts/install-tailwindcss.sh
+        run: TAILWINDCSS_INSTALL_DIR="$HOME/.local/bin" ./scripts/install-tailwindcss.sh
 
       - name: Clippy
         run: env -u CEF_PATH cargo clippy ${{ steps.pkgs.outputs.args }} --all-targets -- -D warnings
@@ -128,16 +148,35 @@ jobs:
           shared-key: test
           cache-all-crates: true
 
+      - name: Cache CEF framework
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/Chromium Embedded Framework.framework
+          key: cef-${{ runner.os }}-${{ env.CEF_VERSION }}
+
+      - name: Cache tailwindcss
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/bin/tailwindcss
+          key: tailwindcss-${{ runner.os }}-${{ env.TAILWINDCSS_VERSION }}
+
+      - name: Add ~/.local/bin to PATH
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Install CEF framework
         run: |
-          command -v export-cef-dir >/dev/null 2>&1 || cargo install export-cef-dir@145.6.1+145.0.28
-          export-cef-dir --force "$HOME/.local/share"
+          if [ ! -d "$HOME/.local/share/Chromium Embedded Framework.framework" ]; then
+            command -v export-cef-dir >/dev/null 2>&1 || cargo install export-cef-dir@${{ env.CEF_VERSION }}
+            export-cef-dir "$HOME/.local/share"
+          fi
 
       - name: Install dioxus-cli
         run: command -v dx >/dev/null 2>&1 || cargo install dioxus-cli --locked --version 0.7.4
 
       - name: Install tailwindcss
-        run: ./scripts/install-tailwindcss.sh
+        run: TAILWINDCSS_INSTALL_DIR="$HOME/.local/bin" ./scripts/install-tailwindcss.sh
 
       - name: Run tests
         run: env -u CEF_PATH cargo test --workspace --exclude bevy_cef_core
@@ -208,10 +247,29 @@ jobs:
           shared-key: build-mac
           cache-all-crates: true
 
+      - name: Cache CEF framework
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/Chromium Embedded Framework.framework
+          key: cef-${{ runner.os }}-${{ env.CEF_VERSION }}
+
+      - name: Cache tailwindcss
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/bin/tailwindcss
+          key: tailwindcss-${{ runner.os }}-${{ env.TAILWINDCSS_VERSION }}
+
+      - name: Add ~/.local/bin to PATH
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Install CEF framework
         run: |
-          command -v export-cef-dir >/dev/null 2>&1 || cargo install export-cef-dir@145.6.1+145.0.28
-          export-cef-dir --force "$HOME/.local/share"
+          if [ ! -d "$HOME/.local/share/Chromium Embedded Framework.framework" ]; then
+            command -v export-cef-dir >/dev/null 2>&1 || cargo install export-cef-dir@${{ env.CEF_VERSION }}
+            export-cef-dir "$HOME/.local/share"
+          fi
 
       - name: Install dioxus-cli
         run: command -v dx >/dev/null 2>&1 || cargo install dioxus-cli --locked --version 0.7.4
@@ -222,10 +280,13 @@ jobs:
           command -v bevy_cef_bundle_app >/dev/null 2>&1 || cargo install bevy_cef_bundle_app
 
       - name: Install cargo-packager (patched for macOS Tahoe)
-        run: cargo install --path patches/cargo-packager-0.11.8
+        run: |
+          if ! cargo-packager --version 2>/dev/null | grep -q '0.11.8'; then
+            cargo install --path patches/cargo-packager-0.11.8
+          fi
 
       - name: Install tailwindcss
-        run: ./scripts/install-tailwindcss.sh
+        run: TAILWINDCSS_INSTALL_DIR="$HOME/.local/bin" ./scripts/install-tailwindcss.sh
 
       - name: Build, sign, notarize, and package DMG
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,25 +56,21 @@ jobs:
           components: rustfmt, clippy
           targets: wasm32-unknown-unknown
 
-      - uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/.crates.toml
-            ~/.cargo/.crates2.json
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          shared-key: lint
+          cache-all-crates: true
+
+      - name: Compute workspace packages (excluding patches)
+        id: pkgs
+        run: |
+          ARGS=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.manifest_path | test("patches") | not) | "-p " + .name' \
+            | tr '\n' ' ')
+          echo "args=$ARGS" >> "$GITHUB_OUTPUT"
 
       - name: Check formatting
-        run: |
-          # Exclude vendored patches from formatting checks
-          PKGS=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.manifest_path | test("patches") | not) | .name')
-          for pkg in $PKGS; do
-            cargo fmt -p "$pkg" -- --check
-          done
+        run: cargo fmt ${{ steps.pkgs.outputs.args }} -- --check
 
       - name: Install CEF framework
         run: |
@@ -88,11 +84,7 @@ jobs:
         run: ./scripts/install-tailwindcss.sh
 
       - name: Clippy
-        run: |
-          PKGS=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.manifest_path | test("patches") | not) | .name')
-          for pkg in $PKGS; do
-            env -u CEF_PATH cargo clippy -p "$pkg" --all-targets -- -D warnings
-          done
+        run: env -u CEF_PATH cargo clippy ${{ steps.pkgs.outputs.args }} --all-targets -- -D warnings
 
   test:
     name: Test
@@ -131,17 +123,10 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/.crates.toml
-            ~/.cargo/.crates2.json
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          shared-key: test
+          cache-all-crates: true
 
       - name: Install CEF framework
         run: |
@@ -193,17 +178,11 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/.crates.toml
-            ~/.cargo/.crates2.json
-            website/target
-          key: website-ci-${{ hashFiles('website/Cargo.lock') }}
-          restore-keys: website-ci-
+          workspaces: website
+          shared-key: website
+          cache-all-crates: true
 
       - name: Install dioxus-cli
         run: command -v dx >/dev/null 2>&1 || cargo install dioxus-cli --locked --version 0.7.4
@@ -224,17 +203,10 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/.crates.toml
-            ~/.cargo/.crates2.json
-            target
-          key: ${{ runner.os }}-build-${{ hashFiles('Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-build-
+          shared-key: build-mac
+          cache-all-crates: true
 
       - name: Install CEF framework
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           if [ ! -d "$HOME/.local/share/Chromium Embedded Framework.framework" ]; then
             command -v export-cef-dir >/dev/null 2>&1 || cargo install export-cef-dir@${{ env.CEF_VERSION }}
-            export-cef-dir "$HOME/.local/share"
+            export-cef-dir --force "$HOME/.local/share"
           fi
 
       - name: Install dioxus-cli
@@ -169,7 +169,7 @@ jobs:
         run: |
           if [ ! -d "$HOME/.local/share/Chromium Embedded Framework.framework" ]; then
             command -v export-cef-dir >/dev/null 2>&1 || cargo install export-cef-dir@${{ env.CEF_VERSION }}
-            export-cef-dir "$HOME/.local/share"
+            export-cef-dir --force "$HOME/.local/share"
           fi
 
       - name: Install dioxus-cli
@@ -268,7 +268,7 @@ jobs:
         run: |
           if [ ! -d "$HOME/.local/share/Chromium Embedded Framework.framework" ]; then
             command -v export-cef-dir >/dev/null 2>&1 || cargo install export-cef-dir@${{ env.CEF_VERSION }}
-            export-cef-dir "$HOME/.local/share"
+            export-cef-dir --force "$HOME/.local/share"
           fi
 
       - name: Install dioxus-cli

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -33,15 +33,11 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - name: Cache cargo
-        uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            website/target
-          key: website-${{ hashFiles('website/Cargo.lock') }}
-          restore-keys: website-
+          workspaces: website
+          shared-key: deploy-website
+          cache-all-crates: true
 
       - name: Install dioxus-cli
         run: cargo install dioxus-cli --locked --version 0.7.4

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -18,6 +18,10 @@ concurrency:
   group: pages
   cancel-in-progress: true
 
+env:
+  CARGO_TERM_COLOR: always
+  TAILWINDCSS_VERSION: "4.2.4"
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -39,11 +43,22 @@ jobs:
           shared-key: deploy-website
           cache-all-crates: true
 
+      - name: Cache tailwindcss
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/bin/tailwindcss
+          key: tailwindcss-${{ runner.os }}-${{ env.TAILWINDCSS_VERSION }}
+
+      - name: Add ~/.local/bin to PATH
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Install dioxus-cli
-        run: cargo install dioxus-cli --locked --version 0.7.4
+        run: command -v dx >/dev/null 2>&1 || cargo install dioxus-cli --locked --version 0.7.4
 
       - name: Install Tailwind CSS
-        run: ./scripts/install-tailwindcss.sh
+        run: TAILWINDCSS_INSTALL_DIR="$HOME/.local/bin" ./scripts/install-tailwindcss.sh
 
       - name: Build Tailwind CSS
         working-directory: website

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   TAILWINDCSS_VERSION: "4.2.4"
+  CEF_VERSION: "145.6.1+145.0.28"
 
 jobs:
   detect-version:
@@ -145,24 +146,46 @@ jobs:
           shared-key: release-macos
           cache-all-crates: true
 
+      - name: Cache CEF framework
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/Chromium Embedded Framework.framework
+          key: cef-${{ runner.os }}-${{ env.CEF_VERSION }}
+
+      - name: Cache tailwindcss
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/bin/tailwindcss
+          key: tailwindcss-${{ runner.os }}-${{ env.TAILWINDCSS_VERSION }}
+
+      - name: Add ~/.local/bin to PATH
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Install dioxus-cli
-        run: cargo install dioxus-cli --locked --version 0.7.4
+        run: command -v dx >/dev/null 2>&1 || cargo install dioxus-cli --locked --version 0.7.4
 
       - name: Install tailwindcss
-        run: ./scripts/install-tailwindcss.sh
+        run: TAILWINDCSS_INSTALL_DIR="$HOME/.local/bin" ./scripts/install-tailwindcss.sh
 
       - name: Install CEF framework
         run: |
-          cargo install export-cef-dir@145.6.1+145.0.28 --force
-          export-cef-dir --force "$HOME/.local/share"
+          if [ ! -d "$HOME/.local/share/Chromium Embedded Framework.framework" ]; then
+            command -v export-cef-dir >/dev/null 2>&1 || cargo install export-cef-dir@${{ env.CEF_VERSION }}
+            export-cef-dir "$HOME/.local/share"
+          fi
 
       - name: Install bevy_cef tools
         run: |
-          cargo install bevy_cef_render_process
-          cargo install bevy_cef_bundle_app
+          command -v bevy_cef_render_process >/dev/null 2>&1 || cargo install bevy_cef_render_process
+          command -v bevy_cef_bundle_app >/dev/null 2>&1 || cargo install bevy_cef_bundle_app
 
       - name: Install cargo-packager (patched for macOS Tahoe)
-        run: cargo install --path patches/cargo-packager-0.11.8
+        run: |
+          if ! cargo-packager --version 2>/dev/null | grep -q '0.11.8'; then
+            cargo install --path patches/cargo-packager-0.11.8
+          fi
 
       - name: Build, sign, notarize, and package DMG
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,16 +140,10 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - name: Cache cargo registry and build
-        uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          shared-key: release-macos
+          cache-all-crates: true
 
       - name: Install dioxus-cli
         run: cargo install dioxus-cli --locked --version 0.7.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,7 @@ jobs:
         run: |
           if [ ! -d "$HOME/.local/share/Chromium Embedded Framework.framework" ]; then
             command -v export-cef-dir >/dev/null 2>&1 || cargo install export-cef-dir@${{ env.CEF_VERSION }}
-            export-cef-dir "$HOME/.local/share"
+            export-cef-dir --force "$HOME/.local/share"
           fi
 
       - name: Install bevy_cef tools

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: run-mac run-mac-local run-doctor build-mac-debug sign-mac-debug build build-mac-local build-mac-release package-local-mac package-release-mac setup-cef install-debug-render-process doctor-mac ensure-run-mac-deps ensure-package-deps ensure-codesign-deps run-website build-website build-website-css lint lint-fix fmt clippy test
+.PHONY: dev local release build-local build-release run-doctor build setup-cef install-debug-render-process doctor-mac ensure-run-mac-deps ensure-package-deps ensure-codesign-deps run-website build-website build-website-css lint lint-fix fmt clippy test
+
+.DEFAULT_GOAL := dev
 
 CARGO_BIN := $(or $(shell command -v cargo 2>/dev/null),$(HOME)/.cargo/bin/cargo)
 RUSTUP_BIN := $(or $(shell command -v rustup 2>/dev/null),$(HOME)/.cargo/bin/rustup)
@@ -14,12 +16,14 @@ CEF_DEBUG_RENDER := $(CEF_FRAMEWORK_DIR)/Libraries/bevy_cef_debug_render_process
 
 # Header / history / UI library `dist/` folders are built by each crate’s `build.rs` via **`dx build`** when you compile `vmux_desktop` (needs `dioxus-cli` on PATH).
 
-run-mac: build-mac-debug
-	exec env -u CEF_PATH ./target/debug/vmux_desktop
-
-build-mac-debug: ensure-run-mac-deps ensure-codesign-deps install-debug-render-process
+dev: ensure-run-mac-deps ensure-codesign-deps install-debug-render-process
 	env -u CEF_PATH "$(CARGO_BIN)" build -p vmux_desktop -p vmux_cli -p vmux_service --features debug
-	@$(MAKE) sign-mac-debug
+	@identity="$$(./scripts/ensure-local-codesign-identity.sh)" && \
+	APPLE_SIGNING_IDENTITY="$$identity" \
+	APP_BINARY="target/debug/vmux_desktop" \
+	HELPER_BINARY="$(CEF_DEBUG_RENDER)" \
+	./scripts/sign-dev-mac.sh
+	exec env -u CEF_PATH ./target/debug/vmux_desktop
 
 build: ensure-run-mac-deps
 	env -u CEF_PATH "$(CARGO_BIN)" build -p vmux_desktop -p vmux_cli -p vmux_service --release
@@ -27,31 +31,24 @@ build: ensure-run-mac-deps
 -include .env
 export
 
-run-mac-local: build-mac-local
-	open "target/release/Vmux Local.app"
-
-package-local-mac: ensure-run-mac-deps ensure-package-deps
+build-local: ensure-run-mac-deps ensure-package-deps ensure-codesign-deps
 	./scripts/package.sh local
-
-package-release-mac: ensure-run-mac-deps ensure-package-deps
-	./scripts/package.sh release
-
-build-mac-local: package-local-mac ensure-codesign-deps
 	@identity="$$(./scripts/ensure-local-codesign-identity.sh)" && \
+	sha="$$(git rev-parse --short HEAD)" && \
 	APPLE_SIGNING_IDENTITY="$$identity" \
 	SKIP_NOTARIZE=1 \
-	APP_BUNDLE="target/release/Vmux Local.app" \
+	APP_BUNDLE="target/release/Vmux ($$sha).app" \
 	./scripts/sign-and-notarize.sh
 
-sign-mac-debug: ensure-codesign-deps
-	@identity="$$(./scripts/ensure-local-codesign-identity.sh)" && \
-	APPLE_SIGNING_IDENTITY="$$identity" \
-	APP_BINARY="target/debug/vmux_desktop" \
-	HELPER_BINARY="$(CEF_DEBUG_RENDER)" \
-	./scripts/sign-debug-mac.sh
+local: build-local
+	@sha="$$(git rev-parse --short HEAD)" && \
+	open "target/release/Vmux ($$sha).app"
 
-build-mac-release:
+build-release: ensure-run-mac-deps ensure-package-deps
 	./scripts/build-mac-release.sh release
+
+release: build-release
+	open "target/release/Vmux.app"
 
 # One-time CEF download (macOS paths; pin matches bevy_cef 0.5.x)
 setup-cef:
@@ -116,7 +113,7 @@ doctor-mac:
 		BEVY_CEF_BUNDLE_APP_BIN="$(BEVY_CEF_BUNDLE_APP_BIN)" CEF_FRAMEWORK_DIR="$(CEF_FRAMEWORK_DIR)" \
 		CEF_DEBUG_RENDER="$(CEF_DEBUG_RENDER)" ./scripts/doctor-mac.sh
 
-# Non-interactive bootstrap so `make run-mac` works even after dependency bumps.
+# Non-interactive bootstrap so `make dev` works even after dependency bumps.
 ensure-run-mac-deps:
 	@echo "Checking build dependencies..."
 	@if [ ! -x "$(CARGO_BIN)" ]; then \

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Requires macOS 13.0 (Ventura) or later.
 make run-doctor
 
 # Run signed debug binary
-make run-mac
+make dev
 ```
 
 See [Makefile](Makefile) for all targets.

--- a/crates/vmux_command/build.rs
+++ b/crates/vmux_command/build.rs
@@ -13,17 +13,17 @@ fn main() {
         .unwrap_or_else(|| "unknown".to_string());
     println!("cargo::rustc-env=VMUX_GIT_HASH={hash}");
 
-    let profile = std::env::var("VMUX_PROFILE").unwrap_or_else(|_| {
+    let profile = std::env::var("VMUX_BUILD_PROFILE").unwrap_or_else(|_| {
         if std::env::var("PROFILE").unwrap_or_default() == "release" {
             "release".to_string()
         } else {
             "dev".to_string()
         }
     });
-    println!("cargo::rustc-env=VMUX_PROFILE={profile}");
+    println!("cargo::rustc-env=VMUX_BUILD_PROFILE={profile}");
     println!("cargo::rerun-if-changed=../../.git/HEAD");
     println!("cargo::rerun-if-changed=../../.git/refs");
-    println!("cargo::rerun-if-env-changed=VMUX_PROFILE");
+    println!("cargo::rerun-if-env-changed=VMUX_BUILD_PROFILE");
 
     let manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
     WebviewAppBuilder::new(manifest_dir, "vmux_command", "vmux_command_app")

--- a/crates/vmux_desktop/build.rs
+++ b/crates/vmux_desktop/build.rs
@@ -12,18 +12,18 @@ fn main() {
 
     println!("cargo::rustc-env=VMUX_GIT_HASH={hash}");
 
-    // Profile: VMUX_PROFILE env var, default to "dev" for debug builds, "release" for release builds
-    let profile = std::env::var("VMUX_PROFILE").unwrap_or_else(|_| {
+    // Profile: VMUX_BUILD_PROFILE env var, default to "dev" for debug builds, "release" for release builds
+    let profile = std::env::var("VMUX_BUILD_PROFILE").unwrap_or_else(|_| {
         if std::env::var("PROFILE").unwrap_or_default() == "release" {
             "release".to_string()
         } else {
             "dev".to_string()
         }
     });
-    println!("cargo::rustc-env=VMUX_PROFILE={profile}");
+    println!("cargo::rustc-env=VMUX_BUILD_PROFILE={profile}");
 
-    // Rebuild when HEAD changes or VMUX_PROFILE changes
+    // Rebuild when HEAD changes or VMUX_BUILD_PROFILE changes
     println!("cargo::rerun-if-changed=../../.git/HEAD");
     println!("cargo::rerun-if-changed=../../.git/refs");
-    println!("cargo::rerun-if-env-changed=VMUX_PROFILE");
+    println!("cargo::rerun-if-env-changed=VMUX_BUILD_PROFILE");
 }

--- a/crates/vmux_desktop/src/lib.rs
+++ b/crates/vmux_desktop/src/lib.rs
@@ -73,7 +73,7 @@ fn primary_window_config(title: String) -> NativeWindow {
 
 impl Plugin for VmuxPlugin {
     fn build(&self, app: &mut App) {
-        let title = match env!("VMUX_PROFILE") {
+        let title = match env!("VMUX_BUILD_PROFILE") {
             "release" => "Vmux".to_string(),
             "local" => format!("Vmux ({})", env!("VMUX_GIT_HASH")),
             "dev" => format!("Vmux Dev ({})", env!("VMUX_GIT_HASH")),

--- a/crates/vmux_desktop/src/main.rs
+++ b/crates/vmux_desktop/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
          \n\
          \x1b[2mv{}{}\x1b[0m\n",
         env!("CARGO_PKG_VERSION"),
-        match env!("VMUX_PROFILE") {
+        match env!("VMUX_BUILD_PROFILE") {
             "release" => String::new(),
             "local" => format!(" ({})", env!("VMUX_GIT_HASH")),
             "dev" => format!(" dev ({})", env!("VMUX_GIT_HASH")),

--- a/crates/vmux_desktop/tests/release_invariants.rs
+++ b/crates/vmux_desktop/tests/release_invariants.rs
@@ -12,21 +12,31 @@ fn startup_does_not_mutate_chromium_safe_storage_acl() {
 }
 
 #[test]
-fn run_mac_uses_signed_debug_binary() {
+fn dev_target_signs_then_runs_debug_binary() {
     let makefile = include_str!("../../../Makefile");
 
-    assert!(makefile.contains("run-mac: build-mac-debug"));
+    assert!(makefile.contains(".DEFAULT_GOAL := dev"));
+    assert!(
+        makefile
+            .contains("dev: ensure-run-mac-deps ensure-codesign-deps install-debug-render-process")
+    );
+    assert!(makefile.contains("./scripts/sign-dev-mac.sh"));
     assert!(makefile.contains("exec env -u CEF_PATH ./target/debug/vmux_desktop"));
-    assert!(makefile.contains("sign-mac-debug"));
     assert!(makefile.contains("identity=\"$$(./scripts/ensure-local-codesign-identity.sh)\" &&"));
+    assert!(!makefile.contains("run-mac:"));
+    assert!(!makefile.contains("build-mac-debug"));
+    assert!(!makefile.contains("sign-mac-debug"));
+    assert!(!makefile.contains("package-local-mac"));
+    assert!(!makefile.contains("package-release-mac"));
 }
 
 #[test]
-fn local_package_uses_stable_bundle_name() {
+fn local_package_uses_per_sha_bundle_name() {
     let package_script = include_str!("../../../scripts/package.sh");
 
-    assert!(package_script.contains("PRODUCT_NAME=\"Vmux Local\""));
-    assert!(!package_script.contains("PRODUCT_NAME=\"Vmux ($GIT_HASH)\""));
+    assert!(package_script.contains("PRODUCT_NAME=\"Vmux ($SHA)\""));
+    assert!(package_script.contains("BUNDLE_ID=\"ai.vmux.desktop.$SHA\""));
+    assert!(!package_script.contains("PRODUCT_NAME=\"Vmux Local\""));
 }
 
 #[test]
@@ -57,19 +67,19 @@ fn local_signing_uses_stable_codesigning_identity() {
 }
 
 #[test]
-fn debug_signing_uses_default_keychain_directly() {
-    let signing_script = include_str!("../../../scripts/sign-debug-mac.sh");
+fn dev_signing_uses_default_keychain_directly() {
+    let signing_script = include_str!("../../../scripts/sign-dev-mac.sh");
 
     assert!(signing_script.contains("CODESIGN_KEYCHAIN"));
     assert!(signing_script.contains("--keychain"));
 }
 
 #[test]
-fn debug_and_local_share_main_bundle_identifier() {
-    let signing_script = include_str!("../../../scripts/sign-debug-mac.sh");
+fn dev_and_local_use_distinct_bundle_identifiers() {
+    let signing_script = include_str!("../../../scripts/sign-dev-mac.sh");
     let package_script = include_str!("../../../scripts/package.sh");
 
-    assert!(signing_script.contains("APP_IDENTIFIER=\"ai.vmux.desktop.local\""));
-    assert!(package_script.contains("BUNDLE_ID=\"ai.vmux.desktop.local\""));
-    assert!(!signing_script.contains("ai.vmux.desktop.dev."));
+    assert!(signing_script.contains("APP_IDENTIFIER=\"ai.vmux.desktop.dev\""));
+    assert!(!signing_script.contains("ai.vmux.desktop.local"));
+    assert!(package_script.contains("BUNDLE_ID=\"ai.vmux.desktop.$SHA\""));
 }

--- a/crates/vmux_layout/build.rs
+++ b/crates/vmux_layout/build.rs
@@ -13,17 +13,17 @@ fn main() {
         .unwrap_or_else(|| "unknown".to_string());
     println!("cargo::rustc-env=VMUX_GIT_HASH={hash}");
 
-    let profile = std::env::var("VMUX_PROFILE").unwrap_or_else(|_| {
+    let profile = std::env::var("VMUX_BUILD_PROFILE").unwrap_or_else(|_| {
         if std::env::var("PROFILE").unwrap_or_default() == "release" {
             "release".to_string()
         } else {
             "dev".to_string()
         }
     });
-    println!("cargo::rustc-env=VMUX_PROFILE={profile}");
+    println!("cargo::rustc-env=VMUX_BUILD_PROFILE={profile}");
     println!("cargo::rerun-if-changed=../../.git/HEAD");
     println!("cargo::rerun-if-changed=../../.git/refs");
-    println!("cargo::rerun-if-env-changed=VMUX_PROFILE");
+    println!("cargo::rerun-if-env-changed=VMUX_BUILD_PROFILE");
 
     let manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
     WebviewAppBuilder::new(manifest_dir, "vmux_layout", "vmux_layout_app")

--- a/crates/vmux_macro/src/lib.rs
+++ b/crates/vmux_macro/src/lib.rs
@@ -200,7 +200,7 @@ fn impl_os_menu(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     Ok(quote! {
         impl #ident {
             pub(crate) fn build_native_root_menu(menu: &mut ::muda::Menu) -> Result<(), ::muda::Error> {
-                let app_name = match env!("VMUX_PROFILE") {
+                let app_name = match env!("VMUX_BUILD_PROFILE") {
                     "release" => "Vmux".to_string(),
                     "local" => format!("Vmux ({})", env!("VMUX_GIT_HASH")),
                     "dev" => format!("Vmux Dev ({})", env!("VMUX_GIT_HASH")),

--- a/crates/vmux_service/build.rs
+++ b/crates/vmux_service/build.rs
@@ -1,6 +1,16 @@
 use std::path::PathBuf;
+use std::process::Command;
 
 fn main() {
+    let hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo::rustc-env=VMUX_GIT_HASH={hash}");
+
     let profile = std::env::var("VMUX_BUILD_PROFILE").unwrap_or_else(|_| {
         match std::env::var("PROFILE").as_deref() {
             Ok("release") => "release".to_string(),
@@ -8,6 +18,9 @@ fn main() {
         }
     });
     println!("cargo::rustc-env=VMUX_BUILD_PROFILE={profile}");
+
+    println!("cargo::rerun-if-changed=../../.git/HEAD");
+    println!("cargo::rerun-if-changed=../../.git/refs");
     println!("cargo::rerun-if-env-changed=VMUX_BUILD_PROFILE");
 
     use vmux_webview_app::build::{CefEmbeddedWebviewFinalize, WebviewAppBuilder};

--- a/crates/vmux_service/build.rs
+++ b/crates/vmux_service/build.rs
@@ -1,14 +1,14 @@
 use std::path::PathBuf;
 
 fn main() {
-    let profile = std::env::var("VMUX_PROFILE").unwrap_or_else(|_| {
+    let profile = std::env::var("VMUX_BUILD_PROFILE").unwrap_or_else(|_| {
         match std::env::var("PROFILE").as_deref() {
             Ok("release") => "release".to_string(),
             _ => "dev".to_string(),
         }
     });
-    println!("cargo::rustc-env=VMUX_PROFILE={profile}");
-    println!("cargo::rerun-if-env-changed=VMUX_PROFILE");
+    println!("cargo::rustc-env=VMUX_BUILD_PROFILE={profile}");
+    println!("cargo::rerun-if-env-changed=VMUX_BUILD_PROFILE");
 
     use vmux_webview_app::build::{CefEmbeddedWebviewFinalize, WebviewAppBuilder};
     let manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());

--- a/crates/vmux_service/src/launchd.rs
+++ b/crates/vmux_service/src/launchd.rs
@@ -50,15 +50,33 @@ pub fn generate_plist(profile: &str, binary_path: &Path, log_path: &Path) -> Str
 /// Write the plist for `profile` pointing at `binary_path`.
 pub fn install(profile: &str, binary_path: &Path) -> std::io::Result<PathBuf> {
     let plist = crate::plist_path(profile);
+    std::fs::create_dir_all(crate::service_dir())?;
+    let log = crate::log_path();
+    reconcile_plist_at(&plist, profile, binary_path, &log)?;
+    bootstrap(&plist)?;
+    Ok(plist)
+}
+
+fn reconcile_plist_at(
+    plist: &Path,
+    profile: &str,
+    binary_path: &Path,
+    log_path: &Path,
+) -> std::io::Result<bool> {
+    let desired = generate_plist(profile, binary_path, log_path);
+    let current = match std::fs::read_to_string(plist) {
+        Ok(s) => Some(s),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => return Err(e),
+    };
+    if current.as_deref() == Some(desired.as_str()) {
+        return Ok(false);
+    }
     if let Some(parent) = plist.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    std::fs::create_dir_all(crate::service_dir())?;
-
-    let xml = generate_plist(profile, binary_path, &crate::log_path());
-    std::fs::write(&plist, xml)?;
-    bootstrap(&plist)?;
-    Ok(plist)
+    std::fs::write(plist, desired)?;
+    Ok(true)
 }
 
 /// Remove the plist and unload from launchd.
@@ -117,12 +135,14 @@ pub fn kickstart(profile: &str) -> std::io::Result<()> {
 /// Make sure the daemon is installed and running. Idempotent.
 /// `binary_path` is the daemon executable (resolved by the caller).
 pub fn ensure_running(profile: &str, binary_path: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(crate::service_dir())?;
     let plist = crate::plist_path(profile);
-    if !plist.exists() {
-        install(profile, binary_path)?;
-    } else {
-        bootstrap(&plist)?;
+    let log = crate::log_path();
+    let rewrote = reconcile_plist_at(&plist, profile, binary_path, &log)?;
+    if rewrote {
+        let _ = bootout(profile);
     }
+    bootstrap(&plist)?;
     kickstart(profile)
 }
 
@@ -130,6 +150,18 @@ pub fn ensure_running(profile: &str, binary_path: &Path) -> std::io::Result<()> 
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_plist(tag: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "vmux-launchd-test-{}-{nanos}-{tag}.plist",
+            std::process::id(),
+        ))
+    }
 
     #[test]
     fn generated_plist_contains_label_binary_log_profile() {
@@ -146,5 +178,97 @@ mod tests {
         assert!(xml.contains("<key>RunAtLoad</key>\n  <false/>"));
         assert!(xml.contains("<key>KeepAlive</key>"));
         assert!(xml.contains("<key>Crashed</key>\n    <true/>"));
+    }
+
+    #[test]
+    fn reconcile_plist_at_writes_when_missing() {
+        let plist = temp_plist("missing");
+        let _ = std::fs::remove_file(&plist);
+        let bin = PathBuf::from("/usr/local/bin/vmux_service");
+        let log = PathBuf::from("/tmp/vmux-dev.log");
+
+        let rewrote = reconcile_plist_at(&plist, "dev", &bin, &log).expect("reconcile");
+
+        assert!(rewrote, "expected reconcile to report write");
+        let on_disk = std::fs::read_to_string(&plist).expect("plist exists");
+        assert_eq!(on_disk, generate_plist("dev", &bin, &log));
+        let _ = std::fs::remove_file(&plist);
+    }
+
+    #[test]
+    fn reconcile_plist_at_rewrites_when_binary_path_drifts() {
+        let plist = temp_plist("binary-drift");
+        let log = PathBuf::from("/tmp/vmux-dev.log");
+        let old_bin = PathBuf::from("/old/worktree/target/debug/vmux_service");
+        let new_bin = PathBuf::from("/new/worktree/target/debug/vmux_service");
+        std::fs::write(&plist, generate_plist("dev", &old_bin, &log)).expect("seed plist");
+
+        let rewrote = reconcile_plist_at(&plist, "dev", &new_bin, &log).expect("reconcile");
+
+        assert!(rewrote, "expected reconcile to rewrite drifted plist");
+        let on_disk = std::fs::read_to_string(&plist).expect("plist exists");
+        assert!(
+            on_disk.contains("/new/worktree/target/debug/vmux_service"),
+            "expected new binary path in {on_disk}"
+        );
+        assert!(
+            !on_disk.contains("/old/worktree/target/debug/vmux_service"),
+            "expected old binary path gone from {on_disk}"
+        );
+        let _ = std::fs::remove_file(&plist);
+    }
+
+    #[test]
+    fn reconcile_plist_at_rewrites_when_env_var_key_drifts() {
+        let plist = temp_plist("env-drift");
+        let bin = PathBuf::from("/usr/local/bin/vmux_service");
+        let log = PathBuf::from("/tmp/vmux-dev.log");
+        let legacy_xml =
+            generate_plist("dev", &bin, &log).replace("VMUX_BUILD_PROFILE", "VMUX_PROFILE");
+        std::fs::write(&plist, &legacy_xml).expect("seed legacy plist");
+
+        let rewrote = reconcile_plist_at(&plist, "dev", &bin, &log).expect("reconcile");
+
+        assert!(
+            rewrote,
+            "expected reconcile to rewrite legacy env-var plist"
+        );
+        let on_disk = std::fs::read_to_string(&plist).expect("plist exists");
+        assert!(
+            on_disk.contains("<key>VMUX_BUILD_PROFILE</key>"),
+            "expected new env var key in {on_disk}"
+        );
+        assert!(
+            !on_disk.contains("<key>VMUX_PROFILE</key>"),
+            "expected legacy env var key gone from {on_disk}"
+        );
+        let _ = std::fs::remove_file(&plist);
+    }
+
+    #[test]
+    fn reconcile_plist_at_no_op_when_matching() {
+        let plist = temp_plist("match");
+        let bin = PathBuf::from("/usr/local/bin/vmux_service");
+        let log = PathBuf::from("/tmp/vmux-dev.log");
+        let xml = generate_plist("dev", &bin, &log);
+        std::fs::write(&plist, &xml).expect("seed matching plist");
+        let mtime_before = std::fs::metadata(&plist)
+            .expect("metadata")
+            .modified()
+            .expect("mtime");
+
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let rewrote = reconcile_plist_at(&plist, "dev", &bin, &log).expect("reconcile");
+
+        assert!(!rewrote, "expected reconcile to skip matching plist");
+        let mtime_after = std::fs::metadata(&plist)
+            .expect("metadata")
+            .modified()
+            .expect("mtime");
+        assert_eq!(
+            mtime_before, mtime_after,
+            "plist should not have been touched"
+        );
+        let _ = std::fs::remove_file(&plist);
     }
 }

--- a/crates/vmux_service/src/launchd.rs
+++ b/crates/vmux_service/src/launchd.rs
@@ -30,7 +30,7 @@ pub fn generate_plist(profile: &str, binary_path: &Path, log_path: &Path) -> Str
   <string>Interactive</string>
   <key>EnvironmentVariables</key>
   <dict>
-    <key>VMUX_PROFILE</key>
+    <key>VMUX_BUILD_PROFILE</key>
     <string>{profile}</string>
   </dict>
   <key>StandardOutPath</key>
@@ -141,7 +141,7 @@ mod tests {
         assert!(xml.contains("<string>ai.vmux.service.dev</string>"));
         assert!(xml.contains("<string>/usr/local/bin/vmux_service</string>"));
         assert!(xml.contains("<string>/tmp/vmux-dev.log</string>"));
-        assert!(xml.contains("<key>VMUX_PROFILE</key>"));
+        assert!(xml.contains("<key>VMUX_BUILD_PROFILE</key>"));
         assert!(xml.contains("<string>dev</string>"));
         assert!(xml.contains("<key>RunAtLoad</key>\n  <false/>"));
         assert!(xml.contains("<key>KeepAlive</key>"));

--- a/crates/vmux_service/src/paths.rs
+++ b/crates/vmux_service/src/paths.rs
@@ -37,8 +37,16 @@ pub fn log_path() -> PathBuf {
 }
 
 /// LaunchAgent label for the given profile.
+///
+/// `release` drops the suffix; `local` expands to the build-time git SHA so
+/// each per-SHA local install registers a distinct background service. All
+/// other profiles (including `dev`) keep the literal profile name as suffix.
 pub fn launchd_label(profile: &str) -> String {
-    format!("ai.vmux.service.{profile}")
+    match profile {
+        "release" => "ai.vmux.service".to_string(),
+        "local" => format!("ai.vmux.service.{}", env!("VMUX_GIT_HASH")),
+        _ => format!("ai.vmux.service.{profile}"),
+    }
 }
 
 /// Path to the LaunchAgent plist for the given profile.
@@ -136,7 +144,16 @@ mod tests {
     #[test]
     fn launchd_label_includes_profile() {
         assert_eq!(launchd_label("dev"), "ai.vmux.service.dev");
-        assert_eq!(launchd_label("release"), "ai.vmux.service.release");
+        assert_eq!(launchd_label("release"), "ai.vmux.service");
+        let local = launchd_label("local");
+        assert!(
+            local.starts_with("ai.vmux.service."),
+            "expected local label to start with 'ai.vmux.service.', got {local}"
+        );
+        assert_ne!(
+            local, "ai.vmux.service.local",
+            "local profile should expand to per-SHA label, not literal 'local'"
+        );
     }
 
     #[test]

--- a/crates/vmux_service/src/paths.rs
+++ b/crates/vmux_service/src/paths.rs
@@ -3,7 +3,7 @@ use std::time::UNIX_EPOCH;
 
 /// Profile this build was compiled for ("release", "local", or "dev").
 pub fn current_profile() -> &'static str {
-    env!("VMUX_PROFILE")
+    env!("VMUX_BUILD_PROFILE")
 }
 
 /// Directory for service runtime files (socket, pid, log).

--- a/docs/plans/2026-05-12-vmux-service-daemon.md
+++ b/docs/plans/2026-05-12-vmux-service-daemon.md
@@ -73,7 +73,7 @@ Append to `crates/vmux_service/src/lib.rs` `tests` module:
 ```rust
     #[test]
     fn current_profile_is_compile_env() {
-        // Set by build.rs; default in tests is "dev" because no VMUX_PROFILE override.
+        // Set by build.rs; default in tests is "dev" because no VMUX_BUILD_PROFILE override.
         // Just assert it's non-empty and is one of the known profiles.
         let p = current_profile();
         assert!(!p.is_empty());
@@ -121,20 +121,20 @@ env -u CEF_PATH cargo test -p vmux_service --lib current_profile_is_compile_env 
 
 Expected: 5 failures with "cannot find function `current_profile`/`launchd_label`/`identity_path`/`log_path`/`plist_path` in this scope" (or similar).
 
-- [ ] **Step 3: Add `VMUX_PROFILE` to `vmux_service` build script**
+- [ ] **Step 3: Add `VMUX_BUILD_PROFILE` to `vmux_service` build script**
 
 Create `crates/vmux_service/build.rs`:
 
 ```rust
 fn main() {
-    let profile = std::env::var("VMUX_PROFILE").unwrap_or_else(|_| {
+    let profile = std::env::var("VMUX_BUILD_PROFILE").unwrap_or_else(|_| {
         match std::env::var("PROFILE").as_deref() {
             Ok("release") => "release".to_string(),
             _ => "dev".to_string(),
         }
     });
-    println!("cargo::rustc-env=VMUX_PROFILE={profile}");
-    println!("cargo::rerun-if-env-changed=VMUX_PROFILE");
+    println!("cargo::rustc-env=VMUX_BUILD_PROFILE={profile}");
+    println!("cargo::rerun-if-env-changed=VMUX_BUILD_PROFILE");
 }
 ```
 
@@ -160,7 +160,7 @@ use std::time::UNIX_EPOCH;
 
 /// Profile this build was compiled for ("release", "local", or "dev").
 pub fn current_profile() -> &'static str {
-    env!("VMUX_PROFILE")
+    env!("VMUX_BUILD_PROFILE")
 }
 
 /// Directory for service runtime files (socket, pid, log).
@@ -906,7 +906,7 @@ pub fn generate_plist(profile: &str, binary_path: &Path, log_path: &Path) -> Str
   <string>Interactive</string>
   <key>EnvironmentVariables</key>
   <dict>
-    <key>VMUX_PROFILE</key>
+    <key>VMUX_BUILD_PROFILE</key>
     <string>{profile}</string>
   </dict>
   <key>StandardOutPath</key>
@@ -1004,7 +1004,7 @@ mod tests {
         assert!(xml.contains("<string>ai.vmux.service.dev</string>"));
         assert!(xml.contains("<string>/usr/local/bin/vmux_service</string>"));
         assert!(xml.contains("<string>/tmp/vmux-dev.log</string>"));
-        assert!(xml.contains("<key>VMUX_PROFILE</key>"));
+        assert!(xml.contains("<key>VMUX_BUILD_PROFILE</key>"));
         assert!(xml.contains("<string>dev</string>"));
         assert!(xml.contains("<key>RunAtLoad</key>\n  <false/>"));
         assert!(xml.contains("<key>KeepAlive</key>"));
@@ -1592,15 +1592,15 @@ Open `crates/vmux_process/build.rs` (already read in design phase). Update `crat
 use std::path::PathBuf;
 
 fn main() {
-    // VMUX_PROFILE plumbing (kept from Task 1)
-    let profile = std::env::var("VMUX_PROFILE").unwrap_or_else(|_| {
+    // VMUX_BUILD_PROFILE plumbing (kept from Task 1)
+    let profile = std::env::var("VMUX_BUILD_PROFILE").unwrap_or_else(|_| {
         match std::env::var("PROFILE").as_deref() {
             Ok("release") => "release".to_string(),
             _ => "dev".to_string(),
         }
     });
-    println!("cargo::rustc-env=VMUX_PROFILE={profile}");
-    println!("cargo::rerun-if-env-changed=VMUX_PROFILE");
+    println!("cargo::rustc-env=VMUX_BUILD_PROFILE={profile}");
+    println!("cargo::rerun-if-env-changed=VMUX_BUILD_PROFILE");
 
     // Webview build (merged from vmux_process/build.rs)
     use vmux_webview_app::build::{CefEmbeddedWebviewFinalize, WebviewAppBuilder};

--- a/docs/specs/2026-05-12-vmux-service-daemon-design.md
+++ b/docs/specs/2026-05-12-vmux-service-daemon-design.md
@@ -113,7 +113,7 @@ required-features = ["web"]
 
 ## Per-profile resources
 
-`VMUX_PROFILE` env var (already populated by `crates/vmux_desktop/build.rs` and `crates/vmux_layout/build.rs`) drives every per-profile suffix. Possible values: `release`, `local`, `dev`, plus arbitrary user-set strings.
+`VMUX_BUILD_PROFILE` env var (already populated by `crates/vmux_desktop/build.rs` and `crates/vmux_layout/build.rs`) drives every per-profile suffix. Possible values: `release`, `local`, `dev`, plus arbitrary user-set strings.
 
 | Resource | Path |
 |---|---|
@@ -127,7 +127,7 @@ required-features = ["web"]
 Helpers in `lib.rs`:
 
 ```rust
-pub fn current_profile() -> &'static str { env!("VMUX_PROFILE") }
+pub fn current_profile() -> &'static str { env!("VMUX_BUILD_PROFILE") }
 pub fn launchd_label(profile: &str) -> String { format!("ai.vmux.service.{profile}") }
 pub fn plist_path(profile: &str) -> PathBuf { /* ~/Library/LaunchAgents/<label>.plist */ }
 pub fn socket_path() -> PathBuf { service_dir().join(format!("vmux-{}.sock", current_profile())) }
@@ -154,7 +154,7 @@ pub fn log_path() -> PathBuf { service_dir().join(format!("vmux-{}.log", current
   </dict>
   <key>ProcessType</key>      <string>Interactive</string>
   <key>EnvironmentVariables</key> <dict>
-    <key>VMUX_PROFILE</key>     <string>{profile}</string>
+    <key>VMUX_BUILD_PROFILE</key>     <string>{profile}</string>
   </dict>
   <key>StandardOutPath</key>  <string>{log-path}</string>
   <key>StandardErrorPath</key><string>{log-path}</string>

--- a/docs/specs/2026-05-13-build-naming-rename-design.md
+++ b/docs/specs/2026-05-13-build-naming-rename-design.md
@@ -1,0 +1,238 @@
+# Build identity rename — dev/local/release suffix scheme + per-SHA local
+
+**Status:** approved (design)
+**Date:** 2026-05-13
+**Linear:** [VMX-117](https://linear.app/vmux/issue/VMX-117)
+
+## Goal
+
+Rename the macOS desktop bundle identifier, app filename, service launchd label, and Makefile targets so that:
+
+1. **Dev** builds get a stable `.dev` identity, distinct from local. (Triggered by `make dev`; `VMUX_BUILD_PROFILE=dev`.)
+2. **Local** builds get a per-commit identity (`<sha>` = git short SHA from `VMUX_GIT_HASH`) so multiple local builds coexist as separate apps in `~/Applications` / Spotlight / Launchpad.
+3. **Release** builds drop the `.release` suffix from the service launchd label, matching the desktop's already-suffix-free release ID.
+4. **Makefile targets** standardize on `build-<profile>` for explicit build and `<profile>` for "build + run" (e.g. `dev`, `local`, `release`). `make` defaults to `dev`. Mac is the implicit default OS — when Windows support lands, Windows-specific targets get a `-win` suffix (`dev-win`, `build-local-win`).
+
+The driving use case is local builds: a contributor wants to keep the `vmx-127` build of Vmux installed alongside the `vmx-130` build without one clobbering the other.
+
+## What's already in place
+
+These pieces of the puzzle are already wired up on `main`:
+
+- `crates/vmux_desktop/build.rs` populates `VMUX_GIT_HASH` (7-char short SHA, falls back to `"unknown"`) and `VMUX_BUILD_PROFILE` (`dev` / `local` / `release`).
+- `crates/vmux_layout/build.rs` and `crates/vmux_command/build.rs` also populate `VMUX_GIT_HASH`.
+- Window title (`crates/vmux_desktop/src/lib.rs:76-81`), CLI version string (`crates/vmux_desktop/src/main.rs:29-34`), and macOS menu app-name (`crates/vmux_macro/src/lib.rs:203-209`) already format as `Vmux (<sha>)` for local and `Vmux Dev (<sha>)` for dev. **Don't touch these.**
+
+This spec only changes the bundle ID, app bundle filename, and launchd label.
+
+## Final naming matrix
+
+### Desktop
+
+| `VMUX_BUILD_PROFILE` | bundle ID | CFBundleName / DisplayName | path |
+|---|---|---|---|
+| `dev` | `ai.vmux.desktop.dev` | n/a (raw binary, no `.app`) | `target/debug/vmux_desktop` |
+| `local` | `ai.vmux.desktop.<sha>` | `Vmux (<sha>)` | `target/release/Vmux (<sha>).app` |
+| `release` | `ai.vmux.desktop` | `Vmux` | `target/release/Vmux.app` |
+
+### Service (launchd label)
+
+| `VMUX_BUILD_PROFILE` | label |
+|---|---|
+| `dev` | `ai.vmux.service.dev` |
+| `local` | `ai.vmux.service.<sha>` |
+| `release` | `ai.vmux.service` *(no suffix)* |
+
+### Service local files
+
+`~/Library/Application Support/Vmux/services/vmux-<profile>.{sock,pid,identity,log}` keeps the `VMUX_BUILD_PROFILE` literal as the suffix on all profiles (so files become `vmux-dev.sock`, `vmux-local.sock`, `vmux-release.sock`). Per-SHA local files would create file-system clutter for no benefit; the launchd-label SHA is what matters for letting separate `.app` bundles register distinct background services.
+
+## Hash rules
+
+- **Source:** `VMUX_GIT_HASH` (already populated by `build.rs` files via `git rev-parse --short HEAD`). The packaging script computes the same value via `git rev-parse --short HEAD` for `.app` filename + bundle ID, since the script runs before `cargo` and can't read `cargo`-emitted env vars.
+- **Same SHA → overwrite.** Rebuilding on the same commit replaces the existing `Vmux (<sha>).app`. No dirty marker, no rebuild counter.
+- **Install location:** unchanged. Build artifacts stay in `target/release/`. Users who want Spotlight/Launchpad/Dock visibility manually drag the `.app` into `~/Applications`.
+
+## Tradeoffs accepted
+
+- **Chromium keychain ACL split (dev ↔ local).** Today, debug + local share `ai.vmux.desktop.local`, so Chromium's safe-storage ACL covers both flows from one keychain prompt (per commit `4c5a4bd`). Splitting dev to `.dev` re-introduces the prompt on the first switch. Accepted because `make run-mac` (dev) and `make build-mac-local` (local) serve distinct workflows and shouldn't share login state.
+- **Chromium keychain ACL per local build.** Each new SHA → new bundle ID → new Chromium safe-storage entry → first-run keychain prompt. Logins / saved passwords don't carry across local rebuilds on different commits. Accepted as the cost of side-by-side installs.
+- **No build cleanup.** Stale `Vmux (<old-sha>).app` directories accumulate in `target/release/` until the user runs `cargo clean` or removes them by hand. Out of scope.
+
+## Implementation surface
+
+### `scripts/package.sh`
+
+Replace the static `local`-profile values with SHA-derived ones. Keep `VMUX_BUILD_PROFILE=local` so the in-binary code that already keys on the literal `"local"` keeps working.
+
+```bash
+case "$PROFILE" in
+    release)
+        PRODUCT_NAME="Vmux"
+        BUNDLE_ID="ai.vmux.desktop"
+        ;;
+    local)
+        SHA="$(git -C "$ROOT" rev-parse --short HEAD)"
+        PRODUCT_NAME="Vmux ($SHA)"
+        BUNDLE_ID="ai.vmux.desktop.$SHA"
+        # VMUX_BUILD_PROFILE stays "local" — VMUX_GIT_HASH carries the SHA into the binary.
+        ;;
+    *)
+        echo "Unknown profile: $PROFILE (expected: release, local)" >&2
+        exit 1
+        ;;
+esac
+```
+
+Existing `sed` patches (Cargo.toml `product-name` / `identifier` + Info.plist `CFBundleName` / `CFBundleDisplayName` / `CFBundleIdentifier`) work unchanged — they consume `$BUNDLE_ID` and `$PRODUCT_NAME`.
+
+`export VMUX_BUILD_PROFILE="$PROFILE"` (already at line 68) is unchanged.
+
+### `crates/vmux_service/build.rs`
+
+Add `VMUX_GIT_HASH` population so `paths.rs` can read it via `env!()`:
+
+```rust
+let hash = Command::new("git")
+    .args(["rev-parse", "--short", "HEAD"])
+    .output()
+    .ok()
+    .filter(|o| o.status.success())
+    .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+    .unwrap_or_else(|| "unknown".to_string());
+println!("cargo::rustc-env=VMUX_GIT_HASH={hash}");
+println!("cargo::rerun-if-changed=../../.git/HEAD");
+println!("cargo::rerun-if-changed=../../.git/refs");
+```
+
+Mirror what `crates/vmux_desktop/build.rs:5-13` does.
+
+### `crates/vmux_service/src/paths.rs`
+
+Match-on-profile in the launchd-label formula:
+
+```rust
+pub fn launchd_label(profile: &str) -> String {
+    match profile {
+        "release" => "ai.vmux.service".to_string(),
+        "local" => format!("ai.vmux.service.{}", env!("VMUX_GIT_HASH")),
+        _ => format!("ai.vmux.service.{profile}"),
+    }
+}
+```
+
+Local-file naming (`vmux-<profile>.sock`, `.pid`, `.identity`, `.log`) keeps the `profile` string literally. The launchd-label suffix change is launchd-only.
+
+Note: `env!("VMUX_GIT_HASH")` is a compile-time constant baked into the `vmux_service` binary at build time. Passing `profile = "local"` at any later runtime call site will always resolve to the SHA the binary was built with, not the calling process's current SHA. That's the intended behavior: each `Vmux (<sha>).app/Contents/MacOS/vmux_service` ships with its own immutable launchd label.
+
+### `scripts/sign-debug-mac.sh` → `scripts/sign-dev-mac.sh`
+
+`git mv scripts/sign-debug-mac.sh scripts/sign-dev-mac.sh`. Then change line 9: `APP_IDENTIFIER="ai.vmux.desktop.local"` → `"ai.vmux.desktop.dev"`.
+
+### `Makefile`
+
+**Target naming convention.** Build targets keep the `build-` verb prefix; run targets drop the verb (running is the default action). Convention: `build-<profile>` for explicit build, `<profile>` for "build + run". Profiles: `dev`, `local`, `release`. Mac is the implicit OS — Windows targets (when added) get a `-win` suffix; mac targets stay unsuffixed. Default `make` (no args) aliases to `make dev`.
+
+Rename / removal map:
+
+| old | new |
+|---|---|
+| `run-mac` | `dev` |
+| `build-mac-debug` | **removed** (inlined into `dev`) |
+| `run-mac-local` | `local` |
+| `build-mac-local` | `build-local` |
+| `build-mac-release` | `build-release` |
+| — *(new)* | `release` (build + open `Vmux.app`) |
+| `package-local-mac` | **removed** (inlined into `build-local`) |
+| `package-release-mac` | **removed** (inlined into `build-release` via `build-mac-release.sh`) |
+| `sign-mac-debug` | **removed** (inlined into `dev`) |
+
+Default target:
+
+```makefile
+.DEFAULT_GOAL := dev
+```
+
+`build-local` and `local`:
+
+```makefile
+local: build-local
+	@sha="$$(git rev-parse --short HEAD)" && \
+	open "target/release/Vmux ($$sha).app"
+
+build-local: ensure-run-mac-deps ensure-package-deps ensure-codesign-deps
+	./scripts/package.sh local
+	@identity="$$(./scripts/ensure-local-codesign-identity.sh)" && \
+	sha="$$(git rev-parse --short HEAD)" && \
+	APPLE_SIGNING_IDENTITY="$$identity" \
+	SKIP_NOTARIZE=1 \
+	APP_BUNDLE="target/release/Vmux ($$sha).app" \
+	./scripts/sign-and-notarize.sh
+
+dev: ensure-run-mac-deps ensure-codesign-deps install-debug-render-process
+	env -u CEF_PATH "$(CARGO_BIN)" build -p vmux_desktop -p vmux_cli -p vmux_service --features debug
+	@identity="$$(./scripts/ensure-local-codesign-identity.sh)" && \
+	APPLE_SIGNING_IDENTITY="$$identity" \
+	APP_BINARY="target/debug/vmux_desktop" \
+	HELPER_BINARY="$(CEF_DEBUG_RENDER)" \
+	./scripts/sign-dev-mac.sh
+	exec env -u CEF_PATH ./target/debug/vmux_desktop
+```
+
+**Asymmetry note:** `dev` only has a run target (no separate `build-dev`) because the dev workflow is iterate-and-launch — there's no use case for "build but don't run". Local and release keep a `build-*` for producing artifacts without launching.
+
+`build-release` keeps its current shape — it already invokes `scripts/build-mac-release.sh` which calls `package.sh` directly (never went through the Makefile `package-release-mac` target):
+
+```makefile
+build-release: ensure-run-mac-deps ensure-package-deps
+	./scripts/build-mac-release.sh release
+
+release: build-release
+	open "target/release/Vmux.app"
+```
+
+`release` runs the full release-build pipeline (sign + notarize via `build-mac-release.sh`) then launches the resulting `Vmux.app`. Without `APPLE_CERTIFICATE` env vars set, `build-mac-release.sh` falls back to the user's login keychain — so a local dev with a valid cert can `make release` without CI plumbing.
+
+Update the `.PHONY` line at the top of `Makefile` to reflect new names + dropped targets. Move `ensure-run-mac-deps` + `ensure-package-deps` from the removed `package-*-mac` targets onto the corresponding `build-*` targets (shown above).
+
+**Script rename for consistency:** `scripts/sign-debug-mac.sh` → `scripts/sign-dev-mac.sh` (no behavior change). The hard-coded `APP_IDENTIFIER` inside the script also flips from `ai.vmux.desktop.local` to `ai.vmux.desktop.dev` per the earlier section. The `scripts/build-mac-release.sh` filename is left as-is — it's an internal script, not user-facing, and renaming it would touch more files for no benefit. Same for `scripts/macos.sh`, `scripts/doctor-mac.sh`.
+
+**Documentation/script call sites referencing old names** (must update):
+
+- `scripts/macos.sh:38` — `make -C "$ROOT" build-mac-local` → `make -C "$ROOT" build-local`
+- `README.md` — any `make run-mac` / `make build-mac-*` mentions
+- `scripts/doctor-mac.sh` — if it suggests targets to the user
+- Any `docs/` content that documents the build flow
+
+### Tests
+
+- `crates/vmux_service/src/paths.rs:138-139` — `launchd_label("release")` assertion changes from `"ai.vmux.service.release"` to `"ai.vmux.service"`. `launchd_label("dev")` unchanged. Add `launchd_label("local")` assertion that matches `^ai\.vmux\.service\.[0-9a-f]{7}$` (or accepts the literal `unknown` fallback when git is unavailable).
+- `crates/vmux_service/src/launchd.rs:141` — same release-label adjustment.
+- `crates/vmux_desktop/tests/release_invariants.rs:72-74` — dev assertions become `ai.vmux.desktop.dev`. Local assertion replaced with regex `^ai\.vmux\.desktop\.[0-9a-f]{7}$` for `BUNDLE_ID`/`APP_IDENTIFIER`.
+
+### Files to grep during implementation, not pre-changed here
+
+- `crates/vmux_desktop/src/profile.rs` — references to literal `"Vmux Local"` strings.
+- `scripts/inject-cef.sh` — already env-var-driven (`VMUX_BUNDLE_ID`); should keep working but verify.
+- `crates/vmux_desktop/Cargo.toml:53-54` — sed-patched at package time, no source change.
+- `packaging/macos/Info.plist` — sed-patched at package time, no source change.
+- README and docs — references to `Vmux Local.app` need updating.
+
+## Out of scope
+
+- Auto-install into `~/Applications/` or `/Applications/`.
+- Dirty-tree marker (`-dirty` suffix).
+- Same-SHA collision detection / refusal.
+- Cleanup of stale per-SHA builds.
+- Symmetrical release rename (`ai.vmux.desktop` → `ai.vmux`). Not requested.
+- Linux-side packaging.
+
+## Verification plan
+
+1. `make` (no args) launches the dev binary (alias for `make dev`).
+2. `make dev` builds + signs + runs the debug binary; `codesign -dv target/debug/vmux_desktop` after first run → expect identifier `ai.vmux.desktop.dev`.
+3. `make build-local` on a clean tree → expect `target/release/Vmux (<sha>).app` exists, `Info.plist` has `CFBundleIdentifier=ai.vmux.desktop.<sha>` and `CFBundleName=Vmux (<sha>)`.
+4. `make build-local`, switch to a different commit, repeat → both `.app` directories coexist in `target/release/`.
+5. `make build-release` → unchanged: `Vmux.app` with `ai.vmux.desktop`. `make release` builds + launches it.
+6. Launch each build, run `launchctl list | grep ai.vmux.service` → dev shows `.dev`, local shows `.<sha>`, release shows bare `ai.vmux.service`.
+7. Per-crate `cargo fmt` / `cargo clippy` / `cargo test` on `vmux_service` and `vmux_desktop`.

--- a/docs/specs/2026-05-13-launchd-auto-heal-stale-plist-design.md
+++ b/docs/specs/2026-05-13-launchd-auto-heal-stale-plist-design.md
@@ -1,0 +1,107 @@
+# launchd `ensure_running` auto-heals stale plists
+
+**Linear:** VMX-118
+**Date:** 2026-05-13
+
+## Problem
+
+`vmux_service::launchd::ensure_running` (in `crates/vmux_service/src/launchd.rs:119-127`) only writes a fresh plist when none exists on disk. When the plist exists but its embedded values have drifted from current reality, `ensure_running` blindly bootstraps the stale plist.
+
+Two real-world drift cases:
+
+1. **Binary path drift** — plist points at a binary in a deleted worktree (e.g., `.worktrees/vmx-109/target/debug/vmux_service` after the worktree was removed).
+2. **Env var rename** — plist embeds `VMUX_PROFILE` from before commit `2249492`; current builds expect `VMUX_BUILD_PROFILE`.
+
+When the binary referenced by the plist no longer exists, `launchctl bootstrap` returns `Input/output error` (exit 5). The service never starts. Desktop CEF children sit until the 15s connection timeout fires:
+
+```
+Terminating current process after 15 seconds with no connection
+```
+
+Manual workaround today:
+
+```bash
+launchctl bootout gui/$(id -u)/ai.vmux.service.dev
+rm ~/Library/LaunchAgents/ai.vmux.service.dev.plist
+```
+
+After that, the missing plist triggers `install()`, which writes fresh contents and bootstraps successfully.
+
+## Goal
+
+`ensure_running` self-heals. Stale plists are detected and rewritten on the next call. No manual `bootout`/`rm` step.
+
+## Design
+
+### Helper: `reconcile_plist_at`
+
+New private function in `launchd.rs`:
+
+```rust
+fn reconcile_plist_at(
+    plist: &Path,
+    profile: &str,
+    binary_path: &Path,
+    log_path: &Path,
+) -> std::io::Result<bool>
+```
+
+- Reads `plist` (treats `NotFound` as "no current contents").
+- Computes desired contents via `generate_plist(profile, binary_path, log_path)`.
+- If equal → returns `Ok(false)`, file untouched.
+- Otherwise → ensures parent directory exists, writes desired contents, returns `Ok(true)`.
+
+Pure relative to file IO at the supplied path. Takes `plist` and `log_path` as arguments so tests can drive it with `tempdir` paths without touching `~/Library/LaunchAgents` or `~/Library/Application Support/Vmux`.
+
+A full string equality check covers the AC requirements (`ProgramArguments[0]`, `EnvironmentVariables`, `StandardOutPath`, `StandardErrorPath`) and is robust against any future field additions to the template.
+
+### Rewrite: `ensure_running`
+
+```rust
+pub fn ensure_running(profile: &str, binary_path: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(crate::service_dir())?;
+    let plist = crate::plist_path(profile);
+    let log = crate::log_path();
+    let rewrote = reconcile_plist_at(&plist, profile, binary_path, &log)?;
+    if rewrote {
+        // Tear down any prior registration so bootstrap doesn't return
+        // "Input/output error" when the previous binary path is gone or
+        // the plist has changed under launchd.
+        let _ = bootout(profile);
+    }
+    bootstrap(&plist)?;
+    kickstart(profile)
+}
+```
+
+The `bootout` is best-effort: when no service is registered, it returns nonzero (already logged at `warn`) and we proceed.
+
+### Refactor: `install`
+
+`install` continues to be the public API for "first-time install" (used by `vmux_service install` CLI subcommand). Reroute its plist-writing path through `reconcile_plist_at` so the write logic lives in one place.
+
+```rust
+pub fn install(profile: &str, binary_path: &Path) -> std::io::Result<PathBuf> {
+    let plist = crate::plist_path(profile);
+    std::fs::create_dir_all(crate::service_dir())?;
+    let log = crate::log_path();
+    let _rewrote = reconcile_plist_at(&plist, profile, binary_path, &log)?;
+    bootstrap(&plist)?;
+    Ok(plist)
+}
+```
+
+### Tests
+
+All in `crates/vmux_service/src/launchd.rs` `#[cfg(test)] mod tests`. Use `tempfile::tempdir` (already a workspace dev-dep — verify) so no system paths are touched and no `launchctl` calls are issued.
+
+1. `reconcile_plist_at_writes_when_missing` — plist absent → returns `Ok(true)`, file now matches `generate_plist`.
+2. `reconcile_plist_at_rewrites_when_binary_path_drifts` — pre-write a plist with `/old/bin/vmux_service`; call with `/new/bin/vmux_service` → returns `Ok(true)`, file now contains the new path. Regression for the issue's worktree-deletion scenario.
+3. `reconcile_plist_at_rewrites_when_env_var_key_drifts` — pre-write a plist whose XML hard-codes `VMUX_PROFILE` (legacy) → returns `Ok(true)`, file now contains `VMUX_BUILD_PROFILE`. Regression for commit `2249492`.
+4. `reconcile_plist_at_no_op_when_matching` — pre-write the current `generate_plist` output → returns `Ok(false)`, file mtime unchanged.
+
+`ensure_running` itself is not unit-tested (it shells out to `launchctl`); the reconciler covers the plist-content invariant from the AC.
+
+## Out of scope
+
+- **Doctor surface.** AC #5 marks the `scripts/doctor-mac.sh` "stale plist detected" message as optional. The auto-heal is silent and runs on every `make dev`, so a doctor warning gives the user no actionable step (it would reconcile itself by the next launch). Skipped to avoid noise. Revisit if drift returns through a different path.

--- a/scripts/doctor-mac.sh
+++ b/scripts/doctor-mac.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# macOS dev environment check for `make run-mac`.
+# macOS dev environment check for `make dev`.
 # Respects NO_COLOR=1 and skips colors when stdout is not a TTY.
 
 set -euo pipefail
@@ -67,7 +67,7 @@ bad_line() {
 printf '\n'
 bar
 printf ' %s🩺  Vmux Doctor%s  %s(macOS)%s\n' "${BOLD}" "${RESET}" "${CYAN}" "${RESET}"
-printf ' %s%s\n' "${DIM}" "Checking everything you need for ${BOLD}make run-mac${RESET}${DIM}…${RESET}"
+printf ' %s%s\n' "${DIM}" "Checking everything you need for ${BOLD}make dev${RESET}${DIM}…${RESET}"
 bar
 printf '\n'
 
@@ -180,7 +180,7 @@ fi
 if security find-identity -v -p codesigning 2>/dev/null | grep -Fq "\"${VMUX_LOCAL_SIGNING_IDENTITY}\""; then
 	ok_line "local codesigning identity — ${VMUX_LOCAL_SIGNING_IDENTITY}"
 else
-	warn_line "local codesigning identity will be created on first make run-mac"
+	warn_line "local codesigning identity will be created on first make dev"
 	tip "Expected prompt: allow Keychain/codesign setup once, preferably with Touch ID"
 fi
 
@@ -200,7 +200,7 @@ printf '\n'
 
 if [[ "${fail}" -eq 0 ]]; then
 	printf ' %s🎉 All required checks passed!%s\n' "${GREEN}${BOLD}" "${RESET}"
-	printf ' %sYou are clear to run:%s %smake run-mac%s\n' "${DIM}" "${RESET}" "${BOLD}" "${RESET}"
+	printf ' %sYou are clear to run:%s %smake dev%s\n' "${DIM}" "${RESET}" "${BOLD}" "${RESET}"
 	if [[ "${warn}" -gt 0 ]]; then
 		printf '\n %s(Warning items above are optional or handled on first run.)%s\n' "${YELLOW}" "${RESET}"
 	fi

--- a/scripts/macos.sh
+++ b/scripts/macos.sh
@@ -15,27 +15,27 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export PATH="${HOME}/.cargo/bin:${PATH}"
 unset CEF_PATH
 
-APP_BUNDLE="${APP_BUNDLE:-$ROOT/target/release/Vmux Local.app}"
+APP_BUNDLE="${APP_BUNDLE:-$ROOT/target/release/Vmux ($(git -C "$ROOT" rev-parse --short HEAD)).app}"
 
 usage() {
 	cat <<'EOF'
 Usage: macos.sh [command]
 
   dev       Build, sign, and run target/debug/vmux_desktop. Default.
-  bundle    Build, sign, and open Vmux Local.app.
+  bundle    Build, sign, and open Vmux (<sha>).app.
   help      Show this help
 
 Environment (optional):
-  APP_BUNDLE  Full path to .app when opening after bundle (default: target/release/Vmux Local.app)
+  APP_BUNDLE  Full path to .app when opening after bundle (default: target/release/Vmux (<sha>).app)
 EOF
 }
 
 cmd_dev() {
-	make -C "$ROOT" run-mac
+	make -C "$ROOT" dev
 }
 
 cmd_bundle() {
-	make -C "$ROOT" build-mac-local
+	make -C "$ROOT" build-local
 	if [[ ! -d "$APP_BUNDLE" ]]; then
 		echo "error: expected app bundle at $APP_BUNDLE" >&2
 		exit 1

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -65,7 +65,7 @@ sed -i '' "/<key>CFBundleName<\/key>/{n;s|<string>.*</string>|<string>$PRODUCT_N
 
 # Export for inject-cef.sh
 export VMUX_BUNDLE_ID="$BUNDLE_ID"
-export VMUX_PROFILE="$PROFILE"
+export VMUX_BUILD_PROFILE="$PROFILE"
 
 # The app bundle path uses the product name from packager metadata.
 # cargo-packager always outputs to target/release/<product-name>.app
@@ -77,12 +77,12 @@ cd "$ROOT"
 if [[ "$PROFILE" == "local" ]]; then
     # Local skips the dmg pass; `make build-mac-local` ad-hoc-signs the
     # .app separately via sign-and-notarize.sh + SKIP_NOTARIZE=1.
-    env -u CEF_PATH VMUX_PROFILE="$PROFILE" cargo packager --release --formats app
+    env -u CEF_PATH VMUX_BUILD_PROFILE="$PROFILE" cargo packager --release --formats app
 else
     # Release: single invocation builds the .app, then the dmg pass'
     # before-each hook injects CEF + signs + notarizes before
     # dmg::package wraps it. Uses formats=["app","dmg"] from Cargo.toml.
-    env -u CEF_PATH VMUX_PROFILE="$PROFILE" cargo packager --release
+    env -u CEF_PATH VMUX_BUILD_PROFILE="$PROFILE" cargo packager --release
 fi
 
 # inject-cef only meaningfully runs in the dmg-format pass (the .app

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -24,8 +24,9 @@ case "$PROFILE" in
         BUNDLE_ID="ai.vmux.desktop"
         ;;
     local)
-        PRODUCT_NAME="Vmux Local"
-        BUNDLE_ID="ai.vmux.desktop.local"
+        SHA="$(git -C "$ROOT" rev-parse --short HEAD)"
+        PRODUCT_NAME="Vmux ($SHA)"
+        BUNDLE_ID="ai.vmux.desktop.$SHA"
         ;;
     *)
         echo "Unknown profile: $PROFILE (expected: release, local)" >&2
@@ -75,7 +76,7 @@ export VMUX_APP_BUNDLE="$ROOT/target/release/$APP_NAME.app"
 echo "==> Running cargo packager"
 cd "$ROOT"
 if [[ "$PROFILE" == "local" ]]; then
-    # Local skips the dmg pass; `make build-mac-local` ad-hoc-signs the
+    # Local skips the dmg pass; `make build-local` ad-hoc-signs the
     # .app separately via sign-and-notarize.sh + SKIP_NOTARIZE=1.
     env -u CEF_PATH VMUX_BUILD_PROFILE="$PROFILE" cargo packager --release --formats app
 else

--- a/scripts/sign-dev-mac.sh
+++ b/scripts/sign-dev-mac.sh
@@ -6,7 +6,7 @@ APP_BINARY="${APP_BINARY:-$ROOT/target/debug/vmux_desktop}"
 HELPER_BINARY="${HELPER_BINARY:-$HOME/.local/share/Chromium Embedded Framework.framework/Libraries/bevy_cef_debug_render_process}"
 ENTITLEMENTS="$ROOT/packaging/macos/Vmux.entitlements"
 CODESIGN_KEYCHAIN="${CODESIGN_KEYCHAIN:-$(security default-keychain -d user | awk -F'"' '/"/ { print $2; exit }')}"
-APP_IDENTIFIER="ai.vmux.desktop.local"
+APP_IDENTIFIER="ai.vmux.desktop.dev"
 
 if [[ -z "${APPLE_SIGNING_IDENTITY:-}" ]]; then
     echo "Error: APPLE_SIGNING_IDENTITY not set." >&2


### PR DESCRIPTION
## Context

CI rebuilds every dependency from scratch on each run because the existing `actions/cache` config uses a coarse key and doesn't prune stale artifacts. The lint job also re-walks the workspace dep graph N times — once per crate — because clippy/fmt run inside per-crate loops.

## Implementation

- Swap `actions/cache@v4` for `Swatinem/rust-cache@v2` in lint, test, website, build-mac (`ci.yml`), release-macos (`release.yml`), and deploy (`deploy-website.yml`). rust-cache keys on rustc version + lockfile, caches `~/.cargo/{registry,git,bin}` plus `target/`, and prunes stale crates to fit within GitHub's 10 GB per-repo cap. Each job uses a distinct `shared-key` so caches don't collide. Website + deploy jobs pass `workspaces: website` since `website/` has its own `Cargo.lock`.
- Compute the workspace package set once via `cargo metadata --no-deps | jq` into a `-p crate1 -p crate2 ...` argument string, exported through `$GITHUB_OUTPUT`. fmt and clippy then run as a single cargo invocation each instead of looping. Same coverage as before (vendored `patches/` still excluded), one dep-graph resolution.
- `cache-all-crates: true` so source crates from `cargo install dx` / `export-cef-dir` / `bevy_cef_*` are cached too — those installs dominate cold-CI wall time.

## Checks / QA

- First CI run on this PR is a cache miss (writes the cache).
- Re-trigger the workflow (push an empty commit or rerun) and confirm `Swatinem/rust-cache` reports `Cache hit` for each job, and that clippy / cargo build skip already-compiled deps.
- Confirm the lint job's "Compute workspace packages" step lists every `vmux_*` crate and no `patches/*` crate.
- For the website + deploy-website jobs, confirm cache hit is keyed on `website/Cargo.lock`, not the root one.