### PR TITLE
VMX-119: Vmux.app as signed background item; embed vmux_service helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin
-          key: cargo-bin-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
+          key: cargo-bin-${{ runner.os }}-dx0.7.4-cef${{ env.CEF_VERSION }}
 
       - name: Cache CEF framework
         uses: actions/cache@v4
@@ -158,7 +158,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin
-          key: cargo-bin-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
+          key: cargo-bin-${{ runner.os }}-dx0.7.4-cef${{ env.CEF_VERSION }}
 
       - name: Cache CEF framework
         uses: actions/cache@v4
@@ -239,7 +239,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin
-          key: cargo-bin-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
+          key: cargo-bin-${{ runner.os }}-dx0.7.4
 
       - name: Install dioxus-cli
         run: command -v dx >/dev/null 2>&1 || cargo install dioxus-cli --locked --version 0.7.4
@@ -269,7 +269,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin
-          key: cargo-bin-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
+          key: cargo-bin-${{ runner.os }}-dx0.7.4-cp0.11.8-cef${{ env.CEF_VERSION }}
 
       - name: Cache CEF framework
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,12 @@ jobs:
           shared-key: release-macos
           cache-all-crates: true
 
+      - name: Cache cargo binaries
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin
+          key: cargo-bin-${{ runner.os }}-dx0.7.4-cp0.11.8-cef${{ env.CEF_VERSION }}
+
       - name: Cache CEF framework
         uses: actions/cache@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6411,6 +6411,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -6461,6 +6462,30 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-service-management"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b213642d6959cc6023ceb1217aa595eaaf09b8094ce95127c103cab611fe65e8"
+dependencies = [
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-security",
 ]
 
 [[package]]
@@ -9199,6 +9224,9 @@ dependencies = [
  "bevy",
  "dioxus",
  "libc",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-service-management",
  "portable-pty",
  "rkyv",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2308,7 +2308,7 @@ dependencies = [
  "base64 0.22.1",
  "cargo-packager-utils",
  "ctor",
- "dirs",
+ "dirs 5.0.1",
  "dunce",
  "flate2",
  "http",
@@ -3634,7 +3634,16 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -3645,8 +3654,20 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5110,7 +5131,7 @@ dependencies = [
  "byteorder-lite",
  "moxcms",
  "num-traits",
- "png 0.18.1",
+ "png",
 ]
 
 [[package]]
@@ -5443,6 +5464,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "libappindicator"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03589b9607c868cc7ae54c0b2a22c8dc03dd41692d48f2d7df73615c6a95dc0a"
+dependencies = [
+ "glib",
+ "gtk",
+ "gtk-sys",
+ "libappindicator-sys",
+ "log",
+]
+
+[[package]]
+name = "libappindicator-sys"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
+dependencies = [
+ "gtk-sys",
+ "libloading 0.7.4",
+ "once_cell",
+]
+
+[[package]]
 name = "libbz2-rs-sys"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5453,6 +5498,16 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
 
 [[package]]
 name = "libloading"
@@ -5830,9 +5885,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.2"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
+checksum = "0ae8844f63b5b118e334e205585b8c5c17b984121dbdb179d44aeb087ffad3cb"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -5844,9 +5899,9 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
  "once_cell",
- "png 0.17.16",
+ "png",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6296,6 +6351,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-core-image"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6345,6 +6410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
+ "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -6695,19 +6761,6 @@ dependencies = [
  "quick-xml 0.38.4",
  "serde",
  "time",
-]
-
-[[package]]
-name = "png"
-version = "0.17.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -7209,6 +7262,17 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8245,7 +8309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -8690,6 +8754,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tray-icon"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47e6d063cfe4ad2e416fcbb310be3a37c5fd85c745b62cb562bfa4a003df674"
+dependencies = [
+ "crossbeam-channel",
+ "dirs 6.0.0",
+ "libappindicator",
+ "muda",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+ "once_cell",
+ "png",
+ "thiserror 2.0.18",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9023,6 +9108,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "tray-icon",
  "url",
  "uuid",
  "vmux_command",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9230,6 +9230,7 @@ dependencies = [
  "portable-pty",
  "rkyv",
  "serde",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-appender",

--- a/Makefile
+++ b/Makefile
@@ -31,14 +31,8 @@ build: ensure-mac-deps
 -include .env
 export
 
-build-local: ensure-mac-deps ensure-package-deps ensure-codesign-deps
-	./scripts/package.sh local
-	@identity="$$(./scripts/ensure-local-codesign-identity.sh)" && \
-	sha="$$(git rev-parse --short HEAD)" && \
-	APPLE_SIGNING_IDENTITY="$$identity" \
-	SKIP_NOTARIZE=1 \
-	APP_BUNDLE="target/release/Vmux ($$sha).app" \
-	./scripts/sign-and-notarize.sh
+build-local: ensure-mac-deps ensure-package-deps
+	./scripts/build-mac-release.sh local
 
 local: build-local
 	@sha="$$(git rev-parse --short HEAD)" && \

--- a/crates/vmux_command/Cargo.toml
+++ b/crates/vmux_command/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bevy = { workspace = true }
 bevy_ecs = { workspace = true }
-muda = "0.17"
+muda = "0.19"
 vmux_macro = { path = "../vmux_macro" }
 vmux_webview_app = { path = "../vmux_webview_app" }
 

--- a/crates/vmux_desktop/Cargo.toml
+++ b/crates/vmux_desktop/Cargo.toml
@@ -58,11 +58,12 @@ copyright = "Copyright 2024-2025 Junichi Sugiura. MIT License."
 homepage = "https://vmux.ai"
 formats = ["app", "dmg"]
 icons = ["../../packaging/macos/Vmux.icns"]
-before-packaging-command = "env -u CEF_PATH cargo build -p vmux_desktop -p vmux_cli -p bevy_cef_debug_render_process --release"
+before-packaging-command = "env -u CEF_PATH cargo build -p vmux_desktop -p vmux_cli -p vmux_service -p bevy_cef_debug_render_process --release"
 before-each-package-command = "bash ../../scripts/before-each-package.sh"
 binaries = [
     { path = "vmux_desktop", main = true },
     { path = "vmux" },
+    { path = "vmux_service" },
 ]
 
 [package.metadata.packager.dmg]

--- a/crates/vmux_desktop/Cargo.toml
+++ b/crates/vmux_desktop/Cargo.toml
@@ -21,7 +21,7 @@ bevy_cef = { workspace = true }
 bevy_cef_core = { workspace = true }
 
 libc = "0.2"
-muda = "0.17"
+muda = "0.19"
 parking_lot = "0.12"
 bevy_reflect = { workspace = true }
 moonshine-save = { workspace = true }
@@ -48,6 +48,7 @@ rfd = { workspace = true }
 notify = { workspace = true }
 semver = "1"
 cargo-packager-updater = "0.2"
+tray-icon = "0.24"
 
 [package.metadata.packager]
 product-name = "Vmux"

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -1,5 +1,8 @@
+use bevy::ecs::message::Messages;
 use bevy::prelude::*;
 use bevy::window::Window;
+
+use crate::terminal::{self, PtyExited, Terminal};
 
 #[derive(Message, Debug, Clone, Copy)]
 pub enum LifecycleEvent {
@@ -17,26 +20,56 @@ impl Plugin for BackgroundLifecyclePlugin {
     }
 }
 
-fn handle_lifecycle_events(
-    mut events: MessageReader<LifecycleEvent>,
-    mut windows: Query<&mut Window>,
-    mut exit: MessageWriter<AppExit>,
-) {
-    for event in events.read() {
+fn handle_lifecycle_events(world: &mut World) {
+    let drained: Vec<LifecycleEvent> = {
+        let mut events = world.resource_mut::<Messages<LifecycleEvent>>();
+        events.drain().collect()
+    };
+
+    for event in drained {
         match event {
             LifecycleEvent::HideAllWindows => {
-                for mut window in &mut windows {
-                    window.visible = false;
+                let mut q = world.query::<&mut Window>();
+                for mut w in q.iter_mut(world) {
+                    w.visible = false;
                 }
             }
             LifecycleEvent::ShowAllWindows => {
-                for mut window in &mut windows {
-                    window.visible = true;
+                let mut q = world.query::<&mut Window>();
+                for mut w in q.iter_mut(world) {
+                    w.visible = true;
                 }
             }
             LifecycleEvent::QuitVmux => {
-                exit.write(AppExit::Success);
+                let live = {
+                    let mut q = world.query_filtered::<(), (With<Terminal>, Without<PtyExited>)>();
+                    q.iter(world).count()
+                };
+                if live > 0 && !terminal::confirm_quit_dialog(live) {
+                    continue;
+                }
+                world
+                    .resource_mut::<Messages<AppExit>>()
+                    .write(AppExit::Success);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn handle_lifecycle_events_uses_world_for_confirm_dialog() {
+        let source = include_str!("background_lifecycle.rs");
+        let exclusive_marker = ["world", ": ", "&mut", " World"].concat();
+        assert!(
+            source.contains(&exclusive_marker),
+            "handle_lifecycle_events must be an exclusive &mut World system to call confirm_quit_dialog"
+        );
+        let confirm_call = ["confirm", "_quit_dialog"].concat();
+        assert!(
+            source.contains(&confirm_call),
+            "QuitVmux arm must call terminal::confirm_quit_dialog"
+        );
     }
 }

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -1,0 +1,45 @@
+use bevy::prelude::*;
+use bevy::window::Window;
+
+#[derive(Message, Debug, Clone, Copy)]
+pub enum LifecycleEvent {
+    HideAllWindows,
+    #[allow(dead_code)]
+    ShowAllWindows,
+    #[allow(dead_code)]
+    QuitVmux,
+}
+
+pub struct BackgroundLifecyclePlugin;
+
+impl Plugin for BackgroundLifecyclePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_message::<LifecycleEvent>();
+        app.add_systems(Update, handle_lifecycle_events);
+    }
+}
+
+fn handle_lifecycle_events(
+    mut events: MessageReader<LifecycleEvent>,
+    mut windows: Query<&mut Window>,
+    mut exit: MessageWriter<AppExit>,
+) {
+    for event in events.read() {
+        match event {
+            LifecycleEvent::HideAllWindows => {
+                for mut window in &mut windows {
+                    window.visible = false;
+                }
+            }
+            LifecycleEvent::ShowAllWindows => {
+                for mut window in &mut windows {
+                    window.visible = true;
+                }
+            }
+            LifecycleEvent::QuitVmux => {
+                // Live-terminal confirm dialog is added in Task A5.
+                exit.write(AppExit::Success);
+            }
+        }
+    }
+}

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -37,7 +37,6 @@ fn handle_lifecycle_events(
                 }
             }
             LifecycleEvent::QuitVmux => {
-                // Live-terminal confirm dialog is added in Task A5.
                 exit.write(AppExit::Success);
             }
         }

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -4,9 +4,7 @@ use bevy::window::Window;
 #[derive(Message, Debug, Clone, Copy)]
 pub enum LifecycleEvent {
     HideAllWindows,
-    #[allow(dead_code)]
     ShowAllWindows,
-    #[allow(dead_code)]
     QuitVmux,
 }
 

--- a/crates/vmux_desktop/src/browser.rs
+++ b/crates/vmux_desktop/src/browser.rs
@@ -22,7 +22,7 @@ use bevy::{
     ecs::{message::Messages, relationship::Relationship},
     prelude::*,
     ui::{UiGlobalTransform, UiSystems},
-    window::{ClosingWindow, PrimaryWindow, WindowResized},
+    window::{PrimaryWindow, WindowResized},
 };
 use bevy_cef::prelude::*;
 use bevy_cef_core::prelude::{RenderTextureMessage, webview_debug_log};
@@ -1037,7 +1037,6 @@ fn on_side_sheet_command_emit(
     )>,
     mut hover_intent: ResMut<PaneHoverIntent>,
     settings: Res<AppSettings>,
-    primary_window: Single<Entity, With<PrimaryWindow>>,
     mut commands: Commands,
 ) {
     let evt = &trigger.event().payload;
@@ -1102,7 +1101,9 @@ fn on_side_sheet_command_emit(
                     commands.entity(next).insert(LastActivatedAt::now());
                 }
             } else if leaf_panes.iter().count() <= 1 {
-                commands.entity(*primary_window).insert(ClosingWindow);
+                if let Ok(mut window) = close_extra.p1().single_mut() {
+                    window.visible = false;
+                }
             } else {
                 let Ok(pane_co) = child_of_q.get(target_pane) else {
                     return;

--- a/crates/vmux_desktop/src/lib.rs
+++ b/crates/vmux_desktop/src/lib.rs
@@ -129,6 +129,7 @@ impl Plugin for VmuxPlugin {
             LayoutPlugin,
             updater::VmuxUpdater::builder().build().plugin(),
             background_lifecycle::BackgroundLifecyclePlugin,
+            tray::TrayPlugin,
         ));
     }
 }

--- a/crates/vmux_desktop/src/lib.rs
+++ b/crates/vmux_desktop/src/lib.rs
@@ -7,6 +7,7 @@
 
 mod agent;
 mod agent_query;
+mod background_lifecycle;
 mod browser;
 mod clipboard;
 mod command;
@@ -127,6 +128,7 @@ impl Plugin for VmuxPlugin {
             ProfilePlugin,
             LayoutPlugin,
             updater::VmuxUpdater::builder().build().plugin(),
+            background_lifecycle::BackgroundLifecyclePlugin,
         ));
     }
 }

--- a/crates/vmux_desktop/src/lib.rs
+++ b/crates/vmux_desktop/src/lib.rs
@@ -28,7 +28,7 @@ mod vibe;
 
 use bevy::asset::io::web::WebAssetPlugin;
 use bevy::prelude::*;
-use bevy::window::{CompositeAlphaMode, Window as NativeWindow, WindowPlugin};
+use bevy::window::{CompositeAlphaMode, ExitCondition, Window as NativeWindow, WindowPlugin};
 use bevy::winit::WinitSettings;
 use std::time::Duration;
 
@@ -84,6 +84,7 @@ impl Plugin for VmuxPlugin {
         let window_plugin = WindowPlugin {
             primary_window: Some(primary_window),
             close_when_requested: false,
+            exit_condition: ExitCondition::DontExit,
             ..default()
         };
 
@@ -139,6 +140,15 @@ mod tests {
         let window = primary_window_config("Vmux".to_string());
 
         assert!(window.ime_enabled);
+    }
+
+    #[test]
+    fn window_plugin_keeps_app_alive_after_last_window_closes() {
+        let source = include_str!("lib.rs");
+        assert!(
+            source.contains("ExitCondition::DontExit"),
+            "WindowPlugin must opt out of automatic exit so Vmux.app survives last-window-close"
+        );
     }
 
     #[test]

--- a/crates/vmux_desktop/src/os_menu.rs
+++ b/crates/vmux_desktop/src/os_menu.rs
@@ -3,7 +3,7 @@ use crate::settings::AppSettings;
 use crate::terminal::{self, PtyExited, Terminal};
 use bevy::ecs::message::Messages;
 use bevy::prelude::*;
-use bevy::window::{ClosingWindow, WindowCloseRequested};
+use bevy::window::WindowCloseRequested;
 use muda::{Menu, MenuEvent};
 use parking_lot::Mutex;
 use std::sync::LazyLock;
@@ -80,25 +80,18 @@ fn handle_quit_request(world: &mut World) {
 /// dialog when terminals are still running. Defers the dialog to the
 /// exclusive `show_pending_close_dialogs` system to avoid deadlocks.
 fn close_with_confirmation(
-    mut commands: Commands,
     mut closed: MessageReader<WindowCloseRequested>,
-    closing: Query<Entity, With<ClosingWindow>>,
+    mut windows: Query<&mut Window>,
     settings: Res<AppSettings>,
     live_terminals: Query<(), (With<Terminal>, Without<PtyExited>)>,
     mut pending: ResMut<PendingWindowClose>,
 ) {
-    // Despawn windows that were marked as closing on the previous frame.
-    for window in closing.iter() {
-        commands.entity(window).despawn();
-    }
-    // Process new close requests.
     for event in closed.read() {
         let should_confirm = terminal::should_confirm_close(&settings);
         if should_confirm && live_terminals.iter().count() > 0 {
-            // Defer dialog to exclusive system
             pending.window = Some(event.window);
-        } else {
-            commands.entity(event.window).try_insert(ClosingWindow);
+        } else if let Ok(mut window) = windows.get_mut(event.window) {
+            window.visible = false;
         }
     }
 }
@@ -118,8 +111,9 @@ fn process_pending_window_close(world: &mut World) {
 
     if (count == 0 || terminal::confirm_quit_dialog(count))
         && let Ok(mut entity_mut) = world.get_entity_mut(window)
+        && let Some(mut win) = entity_mut.get_mut::<Window>()
     {
-        entity_mut.insert(ClosingWindow);
+        win.visible = false;
     }
 }
 
@@ -136,6 +130,24 @@ mod tests {
         assert!(
             source.contains("HideAllWindows") || source.contains("window.visible = false"),
             "handle_quit_request must dispatch a hide action"
+        );
+    }
+
+    #[test]
+    fn window_close_request_hides_window_instead_of_despawning() {
+        let source = include_str!("os_menu.rs");
+        let despawn_marker = ["Closing", "Window"].concat();
+        let inserts = source.matches(&format!("insert({despawn_marker})")).count()
+            + source
+                .matches(&format!("try_insert({despawn_marker})"))
+                .count();
+        assert_eq!(
+            inserts, 0,
+            "WindowCloseRequested must hide the window, not insert ClosingWindow which leads to despawn"
+        );
+        assert!(
+            source.contains("window.visible = false") || source.contains(".visible = false"),
+            "expected the close handler to set window.visible = false"
         );
     }
 }

--- a/crates/vmux_desktop/src/os_menu.rs
+++ b/crates/vmux_desktop/src/os_menu.rs
@@ -1,7 +1,6 @@
 use crate::command::{AppCommand, WriteAppCommands, build_native_root_menu};
 use crate::settings::AppSettings;
 use crate::terminal::{self, PtyExited, Terminal};
-use bevy::app::AppExit;
 use bevy::ecs::message::Messages;
 use bevy::prelude::*;
 use bevy::window::{ClosingWindow, WindowCloseRequested};
@@ -72,23 +71,11 @@ fn forward_menu_events(world: &mut World) {
 }
 
 fn handle_quit_request(world: &mut World) {
-    let should_confirm = world
-        .get_resource::<AppSettings>()
-        .and_then(|s| s.terminal.as_ref())
-        .is_none_or(|t| t.confirm_close);
-
-    if should_confirm {
-        let mut query = world.query_filtered::<(), (With<Terminal>, Without<PtyExited>)>();
-        let count = query.iter(world).count();
-
-        if count > 0 && !terminal::confirm_quit_dialog(count) {
-            return;
-        }
-    }
-
+    // Cmd+Q hides the UI but keeps Vmux.app + vmux_service alive.
+    // Real quit is only available via the tray menu.
     world
-        .resource_mut::<Messages<AppExit>>()
-        .write(AppExit::Success);
+        .resource_mut::<Messages<crate::background_lifecycle::LifecycleEvent>>()
+        .write(crate::background_lifecycle::LifecycleEvent::HideAllWindows);
 }
 
 /// Replacement for bevy's `close_when_requested` that shows a confirmation
@@ -135,5 +122,22 @@ fn process_pending_window_close(world: &mut World) {
         && let Ok(mut entity_mut) = world.get_entity_mut(window)
     {
         entity_mut.insert(ClosingWindow);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn quit_menu_event_hides_windows_not_exit() {
+        let source = include_str!("os_menu.rs");
+        let needle = ["AppExit", "::", "Success"].concat();
+        assert!(
+            !source.contains(&needle),
+            "Cmd+Q must hide windows, not exit the app — terminal state must survive"
+        );
+        assert!(
+            source.contains("HideAllWindows") || source.contains("window.visible = false"),
+            "handle_quit_request must dispatch a hide action"
+        );
     }
 }

--- a/crates/vmux_desktop/src/os_menu.rs
+++ b/crates/vmux_desktop/src/os_menu.rs
@@ -65,7 +65,7 @@ fn forward_menu_events(world: &mut World) {
         } else if let Some(cmd) = AppCommand::from_menu_id(event_id.as_str()) {
             world.resource_mut::<Messages<AppCommand>>().write(cmd);
         } else {
-            warn!(len = event_id.len(), "unknown native menu item");
+            crate::tray::PENDING_TRAY_EVENTS.lock().push(event_id);
         }
     }
 }

--- a/crates/vmux_desktop/src/os_menu.rs
+++ b/crates/vmux_desktop/src/os_menu.rs
@@ -71,8 +71,6 @@ fn forward_menu_events(world: &mut World) {
 }
 
 fn handle_quit_request(world: &mut World) {
-    // Cmd+Q hides the UI but keeps Vmux.app + vmux_service alive.
-    // Real quit is only available via the tray menu.
     world
         .resource_mut::<Messages<crate::background_lifecycle::LifecycleEvent>>()
         .write(crate::background_lifecycle::LifecycleEvent::HideAllWindows);

--- a/crates/vmux_desktop/src/terminal.rs
+++ b/crates/vmux_desktop/src/terminal.rs
@@ -620,8 +620,8 @@ fn ensure_service_started() {
     #[cfg(target_os = "macos")]
     {
         let profile = vmux_service::current_profile();
-        if let Err(e) = vmux_service::launchd::ensure_running(profile, &binary) {
-            tracing::error!(error = %e, "launchd ensure_running failed");
+        if let Err(e) = vmux_service::service_registration::ensure_running(profile, &binary) {
+            tracing::error!(error = ?e, "service registration failed");
         }
     }
     #[cfg(not(target_os = "macos"))]

--- a/crates/vmux_desktop/src/tray.rs
+++ b/crates/vmux_desktop/src/tray.rs
@@ -68,6 +68,8 @@ fn drain_tray_events(
             events.write(LifecycleEvent::ShowAllWindows);
         } else if event_id == handle.quit_id {
             events.write(LifecycleEvent::QuitVmux);
+        } else {
+            tracing::debug!(id = %event_id, "unhandled tray menu event id");
         }
     }
 }

--- a/crates/vmux_desktop/src/tray.rs
+++ b/crates/vmux_desktop/src/tray.rs
@@ -1,25 +1,102 @@
-//! System tray integration for macOS.
-//!
-//! Tray icon for the service when the GUI is closed.
-//!
-//! When the GUI window closes but service-managed processes are still alive,
-//! a tray icon is shown to indicate the service is running.
-//!
-//! NOTE: Full tray-icon integration is deferred to a follow-up.
-//! tray-icon requires a running event loop and careful coordination
-//! with Bevy/winit's event loop on macOS. For now, the service runs
-//! headlessly and the user can relaunch the GUI to reconnect.
-//!
-//! Planned features:
-//! - Tray icon appears when GUI closes with active processes
-//! - Menu: "Show Vmux", "Processes (N active)", "Quit Service"
-//! - Click to relaunch GUI and reattach
+use bevy::prelude::*;
+use parking_lot::Mutex;
+use std::sync::LazyLock;
+use tray_icon::menu::{Menu, MenuItem};
+use tray_icon::{TrayIcon, TrayIconBuilder};
 
-#[allow(dead_code)] // Will be registered in VmuxPlugin once implemented
+use crate::background_lifecycle::LifecycleEvent;
+
+pub(crate) static PENDING_TRAY_EVENTS: LazyLock<Mutex<Vec<String>>> =
+    LazyLock::new(|| Mutex::new(Vec::new()));
+
 pub(crate) struct TrayPlugin;
 
-impl bevy::prelude::Plugin for TrayPlugin {
-    fn build(&self, _app: &mut bevy::prelude::App) {
-        // Placeholder — tray integration will be added in a follow-up PR
+struct TrayHandle {
+    _tray: TrayIcon,
+    show_id: String,
+    quit_id: String,
+}
+
+impl Plugin for TrayPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Startup, setup_tray);
+        app.add_systems(Update, drain_tray_events);
+    }
+}
+
+fn setup_tray(world: &mut World) {
+    let menu = Menu::new();
+    let show = MenuItem::new("Show Vmux", true, None);
+    let quit = MenuItem::new("Quit Vmux", true, None);
+    let show_id = show.id().0.clone();
+    let quit_id = quit.id().0.clone();
+
+    if let Err(e) = menu.append_items(&[&show, &quit]) {
+        tracing::error!(error = %e, "failed to append tray menu items");
+        return;
+    }
+
+    let icon = load_tray_icon();
+    let tray = match TrayIconBuilder::new()
+        .with_menu(Box::new(menu))
+        .with_tooltip("Vmux")
+        .with_icon(icon)
+        .build()
+    {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::error!(error = %e, "failed to build tray icon");
+            return;
+        }
+    };
+
+    world.insert_non_send_resource(TrayHandle {
+        _tray: tray,
+        show_id,
+        quit_id,
+    });
+}
+
+fn drain_tray_events(
+    handle: Option<NonSend<TrayHandle>>,
+    mut events: MessageWriter<LifecycleEvent>,
+) {
+    let Some(handle) = handle else { return };
+    let drained = std::mem::take(&mut *PENDING_TRAY_EVENTS.lock());
+    for event_id in drained {
+        if event_id == handle.show_id {
+            events.write(LifecycleEvent::ShowAllWindows);
+        } else if event_id == handle.quit_id {
+            events.write(LifecycleEvent::QuitVmux);
+        }
+    }
+}
+
+fn load_tray_icon() -> tray_icon::Icon {
+    let rgba = vec![0u8; 16 * 16 * 4];
+    tray_icon::Icon::from_rgba(rgba, 16, 16).expect("valid placeholder rgba")
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn tray_module_not_a_placeholder() {
+        let source = include_str!("tray.rs");
+        let tray_builder = ["Tray", "Icon", "Builder"].concat();
+        let tray_type = ["tray_icon", "::", "Tray", "Icon"].concat();
+        assert!(
+            source.contains(&tray_builder) || source.contains(&tray_type),
+            "tray.rs must wire tray-icon, not be a stub"
+        );
+        let show_needle = ["\"Show", " Vm", "ux\""].concat();
+        assert!(
+            source.contains(&show_needle),
+            "tray must expose a 'Show Vmux' menu item"
+        );
+        let quit_needle = ["\"Quit", " Vm", "ux\""].concat();
+        assert!(
+            source.contains(&quit_needle),
+            "tray must expose a 'Quit Vmux' menu item"
+        );
     }
 }

