### PR TITLE
feat(menu): close-window label + single tray show/hide toggle

### DIFF
--- a/crates/vmux_desktop/src/os_menu.rs
+++ b/crates/vmux_desktop/src/os_menu.rs
@@ -23,6 +23,18 @@ pub(crate) struct LastStackCloseAt(pub Option<std::time::Instant>);
 #[derive(Resource, Default)]
 pub(crate) struct LastNativePageOpenAt(pub Option<std::time::Instant>);
 
+/// Tracks whether the app menu's Close item is currently enabled, so the sync system only touches the
+/// native item when the visible-window state actually flips. Starts `true` to match the menu item's
+/// build-time default (the primary window is visible at startup).
+#[derive(Resource)]
+pub(crate) struct CloseMenuItemEnabled(pub bool);
+
+impl Default for CloseMenuItemEnabled {
+    fn default() -> Self {
+        Self(true)
+    }
+}
+
 static PENDING_MENU_EVENTS: LazyLock<Mutex<Vec<String>>> = LazyLock::new(|| Mutex::new(Vec::new()));
 const WINDOW_CLOSE_SUPPRESSION_WINDOW: std::time::Duration = std::time::Duration::from_millis(300);
 const NATIVE_PAGE_OPEN_CLOSE_SUPPRESSION_WINDOW: std::time::Duration =
@@ -31,6 +43,7 @@ const NATIVE_PAGE_OPEN_CLOSE_SUPPRESSION_WINDOW: std::time::Duration =
 struct OsMenuResource {
     _menu: Menu,
     interactive_mode: Option<InteractiveModeMenuItems>,
+    close_window: Option<MenuItem>,
 }
 
 struct InteractiveModeMenuItems {
@@ -52,6 +65,7 @@ impl Plugin for OsMenuPlugin {
         app.init_resource::<LastMenuCommandAt>()
             .init_resource::<LastStackCloseAt>()
             .init_resource::<LastNativePageOpenAt>()
+            .init_resource::<CloseMenuItemEnabled>()
             .add_systems(Startup, setup)
             .add_systems(
                 Update,
@@ -63,6 +77,7 @@ impl Plugin for OsMenuPlugin {
                     hide_window_on_close_request
                         .after(remember_stack_close_commands)
                         .after(remember_native_page_open_commands),
+                    sync_close_menu_item.after(hide_window_on_close_request),
                 ),
             );
     }
@@ -73,6 +88,7 @@ fn setup(world: &mut World) {
     build_native_root_menu(&mut menu).unwrap();
     append_standard_edit_menu(&menu);
     let interactive_mode = interactive_mode_menu_items(&menu);
+    let close_window = find_menu_item(menu.items(), "app_quit");
 
     #[cfg(target_os = "macos")]
     menu.init_for_nsapp();
@@ -94,6 +110,7 @@ fn setup(world: &mut World) {
     world.insert_non_send(OsMenuResource {
         _menu: menu,
         interactive_mode,
+        close_window,
     });
 }
 
@@ -160,6 +177,23 @@ fn sync_interactive_mode_menu_items(
     };
     if let Some(items) = &menu.interactive_mode {
         items.sync(&mode);
+    }
+}
+
+fn sync_close_menu_item(
+    menu: Option<NonSend<OsMenuResource>>,
+    windows: Query<&Window>,
+    mut enabled: ResMut<CloseMenuItemEnabled>,
+) {
+    let any_visible = windows.iter().any(|w| w.visible);
+    if enabled.0 == any_visible {
+        return;
+    }
+    enabled.0 = any_visible;
+    if let Some(menu) = menu
+        && let Some(item) = &menu.close_window
+    {
+        item.set_enabled(any_visible);
     }
 }
 
@@ -441,6 +475,35 @@ mod tests {
         app.world_mut().run_schedule(Update);
 
         assert!(app.world().get::<Window>(window).unwrap().visible);
+    }
+
+    #[test]
+    fn close_menu_item_disabled_when_all_windows_hidden() {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, CommandPlugin, OsMenuPlugin))
+            .add_message::<WindowCloseRequested>()
+            .insert_resource(test_settings());
+
+        let window = app.world_mut().spawn(Window::default()).id();
+        app.world_mut().run_schedule(Update);
+        assert!(
+            app.world().resource::<CloseMenuItemEnabled>().0,
+            "a visible window means Close is enabled"
+        );
+
+        app.world_mut().get_mut::<Window>(window).unwrap().visible = false;
+        app.world_mut().run_schedule(Update);
+        assert!(
+            !app.world().resource::<CloseMenuItemEnabled>().0,
+            "all windows hidden means Close is disabled"
+        );
+
+        app.world_mut().get_mut::<Window>(window).unwrap().visible = true;
+        app.world_mut().run_schedule(Update);
+        assert!(
+            app.world().resource::<CloseMenuItemEnabled>().0,
+            "showing a window re-enables Close"
+        );
     }
 
     #[test]

