### PR TITLE
fix(cask): drop deprecated depends_on macos string form

### DIFF
--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -7,7 +7,7 @@ cask "vmux" do
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai"
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "Vmux.app"
 

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -5,7 +5,7 @@ cask "vmux" do
   url "https://github.com/vmux-ai/vmux/releases/download/v0.0.15/Vmux_0.0.15_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
-  homepage "https://vmux.ai"
+  homepage "https://vmux.ai/"
 
   depends_on macos: :ventura
 


### PR DESCRIPTION
## Summary
- `brew` warns on load: `Calling string comparison format for depends_on macos: is deprecated! Use depends_on macos: :ventura instead.` (surfaced during `brew upgrade`/`brew info`).
- Switch `Casks/vmux.rb` from `depends_on macos: \">= :ventura\"` to the bare-symbol form `depends_on macos: :ventura`. Per Homebrew, the bare symbol already means \"that release or newer,\" so the minimum-version constraint is unchanged.
- Release skill (`~/.agents/skills/release`, not in-repo) gains a grep guard after the cask sed edits to fail fast if the deprecated string form ever reappears — `brew style` does not catch this DSL deprecation.

## Test plan
- [x] `brew style Casks/vmux.rb` — no `depends_on` offense
- [x] grep guard catches `>= :ventura`, passes on bare symbol
- [ ] after merge: `brew update && brew info --cask vmux` shows no deprecation warning