### PR TITLE
fix(ci): keep bundled CEF in lockstep with the cef crate + smoke-test releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,37 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   TAILWINDCSS_VERSION: "4.2.4"
-  CEF_VERSION: "145.6.1+145.0.28"
   DIOXUS_CLI_VERSION: "0.7.4"
   BINARYEN_VERSION: "127"
   DX_HOME: ${{ github.workspace }}/.dx
 
 jobs:
+  cef-version:
+    name: Resolve CEF version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve cef crate version from Cargo.lock
+        id: resolve
+        run: |
+          set -euo pipefail
+          version=$(awk -F'"' '/^name = "cef"$/{getline; print $2; exit}' Cargo.lock)
+          if [ -z "${version:-}" ]; then
+            echo "::error file=Cargo.lock::could not resolve 'cef' crate version"
+            exit 1
+          fi
+          echo "Resolved CEF version: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    needs: cef-version
+    env:
+      CEF_VERSION: ${{ needs.cef-version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
 
@@ -122,6 +144,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: cef-version
+    env:
+      CEF_VERSION: ${{ needs.cef-version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
 
@@ -274,11 +299,13 @@ jobs:
 
   build-mac:
     name: Build macOS App
-    needs: changes
+    needs: [changes, cef-version]
     if: needs.changes.outputs.packaging == 'true'
     runs-on: macos-latest
     permissions:
       contents: write
+    env:
+      CEF_VERSION: ${{ needs.cef-version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -402,6 +429,50 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           VMUX_UPDATE_PUBLIC_KEY: ${{ secrets.VMUX_UPDATE_PUBLIC_KEY }}
         run: ./scripts/build-mac-release.sh
+
+      - name: Smoke test bundled app
+        if: env.PREP_DONE != '1'
+        run: |
+          set -uo pipefail
+          app="target/release/Vmux.app"
+          bin="$app/Contents/MacOS/Vmux"
+          plist="$app/Contents/Frameworks/Chromium Embedded Framework.framework/Resources/Info.plist"
+
+          want="${CEF_VERSION##*+}"
+          got=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$plist" 2>/dev/null || true)
+          echo "Bundled CEF framework: ${got:-<none>} | cef crate: $CEF_VERSION (expect prefix $want)"
+          case "$got" in
+            "$want" | "$want".*) ;;
+            *)
+              echo "::error::Bundled CEF (${got:-<none>}) does not match cef crate ($CEF_VERSION)"
+              exit 1
+              ;;
+          esac
+
+          HOME="$(mktemp -d)"
+          export HOME
+          log="$(mktemp)"
+          "$bin" >"$log" 2>&1 &
+          pid=$!
+          rc=0
+          sleep 25
+          if kill -0 "$pid" 2>/dev/null; then
+            echo "Vmux survived the 25s startup window — OK"
+          else
+            wait "$pid"
+            code=$?
+            echo "::error::Vmux exited during startup (exit $code) — startup crash"
+            rc=1
+          fi
+
+          kill "$pid" 2>/dev/null || true
+          pkill -f "Vmux.app/Contents/MacOS/Vmux" 2>/dev/null || true
+          pkill -f "vmux_service" 2>/dev/null || true
+          pkill -f "Chromium Embedded Framework" 2>/dev/null || true
+
+          echo "----- startup log -----"
+          cat "$log" || true
+          exit $rc
 
       - name: Upload .dmg artifact
         if: env.PREP_DONE != '1' && env.IS_RELEASE_PR != '1'

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ BEVY_CEF_BUNDLE_APP_BIN := $(or $(shell command -v bevy_cef_bundle_app 2>/dev/nu
 DX_VERSION := 0.7.4
 CARGO_PACKAGER_VERSION := 0.11.8
 BEVY_CEF_BUNDLE_APP_VERSION := 0.8.1
+CEF_VERSION := $(shell awk -F'"' '/^name = "cef"$$/{getline; print $$2; exit}' Cargo.lock)
 CEF_FRAMEWORK_DIR := $(HOME)/.local/share/Chromium Embedded Framework.framework
 CEF_DEBUG_RENDER := $(CEF_FRAMEWORK_DIR)/Libraries/bevy_cef_debug_render_process
 
@@ -52,9 +53,10 @@ build-release: ensure-mac-deps ensure-package-deps
 release: build-release
 	open "target/release/Vmux.app"
 
-# One-time CEF download (macOS paths; pin matches bevy_cef 0.5.x)
+# One-time CEF download (macOS paths; version derived from the cef crate in Cargo.lock)
 setup-cef:
-	"$(CARGO_BIN)" install export-cef-dir@148.2.0+148.0.8 --force
+	@test -n "$(CEF_VERSION)" || { echo "could not resolve cef crate version from Cargo.lock"; exit 1; }
+	"$(CARGO_BIN)" install export-cef-dir@$(CEF_VERSION) --force
 	"$(EXPORT_CEF_BIN)" --force "$$HOME/.local/share"
 
 # Build from vmux-patched bevy_cef_core (required when adding CEF schemes such as vmux://).


### PR DESCRIPTION
## Problem

Installed `0.0.13` (and every release since the CEF-148 bump) panics on launch:

```
dlsym(... cef_component_updater_get): symbol not found
panicked at patches/bevy_cef-0.5.2/src/common/message_loop.rs:104:
assertion failed: loader.load()
```

Root cause is **version drift**. The CEF version was encoded in two places:

| Source | Value |
|---|---|
| `cef` crate (`Cargo.lock`) | `148.2.0+148.0.8` |
| `CEF_VERSION` (`.github/workflows/ci.yml`) | `145.6.1+145.0.28` |

CI built the binary against the 148 bindings but bundled the **145** framework via `export-cef-dir@$CEF_VERSION`. The 148 `LibraryLoader` `dlsym`s `cef_component_updater_get` at startup; it's absent in 145, so `loader.load()` fails its assert and the app dies before a window appears. `release.yml` only checks asset count, never launches the app, so the broken DMG shipped. The Makefile was already on 148, which is why local `make dev` worked and the breakage was release-only.

## Fix — make `Cargo.lock` the single source of truth

- New `cef-version` job resolves the `cef` crate version from `Cargo.lock` and feeds it to `lint` / `test` / `build-mac` via job-level `env`. The hardcoded `CEF_VERSION` is gone — nothing left to drift.
- `Makefile` derives the same value for `setup-cef`.

## Fix — gate releases on a real launch

After packaging, `build-mac` now:
1. asserts the bundled framework's `CFBundleShortVersionString` matches the `cef` crate, then
2. launches the bundled binary (clean `HOME`, 25s window) and **fails if it crashes on startup**.

This PR touches `ci.yml`, which is in the `packaging` paths filter, so `build-mac` runs here and the new smoke test validates the fix end-to-end on this PR.

## Test plan

- [ ] `cef-version` job resolves `148.2.0+148.0.8`
- [ ] `build-mac` bundles CEF 148 and the smoke test passes (app survives startup)
- [ ] lint / test / website jobs green