### PR TITLE
feat(input): windowed native focus + session shortcut tap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9509,6 +9509,8 @@ dependencies = [
  "notify 6.1.1",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation 0.3.2",
  "objc2-quartz-core 0.3.2",
  "parking_lot",

--- a/crates/vmux_browser/src/host_focus.rs
+++ b/crates/vmux_browser/src/host_focus.rs
@@ -46,12 +46,10 @@ pub(crate) fn compute_host_focus_intent(
     terminal_q: Query<(), With<Terminal>>,
     modal_q: Query<(&Node, Has<CefKeyboardTarget>), With<Modal>>,
     mut intent: ResMut<HostFocusIntent>,
-    mut last_logged: Local<Option<HostFocusIntent>>,
 ) {
-    let command_bar_open = is_command_bar_open(&modal_q);
     // While the command bar owns native focus, leave content focus alone — otherwise we would
     // re-steal first-responder from the command bar every frame.
-    let next = if *mode != InteractionMode::User || command_bar_open {
+    let next = if *mode != InteractionMode::User || is_command_bar_open(&modal_q) {
         HostFocusIntent::Unmanaged
     } else {
         let active = focus.stack.and_then(|stack| {
@@ -65,15 +63,6 @@ pub(crate) fn compute_host_focus_intent(
         let is_terminal = active.is_some_and(|webview| terminal_q.contains(webview));
         host_focus_intent(active, is_terminal)
     };
-
-    if *last_logged != Some(next) {
-        info!(
-            target: "vmux::host_focus",
-            "intent {:?} -> {:?} (stack={:?} command_bar_open={command_bar_open})",
-            *last_logged, next, focus.stack
-        );
-        *last_logged = Some(next);
-    }
     set_intent(&mut intent, next);
 }
 
@@ -83,24 +72,13 @@ fn set_intent(intent: &mut ResMut<HostFocusIntent>, next: HostFocusIntent) {
     }
 }
 
-pub(crate) fn apply_windowed_host_focus(
-    intent: Res<HostFocusIntent>,
-    browsers: NonSend<Browsers>,
-    mut last_focused: Local<Option<Entity>>,
-) {
-    let HostFocusIntent::Windowed(webview) = *intent else {
-        *last_focused = None;
-        return;
-    };
-    if !browsers.has_browser(webview) {
-        // Browser not created yet (page just opened); retry next frame.
-        *last_focused = None;
-        return;
-    }
-    browsers.set_windowed_focus(&webview, true);
-    if *last_focused != Some(webview) {
-        info!(target: "vmux::host_focus", "windowed focus -> {webview:?}");
-        *last_focused = Some(webview);
+pub(crate) fn apply_windowed_host_focus(intent: Res<HostFocusIntent>, browsers: NonSend<Browsers>) {
+    // Runs every frame so a page that becomes active before its browser exists still gets focused
+    // once the browser is created. `set_windowed_focus` is a no-op until then.
+    if let HostFocusIntent::Windowed(webview) = *intent
+        && browsers.has_browser(webview)
+    {
+        browsers.set_windowed_focus(&webview, true);
     }
 }
 

--- a/crates/vmux_browser/src/host_focus.rs
+++ b/crates/vmux_browser/src/host_focus.rs
@@ -46,24 +46,35 @@ pub(crate) fn compute_host_focus_intent(
     terminal_q: Query<(), With<Terminal>>,
     modal_q: Query<(&Node, Has<CefKeyboardTarget>), With<Modal>>,
     mut intent: ResMut<HostFocusIntent>,
+    mut last_logged: Local<Option<HostFocusIntent>>,
 ) {
+    let command_bar_open = is_command_bar_open(&modal_q);
     // While the command bar owns native focus, leave content focus alone — otherwise we would
     // re-steal first-responder from the command bar every frame.
-    if *mode != InteractionMode::User || is_command_bar_open(&modal_q) {
-        set_intent(&mut intent, HostFocusIntent::Unmanaged);
-        return;
-    }
+    let next = if *mode != InteractionMode::User || command_bar_open {
+        HostFocusIntent::Unmanaged
+    } else {
+        let active = focus.stack.and_then(|stack| {
+            content_q.iter().find(|&webview| {
+                child_of_q
+                    .get(webview)
+                    .map(|child_of| child_of.get() == stack)
+                    .unwrap_or(false)
+            })
+        });
+        let is_terminal = active.is_some_and(|webview| terminal_q.contains(webview));
+        host_focus_intent(active, is_terminal)
+    };
 
-    let active = focus.stack.and_then(|stack| {
-        content_q.iter().find(|&webview| {
-            child_of_q
-                .get(webview)
-                .map(|child_of| child_of.get() == stack)
-                .unwrap_or(false)
-        })
-    });
-    let is_terminal = active.is_some_and(|webview| terminal_q.contains(webview));
-    set_intent(&mut intent, host_focus_intent(active, is_terminal));
+    if *last_logged != Some(next) {
+        info!(
+            target: "vmux::host_focus",
+            "intent {:?} -> {:?} (stack={:?} command_bar_open={command_bar_open})",
+            *last_logged, next, focus.stack
+        );
+        *last_logged = Some(next);
+    }
+    set_intent(&mut intent, next);
 }
 
 fn set_intent(intent: &mut ResMut<HostFocusIntent>, next: HostFocusIntent) {
@@ -72,11 +83,24 @@ fn set_intent(intent: &mut ResMut<HostFocusIntent>, next: HostFocusIntent) {
     }
 }
 
-pub(crate) fn apply_windowed_host_focus(intent: Res<HostFocusIntent>, browsers: NonSend<Browsers>) {
-    if let HostFocusIntent::Windowed(webview) = *intent
-        && browsers.has_browser(webview)
-    {
-        browsers.set_windowed_focus(&webview, true);
+pub(crate) fn apply_windowed_host_focus(
+    intent: Res<HostFocusIntent>,
+    browsers: NonSend<Browsers>,
+    mut last_focused: Local<Option<Entity>>,
+) {
+    let HostFocusIntent::Windowed(webview) = *intent else {
+        *last_focused = None;
+        return;
+    };
+    if !browsers.has_browser(webview) {
+        // Browser not created yet (page just opened); retry next frame.
+        *last_focused = None;
+        return;
+    }
+    browsers.set_windowed_focus(&webview, true);
+    if *last_focused != Some(webview) {
+        info!(target: "vmux::host_focus", "windowed focus -> {webview:?}");
+        *last_focused = Some(webview);
     }
 }
 

--- a/crates/vmux_browser/src/host_focus.rs
+++ b/crates/vmux_browser/src/host_focus.rs
@@ -1,0 +1,147 @@
+use bevy::ecs::relationship::Relationship;
+use bevy::prelude::*;
+use bevy_cef::prelude::{Browsers, CefKeyboardTarget};
+use vmux_layout::Header;
+use vmux_layout::command_bar::handler::is_command_bar_open;
+use vmux_layout::scene::InteractionMode;
+use vmux_layout::side_sheet::SideSheet;
+use vmux_layout::stack::FocusedStack;
+use vmux_layout::window::Modal;
+use vmux_terminal::Terminal;
+
+use crate::Browser;
+
+/// Which surface should own keyboard first-responder for the active page in User (browse) mode.
+///
+/// Windowed web pages need their native `NSView` to be first-responder to type. Terminals are OSR
+/// and route keys through winit → Bevy → PTY, so the winit host window must hold first-responder
+/// instead. Switching between the two requires actively handing first-responder back and forth,
+/// because a focused web page's `NSView` otherwise keeps it and blacks out the host keyboard.
+#[derive(Resource, Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostFocusIntent {
+    /// Not in User mode — leave focus untouched (OSR/Player path owns it).
+    #[default]
+    Unmanaged,
+    /// Active page is a windowed web page; give this webview native first-responder.
+    Windowed(Entity),
+    /// Active page is a terminal, or there is none — the winit host window must own first-responder.
+    WinitHost,
+}
+
+pub(crate) fn host_focus_intent(
+    active_webview: Option<Entity>,
+    is_terminal: bool,
+) -> HostFocusIntent {
+    match active_webview {
+        Some(webview) if !is_terminal => HostFocusIntent::Windowed(webview),
+        _ => HostFocusIntent::WinitHost,
+    }
+}
+
+pub(crate) fn compute_host_focus_intent(
+    mode: Res<InteractionMode>,
+    focus: Res<FocusedStack>,
+    child_of_q: Query<&ChildOf>,
+    content_q: Query<Entity, (With<Browser>, Without<Header>, Without<SideSheet>)>,
+    terminal_q: Query<(), With<Terminal>>,
+    modal_q: Query<(&Node, Has<CefKeyboardTarget>), With<Modal>>,
+    mut intent: ResMut<HostFocusIntent>,
+) {
+    // While the command bar owns native focus, leave content focus alone — otherwise we would
+    // re-steal first-responder from the command bar every frame.
+    if *mode != InteractionMode::User || is_command_bar_open(&modal_q) {
+        set_intent(&mut intent, HostFocusIntent::Unmanaged);
+        return;
+    }
+
+    let active = focus.stack.and_then(|stack| {
+        content_q.iter().find(|&webview| {
+            child_of_q
+                .get(webview)
+                .map(|child_of| child_of.get() == stack)
+                .unwrap_or(false)
+        })
+    });
+    let is_terminal = active.is_some_and(|webview| terminal_q.contains(webview));
+    set_intent(&mut intent, host_focus_intent(active, is_terminal));
+}
+
+fn set_intent(intent: &mut ResMut<HostFocusIntent>, next: HostFocusIntent) {
+    if **intent != next {
+        **intent = next;
+    }
+}
+
+pub(crate) fn apply_windowed_host_focus(intent: Res<HostFocusIntent>, browsers: NonSend<Browsers>) {
+    if let HostFocusIntent::Windowed(webview) = *intent
+        && browsers.has_browser(webview)
+    {
+        browsers.set_windowed_focus(&webview, true);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<HostFocusIntent>()
+            .insert_resource(InteractionMode::User)
+            .insert_resource(FocusedStack::default())
+            .add_systems(Update, compute_host_focus_intent);
+        app
+    }
+
+    fn intent(app: &App) -> HostFocusIntent {
+        *app.world().resource::<HostFocusIntent>()
+    }
+
+    #[test]
+    fn web_child_of_active_stack_intends_windowed() {
+        let mut app = app();
+        let stack = app.world_mut().spawn_empty().id();
+        let page = app.world_mut().spawn((Browser, ChildOf(stack))).id();
+        app.insert_resource(FocusedStack {
+            stack: Some(stack),
+            ..default()
+        });
+        app.update();
+        assert_eq!(intent(&app), HostFocusIntent::Windowed(page));
+    }
+
+    #[test]
+    fn terminal_child_of_active_stack_intends_winit_host() {
+        let mut app = app();
+        let stack = app.world_mut().spawn_empty().id();
+        app.world_mut().spawn((Browser, Terminal, ChildOf(stack)));
+        app.insert_resource(FocusedStack {
+            stack: Some(stack),
+            ..default()
+        });
+        app.update();
+        assert_eq!(intent(&app), HostFocusIntent::WinitHost);
+    }
+
+    #[test]
+    fn no_active_stack_intends_winit_host() {
+        let mut app = app();
+        app.update();
+        assert_eq!(intent(&app), HostFocusIntent::WinitHost);
+    }
+
+    #[test]
+    fn player_mode_is_unmanaged() {
+        let mut app = app();
+        let stack = app.world_mut().spawn_empty().id();
+        app.world_mut().spawn((Browser, ChildOf(stack)));
+        app.insert_resource(InteractionMode::Player);
+        app.insert_resource(FocusedStack {
+            stack: Some(stack),
+            ..default()
+        });
+        app.update();
+        assert_eq!(intent(&app), HostFocusIntent::Unmanaged);
+    }
+}

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -1177,6 +1177,9 @@ struct CommandBarWindowedFrame {
 }
 
 const COMMAND_BAR_NATIVE_RADIUS_PX: f32 = 16.0;
+/// `zPosition` for the windowed command bar, above the layout chrome overlay (`zPosition` 100) so
+/// the sidebar/header/stack panel never covers it.
+const COMMAND_BAR_NATIVE_Z: f64 = 200.0;
 static NATIVE_COMMAND_BAR_CLICK_FRAME: LazyLock<Mutex<Option<CommandBarWindowedFrame>>> =
     LazyLock::new(|| Mutex::new(None));
 static NATIVE_COMMAND_BAR_DISMISS_REQUESTED: AtomicBool = AtomicBool::new(false);
@@ -1420,6 +1423,9 @@ fn sync_windowed_command_bar(
     );
     browsers.set_windowed_hidden(&entity, false);
     browsers.raise_windowed_to_front(&entity);
+    // The layout chrome (sidebar/header/stack panel) composites as a native overlay at zPosition
+    // 100; raise alone (subview order) leaves the command bar under it. Lift it above.
+    browsers.set_windowed_z_position(&entity, COMMAND_BAR_NATIVE_Z);
     browsers.set_windowed_focus(&entity, true);
     if !*was_open {
         browsers.nudge_windowed_repaint(&entity);

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -180,7 +180,10 @@ impl Plugin for BrowserPlugin {
                     host_focus::apply_windowed_host_focus,
                 )
                     .chain()
-                    .after(sync_keyboard_target),
+                    // Must run after the active windowed page is shown + raised, otherwise
+                    // set_focus lands on a hidden/back view and never sticks.
+                    .after(sync_windowed_frames)
+                    .after(sync_windowed_command_bar),
             );
     }
 }

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -1,5 +1,8 @@
 #![allow(clippy::too_many_arguments, clippy::type_complexity)]
 
+mod host_focus;
+pub use host_focus::HostFocusIntent;
+
 use bevy::{
     ecs::{message::Messages, relationship::Relationship},
     input::{
@@ -168,7 +171,17 @@ impl Plugin for BrowserPlugin {
                     .after(UiSystems::Layout)
                     .before(render_standard_materials),
             )
-            .add_systems(Last, refresh_active_windowed_hover);
+            .add_systems(Last, refresh_active_windowed_hover)
+            .init_resource::<HostFocusIntent>()
+            .add_systems(
+                PostUpdate,
+                (
+                    host_focus::compute_host_focus_intent,
+                    host_focus::apply_windowed_host_focus,
+                )
+                    .chain()
+                    .after(sync_keyboard_target),
+            );
     }
 }
 

--- a/crates/vmux_command/src/command.rs
+++ b/crates/vmux_command/src/command.rs
@@ -409,6 +409,37 @@ mod tests {
     use bevy::input::keyboard::KeyCode;
 
     #[test]
+    fn menu_accelerators_are_registered_as_global_shortcuts() {
+        let shortcuts = AppCommand::default_shortcuts();
+        let has_super = |k: KeyCode| {
+            shortcuts.iter().any(|(s, _)| {
+                matches!(s, Shortcut::Direct(c) if c.key == k && c.modifiers.super_key
+                    && !c.modifiers.shift && !c.modifiers.ctrl && !c.modifiers.alt)
+            })
+        };
+        // Accelerator-only menu commands must also reach the universal shortcut layer so they fire
+        // when a terminal/layout holds focus (winit swallows menu key-equivalents there).
+        assert!(
+            has_super(KeyCode::KeyT),
+            "cmd+T (new tab) must be a global shortcut"
+        );
+        assert!(
+            has_super(KeyCode::KeyN),
+            "cmd+N (new stack) must be a global shortcut"
+        );
+        assert!(
+            has_super(KeyCode::KeyW),
+            "cmd+W (close stack) must be a global shortcut"
+        );
+        assert_eq!(
+            AppCommand::from_menu_id("open_in_new_tab"),
+            Some(AppCommand::Browser(BrowserCommand::Open(
+                OpenCommand::InNewTab { url: None }
+            )))
+        );
+    }
+
+    #[test]
     fn hidden_commands_can_have_default_shortcuts() {
         assert_eq!(
             AppCommand::from_menu_id("terminal_copy_mode"),

--- a/crates/vmux_desktop/Cargo.toml
+++ b/crates/vmux_desktop/Cargo.toml
@@ -67,6 +67,12 @@ objc2-app-kit = { version = "0.3", features = [
 ] }
 objc2-foundation = { version = "0.3", features = ["NSGeometry"] }
 objc2-quartz-core = { version = "0.3", features = ["CALayer", "objc2-core-foundation"] }
+objc2-core-graphics = { version = "0.3", features = ["CGEvent", "CGEventTypes"] }
+objc2-core-foundation = { version = "0.3", features = [
+    "CFBase",
+    "CFRunLoop",
+    "CFMachPort",
+] }
 block2 = "0.6"
 raw-window-handle = "0.6"
 

--- a/crates/vmux_desktop/src/event_tap.rs
+++ b/crates/vmux_desktop/src/event_tap.rs
@@ -1,0 +1,223 @@
+use std::cell::RefCell;
+use std::ffi::c_void;
+use std::ptr::NonNull;
+
+use bevy::prelude::*;
+use bevy::winit::{EventLoopProxyWrapper, WinitUserEvent};
+use objc2_core_foundation::{CFMachPort, CFRetained, CFRunLoop, kCFRunLoopCommonModes};
+use objc2_core_graphics::{
+    CGEvent, CGEventField, CGEventFlags, CGEventMask, CGEventTapLocation, CGEventTapOptions,
+    CGEventTapPlacement, CGEventTapProxy, CGEventType, CGPreflightListenEventAccess,
+    CGRequestListenEventAccess,
+};
+use vmux_command::AppCommand;
+
+use crate::native_keyboard::{KeyAction, classify, key_code_from_vk, push_command};
+use crate::shortcut::{KeyCombo, Modifiers};
+
+struct TapState {
+    port: CFRetained<CFMachPort>,
+    wake: Box<dyn Fn()>,
+}
+
+thread_local! {
+    static TAP_STATE: RefCell<Option<TapState>> = const { RefCell::new(None) };
+}
+
+fn modifiers_from_cg_flags(flags: CGEventFlags) -> Modifiers {
+    Modifiers {
+        ctrl: flags.contains(CGEventFlags::MaskControl),
+        shift: flags.contains(CGEventFlags::MaskShift),
+        alt: flags.contains(CGEventFlags::MaskAlternate),
+        super_key: flags.contains(CGEventFlags::MaskCommand),
+    }
+}
+
+fn combo_from_cg(keycode: u16, flags: CGEventFlags) -> Option<KeyCombo> {
+    Some(KeyCombo {
+        key: key_code_from_vk(keycode)?,
+        modifiers: modifiers_from_cg_flags(flags),
+    })
+}
+
+enum TapOutcome {
+    Pass,
+    Consume(Option<AppCommand>),
+}
+
+/// The session tap fires before any app, so it must hijack keys only while vmux is frontmost.
+/// When not frontmost the classifier is never run, so no chord state is mutated and no command
+/// is queued — other apps' keys pass through untouched.
+fn gate(frontmost: bool, classify_fn: impl FnOnce() -> KeyAction) -> TapOutcome {
+    if !frontmost {
+        return TapOutcome::Pass;
+    }
+    match classify_fn() {
+        KeyAction::Consume(cmd) => TapOutcome::Consume(cmd),
+        KeyAction::PassThrough => TapOutcome::Pass,
+    }
+}
+
+fn app_is_frontmost() -> bool {
+    use objc2_app_kit::NSApplication;
+    use objc2_foundation::MainThreadMarker;
+    let Some(mtm) = MainThreadMarker::new() else {
+        return false;
+    };
+    NSApplication::sharedApplication(mtm).isActive()
+}
+
+unsafe extern "C-unwind" fn tap_callback(
+    _proxy: CGEventTapProxy,
+    event_type: CGEventType,
+    event: NonNull<CGEvent>,
+    _user_info: *mut c_void,
+) -> *mut CGEvent {
+    if event_type == CGEventType::TapDisabledByTimeout
+        || event_type == CGEventType::TapDisabledByUserInput
+    {
+        TAP_STATE.with(|s| {
+            if let Some(state) = s.borrow().as_ref() {
+                CGEvent::tap_enable(&state.port, true);
+            }
+        });
+        return event.as_ptr();
+    }
+
+    TAP_STATE.with(|s| {
+        if let Some(state) = s.borrow().as_ref() {
+            (state.wake)();
+        }
+    });
+
+    if event_type != CGEventType::KeyDown {
+        return event.as_ptr();
+    }
+
+    let ev = unsafe { event.as_ref() };
+    let keycode = CGEvent::integer_value_field(Some(ev), CGEventField::KeyboardEventKeycode) as u16;
+    let flags = CGEvent::flags(Some(ev));
+    let Some(combo) = combo_from_cg(keycode, flags) else {
+        return event.as_ptr();
+    };
+
+    match gate(app_is_frontmost(), || classify(combo)) {
+        TapOutcome::Consume(cmd) => {
+            if let Some(cmd) = cmd {
+                push_command(cmd);
+            }
+            std::ptr::null_mut()
+        }
+        TapOutcome::Pass => event.as_ptr(),
+    }
+}
+
+pub(crate) fn install_event_tap(proxy: Option<Res<EventLoopProxyWrapper>>) {
+    let Some(proxy) = proxy else {
+        return;
+    };
+    let proxy = (**proxy).clone();
+    install(Box::new(move || {
+        let _ = proxy.send_event(WinitUserEvent::WakeUp);
+    }));
+}
+
+fn install(wake: Box<dyn Fn()>) {
+    // First run: show the Input Monitoring prompt. The grant only takes effect after a restart, so
+    // the tap below still returns None this launch and shortcuts fall back to the local monitor.
+    if !CGPreflightListenEventAccess() {
+        CGRequestListenEventAccess();
+    }
+
+    let mask: CGEventMask =
+        (1u64 << CGEventType::KeyDown.0) | (1u64 << CGEventType::FlagsChanged.0);
+    let port = unsafe {
+        CGEvent::tap_create(
+            CGEventTapLocation::SessionEventTap,
+            CGEventTapPlacement::HeadInsertEventTap,
+            CGEventTapOptions::Default,
+            mask,
+            Some(tap_callback),
+            std::ptr::null_mut(),
+        )
+    };
+    let Some(port) = port else {
+        warn!(
+            "event tap not created (Input Monitoring not granted?); shortcuts while a web page is focused need the grant + a restart"
+        );
+        return;
+    };
+    let Some(source) = CFMachPort::new_run_loop_source(None, Some(&port), 0) else {
+        warn!("event tap: failed to create run loop source");
+        return;
+    };
+    let Some(run_loop) = CFRunLoop::current() else {
+        warn!("event tap: no current run loop");
+        return;
+    };
+    let mode = unsafe { kCFRunLoopCommonModes };
+    run_loop.add_source(Some(&source), mode);
+    CGEvent::tap_enable(&port, true);
+    std::mem::forget(source);
+    TAP_STATE.with(|s| {
+        *s.borrow_mut() = Some(TapState { port, wake });
+    });
+    info!("event tap installed (session keyDown/flagsChanged)");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::input::keyboard::KeyCode;
+    use vmux_command::{LayoutCommand, PaneCommand};
+
+    #[test]
+    fn cg_flags_map_to_modifiers() {
+        let m = modifiers_from_cg_flags(CGEventFlags::MaskCommand);
+        assert!(m.super_key && !m.ctrl && !m.alt && !m.shift);
+
+        let m = modifiers_from_cg_flags(CGEventFlags::MaskControl | CGEventFlags::MaskShift);
+        assert!(m.ctrl && m.shift && !m.alt && !m.super_key);
+
+        let m = modifiers_from_cg_flags(CGEventFlags::MaskAlternate);
+        assert!(m.alt && !m.ctrl && !m.shift && !m.super_key);
+
+        let m = modifiers_from_cg_flags(CGEventFlags::empty());
+        assert!(!m.ctrl && !m.shift && !m.alt && !m.super_key);
+    }
+
+    #[test]
+    fn combo_from_cg_resolves_known_keycode() {
+        // 0x09 == kVK_ANSI_V
+        let combo = combo_from_cg(0x09, CGEventFlags::MaskCommand).expect("combo");
+        assert_eq!(combo.key, KeyCode::KeyV);
+        assert!(combo.modifiers.super_key);
+    }
+
+    #[test]
+    fn combo_from_cg_rejects_unknown_keycode() {
+        assert!(combo_from_cg(0xFFFF, CGEventFlags::empty()).is_none());
+    }
+
+    #[test]
+    fn gate_passes_without_classifying_when_not_frontmost() {
+        let outcome = gate(false, || panic!("must not classify when not frontmost"));
+        assert!(matches!(outcome, TapOutcome::Pass));
+    }
+
+    #[test]
+    fn gate_consumes_when_frontmost_and_classifier_consumes() {
+        let cmd = AppCommand::Layout(LayoutCommand::Pane(PaneCommand::SelectLeft));
+        let outcome = gate(true, || KeyAction::Consume(Some(cmd.clone())));
+        match outcome {
+            TapOutcome::Consume(Some(c)) => assert_eq!(c, cmd),
+            _ => panic!("expected consume"),
+        }
+    }
+
+    #[test]
+    fn gate_passes_when_frontmost_and_classifier_passes() {
+        let outcome = gate(true, || KeyAction::PassThrough);
+        assert!(matches!(outcome, TapOutcome::Pass));
+    }
+}

--- a/crates/vmux_desktop/src/focus_native.rs
+++ b/crates/vmux_desktop/src/focus_native.rs
@@ -14,24 +14,43 @@ pub(crate) fn apply_winit_host_focus(
     _non_send: NonSendMarker,
     intent: Res<HostFocusIntent>,
     primary: Query<Entity, With<PrimaryWindow>>,
-    mut announced: Local<bool>,
+    mut reclaimed: Local<bool>,
 ) {
     if *intent != HostFocusIntent::WinitHost {
-        *announced = false;
+        *reclaimed = false;
+        return;
+    }
+    // Retry each frame until the reclaim sticks (the active windowed page/command bar may resign a
+    // frame after the intent flips), then stop — re-asserting every frame fights the page for
+    // first-responder and breaks input.
+    if *reclaimed {
         return;
     }
     let Ok(window_entity) = primary.single() else {
         return;
     };
-    if reclaim_first_responder(window_entity) && !*announced {
-        info!(target: "vmux::host_focus", "winit reclaim first responder (window={window_entity:?})");
-        *announced = true;
+    match reclaim_first_responder(window_entity) {
+        ReclaimOutcome::AlreadyWinit => *reclaimed = true,
+        ReclaimOutcome::Reclaimed => {
+            info!(target: "vmux::host_focus", "winit reclaim ok (window={window_entity:?})");
+            *reclaimed = true;
+        }
+        ReclaimOutcome::Failed => {
+            info!(target: "vmux::host_focus", "winit reclaim FAILED (window={window_entity:?}) — retrying");
+        }
+        ReclaimOutcome::NoView => {}
     }
 }
 
-/// Make the winit content view the window's first responder. Returns `true` if it actually changed
-/// (i.e. winit did not already hold it).
-fn reclaim_first_responder(window_entity: Entity) -> bool {
+enum ReclaimOutcome {
+    AlreadyWinit,
+    Reclaimed,
+    Failed,
+    NoView,
+}
+
+/// Make the winit content view the window's first responder.
+fn reclaim_first_responder(window_entity: Entity) -> ReclaimOutcome {
     use bevy::winit::WINIT_WINDOWS;
     use objc2_app_kit::{NSResponder, NSView};
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
@@ -46,11 +65,11 @@ fn reclaim_first_responder(window_entity: Entity) -> bool {
         }
     });
     let Some(view_ptr) = view_ptr else {
-        return false;
+        return ReclaimOutcome::NoView;
     };
     let view: &NSView = unsafe { &*view_ptr.cast::<NSView>() };
     let Some(window) = view.window() else {
-        return false;
+        return ReclaimOutcome::NoView;
     };
     let responder: &NSResponder = view;
     if let Some(current) = window.firstResponder()
@@ -59,7 +78,11 @@ fn reclaim_first_responder(window_entity: Entity) -> bool {
             responder as *const NSResponder,
         )
     {
-        return false;
+        return ReclaimOutcome::AlreadyWinit;
     }
-    window.makeFirstResponder(Some(responder))
+    if window.makeFirstResponder(Some(responder)) {
+        ReclaimOutcome::Reclaimed
+    } else {
+        ReclaimOutcome::Failed
+    }
 }

--- a/crates/vmux_desktop/src/focus_native.rs
+++ b/crates/vmux_desktop/src/focus_native.rs
@@ -5,34 +5,33 @@ use vmux_browser::HostFocusIntent;
 
 /// When the active page is a terminal (OSR) or there is none, the winit host window must own
 /// macOS first-responder so Bevy delivers keys (terminal → PTY, layout shortcuts). A previously
-/// focused windowed web page leaves its native `NSView` as first-responder, which blacks out the
-/// host keyboard — so on the transition into [`HostFocusIntent::WinitHost`] we explicitly hand
-/// first-responder back to the winit content view. Only acted on transition to avoid re-stealing
-/// focus from in-page text fields every frame.
+/// focused windowed web page or the command bar leaves its native `NSView` as first-responder,
+/// which blacks out the host keyboard — so while [`HostFocusIntent::WinitHost`] is active we hand
+/// first-responder back to the winit content view. Re-asserted every frame (not just on the
+/// transition) because a closing command bar / page can resign a frame *after* the intent flips,
+/// which a one-shot reclaim would miss. `makeFirstResponder` is skipped when winit already holds it.
 pub(crate) fn apply_winit_host_focus(
     _non_send: NonSendMarker,
     intent: Res<HostFocusIntent>,
     primary: Query<Entity, With<PrimaryWindow>>,
-    mut last: Local<Option<HostFocusIntent>>,
+    mut announced: Local<bool>,
 ) {
-    let current = *intent;
-    if current != HostFocusIntent::WinitHost {
-        *last = Some(current);
+    if *intent != HostFocusIntent::WinitHost {
+        *announced = false;
         return;
     }
-    if *last == Some(current) {
-        return;
-    }
-    // Retry on later frames until the window exists, so an early transition isn't dropped.
     let Ok(window_entity) = primary.single() else {
         return;
     };
-    info!(target: "vmux::host_focus", "winit reclaim first responder (window={window_entity:?})");
-    reclaim_first_responder(window_entity);
-    *last = Some(current);
+    if reclaim_first_responder(window_entity) && !*announced {
+        info!(target: "vmux::host_focus", "winit reclaim first responder (window={window_entity:?})");
+        *announced = true;
+    }
 }
 
-fn reclaim_first_responder(window_entity: Entity) {
+/// Make the winit content view the window's first responder. Returns `true` if it actually changed
+/// (i.e. winit did not already hold it).
+fn reclaim_first_responder(window_entity: Entity) -> bool {
     use bevy::winit::WINIT_WINDOWS;
     use objc2_app_kit::{NSResponder, NSView};
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
@@ -47,12 +46,20 @@ fn reclaim_first_responder(window_entity: Entity) {
         }
     });
     let Some(view_ptr) = view_ptr else {
-        return;
+        return false;
     };
     let view: &NSView = unsafe { &*view_ptr.cast::<NSView>() };
     let Some(window) = view.window() else {
-        return;
+        return false;
     };
     let responder: &NSResponder = view;
-    window.makeFirstResponder(Some(responder));
+    if let Some(current) = window.firstResponder()
+        && core::ptr::eq(
+            (&*current) as *const NSResponder,
+            responder as *const NSResponder,
+        )
+    {
+        return false;
+    }
+    window.makeFirstResponder(Some(responder))
 }

--- a/crates/vmux_desktop/src/focus_native.rs
+++ b/crates/vmux_desktop/src/focus_native.rs
@@ -7,9 +7,11 @@ use vmux_browser::HostFocusIntent;
 /// macOS first-responder so Bevy delivers keys (terminal → PTY, layout shortcuts). A previously
 /// focused windowed web page or the command bar leaves its native `NSView` as first-responder,
 /// which blacks out the host keyboard — so while [`HostFocusIntent::WinitHost`] is active we hand
-/// first-responder back to the winit content view. Re-asserted every frame (not just on the
-/// transition) because a closing command bar / page can resign a frame *after* the intent flips,
-/// which a one-shot reclaim would miss. `makeFirstResponder` is skipped when winit already holds it.
+/// first-responder back to the winit content view.
+///
+/// The reclaim is retried each frame *until it sticks*, then stops: the active page/command bar can
+/// resign a frame after the intent flips (so a one-shot reclaim would miss it), but re-asserting
+/// every frame fights the page for first-responder and breaks input.
 pub(crate) fn apply_winit_host_focus(
     _non_send: NonSendMarker,
     intent: Res<HostFocusIntent>,
@@ -20,9 +22,6 @@ pub(crate) fn apply_winit_host_focus(
         *reclaimed = false;
         return;
     }
-    // Retry each frame until the reclaim sticks (the active windowed page/command bar may resign a
-    // frame after the intent flips), then stop — re-asserting every frame fights the page for
-    // first-responder and breaks input.
     if *reclaimed {
         return;
     }
@@ -30,15 +29,9 @@ pub(crate) fn apply_winit_host_focus(
         return;
     };
     match reclaim_first_responder(window_entity) {
-        ReclaimOutcome::AlreadyWinit => *reclaimed = true,
-        ReclaimOutcome::Reclaimed => {
-            info!(target: "vmux::host_focus", "winit reclaim ok (window={window_entity:?})");
-            *reclaimed = true;
-        }
-        ReclaimOutcome::Failed => {
-            info!(target: "vmux::host_focus", "winit reclaim FAILED (window={window_entity:?}) — retrying");
-        }
-        ReclaimOutcome::NoView => {}
+        ReclaimOutcome::AlreadyWinit | ReclaimOutcome::Reclaimed => *reclaimed = true,
+        // Window/view not ready or the current responder refused to resign — retry next frame.
+        ReclaimOutcome::Failed | ReclaimOutcome::NoView => {}
     }
 }
 

--- a/crates/vmux_desktop/src/focus_native.rs
+++ b/crates/vmux_desktop/src/focus_native.rs
@@ -1,0 +1,57 @@
+use bevy::ecs::system::NonSendMarker;
+use bevy::prelude::*;
+use bevy::window::PrimaryWindow;
+use vmux_browser::HostFocusIntent;
+
+/// When the active page is a terminal (OSR) or there is none, the winit host window must own
+/// macOS first-responder so Bevy delivers keys (terminal → PTY, layout shortcuts). A previously
+/// focused windowed web page leaves its native `NSView` as first-responder, which blacks out the
+/// host keyboard — so on the transition into [`HostFocusIntent::WinitHost`] we explicitly hand
+/// first-responder back to the winit content view. Only acted on transition to avoid re-stealing
+/// focus from in-page text fields every frame.
+pub(crate) fn apply_winit_host_focus(
+    _non_send: NonSendMarker,
+    intent: Res<HostFocusIntent>,
+    primary: Query<Entity, With<PrimaryWindow>>,
+    mut last: Local<Option<HostFocusIntent>>,
+) {
+    let current = *intent;
+    if current != HostFocusIntent::WinitHost {
+        *last = Some(current);
+        return;
+    }
+    if *last == Some(current) {
+        return;
+    }
+    // Retry on later frames until the window exists, so an early transition isn't dropped.
+    let Ok(window_entity) = primary.single() else {
+        return;
+    };
+    reclaim_first_responder(window_entity);
+    *last = Some(current);
+}
+
+fn reclaim_first_responder(window_entity: Entity) {
+    use bevy::winit::WINIT_WINDOWS;
+    use objc2_app_kit::{NSResponder, NSView};
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+
+    let view_ptr = WINIT_WINDOWS.with_borrow(|windows| {
+        let id = windows.entity_to_winit.get(&window_entity)?;
+        let wrapper = windows.windows.get(id)?;
+        let handle = wrapper.window_handle().ok()?;
+        match handle.as_raw() {
+            RawWindowHandle::AppKit(h) => Some(h.ns_view.as_ptr()),
+            _ => None,
+        }
+    });
+    let Some(view_ptr) = view_ptr else {
+        return;
+    };
+    let view: &NSView = unsafe { &*view_ptr.cast::<NSView>() };
+    let Some(window) = view.window() else {
+        return;
+    };
+    let responder: &NSResponder = view;
+    window.makeFirstResponder(Some(responder));
+}

--- a/crates/vmux_desktop/src/focus_native.rs
+++ b/crates/vmux_desktop/src/focus_native.rs
@@ -27,6 +27,7 @@ pub(crate) fn apply_winit_host_focus(
     let Ok(window_entity) = primary.single() else {
         return;
     };
+    info!(target: "vmux::host_focus", "winit reclaim first responder (window={window_entity:?})");
     reclaim_first_responder(window_entity);
     *last = Some(current);
 }

--- a/crates/vmux_desktop/src/lib.rs
+++ b/crates/vmux_desktop/src/lib.rs
@@ -7,6 +7,10 @@
 
 mod background_lifecycle;
 #[cfg(target_os = "macos")]
+mod event_tap;
+#[cfg(target_os = "macos")]
+mod focus_native;
+#[cfg(target_os = "macos")]
 mod glass;
 #[cfg(target_os = "macos")]
 mod native_keyboard;
@@ -103,7 +107,8 @@ impl Plugin for VmuxPlugin {
             ));
 
         #[cfg(target_os = "macos")]
-        app.add_plugins(glass::GlassPlugin);
+        app.add_plugins(glass::GlassPlugin)
+            .add_systems(Last, focus_native::apply_winit_host_focus);
     }
 }
 

--- a/crates/vmux_desktop/src/native_keyboard.rs
+++ b/crates/vmux_desktop/src/native_keyboard.rs
@@ -23,12 +23,12 @@ pub(crate) fn set_shortcut_map(map: ShortcutMap) {
     *SHORTCUT_MAP.lock() = Some(map);
 }
 
-enum KeyAction {
+pub(crate) enum KeyAction {
     Consume(Option<AppCommand>),
     PassThrough,
 }
 
-fn decide(
+pub(crate) fn decide(
     map: &ShortcutMap,
     pending: &mut Option<(KeyCombo, Instant)>,
     combo: KeyCombo,
@@ -63,13 +63,17 @@ fn decide(
     KeyAction::PassThrough
 }
 
-fn classify(combo: KeyCombo) -> KeyAction {
+pub(crate) fn classify(combo: KeyCombo) -> KeyAction {
     let guard = SHORTCUT_MAP.lock();
     let Some(map) = guard.as_ref() else {
         return KeyAction::PassThrough;
     };
     let mut pending = PENDING_PREFIX.lock();
     decide(map, &mut pending, combo, Instant::now())
+}
+
+pub(crate) fn push_command(cmd: AppCommand) {
+    PENDING_COMMANDS.lock().push(cmd);
 }
 
 fn translate(key_code: u16, flags: NSEventModifierFlags) -> Option<KeyCombo> {
@@ -83,7 +87,7 @@ fn translate(key_code: u16, flags: NSEventModifierFlags) -> Option<KeyCombo> {
     Some(KeyCombo { key, modifiers })
 }
 
-fn key_code_from_vk(vk: u16) -> Option<KeyCode> {
+pub(crate) fn key_code_from_vk(vk: u16) -> Option<KeyCode> {
     let key = match vk {
         0x00 => KeyCode::KeyA,
         0x01 => KeyCode::KeyS,

--- a/crates/vmux_desktop/src/os_menu.rs
+++ b/crates/vmux_desktop/src/os_menu.rs
@@ -71,6 +71,7 @@ impl Plugin for OsMenuPlugin {
 fn setup(world: &mut World) {
     let mut menu = Menu::new();
     build_native_root_menu(&mut menu).unwrap();
+    append_standard_edit_menu(&menu);
     let interactive_mode = interactive_mode_menu_items(&menu);
 
     #[cfg(target_os = "macos")]
@@ -94,6 +95,31 @@ fn setup(world: &mut World) {
         _menu: menu,
         interactive_mode,
     });
+}
+
+/// CEF/Chromium on macOS routes web-content editing shortcuts (Select All, Cut, Copy, Paste, Undo,
+/// Redo) through the application's standard Edit menu — without it, cmd+A / cmd+C / cmd+V etc. do
+/// nothing in web text inputs. The predefined items use the standard responder-chain selectors and
+/// auto-disable when a non-text view (winit content view for terminals) holds first responder, so
+/// terminal clipboard handling is unaffected.
+fn append_standard_edit_menu(menu: &Menu) {
+    use muda::{PredefinedMenuItem, Submenu};
+
+    let undo = PredefinedMenuItem::undo(None);
+    let redo = PredefinedMenuItem::redo(None);
+    let sep = PredefinedMenuItem::separator();
+    let cut = PredefinedMenuItem::cut(None);
+    let copy = PredefinedMenuItem::copy(None);
+    let paste = PredefinedMenuItem::paste(None);
+    let select_all = PredefinedMenuItem::select_all(None);
+    let Ok(edit) = Submenu::with_items(
+        "Edit",
+        true,
+        &[&undo, &redo, &sep, &cut, &copy, &paste, &select_all],
+    ) else {
+        return;
+    };
+    let _ = menu.append(&edit);
 }
 
 fn interactive_mode_menu_items(menu: &Menu) -> Option<InteractiveModeMenuItems> {

--- a/crates/vmux_desktop/src/shortcut.rs
+++ b/crates/vmux_desktop/src/shortcut.rs
@@ -21,6 +21,10 @@ impl Plugin for ShortcutPlugin {
             crate::native_keyboard::install_native_key_monitor.after(init_shortcuts),
         )
         .add_systems(
+            Startup,
+            crate::event_tap::install_event_tap.after(init_shortcuts),
+        )
+        .add_systems(
             Update,
             crate::native_keyboard::process_monitored_keys.in_set(WriteAppCommands),
         );

--- a/crates/vmux_layout/src/cef.rs
+++ b/crates/vmux_layout/src/cef.rs
@@ -99,6 +99,7 @@ impl Browser {
         (
             Self,
             WebviewWindowed,
+            WebviewWindowedNativeFocus,
             WebviewOpaqueWindowedBackground,
             vmux_core::PageMetadata {
                 title: url.to_string(),
@@ -135,6 +136,7 @@ impl Browser {
         (
             Self,
             WebviewWindowed,
+            WebviewWindowedNativeFocus,
             WebviewOpaqueWindowedBackground,
             vmux_core::PageMetadata {
                 title: title.to_string(),
@@ -256,6 +258,29 @@ mod tests {
             app.world()
                 .get::<WebviewOpaqueWindowedBackground>(page)
                 .is_some()
+        );
+    }
+
+    #[test]
+    fn page_cef_allows_native_first_responder() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+            .add_systems(Startup, build_test_page);
+        app.update();
+
+        let page = app
+            .world_mut()
+            .query_filtered::<Entity, (With<Browser>, Without<LayoutCef>)>()
+            .single(app.world())
+            .expect("page CEF");
+
+        assert!(
+            app.world()
+                .get::<WebviewWindowedNativeFocus>(page)
+                .is_some(),
+            "windowed web pages must allow native first-responder so they are typeable without a click"
         );
     }
 }

--- a/crates/vmux_macro/src/lib.rs
+++ b/crates/vmux_macro/src/lib.rs
@@ -616,6 +616,23 @@ fn impl_leaf_shortcuts(
             continue;
         }
 
+        // Menu accelerators are global shortcuts too: register them in the decide map so they fire
+        // even when a non-CEF view (terminal/layout) holds first responder and the macOS menu
+        // key-equivalent is swallowed by winit. Skip when the variant already declares an explicit
+        // direct shortcut (avoids a duplicate combo).
+        if let (Some(accel), Some(menu_id)) = (&menu_props.accel, &menu_props.id) {
+            let has_explicit_direct = bind_props
+                .bindings
+                .iter()
+                .any(|b| matches!(b, Binding::Direct(_)));
+            if !has_explicit_direct && let Some(combo_tokens) = accel_to_combo_tokens(accel) {
+                let menu_id_str = menu_id.as_str();
+                binding_entries.push(quote! {
+                    (crate::shortcut::Shortcut::Direct(#combo_tokens), ::std::string::String::from(#menu_id_str))
+                });
+            }
+        }
+
         if bind_props.bindings.is_empty() {
             continue;
         }
@@ -826,6 +843,50 @@ fn parse_key_combo_tokens(
     let key_ident = format_ident!("{}", key_str);
 
     Ok(quote! {
+        crate::shortcut::KeyCombo {
+            key: ::bevy::input::keyboard::KeyCode::#key_ident,
+            modifiers: crate::shortcut::Modifiers {
+                ctrl: #ctrl,
+                shift: #shift,
+                alt: #alt,
+                super_key: #super_key,
+            },
+        }
+    })
+}
+
+/// Parse a muda menu accelerator (e.g. `"super+shift+n"`, `"super+["`) into a [`KeyCombo`] token
+/// stream so menu accelerators can also be registered as global shortcuts. Returns `None` for any
+/// accelerator that isn't a single-character key the shortcut layer understands, so unconvertible
+/// accelerators stay menu-only instead of breaking the build.
+fn accel_to_combo_tokens(accel: &str) -> Option<proc_macro2::TokenStream> {
+    let mut ctrl = false;
+    let mut shift = false;
+    let mut alt = false;
+    let mut super_key = false;
+    let mut key: Option<ResolvedKey> = None;
+
+    for part in accel.split('+') {
+        let part = part.trim();
+        match part.to_ascii_lowercase().as_str() {
+            "ctrl" | "control" => ctrl = true,
+            "shift" => shift = true,
+            "alt" | "option" => alt = true,
+            "super" | "cmd" | "command" | "meta" | "cmdorctrl" => super_key = true,
+            _ => {
+                let chars: Vec<char> = part.chars().collect();
+                if key.is_some() || chars.len() != 1 {
+                    return None;
+                }
+                key = Some(resolve_char_literal(chars[0])?);
+            }
+        }
+    }
+
+    let key = key?;
+    let shift = shift || key.implicit_shift;
+    let key_ident = format_ident!("{}", key.key_code);
+    Some(quote! {
         crate::shortcut::KeyCombo {
             key: ::bevy::input::keyboard::KeyCode::#key_ident,
             modifiers: crate::shortcut::Modifiers {

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -1303,7 +1303,20 @@ fn handle_terminal_keyboard(
     );
 
     if target_processes.is_empty() {
-        for _ in er.read() {}
+        let mut dropped = 0usize;
+        for ev in er.read() {
+            if ev.state == ButtonState::Pressed {
+                dropped += 1;
+            }
+        }
+        if dropped > 0 {
+            bevy::log::info!(
+                target: "vmux::host_focus",
+                "terminal_kbd: dropped {dropped} key(s) — no target (kb_targets_empty={} stack={:?})",
+                keyboard_targets.is_empty(),
+                focus.stack
+            );
+        }
         return;
     };
     let active_process_id = target_processes.first().copied();
@@ -1421,6 +1434,12 @@ fn handle_terminal_keyboard(
         if bytes.is_empty() {
             continue;
         }
+        bevy::log::info!(
+            target: "vmux::host_focus",
+            "terminal_kbd: send key={:?} to {} target(s)",
+            event.key_code,
+            target_processes.len()
+        );
         for process_id in &target_processes {
             service.0.send(ClientMessage::ProcessInput {
                 process_id: *process_id,

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -1303,20 +1303,7 @@ fn handle_terminal_keyboard(
     );
 
     if target_processes.is_empty() {
-        let mut dropped = 0usize;
-        for ev in er.read() {
-            if ev.state == ButtonState::Pressed {
-                dropped += 1;
-            }
-        }
-        if dropped > 0 {
-            bevy::log::info!(
-                target: "vmux::host_focus",
-                "terminal_kbd: dropped {dropped} key(s) — no target (kb_targets_empty={} stack={:?})",
-                keyboard_targets.is_empty(),
-                focus.stack
-            );
-        }
+        for _ in er.read() {}
         return;
     };
     let active_process_id = target_processes.first().copied();
@@ -1434,12 +1421,6 @@ fn handle_terminal_keyboard(
         if bytes.is_empty() {
             continue;
         }
-        bevy::log::info!(
-            target: "vmux::host_focus",
-            "terminal_kbd: send key={:?} to {} target(s)",
-            event.key_code,
-            target_processes.len()
-        );
         for process_id in &target_processes {
             service.0.send(ClientMessage::ProcessInput {
                 process_id: *process_id,

--- a/docs/specs/2026-06-09-windowed-focus-shortcuts-design.md
+++ b/docs/specs/2026-06-09-windowed-focus-shortcuts-design.md
@@ -1,0 +1,115 @@
+# Windowed focus + shortcut prioritization
+
+Date: 2026-06-09
+Status: Design — pending review
+
+## Problem
+
+In User (browse) mode on macOS, content pages render as native windowed CEF child views (PR #56). Two focus bugs:
+
+1. **Shortcuts die when a page is focused.** Once a vibe/web page or terminal is focused (e.g. after clicking it), *no* shortcuts fire — not ⌘K, not ⌘W, not ctrl+hjkl, not leader chords.
+2. **New pages aren't typeable until clicked.** Opening a vibe/terminal (new tab, new stack) leaves it un-typeable; the user must click it to give it focus.
+
+Desired end state: **a newly opened page is focused automatically (typeable without a click), and shortcuts always take priority — even while a page is focused.**
+
+## Root cause
+
+CEF windowed views are created as **child `NSView`s of winit's window** (`browsers.rs` `set_as_child`). On macOS, CEF couples two things for a windowed browser:
+
+- **Renderer/logical focus** — needed for a web page to accept typed input and show a caret.
+- **`NSView` first-responder** — set by `host.set_focus(true)`.
+
+There is no way (in windowed mode) to give a web page renderer focus *without* making its `NSView` the macOS first-responder.
+
+Empirically (confirmed against the running app): **while a CEF page holds first-responder, the host process receives no key events at all** — neither winit's `ButtonInput<KeyCode>` (so `process_key_input` dies) nor the app-level `addLocalMonitorForEventsMatchingMask` in `native_keyboard.rs` (so even ⌘K's `Consume` never happens). CEF-focus == total host-keyboard blackout.
+
+PR #56 tried to avoid this with a `FocusCanceler` (`client_handler.rs` `on_set_focus` returns `1` for *every* focus request) so winit always keeps first-responder and keys forward via `CefKeyboardTarget`. The realized behavior falls short:
+
+- The blunt cancel also kills renderer focus, so forwarded keys land nowhere → page not typeable without a click (bug 2).
+- A click still ends with the CEF `NSView` in first-responder → host-keyboard blackout → shortcuts die (bug 1).
+
+## Constraints
+
+- **Terminals cannot be native-focused.** Terminal keystrokes reach the shell only via the Bevy path: `handle_terminal_keyboard` reads `KeyboardInput` → `ServiceClient` → PTY. CEF forwarding is suppressed for terminals (`sync_keyboard_target` sets `suppress.0 = terminal_q.contains(...)`). xterm.js in the terminal page has no PTY pipe of its own. So a terminal needs **winit** to be first-responder.
+- **Web pages need native first-responder** to type in windowed mode (the coupling above).
+- ⇒ Web pages and terminals require *opposite* first-responder states.
+- The app-level local monitor cannot rescue shortcuts while a CEF page is focused (the blackout). Interception must sit **below the app**.
+
+## Chosen approach
+
+Keep windowed rendering (preserve the CPU win). Add a session-level event tap as the universal shortcut layer, and manage first-responder per page type.
+
+### 1. Universal shortcut layer — `CGEventTap`
+
+- Install a session-level `CGEventTap` (`kCGSessionEventTap`, `kCGHeadInsertEventTap`, `kCGEventTapOptionDefault`) for `keyDown` + `flagsChanged`, macOS-only, in `vmux_desktop`.
+- The callback runs the **same `decide()` logic** as `native_keyboard.rs`: `Consume` modifier shortcuts and chord leaders/sequences (return `NULL` to drop, queue the `AppCommand` into the existing `PENDING_COMMANDS`); `PassThrough` everything else (return the event).
+- A session tap fires **before** the event reaches the app, so it works even while a CEF page is first-responder (unlike the local monitor).
+- **Frontmost gate (safety):** the callback must only `Consume`/queue when vmux is the active application (`NSApp.isActive` / frontmost check). When vmux is not frontmost, always pass through — never hijack other apps' keys.
+- **Tap re-enable:** handle `kCGEventTapDisabledByTimeout` / `…ByUserInput` by calling `CGEventTapEnable(true)` from the callback.
+- **Run loop:** add the tap source to the main `CFRunLoop`; the callback queues commands drained by the existing `process_monitored_keys` system.
+
+### 2. Local monitor stays as the no-permission fallback
+
+- Keep `addLocalMonitorForEventsMatchingMask`. No de-duplication needed: the session tap consumes shortcut keydowns *before* they reach the app, so the app-level monitor only ever sees pass-through keys (which produce no command). The two cannot double-fire.
+- When the tap is not granted (see §4), the local monitor still handles shortcuts whenever winit is first-responder (terminal / layout focus). Only "shortcuts while a web page is focused" is lost until the grant.
+
+### 3. Per-page-type first-responder (reuse `allow_native_focus`)
+
+The `WebviewWindowedNativeFocus` marker → `allow_native_focus` → `cancel_native_focus = !allow_native_focus` → whether `FocusCanceler` is attached. Today only the command bar sets the marker; content pages get the canceler.
+
+- **Web / vibe / browse pages** → add `WebviewWindowedNativeFocus` (so `allow_native_focus = true`, **no** `FocusCanceler`) → they can hold first-responder and type natively, like an ordinary browser.
+- **Terminal pages** → no marker (keep `FocusCanceler`) → their CEF view never steals first-responder → winit keeps it → the Bevy key path keeps working.
+- Decision is by page kind at attach time (terminal URL ⇒ withhold marker; otherwise grant it).
+
+### 4. Auto-focus on open / active-page change
+
+A User-mode focus-sync system sets the correct first-responder for the active page whenever the active page changes (covers new tab / new stack / switch):
+
+- Active page is **web/vibe** → `set_windowed_focus(active, true)` → CEF `NSView` becomes first-responder → typeable immediately.
+- Active page is **terminal** → reclaim winit first-responder via AppKit (`[[ns_view window] makeFirstResponder: ns_view]`, objc2) so `KeyboardInput` flows → Bevy path delivers; ensure `CefKeyboardTarget` is on the terminal browser for routing.
+
+This removes the need for a manual click.
+
+### 5. Permission UX — prompt at launch
+
+- The tap needs **Input Monitoring**. Create it at startup; macOS shows the Input Monitoring prompt on first run. Input Monitoring grants typically require an app restart to take effect.
+- Graceful degradation if not (yet) granted: typing + auto-focus still work; shortcuts fire whenever winit/terminal is focused (local-monitor fallback); only "shortcuts while a web page is focused" is unavailable until granted + restart.
+
+## Keyboard data-flow (User mode, tap granted, vmux frontmost)
+
+| Focused page | Shortcut key (⌘K, ctrl+h, leader…) | Normal key (typing) |
+|---|---|---|
+| Web / vibe | tap `Consume` → `AppCommand` (page never sees it) | tap pass-through → CEF `NSView` (first-responder) types natively |
+| Terminal | tap `Consume` → `AppCommand` | tap pass-through → winit (first-responder) → `KeyboardInput` → `handle_terminal_keyboard` → service → PTY |
+| Layout / none | tap `Consume` → `AppCommand` | tap pass-through → winit |
+
+`CefKeyboardTarget` forwarding (`keyboard.rs send_key_event`) remains for Player/OSR mode; it is inert for native-focused windowed web pages (winit gets no `KeyboardInput` to forward) and stays suppressed for terminals.
+
+## Components & files
+
+New (vmux_desktop):
+- `crates/vmux_desktop/src/event_tap.rs` — `CGEventTap` install, callback (frontmost gate + `decide()` + re-enable), run-loop wiring; reuses `ShortcutMap` / `PENDING_COMMANDS` / `decide()` from `native_keyboard`.
+- Register in `ShortcutPlugin` (`shortcut.rs`) on macOS (Startup install, `process_monitored_keys` already drains the queue).
+
+Changed:
+- `crates/vmux_desktop/src/native_keyboard.rs` — expose `decide`/`PENDING_COMMANDS`/translate helpers for reuse; keep the local monitor as fallback.
+- `crates/vmux_browser/src/lib.rs` — add `WebviewWindowedNativeFocus` to web/agent (non-terminal) content browsers at attach; new User-mode focus-sync system (web → `set_windowed_focus(true)`; terminal → reclaim winit first-responder) keyed on `FocusedStack` changes.
+- First-responder reclaim helper (AppKit `makeFirstResponder`, objc2) — in vmux_desktop or patched `bevy_cef_core` where the window handle is available.
+
+Unchanged: the `FocusCanceler` mechanism itself (now applied only to terminals + non-native modals among content); `set_windowed_focus` gate; OSR focus path.
+
+## Testing
+
+- `decide()` parity test: the tap path and local-monitor path classify identically (extend `native_keyboard` tests; share the fn).
+- Frontmost-gate unit: callback passes through (no queue) when not frontmost.
+- Per-type native-focus selection: web/agent browsers receive `WebviewWindowedNativeFocus`; terminals do not (component-level test on attach).
+- Focus-sync system: on active-page change, web → `set_windowed_focus(true)` issued; terminal → winit-reclaim issued (assert via messages/calls, per Bevy message-integration rule).
+- Manual (macOS, requires grant + restart): open new vibe/terminal → typeable without click; ⌘K / ⌘W / ctrl+hjkl / leader chord fire while a web page is focused and while a terminal is focused; switching web↔terminal hands off first-responder correctly; other apps' shortcuts unaffected when vmux is backgrounded.
+
+## Risks / open questions
+
+- **Input Monitoring friction.** A keystroke tap is a sensitive permission; the prompt is alarming and needs a restart. Mitigated by graceful fallback, but it is the main cost of staying windowed.
+- **CGEvent → KeyCombo mapping.** The tap sees `CGEventFlags` + keycode; `decide()` was built for `NSEventModifierFlags`. Need a small, tested converter (or normalize both to the shared `Modifiers`).
+- **First-responder reclaim timing.** Reclaiming winit first-responder for terminals must not fight CEF's own focus handling on the same frame; may need to run after CEF view attach/raise.
+- **Web page blur semantics.** With web pages now genuinely first-responder, `document.hasFocus()` is true (good); confirm clipboard ⌘C/⌘V still behave (the tap consumes them as shortcuts only if bound — they are not vmux shortcuts, so they pass through to the page natively).
+- **Non-macOS.** Tap + native-focus changes are macOS-gated; Linux/OSR path unchanged.

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
@@ -1028,6 +1028,39 @@ impl Browsers {
     #[cfg(not(target_os = "macos"))]
     pub fn raise_windowed_to_front(&self, _: &Entity) {}
 
+    /// Set the `zPosition` of a windowed browser's native view (the liquid-glass container when
+    /// present). The layout chrome composites as a sibling `CALayer` at `zPosition` 100, and a plain
+    /// windowed view sits at 0 — so `raise_windowed_to_front` (subview order) cannot lift the
+    /// command-bar modal above the sidebar/header overlay. A higher `zPosition` can.
+    #[cfg(target_os = "macos")]
+    pub fn set_windowed_z_position(&self, webview: &Entity, z: f64) {
+        use objc2::ClassType;
+        use objc2_app_kit::NSView;
+        let Some(browser) = self.browsers.get(webview) else {
+            return;
+        };
+        if !browser.windowed {
+            return;
+        }
+        let handle = browser.host.window_handle();
+        if handle.is_null() {
+            return;
+        }
+        let view: &NSView = unsafe { &*handle.cast::<NSView>() };
+        let target = browser
+            .native_liquid_glass
+            .as_ref()
+            .map(|glass| glass.as_super())
+            .unwrap_or(view);
+        target.setWantsLayer(true);
+        if let Some(layer) = target.layer() {
+            layer.setZPosition(z);
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    pub fn set_windowed_z_position(&self, _: &Entity, _: f64) {}
+
     #[cfg(target_os = "macos")]
     pub fn lower_windowed_to_back(&self, webview: &Entity) {
         use objc2::ClassType;


### PR DESCRIPTION
## Context

In User (browse) mode content pages render as native windowed CEF child views. Two focus bugs followed: shortcuts died once a page was focused (a CEF `NSView` holding macOS first-responder blacks out the host keyboard entirely, including the app-level event monitor), and newly opened pages weren't typeable until clicked. Together these made ⌘K/⌘W/leader chords unreliable and forced a click before typing.

## Implementation

- **Session `CGEventTap`** (`kCGSessionEventTap`, head-insert) installed in `vmux_desktop` as a universal shortcut layer. It runs the same `decide()` classifier as the local `NSEvent` monitor and shares its chord state + command queue, so the two can't double-fire. Frontmost-gated (never touches other apps' keys), re-enables itself if the system disables it, and wakes the winit loop. The local monitor stays as the no-permission fallback.
- **Native first-responder for content pages**: windowed web/agent pages now carry `WebviewWindowedNativeFocus`, so they hold first-responder and type like an ordinary browser (no `FocusCanceler`). Terminals are OSR and stay unmarked.
- **Auto-focus on open/switch** via a User-mode `HostFocusIntent`: web → `set_windowed_focus(true)`; terminal/none → reclaim winit first-responder with `makeFirstResponder` so terminal keys still reach the PTY. Skipped while the command bar owns focus.
- **Permission UX**: Input Monitoring is requested at launch. Without the grant, typing + auto-focus still work and shortcuts fall back to the local monitor whenever winit/terminal holds focus.

Design doc included: `docs/specs/2026-06-09-windowed-focus-shortcuts-design.md`.

## Checks / QA

Requires Input Monitoring granted + a restart for the tap.

- [ ] Open a new vibe/web page and a new terminal → typeable without a click.
- [ ] ⌘K / ⌘W / ctrl+hjkl / leader chords fire while a web page is focused, and while a terminal is focused.
- [ ] Switch web↔terminal → first-responder hands off correctly (terminal types into the shell, web into the page).
- [ ] Background vmux → other apps' keyboard shortcuts are unaffected.
- [ ] Before granting permission: typing + auto-focus still work; only "shortcuts while a web page is focused" is unavailable.