### PR TITLE
fix(agent): restore vmux://agent/<kind> → /<sid> URL redirect

### DIFF
--- a/crates/vmux_agent/src/session.rs
+++ b/crates/vmux_agent/src/session.rs
@@ -129,8 +129,6 @@ mod url_tests {
     }
 }
 
-pub const PENDING_DISCOVERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-
 pub fn mark_dirty_on_pending_added(
     added_pending: Query<(), Added<PendingAgentSession>>,
     added_session: Query<(), Added<SessionId>>,
@@ -155,7 +153,6 @@ pub fn discover_pending_agent_sessions(
     map: Res<AgentSessionToEntity>,
     q: Query<(Entity, &PendingAgentSession)>,
 ) {
-    let now = std::time::SystemTime::now();
     for (entity, pending) in &q {
         let Some(strategy) = strategies.get_cli(pending.kind) else {
             continue;
@@ -176,10 +173,6 @@ pub fn discover_pending_agent_sessions(
                 .entity(entity)
                 .insert(SessionId(id))
                 .remove::<PendingAgentSession>();
-            continue;
-        }
-        if now.duration_since(pending.spawn_time).unwrap_or_default() >= PENDING_DISCOVERY_TIMEOUT {
-            commands.entity(entity).remove::<PendingAgentSession>();
         }
     }
 }
@@ -335,7 +328,7 @@ mod discovery_tests {
     use crate::client::cli::vibe::VibeStrategy;
 
     #[test]
-    fn pending_with_no_match_within_timeout_keeps_pending() {
+    fn pending_with_no_match_keeps_pending() {
         let mut app = App::new();
         let mut strategies = AgentStrategies::default();
         strategies.register_cli(Box::new(VibeStrategy));
@@ -352,6 +345,62 @@ mod discovery_tests {
         app.update();
         assert!(app.world().get::<PendingAgentSession>(entity).is_some());
         assert!(app.world().get::<SessionId>(entity).is_none());
+    }
+
+    #[test]
+    fn pending_is_retained_long_after_spawn_for_late_session_dir() {
+        use std::path::Path;
+
+        struct NeverDiscovers;
+        impl crate::strategy::AgentStrategy for NeverDiscovers {
+            fn kind(&self) -> AgentKind {
+                AgentKind::Vibe
+            }
+            fn variant(&self) -> crate::AgentVariant {
+                crate::AgentVariant::Cli
+            }
+        }
+        impl crate::CliAgentStrategy for NeverDiscovers {
+            fn sessions_root(&self) -> PathBuf {
+                PathBuf::from("/tmp/none")
+            }
+            fn build_args(&self, _: &crate::McpServerConfig, _: Option<&str>) -> Vec<String> {
+                vec![]
+            }
+            fn build_env(&self, _: &crate::McpServerConfig) -> Vec<(String, String)> {
+                vec![]
+            }
+            fn discover_session(
+                &self,
+                _: &Path,
+                _: SystemTime,
+                _: &HashSet<String>,
+            ) -> Option<String> {
+                None
+            }
+            fn detect_end_time(&self, _: &str) -> bool {
+                false
+            }
+        }
+
+        let mut app = App::new();
+        let mut strategies = AgentStrategies::default();
+        strategies.register_cli(Box::new(NeverDiscovers));
+        app.insert_resource(strategies)
+            .init_resource::<AgentSessionToEntity>()
+            .add_systems(Update, discover_pending_agent_sessions);
+
+        let pending = PendingAgentSession {
+            kind: AgentKind::Vibe,
+            spawn_time: SystemTime::UNIX_EPOCH,
+            cwd: PathBuf::from("/this/path/does/not/exist"),
+        };
+        let entity = app.world_mut().spawn(pending).id();
+        app.update();
+        assert!(
+            app.world().get::<PendingAgentSession>(entity).is_some(),
+            "pending must survive long after spawn so a vibe session dir written mid-session is still discovered"
+        );
     }
 }
 

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -2519,10 +2519,12 @@ fn sync_page_metadata_to_tab(
             continue;
         }
         let content_is_web = meta.url.starts_with("http://") || meta.url.starts_with("https://");
+        let content_is_agent = meta.url.starts_with("vmux://agent/");
         if parent_meta
             .as_ref()
             .is_some_and(|m| m.url.starts_with("vmux://agent/"))
             && !content_is_web
+            && !content_is_agent
         {
             continue;
         }
@@ -3003,6 +3005,44 @@ mod tests {
         assert!(should_show_osr_webview(true, false, true, false, false));
         assert!(should_show_osr_webview(true, true, false, false, false));
         assert!(should_show_osr_webview(true, true, true, false, true));
+    }
+
+    #[test]
+    fn agent_cli_url_redirects_tab_to_session_id() {
+        let mut app = App::new();
+        app.add_systems(Update, sync_page_metadata_to_tab);
+
+        let stack = app
+            .world_mut()
+            .spawn((
+                Stack::default(),
+                PageMetadata {
+                    url: "vmux://agent/vibe/".to_string(),
+                    ..default()
+                },
+            ))
+            .id();
+        let child = app
+            .world_mut()
+            .spawn((
+                Browser,
+                PageMetadata {
+                    url: "vmux://agent/vibe/".to_string(),
+                    ..default()
+                },
+                ChildOf(stack),
+            ))
+            .id();
+
+        app.update();
+
+        app.world_mut().get_mut::<PageMetadata>(child).unwrap().url =
+            "vmux://agent/vibe/abc-123".to_string();
+
+        app.update();
+
+        let stack_url = app.world().get::<PageMetadata>(stack).unwrap().url.clone();
+        assert_eq!(stack_url, "vmux://agent/vibe/abc-123");
     }
 
     #[test]


### PR DESCRIPTION
## Context

Opening a CLI-agent tab from a bare scheme URL (e.g. `vmux://agent/vibe`) no longer redirected the address bar to the session URL (`vmux://agent/vibe/<sid>`) once the agent's session id became known. The URL stayed frozen at the prefix, so the tab wasn't shareable and a restored space re-spawned a fresh session instead of reattaching. This was a regression — it worked previously — caused by two unrelated changes stacking.

## Implementation

Two root causes, both fixed:

- **Discovery give-up (VMX-109, `deed94ee`).** Replacing session polling with a notify watcher introduced a 30s give-up measured from spawn that removed `PendingAgentSession`. Vibe persists its session dir only ~after the first turn (~10s after the first message in a controlled test), and the spawn→first-message gap includes the user reading the banner and typing — so the 30s window routinely closes before the dir appears. Removed the give-up; the pending entity stays discoverable until the process exits (process-exit cleanup already removes it), and the notify watcher re-triggers discovery when the dir lands.

- **Tab-sync guard (#56, `cf59918f`).** `sync_page_metadata_to_tab` switched from a structural check (stack `Has<AgentSession>`) to a URL-string check (stack url `starts_with "vmux://agent/"`). CLI agents keep `AgentSession` on the child terminal, not the stack, so the new guard froze the stack URL at the prefix and blocked the sid even once discovered. Agent-scheme (`vmux://agent/`) child URLs may now update an agent stack, while web/data content is still prevented from clobbering the agent URL.

Both are required: the guard broke the redirect for all CLI agents (claude/codex too); the give-up specifically starves vibe of its sid.

## Checks / QA

- Open a new `vmux://agent/vibe` tab, send a first message, wait for the first response (~10s), and confirm the address bar redirects to `vmux://agent/vibe/<sid>`.
- Repeat with claude/codex agents — the address bar should show `/<sid>` too.
- Restart and restore the space; confirm the agent tab reattaches to the existing session rather than spawning a fresh one.
- Open a website inside an agent stack and confirm the tab URL still follows the web navigation (agent-URL guard didn't over-broaden).