### PR TITLE
fix(packaging): rename main exe to vmux_desktop, fix vmux CLI clash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,7 +435,7 @@ jobs:
         run: |
           set -uo pipefail
           app="target/release/Vmux.app"
-          bin="$app/Contents/MacOS/Vmux"
+          bin="$app/Contents/MacOS/vmux_desktop"
           plist="$app/Contents/Frameworks/Chromium Embedded Framework.framework/Resources/Info.plist"
 
           want="${CEF_VERSION##*+}"
@@ -466,7 +466,7 @@ jobs:
           fi
 
           kill "$pid" 2>/dev/null || true
-          pkill -f "Vmux.app/Contents/MacOS/Vmux" 2>/dev/null || true
+          pkill -f "Vmux.app/Contents/MacOS/vmux_desktop" 2>/dev/null || true
           pkill -f "vmux_service" 2>/dev/null || true
           pkill -f "Chromium Embedded Framework" 2>/dev/null || true
 
@@ -486,7 +486,7 @@ jobs:
         if: env.PREP_DONE != '1' && env.IS_RELEASE_PR == '1'
         run: |
           cd target/release/Vmux.app/Contents/MacOS
-          tar czf "$GITHUB_WORKSPACE/target/release/vmux-v${VERSION}-aarch64-apple-darwin.tar.gz" Vmux
+          tar czf "$GITHUB_WORKSPACE/target/release/vmux-v${VERSION}-aarch64-apple-darwin.tar.gz" vmux_desktop
 
       - name: Create app bundle tarball
         if: env.PREP_DONE != '1' && env.IS_RELEASE_PR == '1'

--- a/crates/vmux_desktop/Cargo.toml
+++ b/crates/vmux_desktop/Cargo.toml
@@ -87,7 +87,7 @@ icons = ["../../packaging/macos/Vmux.icns"]
 before-packaging-command = "bash ../../scripts/build-package-binaries.sh"
 before-each-package-command = "bash ../../scripts/before-each-package.sh"
 binaries = [
-    { path = "Vmux", main = true },
+    { path = "vmux_desktop", main = true },
     { path = "vmux" },
     { path = "Vmux Service" },
 ]

--- a/crates/vmux_desktop/tests/packaging_metadata.rs
+++ b/crates/vmux_desktop/tests/packaging_metadata.rs
@@ -1,23 +1,24 @@
-//! Verify cargo-packager metadata embeds vmux_service in the bundle.
+//! Verify cargo-packager metadata embeds vmux_service in the bundle and that
+//! the main executable name does not case-collide with the vmux CLI.
 
 #[test]