--- a/crates/vmux_desktop/tests/info_plist.rs
+++ b/crates/vmux_desktop/tests/info_plist.rs
@@ -1,0 +1,10 @@
+#[test]
+fn info_plist_marks_app_as_ui_element() {
+    let xml = include_str!("../../../packaging/macos/Info.plist");
+    assert!(xml.contains("<key>LSUIElement</key>"));
+    let after_key = xml.split("<key>LSUIElement</key>").nth(1).unwrap();
+    assert!(
+        after_key.trim_start().starts_with("<true/>"),
+        "LSUIElement must be true so Vmux runs as menu-bar-only"
+    );
+}

--- a/crates/vmux_desktop/tests/no_window_despawn.rs
+++ b/crates/vmux_desktop/tests/no_window_despawn.rs
@@ -1,0 +1,44 @@
+use std::path::Path;
+
+#[test]
+fn no_production_code_inserts_closing_window() {
+    let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let src = crate_root.join("src");
+
+    let mut violations = Vec::new();
+    walk(&src, &mut |path, contents| {
+        for (i, line) in contents.lines().enumerate() {
+            let trimmed = line.trim();
+            if trimmed.starts_with("//") {
+                continue;
+            }
+            if trimmed.contains("insert(ClosingWindow)")
+                || trimmed.contains("try_insert(ClosingWindow)")
+            {
+                violations.push(format!("{}:{} → {}", path.display(), i + 1, trimmed));
+            }
+        }
+    });
+
+    assert!(
+        violations.is_empty(),
+        "Found ClosingWindow inserts that should be window-hide instead:\n{}",
+        violations.join("\n")
+    );
+}
+
+fn walk(dir: &Path, f: &mut dyn FnMut(&Path, &str)) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            walk(&path, f);
+        } else if path.extension().and_then(|s| s.to_str()) == Some("rs")
+            && let Ok(contents) = std::fs::read_to_string(&path)
+        {
+            f(&path, &contents);
+        }
+    }
+}

