### PR TITLE
refactor(layout): drop "chrome" terminology

### DIFF
--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -158,7 +158,7 @@ impl Plugin for BrowserPlugin {
                     sync_keyboard_target,
                     sync_windowed_content_mesh_materials,
                     sync_children_to_ui,
-                    sync_windowed_chrome,
+                    sync_windowed_layout,
                     sync_windowed_frames,
                     sync_windowed_command_bar,
                     apply_repaint_nudge,
@@ -1026,14 +1026,14 @@ fn windowed_pages_to_hide(
         .collect()
 }
 
-fn sync_windowed_chrome(
+fn sync_windowed_layout(
     browsers: NonSend<Browsers>,
-    chrome_q: Query<(Entity, Option<&HostWindow>), (With<LayoutCef>, With<WebviewWindowed>)>,
+    layout_q: Query<(Entity, Option<&HostWindow>), (With<LayoutCef>, With<WebviewWindowed>)>,
     windows: Query<&Window>,
     primary_window: Query<Entity, With<PrimaryWindow>>,
     mut last_raised_frame: Local<std::collections::HashMap<Entity, (i32, i32, i32, i32)>>,
 ) {
-    for (entity, host_window) in &chrome_q {
+    for (entity, host_window) in &layout_q {
         let window_entity = host_window
             .map(|h| h.0)
             .or_else(|| primary_window.single().ok());
@@ -1177,7 +1177,7 @@ struct CommandBarWindowedFrame {
 }
 
 const COMMAND_BAR_NATIVE_RADIUS_PX: f32 = 16.0;
-/// `zPosition` for the windowed command bar, above the layout chrome overlay (`zPosition` 100) so
+/// `zPosition` for the windowed command bar, above the layout overlay (`zPosition` 100) so
 /// the sidebar/header/stack panel never covers it.
 const COMMAND_BAR_NATIVE_Z: f64 = 200.0;
 static NATIVE_COMMAND_BAR_CLICK_FRAME: LazyLock<Mutex<Option<CommandBarWindowedFrame>>> =
@@ -1423,7 +1423,7 @@ fn sync_windowed_command_bar(
     );
     browsers.set_windowed_hidden(&entity, false);
     browsers.raise_windowed_to_front(&entity);
-    // The layout chrome (sidebar/header/stack panel) composites as a native overlay at zPosition
+    // The layout (sidebar/header/stack panel) composites as a native overlay at zPosition
     // 100; raise alone (subview order) leaves the command bar under it. Lift it above.
     browsers.set_windowed_z_position(&entity, COMMAND_BAR_NATIVE_Z);
     browsers.set_windowed_focus(&entity, true);
@@ -3270,10 +3270,10 @@ mod tests {
     }
 
     #[test]
-    fn windowed_chrome_sync_raises_layout_above_bevy_view() {
+    fn windowed_layout_sync_raises_layout_above_bevy_view() {
         let source = include_str!("lib.rs");
         let sync_fn = source
-            .split("fn sync_windowed_chrome")
+            .split("fn sync_windowed_layout")
             .nth(1)
             .and_then(|tail| tail.split("fn apply_repaint_nudge").next())
             .unwrap_or_default();
@@ -3290,14 +3290,14 @@ mod tests {
             .nth(1)
             .and_then(|tail| tail.split(".chain()").next())
             .unwrap_or_default();
-        let chrome_idx = post_update
-            .find("sync_windowed_chrome")
-            .expect("windowed chrome sync");
+        let layout_idx = post_update
+            .find("sync_windowed_layout")
+            .expect("windowed layout sync");
         let page_idx = post_update
             .find("sync_windowed_frames")
             .expect("windowed page sync");
 
-        assert!(chrome_idx < page_idx);
+        assert!(layout_idx < page_idx);
     }
 
     #[test]
@@ -3306,7 +3306,7 @@ mod tests {
         let sync_fn = source
             .split("fn sync_windowed_frames")
             .nth(1)
-            .and_then(|tail| tail.split("fn sync_windowed_chrome").next())
+            .and_then(|tail| tail.split("fn sync_windowed_layout").next())
             .unwrap_or_default();
 
         assert!(sync_fn.contains("browsers.raise_windowed_to_front"));
@@ -3318,7 +3318,7 @@ mod tests {
         let sync_fn = source
             .split("fn sync_windowed_frames")
             .nth(1)
-            .and_then(|tail| tail.split("fn sync_windowed_chrome").next())
+            .and_then(|tail| tail.split("fn sync_windowed_layout").next())
             .unwrap_or_default();
 
         assert!(sync_fn.contains("browsers.raise_windowed_to_front(&entity)"));
@@ -3464,7 +3464,7 @@ mod tests {
         let sync_fn = source
             .split("fn sync_windowed_frames")
             .nth(1)
-            .and_then(|tail| tail.split("fn sync_windowed_chrome").next())
+            .and_then(|tail| tail.split("fn sync_windowed_layout").next())
             .unwrap_or_default();
 
         assert!(!sync_fn.contains("is_command_bar_open"));
@@ -3509,7 +3509,7 @@ mod tests {
         let sync_fn = source
             .split("fn sync_windowed_frames")
             .nth(1)
-            .and_then(|tail| tail.split("fn sync_windowed_chrome").next())
+            .and_then(|tail| tail.split("fn sync_windowed_layout").next())
             .unwrap_or_default();
 
         assert!(sync_fn.contains("settings: Res<AppSettings>"));
@@ -3523,7 +3523,7 @@ mod tests {
         let sync_fn = source
             .split("fn sync_windowed_frames")
             .nth(1)
-            .and_then(|tail| tail.split("fn sync_windowed_chrome").next())
+            .and_then(|tail| tail.split("fn sync_windowed_layout").next())
             .unwrap_or_default();
 
         assert!(sync_fn.contains("visible_pane_count_for_windowed_sync"));
@@ -3536,7 +3536,7 @@ mod tests {
         let sync_fn = source
             .split("fn sync_windowed_frames")
             .nth(1)
-            .and_then(|tail| tail.split("fn sync_windowed_chrome").next())
+            .and_then(|tail| tail.split("fn sync_windowed_layout").next())
             .unwrap_or_default();
 
         assert!(sync_fn.contains("focus: Res<vmux_layout::stack::FocusedStack>"));
@@ -3551,7 +3551,7 @@ mod tests {
         let sync_fn = source
             .split("fn sync_windowed_frames")
             .nth(1)
-            .and_then(|tail| tail.split("fn sync_windowed_chrome").next())
+            .and_then(|tail| tail.split("fn sync_windowed_layout").next())
             .unwrap_or_default();
 
         assert!(sync_fn.contains("browsers.set_windowed_corner_cover"));
@@ -3564,7 +3564,7 @@ mod tests {
         let sync_fn = source
             .split("fn sync_windowed_frames")
             .nth(1)
-            .and_then(|tail| tail.split("fn sync_windowed_chrome").next())
+            .and_then(|tail| tail.split("fn sync_windowed_layout").next())
             .unwrap_or_default();
 
         assert!(!sync_fn.contains("!is_terminal"));
@@ -3577,7 +3577,7 @@ mod tests {
         let sync_fn = source
             .split("fn sync_windowed_frames")
             .nth(1)
-            .and_then(|tail| tail.split("fn sync_windowed_chrome").next())
+            .and_then(|tail| tail.split("fn sync_windowed_layout").next())
             .unwrap_or_default();
 
         assert!(sync_fn.contains("settings.layout.radius * scale"));
@@ -3916,7 +3916,7 @@ mod tests {
         let refresh_fn = source
             .split("fn refresh_active_windowed_hover")
             .nth(1)
-            .and_then(|tail| tail.split("fn sync_windowed_chrome").next())
+            .and_then(|tail| tail.split("fn sync_windowed_layout").next())
             .unwrap_or_default();
 
         assert!(plugin_build.contains("add_systems(Last, refresh_active_windowed_hover)"));

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -211,7 +211,7 @@ fn event_location_in_window_physical_px(event: &objc2_app_kit::NSEvent) -> Optio
 /// (clicks, keys, and pane-crossing hover). Player mode keeps both on for the free camera.
 /// every raw HID report. In browse (User) mode native CEF views own scroll/input, so Bevy must NOT
 /// wake on those — only Player mode's free camera consumes `AccumulatedMouseMotion`. Window events
-/// (resize/focus, OSR chrome hover) and user events (CEF texture wake) stay on in both modes.
+/// (resize/focus, OSR layout hover) and user events (CEF texture wake) stay on in both modes.
 pub(crate) fn foreground_winit_settings(player: bool) -> WinitSettings {
     WinitSettings {
         focused_mode: UpdateMode::Reactive {

--- a/crates/vmux_layout/src/command_bar/style.rs
+++ b/crates/vmux_layout/src/command_bar/style.rs
@@ -323,7 +323,7 @@ mod tests {
     }
 
     #[test]
-    fn layout_css_gives_chrome_controls_readable_glass_background() {
+    fn layout_css_gives_controls_readable_glass_background() {
         let css = include_str!("../../assets/index.css");
 
         assert!(css.contains("--glass: oklch(0.18 0 0 / 0.82);"));
@@ -332,7 +332,7 @@ mod tests {
     }
 
     #[test]
-    fn bundled_layout_css_gives_chrome_controls_readable_glass_background() {
+    fn bundled_layout_css_gives_controls_readable_glass_background() {
         let css = include_str!("../../../vmux_server/assets/index.css");
 
         assert!(css.contains("--glass: oklch(0.18 0 0 / 0.82);"));

--- a/crates/vmux_layout/src/page.rs
+++ b/crates/vmux_layout/src/page.rs
@@ -70,7 +70,7 @@ pub fn Page() -> Element {
     let tabs_error = (tabs_listener.error)();
     let pane_tree_error = (pane_tree_listener.error)();
     let spaces_error = (spaces_listener.error)();
-    let chrome_ready = layout_chrome_ready(
+    let overlay_ready = layout_overlay_ready(
         &state,
         listener_ready(layout_state_received(), &layout_error),
         listener_ready(stacks_state_received(), &stacks_error),
@@ -108,7 +108,7 @@ pub fn Page() -> Element {
 
     rsx! {
         div { class: "fixed inset-0 pointer-events-none text-foreground",
-            if chrome_ready && state.side_sheet_open {
+            if overlay_ready && state.side_sheet_open {
                 aside {
                     class: "pointer-events-auto fixed left-[var(--vmux-side-sheet-left)] top-[var(--vmux-side-sheet-top)] bottom-[var(--vmux-side-sheet-bottom)] min-h-0 overflow-hidden w-[var(--vmux-side-sheet-width)] pt-[var(--vmux-side-sheet-pad-top)]",
                     style: "{side_sheet_vars}",
@@ -121,7 +121,7 @@ pub fn Page() -> Element {
                     }
                 }
             }
-            if chrome_ready && state.header_visible() {
+            if overlay_ready && state.header_visible() {
                 div {
                     class: "pointer-events-auto fixed top-[var(--vmux-header-top)] left-[var(--vmux-header-left)] right-[var(--vmux-header-right)] h-[var(--vmux-header-height)]",
                     style: "{header_vars}",
@@ -142,7 +142,7 @@ fn listener_ready(received: bool, error: &Option<String>) -> bool {
     received || error.is_some()
 }
 
-fn layout_chrome_ready(
+fn layout_overlay_ready(
     state: &LayoutStateEvent,
     layout_ready: bool,
     stacks_ready: bool,
@@ -663,8 +663,8 @@ mod tests {
     }
 
     #[test]
-    fn chrome_waits_for_layout_state() {
-        assert!(!layout_chrome_ready(
+    fn overlay_waits_for_layout_state() {
+        assert!(!layout_overlay_ready(
             &state(false, false),
             false,
             true,
@@ -675,34 +675,34 @@ mod tests {
     }
 
     #[test]
-    fn chrome_waits_for_header_state_when_header_visible() {
+    fn overlay_waits_for_header_state_when_header_visible() {
         let visible = state(true, false);
 
-        assert!(!layout_chrome_ready(
+        assert!(!layout_overlay_ready(
             &visible, true, false, true, true, true
         ));
-        assert!(!layout_chrome_ready(
+        assert!(!layout_overlay_ready(
             &visible, true, true, false, true, true
         ));
-        assert!(layout_chrome_ready(&visible, true, true, true, true, true));
+        assert!(layout_overlay_ready(&visible, true, true, true, true, true));
     }
 
     #[test]
-    fn chrome_waits_for_side_sheet_state_when_side_sheet_visible() {
+    fn overlay_waits_for_side_sheet_state_when_side_sheet_visible() {
         let visible = state(false, true);
 
-        assert!(!layout_chrome_ready(
+        assert!(!layout_overlay_ready(
             &visible, true, true, true, false, true
         ));
-        assert!(!layout_chrome_ready(
+        assert!(!layout_overlay_ready(
             &visible, true, true, true, true, false
         ));
-        assert!(layout_chrome_ready(&visible, true, true, true, true, true));
+        assert!(layout_overlay_ready(&visible, true, true, true, true, true));
     }
 
     #[test]
-    fn chrome_can_be_ready_when_chrome_is_closed() {
-        assert!(layout_chrome_ready(
+    fn overlay_can_be_ready_when_overlay_is_closed() {
+        assert!(layout_overlay_ready(
             &state(false, false),
             true,
             false,

--- a/crates/vmux_layout/src/window.rs
+++ b/crates/vmux_layout/src/window.rs
@@ -1054,7 +1054,7 @@ mod tests {
     }
 
     #[test]
-    fn layout_chrome_uses_transparent_osr_native_overlay() {
+    fn layout_uses_transparent_osr_native_overlay() {
         let mut app = setup_window_app();
         app.update();
 

--- a/crates/vmux_layout/tests/page_source.rs
+++ b/crates/vmux_layout/tests/page_source.rs
@@ -111,10 +111,10 @@ fn layout_page_offsets_header_and_side_sheet_by_window_padding() {
 fn layout_page_gates_header_and_side_sheet_until_host_state_arrives() {
     let source = include_str!("../src/page.rs");
 
-    assert!(source.contains("layout_chrome_ready"));
-    assert!(source.contains("let chrome_ready = layout_chrome_ready"));
-    assert!(source.contains("if chrome_ready && state.side_sheet_open"));
-    assert!(source.contains("if chrome_ready && state.header_visible()"));
+    assert!(source.contains("layout_overlay_ready"));
+    assert!(source.contains("let overlay_ready = layout_overlay_ready"));
+    assert!(source.contains("if overlay_ready && state.side_sheet_open"));
+    assert!(source.contains("if overlay_ready && state.header_visible()"));
 }
 
 #[test]


### PR DESCRIPTION
## Context

Source used the forbidden term "chrome" for the layout UI. Project terminology is "the layout" (UI overlay) and "page" (web content) — never "chrome".

## Implementation

Pure rename, behavior unchanged. `layout_chrome_ready`->`layout_overlay_ready` (+ `overlay_ready` var) in vmux_layout; `sync_windowed_chrome`->`sync_windowed_layout` with `layout_q`/`layout_idx` in vmux_browser; test names, source-asserting string literals, and two comments updated to match.

## Checks / QA

- `rg -i chrome crates/` returns nothing.
- vmux_layout test suite passes (source-asserting tests cover the renamed identifiers).