### PR TITLE
feat(agent): self-anchor + open_page/run/read_terminal for CLI agents

### DIFF
--- a/crates/vmux_agent/src/launch.rs
+++ b/crates/vmux_agent/src/launch.rs
@@ -9,11 +9,12 @@ pub fn build_agent_launch(
     session_id: Option<&str>,
     strategies: &AgentStrategies,
     exe_path: &Path,
+    anchor: vmux_core::ProcessId,
 ) -> Result<TerminalLaunch, String> {
     let strategy = strategies
         .get_cli(kind)
         .ok_or_else(|| format!("CLI strategy not registered for {:?}", kind))?;
-    let mcp_cfg = mcp::resolve(cwd)?;
+    let mcp_cfg = mcp::resolve(cwd, anchor)?;
     let args = strategy.build_args(&mcp_cfg, session_id);
     let mut env: Vec<(String, String)> = std::env::vars().collect();
     env.extend(strategy.build_env(&mcp_cfg));

--- a/crates/vmux_agent/src/mcp.rs
+++ b/crates/vmux_agent/src/mcp.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
-pub use vmux_core::agent::McpServerConfig;
 use vmux_core::ProcessId;
+pub use vmux_core::agent::McpServerConfig;
 
 use crate::exec;
 

--- a/crates/vmux_agent/src/mcp.rs
+++ b/crates/vmux_agent/src/mcp.rs
@@ -1,19 +1,28 @@
 use std::path::{Path, PathBuf};
 
 pub use vmux_core::agent::McpServerConfig;
+use vmux_core::ProcessId;
 
 use crate::exec;
 
-pub fn resolve(cwd: &Path) -> Result<McpServerConfig, String> {
+pub fn resolve(cwd: &Path, anchor: ProcessId) -> Result<McpServerConfig, String> {
     let sidecar = vmux_sidecar_path()?;
-    resolve_with_sidecar(&sidecar, cwd)
+    resolve_with_sidecar(&sidecar, cwd, anchor)
 }
 
-fn resolve_with_sidecar(sidecar: &Path, cwd: &Path) -> Result<McpServerConfig, String> {
+fn resolve_with_sidecar(
+    sidecar: &Path,
+    cwd: &Path,
+    anchor: ProcessId,
+) -> Result<McpServerConfig, String> {
     if exec::is_executable_path(sidecar) {
         return Ok(McpServerConfig {
             command: sidecar.to_string_lossy().to_string(),
-            args: vec!["mcp".to_string()],
+            args: vec![
+                "mcp".to_string(),
+                "--anchor".to_string(),
+                anchor.to_string(),
+            ],
             cwd: None,
         });
     }
@@ -22,10 +31,11 @@ fn resolve_with_sidecar(sidecar: &Path, cwd: &Path) -> Result<McpServerConfig, S
     Ok(McpServerConfig {
         command: "cargo".to_string(),
         args: [
-            "run", "--quiet", "-p", "vmux_cli", "--bin", "vmux", "--", "mcp",
+            "run", "--quiet", "-p", "vmux_cli", "--bin", "vmux", "--", "mcp", "--anchor",
         ]
         .into_iter()
         .map(str::to_string)
+        .chain(std::iter::once(anchor.to_string()))
         .collect(),
         cwd: Some(workspace),
     })
@@ -61,16 +71,41 @@ mod tests {
         std::fs::create_dir_all(&workspace).unwrap();
         std::fs::write(workspace.join("Cargo.toml"), b"[workspace]\n").unwrap();
 
-        let config = resolve_with_sidecar(&temp.join("missing-vmux"), &workspace).unwrap();
+        let anchor = ProcessId::new();
+        let config = resolve_with_sidecar(&temp.join("missing-vmux"), &workspace, anchor).unwrap();
         let _ = std::fs::remove_dir_all(&temp);
 
         assert_eq!(config.command, "cargo");
         assert_eq!(
             config.args,
             vec![
-                "run", "--quiet", "-p", "vmux_cli", "--bin", "vmux", "--", "mcp"
+                "run",
+                "--quiet",
+                "-p",
+                "vmux_cli",
+                "--bin",
+                "vmux",
+                "--",
+                "mcp",
+                "--anchor",
+                &anchor.to_string()
             ]
         );
         assert_eq!(config.cwd, Some(workspace));
+    }
+
+    #[test]
+    fn resolve_appends_anchor_to_args() {
+        let temp = std::env::temp_dir().join(format!("vmux-anchor-{}", std::process::id()));
+        let workspace = temp.join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::write(workspace.join("Cargo.toml"), b"[workspace]\n").unwrap();
+
+        let anchor = ProcessId::new();
+        let config = resolve_with_sidecar(&temp.join("missing-vmux"), &workspace, anchor).unwrap();
+        let _ = std::fs::remove_dir_all(&temp);
+
+        assert!(config.args.windows(2).any(|w| w[0] == "--anchor"));
+        assert!(config.args.iter().any(|a| a == &anchor.to_string()));
     }
 }

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 use bevy_cef::prelude::{CefKeyboardTarget, WebviewExtendStandardMaterial};
 use vmux_command::{AppCommand, WriteAppCommands};
 use vmux_core::agent::{
-    AgentKind, AgentProviderTargetKind, McpServerConfig, PageAgentAttachDefaultRequest,
+    AgentKind, AgentProviderTargetKind, PageAgentAttachDefaultRequest,
     PageAgentAttachRequest, PageAgentSpawnDefaultRequest, PageAgentSpawnStackRequest,
     RestartAgentPty, SpawnAgentInStackRequest,
 };
@@ -1188,6 +1188,29 @@ fn respond_page_agent_attach_default(
     }
 }
 
+fn rebuilt_args_env_for_restart(
+    launch: &TerminalLaunch,
+    strategy: &dyn crate::client::cli::strategy::CliAgentStrategy,
+    session_id: Option<&str>,
+    new_id: ProcessId,
+) -> (Vec<String>, Vec<(String, String)>) {
+    let Ok(mcp_cfg) = crate::mcp::resolve(std::path::Path::new(&launch.cwd), new_id) else {
+        return (launch.args.clone(), launch.env.clone());
+    };
+    let args = strategy.build_args(&mcp_cfg, session_id);
+    let fresh = strategy.build_env(&mcp_cfg);
+    let fresh_keys: std::collections::HashSet<String> =
+        fresh.iter().map(|(k, _)| k.clone()).collect();
+    let mut env: Vec<(String, String)> = launch
+        .env
+        .iter()
+        .filter(|(k, _)| !fresh_keys.contains(k))
+        .cloned()
+        .collect();
+    env.extend(fresh);
+    (args, env)
+}
+
 fn handle_restart_agent_pty(
     mut reader: MessageReader<RestartAgentPty>,
     mut q: Query<(
@@ -1210,31 +1233,27 @@ fn handle_restart_agent_pty(
         service
             .0
             .send(ClientMessage::KillProcess { process_id: *pid });
+        let new_id = ProcessId::new();
 
         let (command, args, cwd, env) = match launch.as_deref() {
             Some(l) => {
-                let mut updated_args = l.args.clone();
-                if let Some(strats) = strategies.as_deref()
-                    && let Some(strategy) = strats.get_cli(session.kind)
+                let (rebuilt_args, rebuilt_env) = match strategies
+                    .as_deref()
+                    .and_then(|s| s.get_cli(session.kind))
                 {
-                    let mcp = McpServerConfig {
-                        command: l.command.clone(),
-                        args: vec![],
-                        cwd: None,
-                    };
-                    updated_args = strategy.build_args(&mcp, session_id.map(|s| s.0.as_str()));
-                }
-                (
-                    l.command.clone(),
-                    updated_args,
-                    l.cwd.clone(),
-                    l.env.clone(),
-                )
+                    Some(strategy) => rebuilt_args_env_for_restart(
+                        l,
+                        strategy,
+                        session_id.map(|s| s.0.as_str()),
+                        new_id,
+                    ),
+                    None => (l.args.clone(), l.env.clone()),
+                };
+                (l.command.clone(), rebuilt_args, l.cwd.clone(), rebuilt_env)
             }
             None => (String::new(), vec![], String::new(), Vec::new()),
         };
 
-        let new_id = ProcessId::new();
         service.0.send(ClientMessage::CreateProcess {
             process_id: new_id,
             command: command.clone(),
@@ -1251,6 +1270,7 @@ fn handle_restart_agent_pty(
         *pid = new_id;
         if let Some(l) = launch.as_mut() {
             l.args = args;
+            l.env = env;
         }
     }
 }
@@ -1293,6 +1313,32 @@ mod tests {
     #[test]
     fn blank_cwd_is_accepted() {
         assert_eq!(valid_cwd("").unwrap(), None);
+    }
+
+    #[test]
+    fn restart_rebuilds_args_with_new_anchor() {
+        let temp = std::env::temp_dir().join(format!("vmux-restart-{}", std::process::id()));
+        std::fs::create_dir_all(&temp).unwrap();
+        std::fs::write(temp.join("Cargo.toml"), b"[workspace]\n").unwrap();
+        let launch = TerminalLaunch {
+            command: "/usr/local/bin/claude".into(),
+            args: vec!["--mcp-config".into(), "OLD".into()],
+            cwd: temp.to_string_lossy().to_string(),
+            env: vec![],
+            kind: vmux_core::terminal::TerminalKind::Claude,
+        };
+        let new_id = ProcessId::new();
+        let (args, _env) = rebuilt_args_env_for_restart(
+            &launch,
+            &crate::client::cli::claude::ClaudeStrategy,
+            None,
+            new_id,
+        );
+        let _ = std::fs::remove_dir_all(&temp);
+        let joined = args.join(" ");
+        assert!(joined.contains("--anchor"), "args carry --anchor: {joined}");
+        assert!(joined.contains(&new_id.to_string()), "anchor is the new id");
+        assert!(!joined.contains("OLD"), "old args replaced");
     }
 
     #[test]

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -984,12 +984,14 @@ fn handle_spawn_agent_requests(
             );
             continue;
         };
+        let process_id = ProcessId::new();
         match crate::build_agent_launch(
             req.kind,
             &req.cwd,
             req.session_id.as_deref(),
             strategies,
             &exe_path,
+            process_id,
         ) {
             Ok(launch) => {
                 clear_stack_children(req.stack, &children_q, &mut commands);
@@ -1007,7 +1009,7 @@ fn handle_spawn_agent_requests(
                 commands
                     .entity(terminal)
                     .insert(CefKeyboardTarget)
-                    .insert((launch, AgentSession { kind: req.kind }));
+                    .insert((launch, AgentSession { kind: req.kind }, process_id));
                 if let Some(id) = req.session_id.clone() {
                     commands.entity(terminal).insert(SessionId(id));
                 } else {

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -139,6 +139,7 @@ impl Plugin for AgentPlugin {
                 (
                     forward_history_open_intent,
                     handle_agent_commands,
+                    handle_agent_self_commands,
                     handle_agent_queries,
                     detect_agent_session_process_exit,
                 )
@@ -439,6 +440,9 @@ fn handle_agent_commands(
                     });
                 AgentCommandResult::Ok
             }
+            ServiceAgentCommand::OpenBeside { .. } | ServiceAgentCommand::FocusSelf { .. } => {
+                continue;
+            }
         };
         if let Some(service) = service.as_ref() {
             service.0.send(ClientMessage::AgentCommandResponse {
@@ -446,6 +450,73 @@ fn handle_agent_commands(
                 result,
             });
         }
+    }
+}
+
+fn resolve_self_pane(
+    anchor: ProcessId,
+    agent_terms: &Query<(Entity, &ProcessId, &ChildOf), With<AgentSession>>,
+    child_of_q: &Query<&ChildOf>,
+) -> Option<(Entity, Entity)> {
+    use bevy::ecs::relationship::Relationship;
+    let (term, _, term_co) = agent_terms.iter().find(|(_, pid, _)| **pid == anchor)?;
+    let stack = term_co.get();
+    let pane = child_of_q.get(stack).ok()?.get();
+    Some((term, pane))
+}
+
+fn handle_agent_self_commands(
+    mut reader: MessageReader<AgentCommandRequest>,
+    agent_terms: Query<(Entity, &ProcessId, &ChildOf), With<AgentSession>>,
+    child_of_q: Query<&ChildOf>,
+    mut open_beside_writer: MessageWriter<vmux_layout::OpenBesideRequest>,
+    mut commands: Commands,
+    service: Option<Res<ServiceClient>>,
+) {
+    use vmux_service::protocol::{AgentCommandResult, AgentPaneDirection, ClientMessage};
+    let Some(service) = service else {
+        for _ in reader.read() {}
+        return;
+    };
+    for request in reader.read() {
+        let result = match &request.command {
+            ServiceAgentCommand::OpenBeside {
+                anchor,
+                direction,
+                url,
+            } => match resolve_self_pane(*anchor, &agent_terms, &child_of_q) {
+                None => AgentCommandResult::Error("self process not found".to_string()),
+                Some((_, pane)) => {
+                    let dir = match direction {
+                        AgentPaneDirection::Top => vmux_command::open::PaneDirection::Top,
+                        AgentPaneDirection::Right => vmux_command::open::PaneDirection::Right,
+                        AgentPaneDirection::Bottom => vmux_command::open::PaneDirection::Bottom,
+                        AgentPaneDirection::Left => vmux_command::open::PaneDirection::Left,
+                    };
+                    open_beside_writer.write(vmux_layout::OpenBesideRequest {
+                        pane,
+                        direction: dir,
+                        url: url.clone(),
+                        request_id: request.request_id.0,
+                    });
+                    AgentCommandResult::Ok
+                }
+            },
+            ServiceAgentCommand::FocusSelf { anchor } => {
+                match resolve_self_pane(*anchor, &agent_terms, &child_of_q) {
+                    None => AgentCommandResult::Error("self process not found".to_string()),
+                    Some((term, _)) => {
+                        vmux_core::focus_pane_entity(term, &mut commands, &child_of_q);
+                        AgentCommandResult::Ok
+                    }
+                }
+            }
+            _ => continue,
+        };
+        service.0.send(ClientMessage::AgentCommandResponse {
+            request_id: request.request_id,
+            result,
+        });
     }
 }
 
@@ -558,10 +629,10 @@ fn handle_agent_queries(
 
     for request in reader.read() {
         match request.query {
-            AgentQuery::ReadLayout => {
+            AgentQuery::ReadLayout { anchor } => {
                 layout_snapshot_writer.write(vmux_layout::reconcile::LayoutSnapshotRequest {
                     request_id: request.request_id.0,
-                    anchor: None,
+                    anchor,
                 });
             }
             AgentQuery::GetSettings => {
@@ -1296,6 +1367,7 @@ mod tests {
             .add_message::<vmux_layout::BrowserGoBackRequest>()
             .add_message::<vmux_layout::BrowserGoForwardRequest>()
             .add_message::<vmux_layout::OpenInNewStackRequest>()
+            .add_message::<vmux_layout::OpenBesideRequest>()
             .add_message::<vmux_layout::reconcile::LayoutApplyRequest>()
             .add_message::<vmux_layout::reconcile::LayoutApplyResponse>()
             .add_message::<vmux_layout::reconcile::LayoutSnapshotRequest>()

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -340,6 +340,8 @@ fn handle_agent_commands(
                                 pane,
                                 cwd: Some(cwd_path),
                                 pending_input: None,
+                                process_id: None,
+                                activate: true,
                             });
                         } else {
                             process_stack_spawn_writer.write(ProcessStackSpawnRequest {
@@ -521,32 +523,48 @@ fn handle_agent_self_commands(
                 command,
                 direction,
                 focus,
-            } => match resolve_self_pane(*anchor, &agent_terms, &child_of_q) {
-                None => AgentCommandResult::Error("self process not found".to_string()),
-                Some((_, pane)) => {
-                    let existing_tabs: Vec<Entity> = pane_children
-                        .get(pane)
-                        .map(|c| c.iter().filter(|&e| tab_filter.contains(e)).collect())
-                        .unwrap_or_default();
-                    let split_dir =
-                        vmux_layout::pane::direction_to_split(&to_pane_direction(direction));
-                    let p2 = vmux_layout::pane::split_leaf_into_two(
-                        &mut commands,
-                        pane,
-                        split_dir,
-                        &existing_tabs,
-                        *focus,
-                    );
-                    let mut data = command.clone().into_bytes();
-                    data.push(b'\n');
-                    terminal_stack_spawn_writer.write(TerminalStackSpawnRequest {
-                        pane: p2,
-                        cwd: None,
-                        pending_input: Some(data),
-                    });
-                    AgentCommandResult::Ok
+                terminal,
+            } => {
+                let mut data = command.clone().into_bytes();
+                data.push(b'\r');
+                match terminal {
+                    Some(pid) => {
+                        service.0.send(ClientMessage::ProcessInput {
+                            process_id: *pid,
+                            data,
+                        });
+                        AgentCommandResult::Text(pid.to_string())
+                    }
+                    None => match resolve_self_pane(*anchor, &agent_terms, &child_of_q) {
+                        None => AgentCommandResult::Error("self process not found".to_string()),
+                        Some((_, pane)) => {
+                            let existing_tabs: Vec<Entity> = pane_children
+                                .get(pane)
+                                .map(|c| c.iter().filter(|&e| tab_filter.contains(e)).collect())
+                                .unwrap_or_default();
+                            let split_dir = vmux_layout::pane::direction_to_split(
+                                &to_pane_direction(direction),
+                            );
+                            let p2 = vmux_layout::pane::split_leaf_into_two(
+                                &mut commands,
+                                pane,
+                                split_dir,
+                                &existing_tabs,
+                                *focus,
+                            );
+                            let new_pid = ProcessId::new();
+                            terminal_stack_spawn_writer.write(TerminalStackSpawnRequest {
+                                pane: p2,
+                                cwd: None,
+                                pending_input: Some(data),
+                                process_id: Some(new_pid),
+                                activate: *focus,
+                            });
+                            AgentCommandResult::Text(new_pid.to_string())
+                        }
+                    },
                 }
-            },
+            }
             _ => continue,
         };
         service.0.send(ClientMessage::AgentCommandResponse {
@@ -702,6 +720,8 @@ fn handle_agent_queries(
                     result: AgentQueryResult::Spaces(json),
                 });
             }
+            // ReadTerminal is answered by the service directly; it never reaches the GUI.
+            AgentQuery::ReadTerminal { .. } => {}
         }
     }
 }

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -4,9 +4,9 @@ use bevy::prelude::*;
 use bevy_cef::prelude::{CefKeyboardTarget, WebviewExtendStandardMaterial};
 use vmux_command::{AppCommand, WriteAppCommands};
 use vmux_core::agent::{
-    AgentKind, AgentProviderTargetKind, PageAgentAttachDefaultRequest,
-    PageAgentAttachRequest, PageAgentSpawnDefaultRequest, PageAgentSpawnStackRequest,
-    RestartAgentPty, SpawnAgentInStackRequest,
+    AgentKind, AgentProviderTargetKind, PageAgentAttachDefaultRequest, PageAgentAttachRequest,
+    PageAgentSpawnDefaultRequest, PageAgentSpawnStackRequest, RestartAgentPty,
+    SpawnAgentInStackRequest,
 };
 use vmux_core::{
     LastActivatedAt, PageMetadata, PageOpenError, PageOpenHandled, PageOpenSet, PageOpenTask, Ready,
@@ -102,6 +102,7 @@ impl Plugin for AgentPlugin {
             .add_message::<TerminalStackSpawnRequest>()
             .add_message::<ProcessStackSpawnRequest>()
             .add_message::<RestartAgentPty>()
+            .init_resource::<bevy::ecs::message::Messages<vmux_layout::OpenBesideRequest>>()
             .add_systems(Startup, session::start_agent_session_watchers)
             .add_systems(
                 Update,
@@ -1006,10 +1007,11 @@ fn handle_spawn_agent_requests(
                         ChildOf(req.stack),
                     ))
                     .id();
-                commands
-                    .entity(terminal)
-                    .insert(CefKeyboardTarget)
-                    .insert((launch, AgentSession { kind: req.kind }, process_id));
+                commands.entity(terminal).insert(CefKeyboardTarget).insert((
+                    launch,
+                    AgentSession { kind: req.kind },
+                    process_id,
+                ));
                 if let Some(id) = req.session_id.clone() {
                     commands.entity(terminal).insert(SessionId(id));
                 } else {
@@ -1237,18 +1239,16 @@ fn handle_restart_agent_pty(
 
         let (command, args, cwd, env) = match launch.as_deref() {
             Some(l) => {
-                let (rebuilt_args, rebuilt_env) = match strategies
-                    .as_deref()
-                    .and_then(|s| s.get_cli(session.kind))
-                {
-                    Some(strategy) => rebuilt_args_env_for_restart(
-                        l,
-                        strategy,
-                        session_id.map(|s| s.0.as_str()),
-                        new_id,
-                    ),
-                    None => (l.args.clone(), l.env.clone()),
-                };
+                let (rebuilt_args, rebuilt_env) =
+                    match strategies.as_deref().and_then(|s| s.get_cli(session.kind)) {
+                        Some(strategy) => rebuilt_args_env_for_restart(
+                            l,
+                            strategy,
+                            session_id.map(|s| s.0.as_str()),
+                            new_id,
+                        ),
+                        None => (l.args.clone(), l.env.clone()),
+                    };
                 (l.command.clone(), rebuilt_args, l.cwd.clone(), rebuilt_env)
             }
             None => (String::new(), vec![], String::new(), Vec::new()),

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -485,6 +485,7 @@ fn handle_agent_self_commands(
                 anchor,
                 direction,
                 url,
+                focus,
             } => match resolve_self_pane(*anchor, &agent_terms, &child_of_q) {
                 None => AgentCommandResult::Error("self process not found".to_string()),
                 Some((_, pane)) => {
@@ -499,6 +500,7 @@ fn handle_agent_self_commands(
                         direction: dir,
                         url: url.clone(),
                         request_id: request.request_id.0,
+                        focus: *focus,
                     });
                     AgentCommandResult::Ok
                 }

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -492,6 +492,7 @@ fn handle_agent_self_commands(
     mut terminal_stack_spawn_writer: MessageWriter<TerminalStackSpawnRequest>,
     mut commands: Commands,
     service: Option<Res<ServiceClient>>,
+    active_space: Option<Res<ActiveSpace>>,
 ) {
     use vmux_service::protocol::{AgentCommandResult, ClientMessage};
     let Some(service) = service else {
@@ -553,9 +554,13 @@ fn handle_agent_self_commands(
                                 *focus,
                             );
                             let new_pid = ProcessId::new();
+                            let cwd = active_space
+                                .as_deref()
+                                .map(|s| space_dir(&s.record.id))
+                                .unwrap_or_else(default_space_dir);
                             terminal_stack_spawn_writer.write(TerminalStackSpawnRequest {
                                 pane: p2,
-                                cwd: None,
+                                cwd: Some(cwd),
                                 pending_input: Some(data),
                                 process_id: Some(new_pid),
                                 activate: *focus,

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -441,7 +441,7 @@ fn handle_agent_commands(
                     });
                 AgentCommandResult::Ok
             }
-            ServiceAgentCommand::OpenBeside { .. } | ServiceAgentCommand::FocusSelf { .. } => {
+            ServiceAgentCommand::OpenBeside { .. } | ServiceAgentCommand::Run { .. } => {
                 continue;
             }
         };
@@ -466,15 +466,32 @@ fn resolve_self_pane(
     Some((term, pane))
 }
 
+fn to_pane_direction(
+    d: &vmux_service::protocol::AgentPaneDirection,
+) -> vmux_command::open::PaneDirection {
+    use vmux_command::open::PaneDirection;
+    use vmux_service::protocol::AgentPaneDirection as D;
+    match d {
+        D::Top => PaneDirection::Top,
+        D::Right => PaneDirection::Right,
+        D::Bottom => PaneDirection::Bottom,
+        D::Left => PaneDirection::Left,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 fn handle_agent_self_commands(
     mut reader: MessageReader<AgentCommandRequest>,
     agent_terms: Query<(Entity, &ProcessId, &ChildOf), With<AgentSession>>,
     child_of_q: Query<&ChildOf>,
+    pane_children: Query<&Children, With<Pane>>,
+    tab_filter: Query<Entity, With<vmux_layout::stack::Stack>>,
     mut open_beside_writer: MessageWriter<vmux_layout::OpenBesideRequest>,
+    mut terminal_stack_spawn_writer: MessageWriter<TerminalStackSpawnRequest>,
     mut commands: Commands,
     service: Option<Res<ServiceClient>>,
 ) {
-    use vmux_service::protocol::{AgentCommandResult, AgentPaneDirection, ClientMessage};
+    use vmux_service::protocol::{AgentCommandResult, ClientMessage};
     let Some(service) = service else {
         for _ in reader.read() {}
         return;
@@ -489,15 +506,9 @@ fn handle_agent_self_commands(
             } => match resolve_self_pane(*anchor, &agent_terms, &child_of_q) {
                 None => AgentCommandResult::Error("self process not found".to_string()),
                 Some((_, pane)) => {
-                    let dir = match direction {
-                        AgentPaneDirection::Top => vmux_command::open::PaneDirection::Top,
-                        AgentPaneDirection::Right => vmux_command::open::PaneDirection::Right,
-                        AgentPaneDirection::Bottom => vmux_command::open::PaneDirection::Bottom,
-                        AgentPaneDirection::Left => vmux_command::open::PaneDirection::Left,
-                    };
                     open_beside_writer.write(vmux_layout::OpenBesideRequest {
                         pane,
-                        direction: dir,
+                        direction: to_pane_direction(direction),
                         url: url.clone(),
                         request_id: request.request_id.0,
                         focus: *focus,
@@ -505,15 +516,37 @@ fn handle_agent_self_commands(
                     AgentCommandResult::Ok
                 }
             },
-            ServiceAgentCommand::FocusSelf { anchor } => {
-                match resolve_self_pane(*anchor, &agent_terms, &child_of_q) {
-                    None => AgentCommandResult::Error("self process not found".to_string()),
-                    Some((term, _)) => {
-                        vmux_core::focus_pane_entity(term, &mut commands, &child_of_q);
-                        AgentCommandResult::Ok
-                    }
+            ServiceAgentCommand::Run {
+                anchor,
+                command,
+                direction,
+                focus,
+            } => match resolve_self_pane(*anchor, &agent_terms, &child_of_q) {
+                None => AgentCommandResult::Error("self process not found".to_string()),
+                Some((_, pane)) => {
+                    let existing_tabs: Vec<Entity> = pane_children
+                        .get(pane)
+                        .map(|c| c.iter().filter(|&e| tab_filter.contains(e)).collect())
+                        .unwrap_or_default();
+                    let split_dir =
+                        vmux_layout::pane::direction_to_split(&to_pane_direction(direction));
+                    let p2 = vmux_layout::pane::split_leaf_into_two(
+                        &mut commands,
+                        pane,
+                        split_dir,
+                        &existing_tabs,
+                        *focus,
+                    );
+                    let mut data = command.clone().into_bytes();
+                    data.push(b'\n');
+                    terminal_stack_spawn_writer.write(TerminalStackSpawnRequest {
+                        pane: p2,
+                        cwd: None,
+                        pending_input: Some(data),
+                    });
+                    AgentCommandResult::Ok
                 }
-            }
+            },
             _ => continue,
         };
         service.0.send(ClientMessage::AgentCommandResponse {

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -561,6 +561,7 @@ fn handle_agent_queries(
             AgentQuery::ReadLayout => {
                 layout_snapshot_writer.write(vmux_layout::reconcile::LayoutSnapshotRequest {
                     request_id: request.request_id.0,
+                    anchor: None,
                 });
             }
             AgentQuery::GetSettings => {

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -4387,8 +4387,7 @@ mod tests {
                 .add_systems(
                     Update,
                     (
-                        crate::handle_browser_navigate_requests
-                            .before(PageOpenSet::ResolveTarget),
+                        crate::handle_browser_navigate_requests.before(PageOpenSet::ResolveTarget),
                         crate::handle_page_open_requests.in_set(PageOpenSet::ResolveTarget),
                         handle_test_known_page_open.in_set(PageOpenSet::HandleKnownPages),
                         crate::attach_cef_page_requests.in_set(PageOpenSet::Fallback),

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -4387,7 +4387,8 @@ mod tests {
                 .add_systems(
                     Update,
                     (
-                        crate::handle_browser_navigate_requests,
+                        crate::handle_browser_navigate_requests
+                            .before(PageOpenSet::ResolveTarget),
                         crate::handle_page_open_requests.in_set(PageOpenSet::ResolveTarget),
                         handle_test_known_page_open.in_set(PageOpenSet::HandleKnownPages),
                         crate::attach_cef_page_requests.in_set(PageOpenSet::Fallback),

--- a/crates/vmux_cli/src/commands.rs
+++ b/crates/vmux_cli/src/commands.rs
@@ -13,6 +13,9 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
-    Mcp,
+    Mcp {
+        #[arg(long)]
+        anchor: Option<String>,
+    },
     Service(service::ServiceArgs),
 }

--- a/crates/vmux_cli/src/commands/mcp.rs
+++ b/crates/vmux_cli/src/commands/mcp.rs
@@ -1,5 +1,6 @@
 use std::io;
 
-pub async fn run() -> io::Result<()> {
-    vmux_mcp::protocol::run_stdio().await
+pub async fn run(anchor: Option<String>) -> io::Result<()> {
+    let anchor = anchor.and_then(|s| s.parse::<vmux_service::protocol::ProcessId>().ok());
+    vmux_mcp::protocol::run_stdio(anchor).await
 }

--- a/crates/vmux_cli/src/main.rs
+++ b/crates/vmux_cli/src/main.rs
@@ -8,7 +8,7 @@ use commands::{Cli, Command, open::OpenAppLauncher};
 async fn main() -> std::io::Result<()> {
     let cli = Cli::parse();
     match cli.command {
-        Some(Command::Mcp) => commands::mcp::run().await,
+        Some(Command::Mcp { anchor }) => commands::mcp::run(anchor).await,
         Some(Command::Service(args)) => {
             let code = commands::service::run(args)?;
             std::process::exit(code);

--- a/crates/vmux_cli/tests/mcp_smoke.rs
+++ b/crates/vmux_cli/tests/mcp_smoke.rs
@@ -44,8 +44,8 @@ fn mcp_tools_list_includes_self_anchor_tools() {
         .write_stdin(stdin)
         .assert()
         .success()
-        .stdout(contains("\"open_beside_me\""))
-        .stdout(contains("\"focus_self\""));
+        .stdout(contains("\"open_page\""))
+        .stdout(contains("\"run\""));
 }
 
 #[test]

--- a/crates/vmux_cli/tests/mcp_smoke.rs
+++ b/crates/vmux_cli/tests/mcp_smoke.rs
@@ -37,6 +37,31 @@ fn mcp_tools_list_includes_layout_tools() {
 }
 
 #[test]
+fn mcp_tools_list_includes_self_anchor_tools() {
+    let stdin = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}\n";
+    let mut cmd = Command::cargo_bin("vmux").unwrap();
+    cmd.arg("mcp")
+        .write_stdin(stdin)
+        .assert()
+        .success()
+        .stdout(contains("\"open_beside_me\""))
+        .stdout(contains("\"focus_self\""));
+}
+
+#[test]
+fn mcp_accepts_anchor_flag() {
+    let stdin = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\"}}\n";
+    let mut cmd = Command::cargo_bin("vmux").unwrap();
+    cmd.arg("mcp")
+        .arg("--anchor")
+        .arg("00000000-0000-0000-0000-000000000000")
+        .write_stdin(stdin)
+        .assert()
+        .success()
+        .stdout(contains("\"name\":\"vmux\""));
+}
+
+#[test]
 fn mcp_tools_list_excludes_legacy_layout_tools() {
     let stdin = "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/list\"}\n";
     let mut cmd = Command::cargo_bin("vmux").unwrap();

--- a/crates/vmux_command/src/open.rs
+++ b/crates/vmux_command/src/open.rs
@@ -48,9 +48,10 @@ pub enum OpenCommand {
         chord = "Ctrl+g, \"",
         variant = "InPane { direction: PaneDirection::Bottom, target: PaneTarget::NewSplit, mode: PaneOpenMode::NewStack, url: None }"
     )]
-    #[mcp(
-        description = "Open a page in a sibling pane in the given direction. Set target=NewSplit to split the current pane, target=Existing to reuse an adjacent pane (falls back to NewSplit if none). Set mode=InPlace to navigate the chosen pane's active stack, mode=NewStack to add a stack to it."
-    )]
+    // Hidden from the agent MCP surface: superseded by the self-relative
+    // `open_page` tool (in_pane targets the focused pane, which is unpredictable
+    // for an agent). Still available via the command bar / keyboard.
+    #[mcp(skip)]
     InPane {
         #[mcp(description = "Which side of the current pane to act on.", enum_values = ["top", "right", "bottom", "left"])]
         direction: PaneDirection,

--- a/crates/vmux_command/tests/open_command_derives.rs
+++ b/crates/vmux_command/tests/open_command_derives.rs
@@ -120,9 +120,10 @@ fn mcp_tool_entries_has_all_variants() {
     let names: Vec<_> = entries.iter().map(|(name, _, _)| *name).collect();
     assert!(names.contains(&"in_place"));
     assert!(names.contains(&"in_new_stack"));
-    assert!(names.contains(&"in_pane"));
     assert!(names.contains(&"in_new_tab"));
     assert!(names.contains(&"in_new_space"));
+    // in_pane is #[mcp(skip)] (superseded by the self-relative open_page tool).
+    assert!(!names.contains(&"in_pane"));
 }
 
 #[test]

--- a/crates/vmux_desktop/src/focus_native.rs
+++ b/crates/vmux_desktop/src/focus_native.rs
@@ -2,6 +2,7 @@ use bevy::ecs::system::NonSendMarker;
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 use vmux_browser::HostFocusIntent;
+use vmux_layout::stack::FocusedStack;
 
 /// When the active page is a terminal (OSR) or there is none, the winit host window must own
 /// macOS first-responder so Bevy delivers keys (terminal → PTY, layout shortcuts). A previously
@@ -15,9 +16,15 @@ use vmux_browser::HostFocusIntent;
 pub(crate) fn apply_winit_host_focus(
     _non_send: NonSendMarker,
     intent: Res<HostFocusIntent>,
+    focus: Res<FocusedStack>,
     primary: Query<Entity, With<PrimaryWindow>>,
     mut reclaimed: Local<bool>,
+    mut last_stack: Local<Option<Entity>>,
 ) {
+    if focus.stack != *last_stack {
+        *last_stack = focus.stack;
+        *reclaimed = false;
+    }
     if *intent != HostFocusIntent::WinitHost {
         *reclaimed = false;
         return;

--- a/crates/vmux_layout/src/lib.rs
+++ b/crates/vmux_layout/src/lib.rs
@@ -69,13 +69,13 @@ pub use command_bar::handler::PendingCommandBarReveal;
 #[cfg(not(target_arch = "wasm32"))]
 pub use header::Header;
 #[cfg(not(target_arch = "wasm32"))]
+pub use pane::{OpenBesideRequest, handle_open_beside_requests};
+#[cfg(not(target_arch = "wasm32"))]
 pub use plugin::LayoutPlugin;
 #[cfg(not(target_arch = "wasm32"))]
 pub use webview_reveal::PendingWebviewReveal;
 #[cfg(not(target_arch = "wasm32"))]
 pub use window::fit_window_to_screen;
-#[cfg(not(target_arch = "wasm32"))]
-pub use pane::{OpenBesideRequest, handle_open_beside_requests};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub const LAYOUT_PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {

--- a/crates/vmux_layout/src/lib.rs
+++ b/crates/vmux_layout/src/lib.rs
@@ -74,6 +74,8 @@ pub use plugin::LayoutPlugin;
 pub use webview_reveal::PendingWebviewReveal;
 #[cfg(not(target_arch = "wasm32"))]
 pub use window::fit_window_to_screen;
+#[cfg(not(target_arch = "wasm32"))]
+pub use pane::{OpenBesideRequest, handle_open_beside_requests};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub const LAYOUT_PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -770,18 +770,23 @@ fn split_leaf_into_two(
     active: Entity,
     split_dir: PaneSplitDirection,
     existing_tabs: &[Entity],
+    activate_new: bool,
 ) -> Entity {
+    let new_ts = if activate_new {
+        LastActivatedAt::now()
+    } else {
+        LastActivatedAt(0)
+    };
     let pane1 = commands
         .spawn((leaf_pane_bundle(), LastActivatedAt::now(), ChildOf(active)))
         .id();
     let p2 = commands
-        .spawn((leaf_pane_bundle(), LastActivatedAt::now(), ChildOf(active)))
+        .spawn((leaf_pane_bundle(), new_ts, ChildOf(active)))
         .id();
     for tab in existing_tabs {
         commands.entity(*tab).insert(ChildOf(pane1));
     }
     commands.entity(active).insert(split_root_bundle(split_dir));
-    commands.entity(p2).insert(LastActivatedAt::now());
     p2
 }
 
@@ -791,6 +796,9 @@ pub struct OpenBesideRequest {
     pub direction: PaneDirection,
     pub url: String,
     pub request_id: [u8; 16],
+    /// When true, focus moves to the newly opened pane. When false, focus stays
+    /// where it is (the agent keeps focus so it can drive the new pane itself).
+    pub focus: bool,
 }
 
 pub fn handle_open_beside_requests(
@@ -807,10 +815,19 @@ pub fn handle_open_beside_requests(
             .map(|c| c.iter().filter(|&e| tab_filter.contains(e)).collect())
             .unwrap_or_default();
         let split_dir = direction_to_split(&req.direction);
-        let p2 = split_leaf_into_two(&mut commands, req.pane, split_dir, &existing_tabs);
-        let new_stack = commands
-            .spawn((stack_bundle(), LastActivatedAt::now(), ChildOf(p2)))
-            .id();
+        let p2 = split_leaf_into_two(
+            &mut commands,
+            req.pane,
+            split_dir,
+            &existing_tabs,
+            req.focus,
+        );
+        let stack_ts = if req.focus {
+            LastActivatedAt::now()
+        } else {
+            LastActivatedAt(0)
+        };
+        let new_stack = commands.spawn((stack_bundle(), stack_ts, ChildOf(p2))).id();
         open_or_prompt_stack(
             new_stack,
             Some(req.url.clone()),
@@ -929,8 +946,13 @@ fn handle_open_in_pane(
                             .get(active)
                             .map(|c| c.iter().filter(|&e| tab_filter.contains(e)).collect())
                             .unwrap_or_default();
-                        let p2 =
-                            split_leaf_into_two(&mut commands, active, split_dir, &existing_tabs);
+                        let p2 = split_leaf_into_two(
+                            &mut commands,
+                            active,
+                            split_dir,
+                            &existing_tabs,
+                            true,
+                        );
                         (p2, true)
                     }
                 }
@@ -940,7 +962,8 @@ fn handle_open_in_pane(
                     .get(active)
                     .map(|c| c.iter().filter(|&e| tab_filter.contains(e)).collect())
                     .unwrap_or_default();
-                let p2 = split_leaf_into_two(&mut commands, active, split_dir, &existing_tabs);
+                let p2 =
+                    split_leaf_into_two(&mut commands, active, split_dir, &existing_tabs, true);
                 (p2, true)
             }
         };
@@ -2990,6 +3013,7 @@ mod tests {
                         active,
                         PaneSplitDirection::Row,
                         &existing_tabs,
+                        true,
                     )
                 },
             )
@@ -3031,6 +3055,7 @@ mod tests {
                 direction: PaneDirection::Right,
                 url: "vmux://terminal/".into(),
                 request_id: [0u8; 16],
+                focus: true,
             });
         app.update();
 
@@ -3038,6 +3063,42 @@ mod tests {
         assert!(world.get::<PaneSplit>(anchor_pane).is_some());
         let kids = world.entity(anchor_pane).get::<Children>().unwrap();
         assert_eq!(kids.iter().count(), 2);
+    }
+
+    #[test]
+    fn open_beside_with_focus_false_leaves_new_stack_unactivated() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<OpenBesideRequest>()
+            .add_message::<PageOpenRequest>()
+            .init_resource::<NewStackContext>()
+            .add_systems(Update, handle_open_beside_requests);
+        let tab = app.world_mut().spawn(crate::tab::tab_bundle()).id();
+        let anchor_pane = app
+            .world_mut()
+            .spawn((leaf_pane_bundle(), LastActivatedAt::now(), ChildOf(tab)))
+            .id();
+        app.world_mut()
+            .spawn((stack_bundle(), LastActivatedAt::now(), ChildOf(anchor_pane)));
+
+        app.world_mut()
+            .resource_mut::<Messages<OpenBesideRequest>>()
+            .write(OpenBesideRequest {
+                pane: anchor_pane,
+                direction: PaneDirection::Right,
+                url: "vmux://terminal/".into(),
+                request_id: [0u8; 16],
+                focus: false,
+            });
+        app.update();
+
+        let world = app.world_mut();
+        let mut stacks = world.query_filtered::<&LastActivatedAt, With<Stack>>();
+        let unactivated = stacks.iter(world).filter(|la| la.0 == 0).count();
+        assert_eq!(
+            unactivated, 1,
+            "focus:false leaves exactly the new stack un-activated (ts 0) so focus stays put"
+        );
     }
 
     #[test]

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -763,6 +763,26 @@ fn direction_to_split(direction: &PaneDirection) -> PaneSplitDirection {
     }
 }
 
+fn split_leaf_into_two(
+    commands: &mut Commands,
+    active: Entity,
+    split_dir: PaneSplitDirection,
+    existing_tabs: &[Entity],
+) -> Entity {
+    let pane1 = commands
+        .spawn((leaf_pane_bundle(), LastActivatedAt::now(), ChildOf(active)))
+        .id();
+    let p2 = commands
+        .spawn((leaf_pane_bundle(), LastActivatedAt::now(), ChildOf(active)))
+        .id();
+    for tab in existing_tabs {
+        commands.entity(*tab).insert(ChildOf(pane1));
+    }
+    commands.entity(active).insert(split_root_bundle(split_dir));
+    commands.entity(p2).insert(LastActivatedAt::now());
+    p2
+}
+
 fn is_after_direction(direction: &PaneDirection) -> bool {
     matches!(direction, PaneDirection::Right | PaneDirection::Bottom)
 }
@@ -872,17 +892,8 @@ fn handle_open_in_pane(
                             .get(active)
                             .map(|c| c.iter().filter(|&e| tab_filter.contains(e)).collect())
                             .unwrap_or_default();
-                        let pane1 = commands
-                            .spawn((leaf_pane_bundle(), LastActivatedAt::now(), ChildOf(active)))
-                            .id();
-                        let p2 = commands
-                            .spawn((leaf_pane_bundle(), LastActivatedAt::now(), ChildOf(active)))
-                            .id();
-                        for tab in &existing_tabs {
-                            commands.entity(*tab).insert(ChildOf(pane1));
-                        }
-                        commands.entity(active).insert(split_root_bundle(split_dir));
-                        commands.entity(p2).insert(LastActivatedAt::now());
+                        let p2 =
+                            split_leaf_into_two(&mut commands, active, split_dir, &existing_tabs);
                         (p2, true)
                     }
                 }
@@ -892,17 +903,7 @@ fn handle_open_in_pane(
                     .get(active)
                     .map(|c| c.iter().filter(|&e| tab_filter.contains(e)).collect())
                     .unwrap_or_default();
-                let pane1 = commands
-                    .spawn((leaf_pane_bundle(), LastActivatedAt::now(), ChildOf(active)))
-                    .id();
-                let p2 = commands
-                    .spawn((leaf_pane_bundle(), LastActivatedAt::now(), ChildOf(active)))
-                    .id();
-                for tab in &existing_tabs {
-                    commands.entity(*tab).insert(ChildOf(pane1));
-                }
-                commands.entity(active).insert(split_root_bundle(split_dir));
-                commands.entity(p2).insert(LastActivatedAt::now());
+                let p2 = split_leaf_into_two(&mut commands, active, split_dir, &existing_tabs);
                 (p2, true)
             }
         };
@@ -2921,6 +2922,53 @@ mod tests {
         );
 
         assert_eq!(result.unwrap(), None);
+    }
+
+    #[test]
+    fn split_leaf_into_two_reparents_tabs_and_splits() {
+        use bevy_ecs::system::RunSystemOnce;
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        let active = app
+            .world_mut()
+            .spawn((leaf_pane_bundle(), LastActivatedAt::now()))
+            .id();
+        let existing = app
+            .world_mut()
+            .spawn((stack_bundle(), LastActivatedAt::now(), ChildOf(active)))
+            .id();
+
+        let p2 = app
+            .world_mut()
+            .run_system_once(
+                move |mut commands: Commands,
+                      children: Query<&Children, With<Pane>>,
+                      tabq: Query<Entity, With<Stack>>| {
+                    let existing_tabs: Vec<Entity> = children
+                        .get(active)
+                        .map(|c| c.iter().filter(|&e| tabq.contains(e)).collect())
+                        .unwrap_or_default();
+                    split_leaf_into_two(
+                        &mut commands,
+                        active,
+                        PaneSplitDirection::Row,
+                        &existing_tabs,
+                    )
+                },
+            )
+            .unwrap();
+
+        let world = app.world_mut();
+        assert!(
+            world.get::<PaneSplit>(active).is_some(),
+            "active became a split root"
+        );
+        assert_ne!(
+            world.entity(existing).get::<ChildOf>().unwrap().get(),
+            active,
+            "stack reparented off active"
+        );
+        assert!(world.get::<PaneSplit>(p2).is_none(), "p2 is a leaf");
     }
 
     #[test]

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -758,14 +758,14 @@ fn handle_pane_commands(
     }
 }
 
-fn direction_to_split(direction: &PaneDirection) -> PaneSplitDirection {
+pub fn direction_to_split(direction: &PaneDirection) -> PaneSplitDirection {
     match direction {
         PaneDirection::Left | PaneDirection::Right => PaneSplitDirection::Row,
         PaneDirection::Top | PaneDirection::Bottom => PaneSplitDirection::Column,
     }
 }
 
-fn split_leaf_into_two(
+pub fn split_leaf_into_two(
     commands: &mut Commands,
     active: Entity,
     split_dir: PaneSplitDirection,

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -53,6 +53,8 @@ impl Plugin for PanePlugin {
             .add_systems(Update, on_pane_select.in_set(ReadAppCommands))
             .add_systems(Update, handle_pane_commands.in_set(ReadAppCommands))
             .add_systems(Update, handle_open_in_pane.in_set(ReadAppCommands))
+            .add_message::<OpenBesideRequest>()
+            .add_systems(Update, handle_open_beside_requests)
             .add_systems(
                 Update,
                 handle_zoom_command
@@ -781,6 +783,41 @@ fn split_leaf_into_two(
     commands.entity(active).insert(split_root_bundle(split_dir));
     commands.entity(p2).insert(LastActivatedAt::now());
     p2
+}
+
+#[derive(Message, Clone)]
+pub struct OpenBesideRequest {
+    pub pane: Entity,
+    pub direction: PaneDirection,
+    pub url: String,
+    pub request_id: [u8; 16],
+}
+
+pub fn handle_open_beside_requests(
+    mut reader: MessageReader<OpenBesideRequest>,
+    pane_children: Query<&Children, With<Pane>>,
+    tab_filter: Query<Entity, With<Stack>>,
+    mut commands: Commands,
+    mut page_open_requests: MessageWriter<PageOpenRequest>,
+    mut new_stack_ctx: ResMut<NewStackContext>,
+) {
+    for req in reader.read() {
+        let existing_tabs: Vec<Entity> = pane_children
+            .get(req.pane)
+            .map(|c| c.iter().filter(|&e| tab_filter.contains(e)).collect())
+            .unwrap_or_default();
+        let split_dir = direction_to_split(&req.direction);
+        let p2 = split_leaf_into_two(&mut commands, req.pane, split_dir, &existing_tabs);
+        let new_stack = commands
+            .spawn((stack_bundle(), LastActivatedAt::now(), ChildOf(p2)))
+            .id();
+        open_or_prompt_stack(
+            new_stack,
+            Some(req.url.clone()),
+            &mut new_stack_ctx,
+            &mut page_open_requests,
+        );
+    }
 }
 
 fn is_after_direction(direction: &PaneDirection) -> bool {
@@ -2969,6 +3006,38 @@ mod tests {
             "stack reparented off active"
         );
         assert!(world.get::<PaneSplit>(p2).is_none(), "p2 is a leaf");
+    }
+
+    #[test]
+    fn open_beside_splits_the_given_pane() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<OpenBesideRequest>()
+            .add_message::<PageOpenRequest>()
+            .init_resource::<NewStackContext>()
+            .add_systems(Update, handle_open_beside_requests);
+        let tab = app.world_mut().spawn(crate::tab::tab_bundle()).id();
+        let anchor_pane = app
+            .world_mut()
+            .spawn((leaf_pane_bundle(), LastActivatedAt::now(), ChildOf(tab)))
+            .id();
+        app.world_mut()
+            .spawn((stack_bundle(), LastActivatedAt::now(), ChildOf(anchor_pane)));
+
+        app.world_mut()
+            .resource_mut::<Messages<OpenBesideRequest>>()
+            .write(OpenBesideRequest {
+                pane: anchor_pane,
+                direction: PaneDirection::Right,
+                url: "vmux://terminal/".into(),
+                request_id: [0u8; 16],
+            });
+        app.update();
+
+        let world = app.world_mut();
+        assert!(world.get::<PaneSplit>(anchor_pane).is_some());
+        let kids = world.entity(anchor_pane).get::<Children>().unwrap();
+        assert_eq!(kids.iter().count(), 2);
     }
 
     #[test]

--- a/crates/vmux_layout/src/protocol.rs
+++ b/crates/vmux_layout/src/protocol.rs
@@ -72,6 +72,8 @@ pub struct Stack {
     pub is_loading: bool,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub favicon_url: String,
+    #[serde(default)]
+    pub is_self: bool,
 }
 
 #[derive(
@@ -273,6 +275,7 @@ mod tests {
                                 kind: "browser".into(),
                                 is_loading: false,
                                 favicon_url: String::new(),
+                                is_self: false,
                             }],
                         },
                         LayoutNode::Pane {

--- a/crates/vmux_layout/src/protocol.rs
+++ b/crates/vmux_layout/src/protocol.rs
@@ -74,6 +74,10 @@ pub struct Stack {
     pub favicon_url: String,
     #[serde(default)]
     pub is_self: bool,
+    /// For terminal stacks: the terminal's `ProcessId` (its handle for `run` /
+    /// `read_terminal`). `None` for browser stacks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub process_id: Option<String>,
 }
 
 #[derive(
@@ -276,6 +280,7 @@ mod tests {
                                 is_loading: false,
                                 favicon_url: String::new(),
                                 is_self: false,
+                                process_id: None,
                             }],
                         },
                         LayoutNode::Pane {

--- a/crates/vmux_layout/src/reconcile.rs
+++ b/crates/vmux_layout/src/reconcile.rs
@@ -331,17 +331,21 @@ pub fn serve_snapshot_requests(
     pane_sizes_q: Query<&PaneSize>,
     zoomed_q: Query<&crate::pane::Zoomed>,
     focused: Res<crate::stack::FocusedStack>,
-    agent_terms: Query<(&vmux_core::ProcessId, &ChildOf), With<vmux_core::agent::AgentSession>>,
+    process_ids: Query<(&vmux_core::ProcessId, &ChildOf)>,
     mut writer: MessageWriter<LayoutSnapshotResponse>,
 ) {
+    let pid_by_stack: HashMap<u64, String> = process_ids
+        .iter()
+        .map(|(pid, co)| (co.get().to_bits(), pid.to_string()))
+        .collect();
     for request in reader.read() {
         let self_stack = request.anchor.and_then(|anchor| {
-            agent_terms
+            process_ids
                 .iter()
                 .find(|(pid, _)| **pid == anchor)
                 .map(|(_, co)| co.get())
         });
-        let snapshot = crate::snapshot::build_layout_snapshot(
+        let mut snapshot = crate::snapshot::build_layout_snapshot(
             &tabs_q,
             &splits_q,
             &leaves_q,
@@ -351,10 +355,34 @@ pub fn serve_snapshot_requests(
             &focused,
             self_stack,
         );
+        for tab in &mut snapshot.tabs {
+            fill_process_ids(&mut tab.root, &pid_by_stack);
+        }
         writer.write(LayoutSnapshotResponse {
             request_id: request.request_id,
             snapshot,
         });
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn fill_process_ids(node: &mut LayoutNode, pid_by_stack: &HashMap<u64, String>) {
+    match node {
+        LayoutNode::Split { children, .. } => {
+            for child in children {
+                fill_process_ids(child, pid_by_stack);
+            }
+        }
+        LayoutNode::Pane { stacks, .. } => {
+            for stack in stacks {
+                if let Some(id) = &stack.id
+                    && let Ok((NodeKind::Stack, bits)) = parse_id(id)
+                    && let Some(pid) = pid_by_stack.get(&bits)
+                {
+                    stack.process_id = Some(pid.clone());
+                }
+            }
+        }
     }
 }
 

--- a/crates/vmux_layout/src/reconcile.rs
+++ b/crates/vmux_layout/src/reconcile.rs
@@ -287,6 +287,8 @@ use bevy::ecs::message::{MessageReader, MessageWriter, Messages};
 #[cfg(not(target_arch = "wasm32"))]
 use bevy::prelude::*;
 #[cfg(not(target_arch = "wasm32"))]
+use bevy::ecs::relationship::Relationship;
+#[cfg(not(target_arch = "wasm32"))]
 use vmux_core::{PageMetadata, PageOpenRequest, PageOpenTarget};
 #[cfg(not(target_arch = "wasm32"))]
 use vmux_history::LastActivatedAt;
@@ -309,6 +311,7 @@ pub struct LayoutApplyResponse {
 #[derive(Message, Clone)]
 pub struct LayoutSnapshotRequest {
     pub request_id: [u8; 16],
+    pub anchor: Option<vmux_core::ProcessId>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -328,9 +331,16 @@ pub fn serve_snapshot_requests(
     pane_sizes_q: Query<&PaneSize>,
     zoomed_q: Query<&crate::pane::Zoomed>,
     focused: Res<crate::stack::FocusedStack>,
+    agent_terms: Query<(&vmux_core::ProcessId, &ChildOf), With<vmux_core::agent::AgentSession>>,
     mut writer: MessageWriter<LayoutSnapshotResponse>,
 ) {
     for request in reader.read() {
+        let self_stack = request.anchor.and_then(|anchor| {
+            agent_terms
+                .iter()
+                .find(|(pid, _)| **pid == anchor)
+                .map(|(_, co)| co.get())
+        });
         let snapshot = crate::snapshot::build_layout_snapshot(
             &tabs_q,
             &splits_q,
@@ -339,6 +349,7 @@ pub fn serve_snapshot_requests(
             &pane_sizes_q,
             &zoomed_q,
             &focused,
+            self_stack,
         );
         writer.write(LayoutSnapshotResponse {
             request_id: request.request_id,
@@ -391,6 +402,7 @@ fn run_build_snapshot(world: &mut World) -> LayoutSnapshot {
         &pane_sizes,
         &zoomed,
         &focused,
+        None,
     )
 }
 
@@ -1847,6 +1859,7 @@ mod tests {
             .resource_mut::<Messages<LayoutSnapshotRequest>>()
             .write(LayoutSnapshotRequest {
                 request_id: [7; 16],
+                anchor: None,
             });
         app.update();
 

--- a/crates/vmux_layout/src/reconcile.rs
+++ b/crates/vmux_layout/src/reconcile.rs
@@ -285,9 +285,9 @@ use crate::{LayoutSpawnRequest, event::PANE_GAP_PX};
 #[cfg(not(target_arch = "wasm32"))]
 use bevy::ecs::message::{MessageReader, MessageWriter, Messages};
 #[cfg(not(target_arch = "wasm32"))]
-use bevy::prelude::*;
-#[cfg(not(target_arch = "wasm32"))]
 use bevy::ecs::relationship::Relationship;
+#[cfg(not(target_arch = "wasm32"))]
+use bevy::prelude::*;
 #[cfg(not(target_arch = "wasm32"))]
 use vmux_core::{PageMetadata, PageOpenRequest, PageOpenTarget};
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/vmux_layout/src/snapshot.rs
+++ b/crates/vmux_layout/src/snapshot.rs
@@ -17,6 +17,7 @@ pub fn build_layout_snapshot(
     pane_sizes_q: &Query<&PaneSize>,
     zoomed_q: &Query<&Zoomed>,
     focused: &FocusedStack,
+    self_stack: Option<Entity>,
 ) -> LayoutSnapshot {
     let active_tab = focused.tab;
     let tabs = tabs_q
@@ -33,6 +34,7 @@ pub fn build_layout_snapshot(
                         stacks_q,
                         pane_sizes_q,
                         zoomed_leaf,
+                        self_stack,
                     )
                 })
                 .unwrap_or(LayoutNode::Pane {
@@ -68,6 +70,7 @@ fn build_node(
     stacks_q: &Query<(Entity, Option<&Children>, Option<&PageMetadata>), With<Stack>>,
     pane_sizes_q: &Query<&PaneSize>,
     zoomed_leaf: Option<Entity>,
+    self_stack: Option<Entity>,
 ) -> LayoutNode {
     if let Ok((split_entity, split, children)) = splits_q.get(entity) {
         let child_entities: Vec<Entity> = children.map(|c| c.iter().collect()).unwrap_or_default();
@@ -90,6 +93,7 @@ fn build_node(
                     stacks_q,
                     pane_sizes_q,
                     zoomed_leaf,
+                    self_stack,
                 )
             })
             .collect();
@@ -108,7 +112,9 @@ fn build_node(
             .map(|c| {
                 c.iter()
                     .filter_map(|child| stacks_q.get(child).ok())
-                    .map(|(stack_entity, _stack_children, page)| build_stack(stack_entity, page))
+                    .map(|(stack_entity, _stack_children, page)| {
+                        build_stack(stack_entity, page, self_stack)
+                    })
                     .collect()
             })
             .unwrap_or_default();
@@ -125,7 +131,11 @@ fn build_node(
     }
 }
 
-fn build_stack(stack_entity: Entity, page: Option<&PageMetadata>) -> StackDto {
+fn build_stack(
+    stack_entity: Entity,
+    page: Option<&PageMetadata>,
+    self_stack: Option<Entity>,
+) -> StackDto {
     let url = page.map(|p| p.url.clone()).unwrap_or_default();
     let kind = if url.starts_with("vmux://terminal/") {
         "terminal"
@@ -139,6 +149,7 @@ fn build_stack(stack_entity: Entity, page: Option<&PageMetadata>) -> StackDto {
         kind: kind.to_string(),
         is_loading: false,
         favicon_url: page.map(|p| p.favicon_url.clone()).unwrap_or_default(),
+        is_self: Some(stack_entity) == self_stack,
     }
 }
 
@@ -155,6 +166,55 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .insert_resource(FocusedStack::default());
         app
+    }
+
+    #[test]
+    fn self_stack_is_marked_is_self() {
+        use bevy::ecs::system::SystemState;
+        let mut app = make_app();
+        let tab = app.world_mut().spawn(LayoutTab { name: "S".into() }).id();
+        let leaf = app
+            .world_mut()
+            .spawn((leaf_pane_bundle(), LastActivatedAt::now(), ChildOf(tab)))
+            .id();
+        let stack = app
+            .world_mut()
+            .spawn((stack_bundle(), LastActivatedAt::now(), ChildOf(leaf)))
+            .id();
+        app.world_mut().entity_mut(stack).insert(PageMetadata {
+            url: "vmux://terminal/x".into(),
+            title: String::new(),
+            favicon_url: String::new(),
+            bg_color: None,
+        });
+
+        let world = app.world_mut();
+        let mut state: SystemState<(
+            Query<(Entity, &LayoutTab, Option<&Children>)>,
+            Query<(Entity, &PaneSplit, Option<&Children>), With<Pane>>,
+            Query<(Entity, Option<&Children>), (With<Pane>, Without<PaneSplit>)>,
+            Query<(Entity, Option<&Children>, Option<&PageMetadata>), With<Stack>>,
+            Query<&PaneSize>,
+            Query<&Zoomed>,
+            Res<FocusedStack>,
+        )> = SystemState::new(world);
+        let (tabs_q, splits_q, leaves_q, stacks_q, pane_sizes_q, zoomed_q, focused) =
+            state.get(world).unwrap();
+        let snap = build_layout_snapshot(
+            &tabs_q,
+            &splits_q,
+            &leaves_q,
+            &stacks_q,
+            &pane_sizes_q,
+            &zoomed_q,
+            &focused,
+            Some(stack),
+        );
+
+        let LayoutNode::Pane { stacks, .. } = &snap.tabs[0].root else {
+            panic!("expected pane");
+        };
+        assert!(stacks[0].is_self);
     }
 
     #[test]
@@ -197,6 +257,7 @@ mod tests {
                         &pane_sizes_q,
                         &zoomed_q,
                         &focused,
+                        None,
                     )
                 },
             )
@@ -249,6 +310,7 @@ mod tests {
                         &pane_sizes_q,
                         &zoomed_q,
                         &focused,
+                        None,
                     )
                 },
             )
@@ -282,6 +344,7 @@ mod tests {
                         &pane_sizes,
                         &zoomed_q,
                         &focused,
+                        None,
                     )
                 },
             )
@@ -336,6 +399,7 @@ mod tests {
                         &pane_sizes,
                         &zoomed_q,
                         &focused,
+                        None,
                     )
                 },
             )
@@ -402,6 +466,7 @@ mod tests {
                         &pane_sizes,
                         &zoomed_q,
                         &focused,
+                        None,
                     )
                 },
             )
@@ -478,6 +543,7 @@ mod tests {
                         &pane_sizes_q,
                         &zoomed_q,
                         &focused,
+                        None,
                     )
                 },
             )

--- a/crates/vmux_layout/src/snapshot.rs
+++ b/crates/vmux_layout/src/snapshot.rs
@@ -150,6 +150,7 @@ fn build_stack(
         is_loading: false,
         favicon_url: page.map(|p| p.favicon_url.clone()).unwrap_or_default(),
         is_self: Some(stack_entity) == self_stack,
+        process_id: None,
     }
 }
 

--- a/crates/vmux_mcp/src/protocol.rs
+++ b/crates/vmux_mcp/src/protocol.rs
@@ -134,6 +134,9 @@ async fn run_agent_command(command: AgentCommand) -> Result<Value, String> {
                     AgentCommandResult::Ok => Ok(json!({
                         "content": [{"type": "text", "text": "ok"}]
                     })),
+                    AgentCommandResult::Text(text) => Ok(json!({
+                        "content": [{"type": "text", "text": text}]
+                    })),
                     AgentCommandResult::Layout(snapshot) => {
                         let text = serde_json::to_string(&snapshot).unwrap_or_default();
                         Ok(json!({
@@ -185,6 +188,11 @@ fn query_result_to_mcp_response(result: vmux_service::protocol::AgentQueryResult
     match result {
         AgentQueryResult::Layout(snapshot) => {
             let text = serde_json::to_string(&snapshot).unwrap_or_default();
+            json!({
+                "content": [{"type": "text", "text": text}]
+            })
+        }
+        AgentQueryResult::Text(text) => {
             json!({
                 "content": [{"type": "text", "text": text}]
             })

--- a/crates/vmux_mcp/src/protocol.rs
+++ b/crates/vmux_mcp/src/protocol.rs
@@ -13,14 +13,14 @@ pub fn read_json_line(reader: &mut impl BufRead) -> io::Result<Option<Value>> {
     Ok(Some(value))
 }
 
-pub async fn run_stdio() -> io::Result<()> {
+pub async fn run_stdio(anchor: Option<vmux_service::protocol::ProcessId>) -> io::Result<()> {
     let stdin = io::stdin();
     let mut reader = stdin.lock();
     let stdout = io::stdout();
     let mut writer = stdout.lock();
 
     while let Some(message) = read_json_line(&mut reader)? {
-        if let Some(response) = handle_message(message).await {
+        if let Some(response) = handle_message(message, anchor).await {
             serde_json::to_writer(&mut writer, &response)?;
             writer.write_all(b"\n")?;
             writer.flush()?;
@@ -29,7 +29,10 @@ pub async fn run_stdio() -> io::Result<()> {
     Ok(())
 }
 
-async fn handle_message(message: Value) -> Option<Value> {
+async fn handle_message(
+    message: Value,
+    anchor: Option<vmux_service::protocol::ProcessId>,
+) -> Option<Value> {
     let id = message.get("id").cloned()?;
     let method = message.get("method").and_then(Value::as_str).unwrap_or("");
     let params = message.get("params").cloned().unwrap_or_else(|| json!({}));
@@ -37,7 +40,7 @@ async fn handle_message(message: Value) -> Option<Value> {
     let result = match method {
         "initialize" => Ok(initialize_result(&params)),
         "tools/list" => Ok(json!({ "tools": crate::tools::tool_definitions() })),
-        "tools/call" => tool_call_result(&params).await,
+        "tools/call" => tool_call_result(&params, anchor).await,
         _ => {
             return Some(json!({
                 "jsonrpc": "2.0",
@@ -81,7 +84,10 @@ fn initialize_result(params: &Value) -> Value {
     })
 }
 
-async fn tool_call_result(params: &Value) -> Result<Value, String> {
+async fn tool_call_result(
+    params: &Value,
+    anchor: Option<vmux_service::protocol::ProcessId>,
+) -> Result<Value, String> {
     let name = params
         .get("name")
         .and_then(Value::as_str)
@@ -91,7 +97,7 @@ async fn tool_call_result(params: &Value) -> Result<Value, String> {
         .cloned()
         .unwrap_or_else(|| json!({}));
 
-    match crate::tools::dispatch_from_tool_call(name, arguments)? {
+    match crate::tools::dispatch_with_anchor(name, arguments, anchor)? {
         crate::tools::DispatchTarget::Command(command) => run_agent_command(command).await,
         crate::tools::DispatchTarget::Query(query) => run_agent_query(query).await,
     }

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -319,7 +319,10 @@ fn open_beside_me_definition() -> ToolDefinition {
         name: "open_beside_me".into(),
         description: "Open a url in a new pane directly beside YOUR pane (the agent calling this). \
 direction is one of right|left|top|bottom (default right). url uses the same rules as browser_navigate \
-(vmux://terminal/ opens a terminal; anything else loads as a browser). Returns ok; call read_layout to learn new ids."
+(vmux://terminal/ opens a terminal; anything else loads as a browser). \
+focus (default true): true moves focus to the new pane (use when the human will interact with it); \
+false keeps focus on your own pane (use when you will drive the new pane yourself, e.g. run a command in it). \
+Returns ok; call read_layout to learn new ids."
             .into(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -327,7 +330,8 @@ direction is one of right|left|top|bottom (default right). url uses the same rul
             "additionalProperties": false,
             "properties": {
                 "direction": {"enum": ["right", "left", "top", "bottom"]},
-                "url": {"type": "string"}
+                "url": {"type": "string"},
+                "focus": {"type": "boolean"}
             }
         }),
     }
@@ -392,10 +396,15 @@ pub fn dispatch_with_anchor(
             "bottom" => AgentPaneDirection::Bottom,
             other => return Err(format!("unknown direction: {other}")),
         };
+        let focus = arguments
+            .get("focus")
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
         return Ok(DispatchTarget::Command(AgentCommand::OpenBeside {
             anchor,
             direction,
             url,
+            focus,
         }));
     }
     if name == "focus_self" {

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -314,15 +314,14 @@ fn list_spaces_definition() -> ToolDefinition {
     }
 }
 
-fn open_beside_me_definition() -> ToolDefinition {
+fn open_page_definition() -> ToolDefinition {
     ToolDefinition {
-        name: "open_beside_me".into(),
-        description: "Open a url in a new pane directly beside YOUR pane (the agent calling this). \
+        name: "open_page".into(),
+        description: "Open a page in a new pane directly beside YOUR pane (the agent calling this). \
 direction is one of right|left|top|bottom (default right). url uses the same rules as browser_navigate \
 (vmux://terminal/ opens a terminal; anything else loads as a browser). \
 focus (default true): true moves focus to the new pane (use when the human will interact with it); \
-false keeps focus on your own pane (use when you will drive the new pane yourself, e.g. run a command in it). \
-Returns ok; call read_layout to learn new ids."
+false keeps focus on your own pane."
             .into(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -337,11 +336,27 @@ Returns ok; call read_layout to learn new ids."
     }
 }
 
-fn focus_self_definition() -> ToolDefinition {
+fn run_definition() -> ToolDefinition {
     ToolDefinition {
-        name: "focus_self".into(),
-        description: "Move keyboard focus to YOUR pane (the agent calling this).".into(),
-        input_schema: serde_json::json!({"type": "object", "properties": {}, "additionalProperties": false}),
+        name: "run".into(),
+        description:
+            "Open a terminal in a new pane beside YOUR pane and run a shell command in it, \
+so the user can watch it live and take over the terminal. \
+direction is one of right|left|top|bottom (default right). \
+focus (default false): false keeps focus on your own pane (you are driving the command); \
+true moves focus to the new terminal (use when you want the user to interact with it). \
+The command is typed into an interactive shell, so the terminal stays usable after it finishes."
+                .into(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "required": ["command"],
+            "additionalProperties": false,
+            "properties": {
+                "command": {"type": "string"},
+                "direction": {"enum": ["right", "left", "top", "bottom"]},
+                "focus": {"type": "boolean"}
+            }
+        }),
     }
 }
 
@@ -359,8 +374,8 @@ pub fn tool_definitions() -> Vec<ToolDefinition> {
     defs.push(update_layout_definition());
     defs.push(get_settings_definition());
     defs.push(list_spaces_definition());
-    defs.push(open_beside_me_definition());
-    defs.push(focus_self_definition());
+    defs.push(open_page_definition());
+    defs.push(run_definition());
     defs
 }
 
@@ -374,28 +389,31 @@ pub fn dispatch_with_anchor(
     anchor: Option<vmux_service::protocol::ProcessId>,
 ) -> Result<DispatchTarget, String> {
     use vmux_service::protocol::AgentPaneDirection;
-    if name == "open_beside_me" {
-        let anchor = anchor
-            .ok_or("open_beside_me requires an agent anchor (not available to this client)")?;
+    fn parse_direction(arguments: &Value) -> Result<AgentPaneDirection, String> {
+        match arguments
+            .get("direction")
+            .and_then(Value::as_str)
+            .unwrap_or("right")
+        {
+            "right" => Ok(AgentPaneDirection::Right),
+            "left" => Ok(AgentPaneDirection::Left),
+            "top" => Ok(AgentPaneDirection::Top),
+            "bottom" => Ok(AgentPaneDirection::Bottom),
+            other => Err(format!("unknown direction: {other}")),
+        }
+    }
+    if name == "open_page" {
+        let anchor =
+            anchor.ok_or("open_page requires an agent anchor (not available to this client)")?;
         let url = arguments
             .get("url")
             .and_then(Value::as_str)
             .unwrap_or("")
             .to_string();
         if url.trim().is_empty() {
-            return Err("open_beside_me.url is empty".to_string());
+            return Err("open_page.url is empty".to_string());
         }
-        let direction = match arguments
-            .get("direction")
-            .and_then(Value::as_str)
-            .unwrap_or("right")
-        {
-            "right" => AgentPaneDirection::Right,
-            "left" => AgentPaneDirection::Left,
-            "top" => AgentPaneDirection::Top,
-            "bottom" => AgentPaneDirection::Bottom,
-            other => return Err(format!("unknown direction: {other}")),
-        };
+        let direction = parse_direction(&arguments)?;
         let focus = arguments
             .get("focus")
             .and_then(Value::as_bool)
@@ -407,10 +425,27 @@ pub fn dispatch_with_anchor(
             focus,
         }));
     }
-    if name == "focus_self" {
-        let anchor =
-            anchor.ok_or("focus_self requires an agent anchor (not available to this client)")?;
-        return Ok(DispatchTarget::Command(AgentCommand::FocusSelf { anchor }));
+    if name == "run" {
+        let anchor = anchor.ok_or("run requires an agent anchor (not available to this client)")?;
+        let command = arguments
+            .get("command")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        if command.trim().is_empty() {
+            return Err("run.command is empty".to_string());
+        }
+        let direction = parse_direction(&arguments)?;
+        let focus = arguments
+            .get("focus")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        return Ok(DispatchTarget::Command(AgentCommand::Run {
+            anchor,
+            command,
+            direction,
+            focus,
+        }));
     }
     if name == "read_layout" {
         return Ok(DispatchTarget::Query(
@@ -680,10 +715,10 @@ mod tests {
     }
 
     #[test]
-    fn open_beside_me_dispatch_uses_anchor() {
+    fn open_page_dispatch_uses_anchor() {
         let anchor = vmux_service::protocol::ProcessId::new();
         let target = dispatch_with_anchor(
-            "open_beside_me",
+            "open_page",
             serde_json::json!({"direction": "right", "url": "vmux://terminal/"}),
             Some(anchor),
         )
@@ -695,13 +730,37 @@ mod tests {
             }
             other => panic!("expected OpenBeside, got {other:?}"),
         }
-        assert!(dispatch_with_anchor("focus_self", serde_json::json!({}), None).is_err());
         assert!(
-            tool_definitions()
-                .iter()
-                .any(|d| d.name == "open_beside_me")
+            dispatch_with_anchor("open_page", serde_json::json!({"url": ""}), Some(anchor))
+                .is_err()
         );
-        assert!(tool_definitions().iter().any(|d| d.name == "focus_self"));
+        assert!(dispatch_with_anchor("open_page", serde_json::json!({"url": "x"}), None).is_err());
+        assert!(tool_definitions().iter().any(|d| d.name == "open_page"));
+        assert!(tool_definitions().iter().any(|d| d.name == "run"));
+    }
+
+    #[test]
+    fn run_dispatch_uses_anchor() {
+        let anchor = vmux_service::protocol::ProcessId::new();
+        let target = dispatch_with_anchor(
+            "run",
+            serde_json::json!({"command": "echo hi"}),
+            Some(anchor),
+        )
+        .unwrap();
+        match target {
+            DispatchTarget::Command(AgentCommand::Run {
+                anchor: a, command, ..
+            }) => {
+                assert_eq!(a, anchor);
+                assert_eq!(command, "echo hi");
+            }
+            other => panic!("expected Run, got {other:?}"),
+        }
+        assert!(
+            dispatch_with_anchor("run", serde_json::json!({"command": " "}), Some(anchor)).is_err()
+        );
+        assert!(dispatch_with_anchor("run", serde_json::json!({"command": "x"}), None).is_err());
     }
 
     #[test]

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -687,7 +687,11 @@ mod tests {
             other => panic!("expected OpenBeside, got {other:?}"),
         }
         assert!(dispatch_with_anchor("focus_self", serde_json::json!({}), None).is_err());
-        assert!(tool_definitions().iter().any(|d| d.name == "open_beside_me"));
+        assert!(
+            tool_definitions()
+                .iter()
+                .any(|d| d.name == "open_beside_me")
+        );
         assert!(tool_definitions().iter().any(|d| d.name == "focus_self"));
     }
 

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -334,7 +334,7 @@ pub fn tool_definitions() -> Vec<ToolDefinition> {
 pub fn dispatch_from_tool_call(name: &str, arguments: Value) -> Result<DispatchTarget, String> {
     if name == "read_layout" {
         return Ok(DispatchTarget::Query(
-            vmux_service::protocol::AgentQuery::ReadLayout,
+            vmux_service::protocol::AgentQuery::ReadLayout { anchor: None },
         ));
     }
     if name == "update_layout" {
@@ -595,7 +595,7 @@ mod tests {
         let target = dispatch_from_tool_call("read_layout", serde_json::json!({})).unwrap();
         assert!(matches!(
             target,
-            DispatchTarget::Query(AgentQuery::ReadLayout)
+            DispatchTarget::Query(AgentQuery::ReadLayout { .. })
         ));
     }
 

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -314,6 +314,33 @@ fn list_spaces_definition() -> ToolDefinition {
     }
 }
 
+fn open_beside_me_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "open_beside_me".into(),
+        description: "Open a url in a new pane directly beside YOUR pane (the agent calling this). \
+direction is one of right|left|top|bottom (default right). url uses the same rules as browser_navigate \
+(vmux://terminal/ opens a terminal; anything else loads as a browser). Returns ok; call read_layout to learn new ids."
+            .into(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "required": ["url"],
+            "additionalProperties": false,
+            "properties": {
+                "direction": {"enum": ["right", "left", "top", "bottom"]},
+                "url": {"type": "string"}
+            }
+        }),
+    }
+}
+
+fn focus_self_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "focus_self".into(),
+        description: "Move keyboard focus to YOUR pane (the agent calling this).".into(),
+        input_schema: serde_json::json!({"type": "object", "properties": {}, "additionalProperties": false}),
+    }
+}
+
 pub fn tool_definitions() -> Vec<ToolDefinition> {
     let mut defs: Vec<ToolDefinition> = AppCommand::mcp_tool_entries()
         .into_iter()
@@ -328,13 +355,57 @@ pub fn tool_definitions() -> Vec<ToolDefinition> {
     defs.push(update_layout_definition());
     defs.push(get_settings_definition());
     defs.push(list_spaces_definition());
+    defs.push(open_beside_me_definition());
+    defs.push(focus_self_definition());
     defs
 }
 
 pub fn dispatch_from_tool_call(name: &str, arguments: Value) -> Result<DispatchTarget, String> {
+    dispatch_with_anchor(name, arguments, None)
+}
+
+pub fn dispatch_with_anchor(
+    name: &str,
+    arguments: Value,
+    anchor: Option<vmux_service::protocol::ProcessId>,
+) -> Result<DispatchTarget, String> {
+    use vmux_service::protocol::AgentPaneDirection;
+    if name == "open_beside_me" {
+        let anchor = anchor
+            .ok_or("open_beside_me requires an agent anchor (not available to this client)")?;
+        let url = arguments
+            .get("url")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        if url.trim().is_empty() {
+            return Err("open_beside_me.url is empty".to_string());
+        }
+        let direction = match arguments
+            .get("direction")
+            .and_then(Value::as_str)
+            .unwrap_or("right")
+        {
+            "right" => AgentPaneDirection::Right,
+            "left" => AgentPaneDirection::Left,
+            "top" => AgentPaneDirection::Top,
+            "bottom" => AgentPaneDirection::Bottom,
+            other => return Err(format!("unknown direction: {other}")),
+        };
+        return Ok(DispatchTarget::Command(AgentCommand::OpenBeside {
+            anchor,
+            direction,
+            url,
+        }));
+    }
+    if name == "focus_self" {
+        let anchor =
+            anchor.ok_or("focus_self requires an agent anchor (not available to this client)")?;
+        return Ok(DispatchTarget::Command(AgentCommand::FocusSelf { anchor }));
+    }
     if name == "read_layout" {
         return Ok(DispatchTarget::Query(
-            vmux_service::protocol::AgentQuery::ReadLayout { anchor: None },
+            vmux_service::protocol::AgentQuery::ReadLayout { anchor },
         ));
     }
     if name == "update_layout" {
@@ -597,6 +668,27 @@ mod tests {
             target,
             DispatchTarget::Query(AgentQuery::ReadLayout { .. })
         ));
+    }
+
+    #[test]
+    fn open_beside_me_dispatch_uses_anchor() {
+        let anchor = vmux_service::protocol::ProcessId::new();
+        let target = dispatch_with_anchor(
+            "open_beside_me",
+            serde_json::json!({"direction": "right", "url": "vmux://terminal/"}),
+            Some(anchor),
+        )
+        .unwrap();
+        match target {
+            DispatchTarget::Command(AgentCommand::OpenBeside { anchor: a, url, .. }) => {
+                assert_eq!(a, anchor);
+                assert_eq!(url, "vmux://terminal/");
+            }
+            other => panic!("expected OpenBeside, got {other:?}"),
+        }
+        assert!(dispatch_with_anchor("focus_self", serde_json::json!({}), None).is_err());
+        assert!(tool_definitions().iter().any(|d| d.name == "open_beside_me"));
+        assert!(tool_definitions().iter().any(|d| d.name == "focus_self"));
     }
 
     #[test]

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -340,12 +340,13 @@ fn run_definition() -> ToolDefinition {
     ToolDefinition {
         name: "run".into(),
         description:
-            "Open a terminal in a new pane beside YOUR pane and run a shell command in it, \
-so the user can watch it live and take over the terminal. \
-direction is one of right|left|top|bottom (default right). \
-focus (default false): false keeps focus on your own pane (you are driving the command); \
-true moves focus to the new terminal (use when you want the user to interact with it). \
-The command is typed into an interactive shell, so the terminal stays usable after it finishes."
+            "Run a shell command in a visible terminal the user can watch live and take over. \
+By default opens a new terminal in a pane beside YOUR pane; pass `terminal` (a terminal id from a \
+previous run or from read_layout's process_id) to run in that existing terminal instead. \
+direction|focus apply only when opening a new terminal (direction default right; \
+focus default false = keep focus on your own pane). \
+The command is typed into an interactive shell, so the terminal stays usable afterwards. \
+Returns the terminal's id; pass it to read_terminal to read the output, or to run again."
                 .into(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -353,8 +354,27 @@ The command is typed into an interactive shell, so the terminal stays usable aft
             "additionalProperties": false,
             "properties": {
                 "command": {"type": "string"},
+                "terminal": {"type": "string"},
                 "direction": {"enum": ["right", "left", "top", "bottom"]},
                 "focus": {"type": "boolean"}
+            }
+        }),
+    }
+}
+
+fn read_terminal_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "read_terminal".into(),
+        description:
+            "Return the current visible scrollback text of a terminal (the same text the user sees). \
+Pass `terminal` = a terminal id returned by run, or a terminal stack's process_id from read_layout."
+                .into(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "required": ["terminal"],
+            "additionalProperties": false,
+            "properties": {
+                "terminal": {"type": "string"}
             }
         }),
     }
@@ -376,6 +396,7 @@ pub fn tool_definitions() -> Vec<ToolDefinition> {
     defs.push(list_spaces_definition());
     defs.push(open_page_definition());
     defs.push(run_definition());
+    defs.push(read_terminal_definition());
     defs
 }
 
@@ -440,12 +461,31 @@ pub fn dispatch_with_anchor(
             .get("focus")
             .and_then(Value::as_bool)
             .unwrap_or(false);
+        let terminal = match arguments.get("terminal").and_then(Value::as_str) {
+            Some(s) if !s.is_empty() => Some(
+                s.parse::<vmux_service::protocol::ProcessId>()
+                    .map_err(|_| format!("run.terminal is not a valid terminal id: {s}"))?,
+            ),
+            _ => None,
+        };
         return Ok(DispatchTarget::Command(AgentCommand::Run {
             anchor,
             command,
             direction,
             focus,
+            terminal,
         }));
+    }
+    if name == "read_terminal" {
+        let process_id = arguments
+            .get("terminal")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .parse::<vmux_service::protocol::ProcessId>()
+            .map_err(|_| "read_terminal.terminal must be a valid terminal id".to_string())?;
+        return Ok(DispatchTarget::Query(
+            vmux_service::protocol::AgentQuery::ReadTerminal { process_id },
+        ));
     }
     if name == "read_layout" {
         return Ok(DispatchTarget::Query(
@@ -761,6 +801,51 @@ mod tests {
             dispatch_with_anchor("run", serde_json::json!({"command": " "}), Some(anchor)).is_err()
         );
         assert!(dispatch_with_anchor("run", serde_json::json!({"command": "x"}), None).is_err());
+    }
+
+    #[test]
+    fn run_with_terminal_targets_existing() {
+        let anchor = vmux_service::protocol::ProcessId::new();
+        let term = vmux_service::protocol::ProcessId::new();
+        let target = dispatch_with_anchor(
+            "run",
+            serde_json::json!({"command": "ls", "terminal": term.to_string()}),
+            Some(anchor),
+        )
+        .unwrap();
+        match target {
+            DispatchTarget::Command(AgentCommand::Run {
+                terminal: Some(t), ..
+            }) => assert_eq!(t, term),
+            other => panic!("expected Run with terminal, got {other:?}"),
+        }
+        assert!(
+            dispatch_with_anchor(
+                "run",
+                serde_json::json!({"command": "ls", "terminal": "nope"}),
+                Some(anchor)
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn read_terminal_dispatch_routes_to_query() {
+        let pid = vmux_service::protocol::ProcessId::new();
+        let target = dispatch_from_tool_call(
+            "read_terminal",
+            serde_json::json!({"terminal": pid.to_string()}),
+        )
+        .unwrap();
+        assert!(matches!(
+            target,
+            DispatchTarget::Query(vmux_service::protocol::AgentQuery::ReadTerminal { .. })
+        ));
+        assert!(
+            dispatch_from_tool_call("read_terminal", serde_json::json!({"terminal": "bad"}))
+                .is_err()
+        );
+        assert!(tool_definitions().iter().any(|d| d.name == "read_terminal"));
     }
 
     #[test]

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use serde_json::Value;
 use vmux_command::command::AppCommand;
 use vmux_macro::McpTool;
-use vmux_service::protocol::{AgentCommand, AgentShellMode};
+use vmux_service::protocol::AgentCommand;
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -17,21 +17,6 @@ pub enum McpParamTool {
     #[mcp(description = "Open the Vmux command bar.")]
     OpenCommandBar {
         #[mcp(enum_values = ["default", "commands", "path"])]
-        mode: Option<String>,
-    },
-    #[mcp(
-        description = "Spawn a process in a new visible Vmux tab. If `command` is omitted, the user's default shell is launched. If `args` is provided as a single string, it is split on whitespace. If `cwd` is omitted, the active space's directory (~/.vmux/<space>) is used. Useful for opening claude/vibe/codex/nvim/etc. directly without going through a shell."
-    )]
-    NewTerminalTab {
-        cwd: Option<String>,
-        command: Option<String>,
-        args: Option<String>,
-    },
-    #[mcp(description = "Run a shell command in a visible Vmux terminal.")]
-    RunShell {
-        command: String,
-        cwd: Option<String>,
-        #[mcp(enum_values = ["new_tab", "active"])]
         mode: Option<String>,
     },
     #[mcp(
@@ -88,34 +73,6 @@ impl McpParamTool {
                 Ok(AgentCommand::AppCommand {
                     id: id.to_string(),
                     args_json: String::new(),
-                })
-            }
-            McpParamTool::NewTerminalTab { cwd, command, args } => {
-                let args_vec = args
-                    .unwrap_or_default()
-                    .split_whitespace()
-                    .map(|s| s.to_string())
-                    .collect();
-                Ok(AgentCommand::NewTerminalTab {
-                    cwd: cwd.unwrap_or_default(),
-                    command: command.unwrap_or_default(),
-                    args: args_vec,
-                    env: vec![],
-                })
-            }
-            McpParamTool::RunShell { command, cwd, mode } => {
-                if command.trim().is_empty() {
-                    return Err("run_shell.command is empty".to_string());
-                }
-                let mode = match mode.as_deref().unwrap_or("new_tab") {
-                    "new_tab" => AgentShellMode::NewTab,
-                    "active" => AgentShellMode::Active,
-                    other => return Err(format!("unknown shell mode: {other}")),
-                };
-                Ok(AgentCommand::RunShell {
-                    command,
-                    cwd: cwd.unwrap_or_default(),
-                    mode,
                 })
             }
             McpParamTool::BrowserNavigate { url, pane } => {
@@ -554,10 +511,16 @@ mod tests {
     fn list_tools_includes_auto_generated_and_handwritten() {
         let names = tool_names();
 
-        for hand in ["open_command_bar", "new_terminal_tab", "run_shell"] {
+        for hand in ["open_command_bar", "open_page", "run", "read_terminal"] {
             assert!(
                 names.contains(&hand.to_string()),
                 "missing hand-written {hand}"
+            );
+        }
+        for removed_tool in ["new_terminal_tab", "run_shell", "in_pane"] {
+            assert!(
+                !names.contains(&removed_tool.to_string()),
+                "superseded tool {removed_tool} should no longer appear in MCP tools"
             );
         }
         for auto in ["terminal_clear", "browser_reload"] {
@@ -616,11 +579,6 @@ mod tests {
     #[test]
     fn browser_navigate_missing_url_returns_error() {
         assert!(dispatch_from_tool_call("browser_navigate", serde_json::json!({})).is_err());
-    }
-
-    #[test]
-    fn empty_run_shell_command_returns_tool_error() {
-        assert!(dispatch_from_tool_call("run_shell", serde_json::json!({"command": ""})).is_err());
     }
 
     #[test]
@@ -685,8 +643,6 @@ mod tests {
             .collect();
         for expected in [
             "open_command_bar",
-            "new_terminal_tab",
-            "run_shell",
             "browser_navigate",
             "terminal_send",
             "select_tab",
@@ -985,43 +941,14 @@ mod tests {
     #[test]
     fn open_command_tools_are_exposed() {
         let names = tool_names();
-        for expected in [
-            "in_place",
-            "in_new_stack",
-            "in_pane",
-            "in_new_tab",
-            "in_new_space",
-        ] {
+        for expected in ["in_place", "in_new_stack", "in_new_tab", "in_new_space"] {
             assert!(
                 names.contains(&expected.to_string()),
                 "missing OpenCommand tool: {expected}"
             );
         }
-    }
-
-    #[test]
-    fn in_pane_tool_has_direction_enum() {
-        let defs = tool_definitions();
-        let in_pane = defs
-            .iter()
-            .find(|d| d.name == "in_pane")
-            .expect("in_pane tool present");
-        let props = in_pane
-            .input_schema
-            .get("properties")
-            .expect("properties key");
-        let dir = props.get("direction").expect("direction property");
-        let enum_vals = dir.get("enum").expect("direction has enum constraint");
-        assert_eq!(
-            enum_vals,
-            &serde_json::json!(["top", "right", "bottom", "left"])
-        );
-        let required = in_pane.input_schema.get("required").expect("required key");
-        let required_arr = required.as_array().expect("required is array");
-        assert!(
-            required_arr.iter().any(|v| v.as_str() == Some("direction")),
-            "direction must be required"
-        );
+        // in_pane is hidden (superseded by open_page).
+        assert!(!names.contains(&"in_pane".to_string()));
     }
 
     #[test]

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -95,8 +95,11 @@ pub enum AgentCommand {
         url: String,
         focus: bool,
     },
-    FocusSelf {
+    Run {
         anchor: ProcessId,
+        command: String,
+        direction: AgentPaneDirection,
+        focus: bool,
     },
 }
 
@@ -154,6 +157,9 @@ pub fn validate_agent_command(command: &AgentCommand) -> Result<(), &'static str
         }
         AgentCommand::OpenBeside { url, .. } if url.trim().is_empty() => {
             Err("open_beside_me.url is empty")
+        }
+        AgentCommand::Run { command, .. } if command.trim().is_empty() => {
+            Err("run.command is empty")
         }
         _ => Ok(()),
     }

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -30,6 +30,14 @@ pub enum AgentShellMode {
     Active,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub enum AgentPaneDirection {
+    Top,
+    Right,
+    Bottom,
+    Left,
+}
+
 #[derive(Debug, Clone, PartialEq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum AgentCommand {
     AppCommand {
@@ -81,6 +89,14 @@ pub enum AgentCommand {
         space_id: Option<String>,
         name: Option<String>,
     },
+    OpenBeside {
+        anchor: ProcessId,
+        direction: AgentPaneDirection,
+        url: String,
+    },
+    FocusSelf {
+        anchor: ProcessId,
+    },
 }
 
 pub const AGENT_QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
@@ -96,7 +112,7 @@ pub enum AgentCommandResult {
 
 #[derive(Debug, Clone, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum AgentQuery {
-    ReadLayout,
+    ReadLayout { anchor: Option<ProcessId> },
     GetSettings,
     ListSpaces,
 }
@@ -134,6 +150,9 @@ pub fn validate_agent_command(command: &AgentCommand) -> Result<(), &'static str
         }
         AgentCommand::SpaceCommand { command, .. } if command.trim().is_empty() => {
             Err("space_command.command is empty")
+        }
+        AgentCommand::OpenBeside { url, .. } if url.trim().is_empty() => {
+            Err("open_beside_me.url is empty")
         }
         _ => Ok(()),
     }
@@ -453,11 +472,32 @@ mod tests {
 
     #[test]
     fn agent_query_read_layout_rkyv_round_trip() {
-        let q = AgentQuery::ReadLayout;
+        let q = AgentQuery::ReadLayout { anchor: None };
         let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&q).unwrap();
         let recovered: AgentQuery =
             rkyv::from_bytes::<AgentQuery, rkyv::rancor::Error>(&bytes).unwrap();
-        assert_eq!(recovered, AgentQuery::ReadLayout);
+        assert_eq!(recovered, AgentQuery::ReadLayout { anchor: None });
+    }
+
+    #[test]
+    fn open_beside_round_trips_and_validates() {
+        let cmd = AgentCommand::OpenBeside {
+            anchor: ProcessId::new(),
+            direction: AgentPaneDirection::Right,
+            url: "vmux://terminal/".into(),
+        };
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&cmd).unwrap();
+        let back: AgentCommand =
+            rkyv::from_bytes::<AgentCommand, rkyv::rancor::Error>(&bytes).unwrap();
+        assert_eq!(back, cmd);
+        assert!(validate_agent_command(&cmd).is_ok());
+
+        let empty = AgentCommand::OpenBeside {
+            anchor: ProcessId::new(),
+            direction: AgentPaneDirection::Right,
+            url: "  ".into(),
+        };
+        assert!(validate_agent_command(&empty).is_err());
     }
 
     #[test]

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -93,6 +93,7 @@ pub enum AgentCommand {
         anchor: ProcessId,
         direction: AgentPaneDirection,
         url: String,
+        focus: bool,
     },
     FocusSelf {
         anchor: ProcessId,
@@ -485,6 +486,7 @@ mod tests {
             anchor: ProcessId::new(),
             direction: AgentPaneDirection::Right,
             url: "vmux://terminal/".into(),
+            focus: true,
         };
         let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&cmd).unwrap();
         let back: AgentCommand =
@@ -496,6 +498,7 @@ mod tests {
             anchor: ProcessId::new(),
             direction: AgentPaneDirection::Right,
             url: "  ".into(),
+            focus: true,
         };
         assert!(validate_agent_command(&empty).is_err());
     }

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -100,6 +100,9 @@ pub enum AgentCommand {
         command: String,
         direction: AgentPaneDirection,
         focus: bool,
+        /// Run in this existing terminal (its `ProcessId`); `None` opens a new
+        /// terminal beside the agent.
+        terminal: Option<ProcessId>,
     },
 }
 
@@ -110,6 +113,7 @@ pub const AGENT_COMMAND_TIMEOUT: std::time::Duration = std::time::Duration::from
 #[derive(Debug, Clone, PartialEq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum AgentCommandResult {
     Ok,
+    Text(String),
     Layout(crate::protocol::layout::LayoutSnapshot),
     Error(String),
 }
@@ -117,6 +121,7 @@ pub enum AgentCommandResult {
 #[derive(Debug, Clone, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum AgentQuery {
     ReadLayout { anchor: Option<ProcessId> },
+    ReadTerminal { process_id: ProcessId },
     GetSettings,
     ListSpaces,
 }
@@ -124,6 +129,7 @@ pub enum AgentQuery {
 #[derive(Debug, Clone, PartialEq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum AgentQueryResult {
     Layout(crate::protocol::layout::LayoutSnapshot),
+    Text(String),
     Settings(String),
     Spaces(String),
     Error(String),
@@ -568,6 +574,7 @@ mod tests {
                         is_loading: false,
                         favicon_url: String::new(),
                         is_self: false,
+                        process_id: None,
                     }],
                 },
             }],

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -518,6 +518,7 @@ mod tests {
                         kind: "browser".into(),
                         is_loading: false,
                         favicon_url: String::new(),
+                        is_self: false,
                     }],
                 },
             }],

--- a/crates/vmux_service/src/server.rs
+++ b/crates/vmux_service/src/server.rs
@@ -520,6 +520,41 @@ async fn handle_client(
             }
 
             ClientMessage::AgentQuery { request_id, query } => {
+                // ReadTerminal is answered by the service directly (it owns the
+                // terminal state); other queries relay to the GUI.
+                let query = match query {
+                    crate::protocol::AgentQuery::ReadTerminal { process_id } => {
+                        let result = {
+                            let mgr = manager.lock().await;
+                            match mgr.processes.get(&process_id) {
+                                Some(process) => {
+                                    let text = match process.snapshot() {
+                                        ServiceMessage::Snapshot { lines, .. } => lines
+                                            .iter()
+                                            .map(|line| {
+                                                line.spans
+                                                    .iter()
+                                                    .map(|span| span.text.as_str())
+                                                    .collect::<String>()
+                                            })
+                                            .collect::<Vec<_>>()
+                                            .join("\n"),
+                                        _ => String::new(),
+                                    };
+                                    crate::protocol::AgentQueryResult::Text(text)
+                                }
+                                None => crate::protocol::AgentQueryResult::Error(format!(
+                                    "process not found: {process_id}"
+                                )),
+                            }
+                        };
+                        let resp = ServiceMessage::AgentQueryResult { request_id, result };
+                        let mut w = writer.lock().await;
+                        write_message!(&mut *w, &resp)?;
+                        continue;
+                    }
+                    other => other,
+                };
                 if agent_tx.receiver_count() == 0 {
                     let resp = ServiceMessage::Error {
                         message: "no desktop subscribed to agent commands".to_string(),

--- a/crates/vmux_service/src/server.rs
+++ b/crates/vmux_service/src/server.rs
@@ -652,7 +652,7 @@ mod tests {
         let request_id = AgentRequestId::new();
         assert!(pending.lock().await.remove(&request_id).is_none());
 
-        let _ = AgentQuery::ReadLayout;
+        let _ = AgentQuery::ReadLayout { anchor: None };
     }
 
     #[tokio::test]

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -202,6 +202,12 @@ pub struct TerminalStackSpawnRequest {
     pub pane: Entity,
     pub cwd: Option<PathBuf>,
     pub pending_input: Option<Vec<u8>>,
+    /// Pin this `ProcessId` on the spawned terminal (so the caller can address
+    /// it later); `None` lets the bundle mint a fresh one.
+    pub process_id: Option<ProcessId>,
+    /// When true, the new stack is activated (focus moves to it). When false,
+    /// focus stays where it is.
+    pub activate: bool,
 }
 
 pub struct TerminalPlugin;
@@ -642,10 +648,15 @@ fn respond_terminal_stack_spawn(
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     for request in reader.read() {
+        let stack_ts = if request.activate {
+            LastActivatedAt::now()
+        } else {
+            LastActivatedAt(0)
+        };
         let stack = commands
             .spawn((
                 vmux_layout::stack::stack_bundle(),
-                LastActivatedAt::now(),
+                stack_ts,
                 ChildOf(request.pane),
             ))
             .id();
@@ -672,6 +683,9 @@ fn respond_terminal_stack_spawn(
             ))
             .id();
         commands.entity(terminal).insert(CefKeyboardTarget);
+        if let Some(pid) = request.process_id {
+            commands.entity(terminal).insert(pid);
+        }
         if let Some(data) = request.pending_input.clone() {
             commands
                 .entity(terminal)
@@ -2935,6 +2949,8 @@ pub fn handle_run_shell_requests(
                 pane,
                 cwd: cwd_path,
                 pending_input: Some(input),
+                process_id: None,
+                activate: true,
             });
         }
     }

--- a/docs/specs/2026-06-12-agent-self-anchor-design.md
+++ b/docs/specs/2026-06-12-agent-self-anchor-design.md
@@ -4,6 +4,24 @@ Give each CLI agent (vibe / claude / codex) a stable handle to its **own** pane,
 
 This is spec #4 of that arc. The next spec, #1 (run a command in a terminal next to the agent, with output read back), builds directly on the primitive defined here.
 
+## Revision (v2): `open_page` / `run` / `read_terminal` agent surface
+
+The model is **Live Share with a coworker**: the agent acts in *visible, shared, interactive* terminals the user can take over. The agent's open/run MCP surface consolidates to self-relative verbs (all resolved via the `ProcessId` anchor below):
+
+- **`open_page { url, direction?=right, focus?=true }`** — open a page (terminal `vmux://terminal/`, else browser) in a new pane beside the agent. (Renamed from the original `open_beside_me`; internal protocol/command names still read `OpenBeside`.)
+- **`run { command, direction?=right, focus?=false }`** — open a terminal beside the agent and **type `command` into an interactive shell** (so the user watches live and can take over; the shell persists after the command). `focus` defaults false (the agent is driving). Reuses `split_leaf_into_two` + `TerminalStackSpawnRequest { pending_input }`.
+- `focus_self` is **removed** — redundant with `update_layout`'s `focused` triple.
+
+**Read-back = "read the visible terminal"** (Live Share): the agent reads scrollback like the user does — no clean stdout/exit capture. Feasible because the service already broadcasts `ProcessOutput` (raw bytes) + `ProcessExited { exit_code }`; future optimization (clean `{output, exit}` for a fresh `run` terminal, or OSC-133 shell-integration markers for existing shells) is purely additive at the read layer.
+
+**Still pending (next increments on this branch):**
+1. `read_terminal { terminal }` — return a terminal's scrollback text; answered by the **service** rendering the `Process` `Term` (reuse `snapshot`/`snapshot_text`).
+2. `run { terminal }` — run in an existing terminal (by handle), not just a new one.
+3. **Terminal handle = `ProcessId`** exposed as `process_id` on terminal `Stack` DTOs in `read_layout`, and returned by `run`, so the agent can target/read specific terminals.
+4. Remove the now-superseded `in_pane`, `run_shell`, `new_terminal_tab` MCP tools (keep `browser_navigate` — that's *navigate an existing browser*, a different job).
+
+The sections below describe the original `open_beside_me`/`focus_self` design; the anchor (`ProcessId`) + `is_self` foundation is unchanged and still current.
+
 ## Motivation
 
 vmux already injects its MCP server into all three CLIs (vibe via `VIBE_MCP_SERVERS`, claude via `--mcp-config`, codex via `-c mcp_servers.vmux`), and they already have layout tools (`read_layout`, `update_layout`, `open_in_*`, `new_terminal_tab`, `run_shell`). Two gaps block the IDE experience:

--- a/docs/specs/2026-06-12-agent-self-anchor-design.md
+++ b/docs/specs/2026-06-12-agent-self-anchor-design.md
@@ -1,0 +1,200 @@
+# Agent Self-Anchor + Relative Layout
+
+Give each CLI agent (vibe / claude / codex) a stable handle to its **own** pane, so it can place panes relative to itself ("open a terminal beside me") and reason about where it lives. This is the foundation for the broader "vmux as an agentic IDE" direction.
+
+This is spec #4 of that arc. The next spec, #1 (run a command in a terminal next to the agent, with output read back), builds directly on the primitive defined here.
+
+## Motivation
+
+vmux already injects its MCP server into all three CLIs (vibe via `VIBE_MCP_SERVERS`, claude via `--mcp-config`, codex via `-c mcp_servers.vmux`), and they already have layout tools (`read_layout`, `update_layout`, `open_in_*`, `new_terminal_tab`, `run_shell`). Two gaps block the IDE experience:
+
+1. **No self-reference.** `read_layout` returns a `focused: {tab, pane, stack}` triple, but that is whatever the **human** last clicked — not the calling agent's pane. If the user focuses another pane, the agent loses track of itself. There is no marker that says "this stack is you."
+2. **No anchor for relative placement.** Because the agent can't identify its own pane, it cannot reliably "open X beside me." `open_in_pane` and friends act against the focused pane.
+
+The MCP server process also has no identity today: `mcp::resolve` (`crates/vmux_agent/src/mcp.rs:14`) injects only `args: ["mcp"]`.
+
+## Approach
+
+Reuse `ProcessId` (`crates/vmux_core/src/process_id.rs:8`, re-exported as `vmux_core::ProcessId` and `vmux_service::protocol::ProcessId`) as the agent's self-anchor. `ProcessId` is a `[u8; 16]` UUID newtype with `Display`/`FromStr`, and it is vmux's canonical PTY handle.
+
+It satisfies the three things an anchor needs:
+
+- **Known at spawn.** `ProcessId::new()` is minted client-side before `CreateProcess` is sent (`crates/vmux_terminal/src/plugin.rs:595`). We can hand it to the launch builder so it lands in the MCP server's argv.
+- **Resolvable.** Terminal entities already carry `&ProcessId` — a direct query, no new lookup map. The `--anchor` string round-trips through the existing `Display`/`FromStr`.
+- **Restart-stable for free.** `ProcessId` is the persistent-session re-attach key. On GUI restart, `reattach_terminal_bundle(process_id)` (`crates/vmux_terminal/src/plugin.rs:683`) re-creates the terminal with the **same** id and sends `AttachProcess`. The MCP server — a child of the still-alive CLI/PTY — keeps sending its original `--anchor`; the restored entity carries the same `ProcessId`; they re-match. No moonshine `Reflect`/`Save` is needed (and `ProcessId` is deliberately not `Reflect`).
+
+No new component is introduced. `vmux_core` is untouched.
+
+### Why `ProcessId` and not a new `AnchorToken`
+
+An earlier draft minted a dedicated `AnchorToken(String)` persisted on the stack via moonshine. `ProcessId` is strictly better: it already exists, is already restart-stable by design, already round-trips as a string, and lives on the **content** entity — so "self" follows the agent if the human drags it into a different stack, rather than being pinned to the original stack.
+
+### Why `ProcessId` and not `SessionId`
+
+`SessionId` (the CLI's own session id) is the agent's *durable* identity, but it is the wrong choice for the *anchor*:
+
+- **Not known at spawn.** Fresh (non-resumed) sessions have no sid until vmux discovers it from the CLI's log dir seconds after launch (the `PendingAgentSession` window). The MCP server's `--anchor` is fixed at CLI-launch time, before the sid exists.
+- **Doesn't identify a pane instance.** Resuming the same sid in two panes yields two stacks with the same `SessionId` — ambiguous "self". `ProcessId` is unique per running process.
+- **Over-scoped.** The anchor only needs to live as long as the MCP server, which shares the process lifetime. A conversation-lifetime id buys nothing here.
+
+`SessionId` still does its own job — it is the durable identity persisted in the stack url and used to resume agents across Mac restart (see Persistence / Restart). The two are complementary, not competing.
+
+## Identity Resolution
+
+Anchor → location walk:
+
+```
+ProcessId (--anchor)
+  → terminal entity with that ProcessId (the one also carrying AgentSession)
+    → parent Stack  (ChildOf)
+      → parent Pane (ChildOf)
+```
+
+Parent chain confirmed by the spawn paths (`respond_process_stack_spawn` / `handle_spawn_agent_requests`): terminal `ChildOf` stack `ChildOf` pane.
+
+- "self stack" = the Stack ancestor of the matching terminal.
+- "self pane" = the Pane ancestor of that stack (the split target for relative placement).
+
+## Injection
+
+The anchor reaches the MCP server as an argv flag, which is uniform across all three CLIs because each serializes `McpServerConfig.args` verbatim (`crates/vmux_agent/src/client/cli/{vibe,claude,codex}.rs`). Env would only work for vibe; argv works for all three.
+
+Changes:
+
+1. `mcp::resolve(cwd)` → `mcp::resolve(cwd, anchor: ProcessId)`; appends `"--anchor", anchor.to_string()` to `args` (`crates/vmux_agent/src/mcp.rs`).
+2. `build_agent_launch` (`crates/vmux_agent/src/launch.rs:6`) takes the `ProcessId` and forwards it to `mcp::resolve`.
+3. `handle_spawn_agent_requests` (`crates/vmux_agent/src/plugin.rs:867`) reorders:
+   - mint `let process_id = ProcessId::new();`
+   - call `build_agent_launch(..., process_id)` so `--anchor <uuid>` is baked into the launch args
+   - spawn the agent terminal, then **pin** that id: `commands.entity(terminal).insert(process_id);` so the bundle's own freshly-minted id is overwritten and the subsequent `CreateProcess` uses the same id that was injected as `--anchor`.
+4. `vmux_cli`'s `mcp` subcommand gains `--anchor <uuid>` (clap), parsed to `Option<ProcessId>` and passed to `run_stdio`.
+
+## MCP Surface
+
+Three additions; the agent never sees or supplies the anchor — the MCP server injects its own `--anchor` value into the outgoing payloads.
+
+### `open_beside_me`
+
+```
+open_beside_me { direction: "right" | "left" | "top" | "bottom" (default "right"), url: string }
+```
+
+Splits the agent's own pane in `direction` and opens `url` in the new pane. `url` accepts any page url (`vmux://terminal/...` for a terminal, anything else loads as a browser), same rules as `update_layout`.
+
+### `focus_self`
+
+```
+focus_self {}
+```
+
+Moves focus to the agent's own stack.
+
+### `read_layout` — `is_self`
+
+`read_layout` gains no new arguments at the agent's level, but the MCP server attaches its anchor to the query. The returned tree marks the caller's stack with `is_self: true`. All other stacks omit it (or `false`).
+
+## Protocol Changes
+
+In `crates/vmux_service/src/protocol.rs` (mirrors the existing `AgentShellMode` pattern — a protocol-local enum, mapped on the GUI side):
+
+- `enum AgentPaneDirection { Top, Right, Bottom, Left }`.
+- `AgentCommand::OpenBeside { anchor: ProcessId, direction: AgentPaneDirection, url: String }`.
+- `AgentCommand::FocusSelf { anchor: ProcessId }`.
+- `AgentQuery::ReadLayout` becomes `AgentQuery::ReadLayout { anchor: Option<ProcessId> }` (was a unit variant).
+- `open_beside_me` and `focus_self` return `AgentCommandResult::Ok` (not the tree); the agent calls `read_layout` afterward to learn any new ids (which now marks `is_self`). `AgentCommandResult::Layout` stays in use by `update_layout`.
+- Extend `validate_agent_command` to accept the new variants.
+
+In `crates/vmux_layout/src/protocol.rs`:
+
+- Add `is_self: bool` (default `false`) to the read/write `Stack` DTO. Read-only: populated on `read_layout`, ignored by the `update_layout` reconciler (like `is_loading`).
+
+## Implementation
+
+### `vmux_mcp` (`crates/vmux_mcp/src/tools.rs`)
+
+- Add `open_beside_me` and `focus_self` as `McpParamTool` variants (parse `direction` string → `AgentPaneDirection`, validate non-empty `url`).
+- `run_stdio` holds the parsed `--anchor` (`Option<ProcessId>`); `dispatch_from_tool_call` gains access to it and stamps it onto `OpenBeside` / `FocusSelf` / `ReadLayout`.
+- If a self-tool is called with no anchor (non-agent MCP client), return a structured tool error.
+
+### `vmux_agent` (`crates/vmux_agent/src/plugin.rs`)
+
+- `handle_agent_commands`: new arms for `OpenBeside` and `FocusSelf` that resolve the anchor and write `vmux_layout` requests (below). They respond `AgentCommandResult::Layout(..)` (via the existing `forward_layout_apply_responses` path) or `Error`.
+- `handle_agent_queries`: thread `anchor` from `ReadLayout` into `LayoutSnapshotRequest`.
+
+### `vmux_layout`
+
+- `OpenBesideRequest { anchor: ProcessId, direction: PaneDirection, url: String, request_id: u64 }` + handler:
+  - resolve `anchor` → terminal → stack → pane (return `Error` if unresolved);
+  - refactor `handle_open_in_pane` (`crates/vmux_layout/src/pane.rs:811`) to take an explicit source pane; the existing keyboard/menu path passes the focused pane, this path passes the resolved anchor pane. Reuse `direction_to_split` (`pane.rs:759`) and the existing split machinery;
+  - spawn a stack in the new pane and write a `PageOpenRequest` for `url`;
+  - on completion, emit the resulting `LayoutSnapshot` (reuse the snapshot/apply-response plumbing) keyed by `request_id`.
+- `FocusSelfRequest { anchor: ProcessId, request_id: u64 }` + handler: resolve to stack, set `FocusedStack`.
+- `LayoutSnapshotRequest` gains `anchor: Option<ProcessId>`; the read walk in `reconcile.rs` (the function around `reconcile.rs:453` that formats node ids from `entity.to_bits()`) sets `is_self: true` on the stack whose descendant terminal matches the anchor.
+
+### `vmux_cli`
+
+- `--anchor <uuid>` on the `mcp` subcommand → `run_stdio(anchor)`.
+
+### Restart edge — keep `--anchor` consistent with `ProcessId`
+
+Agent PTY restart is handled by `handle_restart_agent_pty` (`crates/vmux_agent/src/plugin.rs:1069`). Today it rebuilds the CLI args from a hand-built `McpServerConfig { command: l.command, args: vec![], cwd: None }` and never rebuilds vibe's env — which misconfigures the vmux MCP server after a restart (a pre-existing bug: the agent loses its vmux tools). The fix: mint the new `ProcessId` **first**, then rebuild the launch via `mcp::resolve(cwd, new_id)` → `strategy.build_args` / `strategy.build_env`, so the new `--anchor` (and a correct MCP config) is applied. GUI restart preserves the id via re-attach and needs no change. This is the one correctness detail that must not be missed.
+
+## Data Flow (end to end)
+
+`open_beside_me { direction: "right", url: "vmux://terminal/" }`
+→ MCP server stamps its `--anchor` → `AgentCommand::OpenBeside { anchor, direction: Right, url }`
+→ service relay → `AgentCommandRequest`
+→ `handle_agent_commands` arm → `OpenBesideRequest`
+→ resolve `ProcessId` → terminal → stack → pane
+→ split that pane to the right, open `url` in the new stack
+→ `AgentCommandResult::Ok` → back to the agent (it calls `read_layout` if it needs the new ids).
+
+## Persistence / Restart
+
+Two identities, two lifetimes, each correct for its scope:
+
+| Identity | Lifetime | Persisted | Job |
+|---|---|---|---|
+| `SessionId` (sid) | the conversation — survives Mac restart | yes, in the stack url `vmux://agent/<kind>/<sid>` | resume the right agent into the right pane on relaunch |
+| `ProcessId` | this process | no (deliberately) | bind the currently-running MCP server to its pane |
+
+- No moonshine change. `ProcessId` is not `Reflect` and does not need to be.
+- **GUI restart** (daemon keeps PTYs alive): layout restores, `reattach_terminal_bundle` re-creates the agent terminal with the same `ProcessId`, the still-running MCP server keeps its original `--anchor`, resolution holds.
+- **PTY restart** (one agent process restarts): new `ProcessId`, new MCP server; the restart path rebuilds `--anchor` (see above).
+- **Mac restart / daemon death** (daemon, PTYs, and MCP servers all die): on relaunch the layout restores, each agent stack still carries `vmux://agent/<kind>/<sid>`, and resume runs through the same `SpawnAgentInStackRequest` → `handle_spawn_agent_requests` path (confirmed at `crates/vmux_agent/src/plugin.rs:684`), which mints a fresh `ProcessId` and injects a fresh `--anchor`. Self-anchoring re-establishes automatically. The durable thing that survived is the sid in the stack url, not the anchor — and that is correct, because the anchor only ever needs process lifetime (the MCP server is a child of the CLI process and shares its lifetime).
+
+## Edge Cases
+
+- **No/unparseable anchor** (non-agent MCP client, or a session spawned before this feature): self-tools return a clear error; `read_layout` emits no `is_self`. Pre-existing live agents get anchoring only after a respawn/restart that injects the flag.
+- **Anchor resolves to no live terminal** (agent exited or its stack was closed): `OpenBeside` / `FocusSelf` return `Error("self process not found")`.
+- **Duplicate anchor:** impossible — `ProcessId` is a v4 UUID.
+- **Agent moved to another stack:** resolution follows it (id is on the content entity), so "self" stays correct.
+
+## Testing
+
+`vmux_agent`:
+- `mcp::resolve(cwd, id)` appends `--anchor <uuid>`; each strategy's serialized config carries it (extend the existing per-strategy arg tests in `vibe.rs` / `claude.rs` / `codex.rs`).
+- `handle_spawn_agent_requests` pins the minted `ProcessId` and the value in `--anchor` equals the pinned id.
+- Resolution: with `FocusedStack` pointing at a different pane, the anchor still resolves to the agent's stack.
+
+`vmux_layout`:
+- `open_beside_me` splits the **anchor** pane, not the focused pane (focus a different pane in the test, assert the new pane is a sibling of the anchor pane in the requested direction).
+- `read_layout` marks exactly one stack `is_self`, and it is the agent's.
+- `focus_self` sets `FocusedStack` to the agent's stack.
+- Restart simulation: round-trip through `reattach_terminal_bundle` with the same `ProcessId`, assert resolution still holds.
+
+`vmux_mcp` / `vmux_cli`:
+- `tool_definitions()` includes `open_beside_me` and `focus_self`.
+- self-tool with no anchor → tool error.
+- `vmux_cli/tests/mcp_smoke.rs`: `--anchor` round-trips; `open_beside_me` reaches dispatch.
+
+## Crates Touched
+
+`vmux_layout`, `vmux_agent`, `vmux_mcp`, `vmux_service`, `vmux_cli` (+ its tests). `vmux_core` is untouched.
+
+## Out of Scope (follow-on specs)
+
+- **#1 — run a command beside the agent with read-back.** `run_beside_me { command }`: same anchored split, but spawns a terminal that runs `command` and streams stdout + exit code back via `AgentCommandResult`. Reuses this spec's anchor resolution and anchored-split wholesale.
+- Workspace presets / named IDE layouts.
+- Proactive auto-arrange (steering the agent to set up its workspace unprompted).
+- Editor / file panes (vmux has no code editor today).

--- a/docs/specs/2026-06-12-agent-self-anchor-design.md
+++ b/docs/specs/2026-06-12-agent-self-anchor-design.md
@@ -14,11 +14,11 @@ The model is **Live Share with a coworker**: the agent acts in *visible, shared,
 
 **Read-back = "read the visible terminal"** (Live Share): the agent reads scrollback like the user does — no clean stdout/exit capture. Feasible because the service already broadcasts `ProcessOutput` (raw bytes) + `ProcessExited { exit_code }`; future optimization (clean `{output, exit}` for a fresh `run` terminal, or OSC-133 shell-integration markers for existing shells) is purely additive at the read layer.
 
-**Still pending (next increments on this branch):**
-1. `read_terminal { terminal }` — return a terminal's scrollback text; answered by the **service** rendering the `Process` `Term` (reuse `snapshot`/`snapshot_text`).
-2. `run { terminal }` — run in an existing terminal (by handle), not just a new one.
-3. **Terminal handle = `ProcessId`** exposed as `process_id` on terminal `Stack` DTOs in `read_layout`, and returned by `run`, so the agent can target/read specific terminals.
-4. Remove the now-superseded `in_pane`, `run_shell`, `new_terminal_tab` MCP tools (keep `browser_navigate` — that's *navigate an existing browser*, a different job).
+**Implemented (across the increments on this branch):**
+1. `read_terminal { terminal }` — returns a terminal's scrollback text; answered by the **service** rendering the `Process` `Term` (short-circuits `AgentQuery::ReadTerminal` in `server.rs`).
+2. `run { terminal }` — runs in an existing terminal (by handle) via `ClientMessage::ProcessInput`, not just a new one.
+3. **Terminal handle = `ProcessId`** exposed as `process_id` on terminal `Stack` DTOs in `read_layout` (filled in a post-pass in `serve_snapshot_requests`), and returned by `run`, so the agent can target/read specific terminals.
+4. Removed the superseded `in_pane` (`#[mcp(skip)]`), `run_shell`, `new_terminal_tab` MCP tools (kept `browser_navigate` — that's *navigate an existing browser*, a different job). The internal `AgentCommand::RunShell`/`NewTerminalTab` variants remain but are no longer reachable from the agent surface.
 
 The sections below describe the original `open_beside_me`/`focus_self` design; the anchor (`ProcessId`) + `is_self` foundation is unchanged and still current.
 


### PR DESCRIPTION
## Context

vmux injects its MCP server into the vibe/claude/codex CLIs, but the agents had no handle to their *own* pane and no way to place panes relative to themselves. That blocks the "vmux as an agentic IDE" direction, where an agent's actions surface as visible, shared panes the user can watch and take over (Live Share with a coworker). This PR gives each agent a stable self-anchor and a small, self-relative open/run/read surface.

## Implementation

- **Self-anchor.** Reuse `ProcessId` as the agent's anchor: minted before launch and injected as `--anchor <uuid>` into the MCP server argv (uniform across all three CLIs). The GUI resolves anchor -> terminal -> stack -> pane. It is restart-stable for free (it is the PTY re-attach key); the PTY-restart path rebuilds the MCP config with a fresh anchor.
- **Agent surface.** `open_page { url, direction?, focus? }`, `run { command, direction?, focus?, terminal? }`, and `read_terminal { terminal }` — all resolved via the anchor. `run` opens a terminal beside the agent and types the command into an interactive shell so the user can watch and take over; `focus` is optional so the agent decides whether to steal focus. `read_terminal` returns scrollback, answered directly by the service.
- **read_layout** marks the caller's stack `is_self` and exposes each terminal stack's `process_id` (the `run` / `read_terminal` handle).
- Removed the superseded `in_pane` / `run_shell` / `new_terminal_tab` / `focus_self` / `open_beside_me` tools.
- Fix: `run`-spawned terminals now start in the active space dir (`~/.vmux/<space>`), matching the command-bar path, instead of the daemon's cwd.
- Fix: keyboard focus stays on the terminal after switching/opening a tab — winit first-responder is re-grabbed on focused-stack change instead of requiring a click.

Design spec: `docs/specs/2026-06-12-agent-self-anchor-design.md`.

## Checks / QA

- [ ] Focus a vibe pane, ask it to `open_page` a terminal/browser beside it; it lands in the requested direction and honors `focus`.
- [ ] Ask the agent to `run` a command; a terminal opens beside it, the command runs in an interactive shell, and `pwd` shows the space dir (`~/.vmux/<space>`).
- [ ] `run` with a `terminal` handle types into that existing terminal.
- [ ] `read_terminal` returns the terminal's scrollback; `read_layout` marks `is_self` and shows terminal `process_id`s.
- [ ] Switch/open tabs and type immediately — the terminal accepts input without a click.
- [ ] Restart a vibe PTY and the app; the agent re-anchors and tools still work.
