### PR TITLE
fix(persistence): keep space when a tab is a bare agent-kind url

### DIFF
--- a/crates/vmux_desktop/src/persistence.rs
+++ b/crates/vmux_desktop/src/persistence.rs
@@ -220,7 +220,16 @@ fn is_stale_agent_url(url: &str) -> bool {
     if normalized == "vmux://agent" {
         return false;
     }
+    if is_bare_agent_kind_url(normalized) {
+        return false;
+    }
     vmux_agent::AgentUrl::parse(normalized).is_none()
+}
+
+fn is_bare_agent_kind_url(normalized: &str) -> bool {
+    vmux_agent::AgentKind::all()
+        .into_iter()
+        .any(|kind| normalized == kind.cli_url_prefix().trim_end_matches('/'))
 }
 
 fn space_is_prompt_only_empty_url(body: &str) -> bool {
@@ -774,6 +783,20 @@ mod tests {
     fn known_cli_agent_url_does_not_mark_space_stale() {
         assert!(!space_contains_stale_agent_url(
             r#"url: "vmux://agent/codex/edb5335d-20cf-4c3d-9433-8619c405a0f2""#
+        ));
+    }
+
+    #[test]
+    fn bare_cli_agent_url_does_not_mark_space_stale() {
+        assert!(!space_contains_stale_agent_url(
+            r#"url: "vmux://agent/vibe/""#
+        ));
+    }
+
+    #[test]
+    fn unknown_kind_agent_url_marks_space_stale() {
+        assert!(space_contains_stale_agent_url(
+            r#"url: "vmux://agent/bogus/edb5335d-20cf-4c3d-9433-8619c405a0f2""#
         ));
     }
 


### PR DESCRIPTION
## Context

The whole space (every tab) was deleted on each app restart and replaced by the (duplicated) startup Vibe page. Root cause: a CLI agent tab with no session yet persists with a bare url `vmux://agent/vibe/` (the sid only exists after the agent's first turn). On startup the stale-check parsed that bare url as an invalid/dead agent url and `remove_dir_all`'d the entire space directory before load — so any number of open tabs always came back as two Vibe tabs.

## Implementation

`is_stale_agent_url` now exempts a bare recognized agent-kind url: one that equals any `AgentKind::all()` `cli_url_prefix()` with no session id. Such a url is a valid "new agent" page (same as the configured startup url) and already reopens as a fresh agent in `rebuild_space_views`. Genuinely unparseable agent urls (unknown kind, malformed sid) still mark the space stale, so one bad bare url no longer poisons every other tab.

## Checks / QA

- Open a Vibe tab and do **not** send a message; open a couple of other tabs; quit and relaunch → all tabs persist, space is not wiped.
- A Vibe tab with an established session (`vmux://agent/vibe/<sid>`) still reloads as before.
- An unknown agent kind (`vmux://agent/bogus/<sid>`) is still treated as stale.
- Note: an existing space already containing the duplicated two Vibe tabs will load them once (no longer regenerated every restart); the duplication itself is tracked separately on `fix/osr-layout-duplication`.