### PR TITLE
chore(release): v0.0.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ env:
   TAILWINDCSS_VERSION: "4.2.4"
   CEF_VERSION: "145.6.1+145.0.28"
   DIOXUS_CLI_VERSION: "0.7.4"
+  BINARYEN_VERSION: "127"
+  DX_HOME: ${{ github.workspace }}/.dx
 
 jobs:
   lint:
@@ -250,12 +252,21 @@ jobs:
           path: ~/.cargo/bin
           key: cargo-bin-${{ runner.os }}-dx${{ env.DIOXUS_CLI_VERSION }}-v3
 
+      - name: Cache binaryen
+        uses: actions/cache@v4
+        with:
+          path: .dx/tools/binaryen-${{ env.BINARYEN_VERSION }}
+          key: binaryen-${{ runner.os }}-${{ runner.arch }}-${{ env.BINARYEN_VERSION }}
+
       - name: Install dioxus-cli
         run: |
           if ! dx --version 2>/dev/null | grep -q "${{ env.DIOXUS_CLI_VERSION }}"; then
             cargo install dioxus-cli --locked --version "${{ env.DIOXUS_CLI_VERSION }}" --force
           fi
           dx --version
+
+      - name: Install binaryen
+        run: ./scripts/install-dioxus-binaryen.sh
 
       - name: Build website
         working-directory: website
@@ -326,6 +337,12 @@ jobs:
           path: ~/.cargo/bin
           key: cargo-bin-${{ runner.os }}-dx${{ env.DIOXUS_CLI_VERSION }}-cp0.11.8-cef${{ env.CEF_VERSION }}-v3
 
+      - name: Cache binaryen
+        uses: actions/cache@v4
+        with:
+          path: .dx/tools/binaryen-${{ env.BINARYEN_VERSION }}
+          key: binaryen-${{ runner.os }}-${{ runner.arch }}-${{ env.BINARYEN_VERSION }}
+
       - name: Cache CEF framework
         uses: actions/cache@v4
         with:
@@ -356,6 +373,9 @@ jobs:
             cargo install dioxus-cli --locked --version "${{ env.DIOXUS_CLI_VERSION }}" --force
           fi
           dx --version
+
+      - name: Install binaryen
+        run: ./scripts/install-dioxus-binaryen.sh
 
       - name: Install bevy_cef tools
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ env:
   CARGO_TERM_COLOR: always
   TAILWINDCSS_VERSION: "4.2.4"
   CEF_VERSION: "145.6.1+145.0.28"
+  DIOXUS_CLI_VERSION: "0.7.4"
 
 jobs:
   lint:
@@ -66,7 +67,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin
-          key: cargo-bin-${{ runner.os }}-dx0.7.4-cef${{ env.CEF_VERSION }}-v2
+          key: cargo-bin-${{ runner.os }}-dx${{ env.DIOXUS_CLI_VERSION }}-cef${{ env.CEF_VERSION }}-v3
 
       - name: Cache CEF framework
         uses: actions/cache@v4
@@ -104,9 +105,11 @@ jobs:
           fi
 
       - name: Install dioxus-cli
-        uses: taiki-e/install-action@v2
-        with:
-          tool: dioxus-cli@0.7.4
+        run: |
+          if ! dx --version 2>/dev/null | grep -q "${{ env.DIOXUS_CLI_VERSION }}"; then
+            cargo install dioxus-cli --locked --version "${{ env.DIOXUS_CLI_VERSION }}" --force
+          fi
+          dx --version
 
       - name: Install tailwindcss
         run: TAILWINDCSS_INSTALL_DIR="$HOME/.local/bin" ./scripts/install-tailwindcss.sh
@@ -160,7 +163,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin
-          key: cargo-bin-${{ runner.os }}-dx0.7.4-cef${{ env.CEF_VERSION }}-v2
+          key: cargo-bin-${{ runner.os }}-dx${{ env.DIOXUS_CLI_VERSION }}-cef${{ env.CEF_VERSION }}-v3
 
       - name: Cache CEF framework
         uses: actions/cache@v4
