### PR TITLE
fix: command bar opens on first Cmd+K/Cmd+L (wake reactive loop)

### DIFF
--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -46,6 +46,10 @@ impl Plugin for BackgroundLifecyclePlugin {
             .add_systems(Update, sync_winit_power_mode.after(handle_lifecycle_events))
             .add_systems(Update, keep_awake_while_revealing)
             .add_systems(
+                Update,
+                keep_awake_while_command_bar_opening.after(vmux_command::ReadAppCommands),
+            )
+            .add_systems(
                 Startup,
                 (
                     install_native_mouse_wake_monitor,
@@ -294,6 +298,34 @@ fn keep_awake_while_revealing(
     }
 }
 
+fn command_bar_should_wake(needs_open: bool, has_active_reveal: bool) -> bool {
+    needs_open || has_active_reveal
+}
+
+/// The command bar opens across several reactive frames: the first shortcut may defer
+/// (`NewStackContext::needs_open`) until the CEF webview is ready, then a reveal
+/// (`PendingCommandBarReveal`) waits for the rendered/sized ack. Without an explicit wake the loop
+/// idles after the keystroke and the open stalls until the next input — the user has to press
+/// Cmd+K/Cmd+L twice. Mirror [`keep_awake_while_revealing`] for the modal. Runs after
+/// `ReadAppCommands` so `needs_open` set this frame is observed. Self-terminating: once revealed,
+/// `needs_open` clears and the placeholder reveal is `open_id == 0` (inactive), so we stop waking.
+fn keep_awake_while_command_bar_opening(
+    proxy: Option<Res<EventLoopProxyWrapper>>,
+    new_stack_ctx: Option<Res<vmux_layout::NewStackContext>>,
+    pending: Query<&vmux_layout::PendingCommandBarReveal>,
+) {
+    let needs_open = new_stack_ctx.map(|ctx| ctx.needs_open).unwrap_or(false);
+    let has_active_reveal = pending
+        .iter()
+        .any(vmux_layout::PendingCommandBarReveal::is_active);
+    if !command_bar_should_wake(needs_open, has_active_reveal) {
+        return;
+    }
+    if let Some(proxy) = proxy {
+        let _ = (**proxy).send_event(WinitUserEvent::WakeUp);
+    }
+}
+
 fn handle_lifecycle_events(world: &mut World) {
     let drained: Vec<LifecycleEvent> = {
         let mut events = world.resource_mut::<Messages<LifecycleEvent>>();
@@ -340,6 +372,14 @@ fn hide_all_osr_webviews(world: &mut World) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn command_bar_wake_covers_defer_and_active_reveal() {
+        assert!(command_bar_should_wake(true, false));
+        assert!(command_bar_should_wake(false, true));
+        assert!(command_bar_should_wake(true, true));
+        assert!(!command_bar_should_wake(false, false));
+    }
 
     #[test]
     fn handle_lifecycle_events_uses_world_for_confirm_dialog() {

--- a/crates/vmux_layout/src/command_bar/handler.rs
+++ b/crates/vmux_layout/src/command_bar/handler.rs
@@ -69,6 +69,14 @@ pub struct PendingCommandBarReveal {
     payload: Option<Vec<u8>>,
 }
 
+impl PendingCommandBarReveal {
+    /// True once a real open is in flight (open_id != 0). The prewarm placeholder
+    /// (open_id == 0) is idle and must not keep the event loop awake.
+    pub fn is_active(&self) -> bool {
+        self.open_id != 0
+    }
+}
+
 const COMMAND_BAR_REVEAL_FRAMES: u8 = 2;
 const COMMAND_BAR_REVEAL_FALLBACK_FRAMES: u8 = 10;
 
@@ -2499,6 +2507,26 @@ mod tests {
     #[test]
     fn normalize_url_preserves_vmux_protocol() {
         assert_eq!(normalize_url("vmux://terminal/123"), "vmux://terminal/123");
+    }
+
+    #[test]
+    fn pending_reveal_is_active_only_with_real_open_id() {
+        assert!(
+            !PendingCommandBarReveal {
+                frames: 0,
+                open_id: 0,
+                payload: None,
+            }
+            .is_active()
+        );
+        assert!(
+            PendingCommandBarReveal {
+                frames: 0,
+                open_id: 7,
+                payload: None,
+            }
+            .is_active()
+        );
     }
 
     #[test]

--- a/crates/vmux_layout/src/lib.rs
+++ b/crates/vmux_layout/src/lib.rs
@@ -59,6 +59,8 @@ pub use cef::{
     mirror_metadata_to_url,
 };
 #[cfg(not(target_arch = "wasm32"))]
+pub use command_bar::handler::PendingCommandBarReveal;
+#[cfg(not(target_arch = "wasm32"))]
 pub use header::Header;
 #[cfg(not(target_arch = "wasm32"))]
 pub use plugin::LayoutPlugin;


### PR DESCRIPTION
## Summary
- In reactive update mode the first `Cmd+K`/`Cmd+L` often required a **second press**: the open defers until the CEF webview is ready (`NewStackContext::needs_open`) and the reveal spans several frames (`PendingCommandBarReveal`), but nothing woke the winit loop after the keystroke — so it idled until the next input.
- `keep_awake_while_revealing` already routes a wake for pane reveals (`PendingWebviewReveal`); this adds the parallel `keep_awake_while_command_bar_opening` for the command-bar modal. It sends `WakeUp` while `needs_open` is set or a `PendingCommandBarReveal` is active, runs `.after(vmux_command::ReadAppCommands)` so the same-frame `needs_open` is observed, and self-terminates once revealed (no idle-CPU regression).
- Exposes `PendingCommandBarReveal::is_active()` (open_id != 0; the prewarm placeholder stays inactive) and re-exports the type from `vmux_layout`.

## Test Plan
- [x] `cargo test -p vmux_layout -p vmux_desktop` (incl. new `is_active` + `command_bar_should_wake` unit tests)
- [x] `cargo fmt --check` + `cargo clippy -p vmux_layout -p vmux_desktop`
- [ ] Manual (desktop): cold launch, press `Cmd+K` once → command bar appears on the first press; same for `Cmd+L`