### PR TITLE
test(service): drop obsolete register_*_no_longer_stub assertions

### DIFF
--- a/crates/vmux_service/tests/sm_app_service_module.rs
+++ b/crates/vmux_service/tests/sm_app_service_module.rs
@@ -19,32 +19,6 @@ fn register_main_app_returns_status() {
 
 #[cfg(target_os = "macos")]
 #[test]
-fn register_main_app_no_longer_stub() {
-    use vmux_service::sm_app_service::{SmError, register_main_app};
-    let result = register_main_app();
-    if let Err(SmError::Other(msg)) = &result {
-        assert!(
-            !msg.contains("not yet implemented"),
-            "register_main_app must be implemented; got Other({msg:?})"
-        );
-    }
-}
-
-#[cfg(target_os = "macos")]
-#[test]
-fn register_agent_no_longer_stub() {
-    use vmux_service::sm_app_service::{SmError, register_agent};
-    let result = register_agent("ai.vmux.service.plist");
-    if let Err(SmError::Other(msg)) = &result {
-        assert!(
-            !msg.contains("not yet implemented"),
-            "register_agent must be implemented; got Other({msg:?})"
-        );
-    }
-}
-
-#[cfg(target_os = "macos")]
-#[test]
 fn agent_status_no_longer_stub() {
     use vmux_service::sm_app_service::{Status, agent_status};
     let status = agent_status("ai.vmux.service.plist");


### PR DESCRIPTION
The two removed tests asserted that `register_main_app` and `register_agent` no longer returned `SmError::Other("not yet implemented")`. That stub state was eliminated long ago, and recent commits (f6bee26, a0aecad) stopped registering the main app as a macOS Login Item entirely, leaving `register_main_app` as a thin wrapper with no behavior worth re-asserting here.

Coverage that remains:
- `sm_app_service_module_exposes_register_main_app` still pins the function signature.
- `register_main_app_returns_status` (ignored) covers the end-to-end path when run from a signed `.app`.
- `agent_status_no_longer_stub` still guards the agent status path.

## Verification
```
PKGS=$(BASE=origin/main ./scripts/changed-crates.sh)  # vmux_service
cargo fmt -p vmux_service -- --check
env -u CEF_PATH cargo clippy -p vmux_service --all-targets -- -D warnings
env -u CEF_PATH cargo test -p vmux_service
```
All pass.