@@ -187,9 +190,11 @@ jobs:
           fi
 
       - name: Install dioxus-cli
-        uses: taiki-e/install-action@v2
-        with:
-          tool: dioxus-cli@0.7.4
+        run: |
+          if ! dx --version 2>/dev/null | grep -q "${{ env.DIOXUS_CLI_VERSION }}"; then
+            cargo install dioxus-cli --locked --version "${{ env.DIOXUS_CLI_VERSION }}" --force
+          fi
+          dx --version
 
       - name: Install tailwindcss
         run: TAILWINDCSS_INSTALL_DIR="$HOME/.local/bin" ./scripts/install-tailwindcss.sh
@@ -243,12 +248,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin
-          key: cargo-bin-${{ runner.os }}-dx0.7.4
+          key: cargo-bin-${{ runner.os }}-dx${{ env.DIOXUS_CLI_VERSION }}-v3
 
       - name: Install dioxus-cli
-        uses: taiki-e/install-action@v2
-        with:
-          tool: dioxus-cli@0.7.4
+        run: |
+          if ! dx --version 2>/dev/null | grep -q "${{ env.DIOXUS_CLI_VERSION }}"; then
+            cargo install dioxus-cli --locked --version "${{ env.DIOXUS_CLI_VERSION }}" --force
+          fi
+          dx --version
 
       - name: Build website
         working-directory: website
@@ -317,7 +324,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin
-          key: cargo-bin-${{ runner.os }}-dx0.7.4-cp0.11.8-cef${{ env.CEF_VERSION }}
+          key: cargo-bin-${{ runner.os }}-dx${{ env.DIOXUS_CLI_VERSION }}-cp0.11.8-cef${{ env.CEF_VERSION }}-v3
 
       - name: Cache CEF framework
         uses: actions/cache@v4
@@ -344,9 +351,11 @@ jobs:
           fi
 
       - name: Install dioxus-cli
-        uses: taiki-e/install-action@v2
-        with:
-          tool: dioxus-cli@0.7.4
+        run: |
+          if ! dx --version 2>/dev/null | grep -q "${{ env.DIOXUS_CLI_VERSION }}"; then
+            cargo install dioxus-cli --locked --version "${{ env.DIOXUS_CLI_VERSION }}" --force
+          fi
+          dx --version
 
       - name: Install bevy_cef tools
         run: |

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -21,6 +21,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   TAILWINDCSS_VERSION: "4.2.4"
+  BINARYEN_VERSION: "127"
+  DX_HOME: ${{ github.workspace }}/.dx
 
 jobs:
   deploy:
@@ -49,6 +51,12 @@ jobs:
           path: ~/.local/bin/tailwindcss
           key: tailwindcss-${{ runner.os }}-${{ env.TAILWINDCSS_VERSION }}
 
+      - name: Cache binaryen
+        uses: actions/cache@v4
+        with:
+          path: .dx/tools/binaryen-${{ env.BINARYEN_VERSION }}
+          key: binaryen-${{ runner.os }}-${{ runner.arch }}-${{ env.BINARYEN_VERSION }}
+
       - name: Add ~/.local/bin to PATH
         run: |
           mkdir -p "$HOME/.local/bin"
@@ -56,6 +64,9 @@ jobs:
 
       - name: Install dioxus-cli
         run: command -v dx >/dev/null 2>&1 || cargo install dioxus-cli --locked --version 0.7.4
+
+      - name: Install Binaryen
+        run: ./scripts/install-dioxus-binaryen.sh
 
       - name: Install Tailwind CSS
         run: TAILWINDCSS_INSTALL_DIR="$HOME/.local/bin" ./scripts/install-tailwindcss.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,39 +10,17 @@ Use superpower. Invoke relevant skills BEFORE any response or action. Even a 1% 
 
 ## Pre-commit Checks
 
-NEVER commit or push without running fmt + clippy + test on the Cargo workspace and confirming they pass.
+CI runs fmt, clippy, and tests for PRs.
 
