### PR TITLE
chore(release): v0.0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9396,7 +9396,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9427,7 +9427,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_browser"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9448,7 +9448,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -9460,7 +9460,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9475,7 +9475,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9490,7 +9490,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9538,7 +9538,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9559,7 +9559,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -9593,7 +9593,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "muda",
  "proc-macro2",
@@ -9603,7 +9603,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "serde",
  "serde_json",
@@ -9615,7 +9615,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_server"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "dioxus",
  "regex",
@@ -9634,7 +9634,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "alacritty_terminal",
  "bevy",
@@ -9663,7 +9663,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9686,7 +9686,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9711,7 +9711,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9740,7 +9740,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "dioxus",
  "dioxus-primitives",
@@ -9757,7 +9757,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_vibe_setup"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "bevy",
  "bevy_cef",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.11"
+version = "0.0.12"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "MIT"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.11"
-  sha256 "03beb6b7e8f60a64a50c7db5a82e54431d865cacc0f53e20dfbf0e5ee9e719d3"
+  version "0.0.12"
+  sha256 "b3b0b958a37305130d28f73e127b0fe7f258707498af38b0c110b60c28f9d29f"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.11/Vmux_0.0.11_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.12/Vmux_0.0.12_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai"

--- a/crates/vmux_service/src/registry.rs
+++ b/crates/vmux_service/src/registry.rs
@@ -51,6 +51,11 @@ pub fn ensure_running(profile: &str, exe: &Path) -> Result<(), RegistrationError
                 if let Err(e) = crate::sm_app_service::unregister_main_app() {
                     tracing::debug!(error = %e, "unregister main app login item (ignored)");
                 }
+                if let Err(e) =
+                    crate::sm_app_service::unregister_agent(bundle::EMBEDDED_AGENT_PLIST)
+                {
+                    tracing::debug!(error = %e, "unregister embedded agent (ignored)");
+                }
                 crate::sm_app_service::register_agent(bundle::EMBEDDED_AGENT_PLIST)?;
                 crate::launchd::kickstart(bundle::EMBEDDED_AGENT_LABEL)?;
                 Ok(())

--- a/crates/vmux_service/tests/registry_dispatch.rs
+++ b/crates/vmux_service/tests/registry_dispatch.rs
@@ -26,6 +26,22 @@ fn ensure_running_calls_legacy_cleanup_for_sm_app_service_path() {
 }
 
 #[test]
+fn ensure_running_replaces_embedded_agent_registration() {
+    let source = include_str!("../src/registry.rs");
+    let unregister = source
+        .find("unregister_agent(bundle::EMBEDDED_AGENT_PLIST)")
+        .expect("SmAppService branch must unregister the embedded agent before re-registering it");
+    let register = source
+        .find("register_agent(bundle::EMBEDDED_AGENT_PLIST)")
+        .expect("SmAppService branch must register the embedded agent");
+
+    assert!(
+        unregister < register,
+        "SmAppService branch must replace stale embedded agent registrations before kickstart"
+    );
+}
+
+#[test]
 fn ensure_running_kickstarts_after_register_for_sm_app_service_path() {
     let source = include_str!("../src/registry.rs");
     assert!(

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.11",
-  "pub_date": "2026-06-07T14:29:50Z",
+  "version": "v0.0.12",
+  "pub_date": "2026-06-07T19:20:49Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.11/Vmux-v0.0.11-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTytKM1BOSVJpakRXaExablJCb3FTOWliUUd0bFJyWnZYYUVTZWM1cit3cFZRUElISW9CUHR0cFk4TmQ3SEdtTTJ1ekd4b2J6MHFJaURYYXhMSytpRHdBPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgwODQxOTc1CWZpbGU6Vm11eC12MC4wLjExLWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKY1dwUXh4SFZhWDNzdWEvMkpXV01TUFdnUXFvcWJsMXgwckNmRDNxMGtlNXBSOHhRaHFINWV4NzBWSVdnTGF6Y3FLYVpWU2drUm81RE5iU08rcSttQ0E9PQo=",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.12/Vmux-v0.0.12-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzZLVHFlTStMcTg2U08yRkJlUVlENjd4TG5EWk13UjlUNUVaNmtHQ1NTZy9aempjOGtzUDcrT2NzOE8yZGNQZGtyUVlUSk5VSHNnMmQ3cFVFb0JvblFBPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgwODU3NTI1CWZpbGU6Vm11eC12MC4wLjEyLWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKUFpLcTZtSFBtMlQ2Rlp4V1ZrLzZtUjAyQ2ZkdjdyY0o1a2tSc3M5cFhFSVFXRVAwTFFzYVh5bDZ3VXFEWkI4L0dCWVJFNkxOSXh0ajY4KzlzOSswQWc9PQo=",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.11/Vmux_0.0.11_aarch64.dmg",
-      "filename": "Vmux_0.0.11_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.12/Vmux_0.0.12_aarch64.dmg",
+      "filename": "Vmux_0.0.12_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
## Context
Vmux 0.0.11 can fail to start on machines with stale macOS SMAppService state. macOS may keep an existing ai.vmux.service registration pointing at the old Contents/MacOS/vmux_service path even after the new bundle installs the helper as Contents/Library/LoginItems/Vmux Service.app/Contents/MacOS/Vmux Service.

## Implementation
Bump the workspace to 0.0.12 and have the bundled service registration path unregister the embedded agent before registering it again, so launchd resolves the current bundled helper path. Add a regression test that enforces unregister-before-register ordering for the embedded agent.

## Checks / QA
Smoke-test install or upgrade to 0.0.12 on macOS, then launch Vmux and confirm the app opens and the vmux service helper starts from the bundled LoginItems path.