### PR TITLE
feat(tray): Show/Hide/Quit menu + drop close-confirm dialog

### DIFF
--- a/crates/vmux_desktop/src/os_menu.rs
+++ b/crates/vmux_desktop/src/os_menu.rs
@@ -9,15 +9,6 @@ use vmux_command::{
     build_native_root_menu, open::OpenCommand,
 };
 use vmux_layout::scene::InteractionMode;
-use vmux_setting::AppSettings;
-use vmux_terminal as terminal;
-use vmux_terminal::{PtyExited, Terminal};
-
-/// Resource: window entity awaiting quit confirmation dialog.
-#[derive(Resource, Default)]
-pub(crate) struct PendingWindowClose {
-    pub window: Option<Entity>,
-}
 
 /// When a menu key-equivalent last fired. ⌘W triggers the `stack_close` menu item *and* Chromium's
 /// built-in ⌘W (`performClose:` → `WindowCloseRequested`). The red traffic-light button is the only
@@ -58,8 +49,7 @@ pub struct OsMenuPlugin;
 
 impl Plugin for OsMenuPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<PendingWindowClose>()
-            .init_resource::<LastMenuCommandAt>()
+        app.init_resource::<LastMenuCommandAt>()
             .init_resource::<LastStackCloseAt>()
             .init_resource::<LastNativePageOpenAt>()
             .add_systems(Startup, setup)
@@ -70,10 +60,9 @@ impl Plugin for OsMenuPlugin {
                     sync_interactive_mode_menu_items.after(ReadAppCommands),
                     remember_stack_close_commands.after(WriteAppCommands),
                     remember_native_page_open_commands.after(WriteAppCommands),
-                    close_with_confirmation
+                    hide_window_on_close_request
                         .after(remember_stack_close_commands)
                         .after(remember_native_page_open_commands),
-                    process_pending_window_close,
                 ),
             );
     }
@@ -207,15 +196,9 @@ fn remember_native_page_open_commands(
     }
 }
 
-/// Replacement for bevy's `close_when_requested` that shows a confirmation
-/// dialog when terminals are still running. Defers the dialog to the
-/// exclusive `show_pending_close_dialogs` system to avoid deadlocks.
-fn close_with_confirmation(
+fn hide_window_on_close_request(
     mut closed: MessageReader<WindowCloseRequested>,
     mut windows: Query<&mut Window>,
-    settings: Res<AppSettings>,
-    live_terminals: Query<(), (With<Terminal>, Without<PtyExited>)>,
-    mut pending: ResMut<PendingWindowClose>,
     last_menu_command: Res<LastMenuCommandAt>,
     last_stack_close: Res<LastStackCloseAt>,
     last_native_page_open: Res<LastNativePageOpenAt>,
@@ -249,41 +232,9 @@ fn close_with_confirmation(
             );
             continue;
         }
-        let should_confirm = terminal::should_confirm_close(&settings);
-        let live_terminal_count = live_terminals.iter().count();
-        info!(
-            target: "vmux_desktop::window_close",
-            window = ?event.window,
-            should_confirm,
-            live_terminal_count,
-            "handling WindowCloseRequested"
-        );
-        if should_confirm && live_terminal_count > 0 {
-            pending.window = Some(event.window);
-        } else if let Ok(mut window) = windows.get_mut(event.window) {
+        if let Ok(mut window) = windows.get_mut(event.window) {
             window.visible = false;
         }
-    }
-}
-
-/// Exclusive system: processes pending window close confirmation by showing
-/// a native dialog on the main thread.
-fn process_pending_window_close(world: &mut World) {
-    let window = world.resource::<PendingWindowClose>().window;
-    let Some(window) = window else {
-        return;
-    };
-
-    world.resource_mut::<PendingWindowClose>().window = None;
-
-    let mut query = world.query_filtered::<(), (With<Terminal>, Without<PtyExited>)>();
-    let count = query.iter(world).count();
-
-    if (count == 0 || terminal::confirm_quit_dialog(count))
-        && let Ok(mut entity_mut) = world.get_entity_mut(window)
-        && let Some(mut win) = entity_mut.get_mut::<Window>()
-    {
-        win.visible = false;
     }
 }
 
@@ -295,7 +246,7 @@ mod tests {
     use vmux_layout::settings::{
         FocusRingSettings, LayoutSettings, PaneSettings, SideSheetSettings, WindowSettings,
     };
-    use vmux_setting::{AgentSettings, BrowserSettings, ShortcutSettings};
+    use vmux_setting::{AgentSettings, AppSettings, BrowserSettings, ShortcutSettings};
 
     fn test_settings() -> AppSettings {
         AppSettings {
@@ -352,6 +303,39 @@ mod tests {
             source.contains("window.visible = false") || source.contains(".visible = false"),
             "expected the close handler to set window.visible = false"
         );
+    }
+
+    #[test]
+    fn window_close_hides_without_quit_confirmation() {
+        let source = include_str!("os_menu.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production source");
+
+        assert!(
+            !source.contains("PendingWindowClose"),
+            "window close must not route through a confirmation dialog"
+        );
+        assert!(!source.contains("process_pending_window_close"));
+        assert!(!source.contains("should_confirm"));
+        assert!(!source.contains("confirm_quit_dialog"));
+    }
+
+    #[test]
+    fn unsuppressed_window_close_hides_window() {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, CommandPlugin, OsMenuPlugin))
+            .add_message::<WindowCloseRequested>()
+            .insert_resource(test_settings());
+
+        let window = app.world_mut().spawn(Window::default()).id();
+        app.world_mut()
+            .resource_mut::<Messages<WindowCloseRequested>>()
+            .write(WindowCloseRequested { window });
+
+        app.world_mut().run_schedule(Update);
+
+        assert!(!app.world().get::<Window>(window).unwrap().visible);
     }
 
     #[test]