-Run tests during the edit loop when they support TDD, debugging, or behavior verification. Do not run cargo fmt, cargo clippy, make lint, make lint-fix, or other formatting/linting checks during the edit loop unless the user explicitly asks for an early check.
-
-Fmt, clippy, and linter checks are final-gate checks only. Never run them for exploration, after partial edits, or as a mid-task sanity check. Run them only immediately before a commit, push, or PR, then fix any failures and re-run the workspace checks.
-
-Do not treat "edits are complete" or "task is complete" as permission to run final gates. Final gates require an active commit, push, PR creation, or an explicit user request for checks in the current turn. If no commit/push/PR is requested, stop after edits and report that checks were not run.
-
-```bash
-cargo fmt --all -- --check
-env -u CEF_PATH cargo clippy --workspace --exclude bevy_cef --exclude bevy_cef_core --exclude bevy_cef_debug_render_process --all-targets -- -D warnings
-env -u CEF_PATH cargo test --workspace --exclude bevy_cef --exclude bevy_cef_core --exclude bevy_cef_debug_render_process
-```
-
-Run `make setup-hooks` once to install the pre-push hook that runs these checks automatically.
+Run targeted tests during the edit loop when they support TDD, debugging, or behavior verification. Run broader local checks only when the user asks.
 
 If a change affects an excluded patched CEF crate, run the appropriate package checks too.
-
-The `website/` directory is its own cargo workspace (separate `Cargo.lock`). When `website/**` changes, run fmt + clippy from inside `website/` against `wasm32-unknown-unknown`:
-
-```bash
-cd website
-cargo fmt -- --check
-env -u CEF_PATH cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings
-```
-
-There is no host-runnable test target for `vmux_website` (it builds for `wasm32-unknown-unknown`); skip `cargo test` here unless wasm-bindgen-test is wired up.
 
 If any check fails, fix the issue before committing. Do not push broken code.
 
 ## Platform-Specific Code
 
-This project targets macOS (primary) and Linux (CI). When adding imports or code that uses platform-specific APIs (CEF, winit, AppKit), always add appropriate `#[cfg(...)]` gates. Let the final fmt gate reorder cfg-gated imports.
+This project targets macOS (primary) and Linux (CI). When adding imports or code that uses platform-specific APIs (CEF, winit, AppKit), always add appropriate `#[cfg(...)]` gates. Let rustfmt reorder cfg-gated imports.
 
 ## Rules
 
@@ -77,15 +55,3 @@ Worktree directory: `.worktrees/` (already in `.gitignore`).
 ## Git
 
 Always prefer `git rebase` over `git merge` when updating branches. Use `git push --force-with-lease` after rebasing.
-
-## Before Pushing / Opening PRs
-
-**Mandatory**: Run fmt + clippy + test on the Cargo workspace before every `git push` or PR creation. Do not push or open a PR if any check fails. Fix all errors first.
-
-These checks are final-gate checks. Finish edits first, then run them once immediately before push/PR/commit. Do not run fmt, clippy, or linter checks earlier in the task unless the user explicitly asks for an early check. Tests may run earlier when they support TDD, debugging, or behavior verification. If final gates fail, fix the issue and re-run the workspace checks.
-
-```sh
-make lint-fix  # auto-fix on every workspace package: runs fmt + clippy --fix
-```
-
-If formatting fails, run `make lint-fix` to auto-format, then re-run the workspace checks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9396,7 +9396,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9427,7 +9427,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_browser"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9448,7 +9448,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -9460,7 +9460,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9475,7 +9475,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9490,7 +9490,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9538,7 +9538,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9559,7 +9559,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -9593,7 +9593,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "muda",
  "proc-macro2",
@@ -9603,7 +9603,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -9615,7 +9615,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_server"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "dioxus",
  "regex",
@@ -9634,7 +9634,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "alacritty_terminal",
  "bevy",
@@ -9663,7 +9663,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9686,7 +9686,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9711,7 +9711,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9740,7 +9740,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "dioxus",
  "dioxus-primitives",
@@ -9757,7 +9757,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_vibe_setup"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "bevy",
  "bevy_cef",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.12"
+version = "0.0.13"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "MIT"

