### PR TITLE
chore(release): v0.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9069,7 +9069,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -9081,7 +9081,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9100,7 +9100,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9113,7 +9113,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9150,7 +9150,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9169,7 +9169,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -9197,7 +9197,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9206,7 +9206,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -9218,7 +9218,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "alacritty_terminal",
  "bevy",
@@ -9246,7 +9246,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "dioxus",
  "rkyv",
@@ -9260,7 +9260,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9277,7 +9277,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "dioxus",
  "dioxus-primitives",
@@ -9294,7 +9294,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_webview_app"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "bevy",
  "bevy_cef",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.7"
+version = "0.0.8"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "MIT"


### PR DESCRIPTION
Patch release. Bumps workspace version 0.0.7 -> 0.0.8. Releases on merge.