--- a/crates/vmux_desktop/tests/no_window_despawn.rs
+++ b/crates/vmux_desktop/tests/no_window_despawn.rs
@@ -5,6 +5,10 @@ fn no_production_code_inserts_closing_window() {
     let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let src = crate_root.join("src");
 
+    let marker = ["Closing", "Window"].concat();
+    let insert_needle = format!("insert({marker})");
+    let try_insert_needle = format!("try_insert({marker})");
+
     let mut violations = Vec::new();
     walk(&src, &mut |path, contents| {
         for (i, line) in contents.lines().enumerate() {
@@ -12,9 +16,7 @@ fn no_production_code_inserts_closing_window() {
             if trimmed.starts_with("//") {
                 continue;
             }
-            if trimmed.contains("insert(ClosingWindow)")
-                || trimmed.contains("try_insert(ClosingWindow)")
-            {
+            if trimmed.contains(&insert_needle) || trimmed.contains(&try_insert_needle) {
                 violations.push(format!("{}:{} → {}", path.display(), i + 1, trimmed));
             }
         }

--- a/crates/vmux_desktop/tests/packaging_metadata.rs
+++ b/crates/vmux_desktop/tests/packaging_metadata.rs
@@ -1,0 +1,23 @@
+//! Verify cargo-packager metadata embeds vmux_service in the bundle.
+
+#[test]
+fn packager_binaries_include_vmux_service() {
+    let toml = include_str!("../Cargo.toml");
+    assert!(
+        toml.contains(r#"path = "vmux_service""#),
+        "packager metadata must include vmux_service so it lands in Vmux.app/Contents/MacOS/"
+    );
+}
+
+#[test]
+fn before_packaging_command_builds_vmux_service() {
+    let toml = include_str!("../Cargo.toml");
+    let line = toml
+        .lines()
+        .find(|l| l.starts_with("before-packaging-command"))
+        .expect("before-packaging-command line present");
+    assert!(
+        line.contains("vmux_service"),
+        "before-packaging-command must build vmux_service: {line}"
+    );
+}

--- a/crates/vmux_service/Cargo.toml
+++ b/crates/vmux_service/Cargo.toml
@@ -54,3 +54,6 @@ web-sys = { version = "0.3", features = ["Window", "Document", "Element", "HtmlE
 objc2 = "0.6"
 objc2-foundation = "0.3"
 objc2-service-management = "0.3"
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/crates/vmux_service/Cargo.toml
+++ b/crates/vmux_service/Cargo.toml
@@ -49,3 +49,8 @@ dioxus = { workspace = true }
 vmux_ui = { path = "../vmux_ui", default-features = false }
 wasm-bindgen = { workspace = true }
 web-sys = { version = "0.3", features = ["Window", "Document", "Element", "HtmlElement"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-foundation = "0.3"
+objc2-service-management = "0.3"

--- a/crates/vmux_service/src/bundle.rs
+++ b/crates/vmux_service/src/bundle.rs
@@ -1,0 +1,37 @@
+use std::path::{Path, PathBuf};
+
+/// True if `exe` lives at `<X>.app/Contents/MacOS/<binary>`.
+pub fn is_bundled_path(exe: &Path) -> bool {
+    bundle_root_for(exe).is_some()
+}
+
+/// Returns the `.app` root if `exe` lives inside a macOS bundle.
+pub fn bundle_root_for(exe: &Path) -> Option<PathBuf> {
+    let parent = exe.parent()?;
+    if parent.file_name()?.to_str()? != "MacOS" {
+        return None;
+    }
+    let contents = parent.parent()?;
+    if contents.file_name()?.to_str()? != "Contents" {
+        return None;
+    }
+    let app = contents.parent()?;
+    if app.extension()?.to_str()? == "app" {
+        Some(app.to_path_buf())
+    } else {
+        None
+    }
+}
+
+/// Resolve bundle root for the currently-running executable.
+pub fn current_bundle_root() -> Option<PathBuf> {
+    bundle_root_for(&std::env::current_exe().ok()?)
+}
+
+/// True if the running process lives inside a `.app` bundle.
+pub fn is_bundled() -> bool {
+    current_bundle_root().is_some()
+}
+
+/// Plist filename of the embedded launchd agent (matches packaging/macos/ai.vmux.service.plist).
+pub const EMBEDDED_AGENT_PLIST: &str = "ai.vmux.service.plist";

--- a/crates/vmux_service/src/legacy_plist_cleanup.rs
+++ b/crates/vmux_service/src/legacy_plist_cleanup.rs
@@ -1,0 +1,71 @@
+use std::path::{Path, PathBuf};
+
+const LABEL_PREFIX: &str = "ai.vmux.service";
+
+pub fn launch_agents_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|h| PathBuf::from(h).join("Library/LaunchAgents"))
+}
+
+pub fn label_from_filename(name: &str) -> Option<&str> {
+    let stem = name.strip_suffix(".plist")?;
+    if stem == LABEL_PREFIX || stem.starts_with(&format!("{LABEL_PREFIX}.")) {
+        Some(stem)
+    } else {
+        None
+    }
+}
+
+pub fn find_legacy_plists_in(dir: &Path) -> std::io::Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    if !dir.exists() {
+        return Ok(out);
+    }
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if label_from_filename(name).is_some() {
+            out.push(path);
+        }
+    }
+    Ok(out)
+}
+
+pub fn remove_plist_files(paths: &[PathBuf]) -> std::io::Result<()> {
+    for path in paths {
+        match std::fs::remove_file(path) {
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+pub fn bootout_label(label: &str) {
+    let uid = unsafe { libc::getuid() };
+    let _ = std::process::Command::new("launchctl")
+        .args(["bootout", &format!("gui/{uid}/{label}")])
+        .status();
+}
+
+pub fn cleanup_legacy_registrations() -> std::io::Result<usize> {
+    let Some(dir) = launch_agents_dir() else {
+        return Ok(0);
+    };
+    let paths = find_legacy_plists_in(&dir)?;
+    #[cfg(target_os = "macos")]
+    for path in &paths {
+        if let Some(name) = path.file_name().and_then(|s| s.to_str())
+            && let Some(label) = label_from_filename(name)
+        {
+            bootout_label(label);
+        }
+    }
+    let count = paths.len();
+    remove_plist_files(&paths)?;
+    Ok(count)
+}

--- a/crates/vmux_service/src/lib.rs
+++ b/crates/vmux_service/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod webview;
 
 #[cfg(not(target_arch = "wasm32"))]
+pub mod bundle;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod cli;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod client;

--- a/crates/vmux_service/src/lib.rs
+++ b/crates/vmux_service/src/lib.rs
@@ -18,6 +18,8 @@ pub mod protocol;
 pub mod server;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod service;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod service_registration;
 #[cfg(all(target_os = "macos", not(target_arch = "wasm32")))]
 pub mod sm_app_service;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/vmux_service/src/lib.rs
+++ b/crates/vmux_service/src/lib.rs
@@ -11,6 +11,8 @@ pub mod framing;
 #[cfg(all(target_os = "macos", not(target_arch = "wasm32")))]
 pub mod launchd;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod legacy_plist_cleanup;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod process;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod protocol;

--- a/crates/vmux_service/src/lib.rs
+++ b/crates/vmux_service/src/lib.rs
@@ -16,6 +16,8 @@ pub mod protocol;
 pub mod server;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod service;
+#[cfg(all(target_os = "macos", not(target_arch = "wasm32")))]
+pub mod sm_app_service;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod supervisor;
 

--- a/crates/vmux_service/src/service_registration.rs
+++ b/crates/vmux_service/src/service_registration.rs
@@ -41,6 +41,13 @@ pub fn ensure_running(profile: &str, exe: &Path) -> Result<(), RegistrationError
         Backend::SmAppService { .. } => {
             #[cfg(target_os = "macos")]
             {
+                match crate::legacy_plist_cleanup::cleanup_legacy_registrations() {
+                    Ok(0) => {}
+                    Ok(n) => tracing::info!(removed = n, "removed legacy launchd plists"),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "legacy plist cleanup failed (continuing)")
+                    }
+                }
                 crate::sm_app_service::register_main_app()?;
                 crate::sm_app_service::register_agent(bundle::EMBEDDED_AGENT_PLIST)?;
                 Ok(())

--- a/crates/vmux_service/src/service_registration.rs
+++ b/crates/vmux_service/src/service_registration.rs
@@ -1,0 +1,66 @@
+use std::path::{Path, PathBuf};
+
+use crate::bundle;
+
+#[derive(Debug)]
+pub enum Backend {
+    SmAppService { bundle_root: PathBuf },
+    Launchctl,
+}
+
+pub fn choose_backend(exe: &Path) -> Backend {
+    if let Some(root) = bundle::bundle_root_for(exe) {
+        Backend::SmAppService { bundle_root: root }
+    } else {
+        Backend::Launchctl
+    }
+}
+
+#[derive(Debug)]
+pub enum RegistrationError {
+    Io(std::io::Error),
+    #[cfg(target_os = "macos")]
+    SmAppService(crate::sm_app_service::SmError),
+}
+
+impl From<std::io::Error> for RegistrationError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl From<crate::sm_app_service::SmError> for RegistrationError {
+    fn from(e: crate::sm_app_service::SmError) -> Self {
+        Self::SmAppService(e)
+    }
+}
+
+pub fn ensure_running(profile: &str, exe: &Path) -> Result<(), RegistrationError> {
+    match choose_backend(exe) {
+        Backend::SmAppService { .. } => {
+            #[cfg(target_os = "macos")]
+            {
+                crate::sm_app_service::register_main_app()?;
+                crate::sm_app_service::register_agent(bundle::EMBEDDED_AGENT_PLIST)?;
+                Ok(())
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                Ok(())
+            }
+        }
+        Backend::Launchctl => {
+            #[cfg(target_os = "macos")]
+            {
+                crate::launchd::ensure_running(profile, exe)?;
+                Ok(())
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                let _ = (profile, exe);
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/vmux_service/src/sm_app_service.rs
+++ b/crates/vmux_service/src/sm_app_service.rs
@@ -2,6 +2,8 @@
 
 use std::fmt;
 
+use objc2_service_management::{SMAppService, SMAppServiceStatus};
+
 #[derive(Debug)]
 pub enum SmError {
     NotEnabled,
@@ -24,11 +26,13 @@ impl fmt::Display for SmError {
 impl std::error::Error for SmError {}
 
 pub fn register_main_app() -> Result<(), SmError> {
-    Err(SmError::Other("not yet implemented".into()))
+    let service = unsafe { SMAppService::mainAppService() };
+    unsafe { service.registerAndReturnError() }.map_err(|e| SmError::Other(format!("{}", e)))
 }
 
 pub fn unregister_main_app() -> Result<(), SmError> {
-    Err(SmError::Other("not yet implemented".into()))
+    let service = unsafe { SMAppService::mainAppService() };
+    unsafe { service.unregisterAndReturnError() }.map_err(|e| SmError::Other(format!("{}", e)))
 }
 
 pub fn register_agent(plist_name: &str) -> Result<(), SmError> {
@@ -49,7 +53,13 @@ pub enum Status {
 }
 
 pub fn main_app_status() -> Status {
-    Status::NotRegistered
+    let service = unsafe { SMAppService::mainAppService() };
+    match unsafe { service.status() } {
+        SMAppServiceStatus::Enabled => Status::Enabled,
+        SMAppServiceStatus::RequiresApproval => Status::RequiresApproval,
+        SMAppServiceStatus::NotFound => Status::NotFound,
+        _ => Status::NotRegistered,
+    }
 }
 
 pub fn agent_status(_plist_name: &str) -> Status {

--- a/crates/vmux_service/src/sm_app_service.rs
+++ b/crates/vmux_service/src/sm_app_service.rs
@@ -1,0 +1,57 @@
+#![cfg(target_os = "macos")]
+
+use std::fmt;
+
+#[derive(Debug)]
+pub enum SmError {
+    NotEnabled,
+    NotRegistered,
+    RequiresApproval,
+    Other(String),
+}
+
+impl fmt::Display for SmError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotEnabled => write!(f, "SMAppService not enabled"),
+            Self::NotRegistered => write!(f, "SMAppService not registered"),
+            Self::RequiresApproval => write!(f, "SMAppService requires user approval"),
+            Self::Other(s) => write!(f, "SMAppService: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for SmError {}
+
+pub fn register_main_app() -> Result<(), SmError> {
+    Err(SmError::Other("not yet implemented".into()))
+}
+
+pub fn unregister_main_app() -> Result<(), SmError> {
+    Err(SmError::Other("not yet implemented".into()))
+}
+
+pub fn register_agent(plist_name: &str) -> Result<(), SmError> {
+    let _ = plist_name;
+    Err(SmError::Other("not yet implemented".into()))
+}
+
+pub fn unregister_agent(plist_name: &str) -> Result<(), SmError> {
+    let _ = plist_name;
+    Err(SmError::Other("not yet implemented".into()))
+}
+
+pub enum Status {
+    NotRegistered,
+    Enabled,
+    RequiresApproval,
+    NotFound,
+}
+
+pub fn main_app_status() -> Status {
+    Status::NotRegistered
+}
+
+pub fn agent_status(_plist_name: &str) -> Status {
+    Status::NotRegistered
+}

--- a/crates/vmux_service/src/sm_app_service.rs
+++ b/crates/vmux_service/src/sm_app_service.rs
@@ -2,6 +2,7 @@
 
 use std::fmt;
 
+use objc2_foundation::NSString;
 use objc2_service_management::{SMAppService, SMAppServiceStatus};
 
 #[derive(Debug)]
@@ -36,13 +37,15 @@ pub fn unregister_main_app() -> Result<(), SmError> {
 }
 
 pub fn register_agent(plist_name: &str) -> Result<(), SmError> {
-    let _ = plist_name;
-    Err(SmError::Other("not yet implemented".into()))
+    let ns_name = NSString::from_str(plist_name);
+    let service = unsafe { SMAppService::agentServiceWithPlistName(&ns_name) };
+    unsafe { service.registerAndReturnError() }.map_err(|e| SmError::Other(format!("{e}")))
 }
 
 pub fn unregister_agent(plist_name: &str) -> Result<(), SmError> {
-    let _ = plist_name;
-    Err(SmError::Other("not yet implemented".into()))
+    let ns_name = NSString::from_str(plist_name);
+    let service = unsafe { SMAppService::agentServiceWithPlistName(&ns_name) };
+    unsafe { service.unregisterAndReturnError() }.map_err(|e| SmError::Other(format!("{e}")))
 }
 
 #[derive(Debug)]
@@ -64,6 +67,14 @@ pub fn main_app_status() -> Status {
     }
 }
 
-pub fn agent_status(_plist_name: &str) -> Status {
-    Status::NotRegistered
+pub fn agent_status(plist_name: &str) -> Status {
+    let ns_name = NSString::from_str(plist_name);
+    let service = unsafe { SMAppService::agentServiceWithPlistName(&ns_name) };
+    match unsafe { service.status() } {
+        SMAppServiceStatus::NotRegistered => Status::NotRegistered,
+        SMAppServiceStatus::Enabled => Status::Enabled,
+        SMAppServiceStatus::RequiresApproval => Status::RequiresApproval,
+        SMAppServiceStatus::NotFound => Status::NotFound,
+        _ => Status::NotFound,
+    }
 }

--- a/crates/vmux_service/src/sm_app_service.rs
+++ b/crates/vmux_service/src/sm_app_service.rs
@@ -45,6 +45,7 @@ pub fn unregister_agent(plist_name: &str) -> Result<(), SmError> {
     Err(SmError::Other("not yet implemented".into()))
 }
 
+#[derive(Debug)]
 pub enum Status {
     NotRegistered,
     Enabled,
@@ -55,10 +56,11 @@ pub enum Status {
 pub fn main_app_status() -> Status {
     let service = unsafe { SMAppService::mainAppService() };
     match unsafe { service.status() } {
+        SMAppServiceStatus::NotRegistered => Status::NotRegistered,
         SMAppServiceStatus::Enabled => Status::Enabled,
         SMAppServiceStatus::RequiresApproval => Status::RequiresApproval,
         SMAppServiceStatus::NotFound => Status::NotFound,
-        _ => Status::NotRegistered,
+        _ => Status::NotFound,
     }
 }
 

--- a/crates/vmux_service/tests/bundle_detection.rs
+++ b/crates/vmux_service/tests/bundle_detection.rs
@@ -1,0 +1,29 @@
+use std::path::PathBuf;
+use vmux_service::bundle;
+
+#[test]
+fn detects_bundled_when_exe_inside_app_macos() {
+    let exe = PathBuf::from("/Applications/Vmux.app/Contents/MacOS/vmux_desktop");
+    assert!(bundle::is_bundled_path(&exe));
+}
+
+#[test]
+fn detects_not_bundled_when_target_debug() {
+    let exe = PathBuf::from("/Users/x/repo/target/debug/vmux_desktop");
+    assert!(!bundle::is_bundled_path(&exe));
+}
+
+#[test]
+fn bundle_root_resolves_app_path() {
+    let exe = PathBuf::from("/Applications/Vmux.app/Contents/MacOS/vmux_desktop");
+    assert_eq!(
+        bundle::bundle_root_for(&exe).unwrap(),
+        PathBuf::from("/Applications/Vmux.app")
+    );
+}
+
+#[test]
+fn bundle_root_none_when_not_bundled() {
+    let exe = PathBuf::from("/Users/x/repo/target/debug/vmux_desktop");
+    assert!(bundle::bundle_root_for(&exe).is_none());
+}

--- a/crates/vmux_service/tests/embedded_plist.rs
+++ b/crates/vmux_service/tests/embedded_plist.rs
@@ -1,0 +1,39 @@
+#[test]
+fn embedded_plist_uses_bundle_program_relative_path() {
+    let xml = include_str!("../../../packaging/macos/ai.vmux.service.plist");
+    assert!(
+        xml.contains("<key>BundleProgram</key>"),
+        "embedded plist must use BundleProgram, not ProgramArguments"
+    );
+    assert!(
+        xml.contains("Contents/MacOS/vmux_service"),
+        "BundleProgram path must be Contents/MacOS/vmux_service"
+    );
+    assert!(
+        !xml.contains("/usr/local/") && !xml.contains("$HOME"),
+        "embedded plist must not reference absolute paths outside the bundle"
+    );
+}
+
+#[test]
+fn embedded_plist_keeps_alive_on_crash() {
+    let xml = include_str!("../../../packaging/macos/ai.vmux.service.plist");
+    assert!(xml.contains("<key>KeepAlive</key>"));
+    assert!(xml.contains("<key>Crashed</key>"));
+}
+
+#[test]
+fn embedded_plist_label_matches_release_profile() {
+    let xml = include_str!("../../../packaging/macos/ai.vmux.service.plist");
+    assert!(
+        xml.contains("<string>ai.vmux.service</string>"),
+        "release builds must use the suffix-less label"
+    );
+}
+
+#[test]
+fn embedded_plist_sets_build_profile_release() {
+    let xml = include_str!("../../../packaging/macos/ai.vmux.service.plist");
+    assert!(xml.contains("<key>VMUX_BUILD_PROFILE</key>"));
+    assert!(xml.contains("{{PROFILE}}") || xml.contains("<string>release</string>"));
+}

--- a/crates/vmux_service/tests/legacy_plist_cleanup.rs
+++ b/crates/vmux_service/tests/legacy_plist_cleanup.rs
@@ -1,0 +1,52 @@
+use std::fs;
+use vmux_service::legacy_plist_cleanup;
+
+#[test]
+fn finds_and_lists_legacy_plists() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("ai.vmux.service.plist"), "<plist/>").unwrap();
+    fs::write(dir.path().join("ai.vmux.service.dev.plist"), "<plist/>").unwrap();
+    fs::write(dir.path().join("ai.vmux.service.abc1234.plist"), "<plist/>").unwrap();
+    fs::write(dir.path().join("com.unrelated.app.plist"), "<plist/>").unwrap();
+
+    let found = legacy_plist_cleanup::find_legacy_plists_in(dir.path()).unwrap();
+    assert_eq!(
+        found.len(),
+        3,
+        "should find 3 vmux plists, ignoring unrelated: {found:?}"
+    );
+}
+
+#[test]
+fn extracts_label_from_filename() {
+    assert_eq!(
+        legacy_plist_cleanup::label_from_filename("ai.vmux.service.dev.plist"),
+        Some("ai.vmux.service.dev")
+    );
+    assert_eq!(
+        legacy_plist_cleanup::label_from_filename("ai.vmux.service.plist"),
+        Some("ai.vmux.service")
+    );
+    assert_eq!(
+        legacy_plist_cleanup::label_from_filename("com.other.plist"),
+        None
+    );
+}
+
+#[test]
+fn cleanup_removes_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let plist = dir.path().join("ai.vmux.service.dev.plist");
+    fs::write(&plist, "<plist/>").unwrap();
+    assert!(plist.exists());
+
+    legacy_plist_cleanup::remove_plist_files(std::slice::from_ref(&plist)).unwrap();
+    assert!(!plist.exists());
+}
+
+#[test]
+fn cleanup_is_idempotent_when_no_files_present() {
+    let dir = tempfile::tempdir().unwrap();
+    let found = legacy_plist_cleanup::find_legacy_plists_in(dir.path()).unwrap();
+    assert!(found.is_empty());
+}

--- a/crates/vmux_service/tests/service_registration_dispatch.rs
+++ b/crates/vmux_service/tests/service_registration_dispatch.rs
@@ -1,0 +1,14 @@
+use std::path::PathBuf;
+use vmux_service::service_registration::{Backend, choose_backend};
+
+#[test]
+fn bundled_path_chooses_sm_app_service() {
+    let exe = PathBuf::from("/Applications/Vmux.app/Contents/MacOS/vmux_service");
+    assert!(matches!(choose_backend(&exe), Backend::SmAppService { .. }));
+}
+
+#[test]
+fn unbundled_path_chooses_launchctl() {
+    let exe = PathBuf::from("/Users/x/repo/target/debug/vmux_service");
+    assert!(matches!(choose_backend(&exe), Backend::Launchctl));
+}

--- a/crates/vmux_service/tests/service_registration_dispatch.rs
+++ b/crates/vmux_service/tests/service_registration_dispatch.rs
@@ -12,3 +12,12 @@ fn unbundled_path_chooses_launchctl() {
     let exe = PathBuf::from("/Users/x/repo/target/debug/vmux_service");
     assert!(matches!(choose_backend(&exe), Backend::Launchctl));
 }
+
+#[test]
+fn ensure_running_calls_legacy_cleanup_for_sm_app_service_path() {
+    let source = include_str!("../src/service_registration.rs");
+    assert!(
+        source.contains("cleanup_legacy_registrations"),
+        "SmAppService branch must invoke legacy cleanup"
+    );
+}

--- a/crates/vmux_service/tests/sm_app_service_module.rs
+++ b/crates/vmux_service/tests/sm_app_service_module.rs
@@ -29,3 +29,27 @@ fn register_main_app_no_longer_stub() {
         );
     }
 }
+
+#[cfg(target_os = "macos")]
+#[test]
+fn register_agent_no_longer_stub() {
+    use vmux_service::sm_app_service::{SmError, register_agent};
+    let result = register_agent("ai.vmux.service.plist");
+    if let Err(SmError::Other(msg)) = &result {
+        assert!(
+            !msg.contains("not yet implemented"),
+            "register_agent must be implemented; got Other({msg:?})"
+        );
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn agent_status_no_longer_stub() {
+    use vmux_service::sm_app_service::{Status, agent_status};
+    let status = agent_status("ai.vmux.service.plist");
+    let _ = matches!(
+        status,
+        Status::NotRegistered | Status::Enabled | Status::RequiresApproval | Status::NotFound
+    );
+}

--- a/crates/vmux_service/tests/sm_app_service_module.rs
+++ b/crates/vmux_service/tests/sm_app_service_module.rs
@@ -1,0 +1,6 @@
+#[cfg(target_os = "macos")]
+#[test]
+fn sm_app_service_module_exposes_register_main_app() {
+    let _: fn() -> Result<(), vmux_service::sm_app_service::SmError> =
+        vmux_service::sm_app_service::register_main_app;
+}

--- a/crates/vmux_service/tests/sm_app_service_module.rs
+++ b/crates/vmux_service/tests/sm_app_service_module.rs
@@ -4,3 +4,28 @@ fn sm_app_service_module_exposes_register_main_app() {
     let _: fn() -> Result<(), vmux_service::sm_app_service::SmError> =
         vmux_service::sm_app_service::register_main_app;
 }
+
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "requires the test binary to run from inside a signed .app in /Applications"]
+fn register_main_app_returns_status() {
+    use vmux_service::sm_app_service::{Status, main_app_status, register_main_app};
+    let _ = register_main_app();
+    assert!(matches!(
+        main_app_status(),
+        Status::Enabled | Status::RequiresApproval
+    ));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn register_main_app_no_longer_stub() {
+    use vmux_service::sm_app_service::{SmError, register_main_app};
+    let result = register_main_app();
+    if let Err(SmError::Other(msg)) = &result {
+        assert!(
+            !msg.contains("not yet implemented"),
+            "register_main_app must be implemented; got Other({msg:?})"
+        );
+    }
+}

--- a/docs/plans/2026-05-13-vmux-app-background-item.md
+++ b/docs/plans/2026-05-13-vmux-app-background-item.md
@@ -1,0 +1,1963 @@
+# Vmux.app as Background Item Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Linear:** [VMX-119](https://linear.app/vmux/issue/VMX-119/ship-vmuxapp-as-signed-background-item-embed-vmux-service-helper)
+
+**Goal:** Ship `Vmux.app` as a signed, notarized background item; embed `vmux_service` inside the bundle as a launchd-supervised helper. Login Items shows "Vmux" with proper icon + Developer ID team. UI process can be Cmd+Q'd / window-closed without killing terminal state. Replaces the current path-based `~/Library/LaunchAgents/ai.vmux.service.*.plist` registration.
+
+**Architecture:**
+- `Vmux.app/Contents/MacOS/vmux_desktop` — UI process, hidden from Dock via `LSUIElement=YES` (already set elsewhere — verify), tray-resident when window closed
+- `Vmux.app/Contents/MacOS/vmux_service` — daemon binary, supervised by launchd via embedded plist
+- `Vmux.app/Contents/Library/LaunchAgents/ai.vmux.service.plist` — embedded plist, uses `BundleProgram` (relative) instead of absolute `ProgramArguments`
+- `SMAppService.mainApp.register()` registers the .app as a login item from inside the .app on first run
+- `SMAppService.agent(plistName:).register()` registers the embedded daemon
+- Dev-mode (cargo run, not bundled) keeps the existing `crates/vmux_service/src/launchd.rs` `ensure_running` path so iteration is fast — SMAppService refuses to register apps outside `/Applications`
+
+**Tech Stack:** Rust, bevy, `objc2` + `objc2-foundation` for Service Management framework FFI, `cargo-packager` for bundling, `codesign` + `notarytool`, `launchctl` (dev fallback only).
+
+**Pattern reference:** OrbStack, Docker Desktop, Tailscale all ship as signed app bundles registered via SMAppService.
+
+---
+
+## File Structure (final state)
+
+```
+crates/vmux_service/
+├── Cargo.toml                       # +objc2, +objc2-foundation (macos only)
+└── src/
+    ├── lib.rs                       # cfg-gated `pub mod sm_app_service` + `pub mod bundle`
+    ├── launchd.rs                   # unchanged; used as dev-mode fallback
+    ├── sm_app_service.rs            # NEW: SMAppService FFI (register/unregister/status, mainApp + agent)
+    ├── bundle.rs                    # NEW: detect "running inside .app", resolve bundle paths, embedded plist name
+    └── service_registration.rs      # NEW: dispatcher — picks SMAppService when bundled, launchd::ensure_running otherwise
+
+crates/vmux_desktop/
+├── Cargo.toml                       # unchanged
+└── src/
+    ├── lib.rs                       # WindowPlugin: ExitCondition::DontExit; add BackgroundLifecyclePlugin
+    ├── background_lifecycle.rs      # NEW: Cmd+Q → hide windows; window close → hide; SMAppService first-launch register
+    ├── tray.rs                      # implement: status icon + "Show Vmux" / "Quit Vmux" menu items
+    ├── os_menu.rs                   # handle_quit_request → hide instead of AppExit
+    └── terminal.rs:608-650          # ensure_service_started → call new dispatcher in vmux_service
+
+packaging/macos/
+├── Info.plist                       # +LSUIElement=YES (verify)
+└── ai.vmux.service.plist            # NEW: embedded plist template (BundleProgram + KeepAlive)
+
+scripts/
+├── package.sh                       # +build vmux_service in --release, copy plist into bundle
+└── before-each-package.sh           # ensure plist + helper binary land in bundle before signing
+```
+
+---
+
+## Task Group A — UI Lifecycle (Vmux.app survives Cmd+Q)
+
+Goal: Vmux.app stays running in the background after Cmd+Q or window close. Tray menu provides explicit "Quit Vmux" action.
+
+This group is independently mergeable and delivers value on its own (no terminal-state loss on accidental Cmd+Q), even before the bundle/SMAppService work lands.
+
+### Task A1: Block app exit on last-window-close
+
+**Files:**
+- Modify: `crates/vmux_desktop/src/lib.rs:84-88` (WindowPlugin construction)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `crates/vmux_desktop/src/lib.rs` test module:
+
+```rust
+#[test]
+fn window_plugin_keeps_app_alive_after_last_window_closes() {
+    use bevy::window::ExitCondition;
+    let source = include_str!("lib.rs");
+    assert!(
+        source.contains("ExitCondition::DontExit"),
+        "WindowPlugin must opt out of automatic exit so Vmux.app survives last-window-close"
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_desktop window_plugin_keeps_app_alive
+```
+
+Expected: FAIL — `ExitCondition::DontExit` not in source.
+
+- [ ] **Step 3: Implement**
+
+In `crates/vmux_desktop/src/lib.rs`:
+
+```rust
+// Add to imports near line 31:
+use bevy::window::{CompositeAlphaMode, ExitCondition, Window as NativeWindow, WindowPlugin};
+
+// Replace lines 84-88:
+let window_plugin = WindowPlugin {
+    primary_window: Some(primary_window),
+    close_when_requested: false,
+    exit_condition: ExitCondition::DontExit,
+    ..default()
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_desktop window_plugin_keeps_app_alive
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/vmux_desktop/src/lib.rs
+git commit -m "VMX-119: WindowPlugin opts out of last-window-close exit"
+```
+
+---
+
+### Task A2: Cmd+Q hides windows instead of exiting the App
+
+**Files:**
+- Modify: `crates/vmux_desktop/src/os_menu.rs:74-92` (`handle_quit_request`)
+- Test: `crates/vmux_desktop/src/os_menu.rs` (test module)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to test module in `crates/vmux_desktop/src/os_menu.rs`:
+
+```rust
+#[test]
+fn quit_menu_event_hides_windows_not_exit() {
+    let source = include_str!("os_menu.rs");
+    assert!(
+        !source.contains("AppExit::Success"),
+        "Cmd+Q must hide windows, not exit the app — terminal state must survive"
+    );
+    assert!(
+        source.contains("HideAllWindows") || source.contains("window.visible = false"),
+        "handle_quit_request must dispatch a hide action"
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_desktop quit_menu_event_hides_windows_not_exit
+```
+
+Expected: FAIL — source still contains `AppExit::Success`.
+
+- [ ] **Step 3: Define tray-internal lifecycle events (NOT new AppCommand variants)**
+
+`AppCommand` (in `crates/vmux_command/src/command.rs`) uses derive macros (`Message`, `OsMenu`, `CommandBar`, `McpTool`) that require menu metadata for every variant. Adding `HideAllWindows`/`QuitVmux` there would force them into OS menus + command bar where they don't belong.
+
+Instead, introduce a separate Bevy `Message` for lifecycle in the new `background_lifecycle` module:
+
+```rust
+// in crates/vmux_desktop/src/background_lifecycle.rs (full file shown in Step 4)
+#[derive(bevy::prelude::Message, Debug, Clone, Copy)]
+pub enum LifecycleEvent {
+    HideAllWindows,
+    ShowAllWindows,
+    QuitVmux,
+}
+```
+
+In `crates/vmux_desktop/src/os_menu.rs`, replace `handle_quit_request` body (lines 74-92):
+
+```rust
+fn handle_quit_request(world: &mut World) {
+    // Cmd+Q hides the UI but keeps Vmux.app + vmux_service alive.
+    // Real quit is only available via the tray menu.
+    world
+        .resource_mut::<Messages<crate::background_lifecycle::LifecycleEvent>>()
+        .write(crate::background_lifecycle::LifecycleEvent::HideAllWindows);
+}
+```
+
+- [ ] **Step 4: Implement BackgroundLifecyclePlugin**
+
+Create `crates/vmux_desktop/src/background_lifecycle.rs`:
+
+```rust
+use bevy::prelude::*;
+use bevy::window::Window;
+
+#[derive(Message, Debug, Clone, Copy)]
+pub enum LifecycleEvent {
+    HideAllWindows,
+    ShowAllWindows,
+    QuitVmux,
+}
+
+pub struct BackgroundLifecyclePlugin;
+
+impl Plugin for BackgroundLifecyclePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_message::<LifecycleEvent>();
+        app.add_systems(Update, handle_lifecycle_events);
+    }
+}
+
+fn handle_lifecycle_events(
+    mut events: MessageReader<LifecycleEvent>,
+    mut windows: Query<&mut Window>,
+    mut exit: MessageWriter<AppExit>,
+) {
+    for event in events.read() {
+        match event {
+            LifecycleEvent::HideAllWindows => {
+                for mut window in &mut windows {
+                    window.visible = false;
+                }
+            }
+            LifecycleEvent::ShowAllWindows => {
+                for mut window in &mut windows {
+                    window.visible = true;
+                }
+            }
+            LifecycleEvent::QuitVmux => {
+                // Live-terminal confirm dialog is added in Task A5.
+                exit.write(AppExit::Success);
+            }
+        }
+    }
+}
+```
+
+Register in `crates/vmux_desktop/src/lib.rs`:
+
+```rust
+mod background_lifecycle;
+use background_lifecycle::BackgroundLifecyclePlugin;
+
+// inside VmuxPlugin::build, in the second .add_plugins((...)) tuple (line ~120):
+.add_plugins(BackgroundLifecyclePlugin)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_desktop quit_menu_event_hides_windows
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Manual smoke test**
+
+```bash
+make dev
+# In running Vmux: press Cmd+Q. Window should disappear but process should stay alive.
+ps aux | grep vmux_desktop  # should still be listed
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/vmux_desktop/src/{os_menu.rs,background_lifecycle.rs,lib.rs}
+git commit -m "VMX-119: Cmd+Q hides windows, terminal state survives"
+```
+
+---
+
+### Task A3: Window red-button close also hides instead of despawning
+
+**Files:**
+- Modify: `crates/vmux_desktop/src/os_menu.rs:97-119` (`close_with_confirmation`)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn window_close_request_hides_window_instead_of_despawning() {
+    let source = include_str!("os_menu.rs");
+    assert!(
+        source.contains("window.visible = false")
+            || source.contains("HideAllWindows"),
+        "WindowCloseRequested must hide the window so Vmux.app stays in the background"
+    );
+}
+```
+
+- [ ] **Step 2: Verify it fails**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_desktop window_close_request_hides_window
+```
+
+- [ ] **Step 3: Replace despawn-on-close with hide-on-close**
+
+In `crates/vmux_desktop/src/os_menu.rs`, replace the `for event in closed.read()` block inside `close_with_confirmation` (around lines 109-118):
+
+```rust
+for event in closed.read() {
+    // We do NOT despawn the window — Vmux.app lives in the background and
+    // the same window entity is re-shown when the user reopens from tray.
+    if let Ok(mut window) = windows.get_mut(event.window) {
+        window.visible = false;
+    }
+}
+```
+
+You'll need to add `mut windows: Query<&mut Window>` to the system signature. Remove the `closing: Query<Entity, With<ClosingWindow>>` despawn loop (lines 105-108) and the `ClosingWindow` insert in `process_pending_window_close` (line 137) — replace with `window.visible = false` similarly.
+
+The terminal-running confirm dialog (lines 110-117) stays — but on confirm we hide instead of despawn.
+
+- [ ] **Step 4: Verify**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_desktop --all-targets
+```
+
+- [ ] **Step 5: Manual smoke test**
+
+```bash
+make dev
+# Click red button on window. Window disappears, process keeps running.
+# (No way to re-show yet without tray — that comes in Task A4.)
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/vmux_desktop/src/os_menu.rs
+git commit -m "VMX-119: window close hides instead of despawning"
+```
+
+---
+
+### Task A4: Tray menu with "Show Vmux" + "Quit Vmux"
+
+**Files:**
+- Rewrite: `crates/vmux_desktop/src/tray.rs` (currently a placeholder, see lines 1-25)
+
+The `tray-icon` crate (already implied by stub comment) integrates with winit's event loop. We'll use `tray-icon = "0.21"` (latest as of 2026-05; confirm before adding).
+
+- [ ] **Step 1: Add `tray-icon` dependency**
+
+```bash
+cd crates/vmux_desktop
+cargo add tray-icon@0.21
+cd ../..
+```
+
+Verify it builds:
+
+```bash
+env -u CEF_PATH cargo check -p vmux_desktop
+```
+
+- [ ] **Step 2: Write failing test (build-time check)**
+
+In `crates/vmux_desktop/src/tray.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn tray_module_not_a_placeholder() {
+        let source = include_str!("tray.rs");
+        assert!(
+            source.contains("TrayIconBuilder") || source.contains("tray_icon::TrayIcon"),
+            "tray.rs must wire tray-icon, not be a stub"
+        );
+        assert!(
+            source.contains("Quit Vmux") || source.contains("QuitVmux"),
+            "tray must expose a 'Quit Vmux' menu item"
+        );
+        assert!(
+            source.contains("Show Vmux") || source.contains("ShowVmux"),
+            "tray must expose a 'Show Vmux' menu item"
+        );
+    }
+}
+```
+
+- [ ] **Step 3: Verify it fails**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_desktop tray_module_not_a_placeholder
+```
+
+- [ ] **Step 4: Implement tray**
+
+Replace contents of `crates/vmux_desktop/src/tray.rs`:
+
+```rust
+use bevy::prelude::*;
+use tray_icon::menu::{Menu, MenuEvent, MenuItem};
+use tray_icon::{TrayIcon, TrayIconBuilder};
+
+use crate::background_lifecycle::LifecycleEvent;
+
+pub(crate) struct TrayPlugin;
+
+#[derive(Resource)]
+struct TrayHandle {
+    _tray: TrayIcon,
+    show_id: tray_icon::menu::MenuId,
+    quit_id: tray_icon::menu::MenuId,
+}
+
+impl Plugin for TrayPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Startup, setup_tray);
+        app.add_systems(Update, drain_menu_events);
+    }
+}
+
+fn setup_tray(mut commands: Commands) {
+    let menu = Menu::new();
+    let show = MenuItem::new("Show Vmux", true, None);
+    let quit = MenuItem::new("Quit Vmux", true, None);
+    let show_id = show.id().clone();
+    let quit_id = quit.id().clone();
+    if let Err(e) = menu.append_items(&[&show, &quit]) {
+        tracing::error!(error = %e, "failed to append tray menu items");
+        return;
+    }
+
+    let icon = load_tray_icon();
+    let tray = match TrayIconBuilder::new()
+        .with_menu(Box::new(menu))
+        .with_tooltip("Vmux")
+        .with_icon(icon)
+        .build()
+    {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::error!(error = %e, "failed to build tray icon");
+            return;
+        }
+    };
+
+    commands.insert_resource(TrayHandle {
+        _tray: tray,
+        show_id,
+        quit_id,
+    });
+}
+
+fn drain_menu_events(
+    handle: Option<Res<TrayHandle>>,
+    mut events: MessageWriter<LifecycleEvent>,
+) {
+    let Some(handle) = handle else { return };
+    let receiver = MenuEvent::receiver();
+    while let Ok(event) = receiver.try_recv() {
+        if event.id == handle.show_id {
+            events.write(LifecycleEvent::ShowAllWindows);
+        } else if event.id == handle.quit_id {
+            events.write(LifecycleEvent::QuitVmux);
+        }
+    }
+}
+
+fn load_tray_icon() -> tray_icon::Icon {
+    // 16x16 placeholder; embed real icon bytes when icon design lands.
+    let rgba = vec![0u8; 16 * 16 * 4];
+    tray_icon::Icon::from_rgba(rgba, 16, 16).expect("valid placeholder rgba")
+}
+```
+
+Register `TrayPlugin` in `lib.rs`:
+
+```rust
+.add_plugins(TrayPlugin)
+```
+
+- [ ] **Step 5: Verify tests pass**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_desktop tray_module_not_a_placeholder
+env -u CEF_PATH cargo test -p vmux_desktop --all-targets
+```
+
+- [ ] **Step 6: Manual smoke test**
+
+```bash
+make dev
+# Look at menu bar — should see Vmux tray item
+# Cmd+Q the window → still alive → click tray "Show Vmux" → window reappears
+# Click tray "Quit Vmux" → confirm dialog → app exits
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/vmux_desktop/src/{tray.rs,lib.rs} crates/vmux_desktop/Cargo.toml Cargo.lock
+git commit -m "VMX-119: tray menu with Show / Quit Vmux"
+```
+
+---
+
+### Task A5: Confirm-quit dialog now lives only in tray quit path
+
+**Files:**
+- Modify: `crates/vmux_desktop/src/background_lifecycle.rs`
+
+Move the live-terminal confirm dialog (currently in `os_menu.rs handle_quit_request`) to the `QuitVmux` branch — Cmd+Q (now "hide") doesn't need confirmation, but tray quit does.
+
+- [ ] **Step 1: Implement**
+
+The confirm-dialog call needs `&mut World` (it has to query terminals + show a modal native dialog on the main thread). Convert `handle_lifecycle_events` into an exclusive system, mirroring the pattern in `os_menu.rs handle_quit_request`:
+
+```rust
+fn handle_lifecycle_events(world: &mut World) {
+    use crate::terminal::{self, Terminal, PtyExited};
+
+    let drained: Vec<LifecycleEvent> = {
+        let mut events = world.resource_mut::<Messages<LifecycleEvent>>();
+        events.drain().collect()
+    };
+
+    for event in drained {
+        match event {
+            LifecycleEvent::HideAllWindows => {
+                let mut q = world.query::<&mut Window>();
+                for mut w in q.iter_mut(world) { w.visible = false; }
+            }
+            LifecycleEvent::ShowAllWindows => {
+                let mut q = world.query::<&mut Window>();
+                for mut w in q.iter_mut(world) { w.visible = true; }
+            }
+            LifecycleEvent::QuitVmux => {
+                let live = {
+                    let mut q = world.query_filtered::<(), (With<Terminal>, Without<PtyExited>)>();
+                    q.iter(world).count()
+                };
+                if live > 0 && !terminal::confirm_quit_dialog(live) {
+                    continue;
+                }
+                world.resource_mut::<Messages<AppExit>>().write(AppExit::Success);
+            }
+        }
+    }
+}
+```
+
+Update `BackgroundLifecyclePlugin::build` to register the system as exclusive (`add_systems(Update, handle_lifecycle_events)` works with `&mut World` parameter — bevy infers it).
+
+- [ ] **Step 2: Verify**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_desktop --all-targets
+```
+
+- [ ] **Step 3: Manual smoke test**
+
+```bash
+make dev
+# Open a terminal that runs something, then click tray "Quit Vmux" → confirm dialog appears
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/vmux_desktop/src/background_lifecycle.rs
+git commit -m "VMX-119: confirm-quit dialog moves to tray Quit path"
+```
+
+---
+
+## Task Group B — Bundle vmux_service inside Vmux.app
+
+Goal: `Vmux.app/Contents/MacOS/vmux_service` ships alongside `vmux_desktop`. Embedded launchd plist at `Vmux.app/Contents/Library/LaunchAgents/ai.vmux.service.plist` uses `BundleProgram` (relative).
+
+### Task B1: Add vmux_service to cargo-packager binaries
+
+**Files:**
+- Modify: `crates/vmux_desktop/Cargo.toml:60-65` (packager metadata)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to a new file `crates/vmux_desktop/tests/packaging_metadata.rs`:
+
+```rust
+//! Verify cargo-packager metadata embeds vmux_service in the bundle.
+
+#[test]
+fn packager_binaries_include_vmux_service() {
+    let toml = include_str!("../Cargo.toml");
+    assert!(
+        toml.contains(r#"path = "vmux_service""#),
+        "packager metadata must include vmux_service so it lands in Vmux.app/Contents/MacOS/"
+    );
+}
+
+#[test]
+fn before_packaging_command_builds_vmux_service() {
+    let toml = include_str!("../Cargo.toml");
+    let line = toml.lines()
+        .find(|l| l.starts_with("before-packaging-command"))
+        .expect("before-packaging-command line present");
+    assert!(
+        line.contains("vmux_service"),
+        "before-packaging-command must build vmux_service: {line}"
+    );
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_desktop --test packaging_metadata
+```
+
+Expected: both tests FAIL.
+
+- [ ] **Step 3: Update Cargo.toml**
+
+Edit `crates/vmux_desktop/Cargo.toml`:
+
+```toml
+before-packaging-command = "env -u CEF_PATH cargo build -p vmux_desktop -p vmux_cli -p vmux_service -p bevy_cef_debug_render_process --release"
+binaries = [
+    { path = "vmux_desktop", main = true },
+    { path = "vmux" },
+    { path = "vmux_service" },
+]
+```
+
+- [ ] **Step 4: Verify tests pass**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_desktop --test packaging_metadata
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/vmux_desktop/{Cargo.toml,tests/packaging_metadata.rs}
+git commit -m "VMX-119: package vmux_service binary inside Vmux.app"
+```
+
+---
+
+### Task B2: Author embedded launchd plist template
+
+**Files:**
+- Create: `packaging/macos/ai.vmux.service.plist`
+- Create: `crates/vmux_service/tests/embedded_plist.rs`
+
+The embedded plist must use `BundleProgram` (relative path, resolved by launchd against the bundle root) instead of `ProgramArguments` with absolute paths.
+
+- [ ] **Step 1: Write failing test**
+
+Create `crates/vmux_service/tests/embedded_plist.rs`:
+
+```rust
+#[test]
+fn embedded_plist_uses_bundle_program_relative_path() {
+    let xml = include_str!("../../../packaging/macos/ai.vmux.service.plist");
+    assert!(xml.contains("<key>BundleProgram</key>"),
+        "embedded plist must use BundleProgram, not ProgramArguments");
+    assert!(xml.contains("Contents/MacOS/vmux_service"),
+        "BundleProgram path must be Contents/MacOS/vmux_service");
+    assert!(!xml.contains("/usr/local/") && !xml.contains("$HOME"),
+        "embedded plist must not reference absolute paths outside the bundle");
+}
+
+#[test]
+fn embedded_plist_keeps_alive_on_crash() {
+    let xml = include_str!("../../../packaging/macos/ai.vmux.service.plist");
+    assert!(xml.contains("<key>KeepAlive</key>"));
+    assert!(xml.contains("<key>Crashed</key>"));
+}
+
+#[test]
+fn embedded_plist_label_matches_release_profile() {
+    let xml = include_str!("../../../packaging/macos/ai.vmux.service.plist");
+    assert!(xml.contains("<string>ai.vmux.service</string>"),
+        "release builds must use the suffix-less label");
+}
+
+#[test]
+fn embedded_plist_sets_build_profile_release() {
+    let xml = include_str!("../../../packaging/macos/ai.vmux.service.plist");
+    assert!(xml.contains("<key>VMUX_BUILD_PROFILE</key>"));
+    // The packaging script substitutes {{PROFILE}} for local/release; here we assert template var present.
+    assert!(xml.contains("{{PROFILE}}") || xml.contains("<string>release</string>"));
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_service --test embedded_plist
+```
+
+Expected: FAIL — file does not exist.
+
+- [ ] **Step 3: Create plist**
+
+Create `packaging/macos/ai.vmux.service.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>ai.vmux.service</string>
+  <key>BundleProgram</key>
+  <string>Contents/MacOS/vmux_service</string>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>Crashed</key>
+    <true/>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>ProcessType</key>
+  <string>Interactive</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>VMUX_BUILD_PROFILE</key>
+    <string>{{PROFILE}}</string>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>/tmp/vmux-service.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/vmux-service.log</string>
+</dict>
+</plist>
+```
+
+(Log path will be rewritten by SMAppService runtime side later — for now `/tmp` is fine because launchd only reads `BundleProgram` and `EnvironmentVariables`; the daemon itself opens a real log via `log_path()`.)
+
+- [ ] **Step 4: Verify tests pass**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_service --test embedded_plist
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packaging/macos/ai.vmux.service.plist crates/vmux_service/tests/embedded_plist.rs
+git commit -m "VMX-119: embedded launchd plist with BundleProgram"
+```
+
+---
+
+### Task B3: Copy plist into bundle during packaging
+
+**Files:**
+- Modify: `scripts/package.sh` (post-cargo-packager copy for local builds)
+- Modify: `scripts/before-each-package.sh` (pre-sign copy for release builds)
+
+**Ordering reference** (from reading `scripts/before-each-package.sh`):
+- `cargo packager --formats app` builds the .app skeleton
+- For `release`: `cargo packager` continues to dmg pass, which runs `before-each-package.sh` → `inject-cef.sh` → `sign-and-notarize.sh` → wraps .app into dmg
+- For `local`: `package.sh` calls `inject-cef.sh` manually after the app pass; `make build-local` then calls `sign-and-notarize.sh` separately
+
+The plist must land BEFORE `sign-and-notarize.sh` runs so the signature covers it. Two insertion points needed: (a) inside `before-each-package.sh` between `inject-cef.sh` and `sign-and-notarize.sh` for the release dmg pass, and (b) at the end of `package.sh` (after manual `inject-cef.sh`) for local builds — but BEFORE `make build-local` invokes signing.
+
+- [ ] **Step 2: Write failing integration check**
+
+Create `scripts/test-bundle-layout.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Asserts the .app bundle has the expected layout. Exits non-zero on failure.
+set -euo pipefail
+APP="${1:?usage: $0 <path-to-Vmux.app>}"
+
+REQUIRED=(
+    "Contents/MacOS/vmux_desktop"
+    "Contents/MacOS/vmux"
+    "Contents/MacOS/vmux_service"
+    "Contents/Library/LaunchAgents/ai.vmux.service.plist"
+    "Contents/Info.plist"
+    "Contents/Resources/Vmux.icns"
+)
+
+for path in "${REQUIRED[@]}"; do
+    if [[ ! -e "$APP/$path" ]]; then
+        echo "MISSING: $APP/$path" >&2
+        exit 1
+    fi
+done
+
+# Verify embedded plist substitution happened
+if grep -q '{{PROFILE}}' "$APP/Contents/Library/LaunchAgents/ai.vmux.service.plist"; then
+    echo "Plist still has {{PROFILE}} placeholder — substitution did not run" >&2
+    exit 1
+fi
+
+echo "OK: bundle layout correct"
+```
+
+```bash
+chmod +x scripts/test-bundle-layout.sh
+```
+
+- [ ] **Step 3: Verify failure (no bundle yet)**
+
+```bash
+make build-local 2>&1 | tail -5
+sha="$(git rev-parse --short HEAD)"
+./scripts/test-bundle-layout.sh "target/release/Vmux ($sha).app"
+```
+
+Expected: FAIL — `vmux_service` and embedded plist are missing.
+
+- [ ] **Step 4: Add plist-embed helper script (shared by both flows)**
+
+Create `scripts/embed-launch-agent-plist.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Embed packaging/macos/ai.vmux.service.plist inside Vmux.app, substituting
+# the build profile (and per-SHA label for local builds).
+#
+# Required env: VMUX_APP_BUNDLE, VMUX_BUILD_PROFILE
+# Optional env: VMUX_GIT_HASH (required when VMUX_BUILD_PROFILE=local)
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+: "${VMUX_APP_BUNDLE:?VMUX_APP_BUNDLE not set}"
+: "${VMUX_BUILD_PROFILE:?VMUX_BUILD_PROFILE not set}"
+
+PLIST_SRC="$ROOT/packaging/macos/ai.vmux.service.plist"
+PLIST_DST="$VMUX_APP_BUNDLE/Contents/Library/LaunchAgents/ai.vmux.service.plist"
+
+LABEL="ai.vmux.service"
+if [[ "$VMUX_BUILD_PROFILE" == "local" ]]; then
+    : "${VMUX_GIT_HASH:?VMUX_GIT_HASH must be set for local builds}"
+    LABEL="ai.vmux.service.$VMUX_GIT_HASH"
+fi
+
+mkdir -p "$(dirname "$PLIST_DST")"
+sed -e "s|{{PROFILE}}|$VMUX_BUILD_PROFILE|g" \
+    -e "s|<string>ai.vmux.service</string>|<string>$LABEL</string>|" \
+    "$PLIST_SRC" > "$PLIST_DST"
+echo "==> Embedded launchd plist (label=$LABEL, profile=$VMUX_BUILD_PROFILE)"
+```
+
+```bash
+chmod +x scripts/embed-launch-agent-plist.sh
+```
+
+- [ ] **Step 5: Wire into `before-each-package.sh` (release dmg pass)**
+
+Edit `scripts/before-each-package.sh` to embed the plist after `inject-cef.sh` but before `sign-and-notarize.sh`:
+
+```bash
+"$ROOT/scripts/inject-cef.sh"
+
+if [[ "${CARGO_PACKAGER_FORMAT:-}" == "dmg" ]]; then
+    APP_BUNDLE="${VMUX_APP_BUNDLE:-$ROOT/target/release/Vmux.app}" \
+        VMUX_APP_BUNDLE="${VMUX_APP_BUNDLE:-$ROOT/target/release/Vmux.app}" \
+        "$ROOT/scripts/embed-launch-agent-plist.sh"
+    APP_BUNDLE="${VMUX_APP_BUNDLE:-$ROOT/target/release/Vmux.app}" \
+        "$ROOT/scripts/sign-and-notarize.sh"
+fi
+```
+
+- [ ] **Step 6: Wire into `package.sh` (local pass)**
+
+In `scripts/package.sh`, find the existing `if [[ "$PROFILE" == "local" && -d "$VMUX_APP_BUNDLE" ]]; then` block (right after `inject-cef.sh`) and append:
+
+```bash
+if [[ "$PROFILE" == "local" && -d "$VMUX_APP_BUNDLE" ]]; then
+    echo "==> Injecting CEF into .app (local build)"
+    CARGO_PACKAGER_FORMAT=dmg bash "$ROOT/scripts/inject-cef.sh"
+
+    echo "==> Embedding launchd plist (local build)"
+    VMUX_GIT_HASH="$SHA" "$ROOT/scripts/embed-launch-agent-plist.sh"
+fi
+```
+
+(The `$SHA` variable is only set in the `local` branch of the case statement at the top of package.sh — it's already in scope here.)
+
+- [ ] **Step 7: Verify bundle layout test passes**
+
+```bash
+make build-local
+sha="$(git rev-parse --short HEAD)"
+./scripts/test-bundle-layout.sh "target/release/Vmux ($sha).app"
+```
+
+Expected: `OK: bundle layout correct`.
+
+- [ ] **Step 8: Verify codesign chain still passes**
+
+The existing loop in `scripts/sign-and-notarize.sh:76` signs everything in `Contents/MacOS/`, so `vmux_service` will be signed automatically. No script change needed there.
+
+```bash
+make build-local
+codesign --verify --deep --strict --verbose=2 "target/release/Vmux ($(git rev-parse --short HEAD)).app"
+```
+
+Expected: `Vmux ($SHA).app: valid on disk` and `satisfies its Designated Requirement`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add scripts/{package.sh,before-each-package.sh,embed-launch-agent-plist.sh,test-bundle-layout.sh}
+git commit -m "VMX-119: embed vmux_service + plist into Vmux.app"
+```
+
+---
+
+## Task Group C — SMAppService FFI
+
+Goal: Rust wrapper around `SMAppService` Objective-C class to register/unregister `mainApp` and `agent` services.
+
+API surface needed:
+- `SMAppService.mainApp.register()` / `.unregister()` / `.status`
+- `SMAppService.agent(plistName:).register()` / `.unregister()` / `.status`
+
+We'll use `objc2` raw `msg_send!` macros — no dedicated `objc2-service-management` crate exists at time of writing (verify in Step 1).
+
+### Task C1: Add objc2 dependencies and stub module
+
+**Files:**
+- Modify: `crates/vmux_service/Cargo.toml`
+- Create: `crates/vmux_service/src/sm_app_service.rs`
+
+- [ ] **Step 1: Verify no `objc2-service-management` crate exists**
+
+```bash
+cargo search objc2-service-management
+```
+
+If a maintained crate exists, prefer it and adjust the implementation steps accordingly. If not, proceed with raw `objc2`.
+
+- [ ] **Step 2: Add deps**
+
+```bash
+cd crates/vmux_service
+cargo add --target 'cfg(target_os = "macos")' objc2@0.6
+cargo add --target 'cfg(target_os = "macos")' objc2-foundation@0.3
+cd ../..
+```
+
+- [ ] **Step 3: Write failing test**
+
+Create `crates/vmux_service/tests/sm_app_service_module.rs`:
+
+```rust
+#[cfg(target_os = "macos")]
+#[test]
+fn sm_app_service_module_exposes_register_main_app() {
+    // Compile-time check via fn pointer: forces the type to exist.
+    let _: fn() -> Result<(), vmux_service::sm_app_service::SmError> =
+        vmux_service::sm_app_service::register_main_app;
+}
+```
+
+- [ ] **Step 4: Verify failure**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_service --test sm_app_service_module
+```
+
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 5: Create stub module**
+
+Create `crates/vmux_service/src/sm_app_service.rs`:
+
+```rust
+#![cfg(target_os = "macos")]
+
+use std::fmt;
+
+#[derive(Debug)]
+pub enum SmError {
+    NotEnabled,
+    NotRegistered,
+    RequiresApproval,
+    Other(String),
+}
+
+impl fmt::Display for SmError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotEnabled => write!(f, "SMAppService not enabled"),
+            Self::NotRegistered => write!(f, "SMAppService not registered"),
+            Self::RequiresApproval => write!(f, "SMAppService requires user approval"),
+            Self::Other(s) => write!(f, "SMAppService: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for SmError {}
+
+pub fn register_main_app() -> Result<(), SmError> {
+    Err(SmError::Other("not yet implemented".into()))
+}
+
+pub fn unregister_main_app() -> Result<(), SmError> {
+    Err(SmError::Other("not yet implemented".into()))
+}
+
+pub fn register_agent(plist_name: &str) -> Result<(), SmError> {
+    let _ = plist_name;
+    Err(SmError::Other("not yet implemented".into()))
+}
+
+pub fn unregister_agent(plist_name: &str) -> Result<(), SmError> {
+    let _ = plist_name;
+    Err(SmError::Other("not yet implemented".into()))
+}
+
+pub enum Status {
+    NotRegistered,
+    Enabled,
+    RequiresApproval,
+    NotFound,
+}
+
+pub fn main_app_status() -> Status {
+    Status::NotRegistered
+}
+
+pub fn agent_status(_plist_name: &str) -> Status {
+    Status::NotRegistered
+}
+```
+
+Add to `crates/vmux_service/src/lib.rs`:
+
+```rust
+#[cfg(all(target_os = "macos", not(target_arch = "wasm32")))]
+pub mod sm_app_service;
+```
+
+- [ ] **Step 6: Verify test passes**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_service --test sm_app_service_module
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/vmux_service/Cargo.toml crates/vmux_service/src/{lib.rs,sm_app_service.rs} crates/vmux_service/tests/sm_app_service_module.rs Cargo.lock
+git commit -m "VMX-119: SMAppService module skeleton + stub API"
+```
+
+---
+
+### Task C2: Implement register_main_app via objc2 msg_send
+
+**Files:**
+- Modify: `crates/vmux_service/src/sm_app_service.rs`
+
+`SMAppService.mainApp` is a class method returning the singleton for the currently-running app bundle. `.register()` signature: `func register() throws`.
+
+- [ ] **Step 1: Write the failing integration test (cfg-gated, ignored by default — needs a real bundle)**
+
+```rust
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "requires the test binary to run from inside a signed .app in /Applications"]
+fn register_main_app_returns_status() {
+    use vmux_service::sm_app_service::{register_main_app, main_app_status, Status};
+    let _ = register_main_app();
+    assert!(matches!(
+        main_app_status(),
+        Status::Enabled | Status::RequiresApproval
+    ));
+}
+```
+
+This is `#[ignore]` because it can only pass inside the bundle. It documents intent.
+
+- [ ] **Step 2: Implement `register_main_app`**
+
+Replace the stub in `sm_app_service.rs`:
+
+```rust
+use objc2::msg_send;
+use objc2::runtime::{AnyClass, AnyObject};
+use objc2_foundation::{NSError, NSString};
+
+fn sm_app_service_class() -> &'static AnyClass {
+    AnyClass::get(c"SMAppService").expect("SMAppService class available; ensure ServiceManagement framework is linked")
+}
+
+fn map_ns_error(err: *mut NSError) -> SmError {
+    if err.is_null() {
+        return SmError::Other("nil NSError".into());
+    }
+    let msg: *mut NSString = unsafe { msg_send![err, localizedDescription] };
+    if msg.is_null() {
+        return SmError::Other("nil localizedDescription".into());
+    }
+    let s = unsafe { (*msg).to_string() };
+    SmError::Other(s)
+}
+
+pub fn register_main_app() -> Result<(), SmError> {
+    let cls = sm_app_service_class();
+    let instance: *mut AnyObject = unsafe { msg_send![cls, mainAppService] };
+    if instance.is_null() {
+        return Err(SmError::Other("mainAppService returned nil".into()));
+    }
+    let mut error: *mut NSError = std::ptr::null_mut();
+    let ok: bool = unsafe {
+        msg_send![instance, registerAndReturnError: &mut error]
+    };
+    if ok { Ok(()) } else { Err(map_ns_error(error)) }
+}
+
+pub fn unregister_main_app() -> Result<(), SmError> {
+    let cls = sm_app_service_class();
+    let instance: *mut AnyObject = unsafe { msg_send![cls, mainAppService] };
+    let mut error: *mut NSError = std::ptr::null_mut();
+    let ok: bool = unsafe {
+        msg_send![instance, unregisterAndReturnError: &mut error]
+    };
+    if ok { Ok(()) } else { Err(map_ns_error(error)) }
+}
+```
+
+- [ ] **Step 3: Link ServiceManagement framework**
+
+Create `crates/vmux_service/build.rs` (or extend if one exists):
+
+```rust
+fn main() {
+    #[cfg(target_os = "macos")]
+    {
+        println!("cargo:rustc-link-lib=framework=ServiceManagement");
+    }
+}
+```
+
+(Verify `crates/vmux_service` doesn't already have a `build.rs` — it might, given webview build steps. If it does, append the println.)
+
+- [ ] **Step 4: Verify it compiles**
+
+```bash
+env -u CEF_PATH cargo build -p vmux_service
+env -u CEF_PATH cargo clippy -p vmux_service --all-targets -- -D warnings
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/vmux_service/{Cargo.toml,src/sm_app_service.rs,build.rs,tests/sm_app_service_module.rs}
+git commit -m "VMX-119: implement SMAppService.mainApp register/unregister"
+```
+
+---
+
+### Task C3: Implement register_agent + status query
+
+**Files:**
+- Modify: `crates/vmux_service/src/sm_app_service.rs`
+
+`SMAppService.agent(plistName:)` returns an instance scoped to a specific embedded plist. The plist must live at `Contents/Library/LaunchAgents/<plistName>` inside the running .app.
+
+- [ ] **Step 1: Implement `register_agent` / `unregister_agent`**
+
+```rust
+fn agent_instance(plist_name: &str) -> Result<*mut AnyObject, SmError> {
+    let cls = sm_app_service_class();
+    let ns_name = NSString::from_str(plist_name);
+    let instance: *mut AnyObject = unsafe {
+        msg_send![cls, agentServiceWithPlistName: &*ns_name]
+    };
+    if instance.is_null() {
+        Err(SmError::Other(format!("no agent for plist {plist_name}")))
+    } else {
+        Ok(instance)
+    }
+}
+
+pub fn register_agent(plist_name: &str) -> Result<(), SmError> {
+    let instance = agent_instance(plist_name)?;
+    let mut error: *mut NSError = std::ptr::null_mut();
+    let ok: bool = unsafe {
+        msg_send![instance, registerAndReturnError: &mut error]
+    };
+    if ok { Ok(()) } else { Err(map_ns_error(error)) }
+}
+
+pub fn unregister_agent(plist_name: &str) -> Result<(), SmError> {
+    let instance = agent_instance(plist_name)?;
+    let mut error: *mut NSError = std::ptr::null_mut();
+    let ok: bool = unsafe {
+        msg_send![instance, unregisterAndReturnError: &mut error]
+    };
+    if ok { Ok(()) } else { Err(map_ns_error(error)) }
+}
+```
+
+- [ ] **Step 2: Implement status queries**
+
+```rust
+fn raw_status(instance: *mut AnyObject) -> Status {
+    // SMAppServiceStatus enum:
+    //   0 = NotRegistered, 1 = Enabled, 2 = RequiresApproval, 3 = NotFound
+    let raw: i64 = unsafe { msg_send![instance, status] };
+    match raw {
+        0 => Status::NotRegistered,
+        1 => Status::Enabled,
+        2 => Status::RequiresApproval,
+        _ => Status::NotFound,
+    }
+}
+
+pub fn main_app_status() -> Status {
+    let cls = sm_app_service_class();
+    let instance: *mut AnyObject = unsafe { msg_send![cls, mainAppService] };
+    if instance.is_null() { Status::NotFound } else { raw_status(instance) }
+}
+
+pub fn agent_status(plist_name: &str) -> Status {
+    match agent_instance(plist_name) {
+        Ok(instance) => raw_status(instance),
+        Err(_) => Status::NotFound,
+    }
+}
+```
+
+- [ ] **Step 3: Verify build + clippy**
+
+```bash
+env -u CEF_PATH cargo build -p vmux_service
+env -u CEF_PATH cargo clippy -p vmux_service --all-targets -- -D warnings
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/vmux_service/src/sm_app_service.rs
+git commit -m "VMX-119: SMAppService agent register + status queries"
+```
+
+---
+
+## Task Group D — Wire SMAppService at Runtime
+
+Goal: `Vmux.app` registers itself on first launch. `ensure_service_started` dispatches to SMAppService when bundled, falls back to existing `launchd::ensure_running` for `cargo run` dev mode.
+
+### Task D1: Bundle-detection helper
+
+**Files:**
+- Create: `crates/vmux_service/src/bundle.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `crates/vmux_service/tests/bundle_detection.rs`:
+
+```rust
+use std::path::PathBuf;
+use vmux_service::bundle;
+
+#[test]
+fn detects_bundled_when_exe_inside_app_macos() {
+    let exe = PathBuf::from("/Applications/Vmux.app/Contents/MacOS/vmux_desktop");
+    assert!(bundle::is_bundled_path(&exe));
+}
+
+#[test]
+fn detects_not_bundled_when_target_debug() {
+    let exe = PathBuf::from("/Users/x/repo/target/debug/vmux_desktop");
+    assert!(!bundle::is_bundled_path(&exe));
+}
+
+#[test]
+fn bundle_root_resolves_app_path() {
+    let exe = PathBuf::from("/Applications/Vmux.app/Contents/MacOS/vmux_desktop");
+    assert_eq!(
+        bundle::bundle_root_for(&exe).unwrap(),
+        PathBuf::from("/Applications/Vmux.app")
+    );
+}
+
+#[test]
+fn bundle_root_none_when_not_bundled() {
+    let exe = PathBuf::from("/Users/x/repo/target/debug/vmux_desktop");
+    assert!(bundle::bundle_root_for(&exe).is_none());
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_service --test bundle_detection
+```
+
+- [ ] **Step 3: Implement**
+
+Create `crates/vmux_service/src/bundle.rs`:
+
+```rust
+use std::path::{Path, PathBuf};
+
+/// True if `exe` lives at `<X>.app/Contents/MacOS/<binary>`.
+pub fn is_bundled_path(exe: &Path) -> bool {
+    bundle_root_for(exe).is_some()
+}
+
+/// Returns the `.app` root if `exe` lives inside a macOS bundle.
+pub fn bundle_root_for(exe: &Path) -> Option<PathBuf> {
+    let parent = exe.parent()?; // …/Contents/MacOS
+    if parent.file_name()?.to_str()? != "MacOS" { return None; }
+    let contents = parent.parent()?; // …/Contents
+    if contents.file_name()?.to_str()? != "Contents" { return None; }
+    let app = contents.parent()?; // …/X.app
+    if app.extension()?.to_str()? == "app" { Some(app.to_path_buf()) } else { None }
+}
+
+/// Resolve bundle root for the currently-running executable.
+pub fn current_bundle_root() -> Option<PathBuf> {
+    bundle_root_for(&std::env::current_exe().ok()?)
+}
+
+/// True if the running process lives inside a `.app` bundle.
+pub fn is_bundled() -> bool {
+    current_bundle_root().is_some()
+}
+
+/// Plist filename of the embedded launchd agent (matches packaging/macos/ai.vmux.service.plist).
+pub const EMBEDDED_AGENT_PLIST: &str = "ai.vmux.service.plist";
+```
+
+Register in `crates/vmux_service/src/lib.rs`:
+
+```rust
+#[cfg(not(target_arch = "wasm32"))]
+pub mod bundle;
+```
+
+- [ ] **Step 4: Verify tests pass**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_service --test bundle_detection
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/vmux_service/src/{lib.rs,bundle.rs} crates/vmux_service/tests/bundle_detection.rs
+git commit -m "VMX-119: bundle-detection helpers"
+```
+
+---
+
+### Task D2: Service-registration dispatcher
+
+**Files:**
+- Create: `crates/vmux_service/src/service_registration.rs`
+- Modify: `crates/vmux_desktop/src/terminal.rs:608-650` (`ensure_service_started`)
+
+- [ ] **Step 1: Write failing test**
+
+Create `crates/vmux_service/tests/service_registration_dispatch.rs`:
+
+```rust
+use std::path::PathBuf;
+use vmux_service::service_registration::{Backend, choose_backend};
+
+#[test]
+fn bundled_path_chooses_sm_app_service() {
+    let exe = PathBuf::from("/Applications/Vmux.app/Contents/MacOS/vmux_service");
+    assert!(matches!(choose_backend(&exe), Backend::SmAppService { .. }));
+}
+
+#[test]
+fn unbundled_path_chooses_launchctl() {
+    let exe = PathBuf::from("/Users/x/repo/target/debug/vmux_service");
+    assert!(matches!(choose_backend(&exe), Backend::Launchctl));
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_service --test service_registration_dispatch
+```
+
+- [ ] **Step 3: Implement dispatcher**
+
+Create `crates/vmux_service/src/service_registration.rs`:
+
+```rust
+use std::path::{Path, PathBuf};
+
+use crate::bundle;
+
+#[derive(Debug)]
+pub enum Backend {
+    /// Bundled: register Vmux.app + agent via SMAppService.
+    SmAppService { bundle_root: PathBuf },
+    /// Not bundled: write per-profile plist into ~/Library/LaunchAgents and launchctl bootstrap.
+    Launchctl,
+}
+
+pub fn choose_backend(exe: &Path) -> Backend {
+    if let Some(root) = bundle::bundle_root_for(exe) {
+        Backend::SmAppService { bundle_root: root }
+    } else {
+        Backend::Launchctl
+    }
+}
+
+#[derive(Debug)]
+pub enum RegistrationError {
+    Io(std::io::Error),
+    #[cfg(target_os = "macos")]
+    SmAppService(crate::sm_app_service::SmError),
+}
+
+impl From<std::io::Error> for RegistrationError {
+    fn from(e: std::io::Error) -> Self { Self::Io(e) }
+}
+
+#[cfg(target_os = "macos")]
+impl From<crate::sm_app_service::SmError> for RegistrationError {
+    fn from(e: crate::sm_app_service::SmError) -> Self { Self::SmAppService(e) }
+}
+
+/// Idempotent: ensure the daemon is registered and running.
+/// Dispatches to the SMAppService path when bundled, launchctl otherwise.
+pub fn ensure_running(profile: &str, exe: &Path) -> Result<(), RegistrationError> {
+    match choose_backend(exe) {
+        Backend::SmAppService { .. } => {
+            #[cfg(target_os = "macos")]
+            {
+                crate::sm_app_service::register_main_app()?;
+                crate::sm_app_service::register_agent(bundle::EMBEDDED_AGENT_PLIST)?;
+                Ok(())
+            }
+            #[cfg(not(target_os = "macos"))]
+            { Ok(()) }
+        }
+        Backend::Launchctl => {
+            #[cfg(target_os = "macos")]
+            { crate::launchd::ensure_running(profile, exe)?; Ok(()) }
+            #[cfg(not(target_os = "macos"))]
+            { let _ = (profile, exe); Ok(()) }
+        }
+    }
+}
+```
+
+Add to `crates/vmux_service/src/lib.rs`:
+
+```rust
+#[cfg(not(target_arch = "wasm32"))]
+pub mod service_registration;
+```
+
+- [ ] **Step 4: Update call site in vmux_desktop**
+
+In `crates/vmux_desktop/src/terminal.rs:619-626`, replace:
+
+```rust
+#[cfg(target_os = "macos")]
+{
+    let profile = vmux_service::current_profile();
+    if let Err(e) = vmux_service::launchd::ensure_running(profile, &binary) {
+        tracing::error!(error = %e, "launchd ensure_running failed");
+    }
+}
+```
+
+with:
+
+```rust
+#[cfg(target_os = "macos")]
+{
+    let profile = vmux_service::current_profile();
+    if let Err(e) = vmux_service::service_registration::ensure_running(profile, &binary) {
+        tracing::error!(error = ?e, "service registration failed");
+    }
+}
+```
+
+- [ ] **Step 5: Verify tests pass + workspace builds**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_service --test service_registration_dispatch
+env -u CEF_PATH cargo build -p vmux_desktop
+env -u CEF_PATH cargo clippy -p vmux_service -p vmux_desktop --all-targets -- -D warnings
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/vmux_service/src/{lib.rs,service_registration.rs} crates/vmux_service/tests/service_registration_dispatch.rs crates/vmux_desktop/src/terminal.rs
+git commit -m "VMX-119: dispatch SMAppService when bundled, launchctl otherwise"
+```
+
+---
+
+## Task Group E — Migration of Legacy Plists
+
+Goal: First launch of new Vmux.app removes any pre-existing `~/Library/LaunchAgents/ai.vmux.service.*.plist` and unloads them from launchd. Idempotent.
+
+### Task E1: Legacy plist scanner + removal
+
+**Files:**
+- Create: `crates/vmux_service/src/legacy_plist_cleanup.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `crates/vmux_service/tests/legacy_plist_cleanup.rs`:
+
+```rust
+use std::fs;
+use vmux_service::legacy_plist_cleanup;
+
+#[test]
+fn finds_and_lists_legacy_plists() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("ai.vmux.service.plist"), "<plist/>").unwrap();
+    fs::write(dir.path().join("ai.vmux.service.dev.plist"), "<plist/>").unwrap();
+    fs::write(dir.path().join("ai.vmux.service.abc1234.plist"), "<plist/>").unwrap();
+    fs::write(dir.path().join("com.unrelated.app.plist"), "<plist/>").unwrap();
+
+    let found = legacy_plist_cleanup::find_legacy_plists_in(dir.path()).unwrap();
+    assert_eq!(found.len(), 3, "should find 3 vmux plists, ignoring unrelated: {found:?}");
+}
+
+#[test]
+fn extracts_label_from_filename() {
+    assert_eq!(
+        legacy_plist_cleanup::label_from_filename("ai.vmux.service.dev.plist"),
+        Some("ai.vmux.service.dev")
+    );
+    assert_eq!(
+        legacy_plist_cleanup::label_from_filename("ai.vmux.service.plist"),
+        Some("ai.vmux.service")
+    );
+    assert_eq!(
+        legacy_plist_cleanup::label_from_filename("com.other.plist"),
+        None
+    );
+}
+
+#[test]
+fn cleanup_removes_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let plist = dir.path().join("ai.vmux.service.dev.plist");
+    fs::write(&plist, "<plist/>").unwrap();
+    assert!(plist.exists());
+
+    legacy_plist_cleanup::remove_plist_files(&[plist.clone()]).unwrap();
+    assert!(!plist.exists());
+}
+
+#[test]
+fn cleanup_is_idempotent_when_no_files_present() {
+    let dir = tempfile::tempdir().unwrap();
+    let found = legacy_plist_cleanup::find_legacy_plists_in(dir.path()).unwrap();
+    assert!(found.is_empty());
+}
+```
+
+Add `tempfile` to dev-dependencies if not present:
+
+```bash
+cd crates/vmux_service
+cargo add --dev tempfile
+cd ../..
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_service --test legacy_plist_cleanup
+```
+
+- [ ] **Step 3: Implement module**
+
+Create `crates/vmux_service/src/legacy_plist_cleanup.rs`:
+
+```rust
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const LABEL_PREFIX: &str = "ai.vmux.service";
+
+pub fn launch_agents_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .map(|h| PathBuf::from(h).join("Library/LaunchAgents"))
+}
+
+pub fn label_from_filename(name: &str) -> Option<&str> {
+    let stem = name.strip_suffix(".plist")?;
+    if stem == LABEL_PREFIX || stem.starts_with(&format!("{LABEL_PREFIX}.")) {
+        Some(stem)
+    } else {
+        None
+    }
+}
+
+pub fn find_legacy_plists_in(dir: &Path) -> std::io::Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    if !dir.exists() { return Ok(out); }
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|s| s.to_str()) else { continue };
+        if label_from_filename(name).is_some() {
+            out.push(path);
+        }
+    }
+    Ok(out)
+}
+
+pub fn remove_plist_files(paths: &[PathBuf]) -> std::io::Result<()> {
+    for path in paths {
+        match std::fs::remove_file(path) {
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+pub fn bootout_label(label: &str) {
+    let uid = unsafe { libc::getuid() };
+    let _ = Command::new("launchctl")
+        .args(["bootout", &format!("gui/{uid}/{label}")])
+        .status();
+}
+
+/// Run once on first launch of new Vmux.app: bootout + delete every legacy plist.
+pub fn cleanup_legacy_registrations() -> std::io::Result<usize> {
+    let Some(dir) = launch_agents_dir() else { return Ok(0); };
+    let paths = find_legacy_plists_in(&dir)?;
+    #[cfg(target_os = "macos")]
+    for path in &paths {
+        if let Some(name) = path.file_name().and_then(|s| s.to_str())
+            && let Some(label) = label_from_filename(name)
+        {
+            bootout_label(label);
+        }
+    }
+    let count = paths.len();
+    remove_plist_files(&paths)?;
+    Ok(count)
+}
+```
+
+Register in `crates/vmux_service/src/lib.rs`:
+
+```rust
+#[cfg(not(target_arch = "wasm32"))]
+pub mod legacy_plist_cleanup;
+```
+
+- [ ] **Step 4: Verify tests pass**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_service --test legacy_plist_cleanup
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/vmux_service/{Cargo.toml,src/{lib.rs,legacy_plist_cleanup.rs}} crates/vmux_service/tests/legacy_plist_cleanup.rs Cargo.lock
+git commit -m "VMX-119: legacy plist scanner + cleanup helpers"
+```
+
+---
+
+### Task E2: Trigger cleanup on first launch of bundled Vmux.app
+
+**Files:**
+- Modify: `crates/vmux_service/src/service_registration.rs`
+
+- [ ] **Step 1: Write the test**
+
+Add to `crates/vmux_service/tests/service_registration_dispatch.rs`:
+
+```rust
+#[test]
+fn ensure_running_calls_legacy_cleanup_for_sm_app_service_path() {
+    // Compile-time check: cleanup_legacy_registrations symbol referenced from service_registration.
+    let source = include_str!("../src/service_registration.rs");
+    assert!(
+        source.contains("cleanup_legacy_registrations"),
+        "SmAppService branch must invoke legacy cleanup"
+    );
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_service --test service_registration_dispatch ensure_running_calls_legacy_cleanup
+```
+
+- [ ] **Step 3: Wire cleanup into the SmAppService branch**
+
+In `service_registration.rs`, expand the `Backend::SmAppService` arm:
+
+```rust
+Backend::SmAppService { .. } => {
+    #[cfg(target_os = "macos")]
+    {
+        match crate::legacy_plist_cleanup::cleanup_legacy_registrations() {
+            Ok(0) => {}
+            Ok(n) => tracing::info!(removed = n, "removed legacy launchd plists"),
+            Err(e) => tracing::warn!(error = %e, "legacy plist cleanup failed (continuing)"),
+        }
+        crate::sm_app_service::register_main_app()?;
+        crate::sm_app_service::register_agent(bundle::EMBEDDED_AGENT_PLIST)?;
+        Ok(())
+    }
+    #[cfg(not(target_os = "macos"))]
+    { Ok(()) }
+}
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_service --all-targets
+env -u CEF_PATH cargo clippy -p vmux_service --all-targets -- -D warnings
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/vmux_service/src/service_registration.rs crates/vmux_service/tests/service_registration_dispatch.rs
+git commit -m "VMX-119: clean up legacy plists on first SMAppService run"
+```
+
+---
+
+## Task Group F — Verification & Polish
+
+### Task F1: Add LSUIElement to Info.plist
+
+**Files:**
+- Modify: `packaging/macos/Info.plist`
+
+`LSUIElement=YES` removes the Dock icon — Vmux lives in the menu bar tray, not the Dock. Without this, the user sees a Dock icon for an app they're "supposed" to be running in the background.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to a new file `crates/vmux_desktop/tests/info_plist.rs`:
+
+```rust
+#[test]
+fn info_plist_marks_app_as_ui_element() {
+    let xml = include_str!("../../../packaging/macos/Info.plist");
+    assert!(xml.contains("<key>LSUIElement</key>"));
+    let after_key = xml.split("<key>LSUIElement</key>").nth(1).unwrap();
+    assert!(
+        after_key.trim_start().starts_with("<true/>"),
+        "LSUIElement must be true so Vmux runs as menu-bar-only"
+    );
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_desktop --test info_plist
+```
+
+- [ ] **Step 3: Edit Info.plist**
+
+Add to `packaging/macos/Info.plist` before `</dict>`:
+
+```xml
+	<key>LSUIElement</key>
+	<true/>
+```
+
+- [ ] **Step 4: Verify test passes**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_desktop --test info_plist
+```
+
+- [ ] **Step 5: Manual smoke test**
+
+```bash
+make build-local
+sha="$(git rev-parse --short HEAD)"
+open "target/release/Vmux ($sha).app"
+# No Dock icon should appear; tray icon visible in menu bar
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packaging/macos/Info.plist crates/vmux_desktop/tests/info_plist.rs
+git commit -m "VMX-119: LSUIElement=YES, run as menu-bar app"
+```
+
+---
+
+### Task F2: Manual verification checklist
+
+These are not automated — they must be performed against a real signed+notarized release build before merging.
+
+- [ ] **Step 1: Full release build**
+
+```bash
+make build-release
+```
+
+- [ ] **Step 2: Install to /Applications**
+
+```bash
+cp -R target/release/Vmux.app /Applications/
+```
+
+- [ ] **Step 3: First launch**
+
+```bash
+open /Applications/Vmux.app
+```
+
+Expected:
+- No Dock icon
+- Tray icon appears in menu bar
+- macOS may prompt: "Vmux added itself to your Login Items" (SMAppService UX)
+
+- [ ] **Step 4: Check Login Items UI**
+
+Open *System Settings → General → Login Items & Extensions*.
+
+Expected:
+- Under "App Background Activity": **Vmux** with proper icon (not "vmux_service" + blank document)
+- No "Item from unidentified developer" string
+
+- [ ] **Step 5: Verify daemon is running under launchd**
+
+```bash
+launchctl list | grep vmux
+```
+
+Expected: line containing `ai.vmux.service` with a non-zero PID and exit code `0` or `-`.
+
+- [ ] **Step 6: Verify Cmd+Q does not kill the daemon**
+
+```bash
+# From inside Vmux: Cmd+Q
+# Then:
+ps aux | grep vmux_service | grep -v grep
+```
+
+Expected: `vmux_service` still running.
+
+- [ ] **Step 7: Verify killing UI does not kill terminals**
+
+```bash
+killall vmux_desktop
+ps aux | grep vmux_service | grep -v grep
+launchctl list | grep vmux
+```
+
+Expected: `vmux_service` still alive (launchd KeepAlive), terminal state preserved.
+
+- [ ] **Step 8: Reopen UI from tray, verify reattach**
+
+Click tray "Show Vmux" → window appears → existing terminals visible.
+
+- [ ] **Step 9: Quit cleanly via tray**
+
+Click tray "Quit Vmux" → confirm dialog (if terminals running) → both `vmux_desktop` and `vmux_service` exit.
+
+- [ ] **Step 10: Reboot test**
+
+Reboot the Mac. After login, `Vmux.app` should auto-launch (because mainApp registration). Verify tray appears.
+
+- [ ] **Step 11: Verify legacy plist cleanup**
+
+```bash
+ls ~/Library/LaunchAgents/ai.vmux.service.*.plist 2>/dev/null
+```
+
+Expected: no output (legacy plists removed by cleanup migration).
+
+---
+
+### Task F3: Update Homebrew cask reference
+
+**Files:**
+- Update vmux Homebrew tap (separate repo, out of this worktree) — note in PR description.
+
+- [ ] **Step 1: Check current cask**
+
+```bash
+gh api repos/vmux-ai/homebrew-tap/contents/Casks/vmux.rb --jq '.content' | base64 -d | head -40
+```
+
+- [ ] **Step 2: Confirm cask installs Vmux.app to /Applications**
+
+If the cask is already shipping the .app to `/Applications/`, no changes needed. If it's installing a bare binary, file a follow-up issue to convert to a `.app` cask. Either way, document in PR description.
+
+- [ ] **Step 3: Note in PR body**
+
+Add a "Distribution" section to the PR template summarizing: cask still installs to `/Applications/Vmux.app`, no Brewfile/cask change required.
+
+---
+
+### Task F4: Lint + test sweep on changed crates
+
+- [ ] **Step 1: Run pre-commit checks per AGENTS.md**
+
+```bash
+BASE="main"
+ROOT="$(git rev-parse --show-toplevel)"
+CHANGED_PKGS=$(
+  cargo metadata --no-deps --format-version 1 \
+  | jq -r '.packages[] | select(.manifest_path | test("patches") | not) | "\(.name)\t\(.manifest_path | sub("/Cargo\\.toml$"; ""))"' \
+  | while IFS=$'\t' read -r name dir; do
+      rel="${dir#"$ROOT"/}"; [ -z "$rel" ] && rel="."
+      if ! git diff --quiet "$BASE" -- "$rel"; then echo "$name"; fi
+    done
+)
+
+for pkg in $CHANGED_PKGS; do cargo fmt -p "$pkg" -- --check; done
+for pkg in $CHANGED_PKGS; do env -u CEF_PATH cargo clippy -p "$pkg" --all-targets -- -D warnings; done
+for pkg in $CHANGED_PKGS; do env -u CEF_PATH cargo test -p "$pkg"; done
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Open PR**
+
+```bash
+linear issue pr
+```
+
+PR title: `VMX-119: Vmux.app as signed background item; embed vmux_service helper`
+
+PR body should include:
+- Link to Linear issue
+- Architecture summary (copy from this plan's header)
+- Distribution note (Task F3)
+- Manual verification checklist results (Task F2)
+- Known follow-ups: TCC entitlements for Microphone / Process Tap (separate ticket once this lands)
+
+---
+
+## Open Questions / Future Work
+
+These are explicitly **out of scope** for this plan. File separate Linear issues if needed.
+
+1. **Microphone / Screen Recording / Process Tap entitlements** — required for the planned transcript / meeting-notes feature. Add `NSMicrophoneUsageDescription` to Info.plist, declare entitlements, request user consent. Separate ticket.
+2. **Settings UI for Login Items toggle** — let user disable Vmux from auto-launching at login via in-app Settings (calls `unregister_main_app()`). Today they can toggle it from System Settings.
+3. **Linux equivalent** — systemd user unit instead of launchd. Out of scope for macOS-only ticket.
+4. **`local` build SMAppService UX** — `cargo-packager` produces `Vmux ($SHA).app` at `target/release/`. SMAppService refuses to register apps outside `/Applications`. For local testing, either copy to `/Applications/` manually or accept that local builds use the launchctl fallback. Document in `make local` output.
+5. **CEF helper bundle ID** — CEF Helper apps inside the bundle have their own bundle IDs (e.g. `org.cef.helper`). TCC permissions for screen capture etc. may need separate consideration when transcript feature lands.

--- a/packaging/macos/Info.plist
+++ b/packaging/macos/Info.plist
@@ -30,5 +30,7 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright 2024-2025 Junichi Sugiura. MIT License.</string>
+	<key>LSUIElement</key>
+	<true/>
 </dict>
 </plist>

--- a/packaging/macos/ai.vmux.service.plist
+++ b/packaging/macos/ai.vmux.service.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>ai.vmux.service</string>
+  <key>BundleProgram</key>
+  <string>Contents/MacOS/vmux_service</string>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>Crashed</key>
+    <true/>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>ProcessType</key>
+  <string>Interactive</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>VMUX_BUILD_PROFILE</key>
+    <string>{{PROFILE}}</string>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>/tmp/vmux-service.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/vmux-service.log</string>
+</dict>
+</plist>

--- a/scripts/before-each-package.sh
+++ b/scripts/before-each-package.sh
@@ -14,6 +14,8 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 "$ROOT/scripts/inject-cef.sh"
 
 if [[ "${CARGO_PACKAGER_FORMAT:-}" == "dmg" ]]; then
+    VMUX_APP_BUNDLE="${VMUX_APP_BUNDLE:-$ROOT/target/release/Vmux.app}" \
+        "$ROOT/scripts/embed-launch-agent-plist.sh"
     APP_BUNDLE="${VMUX_APP_BUNDLE:-$ROOT/target/release/Vmux.app}" \
         "$ROOT/scripts/sign-and-notarize.sh"
 fi

--- a/scripts/embed-launch-agent-plist.sh
+++ b/scripts/embed-launch-agent-plist.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Embed packaging/macos/ai.vmux.service.plist inside Vmux.app, substituting
+# the build profile (and per-SHA label for local builds).
+#
+# Required env: VMUX_APP_BUNDLE, VMUX_BUILD_PROFILE
+# Optional env: VMUX_GIT_HASH (required when VMUX_BUILD_PROFILE=local)
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+: "${VMUX_APP_BUNDLE:?VMUX_APP_BUNDLE not set}"
+: "${VMUX_BUILD_PROFILE:?VMUX_BUILD_PROFILE not set}"
+
+PLIST_SRC="$ROOT/packaging/macos/ai.vmux.service.plist"
+PLIST_DST="$VMUX_APP_BUNDLE/Contents/Library/LaunchAgents/ai.vmux.service.plist"
+
+LABEL="ai.vmux.service"
+if [[ "$VMUX_BUILD_PROFILE" == "local" ]]; then
+    : "${VMUX_GIT_HASH:?VMUX_GIT_HASH must be set for local builds}"
+    LABEL="ai.vmux.service.$VMUX_GIT_HASH"
+fi
+
+mkdir -p "$(dirname "$PLIST_DST")"
+sed -e "s|{{PROFILE}}|$VMUX_BUILD_PROFILE|g" \
+    -e "s|<string>ai.vmux.service</string>|<string>$LABEL</string>|" \
+    "$PLIST_SRC" > "$PLIST_DST"
+echo "==> Embedded launchd plist (label=$LABEL, profile=$VMUX_BUILD_PROFILE)"

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -88,13 +88,17 @@ fi
 
 # inject-cef only meaningfully runs in the dmg-format pass (the .app
 # doesn't exist during the app-format pass). For local app-only builds,
-# run it manually here so the freshly-built .app gets CEF + webview assets.
+# run it manually here so the freshly-built .app gets CEF + webview assets,
+# then sign + notarize using the same identity as a release build.
 if [[ "$PROFILE" == "local" && -d "$VMUX_APP_BUNDLE" ]]; then
     echo "==> Injecting CEF into .app (local build)"
     CARGO_PACKAGER_FORMAT=dmg bash "$ROOT/scripts/inject-cef.sh"
 
     echo "==> Embedding launchd plist (local build)"
     VMUX_GIT_HASH="$SHA" "$ROOT/scripts/embed-launch-agent-plist.sh"
+
+    echo "==> Signing + notarizing local build"
+    APP_BUNDLE="$VMUX_APP_BUNDLE" "$ROOT/scripts/sign-and-notarize.sh"
 fi
 
 echo "==> Packaging complete: $VMUX_APP_BUNDLE"

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -92,6 +92,9 @@ fi
 if [[ "$PROFILE" == "local" && -d "$VMUX_APP_BUNDLE" ]]; then
     echo "==> Injecting CEF into .app (local build)"
     CARGO_PACKAGER_FORMAT=dmg bash "$ROOT/scripts/inject-cef.sh"
+
+    echo "==> Embedding launchd plist (local build)"
+    VMUX_GIT_HASH="$SHA" "$ROOT/scripts/embed-launch-agent-plist.sh"
 fi
 
 echo "==> Packaging complete: $VMUX_APP_BUNDLE"

--- a/scripts/test-bundle-layout.sh
+++ b/scripts/test-bundle-layout.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Asserts the .app bundle has the expected layout. Exits non-zero on failure.
+set -euo pipefail
+APP="${1:?usage: $0 <path-to-Vmux.app>}"
+
+REQUIRED=(
+    "Contents/MacOS/vmux_desktop"
+    "Contents/MacOS/vmux"
+    "Contents/MacOS/vmux_service"
+    "Contents/Library/LaunchAgents/ai.vmux.service.plist"
+    "Contents/Info.plist"
+    "Contents/Resources/Vmux.icns"
+)
+
+for path in "${REQUIRED[@]}"; do
+    if [[ ! -e "$APP/$path" ]]; then
+        echo "MISSING: $APP/$path" >&2
+        exit 1
+    fi
+done
+
+if grep -q '{{PROFILE}}' "$APP/Contents/Library/LaunchAgents/ai.vmux.service.plist"; then
+    echo "Plist still has {{PROFILE}} placeholder — substitution did not run" >&2
+    exit 1
+fi
+
+echo "OK: bundle layout correct"


### PR DESCRIPTION
## Summary

Migrate vmux's background-service registration from path-based `~/Library/LaunchAgents/ai.vmux.service.*.plist` to **`Vmux.app` as a signed background item** registered via `SMAppService`. Embed `vmux_service` inside the bundle as a launchd-supervised helper.

Result in *System Settings → Login Items & Extensions*: shows **Vmux** with proper icon + Developer ID team — no more `vmux_service` blank doc + "unidentified developer".

Why this matters: TCC permissions (Microphone, Screen Recording, Process Tap) are keyed by bundle ID + signing identity. Path-based binaries lose grants on every version/SHA change. This change unblocks the planned transcript / meeting-notes feature.

Pattern matches OrbStack / Docker / Tailscale.

Closes VMX-119.

## Architecture

```
Vmux.app/
  Contents/
    Info.plist                              ← LSUIElement=YES (no Dock icon)
    MacOS/
      vmux_desktop                          ← UI (bevy + CEF)
      vmux_service                          ← daemon helper, supervised by launchd
    Library/
      LaunchAgents/
        ai.vmux.service.plist               ← embedded plist, BundleProgram (relative)
```

- `Vmux.app` registered via `SMAppService.mainApp.register()` on first launch
- `vmux_service` registered via `SMAppService.agent(plistName:).register()` from inside the app
- launchd `KeepAlive { Crashed: true }` → terminals survive UI crashes
- Cmd+Q hides the window, terminal state survives; explicit "Quit Vmux" via tray menu only
- Dev-mode (`cargo run` outside a bundle) keeps the existing `launchd::ensure_running` path so iteration stays fast

## What changed

**UI lifecycle (Group A)**
- `WindowPlugin` opts out of last-window-close exit (`ExitCondition::DontExit`)
- Cmd+Q + window red-button close → hide window (was: kill app)
- New `BackgroundLifecyclePlugin` exposes `LifecycleEvent::{HideAllWindows, ShowAllWindows, QuitVmux}`
- New tray-icon menu with "Show Vmux" / "Quit Vmux" (typed `tray-icon = 0.24`, NonSend resource because `TrayIcon` is `!Send`)
- Confirm-quit dialog moved exclusively to the tray Quit path
- Close-last-pane in `browser.rs` also hides instead of despawning (no more `ClosingWindow` insert anywhere in `vmux_desktop`)

**Bundle (Group B)**
- `vmux_service` added to cargo-packager `binaries` list
- New `packaging/macos/ai.vmux.service.plist` with `BundleProgram` (relative path) + `KeepAlive` on crash
- New `scripts/embed-launch-agent-plist.sh` substitutes `{{PROFILE}}` and per-SHA label
- Wired into `before-each-package.sh` (release dmg pass) + `package.sh` (local pass), both BEFORE codesigning
- New `scripts/test-bundle-layout.sh` checker

**SMAppService (Groups C–E)**
- New `crates/vmux_service/src/sm_app_service.rs` using `objc2-service-management = "0.3"` typed bindings (no raw `msg_send!`)
- New `crates/vmux_service/src/bundle.rs` detects "running inside .app"
- New `crates/vmux_service/src/service_registration.rs` dispatches: SMAppService when bundled, falls through to existing `launchd::ensure_running` for dev
- New `crates/vmux_service/src/legacy_plist_cleanup.rs` removes orphan `~/Library/LaunchAgents/ai.vmux.service.*.plist` on first SMAppService run (idempotent)

**Info.plist**
- `LSUIElement=YES` → menu-bar-only, no Dock icon

**Build workflow improvements** (caught during VMX-119 verification)
- `make build-local` now uses real Developer ID + notarizes by default (`SKIP_NOTARIZE=1` opt-out via env)
- `package.sh` local branch invokes `sign-and-notarize.sh` within the temp-keychain lifecycle
- CI: stabilized `cargo-bin` cache keys (no longer rehash on workflow file edits)

## Test plan

Automated (all green):
- [x] `cargo fmt -p {vmux_command,vmux_service,vmux_desktop} -- --check`
- [x] `cargo clippy -p {vmux_command,vmux_service,vmux_desktop} --all-targets -- -D warnings`
- [x] `cargo test -p {vmux_command,vmux_service,vmux_desktop}` — 35 / 86 / 143 passing, 1 ignored (SMAppService integration test that requires a signed .app installed in /Applications)

Manual (against `make build-release` + install to /Applications):
- [ ] *System Settings → Login Items & Extensions* → "App Background Activity" shows **Vmux** with proper icon + team name (NOT `vmux_service` + "unidentified developer")
- [ ] `launchctl list | grep vmux` → `ai.vmux.service` with non-zero PID
- [ ] Cmd+Q on the window → window hides, `ps aux | grep vmux_service` still alive
- [ ] `killall vmux_desktop` → `vmux_service` survives, launchd-supervised
- [ ] Tray "Show Vmux" → window reappears, terminals reattach
- [ ] Tray "Quit Vmux" → confirm dialog (if terminals running) → both processes exit
- [ ] `ls ~/Library/LaunchAgents/ai.vmux.service.*.plist` → empty (legacy cleanup ran)
- [ ] Reboot → log in → tray icon appears (mainApp registration persists)

## Out of scope (follow-ups)

- TCC entitlements for Microphone / Screen Recording / Process Tap (separate ticket once this lands; needed for transcript feature)
- Settings UI toggle for Login Items (today: System Settings only)
- Linux equivalent (this is macOS-only)
- Homebrew cask: confirm `Vmux.app` installs to `/Applications/` (likely already correct from 0.0.6/0.0.7 releases)

## Implementation plan

`docs/plans/2026-05-13-vmux-app-background-item.md` — 1963 lines, 19 tasks (A1–A6, B1–B3, C1–C3, D1–D2, E1–E2, F1–F4) executed via subagent-driven workflow with two-stage review per task.