--- a/crates/build_git_env.rs
+++ b/crates/build_git_env.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 
 pub fn emit() {
     let hash = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
+        .args(["rev-parse", "--short=7", "HEAD"])
         .output()
         .ok()
         .filter(|o| o.status.success())

--- a/crates/vmux_command/src/command.rs
+++ b/crates/vmux_command/src/command.rs
@@ -143,12 +143,14 @@ pub enum BrowserNavigationCommand {
     #[menu(id = "browser_next_page", label = "Forward", accel = "super+]")]
     NextPage,
     #[menu(id = "browser_reload", label = "Reload", accel = "super+r")]
+    #[shortcut(direct = "Super+r")]
     Reload,
     #[menu(
         id = "browser_hard_reload",
         label = "Hard Reload",
         accel = "super+shift+r"
     )]
+    #[shortcut(direct = "Super+Shift+R")]
     HardReload,
     #[menu(id = "browser_stop", label = "Stop Loading", accel = "super+.", hidden)]
     Stop,
@@ -523,6 +525,37 @@ mod tests {
                 BrowserNavigationCommand::PrevPage
             )))
         ));
+    }
+
+    #[test]
+    fn browser_reload_has_direct_shortcut_for_native_webviews() {
+        let reload = Shortcut::Direct(KeyCombo {
+            key: KeyCode::KeyR,
+            modifiers: Modifiers {
+                super_key: true,
+                ..Default::default()
+            },
+        });
+        let hard_reload = Shortcut::Direct(KeyCombo {
+            key: KeyCode::KeyR,
+            modifiers: Modifiers {
+                shift: true,
+                super_key: true,
+                ..Default::default()
+            },
+        });
+        let shortcuts = AppCommand::default_shortcuts();
+
+        assert!(
+            shortcuts
+                .iter()
+                .any(|(shortcut, id)| shortcut == &reload && id == "browser_reload")
+        );
+        assert!(
+            shortcuts
+                .iter()
+                .any(|(shortcut, id)| shortcut == &hard_reload && id == "browser_hard_reload")
+        );
     }
 
     #[test]

--- a/crates/vmux_desktop/tests/release_invariants.rs
+++ b/crates/vmux_desktop/tests/release_invariants.rs
@@ -67,6 +67,14 @@ fn local_package_uses_per_sha_bundle_name() {
 }
 
 #[test]
+fn build_git_env_uses_github_style_short_hash() {
+    let source = include_str!("../../build_git_env.rs");
+
+    assert!(source.contains("\"--short=7\""));
+    assert!(!source.contains("\"--short\", \"HEAD\""));
+}
+
+#[test]
 fn local_package_only_builds_app_bundle() {
     let package_script = include_str!("../../../scripts/package.sh");
 

--- a/crates/vmux_macro/src/lib.rs
+++ b/crates/vmux_macro/src/lib.rs
@@ -344,7 +344,9 @@ mod tests {
             }
         };
 
-        impl_os_menu(input).expect("os menu should generate").to_string()
+        impl_os_menu(input)
+            .expect("os menu should generate")
+            .to_string()
     }
 
     #[test]
@@ -359,14 +361,19 @@ mod tests {
         assert!(tokens.contains("version : Some (about_version)"));
         assert!(tokens.contains("copyright : Some (:: std :: string :: String :: new ())"));
         assert!(!tokens.contains("short_version"));
-        assert!(tokens.contains(":: muda :: PredefinedMenuItem :: about (None , Some (about_metadata))"));
+        assert!(
+            tokens
+                .contains(":: muda :: PredefinedMenuItem :: about (None , Some (about_metadata))")
+        );
     }
 
     #[test]
     fn os_menu_release_about_metadata_omits_commit_hash() {
         let tokens = os_menu_tokens();
 
-        assert!(tokens.contains("\"release\" => format ! (\"v{}\" , env ! (\"CARGO_PKG_VERSION\"))"));
+        assert!(
+            tokens.contains("\"release\" => format ! (\"v{}\" , env ! (\"CARGO_PKG_VERSION\"))")
+        );
     }
 
     #[test]