--- a/crates/vmux_desktop/src/tray.rs
+++ b/crates/vmux_desktop/src/tray.rs
@@ -13,10 +13,8 @@ pub(crate) struct TrayPlugin;
 
 struct TrayHandle {
     _tray: TrayIcon,
-    show: MenuItem,
-    hide: MenuItem,
-    show_id: String,
-    hide_id: String,
+    toggle: MenuItem,
+    toggle_id: String,
     quit_id: String,
     last_any_visible: Option<bool>,
 }
@@ -30,14 +28,12 @@ impl Plugin for TrayPlugin {
 
 fn setup_tray(world: &mut World) {
     let menu = Menu::new();
-    let show = MenuItem::new("Show", false, None);
-    let hide = MenuItem::new("Hide", true, None);
-    let quit = MenuItem::new("Quit", true, None);
-    let show_id = show.id().0.clone();
-    let hide_id = hide.id().0.clone();
+    let toggle = MenuItem::new(toggle_label(true), true, None);
+    let quit = MenuItem::new("Quit Vmux", true, None);
+    let toggle_id = toggle.id().0.clone();
     let quit_id = quit.id().0.clone();
 
-    if let Err(e) = menu.append_items(&[&show, &hide, &quit]) {
+    if let Err(e) = menu.append_items(&[&toggle, &quit]) {
         tracing::error!(error = %e, "failed to append tray menu items");
         return;
     }
@@ -59,10 +55,8 @@ fn setup_tray(world: &mut World) {
 
     world.insert_non_send(TrayHandle {
         _tray: tray,
-        show,
-        hide,
-        show_id,
-        hide_id,
+        toggle,
+        toggle_id,
         quit_id,
         last_any_visible: None,
     });
@@ -70,15 +64,15 @@ fn setup_tray(world: &mut World) {
 
 fn drain_tray_events(
     handle: Option<NonSend<TrayHandle>>,
+    windows: Query<&Window>,
     mut events: MessageWriter<LifecycleEvent>,
 ) {
     let Some(handle) = handle else { return };
     let drained = std::mem::take(&mut *PENDING_TRAY_EVENTS.lock());
+    let any_visible = windows.iter().any(|w| w.visible);
     for event_id in drained {
-        if event_id == handle.show_id {
-            events.write(LifecycleEvent::ShowAllWindows);
-        } else if event_id == handle.hide_id {
-            events.write(LifecycleEvent::HideAllWindows);
+        if event_id == handle.toggle_id {
+            events.write(toggle_lifecycle_event(any_visible));
         } else if event_id == handle.quit_id {
             events.write(LifecycleEvent::QuitVmux);
         } else {
@@ -94,13 +88,23 @@ fn sync_tray_menu_state(handle: Option<NonSendMut<TrayHandle>>, windows: Query<&
         return;
     }
     handle.last_any_visible = Some(any_visible);
-    let (show_enabled, hide_enabled) = tray_visibility_enabled(any_visible);
-    handle.show.set_enabled(show_enabled);
-    handle.hide.set_enabled(hide_enabled);
+    handle.toggle.set_text(toggle_label(any_visible));
 }
 
-fn tray_visibility_enabled(any_visible: bool) -> (bool, bool) {
-    (!any_visible, any_visible)
+fn toggle_label(any_visible: bool) -> &'static str {
+    if any_visible {
+        "Close Window"
+    } else {
+        "Open Window"
+    }
+}
+
+fn toggle_lifecycle_event(any_visible: bool) -> LifecycleEvent {
+    if any_visible {
+        LifecycleEvent::HideAllWindows
+    } else {
+        LifecycleEvent::ShowAllWindows
+    }
 }
 
 fn load_tray_icon() -> tray_icon::Icon {
@@ -136,50 +140,52 @@ mod tests {
             source.contains(&tray_builder) || source.contains(&tray_type),
             "tray.rs must wire tray-icon, not be a stub"
         );
-        let show_needle = ["\"Sh", "ow\""].concat();
+        let open_needle = ["\"Open ", "Window\""].concat();
         assert!(
-            source.contains(&show_needle),
-            "tray must expose a 'Show' menu item"
+            source.contains(&open_needle),
+            "tray toggle must expose an 'Open Window' label"
         );
-        let hide_needle = ["\"Hi", "de\""].concat();
+        let close_needle = ["\"Close ", "Window\""].concat();
         assert!(
-            source.contains(&hide_needle),
-            "tray must expose a 'Hide' menu item"
+            source.contains(&close_needle),
+            "tray toggle must expose a 'Close Window' label"
         );
-        let quit_needle = ["\"Qu", "it\""].concat();
+        let quit_needle = ["\"Quit ", "Vmux\""].concat();
         assert!(
             source.contains(&quit_needle),
-            "tray must expose a 'Quit' menu item"
+            "tray must expose a 'Quit Vmux' menu item"
         );
     }
 
     #[test]
-    fn tray_visibility_enabled_toggles_show_and_hide() {
-        assert_eq!(super::tray_visibility_enabled(true), (false, true));
-        assert_eq!(super::tray_visibility_enabled(false), (true, false));
+    fn toggle_label_reflects_visibility() {
+        assert_eq!(super::toggle_label(true), "Close Window");
+        assert_eq!(super::toggle_label(false), "Open Window");
     }
 
     #[test]
-    fn hide_event_routes_to_hide_all_windows() {
-        let source = include_str!("tray.rs")
-            .split("#[cfg(test)]")
-            .next()
-            .expect("production source");
-
-        assert!(source.contains("hide_id"));
-        assert!(source.contains("LifecycleEvent::HideAllWindows"));
+    fn toggle_event_routes_by_visibility() {
+        use super::LifecycleEvent;
+        assert!(matches!(
+            super::toggle_lifecycle_event(true),
+            LifecycleEvent::HideAllWindows
+        ));
+        assert!(matches!(
+            super::toggle_lifecycle_event(false),
+            LifecycleEvent::ShowAllWindows
+        ));
     }
 
     #[test]
-    fn tray_syncs_enabled_state_with_window_visibility() {
+    fn tray_syncs_toggle_label_with_window_visibility() {
         let source = include_str!("tray.rs")
             .split("#[cfg(test)]")
             .next()
             .expect("production source");
 
         assert!(source.contains("sync_tray_menu_state"));
-        assert!(source.contains("set_enabled"));
-        assert!(source.contains("tray_visibility_enabled"));
+        assert!(source.contains("set_text"));
+        assert!(source.contains("toggle_label"));
     }
 
     #[test]

--- a/crates/vmux_macro/src/lib.rs
+++ b/crates/vmux_macro/src/lib.rs
@@ -305,7 +305,7 @@ fn impl_os_menu(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                     ..::std::default::Default::default()
                 };
                 let mut app_native_submenu = ::muda::Submenu::new(&app_name, true);
-                let quit_label = format!("Quit {}", &app_name);
+                let quit_label = "Close Vmux".to_string();
                 let quit_item = ::muda::MenuItem::with_id(
                     "app_quit",
                     &quit_label,


### PR DESCRIPTION
## Context

The app menu showed "Quit Vmux" (⌘Q) but the action only hides all windows — vmux keeps running in the tray, it never exits. The label was misleading, and it stayed clickable even when every window was already hidden. The tray menu had separate Show/Hide entries, one of which was always disabled.

## Implementation

- App menu: label the item "Close Vmux" and disable it when no window is visible. A `CloseMenuItemEnabled` resource tracks the last applied state so the native item is only touched on a visibility flip.
- Tray: collapse Show/Hide into one toggle whose label flips Open Window ↔ Close Window with window visibility; the click routes to `ShowAllWindows`/`HideAllWindows` based on live window state. Quit renamed to "Quit Vmux". Two entries total.
- Window-close behavior is unchanged (still hide, never exit/despawn).

## Checks / QA

- App menu shows "Close Vmux"; greys out after closing the window, re-enables after reopening from the tray.
- Tray shows one toggle: "Close Window" while visible, "Open Window" while hidden; clicking it toggles the window. Quit Vmux exits.
