### PR TITLE
chore(release): v0.0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9400,7 +9400,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9431,7 +9431,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_browser"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9452,7 +9452,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -9464,7 +9464,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9479,7 +9479,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9494,7 +9494,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9544,7 +9544,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9565,7 +9565,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -9599,7 +9599,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "muda",
  "proc-macro2",
@@ -9609,7 +9609,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "serde",
  "serde_json",
@@ -9621,7 +9621,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_server"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "dioxus",
  "regex",
@@ -9640,7 +9640,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "alacritty_terminal",
  "bevy",
@@ -9669,7 +9669,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9692,7 +9692,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9717,7 +9717,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9746,7 +9746,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "dioxus",
  "dioxus-primitives",
@@ -9763,7 +9763,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_vibe_setup"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "bevy",
  "bevy_cef",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.14"
+version = "0.0.15"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "MIT"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.14"
-  sha256 "6e2006c23fc488a4d6eef1ef6c513d294ea60bf76a24bc515bdf6a203ce33cc9"
+  version "0.0.15"
+  sha256 "8a3008023718b16d623937e8a8b174e6a138fbaad50a092725ff17306ea5afbf"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.14/Vmux_0.0.14_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.15/Vmux_0.0.15_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai"

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.14",
-  "pub_date": "2026-06-10T12:22:54Z",
+  "version": "v0.0.15",
+  "pub_date": "2026-06-12T13:20:03Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.14/Vmux-v0.0.14-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzFUYmpBbVFyUmJOS0VrakVPU3pvNWtYOFZjY3NoUnkzWXYxNUp3S2FZREwvbmQwd2ZlNnhtaG9Ua3pQWjcwWE1hTFgrTUdRTDZmYkxiTko2RjVlUXdnPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgxMDg1OTc0CWZpbGU6Vm11eC12MC4wLjE0LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKMjZUN3V1WENuS2VUblFIa0JwVDNwdWJHeHp0VmxxS0NhL2dZMFE3enV4cERqcUd2akFCVVlvbFoyR3RtZDVhbU1ZTHUzTHZDNXdpbEV2SW1BNStOQmc9PQo=",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.15/Vmux-v0.0.15-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzZ4K2tyeXY3RXYvSmhVeXA3cHNtTnBxVDRMOVB3OU1JNFcyZmV1YXo1V3FUYW81dHIwd0VYNHJrdldhY0Y2RGZzejlpVlRGSlh3aTJrcW1ZM1o2TkEwPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgxMjcwMTcwCWZpbGU6Vm11eC12MC4wLjE1LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKejZXZVpJVTN3TEo0UkozRzkwdjlaTGpsam05cDloSjVWWktJOEdiM1pZLy9YUjduelJEQ0pvRG9pY0pZdWxKNU9WcWMwRXhCcC9FVnNmeDNhVFpiQ1E9PQo=",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.14/Vmux_0.0.14_aarch64.dmg",
-      "filename": "Vmux_0.0.14_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.15/Vmux_0.0.15_aarch64.dmg",
+      "filename": "Vmux_0.0.15_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
Patch release. Bumps workspace version 0.0.14 -> 0.0.15. Releases on merge.