### PR TITLE
chore(release): v0.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8959,7 +8959,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -8971,7 +8971,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -8990,7 +8990,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9003,7 +9003,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9039,7 +9039,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9058,7 +9058,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -9086,7 +9086,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9095,7 +9095,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -9107,7 +9107,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "alacritty_terminal",
  "bevy",
@@ -9131,7 +9131,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "dioxus",
  "rkyv",
@@ -9145,7 +9145,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9162,7 +9162,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "dioxus",
  "dioxus-primitives",
@@ -9179,7 +9179,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_webview_app"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "bevy",
  "bevy_cef",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.6"
+version = "0.0.7"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "MIT"

--- a/crates/vmux_desktop/tests/release_invariants.rs
+++ b/crates/vmux_desktop/tests/release_invariants.rs
@@ -17,8 +17,7 @@ fn dev_target_signs_then_runs_debug_binary() {
 
     assert!(makefile.contains(".DEFAULT_GOAL := dev"));
     assert!(
-        makefile
-            .contains("dev: ensure-run-mac-deps ensure-codesign-deps install-debug-render-process")
+        makefile.contains("dev: ensure-mac-deps ensure-codesign-deps install-debug-render-process")
     );
     assert!(makefile.contains("./scripts/sign-dev-mac.sh"));
     assert!(makefile.contains("exec env -u CEF_PATH ./target/debug/vmux_desktop"));


### PR DESCRIPTION
Patch release. Bumps workspace `version` 0.0.6 → 0.0.7. Releases on merge via `.github/workflows/release.yml`.

## Test plan
- [ ] CI green
- [ ] Release workflow tags v0.0.7 and publishes artifacts after merge