### PR TITLE
fix(cef): windowed page visibility and rounded corners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,6 +937,7 @@ dependencies = [
  "cef-dll-sys",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
+ "objc2-core-graphics",
  "objc2-foundation 0.3.2",
  "objc2-quartz-core 0.3.2",
  "raw-window-handle",
@@ -6584,10 +6585,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.11.1",
+ "block2 0.6.2",
  "dispatch2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -887,6 +887,7 @@ fn sync_windowed_frames(
     settings: Res<AppSettings>,
     layout_hidden: Res<vmux_layout::toggle::LayoutHidden>,
     focus: Res<vmux_layout::stack::FocusedStack>,
+    clear_color: Res<ClearColor>,
     browser_q: Query<
         (
             Entity,
@@ -930,8 +931,8 @@ fn sync_windowed_frames(
         let left = center.x - size_px.x * 0.5;
         let top = center.y - size_px.y * 0.5;
         let scale = 1.0 / computed.inverse_scale_factor.max(1.0e-6);
-        let was_shown = last_raised_frame.contains_key(&entity);
-        if !was_shown {
+        let became_visible = !last_visible_pages.contains(&entity);
+        if became_visible {
             browsers.set_windowed_hidden(&entity, false);
         }
         browsers.set_windowed_frame(&entity, left, top, size_px.x, size_px.y, scale);
@@ -954,6 +955,14 @@ fn sync_windowed_frames(
             scale,
             [focus_ring_color.r, focus_ring_color.g, focus_ring_color.b],
         );
+        let cover_rgb = clear_color.0.to_srgba();
+        browsers.set_windowed_corner_cover(
+            &entity,
+            settings.layout.radius * scale,
+            scale,
+            all_corners,
+            [cover_rgb.red, cover_rgb.green, cover_rgb.blue],
+        );
         if browsers.has_browser(entity) {
             let key = (
                 left.round() as i32,
@@ -962,14 +971,13 @@ fn sync_windowed_frames(
                 size_px.y.round() as i32,
             );
             let changed = last_raised_frame.insert(entity, key) != Some(key);
-            let became_visible = !last_visible_pages.contains(&entity);
             if force_raise || changed || became_visible {
                 browsers.raise_windowed_to_front(&entity);
             }
         }
     }
-    let shown: Vec<Entity> = last_raised_frame.keys().copied().collect();
-    for entity in windowed_pages_to_hide_before_first_show(&hidden, &shown) {
+    let ever_shown: Vec<Entity> = last_raised_frame.keys().copied().collect();
+    for entity in windowed_pages_to_hide(&hidden, &last_visible_pages, &ever_shown) {
         browsers.set_windowed_hidden(&entity, true);
     }
     *last_visible_pages = visible;
@@ -990,11 +998,15 @@ fn visible_pane_count_for_windowed_sync(
     leaf_panes.iter().count().max(1)
 }
 
-fn windowed_pages_to_hide_before_first_show(hidden: &[Entity], shown: &[Entity]) -> Vec<Entity> {
+fn windowed_pages_to_hide(
+    hidden: &[Entity],
+    prev_visible: &[Entity],
+    ever_shown: &[Entity],
+) -> Vec<Entity> {
     hidden
         .iter()
         .copied()
-        .filter(|entity| !shown.contains(entity))
+        .filter(|entity| prev_visible.contains(entity) || !ever_shown.contains(entity))
         .collect()
 }
 
@@ -3239,7 +3251,7 @@ mod tests {
     }
 
     #[test]
-    fn windowed_page_sync_raises_visible_pages_without_hiding_shown_pages() {
+    fn windowed_page_sync_raises_visible_pages_and_hides_inactive() {
         let source = include_str!("lib.rs");
         let sync_fn = source
             .split("fn sync_windowed_frames")
@@ -3248,17 +3260,22 @@ mod tests {
             .unwrap_or_default();
 
         assert!(sync_fn.contains("browsers.raise_windowed_to_front(&entity)"));
-        assert!(sync_fn.contains("windowed_pages_to_hide_before_first_show"));
+        assert!(sync_fn.contains("windowed_pages_to_hide("));
     }
 
     #[test]
-    fn shown_windowed_pages_stay_visible_when_inactive() {
-        let shown = Entity::from_bits(1);
-        let never_shown = Entity::from_bits(2);
+    fn windowed_pages_hide_on_deactivate_and_first_show() {
+        let just_deactivated = Entity::from_bits(1);
+        let still_inactive = Entity::from_bits(2);
+        let never_shown = Entity::from_bits(3);
+
+        let hidden = [just_deactivated, still_inactive, never_shown];
+        let prev_visible = [just_deactivated];
+        let ever_shown = [just_deactivated, still_inactive];
 
         assert_eq!(
-            windowed_pages_to_hide_before_first_show(&[shown, never_shown], &[shown]),
-            vec![never_shown]
+            windowed_pages_to_hide(&hidden, &prev_visible, &ever_shown),
+            vec![just_deactivated, never_shown]
         );
     }
 
@@ -3464,6 +3481,19 @@ mod tests {
         assert!(sync_fn.contains("browsers.set_windowed_focus_ring"));
         assert!(sync_fn.contains("focus.stack == Some(parent)"));
         assert!(sync_fn.contains("pane_count > 1"));
+    }
+
+    #[test]
+    fn windowed_page_sync_covers_corners_over_remote_content() {
+        let source = include_str!("lib.rs");
+        let sync_fn = source
+            .split("fn sync_windowed_frames")
+            .nth(1)
+            .and_then(|tail| tail.split("fn sync_windowed_chrome").next())
+            .unwrap_or_default();
+
+        assert!(sync_fn.contains("browsers.set_windowed_corner_cover"));
+        assert!(sync_fn.contains("clear_color.0.to_srgba()"));
     }
 
     #[test]

--- a/crates/vmux_layout/src/focus_ring.rs
+++ b/crates/vmux_layout/src/focus_ring.rs
@@ -1,6 +1,7 @@
 use crate::{
     cef::Loading,
     pane::{Pane, PaneSplit},
+    scene::InteractionMode,
     settings::LayoutSettings,
     stack::{Stack, active_stack_in_pane, collect_leaf_panes},
     window::{VmuxWindow, WEBVIEW_Z_FOCUS_RING},
@@ -88,6 +89,7 @@ fn sync_focus_ring_to_active_pane(
     pane_layout: Query<(&ComputedNode, &UiGlobalTransform), With<Pane>>,
     glass: Single<(&ComputedNode, &UiGlobalTransform, &Transform), With<VmuxWindow>>,
     settings: Res<LayoutSettings>,
+    mode: Res<InteractionMode>,
     time: Res<Time>,
     mut ring_q: Query<
         (
@@ -108,6 +110,11 @@ fn sync_focus_ring_to_active_pane(
     let Ok((mut tf, mat_h, mut visibility)) = ring_q.single_mut() else {
         return;
     };
+
+    if cfg!(target_os = "macos") && *mode == InteractionMode::User {
+        *visibility = Visibility::Hidden;
+        return;
+    }
 
     let active_pane = focus.pane;
     let Some(active_entity) = active_pane else {
@@ -266,6 +273,18 @@ mod tests {
             side_sheet: crate::settings::SideSheetSettings::default(),
             focus_ring: crate::settings::FocusRingSettings::default(),
         }
+    }
+
+    #[test]
+    fn mesh_focus_ring_hidden_in_windowed_user_mode() {
+        let src = include_str!("focus_ring.rs");
+        let sync = src
+            .split("fn sync_focus_ring_to_active_pane")
+            .nth(1)
+            .and_then(|t| t.split("fn tick_focus_ring_gradient_time").next())
+            .unwrap_or_default();
+        assert!(sync.contains("InteractionMode::User"));
+        assert!(sync.contains("target_os = \"macos\""));
     }
 
     #[test]

--- a/patches/bevy_cef_core-0.5.2/Cargo.toml
+++ b/patches/bevy_cef_core-0.5.2/Cargo.toml
@@ -116,4 +116,8 @@ features = ["NSGeometry"]
 
 [target.'cfg(target_os = "macos")'.dependencies.objc2-quartz-core]
 version = "0.3"
-features = ["CALayer", "objc2-core-graphics"]
+features = ["CALayer", "CAShapeLayer", "objc2-core-graphics"]
+
+[target.'cfg(target_os = "macos")'.dependencies.objc2-core-graphics]
+version = "0.3"
+features = ["CGPath"]

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
@@ -22,7 +22,9 @@ use cef::{
 use cef_dll_sys::{cef_event_flags_t, cef_mouse_button_type_t};
 #[allow(deprecated)]
 use raw_window_handle::RawWindowHandle;
-use std::cell::{Cell, RefCell};
+use std::cell::Cell;
+#[cfg(target_os = "macos")]
+use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Once;
 use std::time::Duration;

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
@@ -22,7 +22,7 @@ use cef::{
 use cef_dll_sys::{cef_event_flags_t, cef_mouse_button_type_t};
 #[allow(deprecated)]
 use raw_window_handle::RawWindowHandle;
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::Once;
 use std::time::Duration;
@@ -88,6 +88,10 @@ pub struct WebviewBrowser {
     allow_native_focus: bool,
     #[cfg(target_os = "macos")]
     native_liquid_glass: Option<objc2::rc::Retained<objc2_app_kit::NSGlassEffectView>>,
+    #[cfg(target_os = "macos")]
+    corner_cover: RefCell<Option<objc2::rc::Retained<objc2_quartz_core::CAShapeLayer>>>,
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+    last_corner_cover: Cell<Option<(i32, bool, i32, i32)>>,
 }
 
 pub struct Browsers {
@@ -312,6 +316,9 @@ impl Browsers {
             allow_native_focus,
             #[cfg(target_os = "macos")]
             native_liquid_glass,
+            #[cfg(target_os = "macos")]
+            corner_cover: RefCell::new(None),
+            last_corner_cover: Cell::new(None),
         };
         self.browsers.insert(webview, webview_browser);
         webview_debug_log(format!(
@@ -736,6 +743,94 @@ impl Browsers {
             layer.setMaskedCorners(if all_corners { all } else { bottom });
         }
     }
+
+    #[cfg(target_os = "macos")]
+    fn update_corner_cover(
+        browser: &WebviewBrowser,
+        view: &objc2_app_kit::NSView,
+        radius: f64,
+        all_corners: bool,
+        color: Option<&objc2_app_kit::NSColor>,
+    ) {
+        use objc2_core_graphics::CGMutablePath;
+        use objc2_quartz_core::{CAShapeLayer, kCAFillRuleEvenOdd};
+        view.setWantsLayer(true);
+        let Some(layer) = view.layer() else {
+            return;
+        };
+        let bounds = layer.bounds();
+        let want_cover = all_corners && radius > 0.0;
+        let key = (
+            radius.round() as i32,
+            all_corners,
+            bounds.size.width.round() as i32,
+            bounds.size.height.round() as i32,
+        );
+        if browser.last_corner_cover.get() == Some(key)
+            && browser.corner_cover.borrow().is_some() == want_cover
+        {
+            return;
+        }
+        browser.last_corner_cover.set(Some(key));
+        if !want_cover {
+            if let Some(cover) = browser.corner_cover.borrow_mut().take() {
+                cover.removeFromSuperlayer();
+            }
+            return;
+        }
+        let existing = browser.corner_cover.borrow().clone();
+        let cover = match existing {
+            Some(c) => c,
+            None => {
+                let c = CAShapeLayer::new();
+                c.setZPosition(1.0);
+                unsafe { c.setFillRule(kCAFillRuleEvenOdd) };
+                *browser.corner_cover.borrow_mut() = Some(c.clone());
+                c
+            }
+        };
+        if let Some(color) = color {
+            cover.setFillColor(Some(&color.CGColor()));
+        }
+        cover.setFrame(bounds);
+        let path = CGMutablePath::new();
+        unsafe {
+            CGMutablePath::add_rect(Some(&path), std::ptr::null(), bounds);
+            CGMutablePath::add_rounded_rect(Some(&path), std::ptr::null(), bounds, radius, radius);
+        }
+        cover.setPath(Some(&path));
+        layer.addSublayer(&cover);
+    }
+
+    #[cfg(target_os = "macos")]
+    pub fn set_windowed_corner_cover(
+        &self,
+        webview: &Entity,
+        radius_px: f32,
+        scale: f32,
+        all_corners: bool,
+        color_rgb: [f32; 3],
+    ) {
+        use objc2_app_kit::{NSColor, NSView};
+        let Some(browser) = self.browsers.get(webview) else {
+            return;
+        };
+        let s = (scale as f64).max(1.0e-6);
+        let radius = (radius_px as f64 / s).max(0.0);
+        let handle = browser.host.window_handle();
+        if handle.is_null() {
+            return;
+        }
+        let view: &NSView = unsafe { &*handle.cast::<NSView>() };
+        let r = color_rgb[0].clamp(0.0, 1.0) as f64;
+        let g = color_rgb[1].clamp(0.0, 1.0) as f64;
+        let b = color_rgb[2].clamp(0.0, 1.0) as f64;
+        let color = NSColor::colorWithSRGBRed_green_blue_alpha(r, g, b, 1.0);
+        Self::update_corner_cover(browser, view, radius, all_corners, Some(&color));
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    pub fn set_windowed_corner_cover(&self, _: &Entity, _: f32, _: f32, _: bool, _: [f32; 3]) {}
 
     #[cfg(target_os = "macos")]
     pub fn set_windowed_frame(
@@ -1778,6 +1873,24 @@ mod tests {
     }
 
     #[test]
+    fn windowed_corner_cover_uses_even_odd_overlay() {
+        let implementation = include_str!("browsers.rs")
+            .split("#[cfg(test)]\nmod tests")
+            .next()
+            .unwrap_or_default();
+        assert!(implementation.contains("fn update_corner_cover"));
+        assert!(implementation.contains("pub fn set_windowed_corner_cover"));
+        let cover_fn = implementation
+            .split("fn update_corner_cover")
+            .nth(1)
+            .and_then(|tail| tail.split("pub fn set_windowed_corner_cover").next())
+            .unwrap_or_default();
+        assert!(cover_fn.contains("kCAFillRuleEvenOdd"));
+        assert!(cover_fn.contains("add_rounded_rect"));
+        assert!(cover_fn.contains("setZPosition"));
+    }
+
+    #[test]
     fn windowed_native_views_support_focus_ring_border() {
         let implementation = include_str!("browsers.rs")
             .split("#[cfg(test)]\nmod tests")
@@ -1835,26 +1948,6 @@ mod tests {
 
         assert!(close_fn.contains("window_handle"));
         assert!(close_fn.contains("removeFromSuperview"));
-    }
-
-    #[test]
-    fn windowed_native_corner_clip_does_not_mutate_cef_sublayers() {
-        let implementation = include_str!("browsers.rs")
-            .split("#[cfg(test)]\nmod tests")
-            .next()
-            .unwrap_or_default();
-        let apply_fn = implementation
-            .split("fn apply_view_tree_corner_radius")
-            .nth(1)
-            .and_then(|tail| {
-                tail.split("#[cfg(target_os = \"macos\")]\n    pub fn set_windowed_frame")
-                    .next()
-            })
-            .unwrap_or_default();
-
-        assert!(!apply_fn.contains("subviews"));
-        assert!(!apply_fn.contains("sublayers"));
-        assert!(!apply_fn.contains("for i in 0.."));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Browse-mode panes render as native windowed CEF views. This fixes two rendering bugs in that path:

- **Inactive tabs bled through.** `sync_windowed_frames` only hid pages that had *never* been shown, so a previously-active page stayed visible beneath the new one. Now show on activation and hide on deactivation symmetrically (keeps the first-show suppression for never-shown pages).
- **Active-pane corners were square with a duplicated focus ring.** The CEF surface is a remote/out-of-process GPU layer that ignores all CoreAnimation clipping (`masksToBounds`, layer mask, sublayer `cornerRadius` all proven no-ops). Corners are now covered by a `CAShapeLayer` overlay filled with the scene `ClearColor` (matches the dark surround), and the OSR mesh focus ring is hidden in windowed mode since the native ring already draws it.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p bevy_cef_core -p vmux_browser -p vmux_layout` clean
- [x] tests pass: bevy_cef_core (93), vmux_browser (72), vmux_layout (223+11)
- [x] Manual (macOS): only the active tab's page is visible per stack; active-pane corners render rounded over websites and terminals; no duplicated focus ring