### PR TITLE
chore(release): v0.0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9069,7 +9069,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9094,7 +9094,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -9106,7 +9106,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9120,7 +9120,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9133,7 +9133,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9173,7 +9173,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9192,7 +9192,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -9224,7 +9224,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9233,7 +9233,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "serde",
  "serde_json",
@@ -9245,7 +9245,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_server"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9257,7 +9257,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "alacritty_terminal",
  "bevy",
@@ -9287,7 +9287,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9311,7 +9311,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9337,7 +9337,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9366,7 +9366,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "dioxus",
  "dioxus-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.9"
+version = "0.0.10"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "MIT"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.9"
-  sha256 "b146d184b07c03381b7127c751197c37d79c392a3454fa620c6db56d67e45ed4"
+  version "0.0.10"
+  sha256 "5ff7630882f03559dd67c20b65fe47e7ac3733b6290bf64da2623de39c3761c2"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.9/Vmux_0.0.9_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.10/Vmux_0.0.10_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai"

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.9",
-  "pub_date": "2026-05-15T16:36:25Z",
+  "version": "v0.0.10",
+  "pub_date": "2026-05-21T01:04:26Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.9/Vmux-v0.0.9-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzQvaVFTR1Y5bHZqYlA2cXZXYmhQR3hUT2g4TFMrUjNZeHg5MnFJdHkycFJpKy9UeEQ3N1hMVlc1cUVXSDUyQVdlSG5RaU5RUjU0THlOUkl2aWxRRUFvPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzc4ODYyNzI5CWZpbGU6Vm11eC12MC4wLjktYWFyY2g2NC1hcHBsZS1kYXJ3aW4uYXBwLnRhci5negpXdDU1RGdSZTdLNUk5bmlpQnpudUhQSjE1eXBsSG5BNThWNk9sQWw3WDhhOGkxcnpYZFNVQTR5aW9YSHI2NFBQaDBQdlRnaEZxcG1nQVhGS0NKU21BZz09Cg==",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.10/Vmux-v0.0.10-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzYwOVE1R1RWQk80Uk1pM3IzRituVHdCQ2h2NjNRQU5ncytpenpUVnd1TEY3RE9HUnl6dTYxMmRpR0ZRWWFDRThobFEzZzJoVjFFVzdlK0FJZEZCTEFnPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzc5MzI1MjUzCWZpbGU6Vm11eC12MC4wLjEwLWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKbVdOR3p3UERTM1FSL2ZnMUp1d3VMREMvTVJzOWVSQlVBT3FPN0pwYmJDdktCQ1A4TW5abFpiaVRjb0lUcjlUOUwxN1FFenpreWpRTmZwQkg2WDVyQkE9PQo=",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.9/Vmux_0.0.9_aarch64.dmg",
-      "filename": "Vmux_0.0.9_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.10/Vmux_0.0.10_aarch64.dmg",
+      "filename": "Vmux_0.0.10_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
Patch release. Bumps workspace version 0.0.9 -> 0.0.10. Releases on merge.