### PR TITLE
fix(service): group helper under Vmux in Login Items

### DIFF
--- a/crates/vmux_service/tests/embedded_plist.rs
+++ b/crates/vmux_service/tests/embedded_plist.rs
@@ -37,3 +37,17 @@ fn embedded_plist_sets_build_profile_release() {
     assert!(xml.contains("<key>VMUX_BUILD_PROFILE</key>"));
     assert!(xml.contains("{{PROFILE}}") || xml.contains("<string>release</string>"));
 }
+
+#[test]
+fn embedded_plist_associates_with_parent_bundle() {
+    let xml = include_str!("../../../packaging/macos/ai.vmux.service.plist");
+    assert!(
+        xml.contains("<key>AssociatedBundleIdentifiers</key>"),
+        "embedded plist must declare AssociatedBundleIdentifiers so Login Items \
+         displays the helper grouped under Vmux.app with the app icon/name"
+    );
+    assert!(
+        xml.contains("<string>ai.vmux.desktop</string>"),
+        "AssociatedBundleIdentifiers must include the parent app bundle id ai.vmux.desktop"
+    );
+}

--- a/packaging/macos/ai.vmux.service.plist
+++ b/packaging/macos/ai.vmux.service.plist
@@ -6,6 +6,10 @@
   <string>ai.vmux.service</string>
   <key>BundleProgram</key>
   <string>Contents/MacOS/vmux_service</string>
+  <key>AssociatedBundleIdentifiers</key>
+  <array>
+    <string>ai.vmux.desktop</string>
+  </array>
   <key>RunAtLoad</key>
   <false/>
   <key>KeepAlive</key>


### PR DESCRIPTION
## Context

macOS Login Items currently shows the SMAppService-registered service helper as a standalone "vmux_service" entry labeled "Item from unidentified developer", with a generic icon. The helper should display grouped under the Vmux app with the Vmux name and icon, the way Docker's helper shows under Docker.

## Implementation

Adds `AssociatedBundleIdentifiers` (containing `ai.vmux.desktop`) to `packaging/macos/ai.vmux.service.plist`. This is the documented mechanism Apple provides for telling Login Items that a launchd item belongs to a parent app — without it, macOS does not inherit the parent app's name and icon for the helper entry even when `BundleProgram` and parent bundle membership are known internally.

The `embed-launch-agent-plist.sh` substitutions (Label rewrite for per-SHA local builds, profile placeholder) are unaffected because they match different strings.

## Checks / QA

- [x] Repackage and reinstall Vmux.app (e.g. `make package` then drop into `/Applications`).
- [ ] Open System Settings → General → Login Items & Extensions → Allow in the Background.
- [ ] Confirm the helper now appears grouped under "Vmux" with the Vmux icon, not as a standalone "vmux_service" entry.