### PR TITLE
ci(release): move release prep into PR; main only publishes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,8 +259,51 @@ jobs:
     needs: changes
     if: needs.changes.outputs.packaging == 'true'
     runs-on: macos-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Detect release PR + idempotency
+        id: relprep
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+          TAG="v$VERSION"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+
+          if [ -z "${BASE_SHA:-}" ]; then
+            echo "Not a pull_request event; skipping release prep."
+            echo "IS_RELEASE_PR=0" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          BASE_VERSION=$(git show "${BASE_SHA}:Cargo.toml" 2>/dev/null | grep -m1 '^version' | sed 's/.*"\(.*\)".*/\1/' || true)
+          if [ "$BASE_VERSION" = "$VERSION" ]; then
+            echo "Version unchanged ($VERSION); not a release PR."
+            echo "IS_RELEASE_PR=0" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          echo "Release PR detected: $BASE_VERSION -> $VERSION"
+          echo "IS_RELEASE_PR=1" >> "$GITHUB_ENV"
+
+          if gh release view "$TAG" --json isDraft,assets >/tmp/r.json 2>/dev/null; then
+            asset_count=$(jq '.assets | length' /tmp/r.json)
+            CASK_URL=$(grep -m1 '^  url' Casks/vmux.rb | sed 's/.*"\(.*\)".*/\1/')
+            EXPECTED_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/Vmux_${VERSION}_aarch64.dmg"
+            if [ "$asset_count" -ge 4 ] && [ "$CASK_URL" = "$EXPECTED_URL" ]; then
+              echo "Draft release ready and cask matches; release prep already complete."
+              echo "PREP_DONE=1" >> "$GITHUB_ENV"
+            fi
+          fi
 
       - uses: dtolnay/rust-toolchain@1.95.0
         with:
@@ -321,6 +364,7 @@ jobs:
         run: TAILWINDCSS_INSTALL_DIR="$HOME/.local/bin" ./scripts/install-tailwindcss.sh
 
       - name: Build, sign, notarize, and package DMG
+        if: env.PREP_DONE != '1'
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -331,9 +375,115 @@ jobs:
           VMUX_UPDATE_PUBLIC_KEY: ${{ secrets.VMUX_UPDATE_PUBLIC_KEY }}
         run: ./scripts/build-mac-release.sh
 
-      - name: Upload .dmg
+      - name: Upload .dmg artifact
+        if: env.PREP_DONE != '1' && env.IS_RELEASE_PR != '1'
         uses: actions/upload-artifact@v4
         with:
           name: Vmux-${{ github.sha }}.dmg
           path: target/release/Vmux_*.dmg
           retention-days: 7