--- a/crates/vmux_macro/src/lib.rs
+++ b/crates/vmux_macro/src/lib.rs
@@ -332,58 +332,6 @@ fn impl_os_menu(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     })
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn os_menu_tokens() -> String {
-        let input: DeriveInput = syn::parse_quote! {
-            enum SampleMenu {
-                #[menu(label = "Sample")]
-                Sample(SampleCommand),
-            }
-        };
-
-        impl_os_menu(input)
-            .expect("os menu should generate")
-            .to_string()
-    }
-
-    #[test]
-    fn os_menu_about_metadata_displays_version_under_title() {
-        let tokens = os_menu_tokens();
-
-        assert!(tokens.contains(":: muda :: AboutMetadata"));
-        assert!(tokens.contains("env ! (\"CARGO_PKG_VERSION\")"));
-        assert!(tokens.contains("env ! (\"VMUX_GIT_HASH\")"));
-        assert!(tokens.contains("\"local\" => format ! (\"v{} ({})\""));
-        assert!(tokens.contains("\"dev\" => format ! (\"v{} ({})\""));
-        assert!(tokens.contains("version : Some (about_version)"));
-        assert!(tokens.contains("copyright : Some (:: std :: string :: String :: new ())"));
-        assert!(!tokens.contains("short_version"));
-        assert!(
-            tokens
-                .contains(":: muda :: PredefinedMenuItem :: about (None , Some (about_metadata))")
-        );
-    }
-
-    #[test]
-    fn os_menu_release_about_metadata_omits_commit_hash() {
-        let tokens = os_menu_tokens();
-
-        assert!(
-            tokens.contains("\"release\" => format ! (\"v{}\" , env ! (\"CARGO_PKG_VERSION\"))")
-        );
-    }
-
-    #[test]
-    fn os_menu_about_metadata_keeps_native_title() {
-        let tokens = os_menu_tokens();
-
-        assert!(!tokens.contains("name : Some"));
-    }
-}
-
 fn impl_os_sub_menu_group(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     let ident = &input.ident;
     let Data::Enum(data) = &input.data else {
@@ -1693,4 +1641,56 @@ fn accel_to_display(accel: &str) -> String {
     }
 
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn os_menu_tokens() -> String {
+        let input: DeriveInput = syn::parse_quote! {
+            enum SampleMenu {
+                #[menu(label = "Sample")]
+                Sample(SampleCommand),
+            }
+        };
+
+        impl_os_menu(input)
+            .expect("os menu should generate")
+            .to_string()
+    }
+
+    #[test]
+    fn os_menu_about_metadata_displays_version_under_title() {
+        let tokens = os_menu_tokens();
+
+        assert!(tokens.contains(":: muda :: AboutMetadata"));
+        assert!(tokens.contains("env ! (\"CARGO_PKG_VERSION\")"));
+        assert!(tokens.contains("env ! (\"VMUX_GIT_HASH\")"));
+        assert!(tokens.contains("\"local\" => format ! (\"v{} ({})\""));
+        assert!(tokens.contains("\"dev\" => format ! (\"v{} ({})\""));
+        assert!(tokens.contains("version : Some (about_version)"));
+        assert!(tokens.contains("copyright : Some (:: std :: string :: String :: new ())"));
+        assert!(!tokens.contains("short_version"));
+        assert!(
+            tokens
+                .contains(":: muda :: PredefinedMenuItem :: about (None , Some (about_metadata))")
+        );
+    }
+
+    #[test]
+    fn os_menu_release_about_metadata_omits_commit_hash() {
+        let tokens = os_menu_tokens();
+
+        assert!(
+            tokens.contains("\"release\" => format ! (\"v{}\" , env ! (\"CARGO_PKG_VERSION\"))")
+        );
+    }
+
+    #[test]
+    fn os_menu_about_metadata_keeps_native_title() {
+        let tokens = os_menu_tokens();
+
+        assert!(!tokens.contains("name : Some"));
+    }
 }

--- a/crates/vmux_macro/src/lib.rs
+++ b/crates/vmux_macro/src/lib.rs
@@ -293,6 +293,17 @@ fn impl_os_menu(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                     "dev" => format!("Vmux Dev ({})", env!("VMUX_GIT_HASH")),
                     other => format!("Vmux ({})", other),
                 };
+                let about_version = match env!("VMUX_BUILD_PROFILE") {
+                    "release" => format!("v{}", env!("CARGO_PKG_VERSION")),
+                    "local" => format!("v{} ({})", env!("CARGO_PKG_VERSION"), env!("VMUX_GIT_HASH")),
+                    "dev" => format!("v{} ({})", env!("CARGO_PKG_VERSION"), env!("VMUX_GIT_HASH")),
+                    _ => format!("v{}", env!("CARGO_PKG_VERSION")),
+                };
+                let about_metadata = ::muda::AboutMetadata {
+                    version: Some(about_version),
+                    copyright: Some(::std::string::String::new()),
+                    ..::std::default::Default::default()
+                };
                 let mut app_native_submenu = ::muda::Submenu::new(&app_name, true);
                 let quit_label = format!("Quit {}", &app_name);
                 let quit_item = ::muda::MenuItem::with_id(
@@ -302,7 +313,7 @@ fn impl_os_menu(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                     ::core::option::Option::Some("super+q".parse().unwrap()),
                 );
                 app_native_submenu.append_items(&[
-                    &::muda::PredefinedMenuItem::about(None, None),
+                    &::muda::PredefinedMenuItem::about(None, Some(about_metadata)),
                     &::muda::PredefinedMenuItem::separator(),
                     &quit_item,
                 ])?;
@@ -319,6 +330,51 @@ fn impl_os_menu(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
             }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn os_menu_tokens() -> String {
+        let input: DeriveInput = syn::parse_quote! {
+            enum SampleMenu {
+                #[menu(label = "Sample")]
+                Sample(SampleCommand),
+            }
+        };
+
+        impl_os_menu(input).expect("os menu should generate").to_string()
+    }
+
+    #[test]
+    fn os_menu_about_metadata_displays_version_under_title() {
+        let tokens = os_menu_tokens();
+
+        assert!(tokens.contains(":: muda :: AboutMetadata"));
+        assert!(tokens.contains("env ! (\"CARGO_PKG_VERSION\")"));
+        assert!(tokens.contains("env ! (\"VMUX_GIT_HASH\")"));
+        assert!(tokens.contains("\"local\" => format ! (\"v{} ({})\""));
+        assert!(tokens.contains("\"dev\" => format ! (\"v{} ({})\""));
+        assert!(tokens.contains("version : Some (about_version)"));
+        assert!(tokens.contains("copyright : Some (:: std :: string :: String :: new ())"));
+        assert!(!tokens.contains("short_version"));
+        assert!(tokens.contains(":: muda :: PredefinedMenuItem :: about (None , Some (about_metadata))"));
+    }
+
+    #[test]
+    fn os_menu_release_about_metadata_omits_commit_hash() {
+        let tokens = os_menu_tokens();
+
+        assert!(tokens.contains("\"release\" => format ! (\"v{}\" , env ! (\"CARGO_PKG_VERSION\"))"));
+    }
+
+    #[test]
+    fn os_menu_about_metadata_keeps_native_title() {
+        let tokens = os_menu_tokens();
+
+        assert!(!tokens.contains("name : Some"));
+    }
 }
 
 fn impl_os_sub_menu_group(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {

--- a/scripts/install-dioxus-binaryen.sh
+++ b/scripts/install-dioxus-binaryen.sh
@@ -43,7 +43,7 @@ fi
 TMP_DIR="$(mktemp -d -t binaryen.XXXXXX)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
-curl -fsSL -o "$TMP_DIR/binaryen.tar.gz" "https://github.com/WebAssembly/binaryen/releases/download/version_${VERSION}/${ASSET}"
+curl --retry 5 --retry-delay 2 --retry-max-time 120 -fsSL -o "$TMP_DIR/binaryen.tar.gz" "https://github.com/WebAssembly/binaryen/releases/download/version_${VERSION}/${ASSET}"
 rm -rf "$INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
 tar -xzf "$TMP_DIR/binaryen.tar.gz" --strip-components 1 -C "$INSTALL_DIR"

--- a/scripts/install-dioxus-binaryen.sh
+++ b/scripts/install-dioxus-binaryen.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${BINARYEN_VERSION:-127}"
+
+case "$(uname -s)-$(uname -m)" in
+    Linux-x86_64)
+        ASSET="binaryen-version_${VERSION}-x86_64-linux.tar.gz"
+        ;;
+    Linux-aarch64 | Linux-arm64)
+        ASSET="binaryen-version_${VERSION}-aarch64-linux.tar.gz"
+        ;;
+    Darwin-x86_64)
+        ASSET="binaryen-version_${VERSION}-x86_64-macos.tar.gz"
+        ;;
+    Darwin-arm64)
+        ASSET="binaryen-version_${VERSION}-arm64-macos.tar.gz"
+        ;;
+    *)
+        echo "unsupported platform for binaryen: $(uname -s)-$(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+if [[ -n "${DX_HOME:-}" ]]; then
+    DX_DIR="$DX_HOME"
+elif [[ "$(uname -s)" == "Darwin" ]]; then
+    DX_DIR="$HOME/.dx"
+else
+    DX_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/.dx"
+fi
+
+INSTALL_DIR="$DX_DIR/tools/binaryen-$VERSION"
+BIN="$INSTALL_DIR/bin/wasm-opt"
+
+if [[ -x "$BIN" ]]; then
+    VERSION_OUTPUT="$("$BIN" --version 2>&1 || true)"
+    if [[ "$VERSION_OUTPUT" == *"version $VERSION"* || "$VERSION_OUTPUT" == *"version_$VERSION"* ]]; then
+        exit 0
+    fi
+fi
+
+TMP_DIR="$(mktemp -d -t binaryen.XXXXXX)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+curl -fsSL -o "$TMP_DIR/binaryen.tar.gz" "https://github.com/WebAssembly/binaryen/releases/download/version_${VERSION}/${ASSET}"
+rm -rf "$INSTALL_DIR"
+mkdir -p "$INSTALL_DIR"
+tar -xzf "$TMP_DIR/binaryen.tar.gz" --strip-components 1 -C "$INSTALL_DIR"
+chmod +x "$BIN"
+
+if command -v xattr >/dev/null 2>&1; then
+    xattr -dr com.apple.quarantine "$INSTALL_DIR" >/dev/null 2>&1 || true
+fi
+
+"$BIN" --version

