### PR TITLE
fix(service): spawn dev daemon as child, skip launchd login item

### DIFF
--- a/crates/vmux_service/src/registry.rs
+++ b/crates/vmux_service/src/registry.rs
@@ -16,6 +16,20 @@ pub fn choose_backend(exe: &Path) -> Backend {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum StartMode {
+    Register,
+    SpawnDetached,
+}
+
+pub fn start_mode_for(exe: &Path) -> StartMode {
+    if bundle::bundle_root_for(exe).is_some() {
+        StartMode::Register
+    } else {
+        StartMode::SpawnDetached
+    }
+}
+
 #[derive(Debug)]
 pub enum RegistrationError {
     Io(std::io::Error),

--- a/crates/vmux_service/tests/start_mode.rs
+++ b/crates/vmux_service/tests/start_mode.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+use vmux_service::registry::{StartMode, start_mode_for};
+
+#[test]
+fn bundled_service_app_registers() {
+    let exe = PathBuf::from(
+        "/Applications/Vmux.app/Contents/Library/LoginItems/Vmux Service.app/Contents/MacOS/Vmux Service",
+    );
+    assert_eq!(start_mode_for(&exe), StartMode::Register);
+}
+
+#[test]
+fn bundled_main_app_registers() {
+    let exe = PathBuf::from("/Applications/Vmux.app/Contents/MacOS/Vmux");
+    assert_eq!(start_mode_for(&exe), StartMode::Register);
+}
+
+#[test]
+fn dev_target_debug_spawns_detached() {
+    let exe = PathBuf::from("/Users/x/repo/target/debug/vmux_service");
+    assert_eq!(start_mode_for(&exe), StartMode::SpawnDetached);
+}
+
+#[test]
+fn plain_bin_spawns_detached() {
+    let exe = PathBuf::from("/usr/local/bin/vmux_service");
+    assert_eq!(start_mode_for(&exe), StartMode::SpawnDetached);
+}

--- a/crates/vmux_terminal/Cargo.toml
+++ b/crates/vmux_terminal/Cargo.toml
@@ -32,7 +32,7 @@ vmux_service = { path = "../vmux_service" }
 vmux_setting = { path = "../vmux_setting" }
 vmux_space = { path = "../vmux_space" }
 
-[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -805,39 +805,42 @@ fn ensure_service_started() {
             return;
         }
     };
-    #[cfg(target_os = "macos")]
-    {
-        let profile = vmux_service::current_profile();
-        if let Err(e) = vmux_service::registry::ensure_running(profile, &binary) {
-            tracing::error!(error = ?e, "service registration failed");
-        }
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        use std::os::unix::process::CommandExt;
-        let log_dir = vmux_service::service_dir();
-        let _ = std::fs::create_dir_all(&log_dir);
-        let stderr_cfg = match std::fs::File::create(vmux_service::log_path()) {
-            Ok(f) => std::process::Stdio::from(f),
-            Err(e) => {
-                tracing::warn!(error = %e, "could not create service log; stderr will be discarded");
-                std::process::Stdio::null()
+    match vmux_service::registry::start_mode_for(&binary) {
+        vmux_service::registry::StartMode::Register => {
+            let profile = vmux_service::current_profile();
+            if let Err(e) = vmux_service::registry::ensure_running(profile, &binary) {
+                tracing::error!(error = ?e, "service registration failed");
             }
-        };
-        let spawn_result = unsafe {
-            std::process::Command::new(&binary)
-                .stdin(std::process::Stdio::null())
-                .stdout(std::process::Stdio::null())
-                .stderr(stderr_cfg)
-                .pre_exec(|| {
-                    libc::setsid();
-                    Ok(())
-                })
-                .spawn()
-        };
-        if let Err(e) = spawn_result {
-            tracing::error!(error = %e, "failed to spawn vmux_service (non-macOS fallback)");
         }
+        vmux_service::registry::StartMode::SpawnDetached => spawn_detached_service(&binary),
+    }
+}
+
+#[cfg(unix)]
+fn spawn_detached_service(binary: &std::path::Path) {
+    use std::os::unix::process::CommandExt;
+    let log_dir = vmux_service::service_dir();
+    let _ = std::fs::create_dir_all(&log_dir);
+    let stderr_cfg = match std::fs::File::create(vmux_service::log_path()) {
+        Ok(f) => std::process::Stdio::from(f),
+        Err(e) => {
+            tracing::warn!(error = %e, "could not create service log; stderr will be discarded");
+            std::process::Stdio::null()
+        }
+    };
+    let spawn_result = unsafe {
+        std::process::Command::new(binary)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(stderr_cfg)
+            .pre_exec(|| {
+                libc::setsid();
+                Ok(())
+            })
+            .spawn()
+    };
+    if let Err(e) = spawn_result {
+        tracing::error!(error = %e, "failed to spawn vmux_service");
     }
 }
 


### PR DESCRIPTION
## Summary

Dev (unbundled) builds were registering a launchd **login item** (`vmux_service`, "unidentified developer") that coexisted with the packaged app's SMAppService agent (`Vmux.app`) — two background registrations for one service.

Root cause: `ensure_service_started` always called `registry::ensure_running`, whose `choose_backend` falls back to the **Launchctl** backend for any exe not inside a `.app`. That writes `~/Library/LaunchAgents/ai.vmux.service.<profile>.plist` and bootstraps it → a persistent login item the user never wanted in dev.

Fix: route startup through a new `start_mode_for(exe)`:
- **bundled** (release/local `.app`) → `Register` → `SMAppService` agent, unchanged.
- **unbundled** (dev) → `SpawnDetached` → spawn the daemon as a detached child (`setsid`), no launchd registration, no login item.

This also unifies the previous macOS/non-macOS split: Linux already spawned a detached child, and now dev/macOS uses the same path.

## Changes

- `vmux_service::registry`: add `StartMode { Register, SpawnDetached }` + pure `start_mode_for` (keyed on `bundle_root_for`).
- `vmux_terminal::plugin`: `ensure_service_started` matches on `start_mode_for`; extracted `spawn_detached_service` helper (`cfg(unix)`).
- `vmux_terminal/Cargo.toml`: widen `libc` dep gate `cfg(all(unix, not(macos)))` → `cfg(unix)` so the spawn path compiles on macOS.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] workspace `clippy -D warnings`
- [x] workspace `cargo test` (all pass)
- [x] new unit tests: `start_mode.rs` (bundled paths → Register; dev/plain paths → SpawnDetached)
- [ ] **Manual (not run here)**: launch a dev build on macOS, confirm no `vmux_service` entry appears in System Settings → Login Items → *Allow in the Background*, and that terminals still attach to the spawned daemon.

## Notes / follow-ups

- Does **not** auto-remove a pre-existing stale `vmux_service` login item from older dev runs — that's a one-time manual cleanup (`launchctl bootout gui/$(id -u)/ai.vmux.service.<profile>` + `rm ~/Library/LaunchAgents/ai.vmux.service.<profile>.plist`). Auto-cleanup was left out to keep scope tight and avoid clobbering CLI-installed (`vmux service install`) services.
- The Launchctl backend stays in place; it's still used by the `vmux service` CLI commands.
