### PR TITLE
chore(release): v0.0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9396,7 +9396,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9427,7 +9427,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_browser"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9448,7 +9448,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -9460,7 +9460,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9475,7 +9475,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9490,7 +9490,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9538,7 +9538,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9559,7 +9559,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -9593,7 +9593,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "muda",
  "proc-macro2",
@@ -9603,7 +9603,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "serde",
  "serde_json",
@@ -9615,7 +9615,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_server"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "dioxus",
  "regex",
@@ -9634,7 +9634,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "alacritty_terminal",
  "bevy",
@@ -9663,7 +9663,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9686,7 +9686,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9711,7 +9711,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9740,7 +9740,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "dioxus",
  "dioxus-primitives",
@@ -9757,7 +9757,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_vibe_setup"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "bevy",
  "bevy_cef",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.10"
+version = "0.0.11"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "MIT"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.10"
-  sha256 "5ff7630882f03559dd67c20b65fe47e7ac3733b6290bf64da2623de39c3761c2"
+  version "0.0.11"
+  sha256 "03beb6b7e8f60a64a50c7db5a82e54431d865cacc0f53e20dfbf0e5ee9e719d3"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.10/Vmux_0.0.10_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.11/Vmux_0.0.11_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai"

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ dev: ensure-mac-deps ensure-codesign-deps install-debug-render-process
 	APP_BINARY="target/debug/vmux_desktop" \
 	HELPER_BINARY="$(CEF_DEBUG_RENDER)" \
 	./scripts/sign-dev-mac.sh
+	@pkill -f "target/debug/vmux_desktop" 2>/dev/null || true
+	@pkill -f "bevy_cef_debug_render_process" 2>/dev/null || true
 	@rust_target_libdir="$$(rustc --print target-libdir)" && \
 	dylib_path="$$rust_target_libdir:$(CURDIR)/target/debug/deps" && \
 	if [ -n "$${DYLD_LIBRARY_PATH:-}" ]; then \

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -553,6 +553,7 @@ fn sync_children_to_ui(
             Option<&HistorySwipeVisualOffset>,
             Has<PendingWebviewReveal>,
             Has<PendingCommandBarReveal>,
+            Has<LayoutCef>,
         ),
         With<Browser>,
     >,
