### PR TITLE
feat(space): name spaces on page + full CRUD via MCP

### DIFF
--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -1302,6 +1302,7 @@ mod tests {
             .add_message::<vmux_terminal::TerminalSendRequest>()
             .add_message::<vmux_terminal::RunShellRequest>()
             .add_message::<vmux_setting::SettingsWriteRequest>()
+            .add_message::<vmux_space::SpaceCommandRequest>()
             .add_message::<vmux_history::query::HistoryOpenIntent>()
             .add_systems(Update, vmux_terminal::handle_terminal_send_requests)
             .insert_resource(FocusedStack::default())

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -265,6 +265,12 @@ pub struct AgentLookups<'w> {
     pub active_space: Option<Res<'w, ActiveSpace>>,
 }
 
+#[derive(bevy::ecs::system::SystemParam)]
+struct AgentSpaceWriters<'w> {
+    layout_apply: MessageWriter<'w, vmux_layout::reconcile::LayoutApplyRequest>,
+    space_command: MessageWriter<'w, vmux_space::SpaceCommandRequest>,
+}
+
 fn handle_agent_commands(
     mut reader: MessageReader<AgentCommandRequest>,
     mut app_commands: MessageWriter<AppCommand>,
@@ -281,7 +287,7 @@ fn handle_agent_commands(
     lookups: AgentLookups,
     mut sp: SettingsParams,
     service: Option<Res<vmux_service::client::ServiceClient>>,
-    mut layout_apply_writer: MessageWriter<vmux_layout::reconcile::LayoutApplyRequest>,
+    mut writers: AgentSpaceWriters,
 ) {
     let active_space = lookups.active_space.as_deref();
     use vmux_service::protocol::{AgentCommandResult, ClientMessage};
@@ -392,10 +398,12 @@ fn handle_agent_commands(
                 }
             }
             ServiceAgentCommand::UpdateLayout { layout } => {
-                layout_apply_writer.write(vmux_layout::reconcile::LayoutApplyRequest {
-                    request_id: request.request_id.0,
-                    snapshot: layout.clone(),
-                });
+                writers
+                    .layout_apply
+                    .write(vmux_layout::reconcile::LayoutApplyRequest {
+                        request_id: request.request_id.0,
+                        snapshot: layout.clone(),
+                    });
                 continue;
             }
             ServiceAgentCommand::BrowserGoBack { pane } => {
@@ -415,6 +423,20 @@ fn handle_agent_commands(
             ServiceAgentCommand::OpenInNewStack { url } => {
                 open_in_new_stack_writer
                     .write(vmux_layout::OpenInNewStackRequest { url: url.clone() });
+                AgentCommandResult::Ok
+            }
+            ServiceAgentCommand::SpaceCommand {
+                command,
+                space_id,
+                name,
+            } => {
+                writers
+                    .space_command
+                    .write(vmux_space::SpaceCommandRequest {
+                        command: command.clone(),
+                        space_id: space_id.clone(),
+                        name: name.clone(),
+                    });
                 AgentCommandResult::Ok
             }
         };
@@ -529,6 +551,7 @@ fn handle_agent_queries(
     mut reader: MessageReader<AgentQueryRequest>,
     service: Option<Res<ServiceClient>>,
     settings: Res<AppSettings>,
+    active_space: Option<Res<ActiveSpace>>,
     mut layout_snapshot_writer: MessageWriter<vmux_layout::reconcile::LayoutSnapshotRequest>,
 ) {
     let Some(service) = service else { return };
@@ -546,6 +569,29 @@ fn handle_agent_queries(
                 service.0.send(ClientMessage::AgentQueryResponse {
                     request_id: request.request_id,
                     result,
+                });
+            }
+            AgentQuery::ListSpaces => {
+                let registry = vmux_space::spaces::read_space_registry_from(
+                    &vmux_core::profile::shared_data_dir(),
+                );
+                let active_id = active_space.as_ref().map(|a| a.record.id.clone());
+                let rows: Vec<serde_json::Value> = registry
+                    .spaces
+                    .iter()
+                    .map(|space| {
+                        serde_json::json!({
+                            "id": space.id,
+                            "name": space.name,
+                            "profile": space.profile,
+                            "is_active": active_id.as_deref() == Some(space.id.as_str()),
+                        })
+                    })
+                    .collect();
+                let json = serde_json::to_string(&rows).unwrap_or_else(|_| "[]".to_string());
+                service.0.send(ClientMessage::AgentQueryResponse {
+                    request_id: request.request_id,
+                    result: AgentQueryResult::Spaces(json),
                 });
             }
         }

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -4302,6 +4302,7 @@ mod tests {
                 .add_message::<vmux_terminal::TerminalSendRequest>()
                 .add_message::<vmux_terminal::RunShellRequest>()
                 .add_message::<vmux_setting::SettingsWriteRequest>()
+                .add_message::<vmux_space::SpaceCommandRequest>()
                 .add_message::<vmux_history::query::HistoryOpenIntent>()
                 .configure_sets(
                     Update,

--- a/crates/vmux_mcp/src/protocol.rs
+++ b/crates/vmux_mcp/src/protocol.rs
@@ -188,6 +188,11 @@ fn query_result_to_mcp_response(result: vmux_service::protocol::AgentQueryResult
                 "content": [{"type": "text", "text": json_str}]
             })
         }
+        AgentQueryResult::Spaces(json_str) => {
+            json!({
+                "content": [{"type": "text", "text": json_str}]
+            })
+        }
         AgentQueryResult::Error(message) => {
             json!({
                 "isError": true,

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -63,6 +63,16 @@ pub enum McpParamTool {
         description = "Search vmux browsing history. Returns up to `limit` entries ranked by frecency."
     )]
     BrowserHistorySearch { query: String, limit: Option<u32> },
+    #[mcp(
+        description = "Create a new space and switch to it. If `name` is omitted, an auto-generated name is used."
+    )]
+    CreateSpace { name: Option<String> },
+    #[mcp(
+        description = "Rename a space by id (the id is stable; only the display name changes). Use list_spaces to discover ids."
+    )]
+    RenameSpace { space_id: String, name: String },
+    #[mcp(description = "Delete a space by id. Use list_spaces to discover ids.")]
+    DeleteSpace { space_id: String },
 }
 
 impl McpParamTool {
@@ -148,6 +158,34 @@ impl McpParamTool {
                 }
                 let limit = limit.unwrap_or(20).min(100);
                 Ok(AgentCommand::BrowserHistorySearch { query, limit })
+            }
+            McpParamTool::CreateSpace { name } => Ok(AgentCommand::SpaceCommand {
+                command: "new".to_string(),
+                space_id: None,
+                name: name.filter(|n| !n.trim().is_empty()),
+            }),
+            McpParamTool::RenameSpace { space_id, name } => {
+                if space_id.trim().is_empty() {
+                    return Err("rename_space.space_id is empty".into());
+                }
+                if name.trim().is_empty() {
+                    return Err("rename_space.name is empty".into());
+                }
+                Ok(AgentCommand::SpaceCommand {
+                    command: "rename".to_string(),
+                    space_id: Some(space_id),
+                    name: Some(name),
+                })
+            }
+            McpParamTool::DeleteSpace { space_id } => {
+                if space_id.trim().is_empty() {
+                    return Err("delete_space.space_id is empty".into());
+                }
+                Ok(AgentCommand::SpaceCommand {
+                    command: "delete".to_string(),
+                    space_id: Some(space_id),
+                    name: None,
+                })
             }
         }
     }
