### PR TITLE
fix(service): stop registering main app as macOS Login Item

### DIFF
--- a/crates/vmux_service/src/service_registration.rs
+++ b/crates/vmux_service/src/service_registration.rs
@@ -48,7 +48,9 @@ pub fn ensure_running(profile: &str, exe: &Path) -> Result<(), RegistrationError
                         tracing::warn!(error = %e, "legacy plist cleanup failed (continuing)")
                     }
                 }
-                crate::sm_app_service::register_main_app()?;
+                if let Err(e) = crate::sm_app_service::unregister_main_app() {
+                    tracing::debug!(error = %e, "unregister main app login item (ignored)");
+                }
                 crate::sm_app_service::register_agent(bundle::EMBEDDED_AGENT_PLIST)?;
                 crate::launchd::kickstart(bundle::EMBEDDED_AGENT_LABEL)?;
                 Ok(())


### PR DESCRIPTION
## Summary
- `vmux_service` no longer calls `SMAppService.mainAppService().register()`, so vmux stops adding itself to **System Settings → General → Login Items → Open at Login**.
- Replaces the call with `unregister_main_app()` (errors swallowed/logged) so existing installs that previously got registered are cleaned up on next launch.
- The launchd-supervised background agent (`register_agent(EMBEDDED_AGENT_PLIST)` + `kickstart`) is untouched — that path is still needed for the helper.

## Test plan
- [x] `cargo fmt -p vmux_service -- --check`
- [x] `env -u CEF_PATH cargo clippy -p vmux_service --all-targets -- -D warnings`
- [x] `env -u CEF_PATH cargo test -p vmux_service` (all pass, 1 pre-existing ignored)
- [x] Manual: launch `Vmux.app`, confirm it does NOT appear under System Settings → Login Items. On a machine where it was previously registered, confirm it disappears after one launch.