### PR TITLE
fix(fullscreen): keep content sharp and dark in native fullscreen

### DIFF
--- a/crates/vmux_desktop/src/glass.rs
+++ b/crates/vmux_desktop/src/glass.rs
@@ -13,6 +13,10 @@ impl Plugin for GlassPlugin {
             .add_systems(PreUpdate, install_window_glass)
             .add_systems(Update, sync_window_glass_visibility)
             .add_systems(
+                Update,
+                handle_toggle_fullscreen_command.in_set(vmux_command::ReadAppCommands),
+            )
+            .add_systems(
                 Last,
                 (
                     reveal_window_after_layout_ready,
@@ -144,10 +148,89 @@ fn glass_backdrop_visible(mode: InteractionMode) -> bool {
     mode == InteractionMode::User
 }
 
-fn sync_window_glass_visibility(mut state: NonSendMut<GlassState>, mode: Res<InteractionMode>) {
-    use objc2::ClassType;
+/// Toggle native macOS fullscreen when the `ToggleFullscreen` command fires (Ctrl+Cmd+F).
+/// vmux hides the native window buttons, so this is the entry point into/out of fullscreen.
+fn handle_toggle_fullscreen_command(
+    state: NonSend<GlassState>,
+    mut reader: MessageReader<vmux_command::AppCommand>,
+) {
+    use vmux_command::{AppCommand, LayoutCommand, WindowCommand};
 
-    let visible = glass_backdrop_visible(*mode);
+    let toggle = reader.read().any(|cmd| {
+        matches!(
+            cmd,
+            AppCommand::Layout(LayoutCommand::Window(WindowCommand::ToggleFullscreen))
+        )
+    });
+    if toggle && let Some(parent_window) = &state._parent_window {
+        parent_window.toggleFullScreen(None);
+    }
+}
+
+fn sync_window_glass_visibility(
+    mut state: NonSendMut<GlassState>,
+    mode: Res<InteractionMode>,
+    mut clear_color: ResMut<ClearColor>,
+    mut window_q: Query<&mut bevy::window::Window, With<bevy::window::PrimaryWindow>>,
+    terminal_focus_q: Query<
+        (),
+        (
+            With<vmux_terminal::Terminal>,
+            With<bevy_cef::prelude::CefKeyboardTarget>,
+        ),
+    >,
+    modal_open_q: Query<
+        (&Node, Has<bevy_cef::prelude::CefKeyboardTarget>),
+        With<vmux_layout::window::Modal>,
+    >,
+) {
+    use objc2::ClassType;
+    use objc2_app_kit::NSWindowStyleMask;
+
+    let bevy_fullscreen = window_q
+        .single()
+        .map(|w| {
+            matches!(
+                w.mode,
+                bevy::window::WindowMode::BorderlessFullscreen(_)
+                    | bevy::window::WindowMode::Fullscreen(..)
+            )
+        })
+        .unwrap_or(false);
+    let native_fullscreen = state
+        ._parent_window
+        .as_ref()
+        .is_some_and(|w| w.styleMask().contains(NSWindowStyleMask::FullScreen));
+    let fullscreen = bevy_fullscreen || native_fullscreen;
+
+    let [r, g, b] = vmux_layout::window::WINDOW_BACKGROUND_SRGB;
+    let want_clear = if fullscreen {
+        Color::srgb(r, g, b)
+    } else {
+        Color::NONE
+    };
+    if clear_color.0 != want_clear {
+        clear_color.0 = want_clear;
+    }
+
+    let terminal_focused = !terminal_focus_q.is_empty();
+    let command_bar_open = vmux_layout::command_bar::handler::is_command_bar_open(&modal_open_q);
+    crate::native_keyboard::set_escape_exits_fullscreen(
+        fullscreen && !terminal_focused && !command_bar_open,
+    );
+
+    if crate::native_keyboard::take_exit_fullscreen_request() {
+        if native_fullscreen {
+            if let Some(parent_window) = &state._parent_window {
+                parent_window.toggleFullScreen(None);
+            }
+        } else if let Ok(mut window) = window_q.single_mut() {
+            window.mode = bevy::window::WindowMode::Windowed;
+        }
+        return;
+    }
+
+    let visible = glass_backdrop_visible(*mode) && !fullscreen;
     if let (Some(backdrop_window), Some(parent_window)) =
         (&state._backdrop_window, &state._parent_window)
     {

--- a/crates/vmux_desktop/src/native_keyboard.rs
+++ b/crates/vmux_desktop/src/native_keyboard.rs
@@ -1,5 +1,6 @@
 use std::ptr::NonNull;
 use std::sync::LazyLock;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use bevy::input::keyboard::KeyCode;
@@ -19,8 +20,26 @@ static PENDING_PREFIX: LazyLock<Mutex<Option<(KeyCombo, Instant)>>> =
 static PENDING_COMMANDS: LazyLock<Mutex<Vec<AppCommand>>> =
     LazyLock::new(|| Mutex::new(Vec::new()));
 
+static ESC_EXITS_FULLSCREEN: AtomicBool = AtomicBool::new(false);
+static EXIT_FULLSCREEN_REQUESTED: AtomicBool = AtomicBool::new(false);
+
 pub(crate) fn set_shortcut_map(map: ShortcutMap) {
     *SHORTCUT_MAP.lock() = Some(map);
+}
+
+pub(crate) fn set_escape_exits_fullscreen(value: bool) {
+    ESC_EXITS_FULLSCREEN.store(value, Ordering::Relaxed);
+}
+
+pub(crate) fn take_exit_fullscreen_request() -> bool {
+    EXIT_FULLSCREEN_REQUESTED.swap(false, Ordering::Relaxed)
+}
+
+fn is_bare_escape(combo: &KeyCombo) -> bool {
+    combo.key == KeyCode::Escape
+        && !combo.modifiers.ctrl
+        && !combo.modifiers.alt
+        && !combo.modifiers.super_key
 }
 
 pub(crate) enum KeyAction {
@@ -64,6 +83,10 @@ pub(crate) fn decide(
 }
 
 pub(crate) fn classify(combo: KeyCombo) -> KeyAction {
+    if is_bare_escape(&combo) && ESC_EXITS_FULLSCREEN.load(Ordering::Relaxed) {
+        EXIT_FULLSCREEN_REQUESTED.store(true, Ordering::Relaxed);
+        return KeyAction::Consume(None);
+    }
     let guard = SHORTCUT_MAP.lock();
     let Some(map) = guard.as_ref() else {
         return KeyAction::PassThrough;
@@ -269,6 +292,14 @@ mod tests {
             _ => panic!("expected SelectLeft"),
         }
         assert!(pending.is_none());
+    }
+
+    #[test]
+    fn bare_escape_detected_only_without_modifiers() {
+        assert!(is_bare_escape(&combo(KeyCode::Escape, false)));
+        assert!(!is_bare_escape(&combo(KeyCode::Escape, true)));
+        assert!(!is_bare_escape(&super_combo(KeyCode::Escape)));
+        assert!(!is_bare_escape(&combo(KeyCode::KeyH, false)));
     }
 
     #[test]

--- a/crates/vmux_layout/src/window.rs
+++ b/crates/vmux_layout/src/window.rs
@@ -75,8 +75,11 @@ impl MaterialExtension for WindowCorners {
 
 pub type WindowMaterial = ExtendedMaterial<StandardMaterial, WindowCorners>;
 
+pub const WINDOW_BACKGROUND_SRGB: [f32; 3] = [0.13, 0.13, 0.14];
+
 fn window_background_color() -> Color {
-    Color::srgba(0.13, 0.13, 0.14, 1.0)
+    let [r, g, b] = WINDOW_BACKGROUND_SRGB;
+    Color::srgba(r, g, b, 1.0)
 }
 
 fn window_surface_alpha(mode: crate::scene::InteractionMode) -> f32 {


### PR DESCRIPTION
## Summary
- The wallpaper-glass NSGlassEffectView backdrop was compositing **in front of** the window content in native fullscreen, frosting the whole page. Now the backdrop is hidden while fullscreen, and the gaps/corners are painted dark via the renderer **clear color** (no native window-opacity toggling — that approach left a title-bar border artifact).
- **Esc** exits fullscreen, unless a terminal is focused or the command bar is open (so vim/CLI Esc still works in terminals).
- **Ctrl+Cmd+F** toggles native fullscreen (vmux hides the native window buttons, so this is the keyboard entry/exit point).

## Test plan
- [ ] Enter fullscreen (Ctrl+Cmd+F or green button): page + chrome stay sharp (no frost); gaps/corners are dark.
- [ ] Esc exits fullscreen when a browser page / chrome is focused; Esc still reaches a focused terminal (e.g. vim).
- [ ] Ctrl+Cmd+F toggles in and out of fullscreen.
- [ ] Windowed unchanged: wallpaper glass intact, no title-bar border before/after a fullscreen round-trip.
- [ ] fmt / clippy / tests pass.
