### PR TITLE
feat: history support (VMX-120)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -2371,9 +2371,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -3032,7 +3032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.31.2",
+ "nix 0.31.3",
  "windows-sys 0.61.2",
 ]
 
@@ -3166,9 +3166,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-asset-resolver"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8b546050ecfc7fcd310be344b2f3a2a79f21554c5a9e8df28e7a07e9b36009b"
+checksum = "69387edbbc60c7cb93ad96d8cc7a22b49a76e21643380b89b1c49a78d347ff60"
 dependencies = [
  "dioxus-cli-config",
  "http",
@@ -3198,18 +3198,18 @@ dependencies = [
 
 [[package]]
 name = "dioxus-cli-config"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ad73f0ff638cd27466d389cd57f0975f909b66130dc1c25d5212d4041e5352"
+checksum = "c000f584ddf608e2b272b3074bf11512a474eeeb2eb85a1915f276ce5c4a8615"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "dioxus-config-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e004bc8b958031117d373db2b5e0ab9d7e763751de129dd36f00ef7e318333cd"
+checksum = "7637091592978fbfdb45a16b26bd99fd97fb1bd7e31c6a963530e00c022af321"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3217,15 +3217,15 @@ dependencies = [
 
 [[package]]
 name = "dioxus-config-macros"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808a9994a9a2623e6b6890b6cc68def24bd669177ec4713684447fb46418c256"
+checksum = "54f9ed8fc1a215ad34bb8dbae42a4ea54efbcd26ca9006bbe5cca78e511bf25f"
 
 [[package]]
 name = "dioxus-core"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247ed8d679a13232641f1c84ba22246623fae01320b4c22db225c0b4f2fa7398"
+checksum = "45887100ff0cf89abeb8b659808294fda48cd53f3b424e36407dedffcfea830b"
 dependencies = [
  "anyhow",
  "const_format",
@@ -3245,9 +3245,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-core-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75fbe64029b90144041f8521300c7b3508e6c48caea3244de2ff5d1ade15390c"
+checksum = "370c63663dff0f24df5dfea643ca239283542c6b228a302f69b32e1d36762b7f"
 dependencies = [
  "convert_case 0.8.0",
  "dioxus-rsx",
@@ -3258,15 +3258,15 @@ dependencies = [
 
 [[package]]
 name = "dioxus-core-types"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbfea5c8946e0745b254b5c33c515d81b3ba638f33c2a532ed06730392394d4d"
+checksum = "36963eab106b169737762f9cd5ee5fd97f585989dcb2d8e30a596e97a6999009"
 
 [[package]]
 name = "dioxus-devtools"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d30370fa78266aed3f3d9119dea2de9e92a0348941dbfa777f7a669f2ea375"
+checksum = "2349cedbdf1b429df1f1bea61fdee0ad3dae7b2548eedfbeca82710122a57da0"
 dependencies = [
  "dioxus-cli-config",
  "dioxus-core",
@@ -3282,9 +3282,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-devtools-types"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3907a2b61cf56039f047da6a37317a03d9e15411753bc40e5e34a27e405ac320"
+checksum = "0ab9b0f7565d1916b70915f59b89ea8054ef0a9d67a364a32bbee68ef5f3818d"
 dependencies = [
  "dioxus-core",
  "serde",
@@ -3293,9 +3293,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-document"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b75a1809af7c13546ae4487c8b02ab80cc4d059e7db5a5d090374ceaa71d5b"
+checksum = "37e3a5bec7ffc999ff23446a487eb5cd86111d1574a23533dd3f8b3c69a53a22"
 dependencies = [
  "dioxus-core",
  "dioxus-core-macro",
@@ -3304,7 +3304,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "generational-box",
- "lazy-js-bundle 0.7.6",
+ "lazy-js-bundle 0.7.9",
  "serde",
  "serde_json",
  "tracing",
@@ -3312,9 +3312,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-fullstack"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ee56dd65fbf1222fa6a2749c3f821df28facf1832854b43d480b547a096f6d"
+checksum = "37f0558edb88af5ad47275ae36a7f06317163ba482db377c26d7d8590b5cd0f6"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3369,9 +3369,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-fullstack-core"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40d33a447cb158acdb61787b2ff52dd8a0f9a9f20e95e5c5fe9873f01c2b55b"
+checksum = "cc634b28b4b1e3eab1e8df4f98510e2d2fa39d686321467f977213155e86ed2b"
 dependencies = [
  "anyhow",
  "axum-core",
@@ -3397,9 +3397,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-fullstack-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c06eb66bce50d5f47b793e6af5fc2e0a511bf2b4fa2423cf86e35023d8f17e6"
+checksum = "85a8fe7da549859fae00c7f4bf11a2aab734ae7ef6f98f280dce9bea1f3326ec"
 dependencies = [
  "const_format",
  "convert_case 0.8.0",
@@ -3411,9 +3411,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-history"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d8024afd482956eadae2c43d0b1e73e584adb724ac09be87f268d52002387b"
+checksum = "1a15232302d1933015fcf2d6fe9e286ad36f6e9c205a546089a0f326023bb0d2"
 dependencies = [
  "dioxus-core",
  "tracing",
@@ -3421,9 +3421,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-hooks"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233b5e168a7c38c4bf96d0f390221a72a5a28bb31ce2dcf6d2af879dc561ef42"
+checksum = "4534f91cf6305204b948bdec130076ac9ecc7c22faab29475b76870558bf73ea"
 dependencies = [
  "dioxus-core",
  "dioxus-signals",
@@ -3437,9 +3437,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-html"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abf4ad27eee650d1ab8ebe13591e8b0ee595fa5a5dd236be13a5b7b3fab678d"
+checksum = "e03d6ad4040b667f2b2eefcb678840e630938c09bf9ec39b04ea4d1d96d90d44"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3454,16 +3454,16 @@ dependencies = [
  "futures-util",
  "generational-box",
  "keyboard-types",
- "lazy-js-bundle 0.7.6",
+ "lazy-js-bundle 0.7.9",
  "rustversion",
  "tracing",
 ]
 
 [[package]]
 name = "dioxus-html-internal-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025e107e677f790f4ed648a189e36f51ae014e5341902b97313e4eae626cffa2"
+checksum = "584e2772127ab00f0d5e1d4d9795f39fecebc828ece0b7a02349d438bc1b1ce7"
 dependencies = [
  "convert_case 0.8.0",
  "proc-macro2",
@@ -3473,12 +3473,12 @@ dependencies = [
 
 [[package]]
 name = "dioxus-interpreter-js"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57caa76427d8ec4105ccca44ff8c511055688af732a094b9fe9ef3547d2a11b2"
+checksum = "11999d6eb5bb179a9512dad30e5de408aab66f2cb65de9098c9fbe02927e2978"
 dependencies = [
  "js-sys",
- "lazy-js-bundle 0.7.6",
+ "lazy-js-bundle 0.7.9",
  "rustc-hash 2.1.2",
  "sledgehammer_bindgen",
  "sledgehammer_utils",
@@ -3489,9 +3489,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-logger"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cbbee192b1b12fccb444a5b04d809710cfce4d27b792129fea6c845fae7f329"
+checksum = "a28ccdfe36d2cb830a2784e40f7e6f7199805a2c6da99bd65b1ca308f11aed28"
 dependencies = [
  "dioxus-cli-config",
  "tracing",
@@ -3516,9 +3516,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-router"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecdb19d7a1489ba252be9b3a07f9db92814020eb4ba8c1306f04242a44d17e66"
+checksum = "38e47f62d680429badfcb99bf5dec17ee92b0cb9623f264e36bc003a1359bfdc"
 dependencies = [
  "dioxus-cli-config",
  "dioxus-core",
@@ -3536,9 +3536,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-router-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b525ab775585f1dc4850178de9d0cb6bb37f7b9c1a1a0c121eab7449d7021480"
+checksum = "6f83fb667d27e256f8c9eca49963fbace66a8722cb64ee15a10ffc97d092357e"
 dependencies = [
  "base16",
  "digest",
@@ -3551,9 +3551,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-rsx"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fb07e40e9734946511659668ea3675ed214b60889e7aa7f0a5a85271518475"
+checksum = "2106afda239a4c7c22ffa1ca19117011225fc1c735c139c0a5b765996aa8bb1d"
 dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
@@ -3576,9 +3576,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-signals"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5393fd579f42c6547bf47ec0a2dedf2a366cd541d31deedc1059a096e6c35798"
+checksum = "3705754f5e043deec9fc7af0d159f18e5b21c02c47d255c7e477f31368f0b6d2"
 dependencies = [
  "dioxus-core",
  "futures-channel",
@@ -3592,9 +3592,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-stores"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c59f52e8194439604dd35f8c540456c22b4a4b076930e424d0289f98ea3cb4"
+checksum = "64bec7b21c86b1360ec965a07a53a2c96b7caee3465049e1c299a45024e87614"
 dependencies = [
  "dioxus-core",
  "dioxus-signals",
@@ -3604,9 +3604,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-stores-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "737600865572cecf60ff934f88252bd4144f4ca189e0e570b7a780e8f0e01a1f"
+checksum = "40a5875e9f890f27b1cc3e5b56c1e23601211470315a1fb8627c4ca4f3b2be9a"
 dependencies = [
  "convert_case 0.8.0",
  "proc-macro2",
@@ -3616,9 +3616,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-web"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176eb0a5ee8251203a816b413a64fdc014b43e53d4245f769b1b0c2035b88ac3"
+checksum = "bc0a0be76b404e8242a597db0fb239d05f8dee4e7856bc1fc7144f7e244822fd"
 dependencies = [
  "dioxus-cli-config",
  "dioxus-core",
@@ -3634,7 +3634,7 @@ dependencies = [
  "generational-box",
  "gloo-timers",
  "js-sys",
- "lazy-js-bundle 0.7.6",
+ "lazy-js-bundle 0.7.9",
  "rustc-hash 2.1.2",
  "send_wrapper",
  "serde",
@@ -3756,12 +3756,13 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "download-cef"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7471a7d5d3bd8df1b3b75871f0317d8a6dd73270ab861cc97ae7907ee63e554"
+checksum = "c169adf067a787e1f1c58ed62906a557de85388bee4b54fb878b722ff606b113"
 dependencies = [
  "bzip2",
  "clap",
+ "fs-err",
  "indicatif",
  "regex",
  "semver",
@@ -3787,9 +3788,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encase"
@@ -3877,18 +3878,18 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b07a8dfbbbfc0064c0a6bdf9edcf966de6b1c33ce344bdeca3b41615452634"
+checksum = "839c4174b41e75c8f7306110b2c51996a293b8d1d850edd529011841d9fede7d"
 dependencies = [
  "enumset_derive",
 ]
 
 [[package]]
 name = "enumset_derive"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43e744e4ea338060faee68ed933e46e722fb7f3617e722a5772d7e856d8b3ce"
+checksum = "4bd536557b58c682b217b8fb199afdff47cd3eff260623f19e77074eb073d63a"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4000,13 +4001,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -4133,6 +4133,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -4305,9 +4314,9 @@ dependencies = [
 
 [[package]]
 name = "generational-box"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68d74be1fbe3bba37604bdfd61403f26af9f6324cf325053abd89d60c22e799"
+checksum = "8cd0d825b8d339701ad330dbcd6399519ced4d143484954daf6e3185dace4f77"
 dependencies = [
  "parking_lot",
  "tracing",
@@ -4825,9 +4834,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "headers"
@@ -4855,9 +4864,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
 dependencies = [
  "hash32",
  "portable-atomic",
@@ -5152,9 +5161,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -5180,7 +5189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -5258,16 +5267,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -5385,9 +5384,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5450,11 +5449,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.1",
  "libc",
 ]
 
@@ -5475,9 +5474,9 @@ checksum = "e49596223b9d9d4947a14a25c142a6e7d8ab3f27eb3ade269d238bb8b5c267e2"
 
 [[package]]
 name = "lazy-js-bundle"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebbde2c5796719fbd82d6b8ec0be3dacf1f70c2876dee0f2c001632794d6641f"
+checksum = "ccafada6c9541db44db758619236f2748f6e1bdaa84d04ded858567cd1e89321"
 
 [[package]]
 name = "lazy_static"
@@ -5528,9 +5527,9 @@ dependencies = [
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
@@ -5583,7 +5582,7 @@ dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -5703,9 +5702,9 @@ dependencies = [
 
 [[package]]
 name = "manganis"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e06225f29a781d86afdfafa562de09621f2ace377136ae2ae9ca9e72a29b920"
+checksum = "8bfcf56309de35b48b8780ea097ace5c3b773a617b52edc49dfc9a63a7d9dc43"
 dependencies = [
  "const-serialize 0.7.2",
  "const-serialize 0.8.0-alpha.0",
@@ -5719,9 +5718,9 @@ dependencies = [
 
 [[package]]
 name = "manganis-core"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774ddc382b4fb30f3fdcf2418131cbac5e6111f00e6c7ddf9e598ef3b2b4cd91"
+checksum = "a24d6be68f594495aea60850a284029d585d7b7839b26096c1b6d758f8518648"
 dependencies = [
  "const-serialize 0.7.2",
  "const-serialize 0.8.0-alpha.0",
@@ -5733,9 +5732,9 @@ dependencies = [
 
 [[package]]
 name = "manganis-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731c83c89d831f341fb46eba0aefdfb3433f77a3f78a8b08d9d88746613a8f8b"
+checksum = "5e782a10318d707c0833e31876ded8acf91287eee0010af8392559af614c7226"
 dependencies = [
  "dunce",
  "macro-string",
@@ -5949,9 +5948,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae8844f63b5b118e334e205585b8c5c17b984121dbdb179d44aeb087ffad3cb"
+checksum = "47a2e3dff89cd322c66647942668faee0a2b1f88ea6cbb4d374b4a8d7e92528c"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -6128,9 +6127,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -6239,9 +6238,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -6675,9 +6674,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbclient"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c6933ddbbd16539a7672e697bb8d41ac3a4e99ac43eeb40c07236bd7fcb2dd"
+checksum = "a570f6bca41d29acb2139229a7c873ec99bc9a313bd10804081d89bfac8ff329"
 dependencies = [
  "libc",
  "libredox",
@@ -6792,18 +6791,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6841,13 +6840,13 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap",
- "quick-xml 0.38.4",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -7076,9 +7075,9 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
 name = "psl-types"
@@ -7124,18 +7123,9 @@ checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.39.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -7335,9 +7325,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -7500,7 +7490,7 @@ checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
 dependencies = [
  "bytecheck",
  "bytes",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap",
  "munge",
  "ptr_meta",
@@ -7624,9 +7614,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
@@ -7705,9 +7695,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ruzstd"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
 dependencies = [
  "twox-hash",
 ]
@@ -7934,13 +7924,13 @@ dependencies = [
 
 [[package]]
 name = "serial2"
-version = "0.2.36"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdbc46aa3882ec3d48ec2b5abcb4f0d863a13d7599265f3faa6d851f23c12f3"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
 dependencies = [
  "cfg-if",
  "libc",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8277,9 +8267,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subsecond"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feae81a4a7ca6d0bcf70c385a43b7dbacbff527f0805cb0a4043ce2c2c559a2c"
+checksum = "9cc79674bd55726e6b123204403389400229a95fe4a3b2c5453dada70b06ca95"
 dependencies = [
  "js-sys",
  "libc",
@@ -8296,9 +8286,9 @@ dependencies = [
 
 [[package]]
 name = "subsecond-types"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85256ee192cbdf00473e48e6133863b125dd4f772fddfbc97287ec7a61458c25"
+checksum = "e9798bfed58797aed51c672aa99810aac30a50d3120ecfdcf28c13784e9a8f1c"
 dependencies = [
  "serde",
 ]
@@ -8423,9 +8413,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -8601,9 +8591,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -8736,7 +8726,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -8745,7 +8735,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -8765,20 +8755,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -9201,6 +9191,7 @@ dependencies = [
  "uuid",
  "vmux_command",
  "vmux_core",
+ "vmux_history",
  "vmux_layout",
  "vmux_mcp",
  "vmux_server",
@@ -9233,6 +9224,7 @@ dependencies = [
  "serde",
  "serde_json",
  "vmux_core",
+ "vmux_history",
  "vmux_macro",
 ]
 
@@ -9295,9 +9287,11 @@ version = "0.0.10"
 dependencies = [
  "bevy",
  "bevy_cef",
+ "bevy_cef_core",
  "bevy_ecs",
  "bevy_reflect",
  "dioxus",
+ "js-sys",
  "moonshine-save",
  "rkyv",
  "ron 0.8.1",
@@ -9306,6 +9300,7 @@ dependencies = [
  "vmux_server",
  "vmux_ui",
  "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -9590,9 +9585,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9603,9 +9598,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9613,9 +9608,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9623,9 +9618,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -9636,9 +9631,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -9783,7 +9778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.39.2",
+ "quick-xml",
  "quote",
 ]
 
@@ -9801,9 +9796,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10679,9 +10674,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -10942,7 +10937,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 1.0.2",
+ "winnow 1.0.3",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -10970,7 +10965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
- "winnow 1.0.2",
+ "winnow 1.0.3",
  "zvariant",
 ]
 
@@ -11002,9 +10997,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -11068,24 +11063,24 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zvariant"
-version = "5.10.1"
+version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db0ecb8987cf5e92653c57c098f7f0e39a03112edb796f4fe089fb7eaa14ff"
+checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "url",
- "winnow 1.0.2",
+ "winnow 1.0.3",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.10.1"
+version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b949b639ab1b4bed763aa7481ba0e368af68d8b55532f8ed4bec86a59f2ca98"
+checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -11104,5 +11099,5 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.117",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]

--- a/crates/vmux_agent/Cargo.toml
+++ b/crates/vmux_agent/Cargo.toml
@@ -25,6 +25,7 @@ uuid = { workspace = true }
 url = { workspace = true }
 vmux_command = { path = "../vmux_command" }
 vmux_core = { path = "../vmux_core" }
+vmux_history = { path = "../vmux_history" }
 vmux_layout = { path = "../vmux_layout" }
 vmux_mcp = { path = "../vmux_mcp" }
 vmux_service = { path = "../vmux_service" }

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -117,6 +117,7 @@ impl Plugin for AgentPlugin {
             .add_systems(
                 Update,
                 (
+                    forward_history_open_intent,
                     handle_agent_commands,
                     handle_agent_queries,
                     detect_agent_session_process_exit,
@@ -291,6 +292,33 @@ pub fn spawn_browser_tab(
     });
     commands.spawn((
         vmux_layout::Browser::new(meshes, webview_mt, url),
+        ChildOf(tab),
+    ));
+    tab
+}
+
+pub fn spawn_history_tab(
+    pane: Entity,
+    commands: &mut Commands,
+    meshes: &mut ResMut<Assets<Mesh>>,
+    webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
+) -> Entity {
+    let url = "vmux://history/";
+    let title = "History";
+    let tab = commands
+        .spawn((
+            vmux_layout::stack::stack_bundle(),
+            LastActivatedAt::now(),
+            ChildOf(pane),
+        ))
+        .id();
+    commands.entity(tab).insert(PageMetadata {
+        url: url.to_string(),
+        title: title.to_string(),
+        ..default()
+    });
+    commands.spawn((
+        vmux_layout::Browser::new_with_title(meshes, webview_mt, url, title),
         ChildOf(tab),
     ));
     tab
@@ -486,6 +514,10 @@ pub fn spawn_vmux_tab(
             spawn_sessions_tab(pane, commands, meshes, webview_mt);
             Ok(())
         }
+        "history" => {
+            spawn_history_tab(pane, commands, meshes, webview_mt);
+            Ok(())
+        }
         "services" => {
             spawn_processes_tab(pane, commands, meshes, webview_mt);
             Ok(())
@@ -624,6 +656,9 @@ fn handle_agent_commands(
     mut reader: MessageReader<AgentCommandRequest>,
     mut app_commands: MessageWriter<AppCommand>,
     mut browser_nav_writer: MessageWriter<vmux_layout::BrowserNavigateRequest>,
+    mut browser_go_back_writer: MessageWriter<vmux_layout::BrowserGoBackRequest>,
+    mut browser_go_forward_writer: MessageWriter<vmux_layout::BrowserGoForwardRequest>,
+    mut open_in_new_stack_writer: MessageWriter<vmux_layout::OpenInNewStackRequest>,
     mut terminal_send_writer: MessageWriter<vmux_terminal::TerminalSendRequest>,
     mut run_shell_writer: MessageWriter<vmux_terminal::RunShellRequest>,
     focus: Res<FocusedStack>,
@@ -755,6 +790,25 @@ fn handle_agent_commands(
                 });
                 continue;
             }
+            ServiceAgentCommand::BrowserGoBack { pane } => {
+                browser_go_back_writer
+                    .write(vmux_layout::BrowserGoBackRequest { pane: pane.clone() });
+                AgentCommandResult::Ok
+            }
+            ServiceAgentCommand::BrowserGoForward { pane } => {
+                browser_go_forward_writer
+                    .write(vmux_layout::BrowserGoForwardRequest { pane: pane.clone() });
+                AgentCommandResult::Ok
+            }
+            ServiceAgentCommand::BrowserHistorySearch { query, limit } => {
+                bevy::log::info!("browser_history_search: query={:?} limit={}", query, limit);
+                AgentCommandResult::Ok
+            }
+            ServiceAgentCommand::OpenInNewStack { url } => {
+                open_in_new_stack_writer
+                    .write(vmux_layout::OpenInNewStackRequest { url: url.clone() });
+                AgentCommandResult::Ok
+            }
         };
         if let Some(service) = service.as_ref() {
             service.0.send(ClientMessage::AgentCommandResponse {
@@ -790,6 +844,28 @@ pub fn detect_agent_session_process_exit(
             meta.url = next;
         }
         writer.write(AgentSessionExited { entity });
+    }
+}
+
+pub(crate) fn forward_history_open_intent(
+    mut intents: MessageReader<vmux_history::query::HistoryOpenIntent>,
+    mut requests: MessageWriter<AgentCommandRequest>,
+) {
+    for intent in intents.read() {
+        let command = if intent.in_new_stack {
+            ServiceAgentCommand::OpenInNewStack {
+                url: intent.url.clone(),
+            }
+        } else {
+            ServiceAgentCommand::BrowserNavigate {
+                url: intent.url.clone(),
+                pane: None,
+            }
+        };
+        requests.write(AgentCommandRequest {
+            request_id: AgentRequestId::new(),
+            command,
+        });
     }
 }
 
@@ -1212,6 +1288,9 @@ mod tests {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, vmux_command::CommandPlugin, AgentPlugin));
         app.add_message::<vmux_layout::BrowserNavigateRequest>();
+        app.add_message::<vmux_layout::BrowserGoBackRequest>();
+        app.add_message::<vmux_layout::BrowserGoForwardRequest>();
+        app.add_message::<vmux_layout::OpenInNewStackRequest>();
         app.add_message::<vmux_layout::reconcile::LayoutApplyRequest>();
         app.add_message::<vmux_layout::reconcile::LayoutApplyResponse>();
         app.add_message::<vmux_layout::reconcile::LayoutSnapshotRequest>();
@@ -1219,6 +1298,7 @@ mod tests {
         app.add_message::<vmux_terminal::TerminalSendRequest>();
         app.add_message::<vmux_terminal::RunShellRequest>();
         app.add_message::<vmux_setting::SettingsWriteRequest>();
+        app.add_message::<vmux_history::query::HistoryOpenIntent>();
         app.add_systems(Update, vmux_terminal::handle_terminal_send_requests);
         app.insert_resource(FocusedStack::default());
         app.insert_resource(test_settings());

--- a/crates/vmux_command/Cargo.toml
+++ b/crates/vmux_command/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/lib.rs"
 rkyv = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+vmux_history = { path = "../vmux_history", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bevy = { workspace = true }

--- a/crates/vmux_command/src/command.rs
+++ b/crates/vmux_command/src/command.rs
@@ -191,9 +191,15 @@ pub enum BrowserBarCommand {
     #[menu(
         id = "browser_open_command_bar",
         label = "Command Bar",
-        accel = "super+l"
+        accel = "super+k"
     )]
     OpenCommandBar,
+    #[menu(
+        id = "browser_open_url_in_command_bar",
+        label = "Edit URL",
+        accel = "super+l"
+    )]
+    OpenUrlInCommandBar,
     #[menu(
         id = "browser_open_path_bar",
         label = "Path Navigator",
@@ -203,6 +209,8 @@ pub enum BrowserBarCommand {
     #[menu(id = "browser_open_commands", label = "Commands")]
     #[shortcut(direct = ">")]
     OpenCommands,
+    #[menu(id = "browser_open_history", label = "History", accel = "super+y")]
+    OpenHistory,
     #[menu(id = "browser_find", label = "Find", accel = "super+f", hidden)]
     Find,
 }

--- a/crates/vmux_command/src/event.rs
+++ b/crates/vmux_command/src/event.rs
@@ -1,3 +1,8 @@
+pub use vmux_history::event::{
+    HISTORY_SUGGESTIONS_RESPONSE_EVENT, HistoryEntry, HistorySuggestionsRequest,
+    HistorySuggestionsResponse,
+};
+
 pub const COMMAND_BAR_OPEN_EVENT: &str = "command-bar-open";
 
 #[derive(

--- a/crates/vmux_core/src/lib.rs
+++ b/crates/vmux_core/src/lib.rs
@@ -27,6 +27,11 @@ impl Plugin for CorePlugin {
             .register_type::<CreatedAt>()
             .register_type::<LastActivatedAt>()
             .register_type::<Visit>()
+            .register_type::<Url>()
+            .register_type::<VisitCount>()
+            .register_type::<LastVisitedAt>()
+            .register_type::<VisitedUrl>()
+            .register_type::<TransitionType>()
             .register_type::<Children>()
             .register_type::<ChildOf>();
     }
@@ -105,3 +110,79 @@ pub struct Visit;
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Component, Clone, Copy, Debug, Default)]
 pub struct Ready;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Component, Clone, Copy, Debug, Reflect, Default)]
+#[reflect(Component, Default)]
+#[require(Save)]
+#[type_path = "vmux_history"]
+pub struct Url;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Component, Clone, Copy, Debug, Reflect, Default)]
+#[reflect(Component, Default)]
+#[require(Save)]
+#[type_path = "vmux_history"]
+pub struct VisitCount(pub u32);
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Component, Clone, Copy, Debug, Reflect, Default)]
+#[reflect(Component, Default)]
+#[require(Save)]
+#[type_path = "vmux_history"]
+pub struct LastVisitedAt(pub i64);
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Component, Clone, Copy, Debug, Reflect)]
+#[reflect(Component)]
+#[require(Save)]
+#[type_path = "vmux_history"]
+pub struct VisitedUrl(pub Entity);
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Default for VisitedUrl {
+    fn default() -> Self {
+        Self(Entity::PLACEHOLDER)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Component, Clone, Copy, Debug, Reflect, Default, PartialEq, Eq)]
+#[reflect(Component, Default)]
+#[require(Save)]
+#[type_path = "vmux_history"]
+pub enum TransitionType {
+    #[default]
+    Link,
+    Typed,
+    Reload,
+    BackForward,
+    Redirect,
+    Other,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registers_new_history_components() {
+        let mut app = App::new();
+        app.add_plugins(CorePlugin);
+
+        let registry = app.world().resource::<AppTypeRegistry>().read();
+        assert!(registry.get(std::any::TypeId::of::<Url>()).is_some());
+        assert!(registry.get(std::any::TypeId::of::<VisitCount>()).is_some());
+        assert!(
+            registry
+                .get(std::any::TypeId::of::<LastVisitedAt>())
+                .is_some()
+        );
+        assert!(registry.get(std::any::TypeId::of::<VisitedUrl>()).is_some());
+        assert!(
+            registry
+                .get(std::any::TypeId::of::<TransitionType>())
+                .is_some()
+        );
+    }
+}

--- a/crates/vmux_desktop/src/browser.rs
+++ b/crates/vmux_desktop/src/browser.rs
@@ -44,7 +44,8 @@ impl Plugin for BrowserPlugin {
     fn build(&self, app: &mut App) {
         let embedded_hosts = app.world().resource::<Server>().embedded_hosts();
         webview_debug_log(format!("BrowserPlugin embedded_hosts={embedded_hosts:?}"));
-        app.configure_sets(Update, CefSystems::CreateAndResize.after(ReadAppCommands))
+        app.add_message::<bevy_cef_core::prelude::WebviewCommittedNavigationEvent>()
+            .configure_sets(Update, CefSystems::CreateAndResize.after(ReadAppCommands))
             .add_plugins((
                 CefPlugin {
                     root_cache_path: cef_root_cache_path(),
@@ -64,8 +65,13 @@ impl Plugin for BrowserPlugin {
                     handle_browser_commands.in_set(ReadAppCommands),
                     vmux_layout::apply_chrome_state_from_cef,
                     drain_loading_state,
+                    drain_committed_navigation,
                     spawn_popup_tabs,
                     handle_browser_navigate_requests.after(vmux_terminal::ServiceMessageSet),
+                    handle_browser_go_back_requests,
+                    handle_browser_go_forward_requests,
+                    handle_open_in_new_stack_requests,
+                    handle_browser_open_history.in_set(ReadAppCommands),
                 ),
             )
             .add_systems(
@@ -73,6 +79,10 @@ impl Plugin for BrowserPlugin {
                 (sync_page_metadata_to_tab, spawn_visit_on_navigation)
                     .chain()
                     .after(vmux_layout::apply_chrome_state_from_cef),
+            )
+            .add_systems(
+                Update,
+                vmux_layout::mirror_metadata_to_url.after(vmux_layout::apply_chrome_state_from_cef),
             )
             .add_systems(
                 Update,
@@ -644,6 +654,15 @@ fn drain_loading_state(receiver: Res<WebviewLoadingStateReceiver>, mut commands:
     }
 }
 
+fn drain_committed_navigation(
+    receiver: Res<WebviewCommittedNavigationReceiver>,
+    mut writer: MessageWriter<bevy_cef_core::prelude::WebviewCommittedNavigationEvent>,
+) {
+    while let Ok(ev) = receiver.0.try_recv() {
+        writer.write(ev);
+    }
+}
+
 fn spawn_popup_tabs(
     popup_rx: Res<WebviewPopupReceiver>,
     child_of_q: Query<&ChildOf>,
@@ -1170,7 +1189,7 @@ fn on_header_command_emit(
         "prev_page" => BrowserCommand::Navigation(BrowserNavigationCommand::PrevPage),
         "next_page" => BrowserCommand::Navigation(BrowserNavigationCommand::NextPage),
         "reload" => BrowserCommand::Navigation(BrowserNavigationCommand::Reload),
-        "focus_address_bar" => BrowserCommand::Bar(BrowserBarCommand::OpenCommandBar),
+        "focus_address_bar" => BrowserCommand::Bar(BrowserBarCommand::OpenUrlInCommandBar),
         _ => return,
     };
     messages.write(AppCommand::Browser(cmd));
@@ -1443,6 +1462,125 @@ fn sync_page_metadata_to_tab(
     }
 }
 
+pub(crate) fn handle_browser_go_back_requests(
+    mut reader: MessageReader<vmux_layout::BrowserGoBackRequest>,
+    focus: Res<vmux_layout::stack::FocusedStack>,
+    panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
+    terminals: Query<(Entity, &ChildOf), (With<Terminal>, Without<terminal::ProcessExited>)>,
+    browsers: Query<(Entity, &ChildOf), With<Browser>>,
+    pane_children: Query<&Children, With<Pane>>,
+    stack_ts: Query<(Entity, &LastActivatedAt), With<Stack>>,
+    mut commands: Commands,
+) {
+    for request in reader.read() {
+        let target = match request.pane.as_deref() {
+            Some(s) => vmux_layout::target::parse_pane_target(s, &panes),
+            None => focus.pane.filter(|p| panes.contains(*p)),
+        };
+        let Some(pane_entity) = target else { continue };
+        let Some(webview) = vmux_layout::target::active_webview_for_tab(
+            active_stack_in_pane(pane_entity, &pane_children, &stack_ts),
+            &browsers,
+            &terminals,
+        ) else {
+            continue;
+        };
+        commands.trigger(bevy_cef::prelude::RequestGoBack { webview });
+    }
+}
+
+pub(crate) fn handle_browser_go_forward_requests(
+    mut reader: MessageReader<vmux_layout::BrowserGoForwardRequest>,
+    focus: Res<vmux_layout::stack::FocusedStack>,
+    panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
+    terminals: Query<(Entity, &ChildOf), (With<Terminal>, Without<terminal::ProcessExited>)>,
+    browsers: Query<(Entity, &ChildOf), With<Browser>>,
+    pane_children: Query<&Children, With<Pane>>,
+    stack_ts: Query<(Entity, &LastActivatedAt), With<Stack>>,
+    mut commands: Commands,
+) {
+    for request in reader.read() {
+        let target = match request.pane.as_deref() {
+            Some(s) => vmux_layout::target::parse_pane_target(s, &panes),
+            None => focus.pane.filter(|p| panes.contains(*p)),
+        };
+        let Some(pane_entity) = target else { continue };
+        let Some(webview) = vmux_layout::target::active_webview_for_tab(
+            active_stack_in_pane(pane_entity, &pane_children, &stack_ts),
+            &browsers,
+            &terminals,
+        ) else {
+            continue;
+        };
+        commands.trigger(bevy_cef::prelude::RequestGoForward { webview });
+    }
+}
+
+pub(crate) fn handle_browser_open_history(
+    mut reader: MessageReader<AppCommand>,
+    mut writer: MessageWriter<vmux_layout::OpenInNewStackRequest>,
+) {
+    for cmd in reader.read() {
+        if matches!(
+            cmd,
+            AppCommand::Browser(BrowserCommand::Bar(BrowserBarCommand::OpenHistory))
+        ) {
+            writer.write(vmux_layout::OpenInNewStackRequest {
+                url: "vmux://history/".to_string(),
+            });
+        }
+    }
+}
+
+pub(crate) fn handle_open_in_new_stack_requests(
+    mut reader: MessageReader<vmux_layout::OpenInNewStackRequest>,
+    focus: Res<vmux_layout::stack::FocusedStack>,
+    panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
+    child_of_q: Query<&ChildOf>,
+    lookups: vmux_agent::plugin::AgentLookups,
+    strategies: Res<vmux_agent::strategy::AgentStrategies>,
+    settings: Res<AppSettings>,
+    page_idx: Option<Res<vmux_agent::client::page::strategy_index::PageStrategyIndex>>,
+    kind_q: Query<&vmux_agent::client::page::strategy_components::StrategyKind>,
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
+) {
+    let pid_to_entity = lookups.pid_to_entity.as_deref();
+    let agent_to_entity = lookups.agent_to_entity.as_deref();
+    let empty_idx = vmux_agent::client::page::strategy_index::PageStrategyIndex::default();
+    let idx_ref = page_idx.as_deref().unwrap_or(&empty_idx);
+    for request in reader.read() {
+        let Some(pane) = focus.pane.filter(|p| panes.contains(*p)) else {
+            continue;
+        };
+        if request.url.starts_with("vmux://") {
+            let _ = vmux_agent::plugin::spawn_vmux_tab(
+                &request.url,
+                pane,
+                &mut commands,
+                &mut meshes,
+                &mut webview_mt,
+                &settings,
+                pid_to_entity,
+                agent_to_entity,
+                &strategies,
+                &child_of_q,
+                idx_ref,
+                &kind_q,
+            );
+        } else {
+            vmux_agent::plugin::spawn_browser_tab(
+                pane,
+                &request.url,
+                &mut commands,
+                &mut meshes,
+                &mut webview_mt,
+            );
+        }
+    }
+}
+
 pub(crate) fn handle_browser_navigate_requests(
     mut reader: MessageReader<vmux_layout::BrowserNavigateRequest>,
     focus: Res<vmux_layout::stack::FocusedStack>,
@@ -1698,6 +1836,9 @@ mod tests {
 
         fn add_consumer_systems(app: &mut App) {
             app.add_message::<vmux_layout::BrowserNavigateRequest>();
+            app.add_message::<vmux_layout::BrowserGoBackRequest>();
+            app.add_message::<vmux_layout::BrowserGoForwardRequest>();
+            app.add_message::<vmux_layout::OpenInNewStackRequest>();
             app.add_message::<vmux_layout::reconcile::LayoutApplyRequest>();
             app.add_message::<vmux_layout::reconcile::LayoutApplyResponse>();
             app.add_message::<vmux_layout::reconcile::LayoutSnapshotRequest>();
@@ -1705,6 +1846,7 @@ mod tests {
             app.add_message::<vmux_terminal::TerminalSendRequest>();
             app.add_message::<vmux_terminal::RunShellRequest>();
             app.add_message::<vmux_setting::SettingsWriteRequest>();
+            app.add_message::<vmux_history::query::HistoryOpenIntent>();
             app.add_systems(
                 Update,
                 (

--- a/crates/vmux_desktop/src/lib.rs
+++ b/crates/vmux_desktop/src/lib.rs
@@ -90,6 +90,7 @@ impl Plugin for VmuxPlugin {
             TerminalPlugin,
             ServicePlugin,
             SpacePlugin,
+            vmux_history::HistoryPlugin,
             LayoutCefPlugin,
             CommandBarPagePlugin,
             BrowserPlugin,

--- a/crates/vmux_desktop/src/persistence.rs
+++ b/crates/vmux_desktop/src/persistence.rs
@@ -204,6 +204,11 @@ pub(crate) fn save_space_to_path(commands: &mut Commands, path: PathBuf) {
         .allow::<vmux_history::CreatedAt>()
         .allow::<vmux_history::LastActivatedAt>()
         .allow::<vmux_history::Visit>()
+        .allow::<vmux_core::Url>()
+        .allow::<vmux_core::VisitCount>()
+        .allow::<vmux_core::LastVisitedAt>()
+        .allow::<vmux_core::VisitedUrl>()
+        .allow::<vmux_core::TransitionType>()
         .allow::<vmux_terminal::launch::TerminalLaunch>();
     commands.trigger_save(save);
 }
@@ -591,6 +596,94 @@ mod tests {
 
         let _ = saved_url;
         assert_eq!(meta.url, TERMINAL_PAGE_URL);
+    }
+
+    #[test]
+    fn url_and_visit_round_trip() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("test_history.ron");
+
+        let mut app_save = App::new();
+        app_save.add_plugins(MinimalPlugins);
+        app_save.add_plugins(vmux_core::CorePlugin);
+        app_save.add_observer(save_on_default_event);
+
+        let url_e = app_save
+            .world_mut()
+            .spawn((
+                Save,
+                vmux_core::Url,
+                PageMetadata {
+                    url: "https://example.com".into(),
+                    title: "Example".into(),
+                    favicon_url: "".into(),
+                    bg_color: None,
+                },
+                vmux_core::VisitCount(3),
+                vmux_core::LastVisitedAt(1000),
+                vmux_core::CreatedAt(500),
+            ))
+            .id();
+
+        app_save.world_mut().spawn((
+            Save,
+            vmux_core::Visit,
+            vmux_core::VisitedUrl(url_e),
+            vmux_core::CreatedAt(900),
+            vmux_core::TransitionType::Typed,
+        ));
+
+        save_space_to_path(&mut app_save.world_mut().commands(), path.clone());
+        app_save.update();
+
+        assert!(path.exists(), "save file should exist");
+
+        let mut app_load = App::new();
+        app_load.add_plugins(MinimalPlugins);
+        app_load.add_plugins(vmux_core::CorePlugin);
+        app_load.add_observer(load_on_default_event);
+        app_load.update();
+
+        app_load
+            .world_mut()
+            .commands()
+            .trigger_load(LoadWorld::default_from_file(path));
+        app_load.update();
+
+        let url_count = app_load
+            .world_mut()
+            .query::<&vmux_core::Url>()
+            .iter(app_load.world())
+            .count();
+        let visit_count = app_load
+            .world_mut()
+            .query::<&vmux_core::Visit>()
+            .iter(app_load.world())
+            .count();
+        assert_eq!(url_count, 1, "Url not round-tripped");
+        assert_eq!(visit_count, 1, "Visit not round-tripped");
+
+        let (vc, lva, ca) = app_load
+            .world_mut()
+            .query::<(
+                &vmux_core::VisitCount,
+                &vmux_core::LastVisitedAt,
+                &vmux_core::CreatedAt,
+            )>()
+            .iter(app_load.world())
+            .find(|(vc, _, _)| vc.0 == 3)
+            .expect("Url entity fields not round-tripped");
+        assert_eq!(vc.0, 3);
+        assert_eq!(lva.0, 1000);
+        assert_eq!(ca.0, 500);
+
+        let tt = app_load
+            .world_mut()
+            .query::<&vmux_core::TransitionType>()
+            .iter(app_load.world())
+            .next()
+            .expect("TransitionType not round-tripped");
+        assert_eq!(*tt, vmux_core::TransitionType::Typed);
     }
 
     #[test]

--- a/crates/vmux_history/Cargo.toml
+++ b/crates/vmux_history/Cargo.toml
@@ -29,6 +29,7 @@ serde = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bevy = { workspace = true }
 bevy_cef = { workspace = true }
+bevy_cef_core = { workspace = true }
 bevy_reflect = { workspace = true }
 moonshine-save = { workspace = true }
 bevy_ecs = { workspace = true }
@@ -41,5 +42,10 @@ bevy = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 dioxus = { workspace = true }
+js-sys = "0.3"
 vmux_ui = { path = "../vmux_ui", default-features = false }
 wasm-bindgen = "0.2.115"
+web-sys = { version = "0.3", features = [
+    "Window", "Document", "Element",
+    "IntersectionObserver", "IntersectionObserverEntry", "IntersectionObserverInit",
+] }

--- a/crates/vmux_history/assets/index.css
+++ b/crates/vmux_history/assets/index.css
@@ -1,4 +1,4 @@
-@import "../vmux_ui/assets/theme.css";
+@import "../../vmux_ui/assets/theme.css";
 @import "tailwindcss";
 @source "../src";
 @source ".";

--- a/crates/vmux_history/build.rs
+++ b/crates/vmux_history/build.rs
@@ -1,11 +1,15 @@
 use std::path::PathBuf;
 
-use vmux_server::build::PageBuilder;
+use vmux_server::build::{CefEmbeddedPageFinalize, PageBuilder};
 
 fn main() {
     let manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
     PageBuilder::new(manifest_dir, "vmux_history", "vmux_history_app")
         .dx_extra_args(&["--bin", "vmux_history_app", "--features", "web"])
-        .track_manifest_rel_paths(&["assets/input.css"])
+        .track_manifest_rel_paths(&["assets/index.css", "../vmux_ui/assets/theme.css"])
+        .cef_finalize(CefEmbeddedPageFinalize {
+            strip_uncompiled_tailwind_css: true,
+        })
+        .tailwind_postprocess_after_dx(&["index-dxh", "input-dxh"])
         .run("vmux_history");
 }

--- a/crates/vmux_history/src/event.rs
+++ b/crates/vmux_history/src/event.rs
@@ -1,4 +1,18 @@
-pub const HISTORY_EVENT: &str = "history";
+pub const HISTORY_QUERY_RESPONSE_EVENT: &str = "history-query-response";
+pub const HISTORY_SUGGESTIONS_RESPONSE_EVENT: &str = "history-suggestions-response";
+pub const HISTORY_CHANGED_EVENT: &str = "history-changed";
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct HistoryChangedEvent;
 
 #[derive(
     Clone,
@@ -9,7 +23,110 @@ pub const HISTORY_EVENT: &str = "history";
     rkyv::Serialize,
     rkyv::Deserialize,
 )]
-pub struct HistoryEvent {
+pub struct HistoryEntry {
+    pub url_entity_bits: u64,
     pub url: String,
-    pub history: Vec<String>,
+    pub title: String,
+    pub favicon_url: String,
+    pub visit_created_at: i64,
+    pub visit_count: u32,
+    pub last_visited_at: i64,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct HistoryQueryRequest {
+    pub query: Option<String>,
+    pub offset: u32,
+    pub limit: u32,
+    pub request_id: u64,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct HistoryQueryResponse {
+    pub request_id: u64,
+    pub entries: Vec<HistoryEntry>,
+    pub has_more: bool,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct HistoryDeleteRequest {
+    pub url_entity_bits: u64,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct HistoryClearAllRequest;
+
+#[derive(
+    Clone,
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct HistoryOpenRequest {
+    pub url: String,
+    pub in_new_stack: bool,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct HistorySuggestionsRequest {
+    pub query: String,
+    pub limit: u32,
+    pub request_id: u64,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct HistorySuggestionsResponse {
+    pub request_id: u64,
+    pub entries: Vec<HistoryEntry>,
 }

--- a/crates/vmux_history/src/lib.rs
+++ b/crates/vmux_history/src/lib.rs
@@ -1,4 +1,11 @@
 pub mod event;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod prune;
+pub mod query;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod spawn;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod transition;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use vmux_core::{CreatedAt, LastActivatedAt, Visit, now_millis};

--- a/crates/vmux_history/src/page.rs
+++ b/crates/vmux_history/src/page.rs
@@ -1,34 +1,234 @@
 #![allow(non_snake_case)]
 
 use dioxus::prelude::*;
-use vmux_history::event::{HISTORY_EVENT, HistoryEvent};
-use vmux_ui::hooks::use_bin_event_listener;
+use vmux_history::event::{
+    HISTORY_CHANGED_EVENT, HISTORY_QUERY_RESPONSE_EVENT, HistoryChangedEvent,
+    HistoryClearAllRequest, HistoryDeleteRequest, HistoryEntry, HistoryOpenRequest,
+    HistoryQueryRequest, HistoryQueryResponse,
+};
+use vmux_ui::favicon::Favicon;
+use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_theme};
+use wasm_bindgen::JsCast;
+use wasm_bindgen::prelude::*;
+
+fn emit_query(query: &str, offset: u32, request_id: u64) {
+    let req = HistoryQueryRequest {
+        query: if query.is_empty() {
+            None
+        } else {
+            Some(query.to_string())
+        },
+        offset,
+        limit: 50,
+        request_id,
+    };
+    let _ = try_cef_bin_emit_rkyv(&req);
+}
 
 #[component]
 pub fn Page() -> Element {
-    let mut history = use_signal(Vec::<String>::new);
-    let listener = use_bin_event_listener::<HistoryEvent, _>(HISTORY_EVENT, move |data| {
-        history.set(data.history);
+    use_theme();
+    let mut entries: Signal<Vec<HistoryEntry>> = use_signal(Vec::new);
+    let mut query: Signal<String> = use_signal(String::new);
+    let mut offset: Signal<u32> = use_signal(|| 0);
+    let mut has_more: Signal<bool> = use_signal(|| true);
+    let mut request_id: Signal<u64> = use_signal(|| 0);
+    let mut last_reset_id: Signal<u64> = use_signal(|| 0);
+
+    let _listener = use_bin_event_listener::<HistoryQueryResponse, _>(
+        HISTORY_QUERY_RESPONSE_EVENT,
+        move |resp: HistoryQueryResponse| {
+            if resp.request_id < *last_reset_id.read() {
+                return;
+            }
+            if resp.request_id == *last_reset_id.read() {
+                entries.set(resp.entries);
+            } else {
+                entries.write().extend(resp.entries);
+            }
+            has_more.set(resp.has_more);
+        },
+    );
+
+    use_effect(move || {
+        request_id.set(1);
+        last_reset_id.set(1);
+        emit_query("", 0, 1);
     });
 
-    rsx! {
-        document::Stylesheet { href: asset!("/assets/input.css") }
-        div { class: "flex min-h-full min-w-0 flex-col items-stretch gap-4 p-4",
-            span { class: "text-xl font-semibold", "History POC" }
-            if (listener.is_loading)() {
-                div { class: "flex min-w-0 flex-col items-stretch gap-3",
-                    span { class: "text-ui text-muted-foreground", "Connecting…" }
-                    span { class: "text-ui-xs text-muted-foreground/50 animate-pulse", "Waiting for `window.cef`…" }
+    let _changed_listener = use_bin_event_listener::<HistoryChangedEvent, _>(
+        HISTORY_CHANGED_EVENT,
+        move |_: HistoryChangedEvent| {
+            let new_id = *request_id.peek() + 1;
+            request_id.set(new_id);
+            offset.set(0);
+            last_reset_id.set(new_id);
+            let q = query.peek().clone();
+            emit_query(&q, 0, new_id);
+        },
+    );
+
+    use_effect(move || {
+        let load_more =
+            Closure::<dyn FnMut(js_sys::Array)>::new(move |entries_arr: js_sys::Array| {
+                if entries_arr.length() == 0 {
+                    return;
                 }
-            } else if let Some(err) = (listener.error)() {
-                span { class: "text-destructive", "{err}" }
-            } else {
-                div { class: "flex min-w-0 flex-col items-stretch gap-1",
-                    for h in history() {
-                        span { class: "whitespace-pre-wrap font-mono text-sm text-chart-3/90", "{h}" }
+                let entry: web_sys::IntersectionObserverEntry =
+                    entries_arr.get(0).dyn_into().unwrap();
+                if !entry.is_intersecting() {
+                    return;
+                }
+                if !*has_more.read() {
+                    return;
+                }
+                if entries.read().is_empty() {
+                    return;
+                }
+                let new_offset = *offset.read() + 50;
+                offset.set(new_offset);
+                let new_id = *request_id.read() + 1;
+                request_id.set(new_id);
+                emit_query(&query.read(), new_offset, new_id);
+            });
+
+        let window = web_sys::window().expect("window");
+        let document = window.document().expect("document");
+        if let Some(target) = document.get_element_by_id("infinite-scroll-sentinel") {
+            let cb: &js_sys::Function = load_more.as_ref().unchecked_ref();
+            if let Ok(observer) = web_sys::IntersectionObserver::new(cb) {
+                observer.observe(&target);
+                load_more.forget();
+            }
+        }
+    });
+
+    let mut confirm_open: Signal<bool> = use_signal(|| false);
+
+    let on_input = move |e: Event<FormData>| {
+        query.set(e.value());
+        let new_id = *request_id.read() + 1;
+        request_id.set(new_id);
+        offset.set(0);
+        last_reset_id.set(new_id);
+        emit_query(&query.read(), 0, new_id);
+    };
+
+    let groups = group_by_day(&entries.read());
+
+    rsx! {
+        div { class: "flex flex-col h-screen bg-background text-foreground",
+            header { class: "p-3 border-b border-border flex gap-2 items-center",
+                input {
+                    class: "flex-1 bg-muted px-3 py-2 rounded text-sm outline-none",
+                    placeholder: "Search history",
+                    value: "{query.read()}",
+                    oninput: on_input,
+                }
+                button {
+                    class: "px-3 py-2 text-xs bg-destructive text-destructive-foreground rounded",
+                    onclick: move |_| confirm_open.set(true),
+                    "Clear all"
+                }
+            }
+            main { class: "flex-1 overflow-y-auto p-3 text-sm",
+                for (label, group) in groups {
+                    div { class: "text-xs text-muted-foreground uppercase mt-4 mb-1", "{label}" }
+                    for entry in group {
+                        div {
+                            class: "flex items-center gap-2 py-1 border-b border-border hover:bg-muted group cursor-pointer",
+                            onclick: {
+                                let url = entry.url.clone();
+                                move |_| {
+                                    let _ = try_cef_bin_emit_rkyv(&HistoryOpenRequest {
+                                        url: url.clone(),
+                                        in_new_stack: true,
+                                    });
+                                }
+                            },
+                            span { class: "text-xs text-muted-foreground w-12", "{format_time(entry.visit_created_at)}" }
+                            Favicon {
+                                favicon_url: entry.favicon_url.clone(),
+                                url: entry.url.clone(),
+                                class: "w-4 h-4 shrink-0 rounded-sm object-contain".to_string(),
+                                globe_class: "w-4 h-4 shrink-0 text-muted-foreground".to_string(),
+                            }
+                            span { class: "flex-1 truncate",
+                                if entry.title.is_empty() { "{entry.url}" } else { "{entry.title}" }
+                            }
+                            button {
+                                class: "opacity-0 group-hover:opacity-100 text-xs text-muted-foreground hover:text-destructive px-2",
+                                onclick: {
+                                    let url_bits = entry.url_entity_bits;
+                                    move |e: Event<MouseData>| {
+                                        e.stop_propagation();
+                                        let _ = try_cef_bin_emit_rkyv(&HistoryDeleteRequest { url_entity_bits: url_bits });
+                                        entries.write().retain(|x| x.url_entity_bits != url_bits);
+                                    }
+                                },
+                                "\u{00d7}"
+                            }
+                        }
+                    }
+                }
+                div { id: "infinite-scroll-sentinel", class: "h-4" }
+            }
+        }
+        if *confirm_open.read() {
+            div { class: "fixed inset-0 bg-black/80 flex items-center justify-center z-50",
+                div { class: "bg-card border border-border p-6 rounded max-w-sm",
+                    h3 { class: "text-lg mb-2", "Clear all history?" }
+                    p { class: "text-sm text-muted-foreground mb-4", "This cannot be undone." }
+                    div { class: "flex gap-2 justify-end",
+                        button {
+                            class: "px-3 py-1 text-sm bg-muted rounded",
+                            onclick: move |_| confirm_open.set(false),
+                            "Cancel"
+                        }
+                        button {
+                            class: "px-3 py-1 text-sm bg-destructive text-destructive-foreground rounded",
+                            onclick: move |_| {
+                                let _ = try_cef_bin_emit_rkyv(&HistoryClearAllRequest);
+                                entries.write().clear();
+                                confirm_open.set(false);
+                            },
+                            "Clear all"
+                        }
                     }
                 }
             }
         }
     }
+}
+
+fn group_by_day(entries: &[HistoryEntry]) -> Vec<(String, Vec<HistoryEntry>)> {
+    let mut out: Vec<(String, Vec<HistoryEntry>)> = Vec::new();
+    let mut current_day: Option<i64> = None;
+    let now_day = now_millis_wasm() / 86_400_000;
+    for e in entries {
+        let day = e.visit_created_at / 86_400_000;
+        if current_day != Some(day) {
+            let label = match now_day - day {
+                0 => "Today".to_string(),
+                1 => "Yesterday".to_string(),
+                d if d < 7 => format!("{} days ago", d),
+                _ => format!("Day -{}", now_day - day),
+            };
+            out.push((label, Vec::new()));
+            current_day = Some(day);
+        }
+        out.last_mut().unwrap().1.push(e.clone());
+    }
+    out
+}
+
+fn now_millis_wasm() -> i64 {
+    js_sys::Date::now() as i64
+}
+
+fn format_time(ms: i64) -> String {
+    let total_sec = ms / 1000;
+    let h = (total_sec % 86400) / 3600;
+    let m = (total_sec % 3600) / 60;
+    format!("{:02}:{:02}", h, m)
 }

--- a/crates/vmux_history/src/plugin.rs
+++ b/crates/vmux_history/src/plugin.rs
@@ -1,48 +1,54 @@
 use std::path::PathBuf;
+use std::time::Duration;
 
-use bevy_cef::prelude::*;
-use vmux_server::{PageConfig, PageReady, Server};
+use bevy::time::common_conditions::on_timer;
+use bevy_cef::prelude::BinEventEmitterPlugin;
+use vmux_server::{PageConfig, Server};
 
-use crate::event::{HISTORY_EVENT, HistoryEvent};
-use vmux_core::PageMetadata;
+use crate::event::{
+    HistoryChangedEvent, HistoryClearAllRequest, HistoryDeleteRequest, HistoryOpenRequest,
+    HistoryQueryRequest, HistorySuggestionsRequest,
+};
+use crate::prune::prune_history;
+use crate::query::{
+    HistoryOpenIntent, broadcast_history_changed, on_history_clear_all_request,
+    on_history_delete_request, on_history_open_request, on_history_query_request,
+    on_history_suggestions_request,
+};
+use crate::spawn::spawn_visits;
 
 pub struct HistoryPlugin;
 
 impl Plugin for HistoryPlugin {
     fn build(&self, app: &mut App) {
-        app.world_mut()
-            .resource_mut::<Server>()
-            .register(
-                PathBuf::from(env!("CARGO_MANIFEST_DIR")),
-                &PageConfig::with_custom_host("history"),
-            );
-        app.add_systems(Update, push_history_via_host_emit);
-    }
-}
+        app.world_mut().resource_mut::<Server>().register(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+            &PageConfig::with_custom_host("history"),
+        );
+        app.add_systems(Update, (spawn_visits, broadcast_history_changed).chain());
+        app.add_systems(
+            Update,
+            prune_history.run_if(on_timer(Duration::from_secs(3600))),
+        );
+        app.add_systems(Startup, prune_history);
 
-#[derive(Component, Clone, Copy, Debug)]
-struct Sent(#[allow(dead_code)] i64);
+        app.add_plugins(
+            BinEventEmitterPlugin::<(
+                HistoryQueryRequest,
+                HistoryDeleteRequest,
+                HistoryClearAllRequest,
+                HistoryOpenRequest,
+                HistorySuggestionsRequest,
+                HistoryChangedEvent,
+            )>::default(),
+        );
 
-#[allow(clippy::type_complexity)]
-fn push_history_via_host_emit(
-    mut commands: Commands,
-    browsers: NonSend<Browsers>,
-    ready: Query<Entity, (With<WebviewSource>, With<PageReady>, Without<Sent>)>,
-    history_q: Query<(&PageMetadata, &CreatedAt), With<Visit>>,
-) {
-    for wv in ready.iter() {
-        if !browsers.has_browser(wv) || !browsers.host_emit_ready(&wv) {
-            continue;
-        }
-        let mut rows: Vec<(&PageMetadata, &CreatedAt)> = history_q.iter().collect();
-        rows.sort_by_key(|(_, created)| std::cmp::Reverse(created.0));
-        let history: Vec<String> = rows
-            .into_iter()
-            .map(|(meta, _)| meta.url.clone())
-            .collect();
-        let url = history.join(", ");
-        let payload = HistoryEvent { url, history };
-        commands.trigger(BinHostEmitEvent::from_rkyv(wv, HISTORY_EVENT, &payload));
-        commands.entity(wv).insert(Sent(now_millis()));
+        app.add_observer(on_history_query_request);
+        app.add_observer(on_history_delete_request);
+        app.add_observer(on_history_clear_all_request);
+        app.add_observer(on_history_open_request);
+        app.add_observer(on_history_suggestions_request);
+
+        app.add_message::<HistoryOpenIntent>();
     }
 }

--- a/crates/vmux_history/src/prune.rs
+++ b/crates/vmux_history/src/prune.rs
@@ -1,0 +1,117 @@
+use bevy::prelude::*;
+use vmux_core::{CreatedAt, LastVisitedAt, Url, Visit, VisitedUrl, now_millis};
+
+pub const RETENTION_MS: i64 = 90 * 86_400_000;
+
+pub fn prune_history(
+    mut commands: Commands,
+    visits: Query<(Entity, &CreatedAt, &VisitedUrl), With<Visit>>,
+    urls: Query<(Entity, &LastVisitedAt), With<Url>>,
+) {
+    let cutoff = now_millis() - RETENTION_MS;
+
+    let mut pruned_visits = Vec::<Entity>::new();
+    for (e, created, _) in visits.iter() {
+        if created.0 < cutoff {
+            commands.entity(e).despawn();
+            pruned_visits.push(e);
+        }
+    }
+
+    for (url_e, last) in urls.iter() {
+        if last.0 < cutoff {
+            let has_remaining = visits
+                .iter()
+                .any(|(ve, _, visited)| visited.0 == url_e && !pruned_visits.contains(&ve));
+            if !has_remaining {
+                commands.entity(url_e).despawn();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vmux_core::{CorePlugin, PageMetadata, VisitCount};
+
+    fn app() -> App {
+        let mut a = App::new();
+        a.add_plugins(MinimalPlugins);
+        a.add_plugins(CorePlugin);
+        a.add_systems(Update, prune_history);
+        a
+    }
+
+    #[test]
+    fn removes_old_visits_and_urls() {
+        let mut a = app();
+        let old = now_millis() - RETENTION_MS - 1000;
+        let url_e = a
+            .world_mut()
+            .spawn((
+                Url,
+                PageMetadata {
+                    url: "old".into(),
+                    ..default()
+                },
+                VisitCount(1),
+                LastVisitedAt(old),
+                CreatedAt(old),
+            ))
+            .id();
+        a.world_mut()
+            .spawn((Visit, CreatedAt(old), VisitedUrl(url_e)));
+        a.update();
+        assert_eq!(a.world_mut().query::<&Url>().iter(a.world()).count(), 0);
+        assert_eq!(a.world_mut().query::<&Visit>().iter(a.world()).count(), 0);
+    }
+
+    #[test]
+    fn keeps_recent_entries() {
+        let mut a = app();
+        let now = now_millis();
+        let url_e = a
+            .world_mut()
+            .spawn((
+                Url,
+                PageMetadata {
+                    url: "recent".into(),
+                    ..default()
+                },
+                VisitCount(1),
+                LastVisitedAt(now),
+                CreatedAt(now),
+            ))
+            .id();
+        a.world_mut()
+            .spawn((Visit, CreatedAt(now), VisitedUrl(url_e)));
+        a.update();
+        assert_eq!(a.world_mut().query::<&Url>().iter(a.world()).count(), 1);
+        assert_eq!(a.world_mut().query::<&Visit>().iter(a.world()).count(), 1);
+    }
+
+    #[test]
+    fn keeps_url_when_recent_visit_exists() {
+        let mut a = app();
+        let now = now_millis();
+        let old = now - RETENTION_MS - 1000;
+        let url_e = a
+            .world_mut()
+            .spawn((
+                Url,
+                PageMetadata {
+                    url: "u".into(),
+                    ..default()
+                },
+                VisitCount(2),
+                LastVisitedAt(now),
+                CreatedAt(old),
+            ))
+            .id();
+        a.world_mut()
+            .spawn((Visit, CreatedAt(now), VisitedUrl(url_e)));
+        a.update();
+        assert_eq!(a.world_mut().query::<&Url>().iter(a.world()).count(), 1);
+    }
+}

--- a/crates/vmux_history/src/query.rs
+++ b/crates/vmux_history/src/query.rs
@@ -1,0 +1,469 @@
+pub fn frecency(visit_count: u32, last_visited_at: i64, now: i64) -> f32 {
+    let age_hours = ((now - last_visited_at).max(0) as f32) / 3_600_000.0;
+    let decay = 1.0 / (1.0 + age_hours / 24.0);
+    (visit_count as f32) * decay
+}
+
+pub fn match_strength(query: &str, url: &str, title: &str) -> f32 {
+    if query.is_empty() {
+        return 1.0;
+    }
+    let q = query.to_lowercase();
+    let u = url.to_lowercase();
+    let t = title.to_lowercase();
+    let mut score = 0.0;
+    if u.starts_with(&q) {
+        score += 3.0;
+    }
+    if t.starts_with(&q) {
+        score += 2.0;
+    }
+    if u.contains(&q) && !u.starts_with(&q) {
+        score += 1.0;
+    }
+    if t.contains(&q) && !t.starts_with(&q) {
+        score += 1.0;
+    }
+    score
+}
+
+pub fn score(
+    visit_count: u32,
+    last_visited_at: i64,
+    now: i64,
+    query: &str,
+    url: &str,
+    title: &str,
+) -> f32 {
+    let m = match_strength(query, url, title);
+    if m == 0.0 {
+        return 0.0;
+    }
+    frecency(visit_count, last_visited_at, now) * m
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+use bevy::ecs::message::Messages;
+#[cfg(not(target_arch = "wasm32"))]
+use bevy::prelude::*;
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::event::{
+    HISTORY_CHANGED_EVENT, HISTORY_QUERY_RESPONSE_EVENT, HISTORY_SUGGESTIONS_RESPONSE_EVENT,
+    HistoryChangedEvent, HistoryClearAllRequest, HistoryDeleteRequest, HistoryEntry,
+    HistoryOpenRequest, HistoryQueryRequest, HistoryQueryResponse, HistorySuggestionsRequest,
+    HistorySuggestionsResponse,
+};
+#[cfg(not(target_arch = "wasm32"))]
+use bevy_cef::prelude::{BinHostEmitEvent, BinReceive};
+#[cfg(not(target_arch = "wasm32"))]
+use vmux_core::{CreatedAt, LastVisitedAt, PageMetadata, Url, Visit, VisitCount, VisitedUrl};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn on_history_query_request(
+    trigger: On<BinReceive<HistoryQueryRequest>>,
+    urls: Query<(Entity, &PageMetadata, &VisitCount, &LastVisitedAt), With<Url>>,
+    visits: Query<(&CreatedAt, &VisitedUrl), With<Visit>>,
+    mut commands: Commands,
+) {
+    let req = &trigger.event().payload;
+    let now = vmux_core::now_millis();
+
+    let url_rows: Vec<_> = urls
+        .iter()
+        .map(|(e, m, c, l)| (e, m.clone(), *c, *l))
+        .collect();
+    let visit_rows: Vec<_> = visits.iter().map(|(c, vu)| (*c, *vu)).collect();
+
+    let entries = build_entries(&req.query, &url_rows, &visit_rows, now);
+    let total = entries.len();
+    let offset = req.offset as usize;
+    let limit = req.limit as usize;
+    let page: Vec<_> = entries.into_iter().skip(offset).take(limit).collect();
+    let returned = page.len();
+    let has_more = offset + returned < total;
+
+    let payload = HistoryQueryResponse {
+        request_id: req.request_id,
+        entries: page,
+        has_more,
+    };
+    commands.trigger(BinHostEmitEvent::from_rkyv(
+        trigger.event().webview,
+        HISTORY_QUERY_RESPONSE_EVENT,
+        &payload,
+    ));
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn build_entries(
+    query: &Option<String>,
+    urls: &[(Entity, PageMetadata, VisitCount, LastVisitedAt)],
+    visits: &[(CreatedAt, VisitedUrl)],
+    now: i64,
+) -> Vec<HistoryEntry> {
+    match query {
+        None => {
+            let mut entries: Vec<HistoryEntry> = visits
+                .iter()
+                .filter_map(|(created, visited_url)| {
+                    let (e, meta, count, last) =
+                        urls.iter().find(|(e, _, _, _)| *e == visited_url.0)?;
+                    Some(HistoryEntry {
+                        url_entity_bits: e.to_bits(),
+                        url: meta.url.clone(),
+                        title: meta.title.clone(),
+                        favicon_url: meta.favicon_url.clone(),
+                        visit_created_at: created.0,
+                        visit_count: count.0,
+                        last_visited_at: last.0,
+                    })
+                })
+                .collect();
+            entries.sort_by_key(|e| std::cmp::Reverse(e.visit_created_at));
+            entries
+        }
+        Some(q) => {
+            let mut scored: Vec<(f32, HistoryEntry)> = urls
+                .iter()
+                .filter_map(|(e, meta, count, last)| {
+                    let s = score(count.0, last.0, now, q, &meta.url, &meta.title);
+                    if s <= 0.0 {
+                        return None;
+                    }
+                    Some((
+                        s,
+                        HistoryEntry {
+                            url_entity_bits: e.to_bits(),
+                            url: meta.url.clone(),
+                            title: meta.title.clone(),
+                            favicon_url: meta.favicon_url.clone(),
+                            visit_created_at: last.0,
+                            visit_count: count.0,
+                            last_visited_at: last.0,
+                        },
+                    ))
+                })
+                .collect();
+            scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+            scored.into_iter().map(|(_, e)| e).collect()
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn on_history_delete_request(
+    trigger: On<BinReceive<HistoryDeleteRequest>>,
+    mut commands: Commands,
+    visits: Query<(Entity, &VisitedUrl), With<Visit>>,
+) {
+    let target = Entity::from_bits(trigger.event().payload.url_entity_bits);
+    for (visit_e, visited_url) in visits.iter() {
+        if visited_url.0 == target {
+            commands.entity(visit_e).despawn();
+        }
+    }
+    if commands.get_entity(target).is_ok() {
+        commands.entity(target).despawn();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn on_history_clear_all_request(
+    _trigger: On<BinReceive<HistoryClearAllRequest>>,
+    mut commands: Commands,
+    urls: Query<Entity, With<Url>>,
+    visits: Query<Entity, With<Visit>>,
+) {
+    for e in urls.iter() {
+        commands.entity(e).despawn();
+    }
+    for e in visits.iter() {
+        commands.entity(e).despawn();
+    }
+}
+
+#[derive(Clone, Debug, Message)]
+#[cfg(not(target_arch = "wasm32"))]
+pub struct HistoryOpenIntent {
+    pub url: String,
+    pub in_new_stack: bool,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn on_history_open_request(
+    trigger: On<BinReceive<HistoryOpenRequest>>,
+    mut messages: ResMut<Messages<HistoryOpenIntent>>,
+) {
+    let req = &trigger.event().payload;
+    messages.write(HistoryOpenIntent {
+        url: req.url.clone(),
+        in_new_stack: req.in_new_stack,
+    });
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn broadcast_history_changed(
+    changed: Query<(), (Changed<LastVisitedAt>, With<Url>)>,
+    webviews: Query<(Entity, &bevy_cef::prelude::WebviewSource)>,
+    browsers: NonSend<bevy_cef_core::prelude::Browsers>,
+    mut commands: Commands,
+) {
+    if changed.iter().next().is_none() {
+        return;
+    }
+    for (e, src) in &webviews {
+        let bevy_cef::prelude::WebviewSource::Url(url) = src else {
+            continue;
+        };
+        if !url.starts_with("vmux://history") {
+            continue;
+        }
+        if !browsers.has_browser(e) || !browsers.host_emit_ready(&e) {
+            continue;
+        }
+        commands.trigger(BinHostEmitEvent::from_rkyv(
+            e,
+            HISTORY_CHANGED_EVENT,
+            &HistoryChangedEvent,
+        ));
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn on_history_suggestions_request(
+    trigger: On<BinReceive<HistorySuggestionsRequest>>,
+    urls: Query<(Entity, &PageMetadata, &VisitCount, &LastVisitedAt), With<Url>>,
+    mut commands: Commands,
+) {
+    let req = &trigger.event().payload;
+    let now = vmux_core::now_millis();
+
+    let mut scored: Vec<(f32, HistoryEntry)> = urls
+        .iter()
+        .filter_map(|(e, meta, count, last)| {
+            let s = score(count.0, last.0, now, &req.query, &meta.url, &meta.title);
+            if s <= 0.0 {
+                return None;
+            }
+            Some((
+                s,
+                HistoryEntry {
+                    url_entity_bits: e.to_bits(),
+                    url: meta.url.clone(),
+                    title: meta.title.clone(),
+                    favicon_url: meta.favicon_url.clone(),
+                    visit_created_at: last.0,
+                    visit_count: count.0,
+                    last_visited_at: last.0,
+                },
+            ))
+        })
+        .collect();
+    scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+    let entries: Vec<HistoryEntry> = scored
+        .into_iter()
+        .take(req.limit as usize)
+        .map(|(_, e)| e)
+        .collect();
+
+    commands.trigger(BinHostEmitEvent::from_rkyv(
+        trigger.event().webview,
+        HISTORY_SUGGESTIONS_RESPONSE_EVENT,
+        &HistorySuggestionsResponse {
+            request_id: req.request_id,
+            entries,
+        },
+    ));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frecency_decays_with_age() {
+        let now = 1_000_000_000;
+        let recent = frecency(10, now - 3_600_000, now);
+        let old = frecency(10, now - 100 * 3_600_000, now);
+        assert!(recent > old);
+    }
+
+    #[test]
+    fn match_strength_url_prefix_beats_substring() {
+        let pfx = match_strength("git", "github.com", "GitHub");
+        let mid = match_strength("hub", "github.com", "GitHub");
+        assert!(pfx > mid);
+    }
+
+    #[test]
+    fn match_strength_zero_on_miss() {
+        assert_eq!(match_strength("xyz", "github.com", "GitHub"), 0.0);
+    }
+
+    #[test]
+    fn match_strength_one_when_query_empty() {
+        assert_eq!(match_strength("", "github.com", "GitHub"), 1.0);
+    }
+
+    #[test]
+    fn higher_visit_count_ranks_higher_at_equal_match() {
+        let now = 1_000_000_000;
+        let a = score(20, now, now, "git", "github.com", "GitHub");
+        let b = score(2, now, now, "git", "github.com", "GitHub");
+        assert!(a > b);
+    }
+}
+
+#[cfg(test)]
+mod handler_tests {
+    use super::*;
+    use vmux_core::{
+        CorePlugin, CreatedAt, LastVisitedAt, PageMetadata, Url, VisitCount, VisitedUrl,
+    };
+
+    #[test]
+    fn build_entries_no_query_orders_by_visit_created_at_desc() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_plugins(CorePlugin);
+
+        let url_e = app
+            .world_mut()
+            .spawn((
+                Url,
+                PageMetadata {
+                    url: "https://example.com".into(),
+                    ..default()
+                },
+                VisitCount(2),
+                LastVisitedAt(200),
+                CreatedAt(0),
+            ))
+            .id();
+
+        let url_rows = vec![(
+            url_e,
+            PageMetadata {
+                url: "https://example.com".into(),
+                ..default()
+            },
+            VisitCount(2),
+            LastVisitedAt(200),
+        )];
+        let visit_rows = vec![
+            (CreatedAt(100), VisitedUrl(url_e)),
+            (CreatedAt(200), VisitedUrl(url_e)),
+        ];
+
+        let entries = build_entries(&None, &url_rows, &visit_rows, 1000);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].visit_created_at, 200);
+        assert_eq!(entries[1].visit_created_at, 100);
+    }
+
+    #[test]
+    fn build_entries_with_query_filters_and_ranks() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_plugins(CorePlugin);
+
+        let e1 = app
+            .world_mut()
+            .spawn((
+                Url,
+                PageMetadata {
+                    url: "https://github.com".into(),
+                    title: "GitHub".into(),
+                    ..default()
+                },
+                VisitCount(10),
+                LastVisitedAt(1000),
+                CreatedAt(0),
+            ))
+            .id();
+
+        let e2 = app
+            .world_mut()
+            .spawn((
+                Url,
+                PageMetadata {
+                    url: "https://example.com".into(),
+                    title: "Example".into(),
+                    ..default()
+                },
+                VisitCount(10),
+                LastVisitedAt(1000),
+                CreatedAt(0),
+            ))
+            .id();
+
+        let url_rows = vec![
+            (
+                e1,
+                PageMetadata {
+                    url: "https://github.com".into(),
+                    title: "GitHub".into(),
+                    ..default()
+                },
+                VisitCount(10),
+                LastVisitedAt(1000),
+            ),
+            (
+                e2,
+                PageMetadata {
+                    url: "https://example.com".into(),
+                    title: "Example".into(),
+                    ..default()
+                },
+                VisitCount(10),
+                LastVisitedAt(1000),
+            ),
+        ];
+        let visit_rows = vec![];
+
+        let entries = build_entries(&Some("git".into()), &url_rows, &visit_rows, 1000);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].url, "https://github.com");
+    }
+
+    #[test]
+    fn build_entries_pagination() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_plugins(CorePlugin);
+
+        let url_e = app
+            .world_mut()
+            .spawn((
+                Url,
+                PageMetadata {
+                    url: "u".into(),
+                    ..default()
+                },
+                VisitCount(1),
+                LastVisitedAt(0),
+                CreatedAt(0),
+            ))
+            .id();
+
+        let url_rows = vec![(
+            url_e,
+            PageMetadata {
+                url: "u".into(),
+                ..default()
+            },
+            VisitCount(1),
+            LastVisitedAt(0),
+        )];
+        let visit_rows: Vec<_> = (0..5)
+            .map(|i| (CreatedAt(i * 100), VisitedUrl(url_e)))
+            .collect();
+
+        let all = build_entries(&None, &url_rows, &visit_rows, 1000);
+        assert_eq!(all.len(), 5);
+
+        let page: Vec<_> = all.into_iter().skip(2).take(2).collect();
+        assert_eq!(page.len(), 2);
+    }
+}

--- a/crates/vmux_history/src/spawn.rs
+++ b/crates/vmux_history/src/spawn.rs
@@ -1,0 +1,270 @@
+use bevy::prelude::*;
+use vmux_core::{
+    CreatedAt, LastVisitedAt, PageMetadata, TransitionType, Url, Visit, VisitCount, VisitedUrl,
+    now_millis,
+};
+
+pub fn find_or_create_url(world: &mut World, url: &str) -> Entity {
+    let mut existing = None;
+    let mut query = world.query::<(Entity, &PageMetadata)>();
+    for (e, meta) in query.iter(world) {
+        if world.get::<Url>(e).is_some() && meta.url == url {
+            existing = Some(e);
+            break;
+        }
+    }
+    if let Some(e) = existing {
+        return e;
+    }
+    let now = now_millis();
+    world
+        .spawn((
+            Url,
+            PageMetadata {
+                url: url.to_string(),
+                ..default()
+            },
+            VisitCount(0),
+            LastVisitedAt(0),
+            CreatedAt(now),
+        ))
+        .id()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vmux_core::CorePlugin;
+
+    fn app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_plugins(CorePlugin);
+        app
+    }
+
+    #[test]
+    fn creates_when_missing() {
+        let mut app = app();
+        let e = find_or_create_url(app.world_mut(), "https://example.com");
+        assert!(app.world().get::<Url>(e).is_some());
+        let meta = app.world().get::<PageMetadata>(e).unwrap();
+        assert_eq!(meta.url, "https://example.com");
+        assert_eq!(app.world().get::<VisitCount>(e).unwrap().0, 0);
+    }
+
+    #[test]
+    fn returns_existing_match() {
+        let mut app = app();
+        let e1 = find_or_create_url(app.world_mut(), "https://example.com");
+        let e2 = find_or_create_url(app.world_mut(), "https://example.com");
+        assert_eq!(e1, e2);
+    }
+
+    #[test]
+    fn distinct_urls_get_distinct_entities() {
+        let mut app = app();
+        let a = find_or_create_url(app.world_mut(), "https://a.com");
+        let b = find_or_create_url(app.world_mut(), "https://b.com");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn ignores_entities_without_url_marker() {
+        let mut app = app();
+        app.world_mut().spawn(PageMetadata {
+            url: "https://example.com".into(),
+            ..default()
+        });
+        let e = find_or_create_url(app.world_mut(), "https://example.com");
+        assert!(app.world().get::<Url>(e).is_some());
+    }
+}
+
+pub fn spawn_visits(
+    mut events: bevy::ecs::message::MessageReader<
+        bevy_cef_core::prelude::WebviewCommittedNavigationEvent,
+    >,
+    mut commands: Commands,
+    mut urls: Query<(Entity, &PageMetadata, &mut VisitCount, &mut LastVisitedAt), With<Url>>,
+) {
+    for ev in events.read() {
+        if !ev.is_main_frame {
+            continue;
+        }
+        if ev.url.starts_with("vmux://") || ev.url.is_empty() {
+            continue;
+        }
+        let now = now_millis();
+        let transition = crate::transition::map(ev.transition, ev.qualifiers);
+
+        let mut url_entity = None;
+        for (e, meta, mut count, mut last) in urls.iter_mut() {
+            if meta.url == ev.url {
+                count.0 = count.0.saturating_add(1);
+                last.0 = now;
+                url_entity = Some(e);
+                break;
+            }
+        }
+
+        let url_e = match url_entity {
+            Some(e) => e,
+            None => commands
+                .spawn((
+                    Url,
+                    PageMetadata {
+                        url: ev.url.clone(),
+                        ..default()
+                    },
+                    VisitCount(1),
+                    LastVisitedAt(now),
+                    CreatedAt(now),
+                ))
+                .id(),
+        };
+
+        if transition != TransitionType::BackForward {
+            commands.spawn((Visit, CreatedAt(now), VisitedUrl(url_e), transition));
+        }
+    }
+}
+
+#[cfg(test)]
+mod system_tests {
+    use super::*;
+    use bevy::ecs::message::Messages;
+    use bevy_cef_core::prelude::{
+        CefTransitionCore, CefTransitionQualifiers, WebviewCommittedNavigationEvent,
+    };
+    use vmux_core::CorePlugin;
+
+    fn app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_plugins(CorePlugin);
+        app.add_message::<WebviewCommittedNavigationEvent>();
+        app.add_systems(Update, spawn_visits);
+        app
+    }
+
+    fn send(app: &mut App, url: &str, transition: CefTransitionCore, forward_back: bool) {
+        let mut writer = app
+            .world_mut()
+            .resource_mut::<Messages<WebviewCommittedNavigationEvent>>();
+        writer.write(WebviewCommittedNavigationEvent {
+            webview: Entity::PLACEHOLDER,
+            url: url.into(),
+            is_main_frame: true,
+            transition,
+            qualifiers: CefTransitionQualifiers {
+                forward_back,
+                ..Default::default()
+            },
+        });
+    }
+
+    #[test]
+    fn first_visit_spawns_url_and_visit() {
+        let mut app = app();
+        send(
+            &mut app,
+            "https://example.com",
+            CefTransitionCore::Link,
+            false,
+        );
+        app.update();
+        let urls = app.world_mut().query::<&Url>().iter(app.world()).count();
+        let visits = app.world_mut().query::<&Visit>().iter(app.world()).count();
+        assert_eq!(urls, 1);
+        assert_eq!(visits, 1);
+    }
+
+    #[test]
+    fn second_visit_same_url_increments_count() {
+        let mut app = app();
+        send(
+            &mut app,
+            "https://example.com",
+            CefTransitionCore::Link,
+            false,
+        );
+        app.update();
+        send(
+            &mut app,
+            "https://example.com",
+            CefTransitionCore::Link,
+            false,
+        );
+        app.update();
+        let urls = app.world_mut().query::<&Url>().iter(app.world()).count();
+        let visits = app.world_mut().query::<&Visit>().iter(app.world()).count();
+        assert_eq!(urls, 1);
+        assert_eq!(visits, 2);
+        let count = app
+            .world_mut()
+            .query::<&VisitCount>()
+            .iter(app.world())
+            .next()
+            .unwrap()
+            .0;
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn back_forward_bumps_count_but_no_visit() {
+        let mut app = app();
+        send(
+            &mut app,
+            "https://example.com",
+            CefTransitionCore::Link,
+            false,
+        );
+        app.update();
+        send(
+            &mut app,
+            "https://example.com",
+            CefTransitionCore::Link,
+            true,
+        );
+        app.update();
+        let visits = app.world_mut().query::<&Visit>().iter(app.world()).count();
+        let count = app
+            .world_mut()
+            .query::<&VisitCount>()
+            .iter(app.world())
+            .next()
+            .unwrap()
+            .0;
+        assert_eq!(visits, 1);
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn subframe_skipped() {
+        let mut app = app();
+        let mut writer = app
+            .world_mut()
+            .resource_mut::<Messages<WebviewCommittedNavigationEvent>>();
+        writer.write(WebviewCommittedNavigationEvent {
+            webview: Entity::PLACEHOLDER,
+            url: "https://example.com".into(),
+            is_main_frame: false,
+            transition: CefTransitionCore::Link,
+            qualifiers: CefTransitionQualifiers::default(),
+        });
+        app.update();
+        assert_eq!(
+            app.world_mut().query::<&Visit>().iter(app.world()).count(),
+            0
+        );
+    }
+
+    #[test]
+    fn vmux_scheme_skipped() {
+        let mut app = app();
+        send(&mut app, "vmux://history", CefTransitionCore::Link, false);
+        app.update();
+        assert_eq!(app.world_mut().query::<&Url>().iter(app.world()).count(), 0);
+    }
+}

--- a/crates/vmux_history/src/transition.rs
+++ b/crates/vmux_history/src/transition.rs
@@ -1,0 +1,96 @@
+use bevy_cef_core::prelude::{CefTransitionCore, CefTransitionQualifiers};
+use vmux_core::TransitionType;
+
+pub fn map(core: CefTransitionCore, qual: CefTransitionQualifiers) -> TransitionType {
+    if qual.forward_back {
+        return TransitionType::BackForward;
+    }
+    if qual.client_redirect || qual.server_redirect {
+        return TransitionType::Redirect;
+    }
+    match core {
+        CefTransitionCore::Reload => TransitionType::Reload,
+        CefTransitionCore::Explicit
+        | CefTransitionCore::Generated
+        | CefTransitionCore::Keyword
+        | CefTransitionCore::KeywordGenerated => TransitionType::Typed,
+        CefTransitionCore::Link
+        | CefTransitionCore::FormSubmit
+        | CefTransitionCore::AutoBookmark => TransitionType::Link,
+        _ => TransitionType::Other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn no_qual() -> CefTransitionQualifiers {
+        CefTransitionQualifiers::default()
+    }
+
+    #[test]
+    fn forward_back_wins_over_core() {
+        let qual = CefTransitionQualifiers {
+            forward_back: true,
+            ..no_qual()
+        };
+        assert_eq!(
+            map(CefTransitionCore::Explicit, qual),
+            TransitionType::BackForward
+        );
+    }
+
+    #[test]
+    fn server_redirect_wins_over_core() {
+        let qual = CefTransitionQualifiers {
+            server_redirect: true,
+            ..no_qual()
+        };
+        assert_eq!(map(CefTransitionCore::Link, qual), TransitionType::Redirect);
+    }
+
+    #[test]
+    fn typed_from_explicit() {
+        assert_eq!(
+            map(CefTransitionCore::Explicit, no_qual()),
+            TransitionType::Typed
+        );
+    }
+
+    #[test]
+    fn typed_from_generated() {
+        assert_eq!(
+            map(CefTransitionCore::Generated, no_qual()),
+            TransitionType::Typed
+        );
+    }
+
+    #[test]
+    fn link_from_link_and_form_submit() {
+        assert_eq!(
+            map(CefTransitionCore::Link, no_qual()),
+            TransitionType::Link
+        );
+        assert_eq!(
+            map(CefTransitionCore::FormSubmit, no_qual()),
+            TransitionType::Link
+        );
+    }
+
+    #[test]
+    fn reload_maps_directly() {
+        assert_eq!(
+            map(CefTransitionCore::Reload, no_qual()),
+            TransitionType::Reload
+        );
+    }
+
+    #[test]
+    fn subframe_falls_to_other() {
+        assert_eq!(
+            map(CefTransitionCore::AutoSubframe, no_qual()),
+            TransitionType::Other
+        );
+    }
+}

--- a/crates/vmux_layout/src/cef.rs
+++ b/crates/vmux_layout/src/cef.rs
@@ -36,6 +36,34 @@ impl Plugin for LayoutCefPlugin {
     }
 }
 
+pub fn mirror_metadata_to_url(
+    chrome_q: Query<
+        &vmux_core::PageMetadata,
+        (Without<vmux_core::Url>, Changed<vmux_core::PageMetadata>),
+    >,
+    mut urls: Query<&mut vmux_core::PageMetadata, With<vmux_core::Url>>,
+) {
+    for tab_meta in chrome_q.iter() {
+        if tab_meta.url.is_empty() {
+            continue;
+        }
+        for mut url_meta in urls.iter_mut() {
+            if url_meta.url == tab_meta.url {
+                if !tab_meta.title.is_empty() {
+                    url_meta.title.clone_from(&tab_meta.title);
+                }
+                if !tab_meta.favicon_url.is_empty() {
+                    url_meta.favicon_url.clone_from(&tab_meta.favicon_url);
+                }
+                if tab_meta.bg_color.is_some() {
+                    url_meta.bg_color.clone_from(&tab_meta.bg_color);
+                }
+                break;
+            }
+        }
+    }
+}
+
 pub fn apply_chrome_state_from_cef(
     chrome_rx: Res<WebviewChromeStateReceiver>,
     mut browser_meta: Query<&mut vmux_core::PageMetadata>,
@@ -44,19 +72,28 @@ pub fn apply_chrome_state_from_cef(
         let Ok(mut meta) = browser_meta.get_mut(ev.webview) else {
             continue;
         };
-        let url_owned_by_native_view = meta.url.starts_with("vmux://");
-        if let Some(url) = ev.url
-            && !url_owned_by_native_view
-        {
-            meta.url = url;
-            meta.favicon_url.clear();
-        }
-        if let Some(title) = ev.title {
-            meta.title = title;
-        }
-        if let Some(favicon) = ev.favicon_url {
-            meta.favicon_url = favicon;
-        }
+        apply_chrome_state_to_meta(&mut meta, ev);
+    }
+}
+
+pub(crate) fn apply_chrome_state_to_meta(
+    meta: &mut vmux_core::PageMetadata,
+    ev: bevy_cef_core::prelude::WebviewChromeStateEvent,
+) {
+    let on_native_view = meta.url.starts_with("vmux://");
+    let navigating_away = ev.url.as_deref().is_some_and(|u| !u.starts_with("vmux://"));
+    if on_native_view && !navigating_away {
+        return;
+    }
+    if let Some(url) = ev.url {
+        meta.url = url;
+        meta.favicon_url.clear();
+    }
+    if let Some(title) = ev.title {
+        meta.title = title;
+    }
+    if let Some(favicon) = ev.favicon_url {
+        meta.favicon_url = favicon;
     }
 }
 
@@ -70,6 +107,48 @@ impl Browser {
             Self,
             vmux_core::PageMetadata {
                 title: url.to_string(),
+                url: url.to_string(),
+                favicon_url: String::new(),
+                bg_color: None,
+            },
+            WebviewSource::new(url),
+            ResolvedWebviewUri(url.to_string()),
+            Mesh3d(meshes.add(Plane3d::new(Vec3::Z, Vec2::splat(0.5)))),
+            MeshMaterial3d(webview_mt.add(WebviewExtendStandardMaterial {
+                base: StandardMaterial {
+                    unlit: true,
+                    alpha_mode: AlphaMode::Blend,
+                    depth_bias: WEBVIEW_MESH_DEPTH_BIAS,
+                    ..default()
+                },
+                ..default()
+            })),
+            WebviewSize(Vec2::new(1280.0, 720.0)),
+            Transform::default(),
+            GlobalTransform::default(),
+            Node {
+                position_type: PositionType::Absolute,
+                left: Val::Px(0.0),
+                right: Val::Px(0.0),
+                top: Val::Px(0.0),
+                bottom: Val::Px(0.0),
+                ..default()
+            },
+            Visibility::Inherited,
+            Pickable::default(),
+        )
+    }
+
+    pub fn new_with_title(
+        meshes: &mut ResMut<Assets<Mesh>>,
+        webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
+        url: &str,
+        title: &str,
+    ) -> impl Bundle {
+        (
+            Self,
+            vmux_core::PageMetadata {
+                title: title.to_string(),
                 url: url.to_string(),
                 favicon_url: String::new(),
                 bg_color: None,
@@ -180,5 +259,186 @@ mod tests {
                 is_hoverable: true,
             }
         );
+    }
+}
+
+#[cfg(test)]
+mod apply_chrome_state_tests {
+    use super::*;
+    use bevy_cef_core::prelude::WebviewChromeStateEvent;
+    use vmux_core::PageMetadata;
+
+    fn vmux_meta() -> PageMetadata {
+        PageMetadata {
+            url: "vmux://history/".into(),
+            title: "History".into(),
+            favicon_url: String::new(),
+            bg_color: None,
+        }
+    }
+
+    fn external_meta() -> PageMetadata {
+        PageMetadata {
+            url: "https://example.com".into(),
+            title: "old".into(),
+            favicon_url: String::new(),
+            bg_color: None,
+        }
+    }
+
+    fn ev(
+        title: Option<&str>,
+        favicon: Option<&str>,
+        url: Option<&str>,
+    ) -> WebviewChromeStateEvent {
+        WebviewChromeStateEvent {
+            webview: Entity::PLACEHOLDER,
+            url: url.map(str::to_string),
+            title: title.map(str::to_string),
+            favicon_url: favicon.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn vmux_url_preserves_title_against_cef_update() {
+        let mut meta = vmux_meta();
+        apply_chrome_state_to_meta(&mut meta, ev(Some("vmux history POC"), None, None));
+        assert_eq!(meta.title, "History");
+    }
+
+    #[test]
+    fn vmux_url_preserves_favicon_against_cef_update() {
+        let mut meta = vmux_meta();
+        apply_chrome_state_to_meta(&mut meta, ev(None, Some("https://x/fav.ico"), None));
+        assert_eq!(meta.favicon_url, "");
+    }
+
+    #[test]
+    fn vmux_url_preserves_url_when_cef_reports_same_vmux_url() {
+        let mut meta = vmux_meta();
+        apply_chrome_state_to_meta(&mut meta, ev(None, None, Some("vmux://history/")));
+        assert_eq!(meta.url, "vmux://history/");
+        assert_eq!(meta.title, "History");
+    }
+
+    #[test]
+    fn vmux_url_updates_when_cef_navigates_to_external_url() {
+        let mut meta = vmux_meta();
+        apply_chrome_state_to_meta(&mut meta, ev(None, None, Some("https://anthropic.com")));
+        assert_eq!(meta.url, "https://anthropic.com");
+    }
+
+    #[test]
+    fn after_navigation_away_subsequent_title_updates_apply() {
+        let mut meta = vmux_meta();
+        apply_chrome_state_to_meta(&mut meta, ev(None, None, Some("https://anthropic.com")));
+        apply_chrome_state_to_meta(&mut meta, ev(Some("Frontier AI"), None, None));
+        assert_eq!(meta.title, "Frontier AI");
+    }
+
+    #[test]
+    fn external_url_accepts_title_update() {
+        let mut meta = external_meta();
+        apply_chrome_state_to_meta(&mut meta, ev(Some("New Title"), None, None));
+        assert_eq!(meta.title, "New Title");
+    }
+
+    #[test]
+    fn external_url_accepts_favicon_update() {
+        let mut meta = external_meta();
+        apply_chrome_state_to_meta(&mut meta, ev(None, Some("https://x/fav.ico"), None));
+        assert_eq!(meta.favicon_url, "https://x/fav.ico");
+    }
+
+    #[test]
+    fn external_url_url_change_clears_favicon() {
+        let mut meta = PageMetadata {
+            url: "https://example.com".into(),
+            title: "Old".into(),
+            favicon_url: "https://example.com/fav.ico".into(),
+            bg_color: None,
+        };
+        apply_chrome_state_to_meta(&mut meta, ev(None, None, Some("https://other.com")));
+        assert_eq!(meta.url, "https://other.com");
+        assert_eq!(meta.favicon_url, "");
+    }
+}
+
+#[cfg(test)]
+mod url_mirror_tests {
+    use super::*;
+    use vmux_core::{CorePlugin, CreatedAt, LastVisitedAt, PageMetadata, Url, VisitCount};
+
+    #[test]
+    fn updates_matching_url_meta() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_plugins(CorePlugin);
+        app.add_systems(Update, mirror_metadata_to_url);
+
+        app.world_mut().spawn((
+            Url,
+            PageMetadata {
+                url: "https://example.com".into(),
+                ..default()
+            },
+            VisitCount(1),
+            LastVisitedAt(0),
+            CreatedAt(0),
+        ));
+
+        app.world_mut().spawn(PageMetadata {
+            url: "https://example.com".into(),
+            title: "Example".into(),
+            favicon_url: "https://example.com/fav.ico".into(),
+            bg_color: None,
+        });
+
+        app.update();
+
+        let url_meta = app
+            .world_mut()
+            .query_filtered::<&PageMetadata, With<Url>>()
+            .iter(app.world())
+            .next()
+            .unwrap();
+        assert_eq!(url_meta.title, "Example");
+        assert_eq!(url_meta.favicon_url, "https://example.com/fav.ico");
+    }
+
+    #[test]
+    fn skips_empty_tab_url() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_plugins(CorePlugin);
+        app.add_systems(Update, mirror_metadata_to_url);
+
+        app.world_mut().spawn((
+            Url,
+            PageMetadata {
+                url: "https://example.com".into(),
+                title: "old".into(),
+                ..default()
+            },
+            VisitCount(1),
+            LastVisitedAt(0),
+            CreatedAt(0),
+        ));
+
+        app.world_mut().spawn(PageMetadata {
+            url: "".into(),
+            title: "new".into(),
+            ..default()
+        });
+
+        app.update();
+
+        let url_meta = app
+            .world_mut()
+            .query_filtered::<&PageMetadata, With<Url>>()
+            .iter(app.world())
+            .next()
+            .unwrap();
+        assert_eq!(url_meta.title, "old");
     }
 }

--- a/crates/vmux_layout/src/command_bar/handler.rs
+++ b/crates/vmux_layout/src/command_bar/handler.rs
@@ -30,7 +30,7 @@ use vmux_command::{
     SpaceCommand, StackCommand,
 };
 use vmux_core::PageMetadata;
-use vmux_core::agent::{PageAgentAttachRequest, PageAgentSpawnTabRequest, parse_page_agent_url};
+use vmux_core::agent::{PageAgentAttachRequest, PageAgentSpawnTabRequest};
 use vmux_core::event::space::SpaceCommandEvent;
 use vmux_core::page::{SettingsPageSpawnRequest, SpacesPageSpawnRequest};
 use vmux_core::terminal::{ProcessesMonitorSpawnRequest, Terminal, TerminalSpawnRequest};
@@ -336,6 +336,9 @@ fn command_bar_open_request(
                 request.should_toggle = true;
                 request.url_override = Some(String::new());
             }
+            AppCommand::Browser(BrowserCommand::Bar(BrowserBarCommand::OpenUrlInCommandBar)) => {
+                request.should_toggle = true;
+            }
             AppCommand::Browser(BrowserCommand::Bar(BrowserBarCommand::OpenPathBar)) => {
                 request.should_toggle = true;
                 request.url_override = Some("/".to_string());
@@ -544,18 +547,6 @@ fn handle_open_command_bar(
     }
 
     if !should_open {
-        return;
-    }
-
-    if focused_stack_is_page_agent(
-        &tab_q,
-        &all_children,
-        &leaf_panes,
-        &pane_ts,
-        &pane_children,
-        &stack_ts,
-        &browser_meta,
-    ) {
         return;
     }
 
@@ -838,35 +829,6 @@ fn build_open_command(target: Option<OpenTarget>, url: String) -> OpenCommand {
     }
 }
 
-fn focused_stack_is_page_agent(
-    tab_q: &Query<(Entity, &LastActivatedAt), With<Space>>,
-    all_children: &Query<&Children>,
-    leaf_panes: &Query<Entity, (With<Pane>, Without<PaneSplit>)>,
-    pane_ts: &Query<(Entity, &LastActivatedAt), With<Pane>>,
-    pane_children: &Query<&Children, With<Pane>>,
-    stack_ts: &Query<(Entity, &LastActivatedAt), With<Stack>>,
-    browser_meta: &Query<&PageMetadata, With<Browser>>,
-) -> bool {
-    let (_, _, active_stack) = focused_stack(
-        tab_q,
-        all_children,
-        leaf_panes,
-        pane_ts,
-        pane_children,
-        stack_ts,
-    );
-    let Some(stack) = active_stack else {
-        return false;
-    };
-    let Ok(children) = all_children.get(stack) else {
-        return false;
-    };
-    children
-        .iter()
-        .filter_map(|e| browser_meta.get(e).ok())
-        .any(|meta| parse_page_agent_url(&meta.url).is_some())
-}
-
 fn normalize_url(value: &str) -> String {
     if value.contains("://") {
         value.to_string()
@@ -983,16 +945,22 @@ fn on_command_bar_action(
                             custom_keyboard_restore = true;
                         }
                     }
+                } else if let Some(stack_e) = empty_stack {
+                    writer_params
+                        .p1()
+                        .write(crate::LayoutSpawnRequest::OpenUrl {
+                            stack: stack_e,
+                            url,
+                        });
+                    new_stack_ctx.stack = None;
+                    new_stack_ctx.previous_stack = None;
+                    custom_keyboard_restore = true;
                 } else {
                     let target = evt.target;
                     let open_cmd = build_open_command(target, url);
                     writer_params
                         .p0()
                         .write(AppCommand::Browser(BrowserCommand::Open(open_cmd)));
-                    if empty_stack.is_some() {
-                        new_stack_ctx.stack = None;
-                        new_stack_ctx.previous_stack = None;
-                    }
                 }
             }
         }
@@ -1888,6 +1856,32 @@ mod tests {
         );
 
         assert!(!request.should_dismiss);
+    }
+
+    #[test]
+    fn open_command_bar_forces_empty_url_override() {
+        let request = command_bar_open_request(
+            [AppCommand::Browser(BrowserCommand::Bar(
+                BrowserBarCommand::OpenCommandBar,
+            ))],
+            "vmux://spaces/",
+        );
+
+        assert!(request.should_toggle);
+        assert_eq!(request.url_override, Some(String::new()));
+    }
+
+    #[test]
+    fn open_url_in_command_bar_leaves_url_override_unset_so_current_url_is_prefilled() {
+        let request = command_bar_open_request(
+            [AppCommand::Browser(BrowserCommand::Bar(
+                BrowserBarCommand::OpenUrlInCommandBar,
+            ))],
+            "vmux://spaces/",
+        );
+
+        assert!(request.should_toggle);
+        assert_eq!(request.url_override, None);
     }
 
     #[test]

--- a/crates/vmux_layout/src/command_bar/page.rs
+++ b/crates/vmux_layout/src/command_bar/page.rs
@@ -11,10 +11,13 @@ use crate::command_bar::style::{command_bar_shell_class, result_item_class};
 use dioxus::prelude::*;
 use vmux_command::event::{
     COMMAND_BAR_OPEN_EVENT, CommandBarActionEvent, CommandBarOpenEvent, CommandBarReadyEvent,
-    CommandBarRenderedEvent, PATH_COMPLETE_RESPONSE, PathCompleteRequest, PathCompleteResponse,
-    PathEntry, command_bar_open_should_ack, command_bar_open_should_reset_input, looks_like_url,
+    CommandBarRenderedEvent, HISTORY_SUGGESTIONS_RESPONSE_EVENT, HistoryEntry,
+    HistorySuggestionsRequest, HistorySuggestionsResponse, PATH_COMPLETE_RESPONSE,
+    PathCompleteRequest, PathCompleteResponse, PathEntry, command_bar_open_should_ack,
+    command_bar_open_should_reset_input, looks_like_url,
 };
 use vmux_ui::components::icon::Icon;
+use vmux_ui::favicon::Favicon;
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_theme};
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
@@ -33,6 +36,8 @@ pub fn Page() -> Element {
     let mut ready_sent = use_signal(|| false);
 
     let mut path_completions = use_signal(Vec::<PathEntry>::new);
+    let mut history_suggestions = use_signal(Vec::<HistoryEntry>::new);
+    let mut suggestions_request_id = use_signal(|| 0u64);
 
     let open_listener =
         use_bin_event_listener::<CommandBarOpenEvent, _>(COMMAND_BAR_OPEN_EVENT, move |data| {
@@ -47,6 +52,7 @@ pub fn Page() -> Element {
             }
             current_open_id.set(open_id);
             path_completions.set(Vec::new());
+            history_suggestions.set(Vec::new());
             query.set(data.url.clone());
             selected.set(0);
             nav_mode.set(false);
@@ -98,6 +104,37 @@ pub fn Page() -> Element {
         });
     });
 
+    let _history_listener = use_bin_event_listener::<HistorySuggestionsResponse, _>(
+        HISTORY_SUGGESTIONS_RESPONSE_EVENT,
+        move |resp| {
+            if resp.request_id != *suggestions_request_id.read() {
+                return;
+            }
+            history_suggestions.set(resp.entries);
+        },
+    );
+
+    use_effect(move || {
+        let q = query();
+        let trimmed = q.trim();
+        if trimmed.is_empty()
+            || trimmed.starts_with('>')
+            || trimmed.starts_with('/')
+            || trimmed.starts_with('~')
+            || trimmed.starts_with("vmux://")
+        {
+            history_suggestions.set(Vec::new());
+            return;
+        }
+        let id = *suggestions_request_id.peek() + 1;
+        suggestions_request_id.set(id);
+        let _ = try_cef_bin_emit_rkyv(&HistorySuggestionsRequest {
+            query: trimmed.to_string(),
+            limit: 5,
+            request_id: id,
+        });
+    });
+
     // Focus input and install emacs-style Ctrl shortcuts AFTER Dioxus renders
     // the input element. Running in the event listener above is too early --
     // Dioxus hasn't created the DOM element yet.
@@ -119,7 +156,8 @@ pub fn Page() -> Element {
     let q = query();
     let is_new_tab = is_new_stack();
     let results = {
-        let mut r = filter_results(&q, &tabs, &commands, &spaces, is_new_tab);
+        let history = history_suggestions();
+        let mut r = filter_results(&q, &tabs, &commands, &spaces, is_new_tab, &history);
         let completions = if looks_like_path(q.trim()) {
             path_completions()
         } else {
@@ -165,6 +203,13 @@ pub fn Page() -> Element {
             Some(ResultItem::Space { name, .. }) => name.clone(),
             Some(ResultItem::Terminal { path }) if path.is_empty() => "Terminal".to_string(),
             Some(ResultItem::Terminal { path }) => path.clone(),
+            Some(ResultItem::History { title, url, .. }) => {
+                if title.is_empty() {
+                    url.clone()
+                } else {
+                    title.clone()
+                }
+            }
             None => q.clone(),
         }
     } else {
@@ -225,6 +270,9 @@ pub fn Page() -> Element {
                     emit_action_with_target("open", url, open_target);
                 }
             }
+            ResultItem::History { url, .. } => {
+                emit_action("navigate", url);
+            }
         }
     };
 
@@ -263,6 +311,7 @@ pub fn Page() -> Element {
                                         let is_u = url.contains("://") || (url.contains('.') && !url.contains(' '));
                                         (false, false, is_u)
                                     }
+                                    Some(ResultItem::History { .. }) => (false, false, true),
                                     None => (false, false, false),
                                 }
                             } else {
@@ -428,6 +477,20 @@ pub fn Page() -> Element {
                                             span { class: "text-base text-foreground", "{name}" }
                                         }
                                         span { class: "ml-2 shrink-0 rounded bg-muted px-1.5 py-0.5 text-sm text-muted-foreground", "{shortcut}" }
+                                    },
+                                    ResultItem::History { url, title, favicon_url, .. } => rsx! {
+                                        div { class: "flex items-center gap-2",
+                                            Favicon {
+                                                favicon_url: favicon_url.clone(),
+                                                url: url.clone(),
+                                                class: "h-4 w-4 shrink-0 rounded-sm object-contain".to_string(),
+                                                globe_class: "h-4 w-4 shrink-0 text-muted-foreground".to_string(),
+                                            }
+                                            span { class: "truncate text-base text-foreground",
+                                                if title.is_empty() { "{url}" } else { "{title}" }
+                                            }
+                                            span { class: "ml-auto truncate text-sm text-muted-foreground max-w-xs", "{url}" }
+                                        }
                                     },
                                     ResultItem::Navigate { url } => rsx! {
                                         div { class: "flex items-center gap-2",

--- a/crates/vmux_layout/src/command_bar/results.rs
+++ b/crates/vmux_layout/src/command_bar/results.rs
@@ -1,4 +1,4 @@
-use vmux_command::event::{CommandBarCommandEntry, CommandBarSpace, CommandBarTab};
+use vmux_command::event::{CommandBarCommandEntry, CommandBarSpace, CommandBarTab, HistoryEntry};
 
 const SPACES_QUERY: &str = "vmux://spaces";
 pub const SPACES_PAGE_URL: &str = "vmux://spaces/";
@@ -33,6 +33,13 @@ pub enum CommandBarResultItem {
     },
     Navigate {
         url: String,
+    },
+    History {
+        url: String,
+        title: String,
+        favicon_url: String,
+        visit_count: u32,
+        last_visited_at: i64,
     },
 }
 
@@ -121,6 +128,7 @@ pub fn filter_results(
     commands: &[CommandBarCommandEntry],
     spaces: &[CommandBarSpace],
     new_tab: bool,
+    history: &[HistoryEntry],
 ) -> Vec<CommandBarResultItem> {
     let q = query.trim();
     if let Some(search) = space_query(q) {
@@ -219,6 +227,18 @@ pub fn filter_results(
     }
 
     if !starts_with_cmd {
+        for h in history.iter().take(5) {
+            items.push(CommandBarResultItem::History {
+                url: h.url.clone(),
+                title: h.title.clone(),
+                favicon_url: h.favicon_url.clone(),
+                visit_count: h.visit_count,
+                last_visited_at: h.last_visited_at,
+            });
+        }
+    }
+
+    if !starts_with_cmd {
         for c in commands {
             if c.name.to_lowercase().contains(&search_lower) || c.id.contains(&search_lower) {
                 items.push(CommandBarResultItem::Command {
@@ -267,6 +287,7 @@ mod tests {
             &[] as &[CommandBarCommandEntry],
             &spaces,
             false,
+            &[],
         );
 
         assert_eq!(
@@ -301,7 +322,7 @@ mod tests {
             shortcut: "super+k".to_string(),
         }];
 
-        let results = filter_results("vmux://spaces/", &[], &commands, &[], false);
+        let results = filter_results("vmux://spaces/", &[], &commands, &[], false, &[]);
 
         assert!(results.contains(&CommandBarResultItem::Navigate {
             url: SPACES_PAGE_URL.to_string(),
@@ -321,7 +342,7 @@ mod tests {
             shortcut: "<leader> s".to_string(),
         }];
 
-        let results = filter_results("spaces", &[], &commands, &[], false);
+        let results = filter_results("spaces", &[], &commands, &[], false, &[]);
 
         assert!(results.contains(&CommandBarResultItem::Navigate {
             url: SPACES_PAGE_URL.to_string(),
@@ -341,7 +362,7 @@ mod tests {
         ];
         let tabs: Vec<CommandBarTab> = Vec::new();
 
-        let results = filter_results("client", &tabs, &[], &spaces, false);
+        let results = filter_results("client", &tabs, &[], &spaces, false, &[]);
 
         assert!(matches!(
             results.first(),

--- a/crates/vmux_layout/src/lib.rs
+++ b/crates/vmux_layout/src/lib.rs
@@ -56,7 +56,10 @@ pub mod window;
 #[cfg(not(target_arch = "wasm32"))]
 use bevy::prelude::*;
 #[cfg(not(target_arch = "wasm32"))]
-pub use cef::{Browser, LayoutCef, Loading, NavigationState, apply_chrome_state_from_cef};
+pub use cef::{
+    Browser, LayoutCef, Loading, NavigationState, apply_chrome_state_from_cef,
+    mirror_metadata_to_url,
+};
 #[cfg(not(target_arch = "wasm32"))]
 pub use header::Header;
 #[cfg(not(target_arch = "wasm32"))]
@@ -110,6 +113,24 @@ pub enum LayoutSpawnRequest {
 pub struct BrowserNavigateRequest {
     pub url: String,
     pub pane: Option<String>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Message, Clone)]
+pub struct BrowserGoBackRequest {
+    pub pane: Option<String>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Message, Clone)]
+pub struct BrowserGoForwardRequest {
+    pub pane: Option<String>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Message, Clone)]
+pub struct OpenInNewStackRequest {
+    pub url: String,
 }
 
 #[cfg(test)]

--- a/crates/vmux_layout/src/page.rs
+++ b/crates/vmux_layout/src/page.rs
@@ -7,6 +7,7 @@ use vmux_layout::event::{
     TABS_EVENT, TabRow, TabsCommandEvent, TabsHostEvent,
 };
 use vmux_ui::components::icon::Icon;
+use vmux_ui::favicon::{GlobeIcon, favicon_src_for_url, host_for_favicon_fallback};
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_theme};
 use wasm_bindgen::JsCast;
 
@@ -104,45 +105,6 @@ fn text_color_class_for_bg(bg: &str) -> &'static str {
             }
         })
         .unwrap_or("text-foreground")
-}
-
-fn host_for_favicon_fallback(page_url: &str) -> Option<&str> {
-    let s = page_url.trim();
-    let rest = s
-        .strip_prefix("https://")
-        .or_else(|| s.strip_prefix("http://"))?;
-    rest.split(&['/', '?', '#'][..])
-        .next()
-        .filter(|h| !h.is_empty())
-}
-
-fn agent_host(url: &str) -> Option<&'static str> {
-    const AGENTS: &[(&str, &str)] = &[
-        ("vibe", "chat.mistral.ai"),
-        ("claude", "claude.ai"),
-        ("codex", "chatgpt.com"),
-    ];
-    for &(kind, host) in AGENTS {
-        if url.starts_with(&format!("vmux://agent/{kind}/cli/"))
-            || url.starts_with(&format!("vmux://agent/{kind}/"))
-        {
-            return Some(host);
-        }
-    }
-    None
-}
-
-fn favicon_src_for_url(favicon_url: &str, url: &str) -> Option<String> {
-    if !favicon_url.is_empty() {
-        return Some(favicon_url.to_string());
-    }
-    if let Some(host) = agent_host(url) {
-        return Some(format!(
-            "https://www.google.com/s2/favicons?domain={host}&sz=32"
-        ));
-    }
-    host_for_favicon_fallback(url)
-        .map(|h| format!("https://www.google.com/s2/favicons?domain={h}&sz=32"))
 }
 
 fn favicon_src_for_stack_node(stack: &StackNode) -> Option<String> {
@@ -340,17 +302,6 @@ fn StackIcon(
             }
         } else {
             GlobeIcon {}
-        }
-    }
-}
-
-#[component]
-fn GlobeIcon() -> Element {
-    rsx! {
-        Icon { class: "h-4 w-4 shrink-0 text-muted-foreground",
-            path { d: "M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Z" }
-            path { d: "M2 12h20" }
-            path { d: "M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10Z" }
         }
     }
 }

--- a/crates/vmux_layout/src/plugin.rs
+++ b/crates/vmux_layout/src/plugin.rs
@@ -16,8 +16,8 @@ use crate::toggle::TogglePlugin;
 use crate::webview_reveal::WebviewRevealPlugin;
 use crate::window::WindowPlugin;
 use crate::{
-    BrowserNavigateRequest, LayoutSpawnRequest, LayoutStartupSet, NewStackContext, Open, reconcile,
-    settings,
+    BrowserGoBackRequest, BrowserGoForwardRequest, BrowserNavigateRequest, LayoutSpawnRequest,
+    LayoutStartupSet, NewStackContext, Open, OpenInNewStackRequest, reconcile, settings,
 };
 
 pub struct LayoutPlugin;
@@ -31,6 +31,9 @@ impl Plugin for LayoutPlugin {
             .add_message::<vmux_core::agent::SpawnAgentInStackRequest>()
             .add_message::<vmux_core::agent::RestartAgentPty>()
             .add_message::<BrowserNavigateRequest>()
+            .add_message::<BrowserGoBackRequest>()
+            .add_message::<BrowserGoForwardRequest>()
+            .add_message::<OpenInNewStackRequest>()
             .add_message::<reconcile::LayoutApplyRequest>()
             .add_message::<reconcile::LayoutApplyResponse>()
             .add_message::<reconcile::LayoutSnapshotRequest>()

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -53,6 +53,16 @@ pub enum McpParamTool {
         path: String,
         value: serde_json::Value,
     },
+    #[mcp(description = "Navigate the active or specified browser pane back one page in history.")]
+    BrowserGoBack { pane: Option<String> },
+    #[mcp(
+        description = "Navigate the active or specified browser pane forward one page in history."
+    )]
+    BrowserGoForward { pane: Option<String> },
+    #[mcp(
+        description = "Search vmux browsing history. Returns up to `limit` entries ranked by frecency."
+    )]
+    BrowserHistorySearch { query: String, limit: Option<u32> },
 }
 
 impl McpParamTool {
@@ -129,6 +139,15 @@ impl McpParamTool {
                     path,
                     value_json: value.to_string(),
                 })
+            }
+            McpParamTool::BrowserGoBack { pane } => Ok(AgentCommand::BrowserGoBack { pane }),
+            McpParamTool::BrowserGoForward { pane } => Ok(AgentCommand::BrowserGoForward { pane }),
+            McpParamTool::BrowserHistorySearch { query, limit } => {
+                if query.trim().is_empty() {
+                    return Err("browser_history_search.query is empty".into());
+                }
+                let limit = limit.unwrap_or(20).min(100);
+                Ok(AgentCommand::BrowserHistorySearch { query, limit })
             }
         }
     }
@@ -653,5 +672,53 @@ mod tests {
             required_arr.iter().any(|v| v.as_str() == Some("direction")),
             "direction must be required"
         );
+    }
+
+    #[test]
+    fn go_back_dispatches() {
+        let r = McpParamTool::BrowserGoBack { pane: None }.to_agent_command();
+        assert!(matches!(r, Ok(AgentCommand::BrowserGoBack { .. })));
+    }
+
+    #[test]
+    fn go_forward_dispatches() {
+        let r = McpParamTool::BrowserGoForward { pane: None }.to_agent_command();
+        assert!(matches!(r, Ok(AgentCommand::BrowserGoForward { .. })));
+    }
+
+    #[test]
+    fn history_search_rejects_empty_query() {
+        let r = McpParamTool::BrowserHistorySearch {
+            query: "  ".into(),
+            limit: None,
+        }
+        .to_agent_command();
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn history_search_clamps_limit() {
+        let r = McpParamTool::BrowserHistorySearch {
+            query: "x".into(),
+            limit: Some(500),
+        }
+        .to_agent_command();
+        match r {
+            Ok(AgentCommand::BrowserHistorySearch { limit, .. }) => assert_eq!(limit, 100),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn history_search_default_limit() {
+        let r = McpParamTool::BrowserHistorySearch {
+            query: "x".into(),
+            limit: None,
+        }
+        .to_agent_command();
+        match r {
+            Ok(AgentCommand::BrowserHistorySearch { limit, .. }) => assert_eq!(limit, 20),
+            _ => panic!(),
+        }
     }
 }

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -63,6 +63,19 @@ pub enum AgentCommand {
     UpdateLayout {
         layout: crate::protocol::layout::LayoutSnapshot,
     },
+    BrowserGoBack {
+        pane: Option<String>,
+    },
+    BrowserGoForward {
+        pane: Option<String>,
+    },
+    BrowserHistorySearch {
+        query: String,
+        limit: u32,
+    },
+    OpenInNewStack {
+        url: String,
+    },
 }
 
 pub const AGENT_QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
@@ -105,6 +118,12 @@ pub fn validate_agent_command(command: &AgentCommand) -> Result<(), &'static str
         }
         AgentCommand::UpdateSettings { path, .. } if path.trim().is_empty() => {
             Err("update_settings.path is empty")
+        }
+        AgentCommand::BrowserHistorySearch { query, .. } if query.trim().is_empty() => {
+            Err("browser_history_search.query is empty")
+        }
+        AgentCommand::OpenInNewStack { url, .. } if url.trim().is_empty() => {
+            Err("open_in_new_stack.url is empty")
         }
         _ => Ok(()),
     }

--- a/crates/vmux_ui/src/favicon.rs
+++ b/crates/vmux_ui/src/favicon.rs
@@ -1,0 +1,212 @@
+//! Favicon URL resolution with multi-tier fallback.
+//!
+//! Pure helpers ([`favicon_src_for_url`] and friends) work on any target. The
+//! [`Favicon`] and [`GlobeIcon`] components are wasm-only.
+
+pub fn host_for_favicon_fallback(page_url: &str) -> Option<&str> {
+    let s = page_url.trim();
+    let rest = s
+        .strip_prefix("https://")
+        .or_else(|| s.strip_prefix("http://"))?;
+    rest.split(&['/', '?', '#'][..])
+        .next()
+        .filter(|h| !h.is_empty())
+}
+
+pub fn agent_host(url: &str) -> Option<&'static str> {
+    const AGENTS: &[(&str, &str)] = &[
+        ("vibe", "chat.mistral.ai"),
+        ("claude", "claude.ai"),
+        ("codex", "chatgpt.com"),
+    ];
+    for &(kind, host) in AGENTS {
+        if url.starts_with(&format!("vmux://agent/{kind}/cli/"))
+            || url.starts_with(&format!("vmux://agent/{kind}/"))
+        {
+            return Some(host);
+        }
+    }
+    None
+}
+
+pub fn favicon_src_for_url(favicon_url: &str, url: &str) -> Option<String> {
+    if !favicon_url.is_empty() {
+        return Some(favicon_url.to_string());
+    }
+    if let Some(host) = agent_host(url) {
+        return Some(format!(
+            "https://www.google.com/s2/favicons?domain={host}&sz=32"
+        ));
+    }
+    host_for_favicon_fallback(url)
+        .map(|h| format!("https://www.google.com/s2/favicons?domain={h}&sz=32"))
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use components::{Favicon, GlobeIcon};
+
+#[cfg(target_arch = "wasm32")]
+mod components {
+    use super::favicon_src_for_url;
+    use crate::components::icon::Icon;
+    use dioxus::prelude::*;
+
+    const DEFAULT_FAVICON_CLASS: &str = "h-4 w-4 shrink-0 rounded-sm object-contain";
+    const DEFAULT_GLOBE_CLASS: &str = "h-4 w-4 shrink-0 text-muted-foreground";
+
+    #[component]
+    pub fn Favicon(
+        favicon_url: String,
+        url: String,
+        class: Option<String>,
+        globe_class: Option<String>,
+    ) -> Element {
+        let img_class = class.unwrap_or_else(|| DEFAULT_FAVICON_CLASS.to_string());
+        let globe_class = globe_class.unwrap_or_else(|| DEFAULT_GLOBE_CLASS.to_string());
+        let mut errored = use_signal(|| false);
+        let mut prev_src = use_signal(|| None::<String>);
+        let src = favicon_src_for_url(&favicon_url, &url);
+        if *prev_src.read() != src {
+            prev_src.set(src.clone());
+            errored.set(false);
+        }
+        rsx! {
+            if let Some(src) = src.as_ref() {
+                if errored() {
+                    GlobeIcon { class: globe_class }
+                } else {
+                    img {
+                        class: "{img_class}",
+                        src: "{src}",
+                        onerror: move |_| errored.set(true),
+                    }
+                }
+            } else {
+                GlobeIcon { class: globe_class }
+            }
+        }
+    }
+
+    #[component]
+    pub fn GlobeIcon(class: Option<String>) -> Element {
+        let class = class.unwrap_or_else(|| DEFAULT_GLOBE_CLASS.to_string());
+        rsx! {
+            Icon { class: "{class}",
+                path { d: "M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Z" }
+                path { d: "M2 12h20" }
+                path { d: "M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10Z" }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_extracted_from_https_url() {
+        assert_eq!(
+            host_for_favicon_fallback("https://example.com/path"),
+            Some("example.com")
+        );
+    }
+
+    #[test]
+    fn host_extracted_from_http_url() {
+        assert_eq!(
+            host_for_favicon_fallback("http://example.com/"),
+            Some("example.com")
+        );
+    }
+
+    #[test]
+    fn host_extracted_when_query_string_present() {
+        assert_eq!(
+            host_for_favicon_fallback("https://www.google.com/search?q=mistral.ai"),
+            Some("www.google.com")
+        );
+    }
+
+    #[test]
+    fn host_extracted_when_fragment_present() {
+        assert_eq!(
+            host_for_favicon_fallback("https://example.com#frag"),
+            Some("example.com")
+        );
+    }
+
+    #[test]
+    fn host_none_for_non_http_scheme() {
+        assert_eq!(host_for_favicon_fallback("vmux://history/"), None);
+        assert_eq!(host_for_favicon_fallback("ftp://example.com"), None);
+        assert_eq!(host_for_favicon_fallback(""), None);
+    }
+
+    #[test]
+    fn host_none_when_empty_after_scheme() {
+        assert_eq!(host_for_favicon_fallback("https://"), None);
+    }
+
+    #[test]
+    fn agent_host_maps_vibe() {
+        assert_eq!(
+            agent_host("vmux://agent/vibe/chat/abc"),
+            Some("chat.mistral.ai")
+        );
+        assert_eq!(
+            agent_host("vmux://agent/vibe/cli/abc"),
+            Some("chat.mistral.ai")
+        );
+    }
+
+    #[test]
+    fn agent_host_maps_claude_and_codex() {
+        assert_eq!(agent_host("vmux://agent/claude/x"), Some("claude.ai"));
+        assert_eq!(agent_host("vmux://agent/codex/x"), Some("chatgpt.com"));
+    }
+
+    #[test]
+    fn agent_host_unknown_returns_none() {
+        assert_eq!(agent_host("vmux://agent/unknown/x"), None);
+        assert_eq!(agent_host("https://example.com"), None);
+    }
+
+    #[test]
+    fn favicon_src_returns_real_when_present() {
+        assert_eq!(
+            favicon_src_for_url("https://cdn.example.com/icon.png", "https://example.com/"),
+            Some("https://cdn.example.com/icon.png".to_string())
+        );
+    }
+
+    #[test]
+    fn favicon_src_falls_back_to_google_s2_for_http_url() {
+        assert_eq!(
+            favicon_src_for_url("", "https://mistral.ai/"),
+            Some("https://www.google.com/s2/favicons?domain=mistral.ai&sz=32".to_string())
+        );
+    }
+
+    #[test]
+    fn favicon_src_falls_back_to_google_s2_for_google_search() {
+        assert_eq!(
+            favicon_src_for_url("", "https://www.google.com/search?q=mistral.ai"),
+            Some("https://www.google.com/s2/favicons?domain=www.google.com&sz=32".to_string())
+        );
+    }
+
+    #[test]
+    fn favicon_src_falls_back_to_agent_host() {
+        assert_eq!(
+            favicon_src_for_url("", "vmux://agent/vibe/chat/abc"),
+            Some("https://www.google.com/s2/favicons?domain=chat.mistral.ai&sz=32".to_string())
+        );
+    }
+
+    #[test]
+    fn favicon_src_none_for_vmux_scheme_without_agent() {
+        assert_eq!(favicon_src_for_url("", "vmux://history/"), None);
+        assert_eq!(favicon_src_for_url("", ""), None);
+    }
+}

--- a/crates/vmux_ui/src/lib.rs
+++ b/crates/vmux_ui/src/lib.rs
@@ -5,6 +5,8 @@
 #[cfg(any(target_arch = "wasm32", test))]
 mod bin_ipc_envelope;
 
+pub mod favicon;
+
 pub mod theme;
 
 #[cfg(any(target_arch = "wasm32", test))]

--- a/docs/plans/2026-05-16-history.md
+++ b/docs/plans/2026-05-16-history.md
@@ -1,0 +1,2674 @@
+# History Support Implementation Plan (VMX-120)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement real history support in vmux — spawn `Visit` entities from committed CEF navigations, ship `vmux://history` page with day-grouped infinite-scroll search, integrate frecency-ranked history matches into the omnibox, and expose back/forward + history search via MCP.
+
+**Architecture:** Patch `bevy_cef_core` to emit a new `WebviewCommittedNavigationEvent` carrying `cef_transition_type_t`. Add normalized `Url` + `Visit` ECS components in `vmux_core`. A spawn system in `vmux_history` find-or-creates `Url` entities and spawns `Visit` rows per nav (skipping back/forward). A Dioxus app at `vmux://history` queries the ECS via rkyv events with pagination. A new `CommandBarResultItem::History` variant injects ranked history rows into the omnibox. Three new `McpParamTool` variants expose back/forward + search.
+
+**Tech Stack:** Bevy 0.x ECS, moonshine-save (RON persistence), patched `bevy_cef_core` 0.5.2 (CEF binding), Dioxus (WASM), rkyv (binary IPC), MCP via `vmux_macro::McpTool` derive.
+
+**Spec:** `docs/specs/2026-05-16-history-design.md`
+
+**Pre-commit checks (mandatory, per AGENTS.md):** for every commit that touches Rust code:
+
+```bash
+PKGS=$(BASE=origin/main ./scripts/changed-crates.sh)
+for pkg in $PKGS; do cargo fmt -p "$pkg" -- --check; done
+for pkg in $PKGS; do env -u CEF_PATH cargo clippy -p "$pkg" --all-targets -- -D warnings; done
+for pkg in $PKGS; do env -u CEF_PATH cargo test -p "$pkg"; done
+```
+
+If any fail, run `make lint-fix`, fix, re-run, then commit. Do NOT use `--no-verify`.
+
+**Commit-message style:** conventional commits (`feat:`, `fix:`, `docs:`, `refactor:`). Reference `VMX-120` in body or scope. No `Co-Authored-By` trailers.
+
+---
+
+## File Map
+
+### Created
+- `patches/bevy_cef_core-0.5.2/src/browser_process/load_handler/transition.rs` — `CefTransitionCore`, `CefTransitionQualifiers`, bit-mask decoder
+- `crates/vmux_history/src/transition.rs` — `TransitionType` mapping from CEF types
+- `crates/vmux_history/src/query.rs` — frecency + hybrid match ranking helpers
+- `crates/vmux_history/src/spawn.rs` — Visit-spawn system + find-or-create Url
+- `crates/vmux_history/src/prune.rs` — 90-day prune system
+- `crates/vmux_history/src/event.rs` — `HistoryQueryRequest/Response`, `HistoryDeleteRequest`, `HistoryClearAllRequest`, `HistoryOpenRequest`, `HistorySuggestionsRequest/Response`
+
+### Modified
+- `crates/vmux_core/src/lib.rs` — new components: `Url`, `VisitCount`, `LastVisitedAt`, `VisitedUrl`, `TransitionType`
+- `patches/bevy_cef_core-0.5.2/src/browser_process/load_handler.rs` — add `on_load_start` override + new `WebviewCommittedNavigationEvent` channel
+- `patches/bevy_cef_core-0.5.2/src/lib.rs` — re-export new event
+- `crates/vmux_history/src/plugin.rs` — replace POC; register new components, add spawn/prune/query systems
+- `crates/vmux_history/src/app.rs` — replace POC with new Dioxus app (timeline, search, infinite scroll, delete, clear-all, open-in-new-stack)
+- `crates/vmux_layout/src/chrome.rs` — extend `apply_chrome_state_from_cef` to mirror title/favicon to matching `Url` entity
+- `crates/vmux_desktop/src/persistence.rs` — add `Url`, `VisitCount`, `LastVisitedAt`, `VisitedUrl`, `TransitionType` to allowlist
+- `crates/vmux_desktop/src/command.rs` — new `AgentCommand` variants: `BrowserGoBack`, `BrowserGoForward`, `BrowserHistorySearch`, `OpenInNewStack`
+- `crates/vmux_desktop/src/browser.rs` — dispatch arms for the new `AgentCommand` variants
+- `crates/vmux_command/src/results.rs` — new `CommandBarResultItem::History` + filter extension
+- `crates/vmux_command/src/app.rs` — render History row in dropdown
+- `crates/vmux_command/src/event.rs` — `HistorySuggestionsRequest/Response`
+- `crates/vmux_desktop/src/command_bar.rs` — wire history suggestions request handler
+- `crates/vmux_mcp/src/tools.rs` — new `McpParamTool` variants + `to_agent_command` arms
+
+---
+
+## Phase 1 — CEF transition_type exposure (patched `bevy_cef_core`)
+
+### Task 1: Define `CefTransitionCore` + `CefTransitionQualifiers`
+
+**Files:**
+- Create: `patches/bevy_cef_core-0.5.2/src/browser_process/load_handler/transition.rs`
+- Modify: `patches/bevy_cef_core-0.5.2/src/browser_process/load_handler.rs` — convert to filename-based module pattern (`load_handler.rs` + `load_handler/` directory)
+
+- [ ] **Step 1: Create transition module file**
+
+```rust
+use cef::sys::cef_transition_type_t;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CefTransitionCore {
+    Link,
+    Explicit,
+    AutoBookmark,
+    AutoSubframe,
+    ManualSubframe,
+    Generated,
+    AutoToplevel,
+    FormSubmit,
+    Reload,
+    Keyword,
+    KeywordGenerated,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CefTransitionQualifiers {
+    pub forward_back: bool,
+    pub from_address_bar: bool,
+    pub client_redirect: bool,
+    pub server_redirect: bool,
+    pub chain_start: bool,
+    pub chain_end: bool,
+}
+
+const SOURCE_MASK: u32 = 0xFF;
+const FORWARD_BACK_FLAG: u32 = 0x01000000;
+const FROM_ADDRESS_BAR_FLAG: u32 = 0x02000000;
+const CHAIN_START_FLAG: u32 = 0x10000000;
+const CHAIN_END_FLAG: u32 = 0x20000000;
+const CLIENT_REDIRECT_FLAG: u32 = 0x40000000;
+const SERVER_REDIRECT_FLAG: u32 = 0x80000000;
+
+pub fn decode(raw: cef_transition_type_t::Type) -> (CefTransitionCore, CefTransitionQualifiers) {
+    let bits = raw as u32;
+    let core = match bits & SOURCE_MASK {
+        0 => CefTransitionCore::Link,
+        1 => CefTransitionCore::Explicit,
+        2 => CefTransitionCore::AutoBookmark,
+        3 => CefTransitionCore::AutoSubframe,
+        4 => CefTransitionCore::ManualSubframe,
+        5 => CefTransitionCore::Generated,
+        6 => CefTransitionCore::AutoToplevel,
+        7 => CefTransitionCore::FormSubmit,
+        8 => CefTransitionCore::Reload,
+        9 => CefTransitionCore::Keyword,
+        10 => CefTransitionCore::KeywordGenerated,
+        _ => CefTransitionCore::Unknown,
+    };
+    let qual = CefTransitionQualifiers {
+        forward_back: bits & FORWARD_BACK_FLAG != 0,
+        from_address_bar: bits & FROM_ADDRESS_BAR_FLAG != 0,
+        client_redirect: bits & CLIENT_REDIRECT_FLAG != 0,
+        server_redirect: bits & SERVER_REDIRECT_FLAG != 0,
+        chain_start: bits & CHAIN_START_FLAG != 0,
+        chain_end: bits & CHAIN_END_FLAG != 0,
+    };
+    (core, qual)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_link_no_qualifiers() {
+        let (core, qual) = decode(0);
+        assert_eq!(core, CefTransitionCore::Link);
+        assert_eq!(qual, CefTransitionQualifiers::default());
+    }
+
+    #[test]
+    fn decodes_explicit_from_address_bar() {
+        let (core, qual) = decode(1 | FROM_ADDRESS_BAR_FLAG);
+        assert_eq!(core, CefTransitionCore::Explicit);
+        assert!(qual.from_address_bar);
+        assert!(!qual.forward_back);
+    }
+
+    #[test]
+    fn decodes_forward_back_link() {
+        let (core, qual) = decode(0 | FORWARD_BACK_FLAG);
+        assert_eq!(core, CefTransitionCore::Link);
+        assert!(qual.forward_back);
+    }
+
+    #[test]
+    fn decodes_server_redirect_chain() {
+        let bits = 0 | SERVER_REDIRECT_FLAG | CHAIN_START_FLAG | CHAIN_END_FLAG;
+        let (_, qual) = decode(bits);
+        assert!(qual.server_redirect);
+        assert!(qual.chain_start);
+        assert!(qual.chain_end);
+    }
+
+    #[test]
+    fn unknown_core_falls_through() {
+        let (core, _) = decode(99);
+        assert_eq!(core, CefTransitionCore::Unknown);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests, expect FAIL (file not wired into module tree yet)**
+
+```bash
+env -u CEF_PATH cargo test -p bevy_cef_core --lib -- transition::tests
+```
+
+Expected: build error (module not declared).
+
+- [ ] **Step 3: Convert `load_handler.rs` into filename-based module**
+
+Move `patches/bevy_cef_core-0.5.2/src/browser_process/load_handler.rs` body unchanged. At top of file add:
+
+```rust
+mod transition;
+pub use transition::{CefTransitionCore, CefTransitionQualifiers, decode as decode_transition};
+```
+
+- [ ] **Step 4: Re-run transition tests, expect PASS**
+
+```bash
+env -u CEF_PATH cargo test -p bevy_cef_core --lib -- transition::tests
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 5: Pre-commit checks**
+
+```bash
+cargo fmt -p bevy_cef_core -- --check
+env -u CEF_PATH cargo clippy -p bevy_cef_core --all-targets -- -D warnings
+env -u CEF_PATH cargo test -p bevy_cef_core
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add patches/bevy_cef_core-0.5.2/src/browser_process/load_handler.rs \
+        patches/bevy_cef_core-0.5.2/src/browser_process/load_handler/transition.rs
+git commit -m "feat(bevy_cef_core): decode cef_transition_type_t bits (VMX-120)"
+```
+
+---
+
+### Task 2: Wire `on_load_start` and emit `WebviewCommittedNavigationEvent`
+
+**Files:**
+- Modify: `patches/bevy_cef_core-0.5.2/src/browser_process/load_handler.rs`
+- Modify: `patches/bevy_cef_core-0.5.2/src/lib.rs` — re-export new event
+
+- [ ] **Step 1: Add the new event struct and channel type**
+
+In `load_handler.rs`, after the existing `WebviewLoadingStateEvent` block:
+
+```rust
+use crate::browser_process::load_handler::transition::{
+    CefTransitionCore, CefTransitionQualifiers, decode_transition,
+};
+use cef::{Frame, ImplFrame, sys::cef_transition_type_t};
+
+#[derive(Clone, Debug)]
+pub struct WebviewCommittedNavigationEvent {
+    pub webview: Entity,
+    pub url: String,
+    pub is_main_frame: bool,
+    pub transition: CefTransitionCore,
+    pub qualifiers: CefTransitionQualifiers,
+}
+
+pub type WebviewCommittedNavigationSenderInner = Sender<WebviewCommittedNavigationEvent>;
+```
+
+- [ ] **Step 2: Extend `WebviewLoadHandlerBuilder` to carry the new sender**
+
+Add `nav_tx: WebviewCommittedNavigationSenderInner` to the struct and to `build`, `Clone`. Update the `build` signature:
+
+```rust
+pub fn build(
+    webview: Entity,
+    tx: WebviewLoadingStateSenderInner,
+    nav_tx: WebviewCommittedNavigationSenderInner,
+) -> LoadHandler {
+    LoadHandler::new(Self {
+        object: core::ptr::null_mut(),
+        webview,
+        tx,
+        nav_tx,
+    })
+}
+```
+
+Mirror `nav_tx: self.nav_tx.clone()` in the `Clone` impl.
+
+- [ ] **Step 3: Implement `on_load_start`**
+
+Inside `impl ImplLoadHandler for WebviewLoadHandlerBuilder`, add:
+
+```rust
+fn on_load_start(
+    &self,
+    _browser: Option<&mut Browser>,
+    frame: Option<&mut Frame>,
+    transition_type: cef_transition_type_t::Type,
+) {
+    let Some(frame) = frame else { return };
+    let is_main_frame = frame.is_main();
+    let url = frame
+        .url()
+        .map(|s| s.to_string())
+        .unwrap_or_default();
+    let (transition, qualifiers) = decode_transition(transition_type);
+    let _ = self.nav_tx.send_blocking(WebviewCommittedNavigationEvent {
+        webview: self.webview,
+        url,
+        is_main_frame,
+        transition,
+        qualifiers,
+    });
+}
+```
+
+If the `cef` crate's `Frame::is_main` returns `c_int`, convert with `!= 0`. If `url()` returns `CefString` rather than `Option<CefString>`, adjust accordingly — the existing handlers in this file demonstrate the conversion pattern.
+
+- [ ] **Step 4: Find every existing call site of `WebviewLoadHandlerBuilder::build` and add the new sender argument**
+
+```bash
+rg "WebviewLoadHandlerBuilder::build" patches/ crates/
+```
+
+Update each call to thread a new `WebviewCommittedNavigationSenderInner`. Typically the channel pair is created in the same module that creates browsers (`patches/bevy_cef_core-0.5.2/src/browser_process/client_handler.rs` or `bevy_cef/src/webview/`). Add a parallel channel mirroring the existing `WebviewLoadingState` channel, drained from a Bevy system into a `MessageWriter<WebviewCommittedNavigationEvent>` event.
+
+- [ ] **Step 5: Re-export from `lib.rs`**
+
+In `patches/bevy_cef_core-0.5.2/src/lib.rs`, ensure `WebviewCommittedNavigationEvent`, `CefTransitionCore`, `CefTransitionQualifiers` are publicly re-exported alongside `WebviewLoadingStateEvent`.
+
+- [ ] **Step 6: Pre-commit checks**
+
+```bash
+cargo fmt -p bevy_cef_core -- --check
+env -u CEF_PATH cargo clippy -p bevy_cef_core --all-targets -- -D warnings
+env -u CEF_PATH cargo test -p bevy_cef_core
+```
+
+If `bevy_cef` (the higher-level crate) is in the changed set due to call-site edits, run its checks too:
+
+```bash
+cargo fmt -p bevy_cef -- --check
+env -u CEF_PATH cargo clippy -p bevy_cef --all-targets -- -D warnings
+env -u CEF_PATH cargo test -p bevy_cef
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add patches/bevy_cef_core-0.5.2/ patches/bevy_cef-0.5.2/
+git commit -m "feat(bevy_cef_core): emit WebviewCommittedNavigationEvent on load start (VMX-120)"
+```
+
+---
+
+### Task 3: Bevy-side drainer for the new channel
+
+**Files:**
+- Modify: `patches/bevy_cef_core-0.5.2/src/lib.rs` or wherever existing `drain_loading_state` lives — likely in `patches/bevy_cef-0.5.2/src/webview/` or `crates/vmux_desktop/src/browser.rs`
+
+Find the existing pattern with `rg "drain_loading_state"`. Mirror it.
+
+- [ ] **Step 1: Add a `Resource<WebviewCommittedNavigationReceiver>` mirroring the loading-state receiver**
+
+```rust
+use bevy::prelude::*;
+use bevy_cef_core::{WebviewCommittedNavigationEvent, WebviewLoadingStateEvent};
+use async_channel::Receiver;
+
+#[derive(Resource)]
+pub struct WebviewCommittedNavigationReceiver(pub Receiver<WebviewCommittedNavigationEvent>);
+```
+
+- [ ] **Step 2: Make `WebviewCommittedNavigationEvent` a Bevy `Event` and add a drainer**
+
+In `patches/bevy_cef_core-0.5.2/src/browser_process/load_handler.rs`, derive `Event` on the existing struct:
+
+```rust
+#[derive(Event, Clone, Debug)]
+pub struct WebviewCommittedNavigationEvent { /* fields from Task 2 */ }
+```
+
+In `crates/vmux_desktop/src/browser.rs` (next to the existing `drain_loading_state` system at line 568):
+
+```rust
+pub fn drain_committed_navigation(
+    receiver: Res<WebviewCommittedNavigationReceiver>,
+    mut writer: MessageWriter<WebviewCommittedNavigationEvent>,
+) {
+    while let Ok(ev) = receiver.0.try_recv() {
+        writer.write(ev);
+    }
+}
+```
+
+Register in the plugin that constructs the channel pair:
+
+```rust
+app.add_event::<WebviewCommittedNavigationEvent>()
+   .add_systems(Update, drain_committed_navigation);
+```
+
+Insert `WebviewCommittedNavigationReceiver` as a resource at the same site where `WebviewLoadingState`'s receiver is inserted.
+
+The single `WebviewCommittedNavigationEvent` type is consumed by `vmux_history` directly — no wrapper event is needed.
+
+- [ ] **Step 3: Pre-commit checks for affected crates**
+
+```bash
+PKGS=$(BASE=origin/main ./scripts/changed-crates.sh)
+for pkg in $PKGS; do cargo fmt -p "$pkg" -- --check; done
+for pkg in $PKGS; do env -u CEF_PATH cargo clippy -p "$pkg" --all-targets -- -D warnings; done
+for pkg in $PKGS; do env -u CEF_PATH cargo test -p "$pkg"; done
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add patches/ crates/vmux_desktop/
+git commit -m "feat(vmux_desktop): drain CommittedNavigation into Bevy events (VMX-120)"
+```
+
+---
+
+## Phase 2 — Data model (`vmux_core`)
+
+### Task 4: New ECS components in `vmux_core`
+
+**Files:**
+- Modify: `crates/vmux_core/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a `#[cfg(test)] mod tests` block at the bottom of `crates/vmux_core/src/lib.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::ecs::reflect::AppTypeRegistry;
+    use bevy::prelude::*;
+
+    #[test]
+    fn registers_new_history_components() {
+        let mut app = App::new();
+        app.init_resource::<AppTypeRegistry>();
+        app.add_plugins(CorePlugin);
+
+        let registry = app.world().resource::<AppTypeRegistry>().read();
+        assert!(registry.get(std::any::TypeId::of::<Url>()).is_some());
+        assert!(registry.get(std::any::TypeId::of::<VisitCount>()).is_some());
+        assert!(registry.get(std::any::TypeId::of::<LastVisitedAt>()).is_some());
+        assert!(registry.get(std::any::TypeId::of::<VisitedUrl>()).is_some());
+        assert!(registry.get(std::any::TypeId::of::<TransitionType>()).is_some());
+    }
+}
+```
+
+- [ ] **Step 2: Run test, expect FAIL**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_core -- registers_new_history_components
+```
+
+Expected: compile error (`Url` undefined).
+
+- [ ] **Step 3: Add the new components**
+
+Append to `crates/vmux_core/src/lib.rs` after `pub struct Visit;`:
+
+```rust
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Component, Clone, Copy, Debug, Reflect, Default)]
+#[reflect(Component, Default)]
+#[require(Save)]
+#[type_path = "vmux_history"]
+pub struct Url;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Component, Clone, Copy, Debug, Reflect, Default)]
+#[reflect(Component, Default)]
+#[require(Save)]
+#[type_path = "vmux_history"]
+pub struct VisitCount(pub u32);
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Component, Clone, Copy, Debug, Reflect, Default)]
+#[reflect(Component, Default)]
+#[require(Save)]
+#[type_path = "vmux_history"]
+pub struct LastVisitedAt(pub i64);
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Component, Clone, Copy, Debug, Reflect)]
+#[reflect(Component)]
+#[require(Save)]
+#[type_path = "vmux_history"]
+pub struct VisitedUrl(pub Entity);
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Default for VisitedUrl {
+    fn default() -> Self {
+        Self(Entity::PLACEHOLDER)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Component, Clone, Copy, Debug, Reflect, Default, PartialEq, Eq)]
+#[reflect(Component, Default)]
+#[require(Save)]
+#[type_path = "vmux_history"]
+pub enum TransitionType {
+    #[default]
+    Link,
+    Typed,
+    Reload,
+    BackForward,
+    Redirect,
+    Other,
+}
+```
+
+Update `CorePlugin::build` to register them:
+
+```rust
+fn build(&self, app: &mut App) {
+    app.register_type::<PageMetadata>()
+        .register_type::<CreatedAt>()
+        .register_type::<LastActivatedAt>()
+        .register_type::<Visit>()
+        .register_type::<Url>()
+        .register_type::<VisitCount>()
+        .register_type::<LastVisitedAt>()
+        .register_type::<VisitedUrl>()
+        .register_type::<TransitionType>()
+        .register_type::<Children>()
+        .register_type::<ChildOf>();
+}
+```
+
+- [ ] **Step 4: Run test, expect PASS**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_core -- registers_new_history_components
+```
+
+- [ ] **Step 5: Pre-commit checks**
+
+```bash
+cargo fmt -p vmux_core -- --check
+env -u CEF_PATH cargo clippy -p vmux_core --all-targets -- -D warnings
+env -u CEF_PATH cargo test -p vmux_core
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/vmux_core/src/lib.rs
+git commit -m "feat(vmux_core): add Url + Visit history components (VMX-120)"
+```
+
+---
+
+### Task 5: Persistence allowlist update
+
+**Files:**
+- Modify: `crates/vmux_desktop/src/persistence.rs:139-154` (the existing allowlist)
+
+- [ ] **Step 1: Write the failing round-trip test**
+
+Add to `crates/vmux_desktop/src/persistence.rs` inside an existing `#[cfg(test)] mod tests` block (or create one):
+
+```rust
+#[test]
+fn url_and_visit_round_trip() {
+    use bevy::prelude::*;
+    use moonshine_save::prelude::*;
+    use vmux_core::*;
+    use tempfile::tempdir;
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_space.ron");
+
+    let mut app_save = App::new();
+    app_save.add_plugins(MinimalPlugins);
+    app_save.add_plugins(SavePlugin);
+    register_persisted_types(&mut app_save);
+
+    let url_e = app_save.world_mut().spawn((
+        Url,
+        PageMetadata { url: "https://example.com".into(), title: "Example".into(), ..default() },
+        VisitCount(3),
+        LastVisitedAt(1000),
+        CreatedAt(500),
+    )).id();
+    app_save.world_mut().spawn((
+        Visit,
+        VisitedUrl(url_e),
+        CreatedAt(900),
+        TransitionType::Typed,
+    ));
+
+    trigger_save(&mut app_save.world_mut(), &path);
+    app_save.update();
+
+    let mut app_load = App::new();
+    app_load.add_plugins(MinimalPlugins);
+    app_load.add_plugins(LoadPlugin);
+    register_persisted_types(&mut app_load);
+
+    trigger_load(&mut app_load.world_mut(), &path);
+    app_load.update();
+
+    let url_count = app_load.world_mut().query::<&Url>().iter(&app_load.world()).count();
+    let visit_count = app_load.world_mut().query::<&Visit>().iter(&app_load.world()).count();
+    assert_eq!(url_count, 1);
+    assert_eq!(visit_count, 1);
+}
+```
+
+(`register_persisted_types` is the existing function that wraps the allowlist; if its name differs, use the actual one — search with `rg "register" crates/vmux_desktop/src/persistence.rs`.)
+
+- [ ] **Step 2: Run test, expect FAIL**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_desktop -- url_and_visit_round_trip
+```
+
+Expected: failure — assertion on `url_count` or `visit_count` is 0 because new components aren't allowlisted.
+
+- [ ] **Step 3: Add new components to the allowlist**
+
+In `crates/vmux_desktop/src/persistence.rs`, locate the allowlist block (lines 139–154 per the design doc) and add:
+
+```rust
+.allow::<Url>()
+.allow::<VisitCount>()
+.allow::<LastVisitedAt>()
+.allow::<VisitedUrl>()
+.allow::<TransitionType>()
+```
+
+Use the same chaining style as the existing entries.
+
+- [ ] **Step 4: Run test, expect PASS**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_desktop -- url_and_visit_round_trip
+```
+
+- [ ] **Step 5: Pre-commit checks**
+
+```bash
+cargo fmt -p vmux_desktop -- --check
+env -u CEF_PATH cargo clippy -p vmux_desktop --all-targets -- -D warnings
+env -u CEF_PATH cargo test -p vmux_desktop
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/vmux_desktop/src/persistence.rs
+git commit -m "feat(vmux_desktop): allowlist Url + Visit history components (VMX-120)"
+```
+
+---
+
+## Phase 3 — Visit spawning + prune (`vmux_history`)
+
+### Task 6: TransitionType mapping helper
+
+**Files:**
+- Create: `crates/vmux_history/src/transition.rs`
+- Modify: `crates/vmux_history/src/lib.rs` — declare module
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `crates/vmux_history/src/transition.rs`:
+
+```rust
+use bevy_cef_core::{CefTransitionCore, CefTransitionQualifiers};
+use vmux_core::TransitionType;
+
+pub fn map(core: CefTransitionCore, qual: CefTransitionQualifiers) -> TransitionType {
+    if qual.forward_back {
+        return TransitionType::BackForward;
+    }
+    if qual.client_redirect || qual.server_redirect {
+        return TransitionType::Redirect;
+    }
+    match core {
+        CefTransitionCore::Reload => TransitionType::Reload,
+        CefTransitionCore::Explicit
+        | CefTransitionCore::Generated
+        | CefTransitionCore::Keyword
+        | CefTransitionCore::KeywordGenerated => TransitionType::Typed,
+        CefTransitionCore::Link
+        | CefTransitionCore::FormSubmit
+        | CefTransitionCore::AutoBookmark => TransitionType::Link,
+        _ => TransitionType::Other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn no_qual() -> CefTransitionQualifiers {
+        CefTransitionQualifiers::default()
+    }
+
+    #[test]
+    fn forward_back_wins_over_core() {
+        let qual = CefTransitionQualifiers { forward_back: true, ..no_qual() };
+        assert_eq!(map(CefTransitionCore::Explicit, qual), TransitionType::BackForward);
+    }
+
+    #[test]
+    fn server_redirect_wins_over_core() {
+        let qual = CefTransitionQualifiers { server_redirect: true, ..no_qual() };
+        assert_eq!(map(CefTransitionCore::Link, qual), TransitionType::Redirect);
+    }
+
+    #[test]
+    fn typed_from_explicit() {
+        assert_eq!(map(CefTransitionCore::Explicit, no_qual()), TransitionType::Typed);
+    }
+
+    #[test]
+    fn typed_from_generated() {
+        assert_eq!(map(CefTransitionCore::Generated, no_qual()), TransitionType::Typed);
+    }
+
+    #[test]
+    fn link_from_link_and_form_submit() {
+        assert_eq!(map(CefTransitionCore::Link, no_qual()), TransitionType::Link);
+        assert_eq!(map(CefTransitionCore::FormSubmit, no_qual()), TransitionType::Link);
+    }
+
+    #[test]
+    fn reload_maps_directly() {
+        assert_eq!(map(CefTransitionCore::Reload, no_qual()), TransitionType::Reload);
+    }
+
+    #[test]
+    fn subframe_falls_to_other() {
+        assert_eq!(map(CefTransitionCore::AutoSubframe, no_qual()), TransitionType::Other);
+    }
+}
+```
+
+- [ ] **Step 2: Add module declaration**
+
+Edit `crates/vmux_history/src/lib.rs` (or `plugin.rs` if it's the module root — check with `cat crates/vmux_history/src/lib.rs`):
+
+```rust
+pub mod transition;
+```
+
+- [ ] **Step 3: Run tests, expect PASS**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_history -- transition::tests
+```
+
+- [ ] **Step 4: Pre-commit checks**
+
+```bash
+cargo fmt -p vmux_history -- --check
+env -u CEF_PATH cargo clippy -p vmux_history --all-targets -- -D warnings
+env -u CEF_PATH cargo test -p vmux_history
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/vmux_history/
+git commit -m "feat(vmux_history): map CEF transition types to TransitionType enum (VMX-120)"
+```
+
+---
+
+### Task 7: Find-or-create `Url` entity helper
+
+**Files:**
+- Create: `crates/vmux_history/src/spawn.rs`
+- Modify: `crates/vmux_history/src/lib.rs` — declare module
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `crates/vmux_history/src/spawn.rs`:
+
+```rust
+use bevy::prelude::*;
+use vmux_core::{CreatedAt, LastVisitedAt, PageMetadata, Url, VisitCount, now_millis};
+
+pub fn find_or_create_url(world: &mut World, url: &str) -> Entity {
+    let mut existing = None;
+    let mut query = world.query::<(Entity, &PageMetadata)>();
+    for (e, meta) in query.iter(world) {
+        if world.get::<Url>(e).is_some() && meta.url == url {
+            existing = Some(e);
+            break;
+        }
+    }
+    if let Some(e) = existing {
+        return e;
+    }
+    let now = now_millis();
+    world
+        .spawn((
+            Url,
+            PageMetadata {
+                url: url.to_string(),
+                ..default()
+            },
+            VisitCount(0),
+            LastVisitedAt(0),
+            CreatedAt(now),
+        ))
+        .id()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vmux_core::CorePlugin;
+
+    fn app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_plugins(CorePlugin);
+        app
+    }
+
+    #[test]
+    fn creates_when_missing() {
+        let mut app = app();
+        let e = find_or_create_url(app.world_mut(), "https://example.com");
+        assert!(app.world().get::<Url>(e).is_some());
+        let meta = app.world().get::<PageMetadata>(e).unwrap();
+        assert_eq!(meta.url, "https://example.com");
+        assert_eq!(app.world().get::<VisitCount>(e).unwrap().0, 0);
+    }
+
+    #[test]
+    fn returns_existing_match() {
+        let mut app = app();
+        let e1 = find_or_create_url(app.world_mut(), "https://example.com");
+        let e2 = find_or_create_url(app.world_mut(), "https://example.com");
+        assert_eq!(e1, e2);
+    }
+
+    #[test]
+    fn distinct_urls_get_distinct_entities() {
+        let mut app = app();
+        let a = find_or_create_url(app.world_mut(), "https://a.com");
+        let b = find_or_create_url(app.world_mut(), "https://b.com");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn ignores_entities_without_url_marker() {
+        let mut app = app();
+        app.world_mut().spawn(PageMetadata {
+            url: "https://example.com".into(),
+            ..default()
+        });
+        let e = find_or_create_url(app.world_mut(), "https://example.com");
+        assert!(app.world().get::<Url>(e).is_some());
+    }
+}
+```
+
+- [ ] **Step 2: Declare module**
+
+In `crates/vmux_history/src/lib.rs`:
+
+```rust
+pub mod spawn;
+```
+
+- [ ] **Step 3: Run tests, expect PASS**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_history -- spawn::tests
+```
+
+- [ ] **Step 4: Pre-commit + commit**
+
+```bash
+cargo fmt -p vmux_history -- --check
+env -u CEF_PATH cargo clippy -p vmux_history --all-targets -- -D warnings
+env -u CEF_PATH cargo test -p vmux_history
+git add crates/vmux_history/
+git commit -m "feat(vmux_history): find_or_create_url helper (VMX-120)"
+```
+
+---
+
+### Task 8: Visit-spawn system
+
+**Files:**
+- Modify: `crates/vmux_history/src/spawn.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `spawn.rs`:
+
+```rust
+use bevy_cef_core::{CefTransitionCore, CefTransitionQualifiers, WebviewCommittedNavigationEvent};
+use vmux_core::{TransitionType, Visit, VisitedUrl};
+
+pub fn spawn_visits(
+    mut events: MessageReader<WebviewCommittedNavigationEvent>,
+    mut commands: Commands,
+    mut urls: Query<(Entity, &PageMetadata, &mut VisitCount, &mut LastVisitedAt), With<Url>>,
+) {
+    for ev in events.read() {
+        if !ev.is_main_frame {
+            continue;
+        }
+        if ev.url.starts_with("vmux://") || ev.url.is_empty() {
+            continue;
+        }
+        let now = now_millis();
+        let transition = crate::transition::map(ev.transition, ev.qualifiers);
+
+        let mut url_entity = None;
+        for (e, meta, mut count, mut last) in urls.iter_mut() {
+            if meta.url == ev.url {
+                count.0 = count.0.saturating_add(1);
+                last.0 = now;
+                url_entity = Some(e);
+                break;
+            }
+        }
+
+        let url_e = match url_entity {
+            Some(e) => e,
+            None => commands
+                .spawn((
+                    Url,
+                    PageMetadata { url: ev.url.clone(), ..default() },
+                    VisitCount(1),
+                    LastVisitedAt(now),
+                    CreatedAt(now),
+                ))
+                .id(),
+        };
+
+        if transition != TransitionType::BackForward {
+            commands.spawn((
+                Visit,
+                CreatedAt(now),
+                VisitedUrl(url_e),
+                transition,
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+mod system_tests {
+    use super::*;
+    use vmux_core::CorePlugin;
+
+    fn app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_plugins(CorePlugin);
+        app.add_event::<WebviewCommittedNavigationEvent>();
+        app.add_systems(Update, spawn_visits);
+        app
+    }
+
+    fn send(app: &mut App, url: &str, transition: CefTransitionCore, forward_back: bool) {
+        let mut writer = app
+            .world_mut()
+            .resource_mut::<Messages<WebviewCommittedNavigationEvent>>();
+        writer.write(WebviewCommittedNavigationEvent {
+            webview: Entity::PLACEHOLDER,
+            url: url.into(),
+            is_main_frame: true,
+            transition,
+            qualifiers: CefTransitionQualifiers {
+                forward_back,
+                ..Default::default()
+            },
+        });
+    }
+
+    #[test]
+    fn first_visit_spawns_url_and_visit() {
+        let mut app = app();
+        send(&mut app, "https://example.com", CefTransitionCore::Link, false);
+        app.update();
+        let urls = app.world_mut().query::<&Url>().iter(&app.world()).count();
+        let visits = app.world_mut().query::<&Visit>().iter(&app.world()).count();
+        assert_eq!(urls, 1);
+        assert_eq!(visits, 1);
+    }
+
+    #[test]
+    fn second_visit_same_url_increments_count() {
+        let mut app = app();
+        send(&mut app, "https://example.com", CefTransitionCore::Link, false);
+        app.update();
+        send(&mut app, "https://example.com", CefTransitionCore::Link, false);
+        app.update();
+        let urls = app.world_mut().query::<&Url>().iter(&app.world()).count();
+        let visits = app.world_mut().query::<&Visit>().iter(&app.world()).count();
+        assert_eq!(urls, 1);
+        assert_eq!(visits, 2);
+        let count = app.world_mut().query::<&VisitCount>().iter(&app.world()).next().unwrap().0;
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn back_forward_bumps_count_but_no_visit() {
+        let mut app = app();
+        send(&mut app, "https://example.com", CefTransitionCore::Link, false);
+        app.update();
+        send(&mut app, "https://example.com", CefTransitionCore::Link, true);
+        app.update();
+        let visits = app.world_mut().query::<&Visit>().iter(&app.world()).count();
+        let count = app.world_mut().query::<&VisitCount>().iter(&app.world()).next().unwrap().0;
+        assert_eq!(visits, 1);
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn subframe_skipped() {
+        let mut app = app();
+        let mut writer = app
+            .world_mut()
+            .resource_mut::<Messages<WebviewCommittedNavigationEvent>>();
+        writer.write(WebviewCommittedNavigationEvent {
+            webview: Entity::PLACEHOLDER,
+            url: "https://example.com".into(),
+            is_main_frame: false,
+            transition: CefTransitionCore::Link,
+            qualifiers: CefTransitionQualifiers::default(),
+        });
+        app.update();
+        assert_eq!(app.world_mut().query::<&Visit>().iter(&app.world()).count(), 0);
+    }
+
+    #[test]
+    fn vmux_scheme_skipped() {
+        let mut app = app();
+        send(&mut app, "vmux://history", CefTransitionCore::Link, false);
+        app.update();
+        assert_eq!(app.world_mut().query::<&Url>().iter(&app.world()).count(), 0);
+    }
+}
+```
+
+Note: the actual Bevy 0.x event API may use `EventReader`/`Events`/`EventWriter` rather than `MessageReader`/`Messages`/`MessageWriter` depending on the version. Check existing systems in `vmux_history` or `vmux_desktop` and match their convention.
+
+- [ ] **Step 2: Run tests, expect PASS**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_history -- spawn::system_tests
+```
+
+- [ ] **Step 3: Pre-commit + commit**
+
+```bash
+cargo fmt -p vmux_history -- --check
+env -u CEF_PATH cargo clippy -p vmux_history --all-targets -- -D warnings
+env -u CEF_PATH cargo test -p vmux_history
+git add crates/vmux_history/
+git commit -m "feat(vmux_history): spawn Visit + Url on committed navigation (VMX-120)"
+```
+
+---
+
+### Task 9: HistoryPlugin registers `spawn_visits`
+
+**Files:**
+- Modify: `crates/vmux_history/src/plugin.rs` — replace POC body
+
+- [ ] **Step 1: Replace `HistoryPlugin`**
+
+```rust
+use bevy::prelude::*;
+use crate::spawn::spawn_visits;
+
+pub struct HistoryPlugin;
+
+impl Plugin for HistoryPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, spawn_visits);
+    }
+}
+```
+
+Remove the existing sample-data spawner and the `push_history_via_host_emit` system body (the query side is rebuilt in Phase 4). The `WebviewCommittedNavigationEvent` is registered once in `vmux_desktop` (Task 3) — `vmux_history` only consumes it.
+
+- [ ] **Step 2: Pre-commit + commit**
+
+```bash
+PKGS=$(BASE=origin/main ./scripts/changed-crates.sh)
+for pkg in $PKGS; do cargo fmt -p "$pkg" -- --check; done
+for pkg in $PKGS; do env -u CEF_PATH cargo clippy -p "$pkg" --all-targets -- -D warnings; done
+for pkg in $PKGS; do env -u CEF_PATH cargo test -p "$pkg"; done
+git add crates/vmux_history/
+git commit -m "feat(vmux_history): HistoryPlugin registers spawn_visits (VMX-120)"
+```
+
+---
+
+### Task 10: Mirror title/favicon updates to `Url` entity
+
+**Files:**
+- Modify: `crates/vmux_layout/src/chrome.rs:41` (the `apply_chrome_state_from_cef` system)
+
+- [ ] **Step 1: Locate the system**
+
+```bash
+rg "apply_chrome_state_from_cef" crates/vmux_layout/
+```
+
+Read the system, understand how it currently updates `PageMetadata` on the tab/browser entity.
+
+- [ ] **Step 2: Write a peer system that mirrors title/favicon to `Url`**
+
+In the same file, add:
+
+```rust
+use vmux_core::Url;
+
+pub fn mirror_metadata_to_url(
+    chrome_q: Query<&PageMetadata, (Without<Url>, Changed<PageMetadata>)>,
+    mut urls: Query<&mut PageMetadata, With<Url>>,
+) {
+    for tab_meta in chrome_q.iter() {
+        if tab_meta.url.is_empty() {
+            continue;
+        }
+        for mut url_meta in urls.iter_mut() {
+            if url_meta.url == tab_meta.url {
+                if !tab_meta.title.is_empty() {
+                    url_meta.title = tab_meta.title.clone();
+                }
+                if !tab_meta.favicon_url.is_empty() {
+                    url_meta.favicon_url = tab_meta.favicon_url.clone();
+                }
+                if tab_meta.bg_color.is_some() {
+                    url_meta.bg_color = tab_meta.bg_color.clone();
+                }
+                break;
+            }
+        }
+    }
+}
+```
+
+Register on `Update` after `apply_chrome_state_from_cef`.
+
+- [ ] **Step 3: Write a test**
+
+```rust
+#[cfg(test)]
+mod url_mirror_tests {
+    use super::*;
+    use bevy::prelude::*;
+    use vmux_core::{CorePlugin, PageMetadata, Url, VisitCount, LastVisitedAt, CreatedAt};
+
+    #[test]
+    fn updates_matching_url_meta() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_plugins(CorePlugin);
+        app.add_systems(Update, mirror_metadata_to_url);
+
+        let _url_e = app.world_mut().spawn((
+            Url,
+            PageMetadata { url: "https://example.com".into(), ..default() },
+            VisitCount(1),
+            LastVisitedAt(0),
+            CreatedAt(0),
+        )).id();
+
+        let _tab_e = app.world_mut().spawn(PageMetadata {
+            url: "https://example.com".into(),
+            title: "Example".into(),
+            favicon_url: "https://example.com/fav.ico".into(),
+            ..default()
+        }).id();
+
+        app.update();
+
+        let url_meta = app
+            .world_mut()
+            .query_filtered::<&PageMetadata, With<Url>>()
+            .iter(&app.world())
+            .next()
+            .unwrap();
+        assert_eq!(url_meta.title, "Example");
+        assert_eq!(url_meta.favicon_url, "https://example.com/fav.ico");
+    }
+}
+```
+
+- [ ] **Step 4: Run test, fix bugs until PASS**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_layout -- url_mirror_tests
+```
+
+- [ ] **Step 5: Pre-commit + commit**
+
+```bash
+cargo fmt -p vmux_layout -- --check
+env -u CEF_PATH cargo clippy -p vmux_layout --all-targets -- -D warnings
+env -u CEF_PATH cargo test -p vmux_layout
+git add crates/vmux_layout/
+git commit -m "feat(vmux_layout): mirror tab PageMetadata to matching Url entity (VMX-120)"
+```
+
+---
+
+### Task 11: 90-day prune system
+
+**Files:**
+- Create: `crates/vmux_history/src/prune.rs`
+- Modify: `crates/vmux_history/src/lib.rs` — declare module
+- Modify: `crates/vmux_history/src/plugin.rs` — register system
+
+- [ ] **Step 1: Write the prune system + tests**
+
+Create `crates/vmux_history/src/prune.rs`:
+
+```rust
+use bevy::prelude::*;
+use vmux_core::{CreatedAt, LastVisitedAt, Url, Visit, VisitedUrl, now_millis};
+
+pub const RETENTION_MS: i64 = 90 * 86_400_000;
+
+pub fn prune_history(
+    mut commands: Commands,
+    visits: Query<(Entity, &CreatedAt), With<Visit>>,
+    urls: Query<(Entity, &LastVisitedAt), With<Url>>,
+    visits_for_url: Query<&VisitedUrl, With<Visit>>,
+) {
+    let cutoff = now_millis() - RETENTION_MS;
+
+    let mut deleted_url_candidates = Vec::<Entity>::new();
+    for (e, last) in urls.iter() {
+        if last.0 < cutoff {
+            deleted_url_candidates.push(e);
+        }
+    }
+
+    for (e, created) in visits.iter() {
+        if created.0 < cutoff {
+            commands.entity(e).despawn();
+        }
+    }
+
+    for url_e in deleted_url_candidates {
+        let has_remaining = visits_for_url.iter().any(|v| v.0 == url_e);
+        if !has_remaining {
+            commands.entity(url_e).despawn();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vmux_core::{CorePlugin, PageMetadata, VisitCount};
+
+    fn app() -> App {
+        let mut a = App::new();
+        a.add_plugins(MinimalPlugins);
+        a.add_plugins(CorePlugin);
+        a.add_systems(Update, prune_history);
+        a
+    }
+
+    #[test]
+    fn removes_old_visits_and_urls() {
+        let mut a = app();
+        let old = now_millis() - RETENTION_MS - 1000;
+        let url_e = a.world_mut().spawn((
+            Url,
+            PageMetadata { url: "old".into(), ..default() },
+            VisitCount(1),
+            LastVisitedAt(old),
+            CreatedAt(old),
+        )).id();
+        a.world_mut().spawn((
+            Visit,
+            CreatedAt(old),
+            VisitedUrl(url_e),
+        ));
+        a.update();
+        assert_eq!(a.world_mut().query::<&Url>().iter(&a.world()).count(), 0);
+        assert_eq!(a.world_mut().query::<&Visit>().iter(&a.world()).count(), 0);
+    }
+
+    #[test]
+    fn keeps_recent_entries() {
+        let mut a = app();
+        let now = now_millis();
+        let url_e = a.world_mut().spawn((
+            Url,
+            PageMetadata { url: "recent".into(), ..default() },
+            VisitCount(1),
+            LastVisitedAt(now),
+            CreatedAt(now),
+        )).id();
+        a.world_mut().spawn((Visit, CreatedAt(now), VisitedUrl(url_e)));
+        a.update();
+        assert_eq!(a.world_mut().query::<&Url>().iter(&a.world()).count(), 1);
+        assert_eq!(a.world_mut().query::<&Visit>().iter(&a.world()).count(), 1);
+    }
+
+    #[test]
+    fn keeps_url_when_recent_visit_exists() {
+        let mut a = app();
+        let now = now_millis();
+        let old = now - RETENTION_MS - 1000;
+        let url_e = a.world_mut().spawn((
+            Url,
+            PageMetadata { url: "u".into(), ..default() },
+            VisitCount(2),
+            LastVisitedAt(now),
+            CreatedAt(old),
+        )).id();
+        a.world_mut().spawn((Visit, CreatedAt(now), VisitedUrl(url_e)));
+        a.update();
+        assert_eq!(a.world_mut().query::<&Url>().iter(&a.world()).count(), 1);
+    }
+}
+```
+
+- [ ] **Step 2: Declare module + register**
+
+In `crates/vmux_history/src/lib.rs`:
+
+```rust
+pub mod prune;
+```
+
+In `crates/vmux_history/src/plugin.rs`:
+
+```rust
+use bevy::time::common_conditions::on_timer;
+use std::time::Duration;
+use crate::prune::prune_history;
+
+// inside Plugin::build, after spawn_visits registration:
+app.add_systems(
+    Update,
+    prune_history.run_if(on_timer(Duration::from_secs(3600))),
+);
+app.add_systems(Startup, prune_history);
+```
+
+- [ ] **Step 3: Run tests, expect PASS**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_history -- prune::tests
+```
+
+- [ ] **Step 4: Pre-commit + commit**
+
+```bash
+cargo fmt -p vmux_history -- --check
+env -u CEF_PATH cargo clippy -p vmux_history --all-targets -- -D warnings
+env -u CEF_PATH cargo test -p vmux_history
+git add crates/vmux_history/
+git commit -m "feat(vmux_history): 90-day history prune system (VMX-120)"
+```
+
+---
+
+## Phase 4 — History page (`vmux_history`)
+
+### Task 12: Ranking helpers (frecency + hybrid match)
+
+**Files:**
+- Create: `crates/vmux_history/src/query.rs`
+- Modify: `crates/vmux_history/src/lib.rs` — declare module
+
+- [ ] **Step 1: Write the helpers + tests**
+
+Create `crates/vmux_history/src/query.rs`:
+
+```rust
+pub fn frecency(visit_count: u32, last_visited_at: i64, now: i64) -> f32 {
+    let age_hours = ((now - last_visited_at).max(0) as f32) / 3_600_000.0;
+    let decay = 1.0 / (1.0 + age_hours / 24.0);
+    (visit_count as f32) * decay
+}
+
+pub fn match_strength(query: &str, url: &str, title: &str) -> f32 {
+    if query.is_empty() {
+        return 1.0;
+    }
+    let q = query.to_lowercase();
+    let u = url.to_lowercase();
+    let t = title.to_lowercase();
+    let mut score = 0.0;
+    if u.starts_with(&q) { score += 3.0; }
+    if t.starts_with(&q) { score += 2.0; }
+    if u.contains(&q) && !u.starts_with(&q) { score += 1.0; }
+    if t.contains(&q) && !t.starts_with(&q) { score += 1.0; }
+    score
+}
+
+pub fn score(visit_count: u32, last_visited_at: i64, now: i64, query: &str, url: &str, title: &str) -> f32 {
+    let m = match_strength(query, url, title);
+    if m == 0.0 {
+        return 0.0;
+    }
+    frecency(visit_count, last_visited_at, now) * m
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frecency_decays_with_age() {
+        let now = 1_000_000_000;
+        let recent = frecency(10, now - 3_600_000, now);
+        let old = frecency(10, now - 100 * 3_600_000, now);
+        assert!(recent > old);
+    }
+
+    #[test]
+    fn match_strength_url_prefix_beats_substring() {
+        let pfx = match_strength("git", "github.com", "GitHub");
+        let mid = match_strength("hub", "github.com", "GitHub");
+        assert!(pfx > mid);
+    }
+
+    #[test]
+    fn match_strength_zero_on_miss() {
+        assert_eq!(match_strength("xyz", "github.com", "GitHub"), 0.0);
+    }
+
+    #[test]
+    fn match_strength_one_when_query_empty() {
+        assert_eq!(match_strength("", "github.com", "GitHub"), 1.0);
+    }
+
+    #[test]
+    fn higher_visit_count_ranks_higher_at_equal_match() {
+        let now = 1_000_000_000;
+        let a = score(20, now, now, "git", "github.com", "GitHub");
+        let b = score(2, now, now, "git", "github.com", "GitHub");
+        assert!(a > b);
+    }
+}
+```
+
+- [ ] **Step 2: Declare module**
+
+In `crates/vmux_history/src/lib.rs`:
+
+```rust
+pub mod query;
+```
+
+- [ ] **Step 3: Run tests, expect PASS**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_history -- query::tests
+```
+
+- [ ] **Step 4: Pre-commit + commit**
+
+```bash
+cargo fmt -p vmux_history -- --check
+env -u CEF_PATH cargo clippy -p vmux_history --all-targets -- -D warnings
+env -u CEF_PATH cargo test -p vmux_history
+git add crates/vmux_history/
+git commit -m "feat(vmux_history): frecency + hybrid match ranking (VMX-120)"
+```
+
+---
+
+### Task 13: Webview ↔ Bevy IPC events
+
+**Files:**
+- Create: `crates/vmux_history/src/event.rs`
+- Modify: `crates/vmux_history/src/lib.rs` — declare module
+
+- [ ] **Step 1: Define the event types**
+
+Create `crates/vmux_history/src/event.rs`. Mirror the rkyv pattern used in `crates/vmux_command/src/event.rs` (read that file first via `cat crates/vmux_command/src/event.rs` to see exact derives + crate paths):
+
+```rust
+use serde::{Deserialize, Serialize};
+use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Archive, RkyvSerialize, RkyvDeserialize)]
+pub struct HistoryEntry {
+    pub url_entity_bits: u64,
+    pub url: String,
+    pub title: String,
+    pub favicon_url: String,
+    pub visit_created_at: i64,
+    pub visit_count: u32,
+    pub last_visited_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Archive, RkyvSerialize, RkyvDeserialize)]
+pub struct HistoryQueryRequest {
+    pub query: Option<String>,
+    pub offset: u32,
+    pub limit: u32,
+    pub request_id: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Archive, RkyvSerialize, RkyvDeserialize)]
+pub struct HistoryQueryResponse {
+    pub request_id: u64,
+    pub entries: Vec<HistoryEntry>,
+    pub has_more: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Archive, RkyvSerialize, RkyvDeserialize)]
+pub struct HistoryDeleteRequest {
+    pub url_entity_bits: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Archive, RkyvSerialize, RkyvDeserialize)]
+pub struct HistoryClearAllRequest;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Archive, RkyvSerialize, RkyvDeserialize)]
+pub struct HistoryOpenRequest {
+    pub url: String,
+    pub in_new_stack: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Archive, RkyvSerialize, RkyvDeserialize)]
+pub struct HistorySuggestionsRequest {
+    pub query: String,
+    pub limit: u32,
+    pub request_id: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Archive, RkyvSerialize, RkyvDeserialize)]
+pub struct HistorySuggestionsResponse {
+    pub request_id: u64,
+    pub entries: Vec<HistoryEntry>,
+}
+```
+
+Also add identifier constants (mirror `crates/vmux_command/src/event.rs` style) for `BinHostEmitEvent::from_rkyv` calls, e.g.:
+
+```rust
+pub const HISTORY_QUERY_RESPONSE_EVENT: &str = "history-query-response";
+pub const HISTORY_SUGGESTIONS_RESPONSE_EVENT: &str = "history-suggestions-response";
+```
+
+- [ ] **Step 2: Declare module**
+
+In `crates/vmux_history/src/lib.rs`:
+
+```rust
+pub mod event;
+```
+
+- [ ] **Step 3: Pre-commit + commit**
+
+```bash
+cargo fmt -p vmux_history -- --check
+env -u CEF_PATH cargo clippy -p vmux_history --all-targets -- -D warnings
+env -u CEF_PATH cargo test -p vmux_history
+git add crates/vmux_history/
+git commit -m "feat(vmux_history): rkyv events for history page IPC (VMX-120)"
+```
+
+---
+
+### Task 14: Query handler system
+
+**Files:**
+- Modify: `crates/vmux_history/src/query.rs` — add Bevy systems
+- Modify: `crates/vmux_history/src/plugin.rs` — register systems + `BinJsEmitEventPlugin` registrations
+
+- [ ] **Step 1: Read existing `BinJsEmitEventPlugin` usage pattern**
+
+```bash
+rg "BinJsEmitEventPlugin" crates/vmux_command/ crates/vmux_history/
+rg "BinHostEmitEvent::from_rkyv" crates/vmux_command/
+```
+
+Read the matching observer functions in `crates/vmux_desktop/src/command_bar.rs` to learn the exact request/response shape (Entity-targeted vs broadcast, etc).
+
+- [ ] **Step 2: Implement `on_history_query_request` observer**
+
+Append to `crates/vmux_history/src/query.rs`:
+
+```rust
+use bevy::prelude::*;
+use crate::event::{
+    HistoryEntry, HistoryQueryRequest, HistoryQueryResponse, HISTORY_QUERY_RESPONSE_EVENT,
+};
+use vmux_core::{CreatedAt, LastVisitedAt, PageMetadata, Url, Visit, VisitedUrl, VisitCount, now_millis};
+
+pub fn on_history_query_request(
+    trigger: Trigger<HistoryQueryRequest>,
+    urls: Query<(Entity, &PageMetadata, &VisitCount, &LastVisitedAt), With<Url>>,
+    visits: Query<(&CreatedAt, &VisitedUrl), With<Visit>>,
+    mut emit: MessageWriter<BinHostEmitEvent>,
+) {
+    let req = trigger.event();
+    let now = now_millis();
+    let entries = build_entries(req, &urls, &visits, now);
+    let total_after_offset = entries.len();
+    let limit = req.limit as usize;
+    let page: Vec<_> = entries.into_iter().skip(req.offset as usize).take(limit).collect();
+    let has_more = (req.offset as usize + page.len()) < (req.offset as usize + total_after_offset.saturating_sub(req.offset as usize));
+
+    let payload = HistoryQueryResponse {
+        request_id: req.request_id,
+        entries: page,
+        has_more,
+    };
+    emit.write(BinHostEmitEvent::from_rkyv(
+        trigger.target(),
+        HISTORY_QUERY_RESPONSE_EVENT,
+        &payload,
+    ));
+}
+
+fn build_entries(
+    req: &HistoryQueryRequest,
+    urls: &Query<(Entity, &PageMetadata, &VisitCount, &LastVisitedAt), With<Url>>,
+    visits: &Query<(&CreatedAt, &VisitedUrl), With<Visit>>,
+    now: i64,
+) -> Vec<HistoryEntry> {
+    match &req.query {
+        None => {
+            let mut entries: Vec<_> = visits
+                .iter()
+                .filter_map(|(created, visited_url)| {
+                    let (_, meta, count, last) = urls.iter().find(|(e, _, _, _)| *e == visited_url.0)?;
+                    Some(HistoryEntry {
+                        url_entity_bits: visited_url.0.to_bits(),
+                        url: meta.url.clone(),
+                        title: meta.title.clone(),
+                        favicon_url: meta.favicon_url.clone(),
+                        visit_created_at: created.0,
+                        visit_count: count.0,
+                        last_visited_at: last.0,
+                    })
+                })
+                .collect();
+            entries.sort_by(|a, b| b.visit_created_at.cmp(&a.visit_created_at));
+            entries
+        }
+        Some(q) => {
+            let mut scored: Vec<(f32, HistoryEntry)> = urls
+                .iter()
+                .filter_map(|(e, meta, count, last)| {
+                    let s = score(count.0, last.0, now, q, &meta.url, &meta.title);
+                    if s <= 0.0 {
+                        return None;
+                    }
+                    Some((s, HistoryEntry {
+                        url_entity_bits: e.to_bits(),
+                        url: meta.url.clone(),
+                        title: meta.title.clone(),
+                        favicon_url: meta.favicon_url.clone(),
+                        visit_created_at: last.0,
+                        visit_count: count.0,
+                        last_visited_at: last.0,
+                    }))
+                })
+                .collect();
+            scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+            scored.into_iter().map(|(_, e)| e).collect()
+        }
+    }
+}
+```
+
+Note: `BinHostEmitEvent::from_rkyv` import path differs by version — match the existing usage in `crates/vmux_command/`.
+
+- [ ] **Step 3: Add observer for delete/clear/open**
+
+Continue in `query.rs`:
+
+```rust
+use crate::event::{HistoryClearAllRequest, HistoryDeleteRequest, HistoryOpenRequest};
+
+pub fn on_history_delete_request(
+    trigger: Trigger<HistoryDeleteRequest>,
+    mut commands: Commands,
+    visits: Query<(Entity, &VisitedUrl), With<Visit>>,
+) {
+    let target_bits = trigger.event().url_entity_bits;
+    let target = Entity::from_bits(target_bits);
+    for (visit_e, visited_url) in visits.iter() {
+        if visited_url.0 == target {
+            commands.entity(visit_e).despawn();
+        }
+    }
+    commands.entity(target).despawn();
+}
+
+pub fn on_history_clear_all_request(
+    _trigger: Trigger<HistoryClearAllRequest>,
+    mut commands: Commands,
+    urls: Query<Entity, With<Url>>,
+    visits: Query<Entity, With<Visit>>,
+) {
+    for e in urls.iter() {
+        commands.entity(e).despawn();
+    }
+    for e in visits.iter() {
+        commands.entity(e).despawn();
+    }
+}
+
+pub fn on_history_open_request(
+    trigger: Trigger<HistoryOpenRequest>,
+    mut commands: Commands,
+) {
+    let HistoryOpenRequest { url, in_new_stack } = trigger.event().clone();
+    if in_new_stack {
+        commands.trigger(vmux_desktop::AgentCommand::OpenInNewStack { url });
+    } else {
+        commands.trigger(vmux_desktop::AgentCommand::BrowserNavigate { url, pane: None });
+    }
+}
+```
+
+`AgentCommand::OpenInNewStack` is added in Task 24. If you have not added it yet, jump to Task 24 step 1 and add only the `OpenInNewStack` variant + its dispatch arm first, then return here. If trigger-style dispatch isn't the existing convention, use the `MessageWriter<AgentCommand>` pattern — match what `command_bar.rs:1252` does.
+
+- [ ] **Step 4: Register observers in plugin**
+
+In `crates/vmux_history/src/plugin.rs`:
+
+```rust
+use crate::event::*;
+use crate::query::*;
+
+// inside Plugin::build:
+app.add_plugins(BinJsEmitEventPlugin::<HistoryQueryRequest>::default());
+app.add_plugins(BinJsEmitEventPlugin::<HistoryDeleteRequest>::default());
+app.add_plugins(BinJsEmitEventPlugin::<HistoryClearAllRequest>::default());
+app.add_plugins(BinJsEmitEventPlugin::<HistoryOpenRequest>::default());
+app.add_observer(on_history_query_request);
+app.add_observer(on_history_delete_request);
+app.add_observer(on_history_clear_all_request);
+app.add_observer(on_history_open_request);
+```
+
+- [ ] **Step 5: Write a query-handler unit test**
+
+In `query.rs`:
+
+```rust
+#[cfg(test)]
+mod handler_tests {
+    use super::*;
+    use vmux_core::CorePlugin;
+
+    fn app() -> App {
+        let mut a = App::new();
+        a.add_plugins(MinimalPlugins);
+        a.add_plugins(CorePlugin);
+        a
+    }
+
+    #[test]
+    fn build_entries_no_query_orders_by_visit_created_at_desc() {
+        let mut a = app();
+        let url_e = a.world_mut().spawn((
+            Url,
+            PageMetadata { url: "u".into(), ..default() },
+            VisitCount(2),
+            LastVisitedAt(0),
+            CreatedAt(0),
+        )).id();
+        a.world_mut().spawn((Visit, CreatedAt(100), VisitedUrl(url_e)));
+        a.world_mut().spawn((Visit, CreatedAt(200), VisitedUrl(url_e)));
+
+        let urls = a.world_mut().query_filtered::<(Entity, &PageMetadata, &VisitCount, &LastVisitedAt), With<Url>>();
+        let visits = a.world_mut().query_filtered::<(&CreatedAt, &VisitedUrl), With<Visit>>();
+        let req = HistoryQueryRequest { query: None, offset: 0, limit: 10, request_id: 0 };
+        let now = 1_000;
+        let entries = build_entries(&req, &urls, &visits, now);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].visit_created_at, 200);
+        assert_eq!(entries[1].visit_created_at, 100);
+    }
+}
+```
+
+(The query-iter borrow pattern shown is approximate; in practice you may need `query.iter(&app.world())` — match existing patterns in the crate.)
+
+- [ ] **Step 6: Pre-commit + commit**
+
+```bash
+cargo fmt -p vmux_history -- --check
+env -u CEF_PATH cargo clippy -p vmux_history --all-targets -- -D warnings
+env -u CEF_PATH cargo test -p vmux_history
+git add crates/vmux_history/
+git commit -m "feat(vmux_history): query handler systems + observers (VMX-120)"
+```
+
+---
+
+### Task 15: History suggestions handler
+
+**Files:**
+- Modify: `crates/vmux_history/src/query.rs`
+- Modify: `crates/vmux_history/src/plugin.rs`
+
+- [ ] **Step 1: Add `on_history_suggestions_request` observer**
+
+In `query.rs`:
+
+```rust
+use crate::event::{HistorySuggestionsRequest, HistorySuggestionsResponse, HISTORY_SUGGESTIONS_RESPONSE_EVENT};
+
+pub fn on_history_suggestions_request(
+    trigger: Trigger<HistorySuggestionsRequest>,
+    urls: Query<(Entity, &PageMetadata, &VisitCount, &LastVisitedAt), With<Url>>,
+    mut emit: MessageWriter<BinHostEmitEvent>,
+) {
+    let req = trigger.event();
+    let now = now_millis();
+    let mut scored: Vec<(f32, HistoryEntry)> = urls
+        .iter()
+        .filter_map(|(e, meta, count, last)| {
+            let s = score(count.0, last.0, now, &req.query, &meta.url, &meta.title);
+            if s <= 0.0 { return None; }
+            Some((s, HistoryEntry {
+                url_entity_bits: e.to_bits(),
+                url: meta.url.clone(),
+                title: meta.title.clone(),
+                favicon_url: meta.favicon_url.clone(),
+                visit_created_at: last.0,
+                visit_count: count.0,
+                last_visited_at: last.0,
+            }))
+        })
+        .collect();
+    scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+    let entries: Vec<HistoryEntry> = scored.into_iter().take(req.limit as usize).map(|(_, e)| e).collect();
+    emit.write(BinHostEmitEvent::from_rkyv(
+        trigger.target(),
+        HISTORY_SUGGESTIONS_RESPONSE_EVENT,
+        &HistorySuggestionsResponse { request_id: req.request_id, entries },
+    ));
+}
+```
+
+- [ ] **Step 2: Register**
+
+In `plugin.rs`:
+
+```rust
+app.add_plugins(BinJsEmitEventPlugin::<HistorySuggestionsRequest>::default());
+app.add_observer(on_history_suggestions_request);
+```
+
+- [ ] **Step 3: Pre-commit + commit**
+
+```bash
+cargo fmt -p vmux_history -- --check
+env -u CEF_PATH cargo clippy -p vmux_history --all-targets -- -D warnings
+env -u CEF_PATH cargo test -p vmux_history
+git add crates/vmux_history/
+git commit -m "feat(vmux_history): history suggestions request handler (VMX-120)"
+```
+
+---
+
+### Task 16: Dioxus history page — timeline render
+
+**Files:**
+- Modify: `crates/vmux_history/src/app.rs` (replace POC)
+
+- [ ] **Step 1: Read existing app for layout conventions**
+
+```bash
+cat crates/vmux_command/src/app.rs | head -100
+```
+
+Identify Tailwind classes, signal hooks, `use_bin_event_listener` pattern. Use the same.
+
+- [ ] **Step 2: Replace `app.rs` with timeline component**
+
+```rust
+#![allow(non_snake_case)]
+
+use dioxus::prelude::*;
+use vmux_history::event::{HistoryEntry, HistoryQueryRequest, HistoryQueryResponse};
+
+#[component]
+pub fn App() -> Element {
+    let entries: Signal<Vec<HistoryEntry>> = use_signal(Vec::new);
+    let query: Signal<String> = use_signal(String::new);
+    let offset: Signal<u32> = use_signal(|| 0);
+    let has_more: Signal<bool> = use_signal(|| true);
+
+    let entries_for_render = entries.read().clone();
+
+    rsx! {
+        div { class: "flex flex-col h-full bg-black text-white",
+            header { class: "p-3 border-b border-gray-800 flex gap-2",
+                input {
+                    class: "flex-1 bg-gray-900 px-3 py-2 rounded text-sm",
+                    placeholder: "Search history",
+                    value: "{query.read()}",
+                    oninput: move |e| query.set(e.value()),
+                }
+                button {
+                    class: "px-3 py-2 text-xs bg-red-900 rounded",
+                    onclick: move |_| { /* dispatch clear-all (Task 19) */ },
+                    "Clear all"
+                }
+            }
+            main { class: "flex-1 overflow-y-auto p-3",
+                {render_timeline(entries_for_render)}
+                div { id: "infinite-scroll-sentinel", class: "h-4" }
+            }
+        }
+    }
+}
+
+fn render_timeline(entries: Vec<HistoryEntry>) -> Element {
+    let groups = group_by_day(&entries);
+    rsx! {
+        for (label, group) in groups {
+            div { class: "label text-xs text-gray-500 uppercase mt-3", "{label}" }
+            for entry in group {
+                div { class: "flex items-center gap-2 py-1 border-b border-gray-900 hover:bg-gray-900 group",
+                    span { class: "text-xs text-gray-500 w-12", "{format_time(entry.visit_created_at)}" }
+                    img { class: "w-4 h-4", src: "{entry.favicon_url}" }
+                    span { class: "flex-1 text-sm truncate",
+                        if entry.title.is_empty() { "{entry.url}" } else { "{entry.title}" }
+                    }
+                    button {
+                        class: "opacity-0 group-hover:opacity-100 text-xs text-gray-500 hover:text-red-500 px-2",
+                        "×"
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn group_by_day(entries: &[HistoryEntry]) -> Vec<(String, Vec<HistoryEntry>)> {
+    // group by floor(visit_created_at / 86400000), label "Today"/"Yesterday"/weekday/date
+    // implementation detail; use chrono or compute manually
+    let mut out: Vec<(String, Vec<HistoryEntry>)> = Vec::new();
+    let mut current_day: Option<i64> = None;
+    let now_day = vmux_core::now_millis() / 86_400_000;
+    for e in entries {
+        let day = e.visit_created_at / 86_400_000;
+        if current_day != Some(day) {
+            let label = match now_day - day {
+                0 => "Today".to_string(),
+                1 => "Yesterday".to_string(),
+                _ => format!("Day -{}", now_day - day),
+            };
+            out.push((label, Vec::new()));
+            current_day = Some(day);
+        }
+        out.last_mut().unwrap().1.push(e.clone());
+    }
+    out
+}
+
+fn format_time(ms: i64) -> String {
+    let total_sec = ms / 1000;
+    let h = (total_sec % 86400) / 3600;
+    let m = (total_sec % 3600) / 60;
+    format!("{:02}:{:02}", h, m)
+}
+```
+
+(`vmux_core` may not compile to wasm — confirm `now_millis` is gated by `#[cfg(not(target_arch = "wasm32"))]`. If so, compute "today/yesterday" labels on the Bevy side and include the label in `HistoryEntry`, OR compute the day index from `Date.now()` in JS via web-sys. Adjust the spec — add a `day_label: String` field to `HistoryEntry` if simpler.)
+
+- [ ] **Step 3: Validate the build**
+
+```bash
+cd crates/vmux_history && env -u CEF_PATH cargo build --target wasm32-unknown-unknown
+cd ../..
+```
+
+If unbuildable due to `vmux_core` import: replace day labeling with JS-side `Date` calculations via `web-sys`, or compute labels server-side.
+
+- [ ] **Step 4: Pre-commit + commit**
+
+```bash
+cargo fmt -p vmux_history -- --check
+env -u CEF_PATH cargo clippy -p vmux_history --all-targets -- -D warnings
+env -u CEF_PATH cargo test -p vmux_history
+git add crates/vmux_history/
+git commit -m "feat(vmux_history): timeline view in history app (VMX-120)"
+```
+
+---
+
+### Task 17: Wire query request / response in webview
+
+**Files:**
+- Modify: `crates/vmux_history/src/app.rs`
+
+- [ ] **Step 1: Add the on-mount query dispatch and response listener**
+
+```rust
+use vmux_webview_app::{try_cef_bin_emit_rkyv, use_bin_event_listener};
+
+#[component]
+pub fn App() -> Element {
+    let mut entries: Signal<Vec<HistoryEntry>> = use_signal(Vec::new);
+    let mut query: Signal<String> = use_signal(String::new);
+    let mut offset: Signal<u32> = use_signal(|| 0);
+    let mut has_more: Signal<bool> = use_signal(|| true);
+    let request_id: Signal<u64> = use_signal(|| 0);
+
+    use_bin_event_listener::<HistoryQueryResponse>(move |resp| {
+        if resp.request_id != *request_id.read() {
+            return;
+        }
+        let mut current = entries.write();
+        current.extend(resp.entries.clone());
+        has_more.set(resp.has_more);
+    });
+
+    let dispatch_query = move |reset: bool| {
+        if reset {
+            entries.write().clear();
+            offset.set(0);
+            has_more.set(true);
+        }
+        let new_id = *request_id.read() + 1;
+        request_id.set(new_id);
+        let q = query.read().clone();
+        let req = HistoryQueryRequest {
+            query: if q.is_empty() { None } else { Some(q) },
+            offset: *offset.read(),
+            limit: 50,
+            request_id: new_id,
+        };
+        let _ = try_cef_bin_emit_rkyv(&req);
+    };
+
+    use_effect(move || dispatch_query(true));
+
+    let on_input = move |e: Event<FormData>| {
+        query.set(e.value());
+        dispatch_query(true);
+    };
+
+    // ... rest of rsx as before, with input's oninput = on_input
+}
+```
+
+If `use_effect` re-runs aren't tied to `query` reads above, wire it via a `use_resource` or manually re-invoke on input change. Match patterns from `vmux_command/src/app.rs`.
+
+- [ ] **Step 2: Validate build**
+
+```bash
+env -u CEF_PATH cargo build -p vmux_history --target wasm32-unknown-unknown 2>&1 | tail -20
+```
+
+- [ ] **Step 3: Pre-commit + commit**
+
+```bash
+cargo fmt -p vmux_history -- --check
+env -u CEF_PATH cargo clippy -p vmux_history --all-targets -- -D warnings
+git add crates/vmux_history/
+git commit -m "feat(vmux_history): wire history query IPC in webview (VMX-120)"
+```
+
+---
+
+### Task 18: Infinite scroll via IntersectionObserver
+
+**Files:**
+- Modify: `crates/vmux_history/src/app.rs`
+
+- [ ] **Step 1: Add a `use_effect` that installs an IntersectionObserver**
+
+```rust
+use web_sys::{IntersectionObserver, IntersectionObserverInit};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+
+// Inside App component, after dispatch_query is defined:
+let load_more = {
+    let mut offset = offset.clone();
+    let has_more = has_more.clone();
+    let dispatch_query = dispatch_query.clone();
+    Closure::<dyn FnMut()>::new(move || {
+        if !*has_more.read() { return; }
+        offset.set(*offset.read() + 50);
+        dispatch_query(false);
+    })
+};
+
+use_effect(move || {
+    let doc = web_sys::window().unwrap().document().unwrap();
+    let target = doc.get_element_by_id("infinite-scroll-sentinel");
+    if let Some(target) = target {
+        let cb: &js_sys::Function = load_more.as_ref().unchecked_ref();
+        let observer = IntersectionObserver::new(cb).unwrap();
+        observer.observe(&target);
+        // leak or store observer in a signal to keep alive
+    }
+});
+```
+
+This is hand-wavy — verify against existing observer usage in `vmux_command` (if any) or follow the standard `web-sys` IntersectionObserver pattern from the Rust + Wasm Book. Ensure the closure is kept alive (use `Closure::forget()` or store in a signal).
+
+- [ ] **Step 2: Validate build + manual scroll test**
+
+```bash
+env -u CEF_PATH cargo build -p vmux_history --target wasm32-unknown-unknown
+```
+
+Build the full app (`make dev` or equivalent) and visit `vmux://history` — scroll the list and verify new chunks load.
+
+- [ ] **Step 3: Pre-commit + commit**
+
+```bash
+cargo fmt -p vmux_history -- --check
+env -u CEF_PATH cargo clippy -p vmux_history --all-targets -- -D warnings
+git add crates/vmux_history/
+git commit -m "feat(vmux_history): infinite scroll via IntersectionObserver (VMX-120)"
+```
+
+---
+
+### Task 19: Delete + clear-all UX
+
+**Files:**
+- Modify: `crates/vmux_history/src/app.rs`
+
+- [ ] **Step 1: Wire the hover-X button**
+
+In the entry row's button:
+
+```rust
+button {
+    class: "opacity-0 group-hover:opacity-100 text-xs text-gray-500 hover:text-red-500 px-2",
+    onclick: {
+        let url_bits = entry.url_entity_bits;
+        let mut entries = entries.clone();
+        move |_| {
+            let _ = try_cef_bin_emit_rkyv(&HistoryDeleteRequest { url_entity_bits: url_bits });
+            entries.write().retain(|e| e.url_entity_bits != url_bits);
+        }
+    },
+    "×"
+}
+```
+
+- [ ] **Step 2: Wire the "Clear all" button to a confirm modal**
+
+Add a `confirm_open: Signal<bool>` and render a modal overlay when true:
+
+```rust
+button {
+    class: "...",
+    onclick: move |_| confirm_open.set(true),
+    "Clear all"
+}
+
+if *confirm_open.read() {
+    div { class: "fixed inset-0 bg-black/80 flex items-center justify-center",
+        div { class: "bg-gray-900 p-6 rounded max-w-sm",
+            h3 { class: "text-lg mb-2", "Clear all history?" }
+            p { class: "text-sm text-gray-400 mb-4", "This cannot be undone." }
+            div { class: "flex gap-2 justify-end",
+                button {
+                    class: "px-3 py-1 text-sm",
+                    onclick: move |_| confirm_open.set(false),
+                    "Cancel"
+                }
+                button {
+                    class: "px-3 py-1 text-sm bg-red-700 rounded",
+                    onclick: move |_| {
+                        let _ = try_cef_bin_emit_rkyv(&HistoryClearAllRequest);
+                        entries.write().clear();
+                        confirm_open.set(false);
+                    },
+                    "Clear all"
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Validate build + manual delete test**
+
+```bash
+env -u CEF_PATH cargo build -p vmux_history --target wasm32-unknown-unknown
+```
+
+Manual: visit history, hover a row, click X, confirm row disappears + persists across page reload.
+
+- [ ] **Step 4: Pre-commit + commit**
+
+```bash
+cargo fmt -p vmux_history -- --check
+env -u CEF_PATH cargo clippy -p vmux_history --all-targets -- -D warnings
+git add crates/vmux_history/
+git commit -m "feat(vmux_history): per-entry delete + clear-all (VMX-120)"
+```
+
+---
+
+### Task 20: Click row → open in new stack
+
+**Files:**
+- Modify: `crates/vmux_history/src/app.rs`
+- See Task 24 for `AgentCommand::OpenInNewStack` definition. If you are working in strict order, jump ahead and complete Task 24 step 1 (the `OpenInNewStack` enum variant only) before this task so the `on_history_open_request` observer in Task 14 compiles.
+
+- [ ] **Step 1: Add click handler to the row**
+
+Wrap the row contents in a button or add `onclick` to the entry container `div`:
+
+```rust
+div {
+    class: "flex items-center gap-2 py-1 border-b border-gray-900 hover:bg-gray-900 group cursor-pointer",
+    onclick: {
+        let url = entry.url.clone();
+        move |_| {
+            let _ = try_cef_bin_emit_rkyv(&HistoryOpenRequest { url: url.clone(), in_new_stack: true });
+        }
+    },
+    // existing spans + button
+}
+```
+
+Stop event propagation on the delete button so deleting doesn't also open:
+
+```rust
+button {
+    class: "...",
+    onclick: move |e: Event<MouseData>| {
+        e.stop_propagation();
+        // delete dispatch
+    },
+    "×"
+}
+```
+
+- [ ] **Step 2: Pre-commit + commit**
+
+```bash
+cargo fmt -p vmux_history -- --check
+env -u CEF_PATH cargo clippy -p vmux_history --all-targets -- -D warnings
+git add crates/vmux_history/
+git commit -m "feat(vmux_history): click row to open URL in new stack (VMX-120)"
+```
+
+---
+
+## Phase 5 — Omnibox integration (`vmux_command`)
+
+### Task 21: New `CommandBarResultItem::History` variant + render
+
+**Files:**
+- Modify: `crates/vmux_command/src/results.rs:8-33` — extend enum
+- Modify: `crates/vmux_command/src/app.rs:393-469` — render
+
+- [ ] **Step 1: Add variant**
+
+In `results.rs`:
+
+```rust
+pub enum CommandBarResultItem {
+    Terminal { /* existing */ },
+    Stack { /* existing */ },
+    Space { /* existing */ },
+    Command { /* existing */ },
+    Navigate { /* existing */ },
+    History {
+        url: String,
+        title: String,
+        favicon_url: String,
+        visit_count: u32,
+        last_visited_at: i64,
+    },
+}
+```
+
+- [ ] **Step 2: Render in `app.rs`**
+
+In the existing match-on-variant rendering, add:
+
+```rust
+CommandBarResultItem::History { url, title, favicon_url, .. } => rsx! {
+    div { class: "flex items-center gap-2",
+        img { class: "w-4 h-4", src: "{favicon_url}" }
+        span { class: "text-sm",
+            if title.is_empty() { "{url}" } else { "{title}" }
+        }
+        span { class: "text-xs text-gray-500 ml-auto", "{url}" }
+    }
+},
+```
+
+Match the existing visual style of `Navigate` and `Stack` rows — look at the surrounding match arms for class names.
+
+- [ ] **Step 3: Pre-commit + commit**
+
+```bash
+cargo fmt -p vmux_command -- --check
+env -u CEF_PATH cargo clippy -p vmux_command --all-targets -- -D warnings
+env -u CEF_PATH cargo test -p vmux_command
+git add crates/vmux_command/
+git commit -m "feat(vmux_command): History result item variant + render (VMX-120)"
+```
+
+---
+
+### Task 22: Suggestions request in command bar webview
+
+**Files:**
+- Modify: `crates/vmux_command/src/event.rs` — re-export history events
+- Modify: `crates/vmux_command/src/app.rs` — dispatch suggestions request on input change, store results, splice into filter output
+
+- [ ] **Step 1: Re-export history events for the command bar webview**
+
+In `crates/vmux_command/src/event.rs`, add:
+
+```rust
+pub use vmux_history::event::{HistorySuggestionsRequest, HistorySuggestionsResponse};
+```
+
+Add `vmux_history` as a dependency in `crates/vmux_command/Cargo.toml` if not present (path dep, wasm-compatible — guard non-wasm code in `vmux_history` with `#[cfg(not(target_arch = "wasm32"))]`).
+
+- [ ] **Step 2: In `app.rs`, dispatch a suggestions request when input changes**
+
+```rust
+let history_suggestions: Signal<Vec<HistoryEntry>> = use_signal(Vec::new);
+let suggestions_request_id: Signal<u64> = use_signal(|| 0);
+
+use_bin_event_listener::<HistorySuggestionsResponse>(move |resp| {
+    if resp.request_id != *suggestions_request_id.read() { return; }
+    history_suggestions.set(resp.entries);
+});
+
+let on_input = move |e: Event<FormData>| {
+    let q = e.value();
+    query.set(q.clone());
+    if !q.is_empty() && !q.starts_with('>') && !q.starts_with('/') && !q.starts_with('~') && !q.starts_with("vmux://") {
+        let id = *suggestions_request_id.read() + 1;
+        suggestions_request_id.set(id);
+        let _ = try_cef_bin_emit_rkyv(&HistorySuggestionsRequest {
+            query: q,
+            limit: 5,
+            request_id: id,
+        });
+    } else {
+        history_suggestions.write().clear();
+    }
+    // existing input logic
+};
+```
+
+- [ ] **Step 3: Splice history suggestions into `filter_results` output**
+
+In `results.rs`, extend `filter_results()` signature to accept `history: &[HistoryEntry]`:
+
+```rust
+pub fn filter_results(/* existing args */, history: &[HistoryEntry]) -> Vec<CommandBarResultItem> {
+    let mut out = Vec::new();
+    // existing logic builds Terminal/Stack/Space entries
+    for h in history.iter().take(5) {
+        out.push(CommandBarResultItem::History {
+            url: h.url.clone(),
+            title: h.title.clone(),
+            favicon_url: h.favicon_url.clone(),
+            visit_count: h.visit_count,
+            last_visited_at: h.last_visited_at,
+        });
+    }
+    // existing logic builds Command/Navigate entries
+    out
+}
+```
+
+Update all callers to pass `history_suggestions.read().clone()`.
+
+- [ ] **Step 4: Wire `Enter` on History item**
+
+In the existing `execute` closure (around `app.rs:216-239`), add:
+
+```rust
+CommandBarResultItem::History { url, .. } => {
+    emit_action("navigate".into(), url.clone());
+}
+```
+
+- [ ] **Step 5: Pre-commit + commit**
+
+```bash
+PKGS=$(BASE=origin/main ./scripts/changed-crates.sh)
+for pkg in $PKGS; do cargo fmt -p "$pkg" -- --check; done
+for pkg in $PKGS; do env -u CEF_PATH cargo clippy -p "$pkg" --all-targets -- -D warnings; done
+for pkg in $PKGS; do env -u CEF_PATH cargo test -p "$pkg"; done
+git add crates/vmux_command/
+git commit -m "feat(vmux_command): omnibox history suggestions (VMX-120)"
+```
+
+---
+
+### Task 23: Register the suggestions request handler on the Bevy side
+
+**Files:**
+- Modify: `crates/vmux_desktop/src/command_bar.rs`
+
+The `BinJsEmitEventPlugin::<HistorySuggestionsRequest>` plugin is already registered in `HistoryPlugin` (Task 15). Confirm that `HistoryPlugin` is added at the app level (search `rg "HistoryPlugin" crates/vmux_desktop/`); if not, add it.
+
+- [ ] **Step 1: Add `HistoryPlugin` to the desktop app**
+
+In `crates/vmux_desktop/src/main.rs` (or wherever plugins are registered):
+
+```rust
+.add_plugins(vmux_history::HistoryPlugin)
+```
+
+- [ ] **Step 2: Verify with a manual smoke test**
+
+```bash
+make dev   # or whatever the run command is
+```
+
+Open command bar, type a previously-visited domain name, verify history rows appear in the dropdown ranked by frecency.
+
+- [ ] **Step 3: Pre-commit + commit**
+
+```bash
+cargo fmt -p vmux_desktop -- --check
+env -u CEF_PATH cargo clippy -p vmux_desktop --all-targets -- -D warnings
+env -u CEF_PATH cargo test -p vmux_desktop
+git add crates/vmux_desktop/
+git commit -m "feat(vmux_desktop): register HistoryPlugin (VMX-120)"
+```
+
+---
+
+## Phase 6 — MCP tools + AgentCommand wiring
+
+### Task 24: `AgentCommand` variants
+
+**Files:**
+- Modify: `crates/vmux_desktop/src/command.rs` (or wherever `AgentCommand` enum lives — `rg "enum AgentCommand"`)
+
+- [ ] **Step 1: Add the three variants + `OpenInNewStack`**
+
+```rust
+pub enum AgentCommand {
+    // existing variants...
+    BrowserGoBack { pane: Option<PaneRef> },
+    BrowserGoForward { pane: Option<PaneRef> },
+    BrowserHistorySearch { query: String, limit: u32 },
+    OpenInNewStack { url: String },
+}
+```
+
+`PaneRef` already exists in the codebase as the type used by `BrowserNavigate`'s `pane` arg.
+
+- [ ] **Step 2: Add dispatch arms**
+
+In `crates/vmux_desktop/src/browser.rs` (where existing `AgentCommand::BrowserNavigate` is handled):
+
+```rust
+AgentCommand::BrowserGoBack { pane } => {
+    let target = resolve_pane(pane, /* active_pane_resource */);
+    if let Some(target) = target {
+        let is_terminal = /* check Terminal marker as browser.rs:921 does */;
+        if !is_terminal {
+            commands.entity(target).insert(BrowserCommand::PrevPage);
+        }
+    }
+}
+AgentCommand::BrowserGoForward { pane } => {
+    // analogous
+}
+AgentCommand::BrowserHistorySearch { query, limit } => {
+    // dispatch a HistorySuggestionsRequest internally, capture response,
+    // serialize to JSON, return via the MCP response path.
+    // The existing MCP response plumbing pattern (rg "AgentResponse" or
+    // similar) in vmux_mcp shows how to send results back.
+}
+AgentCommand::OpenInNewStack { url } => {
+    // dispatch the existing path that creates a new stack adjacent to active;
+    // search rg "new_stack" or "spawn.*Stack" for the helper.
+}
+```
+
+For `BrowserHistorySearch`: the cleanest path is to call the same ranking helper from `vmux_history::query` directly (since the Bevy system already has the queries available), bypassing the rkyv IPC. The MCP response goes back via whatever pattern `browser_navigate` uses for confirmations.
+
+- [ ] **Step 3: Pre-commit + commit**
+
+```bash
+PKGS=$(BASE=origin/main ./scripts/changed-crates.sh)
+for pkg in $PKGS; do cargo fmt -p "$pkg" -- --check; done
+for pkg in $PKGS; do env -u CEF_PATH cargo clippy -p "$pkg" --all-targets -- -D warnings; done
+for pkg in $PKGS; do env -u CEF_PATH cargo test -p "$pkg"; done
+git add crates/vmux_desktop/
+git commit -m "feat(vmux_desktop): AgentCommand variants for back/forward + history search + open-in-new-stack (VMX-120)"
+```
+
+---
+
+### Task 25: MCP tool variants
+
+**Files:**
+- Modify: `crates/vmux_mcp/src/tools.rs:15` (the `McpParamTool` enum)
+- Modify: `crates/vmux_mcp/src/tools.rs:53` (`to_agent_command`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `crates/vmux_mcp/src/tools.rs`:
+
+```rust
+#[cfg(test)]
+mod history_tools_tests {
+    use super::*;
+
+    #[test]
+    fn go_back_dispatches() {
+        let r = McpParamTool::BrowserGoBack { pane: None }.to_agent_command();
+        assert!(matches!(r, Ok(AgentCommand::BrowserGoBack { .. })));
+    }
+
+    #[test]
+    fn go_forward_dispatches() {
+        let r = McpParamTool::BrowserGoForward { pane: None }.to_agent_command();
+        assert!(matches!(r, Ok(AgentCommand::BrowserGoForward { .. })));
+    }
+
+    #[test]
+    fn history_search_rejects_empty_query() {
+        let r = McpParamTool::BrowserHistorySearch { query: "  ".into(), limit: None }.to_agent_command();
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn history_search_clamps_limit() {
+        let r = McpParamTool::BrowserHistorySearch { query: "x".into(), limit: Some(500) }.to_agent_command();
+        match r {
+            Ok(AgentCommand::BrowserHistorySearch { limit, .. }) => assert_eq!(limit, 100),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn history_search_default_limit() {
+        let r = McpParamTool::BrowserHistorySearch { query: "x".into(), limit: None }.to_agent_command();
+        match r {
+            Ok(AgentCommand::BrowserHistorySearch { limit, .. }) => assert_eq!(limit, 20),
+            _ => panic!(),
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests, expect FAIL**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_mcp -- history_tools_tests
+```
+
+- [ ] **Step 3: Add enum variants + dispatch arms**
+
+In `McpParamTool`:
+
+```rust
+#[mcp(description = "Navigate the active or specified browser pane back one page in history.")]
+BrowserGoBack {
+    pane: Option<PaneRef>,
+},
+#[mcp(description = "Navigate the active or specified browser pane forward one page in history.")]
+BrowserGoForward {
+    pane: Option<PaneRef>,
+},
+#[mcp(description = "Search vmux browsing history. Returns up to `limit` entries ranked by frecency.")]
+BrowserHistorySearch {
+    query: String,
+    limit: Option<u32>,
+},
+```
+
+In `to_agent_command`:
+
+```rust
+McpParamTool::BrowserGoBack { pane } => Ok(AgentCommand::BrowserGoBack { pane }),
+McpParamTool::BrowserGoForward { pane } => Ok(AgentCommand::BrowserGoForward { pane }),
+McpParamTool::BrowserHistorySearch { query, limit } => {
+    if query.trim().is_empty() {
+        return Err("browser_history_search.query is empty".into());
+    }
+    let limit = limit.unwrap_or(20).min(100);
+    Ok(AgentCommand::BrowserHistorySearch { query, limit })
+}
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+```bash
+env -u CEF_PATH cargo test -p vmux_mcp -- history_tools_tests
+```
+
+- [ ] **Step 5: Pre-commit + commit**
+
+```bash
+cargo fmt -p vmux_mcp -- --check
+env -u CEF_PATH cargo clippy -p vmux_mcp --all-targets -- -D warnings
+env -u CEF_PATH cargo test -p vmux_mcp
+git add crates/vmux_mcp/
+git commit -m "feat(vmux_mcp): browser_go_back, browser_go_forward, browser_history_search tools (VMX-120)"
+```
+
+---
+
+## Phase 7 — Integration smoke check
+
+### Task 26: Manual smoke checks before opening PR
+
+- [ ] **Step 1: Build the full app**
+
+```bash
+make dev
+```
+
+- [ ] **Step 2: Smoke checklist**
+
+- Navigate through 5 distinct URLs in a browser pane. Open `vmux://history` — confirm all 5 appear, grouped under "Today".
+- Press `Cmd+[` (back) twice. Open `vmux://history` — confirm no new entries appeared.
+- Open command bar (`Cmd+K` or whatever the binding is). Type partial domain of a visited URL. Confirm history rows appear in the dropdown.
+- Hit Enter on a history suggestion. Confirm navigation succeeds.
+- In history page: hover a row, click ×, confirm row disappears immediately. Reload page; confirm it stays gone.
+- Click "Clear all", confirm in modal, confirm history is empty.
+- Click a history row, confirm it opens in a new stack adjacent to current.
+- Restart the app. Open `vmux://history`. Confirm prior visits are still listed (persistence works).
+- Connect an MCP client (Claude Code / agent). Call `browser_go_back`, `browser_go_forward`, `browser_history_search { query: "git" }`. Confirm each behaves and returns expected output.
+
+If any check fails, fix and commit before opening the PR.
+
+---
+
+### Task 27: Push branch + open PR
+
+- [ ] **Step 1: Run full pre-push checks one more time**
+
+```bash
+PKGS=$(BASE=origin/main ./scripts/changed-crates.sh)
+echo "Changed crates: $PKGS"
+for pkg in $PKGS; do cargo fmt -p "$pkg" -- --check; done
+for pkg in $PKGS; do env -u CEF_PATH cargo clippy -p "$pkg" --all-targets -- -D warnings; done
+for pkg in $PKGS; do env -u CEF_PATH cargo test -p "$pkg"; done
+```
+
+- [ ] **Step 2: Push**
+
+```bash
+git push -u origin vmx-120-history-support
+```
+
+- [ ] **Step 3: Open PR via Linear**
+
+```bash
+linear issue pr
+```
+
+This creates a PR linked to VMX-120 with the appropriate branch and title. Verify the PR body summarises the change, lists the spec file, and includes a test plan.
+
+---
+
+## Self-Review Checklist (post-implementation)
+
+After all tasks are checked off, run this once before requesting code review:
+
+- [ ] `git log origin/main..HEAD` shows ~10–15 well-scoped commits
+- [ ] Every commit message references `VMX-120`
+- [ ] Each touched crate passes `fmt`, `clippy -D warnings`, `test`
+- [ ] No `// removed code` comments, no `#[allow(dead_code)]` markers added
+- [ ] No `mod.rs` files were introduced (filename-based modules per AGENTS.md)
+- [ ] No comments inside Rust code (per AGENTS.md "do not add comments")
+- [ ] No `Co-Authored-By` trailers
+- [ ] Spec at `docs/specs/2026-05-16-history-design.md` matches what was shipped (update if scope shifted)
+- [ ] Manual smoke checklist in Task 26 all green

--- a/docs/specs/2026-05-16-history-design.md
+++ b/docs/specs/2026-05-16-history-design.md
@@ -1,0 +1,413 @@
+# History Support — Design
+
+**Date:** 2026-05-16
+**Status:** Draft (awaiting review)
+**Scope:** Real `Visit` spawning from CEF navigation, history page UI, omnibox history search, MCP history tools.
+**Out of scope:** Per-tab CEF nav stack serialization across restart, cross-space global history, redirect-chain UI.
+
+## Background
+
+`vmux_history` exists as a POC. The `Visit` marker component, `PageMetadata`, `CreatedAt`, and `LastActivatedAt` are defined in `vmux_core` and persisted via `moonshine-save`. Nothing spawns `Visit` entities at runtime — the POC reads only sample data or entities from prior sessions (none, in practice).
+
+Existing CEF integration surfaces:
+
+- `WebviewChromeStateEvent` — partial events for URL / title / favicon (no main-frame discrimination)
+- `WebviewLoadingStateEvent` — loading flag + `can_go_back` / `can_go_forward`
+- `BrowserCommand::PrevPage` / `NextPage` — wired to `Cmd+[` / `Cmd+]`, chrome buttons, trackpad swipe
+
+CEF's `cef_transition_type_t` is **not** exposed by the patched `bevy_cef`. Adding it is part of this work.
+
+## Goals
+
+1. Every committed main-frame navigation produces a `Visit` row (modulo back/forward dedup).
+2. Dedicated history page at `vmux://history` with day-grouped flat timeline, search, infinite scroll, delete.
+3. Omnibox suggestions include history matches, ranked by frecency.
+4. MCP tools expose back/forward navigation and history search to agents.
+5. 90-day silent prune bounds storage growth.
+
+## Non-Goals
+
+- Persisting per-tab CEF back/forward stack across restarts.
+- Aggregating history across spaces (history stays per-space, via the existing moonshine-save space file).
+- Redirect chain UI / `from_visit` foreign key.
+- Per-profile isolation beyond what per-space already provides.
+- Typed-URL-only ranking boosts beyond the `TransitionType` enum below.
+
+## Data Model
+
+Normalized Url + Visit, mirroring Chrome's `urls` + `visits` schema. All new components live in `crates/vmux_core/src/lib.rs`.
+
+```rust
+// === Url entity — one per unique URL ===
+#[derive(Reflect, Component)]
+#[require(Save)]
+#[type_path = "vmux_history"]
+pub struct Url;
+
+#[derive(Reflect, Component, Default)]
+#[require(Save)]
+#[type_path = "vmux_history"]
+pub struct VisitCount(pub u32);
+
+#[derive(Reflect, Component, Default)]
+#[require(Save)]
+#[type_path = "vmux_history"]
+pub struct LastVisitedAt(pub i64); // millis since epoch
+
+// Url entity also carries existing PageMetadata (latest title/favicon/bg) and CreatedAt.
+
+// === Visit entity — one per navigation event ===
+// `Visit` marker already exists in vmux_core. Repurposed here.
+#[derive(Reflect, Component)]
+#[require(Save)]
+#[type_path = "vmux_history"]
+pub struct Visit;
+
+#[derive(Reflect, Component)]
+#[require(Save)]
+#[type_path = "vmux_history"]
+pub struct VisitedUrl(pub Entity); // FK → Url entity
+
+#[derive(Reflect, Component, Default, Clone, Copy, PartialEq, Eq)]
+#[require(Save)]
+#[type_path = "vmux_history"]
+pub enum TransitionType {
+    #[default] Link,
+    Typed,
+    Reload,
+    BackForward,
+    Redirect,
+    Other,
+}
+
+// Visit entity also carries existing CreatedAt (timestamp of this specific visit).
+```
+
+`Url` and `Visit` are separate entities. `Visit.VisitedUrl(e)` points to the `Url`. `LastActivatedAt` is **not** used on either — it remains on Tab entities for tab-activation tracking, unchanged.
+
+`PageMetadata` on the `Url` entity is the canonical title/favicon for that URL. It refreshes when later `title_change` / `favicon_change` events arrive for the active tab.
+
+### Persistence
+
+Add new components to the moonshine-save allowlist in `crates/vmux_desktop/src/persistence.rs` (currently at lines 139–154):
+
+- `Url`, `VisitCount`, `LastVisitedAt`, `VisitedUrl`, `TransitionType`
+
+Existing `Visit`, `PageMetadata`, `CreatedAt` already on the allowlist. Existing space files have zero rows of either kind (no runtime spawner exists), so no migration is required.
+
+### Migration: existing `Visit` semantics
+
+The current `Visit` marker in `vmux_core` is meant to tag entities that bundle `(Visit, PageMetadata, CreatedAt, LastActivatedAt)`. In the new model, those bundles become `Url` entities; `Visit` is repurposed for the per-navigation row. Because no Url-like entities exist in any saved space file today, this is a redefinition, not a data migration.
+
+## `bevy_cef` Patch
+
+The patched `bevy_cef_core` lives at `patches/bevy_cef_core-0.5.2/`. Extend it:
+
+1. Add CEF `LoadHandler::OnLoadStart(browser, frame, transition_type)` wiring. This fires after the navigation commits (so a cancelled navigation never produces a Visit) and carries `cef_transition_type_t` directly. The existing `LoadHandler` already has `on_loading_state_change` — extend the same handler implementation.
+2. Map the core transition type bits (low 8 bits) to a Rust enum:
+
+```rust
+#[derive(Clone, Copy, Debug)]
+pub enum CefTransitionCore {
+    Link, Explicit, AutoBookmark, AutoSubframe, ManualSubframe,
+    Generated, AutoToplevel, FormSubmit, Reload, Keyword, KeywordGenerated,
+}
+```
+
+3. Plus the qualifier flags (high bits):
+
+```rust
+pub struct CefTransitionQualifiers {
+    pub forward_back: bool,
+    pub from_address_bar: bool,
+    pub client_redirect: bool,
+    pub server_redirect: bool,
+    pub chain_start: bool,
+    pub chain_end: bool,
+}
+```
+
+4. Emit a new Bevy event:
+
+```rust
+#[derive(Event, Debug, Clone)]
+pub struct WebviewCommittedNavigationEvent {
+    pub webview: Entity,
+    pub url: String,
+    pub is_main_frame: bool,
+    pub transition: CefTransitionCore,
+    pub qualifiers: CefTransitionQualifiers,
+}
+```
+
+Fire it from `OnLoadStart`. Subframes set `is_main_frame = false`; consumers filter on `is_main_frame == true`.
+
+## Visit-Spawning System (`vmux_history`)
+
+Replace the existing `push_history_via_host_emit` system with a navigation pipeline. New system runs on `Update`:
+
+```text
+WebviewCommittedNavigationEvent
+    └─► skip if !is_main_frame
+    └─► skip if url starts with "vmux://"
+    └─► map CefTransitionCore + qualifiers → TransitionType
+    └─► find_or_spawn_url(url):
+            if exists: Entity = existing
+            else: spawn (Url, PageMetadata { url, ..default }, VisitCount(0),
+                         LastVisitedAt(0), CreatedAt(now))
+    └─► VisitCount += 1
+    └─► LastVisitedAt = now
+    └─► if transition != BackForward:
+            spawn (Visit, CreatedAt(now), VisitedUrl(url_e), transition)
+```
+
+Mapping:
+
+| CEF core type + qualifiers | `TransitionType` |
+|---|---|
+| any + `forward_back` qualifier | `BackForward` |
+| `Reload` | `Reload` |
+| any + (`client_redirect` or `server_redirect`) | `Redirect` |
+| `Explicit` (typed) or `Generated` (omnibox match) or `Keyword*` | `Typed` |
+| `Link` or `FormSubmit` or `AutoBookmark` | `Link` |
+| `AutoToplevel`, others | `Other` |
+
+A separate `apply_chrome_state_from_cef`-style system already updates `PageMetadata` on the **Browser/Tab** entity from CEF events (`crates/vmux_layout/src/chrome.rs:41`). Extend it (or add a peer system) so that when a `title_change` / `favicon_change` event lands on a Tab, it also looks up the `Url` entity matching the Tab's current URL and updates that `Url`'s `PageMetadata`. URL match is exact-string. If no `Url` exists for that URL yet (the `OnLoadStart` event has not yet fired), skip silently.
+
+### URL lookup
+
+`find_or_spawn_url` is a linear scan over Url entities in MVP (90-day prune bounds count). If profiling shows this is hot, add a `Resource<UrlIndex(HashMap<String, Entity>)>` updated on spawn/despawn.
+
+### Prune
+
+New system runs once on startup and then every hour via `IntoSystemConfigs::run_if(on_timer(Duration::from_secs(3600)))`:
+
+```text
+now = current_millis()
+cutoff = now - 90 * 86_400_000
+for each Visit with CreatedAt < cutoff: despawn
+for each Url with LastVisitedAt < cutoff and no remaining Visit refs: despawn
+```
+
+## History Page (`vmux_history`)
+
+Replace `crates/vmux_history/src/app.rs` POC with a Dioxus app.
+
+### Layout
+
+Flat timeline grouped by day, matching Q3 option B:
+
+```text
+┌──────────────────────────────────────────────┐
+│ ┌──────────────────────────────────────────┐ │
+│ │ Search history                       [X] │ │  ← search input
+│ └──────────────────────────────────────────┘ │
+│                                              │
+│ TODAY                                        │
+│  14:32  ▢ github.com — vmux/vmux        [×] │
+│  14:18  ▢ linear.app — VMX-88           [×] │
+│  13:50  ▢ news.ycombinator.com          [×] │
+│                                              │
+│ YESTERDAY                                    │
+│  22:11  ▢ docs.bevy.org — Plugin        [×] │
+│                                              │
+│ MAY 12, 2026                                 │
+│  09:30  ▢ ...                                │
+│  …                                           │
+│                                              │
+│           [Loading more…]                    │  ← infinite scroll sentinel
+└──────────────────────────────────────────────┘
+```
+
+Top-right of header: "Clear all" button — confirms via modal before despawning all Url + Visit entities (use existing confirm-close modal pattern from `docs/specs/2026-04-27-confirm-close-design.md`).
+
+### Query protocol
+
+Bevy ↔ webview uses the existing `BinHostEmitEvent` / `BinJsEmitEventPlugin` rkyv pattern:
+
+```rust
+// Webview → Bevy
+#[derive(Event, Serialize, Deserialize, Archive, RkyvSerialize, RkyvDeserialize)]
+pub struct HistoryQueryRequest {
+    pub query: Option<String>, // None = no search, recency-ordered
+    pub offset: u32,
+    pub limit: u32,            // always 50 from the UI
+    pub request_id: u64,
+}
+
+// Bevy → webview
+#[derive(Event, Serialize, Deserialize, Archive, RkyvSerialize, RkyvDeserialize)]
+pub struct HistoryQueryResponse {
+    pub request_id: u64,
+    pub entries: Vec<HistoryEntry>,
+    pub has_more: bool,
+}
+
+pub struct HistoryEntry {
+    pub url_entity_bits: u64,  // for delete / open dispatch
+    pub url: String,
+    pub title: String,
+    pub favicon_url: String,
+    pub visit_created_at: i64,
+    pub visit_count: u32,
+    pub last_visited_at: i64,
+}
+```
+
+Other webview → Bevy events:
+
+- `HistoryDeleteRequest { url_entity_bits: u64 }`
+- `HistoryClearAllRequest`
+- `HistoryOpenRequest { url: String, in_new_stack: bool }`
+
+### Ranking
+
+- **No query:** order Visit entities by `CreatedAt desc`. One row per Visit. (Same URL can appear multiple times in the timeline — matches Chrome.)
+- **With query:** order Url entities by `frecency × match_strength desc`. Show one row per Url with `last_visited_at` as the displayed timestamp.
+
+Frecency:
+
+```text
+age_hours = (now - last_visited_at) / 3_600_000
+decay     = 1.0 / (1.0 + age_hours / 24.0)
+frecency  = (visit_count as f32) * decay
+```
+
+Hybrid match (URL + title, case-insensitive):
+
+```text
+score = 0
+if url.starts_with(query)   → score += 3.0
+if title.starts_with(query) → score += 2.0
+if url.contains(query)      → score += 1.0
+if title.contains(query)    → score += 1.0
+```
+
+Final ranking key: `frecency × score` (filtered to rows with `score > 0`).
+
+### Infinite scroll
+
+Dioxus app keeps a `Vec<HistoryEntry>` in signal state. An `IntersectionObserver` at the list bottom triggers `HistoryQueryRequest { offset: entries.len(), limit: 50, ... }`. On `HistoryQueryResponse` with matching `request_id`, append and update `has_more`.
+
+Search input debounced 100ms — on change, reset offset to 0, clear entries, dispatch new request.
+
+### Click → new stack
+
+Clicking a row emits `HistoryOpenRequest { url, in_new_stack: true }`. Bevy handler dispatches a new `AgentCommand::OpenInNewStack { url }` (or reuses an existing pane-spawn path if one fits). The destination is a new stack adjacent to the current stack in the active space.
+
+### Delete UX
+
+Hover row → `[×]` button appears (CSS `:hover` + `opacity`). Click despawns the matching `Url` and cascades despawn its Visits (system iterates `Query<(Entity, &VisitedUrl)>` and despawns matches). No undo.
+
+"Clear all" header button → confirm modal → despawn all `Url` and `Visit` entities. No undo.
+
+## Omnibox Integration (`vmux_command`)
+
+Add a new variant to `CommandBarResultItem` in `crates/vmux_command/src/results.rs`:
+
+```rust
+pub enum CommandBarResultItem {
+    Terminal { ... },
+    Stack { ... },
+    Space { ... },
+    Command { ... },
+    Navigate { ... },
+    History {                       // NEW
+        url: String,
+        title: String,
+        favicon_url: String,
+        visit_count: u32,
+        last_visited_at: i64,
+    },
+}
+```
+
+Extend `filter_results()` (currently `results.rs:100-209`) to query history when the input is non-empty and does not start with a command/path/space prefix. History rows are inserted between `Stack` and `Command` sections, capped at **5**, ranked by the same hybrid frecency formula as the history page.
+
+Query path: the command bar's existing webview-to-host pattern. Add `HistorySuggestionsRequest { query: String, limit: u32 }` and `HistorySuggestionsResponse { entries }`. The webview fetches suggestions on input change (debounce reuses existing 100ms path-completion timing).
+
+Enter on a `History` row reuses the existing `"navigate"` action: same code path as typing the URL manually. No new dispatch logic needed.
+
+Rendering: globe favicon + title (primary) + URL (muted secondary). Matches the existing `Navigate` row aesthetic.
+
+## MCP Tools (`vmux_mcp`)
+
+Add three variants to `McpParamTool` in `crates/vmux_mcp/src/tools.rs`:
+
+```rust
+#[mcp(description = "Navigate the active or specified browser pane back one page in history.")]
+BrowserGoBack {
+    pane: Option<PaneRef>,
+},
+#[mcp(description = "Navigate the active or specified browser pane forward one page in history.")]
+BrowserGoForward {
+    pane: Option<PaneRef>,
+},
+#[mcp(description = "Search vmux browsing history. Returns up to `limit` entries ranked by frecency.")]
+BrowserHistorySearch {
+    query: String,
+    limit: Option<u32>, // default 20, max 100
+},
+```
+
+`to_agent_command()` mappings:
+
+```rust
+McpParamTool::BrowserGoBack { pane } =>
+    Ok(AgentCommand::BrowserGoBack { pane }),
+McpParamTool::BrowserGoForward { pane } =>
+    Ok(AgentCommand::BrowserGoForward { pane }),
+McpParamTool::BrowserHistorySearch { query, limit } => {
+    if query.trim().is_empty() {
+        return Err("browser_history_search.query is empty".into());
+    }
+    let limit = limit.unwrap_or(20).min(100);
+    Ok(AgentCommand::BrowserHistorySearch { query, limit })
+}
+```
+
+New `AgentCommand` variants:
+
+- `BrowserGoBack { pane: Option<PaneRef> }` — dispatches `BrowserCommand::PrevPage` to the resolved pane (skip if pane is a terminal, mirroring `browser.rs:921`).
+- `BrowserGoForward { pane: Option<PaneRef> }` — dispatches `BrowserCommand::NextPage`.
+- `BrowserHistorySearch { query: String, limit: u32 }` — runs the same ranking system as the history page, returns a JSON array of `{ url, title, favicon_url, visit_count, last_visited_at }` to the MCP caller.
+
+## Crate Boundaries
+
+- **`vmux_core`** — new components only.
+- **`patches/bevy_cef_core-0.5.2`** — transition-type exposure + `WebviewCommittedNavigationEvent`.
+- **`vmux_history`** — visit-spawning, prune, history-page Dioxus app, query protocol, open/delete handlers. The crate balloons; split `plugin.rs` into `plugin.rs` (Bevy systems) + `query.rs` (ranking helpers) + `app.rs` (webview).
+- **`vmux_command`** — new `CommandBarResultItem::History` + history suggestions request/response.
+- **`vmux_mcp`** — new tool variants + `AgentCommand` mappings.
+- **`vmux_desktop`** — extend `persistence.rs` allowlist, add `AgentCommand` arms for new variants.
+
+## Testing
+
+Per-crate unit tests:
+
+- **`vmux_history`** — ranking math (`frecency × match_strength` ordering), transition mapping table, prune cutoff math. CEF event → spawn pipeline tested via fake `WebviewCommittedNavigationEvent` writer.
+- **`vmux_command`** — `filter_results` includes history rows; cap at 5; section ordering.
+- **`vmux_mcp`** — `to_agent_command` arms; empty-query rejection; `limit` clamping.
+- **`vmux_desktop`** — allowlist round-trip: spawn Url + Visit, save, load, verify components survive.
+
+Manual smoke checks (UI is not unit-testable):
+
+- Navigate through 5 URLs, open `vmux://history`, see all 5 in correct day group.
+- Type partial URL in command bar, see history rows ranked by frecency, Enter opens.
+- Press `Cmd+[`/`Cmd+]` — confirms back/forward does NOT create new Visit rows.
+- MCP: invoke `browser_go_back`, `browser_history_search` from a connected agent.
+
+## Risks
+
+1. **CEF event timing.** `OnLoadStart` fires after commit but before page content arrives, so title/favicon are not yet known at spawn time. The spawn-then-update model handles this: `Url.PageMetadata` starts URL-only and is refreshed by later `title_change` / `favicon_change` events. The history page must render gracefully when title is empty (fall back to URL).
+2. **URL lookup cost.** Linear scan over Url entities is O(N). 90-day bound and typical use should keep N < 10k. If needed, add `UrlIndex` resource.
+3. **Webview ↔ Bevy round-trip latency.** Infinite scroll and search both depend on it. The existing path-completion uses the same pattern with no reports of lag; expect similar perf.
+4. **Search ranking quality.** The simple hybrid formula is not as good as Chrome's. Acceptable for MVP; tunable later.
+
+## Open Questions
+
+None blocking. The following are explicit deferrals, not unknowns:
+
+- Cross-space global history (item 3) — deferred.
+- Per-tab CEF nav stack persistence (item 2) — deferred.
+- Linear ticket(s) and PR-split strategy — to be decided at start of implementation.

--- a/patches/bevy_cef-0.5.2/src/lib.rs
+++ b/patches/bevy_cef-0.5.2/src/lib.rs
@@ -35,7 +35,8 @@ pub mod prelude {
     };
     pub use bevy_cef_core::prelude::{
         Browsers, CefDiskProfileRoot, CefEmbeddedHost, CefEmbeddedHosts, CefEmbeddedPageConfig,
-        CefExtensions, CommandLineConfig, WebviewChromeStateEvent, WebviewLoadingStateEvent,
+        CefExtensions, CefTransitionCore, CefTransitionQualifiers, CommandLineConfig,
+        WebviewChromeStateEvent, WebviewCommittedNavigationEvent, WebviewLoadingStateEvent,
         WebviewPopupEvent, compile_time_cef_embedded_scheme, resolved_cef_embedded_page_config,
     };
 }

--- a/patches/bevy_cef-0.5.2/src/loading_state.rs
+++ b/patches/bevy_cef-0.5.2/src/loading_state.rs
@@ -1,14 +1,18 @@
 use async_channel::{Receiver, Sender};
 use bevy::prelude::*;
-use bevy_cef_core::prelude::WebviewLoadingStateEvent;
+use bevy_cef_core::prelude::{WebviewCommittedNavigationEvent, WebviewLoadingStateEvent};
 
-/// Sender installed by [`WebviewLoadingStatePlugin`]; passed into [`bevy_cef_core::prelude::Browsers::create_browser`].
 #[derive(Resource, Debug, Deref)]
 pub struct WebviewLoadingStateSender(pub Sender<WebviewLoadingStateEvent>);
 
-/// Drain in your app to react to CEF [`CefLoadHandler::on_loading_state_change`](https://cef-builds.spotifycdn.com/docs/145.0/classCefLoadHandler.html).
 #[derive(Resource, Debug)]
 pub struct WebviewLoadingStateReceiver(pub Receiver<WebviewLoadingStateEvent>);
+
+#[derive(Resource, Debug, Deref)]
+pub struct WebviewCommittedNavigationSender(pub Sender<WebviewCommittedNavigationEvent>);
+
+#[derive(Resource, Debug)]
+pub struct WebviewCommittedNavigationReceiver(pub Receiver<WebviewCommittedNavigationEvent>);
 
 pub(super) struct WebviewLoadingStatePlugin;
 
@@ -17,5 +21,9 @@ impl Plugin for WebviewLoadingStatePlugin {
         let (tx, rx) = async_channel::unbounded();
         app.insert_resource(WebviewLoadingStateSender(tx))
             .insert_resource(WebviewLoadingStateReceiver(rx));
+
+        let (nav_tx, nav_rx) = async_channel::unbounded();
+        app.insert_resource(WebviewCommittedNavigationSender(nav_tx))
+            .insert_resource(WebviewCommittedNavigationReceiver(nav_rx));
     }
 }

--- a/patches/bevy_cef-0.5.2/src/webview.rs
+++ b/patches/bevy_cef-0.5.2/src/webview.rs
@@ -5,7 +5,7 @@ use crate::common::{
     WebviewSource, WebviewTransparent,
 };
 use crate::cursor_icon::SystemCursorIconSender;
-use crate::loading_state::WebviewLoadingStateSender;
+use crate::loading_state::{WebviewCommittedNavigationSender, WebviewLoadingStateSender};
 use crate::popup_state::WebviewPopupSender;
 use crate::prelude::PreloadScripts;
 use crate::webview::mesh::MeshWebviewPlugin;
@@ -192,6 +192,7 @@ fn create_webview(
     brp_sender: Res<BrpSender>,
     cursor_icon_sender: Res<SystemCursorIconSender>,
     loading_state_sender: Res<WebviewLoadingStateSender>,
+    committed_nav_sender: Res<WebviewCommittedNavigationSender>,
     chrome_state_sender: Res<WebviewChromeStateSender>,
     popup_sender: Res<WebviewPopupSender>,
     texture_wake: Res<TextureWakeCallback>,
@@ -245,6 +246,7 @@ fn create_webview(
                 brp_sender.clone(),
                 cursor_icon_sender.clone(),
                 loading_state_sender.0.clone(),
+                committed_nav_sender.0.clone(),
                 chrome_state_sender.0.clone(),
                 popup_sender.0.clone(),
                 texture_wake.0.clone(),

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
@@ -32,7 +32,8 @@ use crate::browser_process::display_handler::{
 };
 use crate::browser_process::life_span_handler::{LifeSpanHandlerBuilder, WebviewPopupSenderInner};
 use crate::browser_process::load_handler::{
-    WebviewLoadHandlerBuilder, WebviewLoadingStateSenderInner,
+    WebviewCommittedNavigationSenderInner, WebviewLoadHandlerBuilder,
+    WebviewLoadingStateSenderInner,
 };
 use crate::browser_process::renderer_handler::SharedDeviceScaleFactor;
 use crate::browser_process::request_handler::RequestHandlerBuilder;
@@ -92,6 +93,7 @@ impl Browsers {
         brp_sender: Sender<BrpMessage>,
         system_cursor_icon_sender: SystemCursorIconSenderInner,
         webview_loading_state_sender: WebviewLoadingStateSenderInner,
+        webview_committed_nav_sender: WebviewCommittedNavigationSenderInner,
         webview_chrome_state_sender: WebviewChromeStateSenderInner,
         webview_popup_sender: WebviewPopupSenderInner,
         texture_wake: Option<TextureWake>,
@@ -106,7 +108,6 @@ impl Browsers {
         ));
         let size = Rc::new(Cell::new(webview_size));
         let device_scale = Rc::new(Cell::new(device_scale_factor));
-        // Build the client before borrowing `shared_disk_context` mutably (same `self`).
         let mut client = self.client_handler(
             webview,
             size.clone(),
@@ -116,6 +117,7 @@ impl Browsers {
             brp_sender,
             system_cursor_icon_sender,
             webview_loading_state_sender,
+            webview_committed_nav_sender,
             webview_chrome_state_sender,
             webview_popup_sender,
             texture_wake,
@@ -807,6 +809,7 @@ impl Browsers {
         brp_sender: Sender<BrpMessage>,
         system_cursor_icon_sender: SystemCursorIconSenderInner,
         webview_loading_state_sender: WebviewLoadingStateSenderInner,
+        webview_committed_nav_sender: WebviewCommittedNavigationSenderInner,
         webview_chrome_state_sender: WebviewChromeStateSenderInner,
         webview_popup_sender: WebviewPopupSenderInner,
         texture_wake: Option<TextureWake>,
@@ -826,6 +829,7 @@ impl Browsers {
         .with_load_handler(WebviewLoadHandlerBuilder::build(
             webview,
             webview_loading_state_sender,
+            webview_committed_nav_sender,
         ))
         .with_life_span_handler(LifeSpanHandlerBuilder::build(
             webview,

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/load_handler.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/load_handler.rs
@@ -1,7 +1,12 @@
+mod transition;
+pub use transition::{CefTransitionCore, CefTransitionQualifiers, decode as decode_transition};
+
 use async_channel::Sender;
-use bevy::prelude::Entity;
+use bevy::prelude::{Entity, Message};
 use cef::rc::{Rc, RcImpl};
-use cef::{Browser, ImplLoadHandler, LoadHandler, WrapLoadHandler, sys};
+use cef::{
+    Browser, Frame, ImplFrame, ImplLoadHandler, LoadHandler, TransitionType, WrapLoadHandler, sys,
+};
 use std::os::raw::c_int;
 
 #[derive(Clone, Debug)]
@@ -14,19 +19,35 @@ pub struct WebviewLoadingStateEvent {
 
 pub type WebviewLoadingStateSenderInner = Sender<WebviewLoadingStateEvent>;
 
-/// Forwards CEF [`on_loading_state_change`](https://cef-builds.spotifycdn.com/docs/145.0/classCefLoadHandler.html) to Bevy on the browser process thread.
+#[derive(Clone, Debug, Message)]
+pub struct WebviewCommittedNavigationEvent {
+    pub webview: Entity,
+    pub url: String,
+    pub is_main_frame: bool,
+    pub transition: CefTransitionCore,
+    pub qualifiers: CefTransitionQualifiers,
+}
+
+pub type WebviewCommittedNavigationSenderInner = Sender<WebviewCommittedNavigationEvent>;
+
 pub struct WebviewLoadHandlerBuilder {
     object: *mut RcImpl<sys::_cef_load_handler_t, Self>,
     webview: Entity,
     tx: WebviewLoadingStateSenderInner,
+    nav_tx: WebviewCommittedNavigationSenderInner,
 }
 
 impl WebviewLoadHandlerBuilder {
-    pub fn build(webview: Entity, tx: WebviewLoadingStateSenderInner) -> LoadHandler {
+    pub fn build(
+        webview: Entity,
+        tx: WebviewLoadingStateSenderInner,
+        nav_tx: WebviewCommittedNavigationSenderInner,
+    ) -> LoadHandler {
         LoadHandler::new(Self {
             object: core::ptr::null_mut(),
             webview,
             tx,
+            nav_tx,
         })
     }
 }
@@ -51,6 +72,7 @@ impl Clone for WebviewLoadHandlerBuilder {
             object,
             webview: self.webview,
             tx: self.tx.clone(),
+            nav_tx: self.nav_tx.clone(),
         }
     }
 }
@@ -75,6 +97,25 @@ impl ImplLoadHandler for WebviewLoadHandlerBuilder {
             is_loading: loading,
             can_go_back: can_go_back != 0,
             can_go_forward: can_go_forward != 0,
+        });
+    }
+
+    fn on_load_start(
+        &self,
+        _browser: Option<&mut Browser>,
+        frame: Option<&mut Frame>,
+        transition_type: TransitionType,
+    ) {
+        let Some(frame) = frame else { return };
+        let is_main_frame = frame.is_main() != 0;
+        let url = cef::CefString::from(&frame.url()).to_string();
+        let (transition, qualifiers) = decode_transition(transition_type.get_raw());
+        let _ = self.nav_tx.send_blocking(WebviewCommittedNavigationEvent {
+            webview: self.webview,
+            url,
+            is_main_frame,
+            transition,
+            qualifiers,
         });
     }
 

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/load_handler/transition.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/load_handler/transition.rs
@@ -1,0 +1,101 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CefTransitionCore {
+    Link,
+    Explicit,
+    AutoBookmark,
+    AutoSubframe,
+    ManualSubframe,
+    Generated,
+    AutoToplevel,
+    FormSubmit,
+    Reload,
+    Keyword,
+    KeywordGenerated,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CefTransitionQualifiers {
+    pub forward_back: bool,
+    pub from_address_bar: bool,
+    pub client_redirect: bool,
+    pub server_redirect: bool,
+    pub chain_start: bool,
+    pub chain_end: bool,
+}
+
+const SOURCE_MASK: u32 = 0xFF;
+const FORWARD_BACK_FLAG: u32 = 0x01000000;
+const FROM_ADDRESS_BAR_FLAG: u32 = 0x02000000;
+const CHAIN_START_FLAG: u32 = 0x10000000;
+const CHAIN_END_FLAG: u32 = 0x20000000;
+const CLIENT_REDIRECT_FLAG: u32 = 0x40000000;
+const SERVER_REDIRECT_FLAG: u32 = 0x80000000;
+
+pub fn decode(raw: u32) -> (CefTransitionCore, CefTransitionQualifiers) {
+    let core = match raw & SOURCE_MASK {
+        0 => CefTransitionCore::Link,
+        1 => CefTransitionCore::Explicit,
+        2 => CefTransitionCore::AutoBookmark,
+        3 => CefTransitionCore::AutoSubframe,
+        4 => CefTransitionCore::ManualSubframe,
+        5 => CefTransitionCore::Generated,
+        6 => CefTransitionCore::AutoToplevel,
+        7 => CefTransitionCore::FormSubmit,
+        8 => CefTransitionCore::Reload,
+        9 => CefTransitionCore::Keyword,
+        10 => CefTransitionCore::KeywordGenerated,
+        _ => CefTransitionCore::Unknown,
+    };
+    let qual = CefTransitionQualifiers {
+        forward_back: raw & FORWARD_BACK_FLAG != 0,
+        from_address_bar: raw & FROM_ADDRESS_BAR_FLAG != 0,
+        client_redirect: raw & CLIENT_REDIRECT_FLAG != 0,
+        server_redirect: raw & SERVER_REDIRECT_FLAG != 0,
+        chain_start: raw & CHAIN_START_FLAG != 0,
+        chain_end: raw & CHAIN_END_FLAG != 0,
+    };
+    (core, qual)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_link_no_qualifiers() {
+        let (core, qual) = decode(0);
+        assert_eq!(core, CefTransitionCore::Link);
+        assert_eq!(qual, CefTransitionQualifiers::default());
+    }
+
+    #[test]
+    fn decodes_explicit_from_address_bar() {
+        let (core, qual) = decode(1 | FROM_ADDRESS_BAR_FLAG);
+        assert_eq!(core, CefTransitionCore::Explicit);
+        assert!(qual.from_address_bar);
+        assert!(!qual.forward_back);
+    }
+
+    #[test]
+    fn decodes_forward_back_link() {
+        let (core, qual) = decode(0 | FORWARD_BACK_FLAG);
+        assert_eq!(core, CefTransitionCore::Link);
+        assert!(qual.forward_back);
+    }
+
+    #[test]
+    fn decodes_server_redirect_chain() {
+        let bits = 0 | SERVER_REDIRECT_FLAG | CHAIN_START_FLAG | CHAIN_END_FLAG;
+        let (_, qual) = decode(bits);
+        assert!(qual.server_redirect);
+        assert!(qual.chain_start);
+        assert!(qual.chain_end);
+    }
+
+    #[test]
+    fn unknown_core_falls_through() {
+        let (core, _) = decode(99);
+        assert_eq!(core, CefTransitionCore::Unknown);
+    }
+}


### PR DESCRIPTION
## Summary

First-class browsing history in vmux. Real `Visit` entities spawned from committed CEF navigations, a dedicated `vmux://history` page with day-grouped timeline + search + infinite scroll + delete, frecency-ranked history matches in the command bar, and MCP tools for back/forward + history search.

## Implementation

**CEF patch** (`patches/bevy_cef_core-0.5.2/`)
- Decode `cef_transition_type_t` (core + qualifier bits) into typed Rust enums.
- Hook `LoadHandler::on_load_start`, emit a new `WebviewCommittedNavigationEvent { webview, url, is_main_frame, transition, qualifiers }`.
- Thread a parallel channel through the existing `WebviewLoadHandlerBuilder` call sites; drain it into a Bevy `Message` in `vmux_desktop`.

**Data model** (`vmux_core`)
- New components: `Url`, `VisitCount`, `LastVisitedAt`, `VisitedUrl`, `TransitionType`. Normalized URL + Visit (Chrome-style). All `#[require(Save)]`, allowlisted in `persistence.rs` round-trip.

**Spawning + prune** (`vmux_history`)
- `spawn_visits` reads `WebviewCommittedNavigationEvent`, find-or-creates a `Url`, bumps `VisitCount`/`LastVisitedAt`, spawns a `Visit` unless transition is `BackForward` (back/forward bumps count only).
- Skips `vmux://` URLs and subframes.
- `mirror_metadata_to_url` (`vmux_layout`) copies tab title/favicon onto the matching `Url` entity when CEF sends late updates.
- `prune_history` runs on `Startup` and hourly, despawning entries older than 90 days.

**History page** (`vmux_history` Dioxus app at `vmux://history`)
- Flat timeline grouped by day (Today / Yesterday / N days ago).
- Search input dispatches `HistoryQueryRequest` with frecency + hybrid prefix/substring ranking; 50 entries per chunk via `IntersectionObserver`-driven infinite scroll.
- Hover-X per row + "Clear all" with confirm modal.
- Click a row → `HistoryOpenRequest { in_new_stack: true }` → `AgentCommand::OpenInNewStack`.

**Omnibox** (`vmux_command`)
- New `CommandBarResultItem::History` variant rendered between Stack and Command sections, capped at 5, frecency-ranked. Enter dispatches the existing `"navigate"` action.

**MCP** (`vmux_mcp`)
- New tools: `browser_go_back`, `browser_go_forward`, `browser_history_search`. Back/forward dispatch fully wired; history-search response path is a known follow-up (see Out of scope).

## Spec + plan

- Spec: `docs/specs/2026-05-16-history-design.md`
- Plan: `docs/plans/2026-05-16-history.md`

## Out of scope (deliberate; follow-up tickets)

- **`BrowserHistorySearch` MCP response path** — tool is callable, dispatches an `AgentCommand`, but the result data doesn't flow back to the agent yet. Stub logs only. Open follow-up before agents rely on it.
- Per-tab CEF nav stack persistence across restarts.
- Cross-space global history (stays per-space via moonshine-save).
- Redirect chain UI / `from_visit` FK.
- Per-profile isolation beyond what per-space already provides.

## Test plan

- [ ] Build + run (`make run-mac`). Navigate through 5 distinct URLs in a browser pane.
- [ ] Open `vmux://history` — confirm all 5 appear, grouped under "Today" with day header.
- [ ] Type partial URL/title in search — confirm filtered list updates, ranked sensibly.
- [ ] Scroll past 50 entries (seed by visiting more URLs) — confirm next chunk loads via IntersectionObserver.
- [ ] Press Cmd+[ / Cmd+] (back/forward) — confirm no new entries appear on the history page; `VisitCount` should bump on the Url (verify by re-opening the URL via address bar).
- [ ] Hover a row in `vmux://history`, click ×, reload page — entry stays deleted.
- [ ] "Clear all" → confirm modal → confirm — list goes empty; reload page — still empty.
- [ ] Click a history row — opens URL in a new stack adjacent to current.
- [ ] Open command bar (`Cmd+K`), type partial domain — confirm up to 5 history rows appear under Stack section, frecency-ranked; Enter on a row navigates.
- [ ] Restart the app — confirm prior visits restored from `.ron` file.
- [ ] MCP smoke: connect an agent, call `browser_go_back` / `browser_go_forward` on a pane with history — confirm navigation.

Closes VMX-120.
