### PR TITLE
chore(release): v0.0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9069,7 +9069,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "bevy",
  "chrono",
@@ -9081,7 +9081,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -9093,7 +9093,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9112,7 +9112,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9125,7 +9125,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9163,7 +9163,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9182,7 +9182,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -9210,7 +9210,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9219,7 +9219,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -9231,7 +9231,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "alacritty_terminal",
  "bevy",
@@ -9259,7 +9259,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "dioxus",
  "rkyv",
@@ -9273,7 +9273,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9290,7 +9290,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "dioxus",
  "dioxus-primitives",
@@ -9307,7 +9307,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_webview_app"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "bevy",
  "bevy_cef",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.8"
+version = "0.0.9"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "MIT"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.8"
-  sha256 "0c805515856d89249cf0e84ac399cff834f1b9c2f5d4808e60635cf04b22b564"
+  version "0.0.9"
+  sha256 "b146d184b07c03381b7127c751197c37d79c392a3454fa620c6db56d67e45ed4"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.8/Vmux_0.0.8_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.9/Vmux_0.0.9_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai"

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.8",
-  "pub_date": "2026-05-15T01:23:48Z",
+  "version": "v0.0.9",
+  "pub_date": "2026-05-15T16:36:25Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.8/Vmux-v0.0.8-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzV2cXhIV0tkcTZWcFRwenZkY0pqU0dXamFZRFo0bnhWOERuV0NWb1B2TlVsWGtrTGFTcEdadnd3OGVBUExULzYrZ3FKdzRlVTNuQlVvM3hoVWJUZndVPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzc4ODA3ODYxCWZpbGU6Vm11eC12MC4wLjgtYWFyY2g2NC1hcHBsZS1kYXJ3aW4uYXBwLnRhci5negpqVzI5RUNXVTZCVytkcEJLYVpMYnlCbFRHZS9oTmFIWXZhRklUd1BOTWg1WWYwUkxTMklWMUs4SGVHOFJXcHJ1ZlMxNjZldGxCUFNad3ZiQit1NFFBUT09Cg==",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.9/Vmux-v0.0.9-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzQvaVFTR1Y5bHZqYlA2cXZXYmhQR3hUT2g4TFMrUjNZeHg5MnFJdHkycFJpKy9UeEQ3N1hMVlc1cUVXSDUyQVdlSG5RaU5RUjU0THlOUkl2aWxRRUFvPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzc4ODYyNzI5CWZpbGU6Vm11eC12MC4wLjktYWFyY2g2NC1hcHBsZS1kYXJ3aW4uYXBwLnRhci5negpXdDU1RGdSZTdLNUk5bmlpQnpudUhQSjE1eXBsSG5BNThWNk9sQWw3WDhhOGkxcnpYZFNVQTR5aW9YSHI2NFBQaDBQdlRnaEZxcG1nQVhGS0NKU21BZz09Cg==",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.8/Vmux_0.0.8_aarch64.dmg",
-      "filename": "Vmux_0.0.8_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.9/Vmux_0.0.9_aarch64.dmg",
+      "filename": "Vmux_0.0.9_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
Patch release. Bumps workspace version 0.0.8 -> 0.0.9. Releases on merge.