@@ -268,6 +306,14 @@ fn get_settings_definition() -> ToolDefinition {
     }
 }
 
+fn list_spaces_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "list_spaces".into(),
+        description: "List all spaces as a JSON array of { id, name, profile, is_active }. Use the `id` with rename_space / delete_space.".into(),
+        input_schema: serde_json::json!({"type": "object", "properties": {}, "additionalProperties": false}),
+    }
+}
+
 pub fn tool_definitions() -> Vec<ToolDefinition> {
     let mut defs: Vec<ToolDefinition> = AppCommand::mcp_tool_entries()
         .into_iter()
@@ -281,6 +327,7 @@ pub fn tool_definitions() -> Vec<ToolDefinition> {
     defs.push(read_layout_definition());
     defs.push(update_layout_definition());
     defs.push(get_settings_definition());
+    defs.push(list_spaces_definition());
     defs
 }
 
@@ -301,6 +348,11 @@ pub fn dispatch_from_tool_call(name: &str, arguments: Value) -> Result<DispatchT
     if name == "get_settings" {
         return Ok(DispatchTarget::Query(
             vmux_service::protocol::AgentQuery::GetSettings,
+        ));
+    }
+    if name == "list_spaces" {
+        return Ok(DispatchTarget::Query(
+            vmux_service::protocol::AgentQuery::ListSpaces,
         ));
     }
     if let Some(parsed) = McpParamTool::from_mcp_call(name, arguments.clone()) {
@@ -630,6 +682,55 @@ mod tests {
             target,
             DispatchTarget::Query(AgentQuery::GetSettings)
         ));
+    }
+
+    #[test]
+    fn list_spaces_dispatches_to_query() {
+        let target = dispatch_from_tool_call("list_spaces", serde_json::json!({})).unwrap();
+        assert!(matches!(
+            target,
+            DispatchTarget::Query(AgentQuery::ListSpaces)
+        ));
+    }
+
+    #[test]
+    fn rename_space_dispatches_to_space_command() {
+        let target = dispatch_from_tool_call(
+            "rename_space",
+            serde_json::json!({"space_id": "work", "name": "Client A"}),
+        )
+        .unwrap();
+        match target {
+            DispatchTarget::Command(AgentCommand::SpaceCommand {
+                command,
+                space_id,
+                name,
+            }) => {
+                assert_eq!(command, "rename");
+                assert_eq!(space_id.as_deref(), Some("work"));
+                assert_eq!(name.as_deref(), Some("Client A"));
+            }
+            other => panic!("expected SpaceCommand, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn create_space_dispatches_to_space_command() {
+        let target =
+            dispatch_from_tool_call("create_space", serde_json::json!({"name": "Work"})).unwrap();
+        match target {
+            DispatchTarget::Command(AgentCommand::SpaceCommand { command, name, .. }) => {
+                assert_eq!(command, "new");
+                assert_eq!(name.as_deref(), Some("Work"));
+            }
+            other => panic!("expected SpaceCommand, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn delete_space_empty_id_returns_error() {
+        let result = dispatch_from_tool_call("delete_space", serde_json::json!({"space_id": ""}));
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -76,6 +76,11 @@ pub enum AgentCommand {
     OpenInNewStack {
         url: String,
     },
+    SpaceCommand {
+        command: String,
+        space_id: Option<String>,
+        name: Option<String>,
+    },
 }
 
 pub const AGENT_QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
@@ -93,12 +98,14 @@ pub enum AgentCommandResult {
 pub enum AgentQuery {
     ReadLayout,
     GetSettings,
+    ListSpaces,
 }
 
 #[derive(Debug, Clone, PartialEq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum AgentQueryResult {
     Layout(crate::protocol::layout::LayoutSnapshot),
     Settings(String),
+    Spaces(String),
     Error(String),
 }
 
@@ -124,6 +131,9 @@ pub fn validate_agent_command(command: &AgentCommand) -> Result<(), &'static str
         }
         AgentCommand::OpenInNewStack { url, .. } if url.trim().is_empty() => {
             Err("open_in_new_stack.url is empty")
+        }
+        AgentCommand::SpaceCommand { command, .. } if command.trim().is_empty() => {
+            Err("space_command.command is empty")
         }
         _ => Ok(()),
     }

--- a/crates/vmux_space/src/lib.rs
+++ b/crates/vmux_space/src/lib.rs
@@ -24,6 +24,6 @@ pub const PAGE_MANIFEST: vmux_core::page::PageManifest =
     vmux_core::page::PageManifest { host: "spaces" };
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use plugin::{SaveSpaceRequest, SpacePlugin};
+pub use plugin::{SaveSpaceRequest, SpaceCommandRequest, SpacePlugin};
 #[cfg(not(target_arch = "wasm32"))]
 pub use spaces::{ActiveSpace, Spaces};

--- a/crates/vmux_space/src/page.rs
+++ b/crates/vmux_space/src/page.rs
@@ -10,6 +10,7 @@ pub fn Page() -> Element {
     use_theme();
     let mut state = use_signal(SpacesListEvent::default);
     let mut selected = use_signal(|| 0usize);
+    let mut new_name = use_signal(String::new);
 
     let _listener = use_bin_event_listener::<SpacesListEvent, _>(SPACES_LIST_EVENT, move |data| {
         selected.set(0);
@@ -74,12 +75,29 @@ pub fn Page() -> Element {
                     h1 { class: "text-lg font-semibold", "Spaces" }
                     div { class: "mt-1 truncate text-xs text-muted-foreground", "{active_name}" }
                 }
-                button {
-                    class: "rounded-md border border-border bg-card px-3 py-1.5 text-sm text-foreground transition-colors hover:border-foreground/30 hover:bg-muted",
-                    onclick: move |_| {
-                        emit_command("new", None, Some(format!("Space {}", count + 1)));
-                    },
-                    "New"
+                div { class: "flex shrink-0 items-center gap-2",
+                    input {
+                        class: "w-44 rounded-md border border-border bg-card px-3 py-1.5 text-sm text-foreground outline-none placeholder:text-muted-foreground focus:border-foreground/30",
+                        r#type: "text",
+                        placeholder: "New space name",
+                        value: "{new_name}",
+                        oninput: move |e| new_name.set(e.value()),
+                        onkeydown: move |e| {
+                            e.stop_propagation();
+                            if e.key() == Key::Enter {
+                                emit_command("new", None, Some(new_space_name(&new_name(), count)));
+                                new_name.set(String::new());
+                            }
+                        },
+                    }
+                    button {
+                        class: "rounded-md border border-border bg-card px-3 py-1.5 text-sm text-foreground transition-colors hover:border-foreground/30 hover:bg-muted",
+                        onclick: move |_| {
+                            emit_command("new", None, Some(new_space_name(&new_name(), count)));
+                            new_name.set(String::new());
+                        },
+                        "New"
+                    }
                 }
             }
             div { class: "min-h-0 flex-1 overflow-y-auto p-3",
@@ -99,6 +117,15 @@ pub fn Page() -> Element {
                 }
             }
         }
+    }
+}
+
+fn new_space_name(typed: &str, count: usize) -> String {
+    let trimmed = typed.trim();
+    if trimmed.is_empty() {
+        format!("Space {}", count + 1)
+    } else {
+        trimmed.to_string()
     }
 }
 

--- a/crates/vmux_space/src/plugin.rs
+++ b/crates/vmux_space/src/plugin.rs
@@ -26,6 +26,15 @@ pub struct SaveSpaceRequest {
     pub path: PathBuf,
 }
 
+/// A space CRUD request from a non-web source (e.g. the agent/MCP). Relayed into
+/// the same `SpaceCommandEvent` flow the web spaces page uses.
+#[derive(Message, Clone)]
+pub struct SpaceCommandRequest {
+    pub command: String,
+    pub space_id: Option<String>,
+    pub name: Option<String>,
+}
+
 pub struct SpacePlugin;
 
 impl Plugin for SpacePlugin {
@@ -33,6 +42,8 @@ impl Plugin for SpacePlugin {
         app.world_mut().spawn(crate::PAGE_MANIFEST);
         app.init_resource::<ActiveSpace>()
             .add_message::<SaveSpaceRequest>()
+            .add_message::<SpaceCommandRequest>()
+            .add_systems(Update, relay_space_command_requests)
             .add_systems(Startup, ensure_space_registry)
             .add_systems(
                 Startup,
@@ -151,6 +162,15 @@ fn ensure_space_registry() {
         return;
     }
     write_space_registry_to(&root, &read_space_registry_from(&root));
+}
+
+fn rename_space_record(registry: &mut SpaceRegistry, id: &str, name: &str) -> bool {
+    if let Some(space) = registry.spaces.iter_mut().find(|space| space.id == id) {
+        space.name = name.to_string();
+        true
+    } else {
+        false
+    }
 }
 
 fn delete_space_record(registry: &mut SpaceRegistry, id: &str) -> Option<SpaceRecord> {
@@ -315,6 +335,22 @@ fn apply_pending_space_switch(
     }
 }
 
+fn relay_space_command_requests(
+    mut reader: MessageReader<SpaceCommandRequest>,
+    mut commands: Commands,
+) {
+    for request in reader.read() {
+        commands.trigger(BinReceive {
+            webview: Entity::PLACEHOLDER,
+            payload: SpaceCommandEvent {
+                command: request.command.clone(),
+                space_id: request.space_id.clone(),
+                name: request.name.clone(),
+            },
+        });
+    }
+}
+
 fn on_space_command(
     trigger: On<BinReceive<SpaceCommandEvent>>,
     mut active: ResMut<ActiveSpace>,
@@ -391,6 +427,22 @@ fn on_space_command(
             record: target,
             delay_frames: 1,
         });
+        return;
+    }
+
+    if evt.command == "rename" {
+        let Some(id) = evt.space_id.as_deref() else {
+            return;
+        };
+        let Some(name) = evt.name.as_deref().map(str::trim).filter(|n| !n.is_empty()) else {
+            return;
+        };
+        if rename_space_record(&mut registry, id, name) {
+            write_space_registry_to(&root, &registry);
+            if active.record.id == id {
+                active.record.name = name.to_string();
+            }
+        }
         return;
     }
 
@@ -691,6 +743,34 @@ mod tests {
 
         assert_eq!(deleted.id, "work");
         assert_eq!(registry.spaces, vec![bootstrap_space_record()]);
+    }
+
+    #[test]
+    fn rename_space_record_changes_name_keeps_id() {
+        let mut registry = SpaceRegistry {
+            spaces: vec![
+                bootstrap_space_record(),
+                SpaceRecord {
+                    id: "work".to_string(),
+                    name: "Work".to_string(),
+                    profile: BOOTSTRAP_PROFILE_NAME.to_string(),
+                },
+            ],
+        };
+
+        assert!(rename_space_record(&mut registry, "work", "Client A"));
+
+        let renamed = registry.spaces.iter().find(|s| s.id == "work").unwrap();
+        assert_eq!(renamed.name, "Client A");
+        assert_eq!(renamed.id, "work");
+    }
+
+    #[test]
+    fn rename_space_record_unknown_id_is_noop() {
+        let mut registry = SpaceRegistry {
+            spaces: vec![bootstrap_space_record()],
+        };
+        assert!(!rename_space_record(&mut registry, "nope", "X"));
     }
 
     #[test]


### PR DESCRIPTION
## Context

Make spaces nameable and fully manageable by the agent. Previously the spaces page only had an auto-named "New" button, and the agent had no way to manage spaces.

> Stacked on #78 (`feat/per-space-startup`) — review/merge that first. Base branch is set to `feat/per-space-startup`.

## Implementation

- **Spaces page name input** (`vmux_space/src/page.rs`): a text field next to "New"; Enter or the button creates a space with the typed name (blank → `Space N`). Uses the existing `SpaceCommandEvent { command: "new", name }` flow.
- **Rename op** (`vmux_space/src/plugin.rs`): new `"rename"` command in `on_space_command`, backed by a pure `rename_space_record` helper. The space **id stays stable** (it keys `settings.spaces` and the on-disk layout path) — only the display name changes. The spaces page re-broadcasts automatically on registry change.
- **Full CRUD via MCP** (`vmux_mcp`): `create_space { name? }`, `list_spaces` (returns `[{id,name,profile,is_active}]`), `rename_space { space_id, name }`, `delete_space { space_id }`. Create/rename/delete map to a generic `AgentCommand::SpaceCommand`; list is an `AgentQuery::ListSpaces`.
- **Routing**: agent space commands flow through a typed `SpaceCommandRequest` message (in `vmux_space`) that relays into the existing `SpaceCommandEvent` observer — so `vmux_agent` needs no `bevy_cef` dependency. `list_spaces` is answered in `handle_agent_queries` from the registry + active space.

## Checks / QA

- Spaces page: type a name, press Enter (and click New) → a space with that name is created; blank input → `Space N`.
- Agent: `list_spaces` returns the spaces with ids; `create_space {name}` adds one; `rename_space {space_id,name}` renames it (id unchanged — verify per-space `settings.spaces` entry stays attached); `delete_space {space_id}` removes it (last space is kept).
- Rename a non-active space → the spaces page list updates.
