### PR TITLE
ci: cache ~/.cargo/bin to skip recompiling tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,12 @@ jobs:
           shared-key: lint
           cache-all-crates: true
 
+      - name: Cache cargo binaries
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin
+          key: cargo-bin-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
+
       - name: Cache CEF framework
         uses: actions/cache@v4
         with:
@@ -148,6 +154,12 @@ jobs:
           shared-key: test
           cache-all-crates: true
 
+      - name: Cache cargo binaries
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin
+          key: cargo-bin-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
+
       - name: Cache CEF framework
         uses: actions/cache@v4
         with:
@@ -223,6 +235,12 @@ jobs:
           shared-key: website
           cache-all-crates: true
 
+      - name: Cache cargo binaries
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin
+          key: cargo-bin-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
+
       - name: Install dioxus-cli
         run: command -v dx >/dev/null 2>&1 || cargo install dioxus-cli --locked --version 0.7.4
 
@@ -246,6 +264,12 @@ jobs:
         with:
           shared-key: build-mac
           cache-all-crates: true
+
+      - name: Cache cargo binaries
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin
+          key: cargo-bin-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
 
       - name: Cache CEF framework
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- Add `actions/cache@v4` for `~/.cargo/bin` to all four CI jobs (lint, test, website, build-mac).
- Key: `cargo-bin-<os>-<hash of ci.yml>` so any tool/version bump in the workflow invalidates the cache.

## Why
`Swatinem/rust-cache` does not cache `~/.cargo/bin`. Every run was rebuilding `dioxus-cli`, `bevy_cef_render_process`, `bevy_cef_bundle_app`, `cargo-packager`, and (on CEF cache miss) `export-cef-dir` from source — minutes per job, four jobs.

## Test plan
- [ ] First run: cache populates (still slow this time).
- [ ] Next run on this branch: cargo bin cache restored, install steps skip via `command -v` guards.