--- a/scripts/install-tailwindcss.sh
+++ b/scripts/install-tailwindcss.sh
@@ -34,7 +34,7 @@ esac
 TMP="$(mktemp -t tailwindcss.XXXXXX)"
 trap 'rm -f "$TMP"' EXIT
 
-curl -fsSL -o "$TMP" "https://github.com/tailwindlabs/tailwindcss/releases/download/v${VERSION}/${ASSET}"
+curl --retry 5 --retry-delay 2 --retry-max-time 120 -fsSL -o "$TMP" "https://github.com/tailwindlabs/tailwindcss/releases/download/v${VERSION}/${ASSET}"
 chmod +x "$TMP"
 mkdir -p "$INSTALL_DIR"
 


### PR DESCRIPTION
## Context
Fixes native browser reload shortcuts and improves macOS About dialog build info for the v0.0.13 release branch. Removes local final-gate guidance from AGENTS.md so CI owns fmt, clippy, and workspace tests.

## Implementation
Adds direct Cmd+R and Cmd+Shift+R command bindings, passes AboutMetadata with a v-prefixed version and 7-character git hash for dev/local builds, and blanks copyright metadata. Bumps the workspace and lockfile package versions to 0.0.13.

## Checks / QA
Open About Vmux in a dev/local build and confirm it shows the app title, v0.0.13 plus a 7-character hex hash, and no copyright row.
Press Cmd+R and Cmd+Shift+R in a native webview and confirm reload and hard reload fire.
Let CI validate fmt, clippy, and workspace tests.