+
+      - name: Create binary tarball
+        if: env.PREP_DONE != '1' && env.IS_RELEASE_PR == '1'
+        run: |
+          cd target/release/Vmux.app/Contents/MacOS
+          tar czf "$GITHUB_WORKSPACE/target/release/vmux-v${VERSION}-aarch64-apple-darwin.tar.gz" Vmux
+
+      - name: Create app bundle tarball
+        if: env.PREP_DONE != '1' && env.IS_RELEASE_PR == '1'
+        run: |
+          cd target/release
+          tar czf "Vmux-v${VERSION}-aarch64-apple-darwin.app.tar.gz" Vmux.app
+
+      - name: Sign update artifact (minisign)
+        if: env.PREP_DONE != '1' && env.IS_RELEASE_PR == '1'
+        env:
+          VMUX_UPDATE_PRIVATE_KEY: ${{ secrets.VMUX_UPDATE_PRIVATE_KEY }}
+          VMUX_UPDATE_PRIVATE_KEY_PASSWORD: ${{ secrets.VMUX_UPDATE_PRIVATE_KEY_PASSWORD }}
+        run: |
+          TARBALL="target/release/Vmux-v${VERSION}-aarch64-apple-darwin.app.tar.gz"
+          cargo packager signer sign "${TARBALL}" \
+            --private-key "${VMUX_UPDATE_PRIVATE_KEY}" \
+            --password "${VMUX_UPDATE_PRIVATE_KEY_PASSWORD}"
+
+      - name: Update Homebrew cask + manifest
+        if: env.PREP_DONE != '1' && env.IS_RELEASE_PR == '1'
+        run: |
+          set -euo pipefail
+          DMG_NAME="Vmux_${VERSION}_aarch64.dmg"
+          DMG_PATH="target/release/${DMG_NAME}"
+          DMG_SHA=$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')
+          DMG_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${DMG_NAME}"
+
+          sed -i '' "s/version \".*\"/version \"${VERSION}\"/" Casks/vmux.rb
+          sed -i '' "s/sha256 \".*\"/sha256 \"${DMG_SHA}\"/" Casks/vmux.rb
+          sed -i '' "s|^  url \".*\"|  url \"${DMG_URL}\"|" Casks/vmux.rb
+
+          TARBALL="target/release/Vmux-v${VERSION}-aarch64-apple-darwin.app.tar.gz"
+          SIG=$(cat "${TARBALL}.sig")
+          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/Vmux-v${VERSION}-aarch64-apple-darwin.app.tar.gz"
+          DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          mkdir -p website/public
+          cat > website/public/updates.json <<EOF
+          {
+            "version": "v${VERSION}",
+            "pub_date": "${DATE}",
+            "platforms": {
+              "macos-aarch64": {
+                "url": "${URL}",
+                "signature": "${SIG}",
+                "format": "app"
+              }
+            },
+            "downloads": {
+              "macos-aarch64": {
+                "url": "${DMG_URL}",
+                "filename": "${DMG_NAME}"
+              }
+            }
+          }
+          EOF
+
+      - name: Create or update draft release with assets
+        if: env.PREP_DONE != '1' && env.IS_RELEASE_PR == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          ASSETS=(
+            "target/release/Vmux_${VERSION}_aarch64.dmg"
+            "target/release/vmux-v${VERSION}-aarch64-apple-darwin.tar.gz"
+            "target/release/Vmux-v${VERSION}-aarch64-apple-darwin.app.tar.gz"
+            "target/release/Vmux-v${VERSION}-aarch64-apple-darwin.app.tar.gz.sig"
+          )
+          if gh release view "$TAG" --json isDraft >/tmp/r.json 2>/dev/null; then
+            is_draft=$(jq -r .isDraft /tmp/r.json)
+            if [ "$is_draft" != "true" ]; then
+              echo "::error::Release $TAG already published; refusing to upload."
+              exit 1
+            fi
+            gh release upload "$TAG" "${ASSETS[@]}" --clobber
+          else
+            gh release create "$TAG" \
+              --draft \
+              --target "${{ github.event.pull_request.head.sha }}" \
+              --title "Vmux $TAG" \
+              --generate-notes \
+              "${ASSETS[@]}"
+          fi
+
+      - name: Commit cask + manifest to PR branch
+        if: env.PREP_DONE != '1' && env.IS_RELEASE_PR == '1'
+        env:
+          PR_BRANCH: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/vmux.rb website/public/updates.json
+          if git diff --cached --quiet; then
+            echo "Nothing to commit"
+            exit 0
+          fi
+          git commit -m "chore(release): update cask and update manifest to ${VERSION}"
+          git push origin "HEAD:${PR_BRANCH}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Detect release PR + idempotency
         id: relprep
@@ -406,48 +405,11 @@ jobs:
             --private-key "${VMUX_UPDATE_PRIVATE_KEY}" \
             --password "${VMUX_UPDATE_PRIVATE_KEY_PASSWORD}"
 