@@ -584,6 +585,7 @@ fn sync_children_to_ui(
         history_swipe_visual,
         pending_webview_reveal,
         pending_command_bar_reveal,
+        is_layout_cef,
     ) in browser_q.iter_mut()
     {
         let parent = child_of.get();
@@ -651,7 +653,7 @@ fn sync_children_to_ui(
         let ty = -delta_px.y / glass_size_px.y;
         let z = if modal.is_some() {
             WEBVIEW_Z_MODAL
-        } else if status.is_some() {
+        } else if is_layout_cef || status.is_some() {
             WEBVIEW_Z_HEADER
         } else if side_sheet.is_some() {
             WEBVIEW_Z_SIDE_SHEET
@@ -690,6 +692,36 @@ fn transform_near(a: &Transform, b: &Transform) -> bool {
         && a.rotation.dot(b.rotation).abs() > 0.9999
 }
 
+#[derive(Clone, Copy, PartialEq)]
+struct WindowedBackendSignature {
+    width: f32,
+    height: f32,
+    scale: f32,
+}
+
+#[derive(Resource, Default)]
+struct WindowedBackendCameraState {
+    mismatch: Option<WindowedBackendSignature>,
+}
+
+fn windowed_backend_signature(world: &mut World) -> Option<WindowedBackendSignature> {
+    let mut window_q = world.query_filtered::<&Window, With<PrimaryWindow>>();
+    let Ok(window) = window_q.single(world) else {
+        return None;
+    };
+    Some(WindowedBackendSignature {
+        width: window.resolution.width(),
+        height: window.resolution.height(),
+        scale: window.resolution.scale_factor(),
+    })
+}
+
+fn clear_windowed_backend_camera_state(world: &mut World) {
+    if let Some(mut state) = world.get_resource_mut::<WindowedBackendCameraState>() {
+        state.mismatch = None;
+    }
+}
+
 fn camera_supports_windowed_webviews(world: &mut World) -> bool {
     let expected = {
         let mut window_q = world.query_filtered::<&Window, With<PrimaryWindow>>();
@@ -709,6 +741,31 @@ fn camera_supports_windowed_webviews(world: &mut World) -> bool {
         *camera
     };
     transform_near(&camera, &expected)
+}
+
+fn windowed_backend_should_use_windowed(
+    world: &mut World,
+    mode: vmux_layout::scene::InteractionMode,
+) -> bool {
+    if !webview_should_use_windowed(mode) {
+        clear_windowed_backend_camera_state(world);
+        return false;
+    }
+    if camera_supports_windowed_webviews(world) {
+        clear_windowed_backend_camera_state(world);
+        return true;
+    }
+    let Some(signature) = windowed_backend_signature(world) else {
+        clear_windowed_backend_camera_state(world);
+        return true;
+    };
+    if !world.contains_resource::<WindowedBackendCameraState>() {
+        world.insert_resource(WindowedBackendCameraState::default());
+    }
+    let mut state = world.resource_mut::<WindowedBackendCameraState>();
+    let should_keep_windowed = state.mismatch != Some(signature);
+    state.mismatch = Some(signature);
+    should_keep_windowed
 }
 
 fn set_windowed_content_mesh_material(
@@ -759,19 +816,27 @@ fn sync_cef_backend_for_interaction_mode(world: &mut World) {
         .get_resource::<vmux_layout::scene::InteractionMode>()
         .copied()
         .unwrap_or_default();
-    let base_windowed =
-        webview_should_use_windowed(mode) && camera_supports_windowed_webviews(world);
-    let mut query = world.query_filtered::<Entity, (With<Browser>, With<WebviewSource>)>();
-    let entities: Vec<Entity> = query.iter(world).collect();
-    let target_windowed = |_entity: Entity| base_windowed;
+    let base_windowed = windowed_backend_should_use_windowed(world, mode);
+    let mut query = world.query_filtered::<(Entity, Has<LayoutCef>, Has<WebviewNativeOverlay>), (
+        With<Browser>,
+        With<WebviewSource>,
+    )>();
+    let entities: Vec<(Entity, bool, bool)> = query.iter(world).collect();
+    let target_windowed = |_entity: Entity, is_layout: bool| base_windowed && !is_layout;
+    let target_native_overlay = |is_layout: bool| {
+        cfg!(target_os = "macos") && mode == vmux_layout::scene::InteractionMode::User && is_layout
+    };
     let mut recreate = Vec::new();
     {
         let browsers = world.non_send::<Browsers>();
-        for &entity in &entities {
-            if browsers
-                .is_windowed(&entity)
-                .is_some_and(|actual| actual != target_windowed(entity))
-            {
+        for &(entity, is_layout, actual_native_overlay) in &entities {
+            let has_browser = browsers.has_browser(entity);
+            let actual_windowed = browsers.is_windowed(&entity);
+            let want_windowed = target_windowed(entity, is_layout);
+            let want_native_overlay = target_native_overlay(is_layout);
+            let needs_recreate = actual_windowed.is_some_and(|actual| actual != want_windowed)
+                || has_browser && actual_native_overlay != want_native_overlay;
+            if needs_recreate {
                 recreate.push(entity);
             }
         }
@@ -782,11 +847,14 @@ fn sync_cef_backend_for_interaction_mode(world: &mut World) {
             browsers.close(entity);
         }
     }
-    for entity in entities {
-        let want_windowed = target_windowed(entity);
+    for (entity, is_layout, _) in entities {
+        let want_windowed = target_windowed(entity, is_layout);
+        let want_native_overlay = target_native_overlay(is_layout);
         let marker_matches = world.get::<WebviewWindowed>(entity).is_some() == want_windowed;
+        let overlay_matches =
+            world.get::<WebviewNativeOverlay>(entity).is_some() == want_native_overlay;
         let needs_recreate = recreate.contains(&entity);
-        if marker_matches && !needs_recreate {
+        if marker_matches && overlay_matches && !needs_recreate {
             continue;
         }
         let Ok(mut entity_mut) = world.get_entity_mut(entity) else {
@@ -796,6 +864,11 @@ fn sync_cef_backend_for_interaction_mode(world: &mut World) {
             entity_mut.insert(WebviewWindowed);
         } else {
             entity_mut.remove::<WebviewWindowed>();
+        }
+        if want_native_overlay {
+            entity_mut.insert(WebviewNativeOverlay);
+        } else {
+            entity_mut.remove::<WebviewNativeOverlay>();
         }
         if needs_recreate {
             entity_mut
@@ -834,16 +907,19 @@ fn sync_windowed_frames(
     all_children: Query<&Children>,
     leaf_panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
     mut last_raised_frame: Local<std::collections::HashMap<Entity, (i32, i32, i32, i32)>>,
+    mut last_visible_pages: Local<Vec<Entity>>,
 ) {
     let visible_pane_count =
         visible_pane_count_for_windowed_sync(focus.tab, &all_children, &leaf_panes);
     let force_raise = layout_hidden.is_changed();
+    let mut hidden = Vec::new();
+    let mut visible = Vec::new();
     for (entity, tf, self_computed, self_ui_gt, child_of) in &browser_q {
         if tf.scale.x <= 1.0e-3 {
-            browsers.set_windowed_hidden(&entity, true);
-            last_raised_frame.remove(&entity);
+            hidden.push(entity);
             continue;
         }
+        visible.push(entity);
         let parent = child_of.get();
         let pane_entity = child_of_q.get(parent).map(|co| co.get()).unwrap_or(parent);
         let (computed, ui_gt) = pane_rect
@@ -854,7 +930,10 @@ fn sync_windowed_frames(
         let left = center.x - size_px.x * 0.5;
         let top = center.y - size_px.y * 0.5;
         let scale = 1.0 / computed.inverse_scale_factor.max(1.0e-6);
-        browsers.set_windowed_hidden(&entity, false);
+        let was_shown = last_raised_frame.contains_key(&entity);
+        if !was_shown {
+            browsers.set_windowed_hidden(&entity, false);
+        }
         browsers.set_windowed_frame(&entity, left, top, size_px.x, size_px.y, scale);
         let all_corners = layout_hidden.0 || visible_pane_count > 1;
         browsers.set_windowed_corner_radius(
@@ -883,11 +962,17 @@ fn sync_windowed_frames(
                 size_px.y.round() as i32,
             );
             let changed = last_raised_frame.insert(entity, key) != Some(key);
-            if force_raise || changed {
+            let became_visible = !last_visible_pages.contains(&entity);
+            if force_raise || changed || became_visible {
                 browsers.raise_windowed_to_front(&entity);
             }
         }
     }
+    let shown: Vec<Entity> = last_raised_frame.keys().copied().collect();
+    for entity in windowed_pages_to_hide_before_first_show(&hidden, &shown) {
+        browsers.set_windowed_hidden(&entity, true);
+    }
+    *last_visible_pages = visible;
 }
 
 fn visible_pane_count_for_windowed_sync(
@@ -903,6 +988,14 @@ fn visible_pane_count_for_windowed_sync(
         }
     }
     leaf_panes.iter().count().max(1)
+}
+
+fn windowed_pages_to_hide_before_first_show(hidden: &[Entity], shown: &[Entity]) -> Vec<Entity> {
+    hidden
+        .iter()
+        .copied()
+        .filter(|entity| !shown.contains(entity))
+        .collect()
 }
 
 fn sync_windowed_chrome(
@@ -1467,6 +1560,7 @@ fn sync_osr_webview_focus(
             Has<Modal>,
             Has<CefKeyboardTarget>,
             Has<WebviewWindowed>,
+            Has<LayoutCef>,
         ),
         With<WebviewSource>,
     >,
@@ -1484,6 +1578,7 @@ fn sync_osr_webview_focus(
     mut last_ready_set: Local<Vec<Entity>>,
 ) {
     ready.clear();
+    let mut layout_shells = Vec::new();
     let mut modal_keyboard_target = None;
     for (
         entity,
@@ -1494,6 +1589,7 @@ fn sync_osr_webview_focus(
         is_modal,
         has_keyboard_target,
         is_windowed,
+        is_layout,
     ) in webviews.iter()
     {
         if !browsers.has_browser(entity) {
@@ -1506,6 +1602,9 @@ fn sync_osr_webview_focus(
             pending_reveal || pending_command_bar_reveal,
         ) {
             ready.push(entity);
+            if is_layout {
+                layout_shells.push(entity);
+            }
             if is_modal && has_keyboard_target {
                 modal_keyboard_target = Some((entity, is_windowed));
             }
@@ -1546,9 +1645,9 @@ fn sync_osr_webview_focus(
     } else if *last_active == active && *last_ready_set == *ready {
     } else {
         auxiliary.clear();
-        if let Some(active) = active {
-            auxiliary.extend(ready.iter().copied().filter(|&e| e != active));
-        }
+        let (active, next_auxiliary) =
+            osr_focus_targets(ready.as_slice(), active, |e| layout_shells.contains(&e));
+        auxiliary.extend(next_auxiliary);
         webview_debug_log(format!(
             "osr focus active={active:?} auxiliary={:?} ready={ready:?}",
             auxiliary.as_slice()
@@ -1623,6 +1722,20 @@ fn choose_osr_active_webview(
             .or(active_stack)
             .or(Some(fallback))
     }
+}
+
+fn osr_focus_targets(
+    ready: &[Entity],
+    active: Option<Entity>,
+    mut is_layout: impl FnMut(Entity) -> bool,
+) -> (Option<Entity>, Vec<Entity>) {
+    let active = active.filter(|&e| !is_layout(e));
+    let auxiliary = ready
+        .iter()
+        .copied()
+        .filter(|&e| Some(e) != active)
+        .collect();
+    (active, auxiliary)
 }
 
 fn should_show_osr_webview(
@@ -2951,6 +3064,84 @@ mod tests {
     }
 
     #[test]
+    fn layout_shell_osr_renders_above_player_page_osr() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<vmux_layout::NewStackContext>()
+            .add_systems(Update, sync_children_to_ui);
+
+        let glass = app
+            .world_mut()
+            .spawn((
+                VmuxWindow,
+                ComputedNode {
+                    size: Vec2::new(1200.0, 800.0),
+                    ..default()
+                },
+                UiGlobalTransform::default(),
+            ))
+            .id();
+        let layout = app
+            .world_mut()
+            .spawn((
+                Browser,
+                LayoutCef,
+                Transform::default(),
+                ComputedNode {
+                    size: Vec2::new(1200.0, 800.0),
+                    ..default()
+                },
+                bevy::ui::ComputedStackIndex(0),
+                UiGlobalTransform::default(),
+                WebviewSize(Vec2::ONE),
+                ChildOf(glass),
+            ))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((Tab::default(), LastActivatedAt(1)))
+            .id();
+        let pane = app
+            .world_mut()
+            .spawn((
+                Pane,
+                ComputedNode {
+                    size: Vec2::new(1200.0, 740.0),
+                    ..default()
+                },
+                UiGlobalTransform::default(),
+                ChildOf(tab),
+            ))
+            .id();
+        let stack = app
+            .world_mut()
+            .spawn((Stack::default(), LastActivatedAt(1), ChildOf(pane)))
+            .id();
+        let page = app
+            .world_mut()
+            .spawn((
+                Browser,
+                Transform::default(),
+                ComputedNode {
+                    size: Vec2::new(1200.0, 740.0),
+                    ..default()
+                },
+                bevy::ui::ComputedStackIndex(0),
+                UiGlobalTransform::default(),
+                WebviewSize(Vec2::ONE),
+                ChildOf(stack),
+            ))
+            .id();
+
+        app.update();
+
+        let layout_z = app.world().get::<Transform>(layout).unwrap().translation.z;
+        let page_z = app.world().get::<Transform>(page).unwrap().translation.z;
+
+        assert!(layout_z > page_z);
+    }
+
+    #[test]
     fn pending_reveal_webviews_keep_cef_running() {
         assert!(webview_osr_should_run(
             Vec2::ZERO,
@@ -2978,6 +3169,29 @@ mod tests {
         assert_eq!(
             choose_osr_active_webview(Some((modal, true)), Some(pane), pane),
             None
+        );
+    }
+
+    #[test]
+    fn layout_shell_is_auxiliary_osr_focus_target() {
+        let active = Entity::from_bits(1);
+        let layout = Entity::from_bits(2);
+        let sidecar = Entity::from_bits(3);
+
+        assert_eq!(
+            osr_focus_targets(&[active, layout, sidecar], Some(active), |e| e == layout),
+            (Some(active), vec![layout, sidecar])
+        );
+    }
+
+    #[test]
+    fn layout_shell_is_not_active_osr_focus_target() {
+        let layout = Entity::from_bits(1);
+        let sidecar = Entity::from_bits(2);
+
+        assert_eq!(
+            osr_focus_targets(&[layout, sidecar], Some(layout), |e| e == layout),
+            (None, vec![layout, sidecar])
         );
     }
 
@@ -3022,6 +3236,30 @@ mod tests {
             .unwrap_or_default();
 
         assert!(sync_fn.contains("browsers.raise_windowed_to_front"));
+    }
+
+    #[test]
+    fn windowed_page_sync_raises_visible_pages_without_hiding_shown_pages() {
+        let source = include_str!("lib.rs");
+        let sync_fn = source
+            .split("fn sync_windowed_frames")
+            .nth(1)
+            .and_then(|tail| tail.split("fn sync_windowed_chrome").next())
+            .unwrap_or_default();
+
+        assert!(sync_fn.contains("browsers.raise_windowed_to_front(&entity)"));
+        assert!(sync_fn.contains("windowed_pages_to_hide_before_first_show"));
+    }
+
+    #[test]
+    fn shown_windowed_pages_stay_visible_when_inactive() {
+        let shown = Entity::from_bits(1);
+        let never_shown = Entity::from_bits(2);
+
+        assert_eq!(
+            windowed_pages_to_hide_before_first_show(&[shown, never_shown], &[shown]),
+            vec![never_shown]
+        );
     }
 
     #[test]
@@ -3268,7 +3506,7 @@ mod tests {
     }
 
     #[test]
-    fn browser_mode_does_not_force_layout_shell_osr() {
+    fn browser_mode_keeps_layout_shell_osr_for_wallpaper_glass() {
         let source = include_str!("lib.rs");
         let backend_fn = source
             .split("fn sync_cef_backend_for_interaction_mode")
@@ -3276,8 +3514,23 @@ mod tests {
             .and_then(|tail| tail.split("fn sync_windowed_frames").next())
             .unwrap_or_default();
 
-        assert!(!backend_fn.contains("With<LayoutCef>"));
+        assert!(backend_fn.contains("Has<LayoutCef>"));
+        assert!(backend_fn.contains("!is_layout"));
+        assert!(backend_fn.contains("WebviewNativeOverlay"));
         assert!(!backend_fn.contains("With<Modal>"));
+    }
+
+    #[test]
+    fn layout_overlay_mode_change_recreates_browser() {
+        let source = include_str!("lib.rs");
+        let backend_fn = source
+            .split("fn sync_cef_backend_for_interaction_mode")
+            .nth(1)
+            .and_then(|tail| tail.split("fn sync_windowed_frames").next())
+            .unwrap_or_default();
+
+        assert!(backend_fn.contains("actual_native_overlay != want_native_overlay"));
+        assert!(backend_fn.contains("browsers.has_browser(entity)"));
     }
 
     #[test]
@@ -3296,7 +3549,7 @@ mod tests {
     }
 
     #[test]
-    fn browser_mode_windows_layout_pages_and_modal_on_macos() {
+    fn browser_mode_keeps_layout_osr_and_windows_pages_and_modal_on_macos() {
         let mut app = App::new();
         app.world_mut().insert_non_send(Browsers::default());
         app.insert_resource(vmux_layout::scene::InteractionMode::User);
@@ -3320,8 +3573,9 @@ mod tests {
 
         sync_cef_backend_for_interaction_mode(app.world_mut());
 
+        assert!(app.world().get::<WebviewWindowed>(layout).is_none());
         assert_eq!(
-            app.world().get::<WebviewWindowed>(layout).is_some(),
+            app.world().get::<WebviewNativeOverlay>(layout).is_some(),
             cfg!(target_os = "macos")
         );
         assert_eq!(
@@ -3364,8 +3618,46 @@ mod tests {
             .id();
 
         sync_cef_backend_for_interaction_mode(app.world_mut());
+        sync_cef_backend_for_interaction_mode(app.world_mut());
 
         assert!(app.world().get::<WebviewWindowed>(page).is_none());
+    }
+
+    #[test]
+    fn browser_mode_keeps_windowed_pages_for_first_resize_camera_mismatch() {
+        let mut app = App::new();
+        app.world_mut().insert_non_send(Browsers::default());
+        app.insert_resource(vmux_layout::scene::InteractionMode::User);
+        let old_window = Window {
+            resolution: (800, 600).into(),
+            ..default()
+        };
+        let stale_home =
+            vmux_layout::scene::frame_main_camera_transform(&old_window, 800.0 / 600.0, 0.0);
+        app.world_mut().spawn((
+            Window {
+                resolution: (1200, 900).into(),
+                ..default()
+            },
+            PrimaryWindow,
+        ));
+        app.world_mut()
+            .spawn((vmux_layout::scene::MainCamera, stale_home));
+        let page = app
+            .world_mut()
+            .spawn((
+                Browser,
+                WebviewWindowed,
+                WebviewSource::new("https://example.com/"),
+            ))
+            .id();
+
+        sync_cef_backend_for_interaction_mode(app.world_mut());
+
+        assert_eq!(
+            app.world().get::<WebviewWindowed>(page).is_some(),
+            cfg!(target_os = "macos")
+        );
     }
 
     #[test]

--- a/crates/vmux_desktop/Cargo.toml
+++ b/crates/vmux_desktop/Cargo.toml
@@ -63,6 +63,7 @@ objc2-app-kit = { version = "0.3", features = [
     "NSGraphics",
     "NSColor",
     "NSGlassEffectView",
+    "NSPanel",
 ] }
 objc2-foundation = { version = "0.3", features = ["NSGeometry"] }
 objc2-quartz-core = { version = "0.3", features = ["CALayer", "objc2-core-foundation"] }

--- a/crates/vmux_desktop/Cargo.toml
+++ b/crates/vmux_desktop/Cargo.toml
@@ -77,12 +77,12 @@ copyright = "Copyright 2024-2025 Junichi Sugiura. MIT License."
 homepage = "https://vmux.ai"
 formats = ["app", "dmg"]
 icons = ["../../packaging/macos/Vmux.icns"]
-before-packaging-command = "env -u CEF_PATH cargo build -p vmux_desktop -p vmux_cli -p vmux_service -p bevy_cef_debug_render_process --release"
+before-packaging-command = "bash ../../scripts/build-package-binaries.sh"
 before-each-package-command = "bash ../../scripts/before-each-package.sh"
 binaries = [
-    { path = "vmux_desktop", main = true },
+    { path = "Vmux", main = true },
     { path = "vmux" },
-    { path = "vmux_service" },
+    { path = "Vmux Service" },
 ]
 
 [package.metadata.packager.dmg]

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -63,11 +63,14 @@ static LAST_NATIVE_MOUSE_WAKE: LazyLock<Mutex<Option<Instant>>> =
 
 #[cfg(target_os = "macos")]
 fn activate_primary_window_on_startup(
-    primary_window: Query<Entity, With<bevy::window::PrimaryWindow>>,
+    primary_window: Query<(Entity, &Window), With<bevy::window::PrimaryWindow>>,
 ) {
-    let Ok(window_entity) = primary_window.single() else {
+    let Ok((window_entity, window)) = primary_window.single() else {
         return;
     };
+    if !window.visible {
+        return;
+    }
     activate_native_window(window_entity);
 }
 
@@ -75,7 +78,7 @@ fn activate_primary_window_on_startup(
 fn activate_primary_window_on_startup() {}
 
 #[cfg(target_os = "macos")]
-fn activate_native_window(window_entity: Entity) {
+pub(crate) fn activate_native_window(window_entity: Entity) {
     use bevy::winit::WINIT_WINDOWS;
     use objc2_app_kit::{NSApp, NSView};
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
@@ -508,6 +511,17 @@ mod tests {
         assert!(plugin_build.contains("activate_primary_window_on_startup"));
         assert!(source.contains("activateIgnoringOtherApps"));
         assert!(source.contains("makeKeyAndOrderFront"));
+    }
+
+    #[test]
+    fn startup_activation_waits_for_visible_window() {
+        let source = include_str!("background_lifecycle.rs")
+            .split("fn activate_primary_window_on_startup")
+            .nth(1)
+            .and_then(|tail| tail.split("#[cfg(not(target_os = \"macos\"))]").next())
+            .unwrap_or_default();
+
+        assert!(source.contains("if !window.visible"));
     }
 
     #[test]

--- a/crates/vmux_desktop/src/glass.rs
+++ b/crates/vmux_desktop/src/glass.rs
@@ -7,10 +7,8 @@ impl Plugin for GlassPlugin {
     fn build(&self, app: &mut App) {
         app.init_non_send::<GlassState>()
             .init_non_send::<CommandBarOverlay>()
-            .add_systems(
-                Update,
-                (install_window_glass, sync_window_glass_visibility).chain(),
-            )
+            .add_systems(PreUpdate, install_window_glass)
+            .add_systems(Update, sync_window_glass_visibility)
             // Run after PostUpdate's `sync_windowed_frames` (which raises each page to front every
             // frame) so the overlay stays on top of the pages.
             .add_systems(Last, sync_command_bar_overlay);
@@ -26,7 +24,7 @@ struct GlassState {
 
 fn install_window_glass(
     mut state: NonSendMut<GlassState>,
-    window: Query<Entity, With<bevy::window::PrimaryWindow>>,
+    mut window: Query<(Entity, &mut Window), With<bevy::window::PrimaryWindow>>,
 ) {
     use bevy::winit::WINIT_WINDOWS;
     use objc2::{MainThreadMarker, rc::Retained, runtime::AnyClass};
@@ -42,7 +40,7 @@ fn install_window_glass(
     let Some(mtm) = MainThreadMarker::new() else {
         return;
     };
-    let Ok(entity) = window.single() else {
+    let Ok((entity, mut window)) = window.single_mut() else {
         return;
     };
     let ns_view = WINIT_WINDOWS.with_borrow(|windows| {
@@ -67,6 +65,8 @@ fn install_window_glass(
     if AnyClass::get(c"NSGlassEffectView").is_none() {
         warn!("glass: NSGlassEffectView unavailable (needs macOS 26+)");
         state.installed = true;
+        window.visible = true;
+        crate::background_lifecycle::activate_native_window(entity);
         return;
     }
     let glass: Retained<NSGlassEffectView> = NSGlassEffectView::new(mtm);
@@ -80,6 +80,8 @@ fn install_window_glass(
     state.visible = true;
     state._glass = Some(glass);
     state.installed = true;
+    window.visible = true;
+    crate::background_lifecycle::activate_native_window(entity);
     info!("glass: NSGlassEffectView installed as window backdrop (behind content view)");
 }
 
@@ -214,5 +216,18 @@ mod tests {
     fn glass_backdrop_is_hidden_in_player_mode() {
         assert!(!glass_backdrop_visible(InteractionMode::Player));
         assert!(glass_backdrop_visible(InteractionMode::User));
+    }
+
+    #[test]
+    fn window_reveals_after_backdrop_install() {
+        let source = include_str!("glass.rs");
+        let install = source
+            .split("fn install_window_glass")
+            .nth(1)
+            .and_then(|tail| tail.split("fn glass_backdrop_visible").next())
+            .unwrap_or_default();
+
+        assert!(install.contains("window.visible = true"));
+        assert!(install.contains("activate_native_window"));
     }
 }

--- a/crates/vmux_desktop/src/glass.rs
+++ b/crates/vmux_desktop/src/glass.rs
@@ -1,4 +1,6 @@
 use bevy::prelude::*;
+use vmux_core::page::PageReady;
+use vmux_layout::cef::LayoutCef;
 use vmux_layout::scene::InteractionMode;
 
 pub(crate) struct GlassPlugin;
@@ -6,12 +8,19 @@ pub(crate) struct GlassPlugin;
 impl Plugin for GlassPlugin {
     fn build(&self, app: &mut App) {
         app.init_non_send::<GlassState>()
+            .init_non_send::<LayoutOverlay>()
             .init_non_send::<CommandBarOverlay>()
             .add_systems(PreUpdate, install_window_glass)
             .add_systems(Update, sync_window_glass_visibility)
-            // Run after PostUpdate's `sync_windowed_frames` (which raises each page to front every
-            // frame) so the overlay stays on top of the pages.
-            .add_systems(Last, sync_command_bar_overlay);
+            .add_systems(
+                Last,
+                (
+                    reveal_window_after_layout_ready,
+                    sync_layout_overlay,
+                    sync_command_bar_overlay,
+                )
+                    .chain(),
+            );
     }
 }
 
@@ -19,19 +28,24 @@ impl Plugin for GlassPlugin {
 struct GlassState {
     installed: bool,
     visible: bool,
+    revealed: bool,
     _glass: Option<objc2::rc::Retained<objc2_app_kit::NSGlassEffectView>>,
+    _backdrop_window: Option<objc2::rc::Retained<objc2_app_kit::NSPanel>>,
+    _parent_window: Option<objc2::rc::Retained<objc2_app_kit::NSWindow>>,
 }
 
 fn install_window_glass(
     mut state: NonSendMut<GlassState>,
-    mut window: Query<(Entity, &mut Window), With<bevy::window::PrimaryWindow>>,
+    window: Query<Entity, With<bevy::window::PrimaryWindow>>,
 ) {
     use bevy::winit::WINIT_WINDOWS;
-    use objc2::{MainThreadMarker, rc::Retained, runtime::AnyClass};
+    use objc2::{ClassType, MainThreadMarker, MainThreadOnly, rc::Retained, runtime::AnyClass};
     use objc2_app_kit::{
-        NSAutoresizingMaskOptions, NSGlassEffectView, NSGlassEffectViewStyle, NSView,
-        NSWindowOrderingMode,
+        NSAutoresizingMaskOptions, NSBackingStoreType, NSColor, NSGlassEffectView,
+        NSGlassEffectViewStyle, NSPanel, NSView, NSWindowCollectionBehavior, NSWindowOrderingMode,
+        NSWindowStyleMask,
     };
+    use objc2_foundation::{NSPoint, NSRect, NSSize};
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
     if state.installed {
@@ -40,7 +54,7 @@ fn install_window_glass(
     let Some(mtm) = MainThreadMarker::new() else {
         return;
     };
-    let Ok((entity, mut window)) = window.single_mut() else {
+    let Ok(entity) = window.single() else {
         return;
     };
     let ns_view = WINIT_WINDOWS.with_borrow(|windows| {
@@ -56,33 +70,74 @@ fn install_window_glass(
         return;
     };
     let content: &NSView = unsafe { &*ns_view.as_ptr().cast::<NSView>() };
-    // Insert glass as a sibling *behind* the winit content view (its NSWindow frame view), so the
-    // transparent Bevy/OSR surface composites over it. A content-view subview would render in front
-    // of the OSR layer and hide the chrome.
-    let Some(parent) = (unsafe { content.superview() }) else {
+    let Some(parent_window) = content.window() else {
         return;
     };
     if AnyClass::get(c"NSGlassEffectView").is_none() {
         warn!("glass: NSGlassEffectView unavailable (needs macOS 26+)");
         state.installed = true;
-        window.visible = true;
-        crate::background_lifecycle::activate_native_window(entity);
         return;
     }
+    let frame = parent_window.frame();
+    let backdrop_window = NSPanel::initWithContentRect_styleMask_backing_defer(
+        NSPanel::alloc(mtm),
+        frame,
+        NSWindowStyleMask::Borderless | NSWindowStyleMask::NonactivatingPanel,
+        NSBackingStoreType::Buffered,
+        false,
+    );
+    let clear_color = NSColor::clearColor();
+    let backdrop: &objc2_app_kit::NSWindow = backdrop_window.as_super();
+    backdrop.setOpaque(false);
+    backdrop.setBackgroundColor(Some(&clear_color));
+    backdrop.setHasShadow(false);
+    backdrop.setIgnoresMouseEvents(true);
+    backdrop.setCanHide(false);
+    backdrop.setHidesOnDeactivate(false);
+    backdrop_window.setFloatingPanel(false);
+    backdrop_window.setBecomesKeyOnlyIfNeeded(true);
+    backdrop.setCollectionBehavior(
+        NSWindowCollectionBehavior::CanJoinAllSpaces
+            | NSWindowCollectionBehavior::FullScreenAuxiliary
+            | NSWindowCollectionBehavior::IgnoresCycle,
+    );
     let glass: Retained<NSGlassEffectView> = NSGlassEffectView::new(mtm);
-    glass.setStyle(NSGlassEffectViewStyle::Regular);
+    glass.setStyle(NSGlassEffectViewStyle::Clear);
+    glass.setTintColor(Some(&NSColor::clearColor()));
     let glass_view: &NSView = &glass;
-    glass_view.setFrame(parent.bounds());
+    glass_view.setFrame(NSRect::new(
+        NSPoint::new(0.0, 0.0),
+        NSSize::new(frame.size.width, frame.size.height),
+    ));
     glass_view.setAutoresizingMask(
         NSAutoresizingMaskOptions::ViewWidthSizable | NSAutoresizingMaskOptions::ViewHeightSizable,
     );
-    parent.addSubview_positioned_relativeTo(glass_view, NSWindowOrderingMode::Below, Some(content));
+    backdrop.setContentView(Some(glass_view));
+    unsafe {
+        parent_window.addChildWindow_ordered(backdrop, NSWindowOrderingMode::Below);
+    }
     state.visible = true;
     state._glass = Some(glass);
+    state._backdrop_window = Some(backdrop_window);
+    state._parent_window = Some(parent_window);
     state.installed = true;
+    info!("glass: NSGlassEffectView installed in nonactivating child-window backdrop");
+}
+
+fn reveal_window_after_layout_ready(
+    mut state: NonSendMut<GlassState>,
+    mut window: Query<(Entity, &mut Window), With<bevy::window::PrimaryWindow>>,
+    layout_ready: Query<(), (With<LayoutCef>, With<PageReady>)>,
+) {
+    if state.revealed || !state.installed || layout_ready.is_empty() {
+        return;
+    }
+    let Ok((entity, mut window)) = window.single_mut() else {
+        return;
+    };
     window.visible = true;
+    state.revealed = true;
     crate::background_lifecycle::activate_native_window(entity);
-    info!("glass: NSGlassEffectView installed as window backdrop (behind content view)");
 }
 
 fn glass_backdrop_visible(mode: InteractionMode) -> bool {
@@ -90,7 +145,15 @@ fn glass_backdrop_visible(mode: InteractionMode) -> bool {
 }
 
 fn sync_window_glass_visibility(mut state: NonSendMut<GlassState>, mode: Res<InteractionMode>) {
+    use objc2::ClassType;
+
     let visible = glass_backdrop_visible(*mode);
+    if let (Some(backdrop_window), Some(parent_window)) =
+        (&state._backdrop_window, &state._parent_window)
+    {
+        let backdrop_window: &objc2_app_kit::NSWindow = backdrop_window.as_super();
+        backdrop_window.setFrame_display(parent_window.frame(), false);
+    }
     if state.visible == visible {
         return;
     }
@@ -99,6 +162,13 @@ fn sync_window_glass_visibility(mut state: NonSendMut<GlassState>, mode: Res<Int
         glass_view.setHidden(!visible);
     }
     state.visible = visible;
+}
+
+#[derive(Default)]
+struct LayoutOverlay {
+    layer: Option<objc2::rc::Retained<objc2_quartz_core::CALayer>>,
+    shown: bool,
+    held: Option<bevy_cef_core::prelude::AcceleratedFrame>,
 }
 
 #[derive(Default)]
@@ -121,6 +191,87 @@ fn primary_content_view_ptr(entity: Entity) -> Option<*mut core::ffi::c_void> {
             _ => None,
         }
     })
+}
+
+fn sync_layout_overlay(
+    mut state: NonSendMut<LayoutOverlay>,
+    layout_e_q: Query<Entity, With<LayoutCef>>,
+    window_q: Query<Entity, With<bevy::window::PrimaryWindow>>,
+    windows: Query<&bevy::window::Window>,
+    mode: Res<InteractionMode>,
+    overlay_frames: Res<bevy_cef::prelude::NativeOverlayFrames>,
+) {
+    use objc2::{MainThreadMarker, rc::Retained, runtime::AnyObject};
+    use objc2_app_kit::{NSColor, NSView};
+    use objc2_quartz_core::CALayer;
+
+    if *mode != InteractionMode::User {
+        if state.shown {
+            if let Some(layer) = &state.layer {
+                layer.setHidden(true);
+            }
+            state.shown = false;
+            state.held = None;
+        }
+        return;
+    }
+    let Some(_mtm) = MainThreadMarker::new() else {
+        return;
+    };
+    let (Ok(window_e), Ok(layout_e)) = (window_q.single(), layout_e_q.single()) else {
+        return;
+    };
+    let next = overlay_frames
+        .0
+        .lock()
+        .ok()
+        .and_then(|mut map| map.remove(&layout_e));
+    if next.is_none() && state.held.is_none() {
+        return;
+    }
+    let Some(ns_view) = primary_content_view_ptr(window_e) else {
+        return;
+    };
+    let content: &NSView = unsafe { &*ns_view.cast::<NSView>() };
+    content.setWantsLayer(true);
+    let Some(host_layer) = content.layer() else {
+        return;
+    };
+    let clear_color = NSColor::clearColor();
+    host_layer.setOpaque(false);
+    host_layer.setBackgroundColor(Some(&clear_color.CGColor()));
+    let bounds = content.bounds();
+
+    if state.layer.is_none() {
+        let layer: Retained<objc2_quartz_core::CALayer> = CALayer::new();
+        layer.setOpaque(false);
+        layer.setBackgroundColor(Some(&clear_color.CGColor()));
+        layer.setZPosition(100.0);
+        host_layer.addSublayer(&layer);
+        state.layer = Some(layer);
+    }
+    let Some(layer) = state.layer.clone() else {
+        return;
+    };
+    layer.setOpaque(false);
+    layer.setBackgroundColor(Some(&clear_color.CGColor()));
+    layer.setFrame(bounds);
+    layer.setContentsScale(
+        windows
+            .get(window_e)
+            .map(|w| w.resolution.scale_factor() as f64)
+            .unwrap_or(2.0),
+    );
+
+    if let Some(frame) = next {
+        let io_surface = frame.io_surface as *mut AnyObject;
+        if !io_surface.is_null() {
+            unsafe { layer.setContents(Some(&*io_surface)) };
+            state.held = Some(frame);
+        }
+    }
+    layer.setHidden(false);
+    state.shown = true;
 }
 
 /// A2: show the command bar's OSR IOSurface in a full-window native overlay composited **above** the
@@ -219,15 +370,157 @@ mod tests {
     }
 
     #[test]
-    fn window_reveals_after_backdrop_install() {
+    fn glass_install_does_not_reveal_window() {
         let source = include_str!("glass.rs");
         let install = source
             .split("fn install_window_glass")
             .nth(1)
-            .and_then(|tail| tail.split("fn glass_backdrop_visible").next())
+            .and_then(|tail| tail.split("fn reveal_window_after_layout_ready").next())
             .unwrap_or_default();
 
-        assert!(install.contains("window.visible = true"));
-        assert!(install.contains("activate_native_window"));
+        assert!(!install.contains("window.visible = true"));
+        assert!(!install.contains("activate_native_window"));
+    }
+
+    #[test]
+    fn window_backdrop_uses_clear_glass_style() {
+        let source = include_str!("glass.rs");
+        let install = source
+            .split("fn install_window_glass")
+            .nth(1)
+            .and_then(|tail| tail.split("fn reveal_window_after_layout_ready").next())
+            .unwrap_or_default();
+
+        assert!(install.contains("NSGlassEffectViewStyle::Clear"));
+        assert!(!install.contains("NSGlassEffectViewStyle::Regular"));
+    }
+
+    #[test]
+    fn window_backdrop_uses_clear_glass_tint() {
+        let source = include_str!("glass.rs");
+        let install = source
+            .split("fn install_window_glass")
+            .nth(1)
+            .and_then(|tail| tail.split("fn reveal_window_after_layout_ready").next())
+            .unwrap_or_default();
+
+        assert!(install.contains("glass.setTintColor(Some(&NSColor::clearColor()))"));
+    }
+
+    #[test]
+    fn window_backdrop_lives_in_nonactivating_child_window() {
+        let source = include_str!("glass.rs");
+        let install = source
+            .split("fn install_window_glass")
+            .nth(1)
+            .and_then(|tail| tail.split("fn reveal_window_after_layout_ready").next())
+            .unwrap_or_default();
+
+        assert!(install.contains("NSPanel"));
+        assert!(install.contains("NSWindowStyleMask::NonactivatingPanel"));
+        assert!(install.contains("setIgnoresMouseEvents(true)"));
+        assert!(install.contains("addChildWindow_ordered"));
+        assert!(install.contains("NSWindowOrderingMode::Below"));
+    }
+
+    #[test]
+    fn window_backdrop_tracks_parent_window_frame() {
+        let source = include_str!("glass.rs");
+        let sync = source
+            .split("fn sync_window_glass_visibility")
+            .nth(1)
+            .and_then(|tail| {
+                tail.split("#[derive(Default)]\nstruct LayoutOverlay")
+                    .next()
+            })
+            .unwrap_or_default();
+
+        assert!(sync.contains("backdrop_window.setFrame_display(parent_window.frame(), false)"));
+    }
+
+    #[test]
+    fn desktop_enables_nspanel_binding_for_glass_backdrop() {
+        let manifest = include_str!("../Cargo.toml");
+
+        assert!(manifest.contains("\"NSPanel\""));
+    }
+
+    #[test]
+    fn layout_overlay_uses_layer_for_hit_test_passthrough() {
+        let source = include_str!("glass.rs");
+        let overlay = source
+            .split("fn sync_layout_overlay")
+            .nth(1)
+            .and_then(|tail| tail.split("fn sync_command_bar_overlay").next())
+            .unwrap_or_default();
+
+        assert!(overlay.contains("Retained<objc2_quartz_core::CALayer>"));
+        assert!(overlay.contains("CALayer::new()"));
+        assert!(overlay.contains("addSublayer"));
+        assert!(overlay.contains("layer.setContents"));
+        assert!(!overlay.contains("NSView::initWithFrame"));
+    }
+
+    #[test]
+    fn layout_overlay_keeps_host_and_overlay_layers_transparent() {
+        let source = include_str!("glass.rs");
+        let overlay = source
+            .split("fn sync_layout_overlay")
+            .nth(1)
+            .and_then(|tail| tail.split("fn sync_command_bar_overlay").next())
+            .unwrap_or_default();
+
+        assert!(overlay.contains("host_layer.setOpaque(false)"));
+        assert!(overlay.contains("host_layer.setBackgroundColor(Some(&clear_color.CGColor()))"));
+        assert!(overlay.contains("layer.setBackgroundColor(Some(&clear_color.CGColor()))"));
+    }
+
+    fn reveal_test_app(layout_ready: bool) -> App {
+        let mut app = App::new();
+        app.add_systems(Update, reveal_window_after_layout_ready);
+        app.world_mut().insert_non_send(GlassState {
+            installed: true,
+            ..default()
+        });
+        app.world_mut().spawn((
+            Window {
+                visible: false,
+                ..default()
+            },
+            bevy::window::PrimaryWindow,
+        ));
+        let mut layout = app.world_mut().spawn((LayoutCef,));
+        if layout_ready {
+            layout.insert(PageReady::default());
+        }
+        app
+    }
+
+    #[test]
+    fn startup_window_stays_hidden_until_layout_ready() {
+        let mut app = reveal_test_app(false);
+
+        app.update();
+
+        let window = app
+            .world_mut()
+            .query_filtered::<&Window, With<bevy::window::PrimaryWindow>>()
+            .single(app.world())
+            .expect("primary window");
+        assert!(!window.visible);
+    }
+
+    #[test]
+    fn startup_window_reveals_after_layout_ready() {
+        let mut app = reveal_test_app(true);
+
+        app.update();
+
+        let window = app
+            .world_mut()
+            .query_filtered::<&Window, With<bevy::window::PrimaryWindow>>()
+            .single(app.world())
+            .expect("primary window");
+        assert!(window.visible);
     }
 }

--- a/crates/vmux_desktop/src/lib.rs
+++ b/crates/vmux_desktop/src/lib.rs
@@ -45,6 +45,7 @@ fn primary_window_config(title: String) -> NativeWindow {
         movable_by_window_background: false,
         fullsize_content_view: true,
         ime_enabled: true,
+        visible: !cfg!(target_os = "macos"),
         ..default()
     }
 }
@@ -115,6 +116,13 @@ mod tests {
         let window = primary_window_config("Vmux".to_string());
 
         assert!(window.ime_enabled);
+    }
+
+    #[test]
+    fn primary_window_starts_hidden_on_macos_until_backdrop_is_ready() {
+        let window = primary_window_config("Vmux".to_string());
+
+        assert_eq!(window.visible, !cfg!(target_os = "macos"));
     }
 
     #[test]

--- a/crates/vmux_desktop/tests/packaging_metadata.rs
+++ b/crates/vmux_desktop/tests/packaging_metadata.rs
@@ -1,23 +1,94 @@
 //! Verify cargo-packager metadata embeds vmux_service in the bundle.
 
 #[test]
-fn packager_binaries_include_vmux_service() {
+fn packager_binaries_use_user_facing_names() {
     let toml = include_str!("../Cargo.toml");
     assert!(
-        toml.contains(r#"path = "vmux_service""#),
-        "packager metadata must include vmux_service so it lands in Vmux.app/Contents/MacOS/"
+        toml.contains(r#"{ path = "Vmux", main = true }"#),
+        "packager metadata must install the app executable as Vmux"
+    );
+    assert!(
+        toml.contains(r#"{ path = "Vmux Service" }"#),
+        "packager metadata must install the service executable as Vmux Service"
+    );
+    assert!(
+        !toml.contains(r#"{ path = "vmux_desktop", main = true }"#),
+        "packager metadata must not expose vmux_desktop in the app bundle"
+    );
+    assert!(
+        !toml.contains(r#"{ path = "vmux_service" }"#),
+        "packager metadata must not expose vmux_service in the app bundle"
     );
 }
 
 #[test]
-fn before_packaging_command_builds_vmux_service() {
+fn before_packaging_command_prepares_named_binaries() {
     let toml = include_str!("../Cargo.toml");
     let line = toml
         .lines()
         .find(|l| l.starts_with("before-packaging-command"))
         .expect("before-packaging-command line present");
     assert!(
-        line.contains("vmux_service"),
-        "before-packaging-command must build vmux_service: {line}"
+        line.contains("scripts/build-package-binaries.sh"),
+        "before-packaging-command must prepare user-facing binary names: {line}"
+    );
+    let script = include_str!("../../../scripts/build-package-binaries.sh");
+    assert!(script.contains("target/release/vmux_desktop"));
+    assert!(script.contains("target/release/Vmux"));
+    assert!(script.contains("target/release/vmux_service"));
+    assert!(script.contains("target/release/Vmux Service"));
+}
+
+#[test]
+fn macos_bundle_scripts_expect_user_facing_helper_names_and_icons() {
+    let layout_script = include_str!("../../../scripts/test-bundle-layout.sh");
+    let required_block = layout_script.split("FORBIDDEN=(").next().unwrap();
+    assert!(required_block.contains("Contents/MacOS/Vmux"));
+    assert!(
+        required_block.contains("Contents/Frameworks/Vmux Helper.app/Contents/MacOS/Vmux Helper")
+    );
+    assert!(
+        required_block.contains("Contents/Frameworks/Vmux Helper.app/Contents/Resources/Vmux.icns")
+    );
+    assert!(
+        required_block
+            .contains("Contents/Library/LoginItems/Vmux Service.app/Contents/MacOS/Vmux Service")
+    );
+    assert!(
+        required_block
+            .contains("Contents/Library/LoginItems/Vmux Service.app/Contents/Resources/Vmux.icns")
+    );
+    assert!(!required_block.contains("Contents/MacOS/vmux_desktop"));
+    assert!(!required_block.contains("Contents/MacOS/vmux_service"));
+    assert!(!required_block.contains("vmux_desktop Helper.app"));
+}
+
+#[test]
+fn cef_injection_uses_named_helper_base_and_icon() {
+    let inject_script = include_str!("../../../scripts/inject-cef.sh");
+    assert!(inject_script.contains("--bin-name Vmux"));
+    assert!(inject_script.contains("Vmux Helper.app"));
+    assert!(inject_script.contains("CFBundleIconFile"));
+    assert!(inject_script.contains("Vmux.icns"));
+}
+
+#[test]
+fn signing_includes_service_helper_app() {
+    let signing_script = include_str!("../../../scripts/sign-and-notarize.sh");
+    assert!(signing_script.contains("$APP_BUNDLE/Contents/Library"));
+    assert!(signing_script.contains("Vmux Service"));
+    assert!(signing_script.contains("ai.vmux.service%s"));
+}
+
+#[test]
+fn generated_info_plist_uses_named_executable() {
+    let info_plist = include_str!("../../../packaging/macos/Info.plist");
+    let after_key = info_plist
+        .split("<key>CFBundleExecutable</key>")
+        .nth(1)
+        .expect("CFBundleExecutable key");
+    assert!(
+        after_key.trim_start().starts_with("<string>Vmux</string>"),
+        "CFBundleExecutable must be Vmux so helper processes are named Vmux Helper"
     );
 }

--- a/crates/vmux_desktop/tests/release_invariants.rs
+++ b/crates/vmux_desktop/tests/release_invariants.rs
@@ -60,6 +60,14 @@ fn local_package_only_builds_app_bundle() {
 }
 
 #[test]
+fn cef_injection_uses_ci_cached_framework_path() {
+    let inject_script = include_str!("../../../scripts/inject-cef.sh");
+
+    assert!(inject_script.contains("--cef-framework \"$CEF_FRAMEWORK\""));
+    assert!(inject_script.contains("CEF_FRAMEWORK=\"${CEF_FRAMEWORK:-${HOME}/.local/share/Chromium Embedded Framework.framework}\""));
+}
+
+#[test]
 fn local_signing_uses_stable_codesigning_identity() {
     let signing_script = include_str!("../../../scripts/ensure-local-codesign-identity.sh");
 

--- a/crates/vmux_desktop/tests/release_invariants.rs
+++ b/crates/vmux_desktop/tests/release_invariants.rs
@@ -43,6 +43,21 @@ fn dev_target_keeps_service_out_of_desktop_dynamic_linking_build() {
 }
 
 #[test]
+fn dev_target_stops_existing_debug_desktop_before_cef_initialize() {
+    let makefile = include_str!("../../../Makefile");
+    let stop_idx = makefile
+        .find("target/debug/vmux_desktop")
+        .expect("debug desktop stop");
+    let run_idx = makefile
+        .find("exec env -u CEF_PATH")
+        .expect("debug desktop run");
+
+    assert!(makefile.contains("pkill -f \"target/debug/vmux_desktop\""));
+    assert!(makefile.contains("pkill -f \"bevy_cef_debug_render_process\""));
+    assert!(stop_idx < run_idx);
+}
+
+#[test]
 fn local_package_uses_per_sha_bundle_name() {
     let package_script = include_str!("../../../scripts/package.sh");
 

--- a/crates/vmux_layout/assets/index.css
+++ b/crates/vmux_layout/assets/index.css
@@ -18,7 +18,7 @@
     --foreground: oklch(1 0 0);
     --muted-foreground: oklch(0.82 0 0);
     --sidebar-primary-foreground: oklch(1 0 0);
-    --glass: transparent;
+    --glass: oklch(0.18 0 0 / 0.82);
     --glass-hover: oklch(1 0 0 / 0.08);
     --glass-active: oklch(1 0 0 / 0.14);
     --glass-border: oklch(1 0 0 / 0.20);

--- a/crates/vmux_layout/src/cef.rs
+++ b/crates/vmux_layout/src/cef.rs
@@ -99,6 +99,7 @@ impl Browser {
         (
             Self,
             WebviewWindowed,
+            WebviewOpaqueWindowedBackground,
             vmux_core::PageMetadata {
                 title: url.to_string(),
                 url: url.to_string(),
@@ -134,6 +135,7 @@ impl Browser {
         (
             Self,
             WebviewWindowed,
+            WebviewOpaqueWindowedBackground,
             vmux_core::PageMetadata {
                 title: title.to_string(),
                 url: url.to_string(),
@@ -167,12 +169,7 @@ pub fn layout_cef_bundle(
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) -> impl Bundle {
     (
-        (
-            LayoutCef,
-            WebviewWindowed,
-            WebviewNativeLiquidGlass,
-            WebviewMaxFrameRate(30),
-        ),
+        LayoutCef,
         Browser,
         HostWindow(host_window),
         WebviewTransparent,
@@ -210,6 +207,18 @@ mod tests {
         commands.spawn(layout_cef_bundle(host, &mut meshes, &mut webview_mt));
     }
 
+    fn build_test_page(
+        mut commands: Commands,
+        mut meshes: ResMut<Assets<Mesh>>,
+        mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
+    ) {
+        commands.spawn(Browser::new(
+            &mut meshes,
+            &mut webview_mt,
+            "https://example.com",
+        ));
+    }
+
     #[test]
     fn layout_cef_uses_manual_pointer_routing() {
         let mut app = App::new();
@@ -226,6 +235,28 @@ mod tests {
             .expect("layout CEF shell pickable");
 
         assert_eq!(pickable, &Pickable::IGNORE);
+    }
+
+    #[test]
+    fn page_cef_uses_opaque_dark_initial_background() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+            .add_systems(Startup, build_test_page);
+        app.update();
+
+        let page = app
+            .world_mut()
+            .query_filtered::<Entity, (With<Browser>, Without<LayoutCef>)>()
+            .single(app.world())
+            .expect("page CEF");
+
+        assert!(
+            app.world()
+                .get::<WebviewOpaqueWindowedBackground>(page)
+                .is_some()
+        );
     }
 }
 

--- a/crates/vmux_layout/src/command_bar/style.rs
+++ b/crates/vmux_layout/src/command_bar/style.rs
@@ -323,10 +323,20 @@ mod tests {
     }
 
     #[test]
-    fn layout_css_keeps_glass_background_transparent() {
+    fn layout_css_gives_chrome_controls_readable_glass_background() {
         let css = include_str!("../../assets/index.css");
 
-        assert!(css.contains("--glass: transparent;"));
+        assert!(css.contains("--glass: oklch(0.18 0 0 / 0.82);"));
+        assert!(!css.contains("--glass: transparent;"));
+        assert!(!css.contains("--glass: oklch(0.36 0 0 / 0.82);"));
+    }
+
+    #[test]
+    fn bundled_layout_css_gives_chrome_controls_readable_glass_background() {
+        let css = include_str!("../../../vmux_server/assets/index.css");
+
+        assert!(css.contains("--glass: oklch(0.18 0 0 / 0.82);"));
+        assert!(!css.contains("--glass: transparent;"));
         assert!(!css.contains("--glass: oklch(0.36 0 0 / 0.82);"));
     }
 }

--- a/crates/vmux_layout/src/page.rs
+++ b/crates/vmux_layout/src/page.rs
@@ -16,12 +16,68 @@ pub fn Page() -> Element {
     use_theme();
 
     let mut layout_state = use_signal(LayoutStateEvent::default);
-    let _layout_listener =
+    let mut layout_state_received = use_signal(|| false);
+    let layout_listener =
         use_bin_event_listener::<LayoutStateEvent, _>(LAYOUT_STATE_EVENT, move |data| {
+            layout_state_received.set(true);
             layout_state.set(data);
         });
 
+    let mut stacks_state = use_signal(StacksHostEvent::default);
+    let mut stacks_state_received = use_signal(|| false);
+    let stacks_listener = use_bin_event_listener::<StacksHostEvent, _>(STACKS_EVENT, move |data| {
+        stacks_state_received.set(true);
+        stacks_state.set(data);
+    });
+
+    let mut tabs_state = use_signal(TabsHostEvent::default);
+    let mut tabs_state_received = use_signal(|| false);
+    let tabs_listener = use_bin_event_listener::<TabsHostEvent, _>(TABS_EVENT, move |data| {
+        tabs_state_received.set(true);
+        tabs_state.set(data);
+    });
+
+    let mut reload_key = use_signal(|| 0u32);
+    let _reload_listener = use_bin_event_listener::<ReloadEvent, _>(RELOAD_EVENT, move |_| {
+        reload_key.set(reload_key() + 1);
+    });
+
+    let mut pane_tree_state = use_signal(PaneTreeEvent::default);
+    let mut pane_tree_state_received = use_signal(|| false);
+    let pane_tree_listener =
+        use_bin_event_listener::<PaneTreeEvent, _>(PANE_TREE_EVENT, move |data| {
+            pane_tree_state_received.set(true);
+            pane_tree_state.set(data);
+        });
+
+    let mut spaces_state = use_signal(vmux_core::event::space::SpacesListEvent::default);
+    let mut spaces_state_received = use_signal(|| false);
+    let spaces_listener = use_bin_event_listener::<vmux_core::event::space::SpacesListEvent, _>(
+        vmux_core::event::space::SPACES_LIST_EVENT,
+        move |data| {
+            spaces_state_received.set(true);
+            spaces_state.set(data);
+        },
+    );
+
     let state = layout_state();
+    let stacks = stacks_state();
+    let tabs = tabs_state();
+    let PaneTreeEvent { panes } = pane_tree_state();
+    let active_space = spaces_state().spaces.into_iter().find(|s| s.is_active);
+    let layout_error = (layout_listener.error)();
+    let stacks_error = (stacks_listener.error)();
+    let tabs_error = (tabs_listener.error)();
+    let pane_tree_error = (pane_tree_listener.error)();
+    let spaces_error = (spaces_listener.error)();
+    let chrome_ready = layout_chrome_ready(
+        &state,
+        listener_ready(layout_state_received(), &layout_error),
+        listener_ready(stacks_state_received(), &stacks_error),
+        listener_ready(tabs_state_received(), &tabs_error),
+        listener_ready(pane_tree_state_received(), &pane_tree_error),
+        listener_ready(spaces_state_received(), &spaces_error),
+    );
     let radius_px = state.radius;
     use_effect(move || {
         if let Some(doc) = web_sys::window().and_then(|w| w.document())
@@ -52,24 +108,51 @@ pub fn Page() -> Element {
 
     rsx! {
         div { class: "fixed inset-0 pointer-events-none text-foreground",
-            if state.side_sheet_open {
+            if chrome_ready && state.side_sheet_open {
                 aside {
                     class: "pointer-events-auto fixed left-[var(--vmux-side-sheet-left)] top-[var(--vmux-side-sheet-top)] bottom-[var(--vmux-side-sheet-bottom)] min-h-0 overflow-hidden w-[var(--vmux-side-sheet-width)] pt-[var(--vmux-side-sheet-pad-top)]",
                     style: "{side_sheet_vars}",
                     div { class: "flex h-full min-h-0 flex-col",
-                        SideSheetView {}
+                        SideSheetView {
+                            panes,
+                            active_space,
+                            pane_tree_error: pane_tree_error.clone(),
+                        }
                     }
                 }
             }
-            if state.header_visible() {
+            if chrome_ready && state.header_visible() {
                 div {
                     class: "pointer-events-auto fixed top-[var(--vmux-header-top)] left-[var(--vmux-header-left)] right-[var(--vmux-header-right)] h-[var(--vmux-header-height)]",
                     style: "{header_vars}",
-                    HeaderView {}
+                    HeaderView {
+                        stacks_state: stacks,
+                        tabs_state: tabs,
+                        reload_key: reload_key(),
+                        stacks_error: stacks_error.clone(),
+                        tabs_error: tabs_error.clone(),
+                    }
                 }
             }
         }
     }
+}
+
+fn listener_ready(received: bool, error: &Option<String>) -> bool {
+    received || error.is_some()
+}
+
+fn layout_chrome_ready(
+    state: &LayoutStateEvent,
+    layout_ready: bool,
+    stacks_ready: bool,
+    tabs_ready: bool,
+    pane_tree_ready: bool,
+    spaces_ready: bool,
+) -> bool {
+    layout_ready
+        && (!state.header_visible() || (stacks_ready && tabs_ready))
+        && (!state.side_sheet_open || (pane_tree_ready && spaces_ready))
 }
 
 fn parse_rgb(s: &str) -> Option<(u8, u8, u8)> {
@@ -134,35 +217,22 @@ fn format_address(stack: &StackRow) -> String {
 }
 
 #[component]
-fn HeaderView() -> Element {
-    let mut stacks_state = use_signal(StacksHostEvent::default);
-    let listener = use_bin_event_listener::<StacksHostEvent, _>(STACKS_EVENT, move |data| {
-        stacks_state.set(data);
-    });
-
-    let mut tabs_state = use_signal(TabsHostEvent::default);
-    let tabs_listener = use_bin_event_listener::<TabsHostEvent, _>(TABS_EVENT, move |data| {
-        tabs_state.set(data);
-    });
-
-    let mut reload_key = use_signal(|| 0u32);
-    let _reload_listener = use_bin_event_listener::<ReloadEvent, _>(RELOAD_EVENT, move |_| {
-        reload_key.set(reload_key() + 1);
-    });
-
+fn HeaderView(
+    stacks_state: StacksHostEvent,
+    tabs_state: TabsHostEvent,
+    reload_key: u32,
+    stacks_error: Option<String>,
+    tabs_error: Option<String>,
+) -> Element {
     let StacksHostEvent {
         stacks,
         can_go_back,
         can_go_forward,
         is_zoomed: _,
-    } = stacks_state();
-    let TabsHostEvent { tabs } = tabs_state();
+    } = stacks_state;
+    let TabsHostEvent { tabs } = tabs_state;
     let active_row = stacks.iter().find(|t| t.is_active).cloned();
     let active_bg_color = active_row.as_ref().and_then(|r| r.bg_color.clone());
-    let listener_loading = (listener.is_loading)();
-    let listener_error = (listener.error)();
-    let tabs_loading = (tabs_listener.is_loading)();
-    let tabs_error = (tabs_listener.error)();
 
     let (url_row_style, url_row_class) = url_row_cef(active_bg_color.as_deref());
 
@@ -170,9 +240,7 @@ fn HeaderView() -> Element {
         div {
             class: "flex h-full min-h-0 min-w-0 flex-col text-foreground",
             div { class: "flex min-w-0 shrink-0 items-center gap-1 pl-[var(--vmux-tab-row-pad-left)] pr-2",
-                if tabs_loading {
-                    span { class: "text-ui text-muted-foreground", "Connecting..." }
-                } else if let Some(err) = tabs_error {
+                if let Some(err) = tabs_error {
                     span { class: "text-ui text-destructive", "{err}" }
                 } else {
                     div { class: "flex min-w-0 flex-1 items-center gap-1 overflow-x-auto pl-2",
@@ -192,9 +260,7 @@ fn HeaderView() -> Element {
             div {
                 class: "{url_row_class}",
                 style: "{url_row_style}",
-                if listener_loading {
-                    span { class: "text-ui text-muted-foreground", "Connecting..." }
-                } else if let Some(err) = listener_error {
+                if let Some(err) = stacks_error {
                     span { class: "text-ui text-destructive", "{err}" }
                 } else {
                     NavButton { label: "Back", command: "prev_page", disabled: !can_go_back,
@@ -212,7 +278,7 @@ fn HeaderView() -> Element {
                     NavButton { label: "Reload", command: "reload", disabled: active_row.as_ref().is_none_or(|t| t.url.is_empty()),
                         span {
                             key: "{reload_key}",
-                            class: if reload_key() > 0 { "inline-flex animate-spin-once" } else { "inline-flex" },
+                            class: if reload_key > 0 { "inline-flex animate-spin-once" } else { "inline-flex" },
                             Icon { class: "h-4 w-4",
                                 path { d: "M21 12a9 9 0 11-3-6.7L21 8" }
                                 path { d: "M21 3v5h-5" }
@@ -473,23 +539,11 @@ fn NewTabButton() -> Element {
 }
 
 #[component]
-fn SideSheetView() -> Element {
-    let mut tree_state = use_signal(PaneTreeEvent::default);
-    let listener = use_bin_event_listener::<PaneTreeEvent, _>(PANE_TREE_EVENT, move |data| {
-        tree_state.set(data);
-    });
-
-    let mut spaces_state = use_signal(vmux_core::event::space::SpacesListEvent::default);
-    let _spaces_listener = use_bin_event_listener::<vmux_core::event::space::SpacesListEvent, _>(
-        vmux_core::event::space::SPACES_LIST_EVENT,
-        move |data| {
-            spaces_state.set(data);
-        },
-    );
-
-    let PaneTreeEvent { panes } = tree_state();
-    let active_space = spaces_state().spaces.into_iter().find(|s| s.is_active);
-
+fn SideSheetView(
+    panes: Vec<PaneNode>,
+    active_space: Option<vmux_core::event::space::SpaceRow>,
+    pane_tree_error: Option<String>,
+) -> Element {
     rsx! {
         div { class: "flex min-h-0 flex-1 flex-col overflow-y-auto px-2 pb-3 pt-2 text-foreground",
             if let Some(space) = active_space {
@@ -497,11 +551,7 @@ fn SideSheetView() -> Element {
                     SideSheetSpaceRow { key: "{space.id}", space }
                 }
             }
-            if (listener.is_loading)() {
-                div { class: "flex items-center px-2 py-1",
-                    span { class: "text-ui text-muted-foreground", "Connecting..." }
-                }
-            } else if let Some(err) = (listener.error)() {
+            if let Some(err) = pane_tree_error {
                 div { class: "flex items-center px-2 py-1",
                     span { class: "text-ui text-destructive", "{err}" }
                 }
@@ -662,5 +712,68 @@ fn SideSheetStackRow(stack: StackNode, pane_id: u64) -> Element {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state(header_open: bool, side_sheet_open: bool) -> LayoutStateEvent {
+        LayoutStateEvent {
+            header_open,
+            side_sheet_open,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn chrome_waits_for_layout_state() {
+        assert!(!layout_chrome_ready(
+            &state(false, false),
+            false,
+            true,
+            true,
+            true,
+            true
+        ));
+    }
+
+    #[test]
+    fn chrome_waits_for_header_state_when_header_visible() {
+        let visible = state(true, false);
+
+        assert!(!layout_chrome_ready(
+            &visible, true, false, true, true, true
+        ));
+        assert!(!layout_chrome_ready(
+            &visible, true, true, false, true, true
+        ));
+        assert!(layout_chrome_ready(&visible, true, true, true, true, true));
+    }
+
+    #[test]
+    fn chrome_waits_for_side_sheet_state_when_side_sheet_visible() {
+        let visible = state(false, true);
+
+        assert!(!layout_chrome_ready(
+            &visible, true, true, true, false, true
+        ));
+        assert!(!layout_chrome_ready(
+            &visible, true, true, true, true, false
+        ));
+        assert!(layout_chrome_ready(&visible, true, true, true, true, true));
+    }
+
+    #[test]
+    fn chrome_can_be_ready_when_chrome_is_closed() {
+        assert!(layout_chrome_ready(
+            &state(false, false),
+            true,
+            false,
+            false,
+            false,
+            false
+        ));
     }
 }

--- a/crates/vmux_layout/src/page.rs
+++ b/crates/vmux_layout/src/page.rs
@@ -155,45 +155,6 @@ fn layout_chrome_ready(
         && (!state.side_sheet_open || (pane_tree_ready && spaces_ready))
 }
 
-fn parse_rgb(s: &str) -> Option<(u8, u8, u8)> {
-    let trimmed = s.trim();
-    if let Some(rest) = trimmed.strip_prefix('#')
-        && rest.len() == 6
-    {
-        let r = u8::from_str_radix(&rest[0..2], 16).ok()?;
-        let g = u8::from_str_radix(&rest[2..4], 16).ok()?;
-        let b = u8::from_str_radix(&rest[4..6], 16).ok()?;
-        return Some((r, g, b));
-    }
-    if let Some(inner) = trimmed
-        .strip_prefix("rgb(")
-        .and_then(|s| s.strip_suffix(')'))
-    {
-        let parts: Vec<&str> = inner.split(',').map(|p| p.trim()).collect();
-        if parts.len() == 3 {
-            return Some((
-                parts[0].parse().ok()?,
-                parts[1].parse().ok()?,
-                parts[2].parse().ok()?,
-            ));
-        }
-    }
-    None
-}
-
-fn text_color_class_for_bg(bg: &str) -> &'static str {
-    parse_rgb(bg)
-        .map(|(r, g, b)| {
-            let lum = 0.299 * r as f32 + 0.587 * g as f32 + 0.114 * b as f32;
-            if lum > 128.0 {
-                "text-zinc-900"
-            } else {
-                "text-zinc-100"
-            }
-        })
-        .unwrap_or("text-foreground")
-}
-
 fn favicon_src_for_stack_node(stack: &StackNode) -> Option<String> {
     favicon_src_for_url(&stack.favicon_url, &stack.url)
 }
@@ -295,21 +256,11 @@ fn HeaderView(
     }
 }
 
-fn url_row_cef(bg_color: Option<&str>) -> (String, String) {
-    if let Some(color) = bg_color {
-        let text_class = text_color_class_for_bg(color);
-        (
-            format!("--vmux-url-bg:{color};"),
-            format!(
-                "flex min-w-0 flex-1 shrink-0 items-center gap-1 rounded-t-[var(--radius)] px-2 bg-[var(--vmux-url-bg)] {text_class}"
-            ),
-        )
-    } else {
-        (
-            String::new(),
-            "flex min-w-0 flex-1 shrink-0 items-center gap-1 rounded-t-[var(--radius)] px-2 bg-glass backdrop-blur-xl backdrop-saturate-150 text-foreground".to_string(),
-        )
-    }
+fn url_row_cef(_bg_color: Option<&str>) -> (String, String) {
+    (
+        String::new(),
+        "flex min-w-0 flex-1 shrink-0 items-center gap-1 rounded-t-[var(--radius)] px-2 bg-glass backdrop-blur-xl backdrop-saturate-150 text-foreground".to_string(),
+    )
 }
 
 #[component]
@@ -436,28 +387,12 @@ fn Tab(tab: TabRow) -> Element {
     let tab_box_classes = "group flex h-10 w-52 min-w-52 max-w-52 basis-52 shrink-0 grow-0 -mb-[3px] pb-[3px] cursor-pointer items-center gap-2 px-3.5";
 
     let (tab_style, tab_class, title_class, close_class) = if is_active {
-        if let Some(ref color) = tab.bg_color {
-            let text_class = text_color_class_for_bg(color);
-            (
-                format!("--tab-bg:{color};"),
-                format!(
-                    "{skirt_classes} {tab_box_classes} rounded-t-md bg-[var(--tab-bg)] {text_class}"
-                ),
-                format!("min-w-0 flex-1 truncate text-ui font-medium {text_class}"),
-                format!(
-                    "flex h-4 w-4 cursor-pointer shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 hover:bg-white/20 {text_class}"
-                ),
-            )
-        } else {
-            (
-                "--tab-bg:var(--glass);".to_string(),
-                format!(
-                    "{skirt_classes} {tab_box_classes} glass rounded-t-md border-b-0"
-                ),
-                "min-w-0 flex-1 truncate text-ui font-medium text-foreground".to_string(),
-                "flex h-4 w-4 cursor-pointer shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 hover:bg-foreground/10".to_string(),
-            )
-        }
+        (
+            "--tab-bg:var(--glass);".to_string(),
+            format!("{skirt_classes} {tab_box_classes} glass rounded-t-md border-b-0"),
+            "min-w-0 flex-1 truncate text-ui font-medium text-foreground".to_string(),
+            "flex h-4 w-4 cursor-pointer shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 hover:bg-foreground/10".to_string(),
+        )
     } else {
         (
             String::new(),

--- a/crates/vmux_layout/src/tab.rs
+++ b/crates/vmux_layout/src/tab.rs
@@ -7,6 +7,7 @@ use crate::{
 use bevy::{
     ecs::{message::Messages, relationship::Relationship},
     prelude::*,
+    ui::UiSystems,
     window::PrimaryWindow,
 };
 use bevy_cef::prelude::*;
@@ -33,7 +34,7 @@ impl Plugin for TabPlugin {
                     .in_set(ReadAppCommands)
                     .in_set(TabCommandSet),
             )
-            .add_systems(PostUpdate, sync_tab_visibility);
+            .add_systems(PostUpdate, sync_tab_visibility.before(UiSystems::Layout));
     }
 }
 
@@ -355,6 +356,18 @@ mod tests {
         let id = target.to_bits().to_string();
 
         assert_eq!(tab_target(Some(&id), [other, target]), Some(target));
+    }
+
+    #[test]
+    fn tab_visibility_sync_runs_before_ui_layout() {
+        let source = include_str!("tab.rs");
+        let plugin = source
+            .split("impl Plugin for TabPlugin")
+            .nth(1)
+            .and_then(|tail| tail.split("#[derive(Component").next())
+            .unwrap_or_default();
+
+        assert!(plugin.contains("sync_tab_visibility.before(UiSystems::Layout)"));
     }
 
     fn test_settings() -> LayoutSettings {

--- a/crates/vmux_layout/src/window.rs
+++ b/crates/vmux_layout/src/window.rs
@@ -1051,7 +1051,7 @@ mod tests {
     }
 
     #[test]
-    fn layout_chrome_uses_transparent_liquid_glass() {
+    fn layout_chrome_uses_transparent_osr_native_overlay() {
         let mut app = setup_window_app();
         app.update();
 
@@ -1071,10 +1071,21 @@ mod tests {
                 .get::<WebviewOpaqueWindowedBackground>(layout_shell)
                 .is_none()
         );
+        assert!(app.world().get::<WebviewWindowed>(layout_shell).is_none());
         assert!(
             app.world()
-                .get::<WebviewNativeLiquidGlass>(layout_shell)
+                .get::<WebviewTransparent>(layout_shell)
                 .is_some()
+        );
+        assert!(
+            app.world()
+                .get::<WebviewNativeOverlay>(layout_shell)
+                .is_none()
+        );
+        assert!(
+            app.world()
+                .get::<WebviewMaxFrameRate>(layout_shell)
+                .is_none()
         );
         assert!(
             app.world()

--- a/crates/vmux_layout/tests/page_source.rs
+++ b/crates/vmux_layout/tests/page_source.rs
@@ -108,6 +108,16 @@ fn layout_page_offsets_header_and_side_sheet_by_window_padding() {
 }
 
 #[test]
+fn layout_page_gates_header_and_side_sheet_until_host_state_arrives() {
+    let source = include_str!("../src/page.rs");
+
+    assert!(source.contains("layout_chrome_ready"));
+    assert!(source.contains("let chrome_ready = layout_chrome_ready"));
+    assert!(source.contains("if chrome_ready && state.side_sheet_open"));
+    assert!(source.contains("if chrome_ready && state.header_visible()"));
+}
+
+#[test]
 fn command_bar_page_installs_document_pointer_dismiss_listener() {
     let source = include_str!("../src/command_bar/page.rs");
 

--- a/crates/vmux_layout/tests/page_source.rs
+++ b/crates/vmux_layout/tests/page_source.rs
@@ -47,7 +47,7 @@ fn header_tabs_use_same_fixed_width_for_active_and_inactive_states() {
     assert!(!tab.contains("max-w-[200px]"));
     assert!(!tab.contains("w-[200px]"));
     assert_eq!(tab.matches(footprint).count(), 1);
-    assert_eq!(tab.matches("{tab_box_classes}").count(), 3);
+    assert_eq!(tab.matches("{tab_box_classes}").count(), 2);
     assert!(!tab.contains("width:200px"));
     assert!(!tab.contains("flex:0 0"));
     assert!(tab.contains("before:-left-2"));
@@ -115,6 +115,29 @@ fn layout_page_gates_header_and_side_sheet_until_host_state_arrives() {
     assert!(source.contains("let chrome_ready = layout_chrome_ready"));
     assert!(source.contains("if chrome_ready && state.side_sheet_open"));
     assert!(source.contains("if chrome_ready && state.header_visible()"));
+}
+
+#[test]
+fn header_url_row_uses_glass_instead_of_page_bg_color() {
+    let source = include_str!("../src/page.rs");
+    let url_row = source
+        .split("fn url_row_cef")
+        .nth(1)
+        .and_then(|rest| rest.split("#[component]\nfn HeaderAddressBar").next())
+        .expect("url row helper");
+
+    assert!(url_row.contains("bg-glass"));
+    assert!(!url_row.contains("bg-[var(--vmux-url-bg)]"));
+    assert!(!url_row.contains("--vmux-url-bg:{color};"));
+}
+
+#[test]
+fn active_tab_uses_glass_instead_of_page_bg_color() {
+    let tab = tab_component_source();
+
+    assert!(tab.contains("glass rounded-t-md"));
+    assert!(!tab.contains("bg-[var(--tab-bg)]"));
+    assert!(!tab.contains("--tab-bg:{color};"));
 }
 
 #[test]

--- a/crates/vmux_server/assets/index.css
+++ b/crates/vmux_server/assets/index.css
@@ -100,10 +100,10 @@
     --foreground: oklch(1 0 0);
     --muted-foreground: oklch(0.82 0 0);
     --sidebar-primary-foreground: oklch(1 0 0);
-    --glass: oklch(0.36 0 0 / 0.82);
-    --glass-hover: oklch(0.44 0 0 / 0.86);
-    --glass-active: oklch(0.50 0 0 / 0.90);
-    --glass-border: oklch(0.52 0 0 / 0.36);
+    --glass: oklch(0.18 0 0 / 0.82);
+    --glass-hover: oklch(1 0 0 / 0.08);
+    --glass-active: oklch(1 0 0 / 0.14);
+    --glass-border: oklch(1 0 0 / 0.20);
   }
 }
 

--- a/crates/vmux_service/src/paths.rs
+++ b/crates/vmux_service/src/paths.rs
@@ -62,14 +62,32 @@ pub fn plist_path(profile: &str) -> PathBuf {
 /// (where it points to the daemon binary alongside them) so identity checks
 /// agree on the same target file.
 pub fn daemon_binary_path() -> std::io::Result<PathBuf> {
-    let mut p = std::env::current_exe()?;
-    if p.file_name().and_then(|n| n.to_str()) == Some("vmux_service") {
-        Ok(p)
-    } else {
-        p.pop();
-        p.push("vmux_service");
-        Ok(p)
+    Ok(daemon_binary_path_for_exe(&std::env::current_exe()?))
+}
+
+fn daemon_binary_path_for_exe(exe: &Path) -> PathBuf {
+    if matches!(
+        exe.file_name().and_then(|n| n.to_str()),
+        Some("vmux_service" | "Vmux Service")
+    ) {
+        return exe.to_path_buf();
     }
+
+    if let Some(root) = crate::bundle::bundle_root_for(exe) {
+        return root
+            .join("Contents")
+            .join("Library")
+            .join("LoginItems")
+            .join("Vmux Service.app")
+            .join("Contents")
+            .join("MacOS")
+            .join("Vmux Service");
+    }
+
+    let mut p = exe.to_path_buf();
+    p.pop();
+    p.push("vmux_service");
+    p
 }
 
 /// Identity for the daemon binary. Changes when the binary path, size,
@@ -126,6 +144,37 @@ mod tests {
         let _ = std::fs::remove_file(&path);
 
         assert_ne!(old_identity, new_identity);
+    }
+
+    #[test]
+    fn bundled_main_app_resolves_named_service_app_executable() {
+        let exe = PathBuf::from("/Applications/Vmux.app/Contents/MacOS/Vmux");
+
+        assert_eq!(
+            daemon_binary_path_for_exe(&exe),
+            PathBuf::from(
+                "/Applications/Vmux.app/Contents/Library/LoginItems/Vmux Service.app/Contents/MacOS/Vmux Service"
+            )
+        );
+    }
+
+    #[test]
+    fn bundled_service_app_resolves_to_self() {
+        let exe = PathBuf::from(
+            "/Applications/Vmux.app/Contents/Library/LoginItems/Vmux Service.app/Contents/MacOS/Vmux Service",
+        );
+
+        assert_eq!(daemon_binary_path_for_exe(&exe), exe);
+    }
+
+    #[test]
+    fn unbundled_debug_app_resolves_legacy_service_binary() {
+        let exe = PathBuf::from("/Users/x/repo/target/debug/vmux_desktop");
+
+        assert_eq!(
+            daemon_binary_path_for_exe(&exe),
+            PathBuf::from("/Users/x/repo/target/debug/vmux_service")
+        );
     }
 
     #[test]

--- a/crates/vmux_service/tests/bundle_detection.rs
+++ b/crates/vmux_service/tests/bundle_detection.rs
@@ -3,7 +3,7 @@ use vmux_service::bundle;
 
 #[test]
 fn detects_bundled_when_exe_inside_app_macos() {
-    let exe = PathBuf::from("/Applications/Vmux.app/Contents/MacOS/vmux_desktop");
+    let exe = PathBuf::from("/Applications/Vmux.app/Contents/MacOS/Vmux");
     assert!(bundle::is_bundled_path(&exe));
 }
 
@@ -15,7 +15,7 @@ fn detects_not_bundled_when_target_debug() {
 
 #[test]
 fn bundle_root_resolves_app_path() {
-    let exe = PathBuf::from("/Applications/Vmux.app/Contents/MacOS/vmux_desktop");
+    let exe = PathBuf::from("/Applications/Vmux.app/Contents/MacOS/Vmux");
     assert_eq!(
         bundle::bundle_root_for(&exe).unwrap(),
         PathBuf::from("/Applications/Vmux.app")

--- a/crates/vmux_service/tests/embedded_plist.rs
+++ b/crates/vmux_service/tests/embedded_plist.rs
@@ -6,8 +6,8 @@ fn embedded_plist_uses_bundle_program_relative_path() {
         "embedded plist must use BundleProgram, not ProgramArguments"
     );
     assert!(
-        xml.contains("Contents/MacOS/vmux_service"),
-        "BundleProgram path must be Contents/MacOS/vmux_service"
+        xml.contains("Contents/Library/LoginItems/Vmux Service.app/Contents/MacOS/Vmux Service"),
+        "BundleProgram path must point at the bundled Vmux Service.app executable"
     );
     assert!(
         !xml.contains("/usr/local/") && !xml.contains("$HOME"),
@@ -50,4 +50,15 @@ fn embedded_plist_associates_with_parent_bundle() {
         xml.contains("<string>ai.vmux.desktop</string>"),
         "AssociatedBundleIdentifiers must include the parent app bundle id ai.vmux.desktop"
     );
+}
+
+#[test]
+fn embed_script_creates_named_service_app_with_icon() {
+    let script = include_str!("../../../scripts/embed-launch-agent-plist.sh");
+    assert!(script.contains("Vmux Service.app"));
+    assert!(script.contains("CFBundleDisplayName"));
+    assert!(script.contains("CFBundleIconFile"));
+    assert!(script.contains("Vmux.icns"));
+    assert!(script.contains("Contents/MacOS/Vmux Service"));
+    assert!(script.contains("Contents/Resources/Vmux.icns"));
 }

--- a/crates/vmux_service/tests/registry_dispatch.rs
+++ b/crates/vmux_service/tests/registry_dispatch.rs
@@ -4,7 +4,9 @@ use vmux_service::registry::{Backend, choose_backend};
 
 #[test]
 fn bundled_path_chooses_sm_app_service() {
-    let exe = PathBuf::from("/Applications/Vmux.app/Contents/MacOS/vmux_service");
+    let exe = PathBuf::from(
+        "/Applications/Vmux.app/Contents/Library/LoginItems/Vmux Service.app/Contents/MacOS/Vmux Service",
+    );
     assert!(matches!(choose_backend(&exe), Backend::SmAppService { .. }));
 }
 

--- a/packaging/macos/Info.plist
+++ b/packaging/macos/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDisplayName</key>
 	<string>Vmux</string>
 	<key>CFBundleExecutable</key>
-	<string>vmux_desktop</string>
+	<string>Vmux</string>
 	<key>CFBundleIdentifier</key>
 	<string>ai.vmux.desktop</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/packaging/macos/ai.vmux.service.plist
+++ b/packaging/macos/ai.vmux.service.plist
@@ -5,7 +5,7 @@
   <key>Label</key>
   <string>ai.vmux.service</string>
   <key>BundleProgram</key>
-  <string>Contents/MacOS/vmux_service</string>
+  <string>Contents/Library/LoginItems/Vmux Service.app/Contents/MacOS/Vmux Service</string>
   <key>AssociatedBundleIdentifiers</key>
   <array>
     <string>ai.vmux.desktop</string>

--- a/patches/bevy_cef-0.5.2/src/webview.rs
+++ b/patches/bevy_cef-0.5.2/src/webview.rs
@@ -2,8 +2,8 @@ use crate::cef_state::WebviewCefStateSender;
 use crate::common::localhost::responser::{InlineHtmlId, InlineHtmlStore};
 use crate::common::{
     BinIpcEventRawSender, HostWindow, IpcEventRawSender, ResolvedWebviewUri, WebviewMaxFrameRate,
-    WebviewNativeLiquidGlass, WebviewOpaqueWindowedBackground, WebviewSize, WebviewSource,
-    WebviewTransparent, WebviewWindowed, WebviewWindowedNativeFocus,
+    WebviewNativeLiquidGlass, WebviewNativeOverlay, WebviewOpaqueWindowedBackground, WebviewSize,
+    WebviewSource, WebviewTransparent, WebviewWindowed, WebviewWindowedNativeFocus,
 };
 use crate::cursor_icon::SystemCursorIconSender;
 use crate::loading_state::{WebviewCommittedNavigationSender, WebviewLoadingStateSender};
@@ -277,6 +277,7 @@ fn create_webview(
             Has<WebviewNativeLiquidGlass>,
             Has<WebviewOpaqueWindowedBackground>,
             Has<WebviewWindowedNativeFocus>,
+            Has<WebviewNativeOverlay>,
         ),
         With<ResolvedWebviewUri>,
     >,
@@ -296,6 +297,7 @@ fn create_webview(
             native_liquid_glass,
             opaque_windowed_background,
             windowed_native_focus,
+            native_overlay,
         ) in
             webviews.iter()
         {
@@ -355,6 +357,11 @@ fn create_webview(
                 },
                 windowless_frame_rate,
                 windowed,
+                // Transparent OSR webviews that render to a Bevy mesh (not a native overlay) must use
+                // CPU paint: the accelerated shared-texture path blits transparent surfaces to black
+                // on the mesh. The layout is the only such case (transparent + mesh in player mode);
+                // it routes through the native overlay (accelerated) in user mode.
+                !transparent || native_overlay,
                 native_liquid_glass,
                 windowed && windowed_native_focus,
             );

--- a/patches/bevy_cef-0.5.2/src/webview/accelerated_upload.rs
+++ b/patches/bevy_cef-0.5.2/src/webview/accelerated_upload.rs
@@ -74,8 +74,8 @@ fn queue_accelerated_uploads(
         }
     }
     for (webview, mut frame) in latest {
-        // Native-overlay webviews don't blit to a Bevy texture; hand the newest frame to the overlay.
-        if overlay_webviews.contains(webview) {
+        let overlay = overlay_webviews.contains(webview);
+        if overlay {
             if let Ok(mut overlay) = overlay_frames.0.lock() {
                 overlay.insert(webview, frame);
             }
@@ -116,10 +116,21 @@ fn extract_accelerated_uploads(
     main: Extract<Res<WebviewAcceleratedQueue>>,
     mut extracted: ResMut<ExtractedAcceleratedUploads>,
 ) {
-    extracted.0.clear();
     if let Ok(mut pending) = main.0.lock() {
         extracted.0.append(&mut pending);
     }
+    coalesce_pending_accelerated_uploads(&mut extracted.0);
+}
+
+fn coalesce_pending_accelerated_uploads(uploads: &mut Vec<PendingAcceleratedUpload>) {
+    if uploads.len() < 2 {
+        return;
+    }
+    let mut latest = HashMap::new();
+    for upload in uploads.drain(..) {
+        latest.insert(upload.frame.webview, upload);
+    }
+    uploads.extend(latest.into_values());
 }
 
 fn upload_accelerated_textures(
@@ -128,16 +139,20 @@ fn upload_accelerated_textures(
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
 ) {
-    for upload in extracted.0.drain(..) {
-        let PendingAcceleratedUpload { image, frame } = upload;
-        let Some(gpu) = gpu_images.get(image) else {
+    let uploads = std::mem::take(&mut extracted.0);
+    let mut retry = Vec::new();
+    for upload in uploads {
+        let Some(gpu) = gpu_images.get(upload.image) else {
+            retry.push(upload);
             continue;
         };
-        if gpu.texture_descriptor.size.width != frame.width
-            || gpu.texture_descriptor.size.height != frame.height
+        if gpu.texture_descriptor.size.width != upload.frame.width
+            || gpu.texture_descriptor.size.height != upload.frame.height
         {
+            retry.push(upload);
             continue;
         }
+        let PendingAcceleratedUpload { frame, .. } = upload;
         let AcceleratedFrame {
             handle,
             keepalive,
@@ -190,5 +205,35 @@ fn upload_accelerated_textures(
         render_queue.on_submitted_work_done(move || {
             drop((keepalive, src));
         });
+    }
+    if !retry.is_empty() {
+        extracted.0.extend(retry);
+        coalesce_pending_accelerated_uploads(&mut extracted.0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn accelerated_uploads_survive_gpu_asset_resize_lag() {
+        let source = include_str!("accelerated_upload.rs");
+        let extract = source
+            .split("fn extract_accelerated_uploads")
+            .nth(1)
+            .and_then(|tail| tail.split("fn upload_accelerated_textures").next())
+            .expect("extract system source");
+        let upload = source
+            .split("fn upload_accelerated_textures")
+            .nth(1)
+            .expect("upload system source");
+
+        assert!(
+            !extract.contains("extracted.0.clear();"),
+            "deferred accelerated uploads must survive extract frames"
+        );
+        assert!(
+            upload.contains("retry.push(upload);"),
+            "GPU-size misses must retry instead of dropping one-shot frames"
+        );
     }
 }

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
@@ -145,6 +145,8 @@ impl Browsers {
         allow_native_focus: bool,
     ) {
         let _ = native_liquid_glass;
+        // Only consumed by the macOS windowless window-info below; non-macOS OSR is CPU-only.
+        let _ = shared_texture;
         let windowless_frame_rate = normalize_windowless_frame_rate(windowless_frame_rate);
         info!(
             "cef_create_browser webview={webview:?} uri={_uri} size={}x{} scale={device_scale_factor} windowed={windowed} bg={background_color:?} fps={windowless_frame_rate} native_liquid_glass={native_liquid_glass} allow_native_focus={allow_native_focus}",

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
@@ -140,11 +140,16 @@ impl Browsers {
         background_color: Option<u32>,
         windowless_frame_rate: i32,
         windowed: bool,
+        shared_texture: bool,
         native_liquid_glass: bool,
         allow_native_focus: bool,
     ) {
         let _ = native_liquid_glass;
         let windowless_frame_rate = normalize_windowless_frame_rate(windowless_frame_rate);
+        info!(
+            "cef_create_browser webview={webview:?} uri={_uri} size={}x{} scale={device_scale_factor} windowed={windowed} bg={background_color:?} fps={windowless_frame_rate} native_liquid_glass={native_liquid_glass} allow_native_focus={allow_native_focus}",
+            webview_size.x, webview_size.y
+        );
         webview_debug_log(format!(
             "Browsers::create_browser entity={webview:?} uri={_uri} size={webview_size:?} scale={device_scale_factor} disk_profile={} bg={background_color:?} fps={windowless_frame_rate} allow_native_focus={allow_native_focus}",
             disk_profile_root.is_some_and(|s| !s.trim().is_empty())
@@ -251,7 +256,7 @@ impl Browsers {
                     windowless_rendering_enabled: true as _,
                     external_begin_frame_enabled: false as _,
                     parent_view: parent,
-                    shared_texture_enabled: true as _,
+                    shared_texture_enabled: shared_texture as _,
                     ..Default::default()
                 }
             }
@@ -647,7 +652,8 @@ impl Browsers {
         let frame = view.frame();
         let hidden = view.isHidden();
         let glass = NSGlassEffectView::new(mtm);
-        glass.setStyle(NSGlassEffectViewStyle::Regular);
+        glass.setStyle(NSGlassEffectViewStyle::Clear);
+        glass.setTintColor(Some(&NSColor::clearColor()));
         let glass_view: &NSView = glass.as_super();
         Self::make_view_tree_transparent(glass_view, &clear_color);
         glass_view.setFrame(frame);
@@ -693,6 +699,23 @@ impl Browsers {
         for i in 0..sublayers.count() {
             let child = sublayers.objectAtIndex(i);
             Self::make_layer_tree_transparent(&child, clear_color);
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn refresh_windowed_transparency(browser: &WebviewBrowser, view: &objc2_app_kit::NSView) {
+        use objc2::ClassType;
+        if browser.native_liquid_glass.is_none() {
+            return;
+        }
+        let clear_color = objc2_app_kit::NSColor::clearColor();
+        Self::make_view_tree_transparent(view, &clear_color);
+        if let Some(glass_view) = browser
+            .native_liquid_glass
+            .as_ref()
+            .map(|glass| glass.as_super())
+        {
+            Self::make_view_tree_transparent(glass_view, &clear_color);
         }
     }
 
@@ -757,6 +780,7 @@ impl Browsers {
             (parent_h - top_px as f64 / s - h).max(0.0)
         };
         let frame = (x, y, w, h);
+        Self::refresh_windowed_transparency(browser, view);
         if browser.last_frame.get() == Some(frame) {
             return;
         }
@@ -768,11 +792,7 @@ impl Browsers {
         } else {
             view.setFrame(rect);
         }
-        let clear_color = objc2_app_kit::NSColor::clearColor();
-        Self::make_view_tree_transparent(view, &clear_color);
-        if let Some(glass_view) = glass_view {
-            Self::make_view_tree_transparent(glass_view, &clear_color);
-        }
+        Self::refresh_windowed_transparency(browser, view);
         browser.host.was_resized();
     }
 
@@ -967,6 +987,7 @@ impl Browsers {
         if let Some(glass) = &browser.native_liquid_glass {
             view.setFrame(glass.as_super().bounds());
         }
+        Self::refresh_windowed_transparency(browser, view);
         browser.host.was_resized();
         browser.last_frame.set(None);
         true
@@ -982,6 +1003,10 @@ impl Browsers {
     /// The browser will be removed from the hash map after closing.
     pub fn close(&mut self, webview: &Entity) {
         if let Some(browser) = self.browsers.remove(webview) {
+            info!(
+                "cef_close_browser webview={webview:?} windowed={}",
+                browser.windowed
+            );
             #[cfg(target_os = "macos")]
             {
                 use objc2::ClassType;
@@ -1621,9 +1646,28 @@ mod tests {
             })
             .unwrap_or_default();
 
-        assert!(create_fn.contains("NSGlassEffectViewStyle::Regular"));
+        assert!(create_fn.contains("NSGlassEffectViewStyle::Clear"));
+        assert!(!create_fn.contains("NSGlassEffectViewStyle::Regular"));
         assert!(create_fn.contains("glass.setContentView(Some(view))"));
         assert!(create_fn.contains("view.setFrame(glass_view.bounds())"));
+    }
+
+    #[test]
+    fn native_liquid_glass_uses_clear_tint() {
+        let implementation = include_str!("browsers.rs")
+            .split("#[cfg(test)]\nmod tests")
+            .next()
+            .unwrap_or_default();
+        let create_fn = implementation
+            .split("fn create_native_liquid_glass")
+            .nth(1)
+            .and_then(|tail| {
+                tail.split("#[cfg(target_os = \"macos\")]\n    pub fn set_windowed_frame")
+                    .next()
+            })
+            .unwrap_or_default();
+
+        assert!(create_fn.contains("glass.setTintColor(Some(&NSColor::clearColor()))"));
     }
 
     #[test]
@@ -1662,6 +1706,48 @@ mod tests {
         assert!(implementation.contains("for i in 0..sublayers.count()"));
         assert!(implementation.contains("let child = sublayers.objectAtIndex(i)"));
         assert!(implementation.contains("Self::make_layer_tree_transparent(&child, clear_color)"));
+    }
+
+    #[test]
+    fn windowed_frame_refreshes_transparency_before_same_frame_return() {
+        let implementation = include_str!("browsers.rs")
+            .split("#[cfg(test)]\nmod tests")
+            .next()
+            .unwrap_or_default();
+        let set_frame_fn = implementation
+            .split("#[cfg(target_os = \"macos\")]\n    pub fn set_windowed_frame")
+            .nth(1)
+            .and_then(|tail| {
+                tail.split("#[cfg(not(target_os = \"macos\"))]\n    pub fn set_windowed_frame")
+                    .next()
+            })
+            .unwrap_or_default();
+        let refresh_idx = set_frame_fn
+            .find("Self::refresh_windowed_transparency")
+            .expect("windowed transparency refresh");
+        let cache_idx = set_frame_fn
+            .find("browser.last_frame.get() == Some(frame)")
+            .expect("same frame cache check");
+
+        assert!(refresh_idx < cache_idx);
+    }
+
+    #[test]
+    fn windowed_repaint_nudge_refreshes_transparency() {
+        let implementation = include_str!("browsers.rs")
+            .split("#[cfg(test)]\nmod tests")
+            .next()
+            .unwrap_or_default();
+        let nudge_fn = implementation
+            .split("#[cfg(target_os = \"macos\")]\n    pub fn nudge_windowed_repaint")
+            .nth(1)
+            .and_then(|tail| {
+                tail.split("#[cfg(not(target_os = \"macos\"))]\n    pub fn nudge_windowed_repaint")
+                    .next()
+            })
+            .unwrap_or_default();
+
+        assert!(nudge_fn.contains("Self::refresh_windowed_transparency"));
     }
 
     #[test]

--- a/scripts/build-package-binaries.sh
+++ b/scripts/build-package-binaries.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$ROOT"
+env -u CEF_PATH cargo build -p vmux_desktop -p vmux_cli -p vmux_service -p bevy_cef_debug_render_process --release
+cp -f target/release/vmux_desktop target/release/Vmux
+cp -f target/release/vmux_service "target/release/Vmux Service"

--- a/scripts/embed-launch-agent-plist.sh
+++ b/scripts/embed-launch-agent-plist.sh
@@ -12,6 +12,12 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 PLIST_SRC="$ROOT/packaging/macos/ai.vmux.service.plist"
 PLIST_DST="$VMUX_APP_BUNDLE/Contents/Library/LaunchAgents/ai.vmux.service.plist"
+SERVICE_APP="$VMUX_APP_BUNDLE/Contents/Library/LoginItems/Vmux Service.app"
+SERVICE_SRC="$VMUX_APP_BUNDLE/Contents/MacOS/Vmux Service"
+SERVICE_EXEC="$SERVICE_APP/Contents/MacOS/Vmux Service"
+SERVICE_INFO="$SERVICE_APP/Contents/Info.plist"
+SERVICE_ICON="$SERVICE_APP/Contents/Resources/Vmux.icns"
+PARENT_BUNDLE_ID="${VMUX_BUNDLE_ID:-ai.vmux.desktop}"
 
 LABEL="ai.vmux.service"
 if [[ "$VMUX_BUILD_PROFILE" == "local" ]]; then
@@ -19,8 +25,45 @@ if [[ "$VMUX_BUILD_PROFILE" == "local" ]]; then
     LABEL="ai.vmux.service.$VMUX_GIT_HASH"
 fi
 
+mkdir -p "$SERVICE_APP/Contents/MacOS" "$SERVICE_APP/Contents/Resources"
+if [[ -f "$SERVICE_SRC" ]]; then
+    mv -f "$SERVICE_SRC" "$SERVICE_EXEC"
+elif [[ ! -f "$SERVICE_EXEC" ]]; then
+    echo "Missing service executable: $SERVICE_SRC" >&2
+    exit 1
+fi
+
+cp -f "$ROOT/packaging/macos/Vmux.icns" "$SERVICE_ICON"
+cat > "$SERVICE_INFO" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleDisplayName</key>
+  <string>Vmux Service</string>
+  <key>CFBundleExecutable</key>
+  <string>Vmux Service</string>
+  <key>CFBundleIdentifier</key>
+  <string>$LABEL</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>Vmux Service</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleIconFile</key>
+  <string>Vmux</string>
+  <key>LSUIElement</key>
+  <true/>
+</dict>
+</plist>
+EOF
+
 mkdir -p "$(dirname "$PLIST_DST")"
 sed -e "s|{{PROFILE}}|$VMUX_BUILD_PROFILE|g" \
     -e "s|<string>ai.vmux.service</string>|<string>$LABEL</string>|" \
+    -e "s|<string>ai.vmux.desktop</string>|<string>$PARENT_BUNDLE_ID</string>|" \
     "$PLIST_SRC" > "$PLIST_DST"
 echo "==> Embedded launchd plist (label=$LABEL, profile=$VMUX_BUILD_PROFILE)"

--- a/scripts/inject-cef.sh
+++ b/scripts/inject-cef.sh
@@ -17,6 +17,7 @@ unset CEF_PATH
 
 APP_BUNDLE="${VMUX_APP_BUNDLE:-${ROOT}/target/release/Vmux.app}"
 BUNDLE_ID_BASE="${VMUX_BUNDLE_ID:-ai.vmux.desktop}"
+CEF_FRAMEWORK="${CEF_FRAMEWORK:-${HOME}/.local/share/Chromium Embedded Framework.framework}"
 HELPER_BIN="${ROOT}/target/release/bevy_cef_debug_render_process"
 
 if [[ ! -d "$APP_BUNDLE" ]]; then
@@ -43,13 +44,33 @@ if [[ ! -f "$HELPER_BIN" ]]; then
 fi
 
 echo "==> inject-cef: running bevy_cef_bundle_app"
-bevy_cef_bundle_app --app "$APP_BUNDLE" --bundle-id-base "$BUNDLE_ID_BASE" --helper-bin "$HELPER_BIN" --no-sign
+bevy_cef_bundle_app --app "$APP_BUNDLE" --bundle-id-base "$BUNDLE_ID_BASE" --bin-name Vmux --cef-framework "$CEF_FRAMEWORK" --helper-bin "$HELPER_BIN" --no-sign
 
 # Copy app icon (cargo-packager handles this via icons config, but ensure it's there)
 ICNS_SRC="$ROOT/packaging/macos/Vmux.icns"
 if [[ -f "$ICNS_SRC" && ! -f "$APP_BUNDLE/Contents/Resources/Vmux.icns" ]]; then
     mkdir -p "$APP_BUNDLE/Contents/Resources"
     cp -f "$ICNS_SRC" "$APP_BUNDLE/Contents/Resources/Vmux.icns"
+fi
+
+if [[ -f "$ICNS_SRC" ]]; then
+    CEF_HELPER_APPS=(
+        "Vmux Helper.app"
+        "Vmux Helper (GPU).app"
+        "Vmux Helper (Renderer).app"
+        "Vmux Helper (Plugin).app"
+        "Vmux Helper (Alerts).app"
+    )
+    for helper_name in "${CEF_HELPER_APPS[@]}"; do
+        helper_app="$APP_BUNDLE/Contents/Frameworks/$helper_name"
+        [[ -d "$helper_app" ]] || continue
+        mkdir -p "$helper_app/Contents/Resources"
+        cp -f "$ICNS_SRC" "$helper_app/Contents/Resources/Vmux.icns"
+        plist="$helper_app/Contents/Info.plist"
+        [[ -f "$plist" ]] || continue
+        /usr/libexec/PlistBuddy -c "Set :CFBundleIconFile Vmux" "$plist" 2>/dev/null \
+            || /usr/libexec/PlistBuddy -c "Add :CFBundleIconFile string Vmux" "$plist"
+    done
 fi
 
 echo "==> inject-cef: done"

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -46,6 +46,7 @@ esac
 aux_identifier() {
     local name="$1"
     case "$name" in
+        "Vmux Service") printf 'ai.vmux.service%s' "$IDENT_SUFFIX" ;;
         vmux_service) printf 'ai.vmux.service%s' "$IDENT_SUFFIX" ;;
         vmux)         printf 'ai.vmux.cli%s'     "$IDENT_SUFFIX" ;;
         *)            printf 'ai.vmux.%s%s' "$name" "$IDENT_SUFFIX" ;;
@@ -93,8 +94,13 @@ if [ -d "$APP_BUNDLE/Contents/Frameworks/Chromium Embedded Framework.framework" 
         "$APP_BUNDLE/Contents/Frameworks/Chromium Embedded Framework.framework"
 fi
 
-# Sign all CEF Helper app bundles
-find "$APP_BUNDLE/Contents/Frameworks" -name "*.app" -type d | while read -r helper; do
+NESTED_APP_DIRS=("$APP_BUNDLE/Contents/Frameworks")
+if [[ -d "$APP_BUNDLE/Contents/Library" ]]; then
+    NESTED_APP_DIRS+=("$APP_BUNDLE/Contents/Library")
+fi
+
+# Sign all CEF and service helper app bundles
+find "${NESTED_APP_DIRS[@]}" -name "*.app" -type d | while read -r helper; do
     echo "  Signing: ${helper#$APP_BUNDLE/}"
     codesign --force --verify --verbose \
         ${CODESIGN_KEYCHAIN_ARGS[@]+"${CODESIGN_KEYCHAIN_ARGS[@]}"} \

--- a/scripts/test-bundle-layout.sh
+++ b/scripts/test-bundle-layout.sh
@@ -4,9 +4,13 @@ set -euo pipefail
 APP="${1:?usage: $0 <path-to-Vmux.app>}"
 
 REQUIRED=(
-    "Contents/MacOS/vmux_desktop"
+    "Contents/MacOS/Vmux"
     "Contents/MacOS/vmux"
-    "Contents/MacOS/vmux_service"
+    "Contents/Frameworks/Vmux Helper.app/Contents/MacOS/Vmux Helper"
+    "Contents/Frameworks/Vmux Helper.app/Contents/Resources/Vmux.icns"
+    "Contents/Frameworks/Vmux Helper (Renderer).app/Contents/MacOS/Vmux Helper (Renderer)"
+    "Contents/Library/LoginItems/Vmux Service.app/Contents/MacOS/Vmux Service"
+    "Contents/Library/LoginItems/Vmux Service.app/Contents/Resources/Vmux.icns"
     "Contents/Library/LaunchAgents/ai.vmux.service.plist"
     "Contents/Info.plist"
     "Contents/Resources/Vmux.icns"
@@ -23,5 +27,18 @@ if grep -q '{{PROFILE}}' "$APP/Contents/Library/LaunchAgents/ai.vmux.service.pli
     echo "Plist still has {{PROFILE}} placeholder — substitution did not run" >&2
     exit 1
 fi
+
+FORBIDDEN=(
+    "Contents/MacOS/vmux_desktop"
+    "Contents/MacOS/vmux_service"
+    "Contents/Frameworks/vmux_desktop Helper.app"
+)
+
+for path in "${FORBIDDEN[@]}"; do
+    if [[ -e "$APP/$path" ]]; then
+        echo "FORBIDDEN: $APP/$path" >&2
+        exit 1
+    fi
+done
 
 echo "OK: bundle layout correct"

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.10",
-  "pub_date": "2026-05-21T01:04:26Z",
+  "version": "v0.0.11",
+  "pub_date": "2026-06-07T14:29:50Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.10/Vmux-v0.0.10-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzYwOVE1R1RWQk80Uk1pM3IzRituVHdCQ2h2NjNRQU5ncytpenpUVnd1TEY3RE9HUnl6dTYxMmRpR0ZRWWFDRThobFEzZzJoVjFFVzdlK0FJZEZCTEFnPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzc5MzI1MjUzCWZpbGU6Vm11eC12MC4wLjEwLWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKbVdOR3p3UERTM1FSL2ZnMUp1d3VMREMvTVJzOWVSQlVBT3FPN0pwYmJDdktCQ1A4TW5abFpiaVRjb0lUcjlUOUwxN1FFenpreWpRTmZwQkg2WDVyQkE9PQo=",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.11/Vmux-v0.0.11-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTytKM1BOSVJpakRXaExablJCb3FTOWliUUd0bFJyWnZYYUVTZWM1cit3cFZRUElISW9CUHR0cFk4TmQ3SEdtTTJ1ekd4b2J6MHFJaURYYXhMSytpRHdBPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgwODQxOTc1CWZpbGU6Vm11eC12MC4wLjExLWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKY1dwUXh4SFZhWDNzdWEvMkpXV01TUFdnUXFvcWJsMXgwckNmRDNxMGtlNXBSOHhRaHFINWV4NzBWSVdnTGF6Y3FLYVpWU2drUm81RE5iU08rcSttQ0E9PQo=",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.10/Vmux_0.0.10_aarch64.dmg",
-      "filename": "Vmux_0.0.10_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.11/Vmux_0.0.11_aarch64.dmg",
+      "filename": "Vmux_0.0.11_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
Patch release. Bumps workspace version 0.0.10 -> 0.0.11. Includes a startup chrome fix that keeps the header and side sheet hidden until their initial host state arrives, avoiding the brief flash on app load.