--- a/crates/vmux_desktop/src/tray.rs
+++ b/crates/vmux_desktop/src/tray.rs
@@ -13,25 +13,31 @@ pub(crate) struct TrayPlugin;
 
 struct TrayHandle {
     _tray: TrayIcon,
+    show: MenuItem,
+    hide: MenuItem,
     show_id: String,
+    hide_id: String,
     quit_id: String,
+    last_any_visible: Option<bool>,
 }
 
 impl Plugin for TrayPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, setup_tray)
-            .add_systems(Update, drain_tray_events);
+            .add_systems(Update, (drain_tray_events, sync_tray_menu_state));
     }
 }
 
 fn setup_tray(world: &mut World) {
     let menu = Menu::new();
-    let show = MenuItem::new("Show Vmux", true, None);
-    let quit = MenuItem::new("Quit Vmux", true, None);
+    let show = MenuItem::new("Show", false, None);
+    let hide = MenuItem::new("Hide", true, None);
+    let quit = MenuItem::new("Quit", true, None);
     let show_id = show.id().0.clone();
+    let hide_id = hide.id().0.clone();
     let quit_id = quit.id().0.clone();
 
-    if let Err(e) = menu.append_items(&[&show, &quit]) {
+    if let Err(e) = menu.append_items(&[&show, &hide, &quit]) {
         tracing::error!(error = %e, "failed to append tray menu items");
         return;
     }
@@ -53,8 +59,12 @@ fn setup_tray(world: &mut World) {
 
     world.insert_non_send(TrayHandle {
         _tray: tray,
+        show,
+        hide,
         show_id,
+        hide_id,
         quit_id,
+        last_any_visible: None,
     });
 }
 
@@ -67,12 +77,30 @@ fn drain_tray_events(
     for event_id in drained {
         if event_id == handle.show_id {
             events.write(LifecycleEvent::ShowAllWindows);
+        } else if event_id == handle.hide_id {
+            events.write(LifecycleEvent::HideAllWindows);
         } else if event_id == handle.quit_id {
             events.write(LifecycleEvent::QuitVmux);
         } else {
             tracing::debug!(id = %event_id, "unhandled tray menu event id");
         }
     }
+}
+
+fn sync_tray_menu_state(handle: Option<NonSendMut<TrayHandle>>, windows: Query<&Window>) {
+    let Some(mut handle) = handle else { return };
+    let any_visible = windows.iter().any(|w| w.visible);
+    if handle.last_any_visible == Some(any_visible) {
+        return;
+    }
+    handle.last_any_visible = Some(any_visible);
+    let (show_enabled, hide_enabled) = tray_visibility_enabled(any_visible);
+    handle.show.set_enabled(show_enabled);
+    handle.hide.set_enabled(hide_enabled);
+}
+
+fn tray_visibility_enabled(any_visible: bool) -> (bool, bool) {
+    (!any_visible, any_visible)
 }
 
 fn load_tray_icon() -> tray_icon::Icon {
@@ -108,16 +136,50 @@ mod tests {
             source.contains(&tray_builder) || source.contains(&tray_type),
             "tray.rs must wire tray-icon, not be a stub"
         );
-        let show_needle = ["\"Show", " Vm", "ux\""].concat();
+        let show_needle = ["\"Sh", "ow\""].concat();
         assert!(
             source.contains(&show_needle),
-            "tray must expose a 'Show Vmux' menu item"
+            "tray must expose a 'Show' menu item"
         );
-        let quit_needle = ["\"Quit", " Vm", "ux\""].concat();
+        let hide_needle = ["\"Hi", "de\""].concat();
+        assert!(
+            source.contains(&hide_needle),
+            "tray must expose a 'Hide' menu item"
+        );
+        let quit_needle = ["\"Qu", "it\""].concat();
         assert!(
             source.contains(&quit_needle),
-            "tray must expose a 'Quit Vmux' menu item"
+            "tray must expose a 'Quit' menu item"
         );
+    }
+
+    #[test]
+    fn tray_visibility_enabled_toggles_show_and_hide() {
+        assert_eq!(super::tray_visibility_enabled(true), (false, true));
+        assert_eq!(super::tray_visibility_enabled(false), (true, false));
+    }
+
+    #[test]
+    fn hide_event_routes_to_hide_all_windows() {
+        let source = include_str!("tray.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production source");
+
+        assert!(source.contains("hide_id"));
+        assert!(source.contains("LifecycleEvent::HideAllWindows"));
+    }
+
+    #[test]
+    fn tray_syncs_enabled_state_with_window_visibility() {
+        let source = include_str!("tray.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production source");
+
+        assert!(source.contains("sync_tray_menu_state"));
+        assert!(source.contains("set_enabled"));
+        assert!(source.contains("tray_visibility_enabled"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Tray menu now exposes three items: **Show**, **Hide**, **Quit**.
- Show/Hide enable state tracks window visibility: any window visible → Show disabled / Hide enabled; all hidden → reverse. Synced each tick, skips redundant OS calls.
- Hide fires the existing `LifecycleEvent::HideAllWindows`.
- Red traffic-light close now just hides the window — removed the "Quit Vmux?" confirmation dialog (closing only hides; terminals survive, so the prompt was misleading). Suppression logic (⌘W / tab / stack / native-page) unchanged. Real Quit still confirms.

## Test plan
- [x] `cargo test -p vmux_desktop --lib` (71 pass)
- [x] `cargo fmt`, `cargo clippy -p vmux_desktop --all-targets` clean
- [ ] Manual: tray Show/Hide greys out correctly; red-button close hides without dialog