-      - name: Update Homebrew cask + manifest
-        if: env.PREP_DONE != '1' && env.IS_RELEASE_PR == '1'
-        run: |
-          set -euo pipefail
-          DMG_NAME="Vmux_${VERSION}_aarch64.dmg"
-          DMG_PATH="target/release/${DMG_NAME}"
-          DMG_SHA=$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')
-          DMG_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${DMG_NAME}"
-
-          sed -i '' "s/version \".*\"/version \"${VERSION}\"/" Casks/vmux.rb
-          sed -i '' "s/sha256 \".*\"/sha256 \"${DMG_SHA}\"/" Casks/vmux.rb
-          sed -i '' "s|^  url \".*\"|  url \"${DMG_URL}\"|" Casks/vmux.rb
-
-          TARBALL="target/release/Vmux-v${VERSION}-aarch64-apple-darwin.app.tar.gz"
-          SIG=$(cat "${TARBALL}.sig")
-          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/Vmux-v${VERSION}-aarch64-apple-darwin.app.tar.gz"
-          DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          mkdir -p website/public
-          cat > website/public/updates.json <<EOF
-          {
-            "version": "v${VERSION}",
-            "pub_date": "${DATE}",
-            "platforms": {
-              "macos-aarch64": {
-                "url": "${URL}",
-                "signature": "${SIG}",
-                "format": "app"
-              }
-            },
-            "downloads": {
-              "macos-aarch64": {
-                "url": "${DMG_URL}",
-                "filename": "${DMG_NAME}"
-              }
-            }
-          }
-          EOF
-
       - name: Create or update draft release with assets
         if: env.PREP_DONE != '1' && env.IS_RELEASE_PR == '1'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
           ASSETS=(
@@ -466,24 +428,8 @@ jobs:
           else
             gh release create "$TAG" \
               --draft \
-              --target "${{ github.event.pull_request.head.sha }}" \
+              --target "$HEAD_SHA" \
               --title "Vmux $TAG" \
               --generate-notes \
               "${ASSETS[@]}"
           fi
-
-      - name: Commit cask + manifest to PR branch
-        if: env.PREP_DONE != '1' && env.IS_RELEASE_PR == '1'
-        env:
-          PR_BRANCH: ${{ github.head_ref }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Casks/vmux.rb website/public/updates.json
-          if git diff --cached --quiet; then
-            echo "Nothing to commit"
-            exit 0
-          fi
-          git commit -m "chore(release): update cask and update manifest to ${VERSION}"
-          git push origin "HEAD:${PR_BRANCH}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       force:
-        description: "Release current Cargo.toml version even if unchanged from previous commit"
+        description: "Publish current Cargo.toml version even if unchanged from previous commit"
         type: boolean
         default: false
 
@@ -18,11 +18,6 @@ permissions:
 concurrency:
   group: release-main
   cancel-in-progress: false
-
-env:
-  CARGO_TERM_COLOR: always
-  TAILWINDCSS_VERSION: "4.2.4"
-  CEF_VERSION: "145.6.1+145.0.28"
 
 jobs:
   detect-version:
@@ -36,327 +31,58 @@ jobs:
       version: ${{ steps.detect.outputs.version }}
       tag: ${{ steps.detect.outputs.tag }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Detect version bump
         id: detect
         run: |
+          set -euo pipefail
           VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
-          SEMVER_RE='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$'
-          if ! printf '%s\n' "$VERSION" | grep -Eq "$SEMVER_RE"; then
-            echo "::error::Invalid Cargo.toml version: $VERSION"
-            exit 1
-          fi
           PREV_REF="HEAD^"
           if [ -n "${BEFORE_SHA:-}" ] && ! printf '%s\n' "$BEFORE_SHA" | grep -Eq '^0+$' && git cat-file -e "${BEFORE_SHA}:Cargo.toml" 2>/dev/null; then
             PREV_REF="$BEFORE_SHA"
           fi
           PREV_VERSION=$(git show "${PREV_REF}:Cargo.toml" 2>/dev/null | grep -m1 '^version' | sed 's/.*"\(.*\)".*/\1/' || true)
-          if [ "$PREV_VERSION" = "$VERSION" ]; then
-            if [ "${FORCE_RELEASE:-false}" = "true" ]; then
-              echo "Cargo.toml version unchanged ($VERSION); forcing release via workflow_dispatch."
-            else
-              echo "Cargo.toml version unchanged ($VERSION); skipping release."
-              echo "should_release=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          fi
-          TAG="v$VERSION"
-          RELEASE_SHA=$(git rev-parse HEAD)
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            TAG_SHA=$(git rev-parse "$TAG^{commit}")
-            if [ "$TAG_SHA" != "$RELEASE_SHA" ]; then
-              echo "::error::Tag already exists locally at $TAG_SHA, expected $RELEASE_SHA: $TAG"
-              exit 1
-            fi
-            echo "Tag already exists locally at release commit; resuming: $TAG"
-          fi
-          remote_tag_sha=$(git ls-remote --tags origin "refs/tags/$TAG^{}" | awk '{print $1}')
-          if [ -z "$remote_tag_sha" ]; then
-            remote_tag_sha=$(git ls-remote --tags origin "refs/tags/$TAG" | awk '{print $1}')
-          fi
-          if [ -n "$remote_tag_sha" ]; then
-            if [ "$remote_tag_sha" != "$RELEASE_SHA" ]; then
-              echo "::error::Tag already exists on origin at $remote_tag_sha, expected $RELEASE_SHA: $TAG"
-              exit 1
-            fi
-            echo "Tag already exists on origin at release commit; resuming: $TAG"
+          if [ "$PREV_VERSION" = "$VERSION" ] && [ "${FORCE_RELEASE:-false}" != "true" ]; then
+            echo "Version unchanged ($VERSION); skipping publish."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           echo "Detected version bump: $PREV_VERSION -> $VERSION"
           echo "should_release=true" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 
-  release-macos:
-    name: Release macOS
+  publish:
+    name: Publish Release
     needs: detect-version
     if: needs.detect-version.outputs.should_release == 'true'
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     env:
-      VERSION: ${{ needs.detect-version.outputs.version }}
       TAG: ${{ needs.detect-version.outputs.tag }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
 
-      - name: Re-run guard — exit if release already published with all assets
+      - name: Verify draft release exists with all assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          if gh release view "$TAG" --json isDraft,assets >/tmp/r.json 2>/dev/null; then
-            is_draft=$(jq -r .isDraft /tmp/r.json)
-            asset_count=$(jq '.assets | length' /tmp/r.json)
-            if [ "$is_draft" = "false" ] && [ "$asset_count" -ge 4 ]; then
-              echo "Release $TAG already published with $asset_count assets; nothing to do."
-              echo "ALREADY_DONE=1" >> "$GITHUB_ENV"
-            fi
+          if ! gh release view "$TAG" --json isDraft,assets >/tmp/r.json 2>/dev/null; then
+            echo "::error::No release for $TAG. CI on the release PR should have created a draft. Aborting."
+            exit 1
           fi
-
-      - name: Validate release secrets
-        if: env.ALREADY_DONE != '1'
-        env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          VMUX_UPDATE_PUBLIC_KEY: ${{ secrets.VMUX_UPDATE_PUBLIC_KEY }}
-          VMUX_UPDATE_PRIVATE_KEY: ${{ secrets.VMUX_UPDATE_PRIVATE_KEY }}
-          VMUX_UPDATE_PRIVATE_KEY_PASSWORD: ${{ secrets.VMUX_UPDATE_PRIVATE_KEY_PASSWORD }}
-        run: |
-          missing=0
-          for name in \
-            APPLE_CERTIFICATE \
-            APPLE_CERTIFICATE_PASSWORD \
-            APPLE_SIGNING_IDENTITY \
-            APPLE_ID \
-            APPLE_APP_PASSWORD \
-            APPLE_TEAM_ID \
-            VMUX_UPDATE_PUBLIC_KEY \
-            VMUX_UPDATE_PRIVATE_KEY \
-            VMUX_UPDATE_PRIVATE_KEY_PASSWORD
-          do
-            if [ -z "${!name:-}" ]; then
-              echo "::error::Missing GitHub secret: $name"
-              missing=1
-            fi
-          done
-          exit "$missing"
-
-      - name: Install Rust toolchain
-        if: env.ALREADY_DONE != '1'
-        uses: dtolnay/rust-toolchain@1.95.0
-        with:
-          targets: wasm32-unknown-unknown
-
-      - if: env.ALREADY_DONE != '1'
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-macos
-          cache-all-crates: true
-
-      - name: Cache cargo binaries
-        if: env.ALREADY_DONE != '1'
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/bin
-          key: cargo-bin-${{ runner.os }}-dx0.7.4-cp0.11.8-cef${{ env.CEF_VERSION }}
-
-      - name: Cache CEF framework
-        if: env.ALREADY_DONE != '1'
-        uses: actions/cache@v4
-        with:
-          path: ~/.local/share/Chromium Embedded Framework.framework
-          key: cef-${{ runner.os }}-${{ env.CEF_VERSION }}
-
-      - name: Cache tailwindcss
-        if: env.ALREADY_DONE != '1'
-        uses: actions/cache@v4
-        with:
-          path: ~/.local/bin/tailwindcss
-          key: tailwindcss-${{ runner.os }}-${{ env.TAILWINDCSS_VERSION }}
-
-      - name: Add ~/.local/bin to PATH
-        if: env.ALREADY_DONE != '1'
-        run: |
-          mkdir -p "$HOME/.local/bin"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: Install dioxus-cli
-        if: env.ALREADY_DONE != '1'
-        run: command -v dx >/dev/null 2>&1 || cargo install dioxus-cli --locked --version 0.7.4
-
-      - name: Install tailwindcss
-        if: env.ALREADY_DONE != '1'
-        run: TAILWINDCSS_INSTALL_DIR="$HOME/.local/bin" ./scripts/install-tailwindcss.sh
-
-      - name: Install CEF framework
-        if: env.ALREADY_DONE != '1'
-        run: |
-          if [ ! -d "$HOME/.local/share/Chromium Embedded Framework.framework" ]; then
-            command -v export-cef-dir >/dev/null 2>&1 || cargo install export-cef-dir@${{ env.CEF_VERSION }}
-            export-cef-dir --force "$HOME/.local/share"
+          asset_count=$(jq '.assets | length' /tmp/r.json)
+          if [ "$asset_count" -lt 4 ]; then
+            echo "::error::Release $TAG has only $asset_count assets; expected 4. Aborting."
+            exit 1
           fi
-
-      - name: Install bevy_cef tools
-        if: env.ALREADY_DONE != '1'
-        run: |
-          command -v bevy_cef_render_process >/dev/null 2>&1 || cargo install bevy_cef_render_process
-          command -v bevy_cef_bundle_app >/dev/null 2>&1 || cargo install bevy_cef_bundle_app
-
-      - name: Install cargo-packager (patched for macOS Tahoe)
-        if: env.ALREADY_DONE != '1'
-        run: |
-          if ! cargo-packager --version 2>/dev/null | grep -q '0.11.8'; then
-            cargo install --path patches/cargo-packager-0.11.8
-          fi
-
-      - name: Build, sign, notarize, and package DMG
-        if: env.ALREADY_DONE != '1'
-        env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          VMUX_UPDATE_PUBLIC_KEY: ${{ secrets.VMUX_UPDATE_PUBLIC_KEY }}
-        run: ./scripts/build-mac-release.sh
-
-      - name: Create binary tarball
-        if: env.ALREADY_DONE != '1'
-        run: |
-          cd target/release/Vmux.app/Contents/MacOS
-          tar czf "$GITHUB_WORKSPACE/target/release/vmux-v${VERSION}-aarch64-apple-darwin.tar.gz" Vmux
-
-      - name: Create app bundle tarball
-        if: env.ALREADY_DONE != '1'
-        run: |
-          cd target/release
-          tar czf "Vmux-v${VERSION}-aarch64-apple-darwin.app.tar.gz" Vmux.app
-
-      - name: Sign update artifact (minisign)
-        if: env.ALREADY_DONE != '1'
-        env:
-          VMUX_UPDATE_PRIVATE_KEY: ${{ secrets.VMUX_UPDATE_PRIVATE_KEY }}
-          VMUX_UPDATE_PRIVATE_KEY_PASSWORD: ${{ secrets.VMUX_UPDATE_PRIVATE_KEY_PASSWORD }}
-        run: |
-          TARBALL="target/release/Vmux-v${VERSION}-aarch64-apple-darwin.app.tar.gz"
-          cargo packager signer sign "${TARBALL}" \
-            --private-key "${VMUX_UPDATE_PRIVATE_KEY}" \
-            --password "${VMUX_UPDATE_PRIVATE_KEY_PASSWORD}"
-
-      - name: Generate update manifest
-        if: env.ALREADY_DONE != '1'
-        run: |
-          TARBALL="target/release/Vmux-v${VERSION}-aarch64-apple-darwin.app.tar.gz"
-          SIG=$(cat "${TARBALL}.sig")
-          URL="https://github.com/vmux-ai/vmux/releases/download/v${VERSION}/Vmux-v${VERSION}-aarch64-apple-darwin.app.tar.gz"
-          DMG_NAME="Vmux_${VERSION}_aarch64.dmg"
-          DMG_PATH="target/release/${DMG_NAME}"
-          DMG_URL="https://github.com/vmux-ai/vmux/releases/download/v${VERSION}/${DMG_NAME}"
-          DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          mkdir -p website/public
-          cat > website/public/updates.json <<EOF
-          {
-            "version": "v${VERSION}",
-            "pub_date": "${DATE}",
-            "platforms": {
-              "macos-aarch64": {
-                "url": "${URL}",
-                "signature": "${SIG}",
-                "format": "app"
-              }
-            },
-            "downloads": {
-              "macos-aarch64": {
-                "url": "${DMG_URL}",
-                "filename": "${DMG_NAME}"
-              }
-            }
-          }
-          EOF
-
-      - name: Capture release SHA
-        if: env.ALREADY_DONE != '1'
-        run: echo "RELEASE_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
-
-      - name: Update Homebrew cask
-        if: env.ALREADY_DONE != '1'
-        run: |
-          DMG_NAME="Vmux_${VERSION}_aarch64.dmg"
-          DMG_PATH="target/release/${DMG_NAME}"
-          DMG_SHA=$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')
-
-          sed -i '' "s/version \".*\"/version \"${VERSION}\"/" Casks/vmux.rb
-          sed -i '' "s/sha256 \".*\"/sha256 \"${DMG_SHA}\"/" Casks/vmux.rb
-          sed -i '' "s|^  url \".*\"|  url \"https://github.com/vmux-ai/vmux/releases/download/v${VERSION}/${DMG_NAME}\"|" Casks/vmux.rb
-
-      - name: Create or update draft release with assets
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: env.ALREADY_DONE != '1'
-        run: |
-          set -euo pipefail
-          DMG="target/release/Vmux_${VERSION}_aarch64.dmg"
-          ASSETS=(
-            "$DMG"
-            "target/release/vmux-v${VERSION}-aarch64-apple-darwin.tar.gz"
-            "target/release/Vmux-v${VERSION}-aarch64-apple-darwin.app.tar.gz"
-            "target/release/Vmux-v${VERSION}-aarch64-apple-darwin.app.tar.gz.sig"
-          )
-          if gh release view "$TAG" --json isDraft >/tmp/r.json 2>/dev/null; then
-            is_draft=$(jq -r .isDraft /tmp/r.json)
-            if [ "$is_draft" != "true" ]; then
-              echo "::error::Release $TAG already published but missing assets — refusing to upload to a public release. Inspect manually."
-              exit 1
-            fi
-            gh release upload "$TAG" "${ASSETS[@]}" --clobber
-          else
-            gh release create "$TAG" \
-              --draft \
-              --target "$RELEASE_SHA" \
-              --title "Vmux $TAG" \
-              --generate-notes \
-              "${ASSETS[@]}"
-          fi
-
-      - name: Commit cask + manifest to main
-        if: env.ALREADY_DONE != '1'
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Casks/vmux.rb website/public/updates.json
-          if git diff --cached --quiet; then
-            echo "Nothing to commit"
-            exit 0
-          fi
-          git commit -m "chore(release): update cask and update manifest to ${VERSION}"
-          for i in 1 2 3; do
-            if git pull --rebase origin main; then
-              break
-            fi
-            if [ "$i" -eq 3 ]; then
-              echo "::error::Failed to rebase onto main after 3 attempts"
-              exit 1
-            fi
-            sleep 5
-          done
-          git push origin HEAD:main
 
       - name: Re-target tag to current main HEAD
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: env.ALREADY_DONE != '1'
         run: |
           set -euo pipefail
           NEW_HEAD=$(git rev-parse HEAD)
@@ -371,11 +97,9 @@ jobs:
       - name: Publish release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: env.ALREADY_DONE != '1'
         run: gh release edit "$TAG" --draft=false
 
       - name: Dispatch website deploy
         env:
           GH_TOKEN: ${{ github.token }}
-        if: env.ALREADY_DONE != '1'
         run: gh workflow run deploy-website.yml --ref main


### PR DESCRIPTION
## Summary
Refactors release flow so cask + manifest land in the version-bump PR (not after merge), and the cask commit comes from the local /release skill (not from CI). Eliminates branch-protection bypass and PAT requirements.

**ci.yml `build-mac` job**: detects release PRs (Cargo.toml version diff vs base), builds + signs + notarizes, uploads assets to a draft GitHub Release. Idempotent re-run via `PREP_DONE` guard (skips rebuild when cask URL already matches and draft has all 4 assets).

**release.yml**: stripped down to publish-only — re-target tag to current main HEAD, flip draft → published, dispatch website deploy. No more rebuild on main push.

**/release skill**: after CI builds + uploads to draft, downloads DMG + signature, updates cask + manifest in the worktree, commits + pushes from local. The local push triggers fresh CI which validates the cask commit. Skill merges on green.

## Why
v0.0.7 and v0.0.8 both failed mid-release because the bot tried to push the cask commit to main directly, hitting branch-protection's required status checks. v0.0.8 needed manual recovery.

Moving the cask commit into the PR — and pushing it from the user's local machine via the skill — means it goes through the standard PR pipeline. No bypass, no PAT, no race with workflow-file PRs.

## Test plan
- [ ] Merge this PR (no release triggered — Cargo.toml unchanged)
- [ ] Run `/release patch` → expect v0.0.9 to be cut hands-free, end-to-end