### PR TITLE
fix(vmux_service): kickstart bundled daemon after SMAppService register

### DIFF
--- a/crates/vmux_service/src/bundle.rs
+++ b/crates/vmux_service/src/bundle.rs
@@ -35,3 +35,7 @@ pub fn is_bundled() -> bool {
 
 /// Plist filename of the embedded launchd agent (matches packaging/macos/ai.vmux.service.plist).
 pub const EMBEDDED_AGENT_PLIST: &str = "ai.vmux.service.plist";
+
+/// launchd label of the embedded agent (matches the <Label> in
+/// packaging/macos/ai.vmux.service.plist).
+pub const EMBEDDED_AGENT_LABEL: &str = "ai.vmux.service";

--- a/crates/vmux_service/src/launchd.rs
+++ b/crates/vmux_service/src/launchd.rs
@@ -120,9 +120,8 @@ pub fn bootout(profile: &str) -> std::io::Result<()> {
 }
 
 /// `launchctl kickstart -k gui/<uid>/<label>` -- restart cleanly.
-pub fn kickstart(profile: &str) -> std::io::Result<()> {
+pub fn kickstart(label: &str) -> std::io::Result<()> {
     let uid = current_uid();
-    let label = crate::launchd_label(profile);
     let status = Command::new("launchctl")
         .args(["kickstart", "-k", &format!("gui/{uid}/{label}")])
         .status()?;
@@ -143,7 +142,7 @@ pub fn ensure_running(profile: &str, binary_path: &Path) -> std::io::Result<()> 
         let _ = bootout(profile);
     }
     bootstrap(&plist)?;
-    kickstart(profile)
+    kickstart(&crate::launchd_label(profile))
 }
 
 #[cfg(test)]

--- a/crates/vmux_service/src/service_registration.rs
+++ b/crates/vmux_service/src/service_registration.rs
@@ -50,6 +50,7 @@ pub fn ensure_running(profile: &str, exe: &Path) -> Result<(), RegistrationError
                 }
                 crate::sm_app_service::register_main_app()?;
                 crate::sm_app_service::register_agent(bundle::EMBEDDED_AGENT_PLIST)?;
+                crate::launchd::kickstart(bundle::EMBEDDED_AGENT_LABEL)?;
                 Ok(())
             }
             #[cfg(not(target_os = "macos"))]

--- a/crates/vmux_service/tests/service_registration_dispatch.rs
+++ b/crates/vmux_service/tests/service_registration_dispatch.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use vmux_service::bundle::{EMBEDDED_AGENT_LABEL, EMBEDDED_AGENT_PLIST};
 use vmux_service::service_registration::{Backend, choose_backend};
 
 #[test]
@@ -19,5 +20,24 @@ fn ensure_running_calls_legacy_cleanup_for_sm_app_service_path() {
     assert!(
         source.contains("cleanup_legacy_registrations"),
         "SmAppService branch must invoke legacy cleanup"
+    );
+}
+
+#[test]
+fn ensure_running_kickstarts_after_register_for_sm_app_service_path() {
+    let source = include_str!("../src/service_registration.rs");
+    assert!(
+        source.contains("crate::launchd::kickstart(bundle::EMBEDDED_AGENT_LABEL)"),
+        "SmAppService branch must kickstart the embedded agent so it actually runs after registration"
+    );
+}
+
+#[test]
+fn embedded_agent_label_matches_packaging_plist() {
+    let plist = include_str!("../../../packaging/macos/ai.vmux.service.plist");
+    let needle = format!("<string>{EMBEDDED_AGENT_LABEL}</string>");
+    assert!(
+        plist.contains(&needle),
+        "EMBEDDED_AGENT_LABEL ({EMBEDDED_AGENT_LABEL}) must match the <Label> in {EMBEDDED_AGENT_PLIST}"
     );
 }


### PR DESCRIPTION
## Summary

`SMAppService::register*` only enables the launch agent — it does not launch the daemon. After upgrade (or any cold start of the bundled app), `vmux_service` stays in `exited` state, the unix socket is never created, and `try_connect_service` polls/gives up. Symptom: terminal panes (and `vmux://vibe/`, `vmux://claude/`, `vmux://codex/` agent tabs) stuck on "Loading…".

The unbundled `Backend::Launchctl` path already calls `kickstart` after `bootstrap`. The bundled `Backend::SmAppService` path was missing the equivalent.

## Changes

- `service_registration::ensure_running` now calls `launchd::kickstart(EMBEDDED_AGENT_LABEL)` after `register_agent` in the SMAppService branch.
- New `bundle::EMBEDDED_AGENT_LABEL = "ai.vmux.service"` constant, paired with the existing `EMBEDDED_AGENT_PLIST`.
- `launchd::kickstart` refactored to take a label directly (was: profile → label internally). Internal caller (`launchd::ensure_running`) updated.
- Tests:
  - `ensure_running_kickstarts_after_register_for_sm_app_service_path` — source-string check matching the existing `cleanup_legacy_registrations` test pattern.
  - `embedded_agent_label_matches_packaging_plist` — `include_str!`s the packaging plist and asserts the constant matches `<Label>`.

## Test plan

- [x] `cargo fmt -p vmux_service -- --check`
- [x] `env -u CEF_PATH cargo clippy -p vmux_service --all-targets -- -D warnings`
- [x] `env -u CEF_PATH cargo test -p vmux_service` (includes 2 new tests)
- [ ] Manual: install via brew, launch Vmux on a clean session, open `vmux://vibe/`, terminal should attach instead of stuck "Loading…"