-fn packager_binaries_use_user_facing_names() {
+fn packager_binaries_avoid_case_insensitive_collision() {
     let toml = include_str!("../Cargo.toml");
     assert!(
-        toml.contains(r#"{ path = "Vmux", main = true }"#),
-        "packager metadata must install the app executable as Vmux"
+        toml.contains(r#"{ path = "vmux_desktop", main = true }"#),
+        "main executable must be vmux_desktop so it does not case-collide with the vmux CLI"
+    );
+    assert!(
+        toml.contains(r#"{ path = "vmux" }"#),
+        "packager metadata must install the CLI executable as vmux"
     );
     assert!(
         toml.contains(r#"{ path = "Vmux Service" }"#),
         "packager metadata must install the service executable as Vmux Service"
     );
     assert!(
-        !toml.contains(r#"{ path = "vmux_desktop", main = true }"#),
-        "packager metadata must not expose vmux_desktop in the app bundle"
-    );
-    assert!(
-        !toml.contains(r#"{ path = "vmux_service" }"#),
-        "packager metadata must not expose vmux_service in the app bundle"
+        !toml.contains(r#"{ path = "Vmux", main = true }"#),
+        "main executable must not be Vmux (case-insensitive clash with the vmux CLI)"
     );
 }
 
@@ -30,25 +31,30 @@ fn before_packaging_command_prepares_named_binaries() {
         .expect("before-packaging-command line present");
     assert!(
         line.contains("scripts/build-package-binaries.sh"),
-        "before-packaging-command must prepare user-facing binary names: {line}"
+        "before-packaging-command must prepare the bundled binaries: {line}"
     );
     let script = include_str!("../../../scripts/build-package-binaries.sh");
-    assert!(script.contains("target/release/vmux_desktop"));
-    assert!(script.contains("target/release/Vmux"));
-    assert!(script.contains("target/release/vmux_service"));
-    assert!(script.contains("target/release/Vmux Service"));
+    assert!(script.contains("-p vmux_desktop"));
+    assert!(script.contains("-p vmux_cli"));
+    assert!(script.contains(r#"target/release/Vmux Service"#));
+    assert!(
+        !script.contains("target/release/vmux_desktop target/release/Vmux"),
+        "must not copy the GUI binary over the vmux name (case-insensitive clash)"
+    );
 }
 
 #[test]
-fn macos_bundle_scripts_expect_user_facing_helper_names_and_icons() {
+fn macos_bundle_layout_uses_collision_safe_names() {
     let layout_script = include_str!("../../../scripts/test-bundle-layout.sh");
     let required_block = layout_script.split("FORBIDDEN=(").next().unwrap();
-    assert!(required_block.contains("Contents/MacOS/Vmux"));
+    assert!(required_block.contains("Contents/MacOS/vmux_desktop"));
+    assert!(required_block.contains("Contents/MacOS/vmux"));
+    assert!(required_block.contains(
+        "Contents/Frameworks/vmux_desktop Helper.app/Contents/MacOS/vmux_desktop Helper"
+    ));
     assert!(
-        required_block.contains("Contents/Frameworks/Vmux Helper.app/Contents/MacOS/Vmux Helper")
-    );
-    assert!(
-        required_block.contains("Contents/Frameworks/Vmux Helper.app/Contents/Resources/Vmux.icns")
+        required_block
+            .contains("Contents/Frameworks/vmux_desktop Helper.app/Contents/Resources/Vmux.icns")
     );
     assert!(
         required_block
@@ -58,16 +64,14 @@ fn macos_bundle_scripts_expect_user_facing_helper_names_and_icons() {
         required_block
             .contains("Contents/Library/LoginItems/Vmux Service.app/Contents/Resources/Vmux.icns")
     );
-    assert!(!required_block.contains("Contents/MacOS/vmux_desktop"));
-    assert!(!required_block.contains("Contents/MacOS/vmux_service"));
-    assert!(!required_block.contains("vmux_desktop Helper.app"));
+    assert!(!required_block.contains("Contents/Frameworks/Vmux Helper.app/"));
 }
 
 #[test]
 fn cef_injection_uses_named_helper_base_and_icon() {
     let inject_script = include_str!("../../../scripts/inject-cef.sh");
-    assert!(inject_script.contains("--bin-name Vmux"));
-    assert!(inject_script.contains("Vmux Helper.app"));
+    assert!(inject_script.contains("--bin-name vmux_desktop"));
+    assert!(inject_script.contains("vmux_desktop Helper.app"));
     assert!(inject_script.contains("CFBundleIconFile"));
     assert!(inject_script.contains("Vmux.icns"));
 }
@@ -88,7 +92,9 @@ fn generated_info_plist_uses_named_executable() {
         .nth(1)
         .expect("CFBundleExecutable key");
     assert!(
-        after_key.trim_start().starts_with("<string>Vmux</string>"),
-        "CFBundleExecutable must be Vmux so helper processes are named Vmux Helper"
+        after_key
+            .trim_start()
+            .starts_with("<string>vmux_desktop</string>"),
+        "CFBundleExecutable must be vmux_desktop to match the bundled main binary"
     );
 }

--- a/packaging/macos/Info.plist
+++ b/packaging/macos/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDisplayName</key>
 	<string>Vmux</string>
 	<key>CFBundleExecutable</key>
-	<string>Vmux</string>
+	<string>vmux_desktop</string>
 	<key>CFBundleIdentifier</key>
 	<string>ai.vmux.desktop</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/scripts/build-package-binaries.sh
+++ b/scripts/build-package-binaries.sh
@@ -5,5 +5,4 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 cd "$ROOT"
 env -u CEF_PATH cargo build -p vmux_desktop -p vmux_cli -p vmux_service -p bevy_cef_debug_render_process --release
-cp -f target/release/vmux_desktop target/release/Vmux
 cp -f target/release/vmux_service "target/release/Vmux Service"

--- a/scripts/inject-cef.sh
+++ b/scripts/inject-cef.sh
@@ -44,7 +44,7 @@ if [[ ! -f "$HELPER_BIN" ]]; then
 fi
 
 echo "==> inject-cef: running bevy_cef_bundle_app"
-bevy_cef_bundle_app --app "$APP_BUNDLE" --bundle-id-base "$BUNDLE_ID_BASE" --bin-name Vmux --cef-framework "$CEF_FRAMEWORK" --helper-bin "$HELPER_BIN" --no-sign
+bevy_cef_bundle_app --app "$APP_BUNDLE" --bundle-id-base "$BUNDLE_ID_BASE" --bin-name vmux_desktop --cef-framework "$CEF_FRAMEWORK" --helper-bin "$HELPER_BIN" --no-sign
 
 # Trim non-English Chromium locale packs to cut bundle size. Must run before
 # the app is (re)signed/notarized below, since editing the framework
@@ -80,11 +80,11 @@ fi
 
 if [[ -f "$ICNS_SRC" ]]; then
     CEF_HELPER_APPS=(
-        "Vmux Helper.app"
-        "Vmux Helper (GPU).app"
-        "Vmux Helper (Renderer).app"
-        "Vmux Helper (Plugin).app"
-        "Vmux Helper (Alerts).app"
+        "vmux_desktop Helper.app"
+        "vmux_desktop Helper (GPU).app"
+        "vmux_desktop Helper (Renderer).app"
+        "vmux_desktop Helper (Plugin).app"
+        "vmux_desktop Helper (Alerts).app"
     )
     for helper_name in "${CEF_HELPER_APPS[@]}"; do
         helper_app="$APP_BUNDLE/Contents/Frameworks/$helper_name"

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -116,7 +116,7 @@ done
 find "$APP_BUNDLE/Contents/MacOS" -type f -perm +111 | while read -r binary; do
     file "$binary" | grep -q "Mach-O" || continue
     name="$(basename "$binary")"
-    [ "$name" = "Vmux" ] && continue
+    [ "$name" = "vmux_desktop" ] && continue
     ident="$(aux_identifier "$name")"
     echo "  Signing: ${binary#$APP_BUNDLE/} (identifier=$ident)"
     codesign --force --verify --verbose \

--- a/scripts/test-bundle-layout.sh
+++ b/scripts/test-bundle-layout.sh
@@ -4,11 +4,11 @@ set -euo pipefail
 APP="${1:?usage: $0 <path-to-Vmux.app>}"
 
 REQUIRED=(
-    "Contents/MacOS/Vmux"
+    "Contents/MacOS/vmux_desktop"
     "Contents/MacOS/vmux"
-    "Contents/Frameworks/Vmux Helper.app/Contents/MacOS/Vmux Helper"
-    "Contents/Frameworks/Vmux Helper.app/Contents/Resources/Vmux.icns"
-    "Contents/Frameworks/Vmux Helper (Renderer).app/Contents/MacOS/Vmux Helper (Renderer)"
+    "Contents/Frameworks/vmux_desktop Helper.app/Contents/MacOS/vmux_desktop Helper"
+    "Contents/Frameworks/vmux_desktop Helper.app/Contents/Resources/Vmux.icns"
+    "Contents/Frameworks/vmux_desktop Helper (Renderer).app/Contents/MacOS/vmux_desktop Helper (Renderer)"
     "Contents/Library/LoginItems/Vmux Service.app/Contents/MacOS/Vmux Service"
     "Contents/Library/LoginItems/Vmux Service.app/Contents/Resources/Vmux.icns"
     "Contents/Library/LaunchAgents/ai.vmux.service.plist"
@@ -29,9 +29,8 @@ if grep -q '{{PROFILE}}' "$APP/Contents/Library/LaunchAgents/ai.vmux.service.pli
 fi
 
 FORBIDDEN=(
-    "Contents/MacOS/vmux_desktop"
     "Contents/MacOS/vmux_service"
-    "Contents/Frameworks/vmux_desktop Helper.app"
+    "Contents/Frameworks/Vmux Helper.app"
 )
 
 for path in "${FORBIDDEN[@]}"; do
@@ -40,5 +39,10 @@ for path in "${FORBIDDEN[@]}"; do
         exit 1
     fi
 done
+
+if cmp -s "$APP/Contents/MacOS/vmux" "$APP/Contents/MacOS/vmux_desktop"; then
+    echo "COLLISION: Contents/MacOS/vmux is identical to vmux_desktop (case-insensitive name clash)" >&2
+    exit 1
+fi
 
 echo "OK: bundle layout correct"


### PR DESCRIPTION
## Context

In the release bundle the desktop app shipped as `Contents/MacOS/Vmux` and the CLI as `Contents/MacOS/vmux`. macOS's default APFS is case-insensitive, so those two names collapse into a single file — the 94 MB CEF desktop binary — and the real `vmux` CLI is clobbered. Agents launch the vmux MCP server by absolute path (`<bundle>/vmux mcp`), so they were actually running the GUI binary with `mcp` as a positional arg. CEF's Chrome runtime opened `mcp` as a URL (the stray "This site can't be reached: mcp/" Chromium window), and the MCP stdio server never started, so agents got no vmux tools. The collision was originally fixed in `cd63b5d8` and silently reintroduced by the v0.0.11 rename in #57.

## Implementation

Rename the main bundled executable `Vmux` → `vmux_desktop` so it no longer case-collides with the `vmux` CLI. The `.app` is still `Vmux.app` (from `product-name`), and the menu/window name stays "Vmux" (CFBundleName + Rust window title), so only the Activity Monitor process name and CEF helper apps change to `vmux_desktop`. Runtime path resolution (`bundle_root_for`, `daemon_binary_path_for_exe`, resources dir) keys off the `Contents/MacOS` structure rather than the exe filename, so no Rust changes are needed.

Touched: packager `binaries` list, `build-package-binaries.sh` (drop the `cp … Vmux`), `inject-cef.sh` (`--bin-name` + helper names), `sign-and-notarize.sh` (main-exe skip guard), CI smoke-test/pkill/tarball paths, and `test-bundle-layout.sh`. The layout test gains a `cmp` guard that fails if `vmux` and `vmux_desktop` are byte-identical, so a future case-collision regression is caught in CI.

## Checks / QA

- [ ] Build a release bundle and confirm `Contents/MacOS/vmux` and `Contents/MacOS/vmux_desktop` are distinct binaries (CLI vs GUI), e.g. `shasum` differs.
- [ ] `scripts/test-bundle-layout.sh <Vmux.app>` passes (incl. new collision guard).
- [ ] Launch an agent (claude/codex/vibe) session and confirm no stray Chromium window opens and the vmux MCP tools are available.
- [ ] App still shows as "Vmux" in the menu bar / Dock; `open -a Vmux` works.