### PR TITLE
fix(terminal): scroll terminals like a standard emulator

### DIFF
--- a/crates/vmux_service/src/process.rs
+++ b/crates/vmux_service/src/process.rs
@@ -189,6 +189,29 @@ fn copy_mode_scroll_input(
     Some((format!("\x1b[<{button};{x};{y}M").into_bytes(), scroll_rows))
 }
 
+fn sgr_mouse_wheel_bytes(up: bool, col: u16, row: u16, modifiers: u8) -> Vec<u8> {
+    let mut cb: u32 = if up { 64 } else { 65 };
+    if modifiers & MOD_SHIFT != 0 {
+        cb += 4;
+    }
+    if modifiers & MOD_ALT != 0 {
+        cb += 8;
+    }
+    if modifiers & MOD_CTRL != 0 {
+        cb += 16;
+    }
+    format!("\x1b[<{cb};{};{}M", col + 1, row + 1).into_bytes()
+}
+
+fn alternate_scroll_bytes(up: bool, app_cursor: bool) -> &'static [u8] {
+    match (up, app_cursor) {
+        (true, false) => b"\x1b[A",
+        (false, false) => b"\x1b[B",
+        (true, true) => b"\x1bOA",
+        (false, true) => b"\x1bOB",
+    }
+}
+
 impl Process {
     pub fn new(
         id: ProcessId,
@@ -811,6 +834,38 @@ impl Process {
             }
         }
         actual
+    }
+
+    fn scroll_viewport(&mut self, delta: i32) -> i32 {
+        let old_offset = self.term.grid().display_offset() as i32;
+        self.term.scroll_display(Scroll::Delta(delta));
+        let new_offset = self.term.grid().display_offset() as i32;
+        let actual = new_offset - old_offset;
+        if actual != 0 {
+            self.line_hashes.clear();
+        }
+        actual
+    }
+
+    pub fn handle_mouse_wheel(&mut self, up: bool, col: u16, row: u16, modifiers: u8) {
+        use alacritty_terminal::term::TermMode;
+        let delta = if up { 1 } else { -1 };
+        if self.copy_mode.is_some() {
+            if self.scroll_copy_mode_viewport(delta) != 0 {
+                self.sync_viewport();
+            }
+            return;
+        }
+        let mode = self.term.mode();
+        if mode.intersects(TermMode::MOUSE_MODE) {
+            let bytes = sgr_mouse_wheel_bytes(up, col, row, modifiers);
+            Self::write_input_to_writer(&self.pty_writer, &bytes);
+        } else if mode.contains(TermMode::ALT_SCREEN) && mode.contains(TermMode::ALTERNATE_SCROLL) {
+            let bytes = alternate_scroll_bytes(up, mode.contains(TermMode::APP_CURSOR));
+            Self::write_input_to_writer(&self.pty_writer, bytes);
+        } else if self.scroll_viewport(delta) != 0 {
+            self.sync_viewport();
+        }
     }
 
     fn last_non_blank_col(&self, row: u16) -> u16 {
@@ -1695,6 +1750,110 @@ mod tests {
         process.kill();
 
         assert_eq!(*captured.lock().unwrap(), b"\x1b[<64;7;5M".to_vec());
+    }
+
+    fn capturing_process(cols: u16, rows: u16) -> (Process, Arc<Mutex<Vec<u8>>>) {
+        #[derive(Clone)]
+        struct CapturingWriter(Arc<Mutex<Vec<u8>>>);
+
+        impl Write for CapturingWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let (wake_tx, _) = mpsc::unbounded_channel();
+        let mut process = Process::new_with_wake(
+            ProcessId::new(),
+            "/bin/sh".to_string(),
+            vec![],
+            String::new(),
+            Vec::new(),
+            cols,
+            rows,
+            wake_tx,
+        )
+        .expect("process should spawn");
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        process.pty_writer = Arc::new(Mutex::new(Box::new(CapturingWriter(captured.clone()))));
+        (process, captured)
+    }
+
+    #[test]
+    fn mouse_wheel_in_mouse_mode_forwards_sgr() {
+        let (mut process, captured) = capturing_process(12, 8);
+        process.process_output_for_test(b"\x1b[?1000h");
+        process.handle_mouse_wheel(true, 6, 4, 0);
+        process.handle_mouse_wheel(false, 0, 0, 0);
+        process.kill();
+        assert_eq!(
+            *captured.lock().unwrap(),
+            b"\x1b[<64;7;5M\x1b[<65;1;1M".to_vec()
+        );
+    }
+
+    #[test]
+    fn mouse_wheel_in_alt_screen_sends_arrow_keys() {
+        let (mut process, captured) = capturing_process(12, 8);
+        process.process_output_for_test(b"\x1b[?1049h");
+        process.handle_mouse_wheel(true, 0, 0, 0);
+        process.handle_mouse_wheel(false, 0, 0, 0);
+        process.kill();
+        assert_eq!(*captured.lock().unwrap(), b"\x1b[A\x1b[B".to_vec());
+    }
+
+    #[test]
+    fn mouse_wheel_in_alt_screen_app_cursor_sends_ss3_arrows() {
+        let (mut process, captured) = capturing_process(12, 8);
+        process.process_output_for_test(b"\x1b[?1049h\x1b[?1h");
+        process.handle_mouse_wheel(true, 0, 0, 0);
+        process.kill();
+        assert_eq!(*captured.lock().unwrap(), b"\x1bOA".to_vec());
+    }
+
+    #[test]
+    fn mouse_wheel_in_alt_screen_without_alternate_scroll_is_inert() {
+        let (mut process, captured) = capturing_process(12, 8);
+        process.process_output_for_test(b"\x1b[?1049h\x1b[?1007l");
+        process.handle_mouse_wheel(true, 0, 0, 0);
+        process.kill();
+        assert!(captured.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn mouse_wheel_on_normal_screen_scrolls_into_scrollback() {
+        let (mut process, captured) = capturing_process(12, 4);
+        let mut feed = Vec::new();
+        for i in 0..40 {
+            feed.extend_from_slice(format!("line{i}\r\n").as_bytes());
+        }
+        process.process_output_for_test(&feed);
+        assert_eq!(process.term.grid().display_offset(), 0);
+
+        let mut patches = process.subscribe();
+        process.handle_mouse_wheel(true, 0, 0, 0);
+        let offset = process.term.grid().display_offset();
+        process.kill();
+
+        assert!(
+            offset >= 1,
+            "wheel up on a normal screen should scroll into scrollback, got offset {offset}"
+        );
+        assert!(
+            captured.lock().unwrap().is_empty(),
+            "scrollback scroll must not write to the pty"
+        );
+        let broadcast_patch = std::iter::from_fn(|| patches.try_recv().ok())
+            .any(|msg| matches!(msg, ServiceMessage::ViewportPatch { .. }));
+        assert!(
+            broadcast_patch,
+            "scrollback scroll must broadcast a viewport patch so the frontend re-renders"
+        );
     }
 
     #[test]

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -161,6 +161,13 @@ pub enum ClientMessage {
         process_id: ProcessId,
         data: Vec<u8>,
     },
+    MouseWheel {
+        process_id: ProcessId,
+        up: bool,
+        col: u16,
+        row: u16,
+        modifiers: u8,
+    },
     ResizeProcess {
         process_id: ProcessId,
         cols: u16,

--- a/crates/vmux_service/src/server.rs
+++ b/crates/vmux_service/src/server.rs
@@ -271,6 +271,19 @@ async fn handle_client(
                 }
             }
 
+            ClientMessage::MouseWheel {
+                process_id,
+                up,
+                col,
+                row,
+                modifiers,
+            } => {
+                with_process_mut(&manager, process_id, |process| {
+                    process.handle_mouse_wheel(up, col, row, modifiers)
+                })
+                .await;
+            }
+
             ClientMessage::ResizeProcess {
                 process_id,
                 cols,

--- a/crates/vmux_terminal/Cargo.toml
+++ b/crates/vmux_terminal/Cargo.toml
@@ -48,4 +48,5 @@ web-sys = { version = "0.3", features = [
     "Window", "Document", "Element", "HtmlElement", "Node",
     "DomRect", "CssStyleDeclaration",
     "ResizeObserver", "ResizeObserverEntry",
+    "MouseEvent", "WheelEvent",
 ] }

--- a/crates/vmux_terminal/src/page.rs
+++ b/crates/vmux_terminal/src/page.rs
@@ -120,6 +120,8 @@ pub fn Page() -> Element {
     let cell_dims = use_signal(|| (0.0f64, 0.0f64));
     // Last emitted mouse cell position for move-event throttling.
     let mut last_mouse_cell = use_signal(|| (-1i32, -1i32));
+    // Accumulated wheel delta (pixels) not yet converted into scroll notches.
+    let mut wheel_accum = use_signal(|| 0.0f64);
 
     // Set up character measurement span and ResizeObserver (runs once after mount).
     use_effect(move || {
@@ -213,6 +215,38 @@ pub fn Page() -> Element {
 
             oncontextmenu: move |e: Event<MouseData>| {
                 e.prevent_default();
+            },
+
+            onwheel: move |e: Event<WheelData>| {
+                e.prevent_default();
+                let dims = cell_dims();
+                let (_, ch) = dims;
+                let data = e.data();
+                let Some(raw) = data.downcast::<web_sys::WheelEvent>() else {
+                    return;
+                };
+                let line_px = if ch > 0.0 { ch } else { 16.0 };
+                let px = match raw.delta_mode() {
+                    1 => raw.delta_y() * line_px,
+                    2 => raw.delta_y() * line_px * 3.0,
+                    _ => raw.delta_y(),
+                };
+                let total = wheel_accum() + px;
+                let notches = (total / line_px).trunc();
+                wheel_accum.set(total - notches * line_px);
+                let count = (notches as i32).clamp(-10, 10);
+                if count == 0 {
+                    return;
+                }
+                if let Some((col, row)) =
+                    client_to_cell(raw.client_x() as f64, raw.client_y() as f64, padding, dims)
+                {
+                    let button = if count < 0 { 64 } else { 65 };
+                    let modifiers = wheel_modifier_bits(raw);
+                    for _ in 0..count.unsigned_abs() {
+                        emit_mouse(button, col, row, modifiers, true, false);
+                    }
+                }
             },
 
             if copy_mode() {
@@ -525,7 +559,17 @@ fn parse_px(cs: &web_sys::CssStyleDeclaration, prop: &str) -> f64 {
 // ---------------------------------------------------------------------------
 
 /// Convert mouse client coordinates to terminal grid (col, row).
-fn mouse_to_cell(e: &Event<MouseData>, padding: f64, (cw, ch): (f64, f64)) -> Option<(u16, u16)> {
+fn mouse_to_cell(e: &Event<MouseData>, padding: f64, dims: (f64, f64)) -> Option<(u16, u16)> {
+    let client = e.client_coordinates();
+    client_to_cell(client.x, client.y, padding, dims)
+}
+
+fn client_to_cell(
+    client_x: f64,
+    client_y: f64,
+    padding: f64,
+    (cw, ch): (f64, f64),
+) -> Option<(u16, u16)> {
     if cw <= 0.0 || ch <= 0.0 {
         return None;
     }
@@ -533,9 +577,8 @@ fn mouse_to_cell(e: &Event<MouseData>, padding: f64, (cw, ch): (f64, f64)) -> Op
         .document()?
         .get_element_by_id(CONTAINER_ID)?;
     let rect = container.get_bounding_client_rect();
-    let client = e.client_coordinates();
-    let x = client.x - rect.left() - padding;
-    let y = client.y - rect.top() - padding;
+    let x = client_x - rect.left() - padding;
+    let y = client_y - rect.top() - padding;
     let col = (x / cw).floor().max(0.0) as u16;
     let row = (y / ch).floor().max(0.0) as u16;
     Some((col, row))
@@ -579,6 +622,23 @@ fn modifier_bits(e: &Event<MouseData>) -> u8 {
         m |= MOD_SHIFT;
     }
     if mods.contains(Modifiers::META) {
+        m |= MOD_SUPER;
+    }
+    m
+}
+
+fn wheel_modifier_bits(e: &web_sys::WheelEvent) -> u8 {
+    let mut m = 0u8;
+    if e.ctrl_key() {
+        m |= MOD_CTRL;
+    }
+    if e.alt_key() {
+        m |= MOD_ALT;
+    }
+    if e.shift_key() {
+        m |= MOD_SHIFT;
+    }
+    if e.meta_key() {
         m |= MOD_SUPER;
     }
     m

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -6,7 +6,6 @@ use bevy::{
     input::{
         ButtonState, InputSystems,
         keyboard::{Key, KeyboardInput},
-        mouse::{MouseScrollUnit, MouseWheel},
     },
     picking::Pickable,
     prelude::*,
@@ -268,10 +267,8 @@ impl Plugin for TerminalPlugin {
             )>::default())
             .add_systems(
                 PreUpdate,
-                (
-                    handle_terminal_keyboard.run_if(on_message::<KeyboardInput>),
-                    handle_terminal_scroll.run_if(on_message::<MouseWheel>),
-                )
+                handle_terminal_keyboard
+                    .run_if(on_message::<KeyboardInput>)
                     .after(InputSystems),
             );
         add_terminal_update_systems(app)
@@ -2083,57 +2080,6 @@ fn key_code_from_web_code(code: &str) -> KeyCode {
     }
 }
 
-/// Handle mouse wheel scrolling — sends scroll input to service.
-fn handle_terminal_scroll(
-    mut er: MessageReader<MouseWheel>,
-    targeted_terminals: Query<&ProcessId, (With<Terminal>, With<CefKeyboardTarget>)>,
-    keyboard_targets: Query<(), With<CefKeyboardTarget>>,
-    terminals: Query<(&ProcessId, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
-    focus: Res<vmux_layout::stack::FocusedStack>,
-    mode: Res<vmux_layout::scene::InteractionMode>,
-    service: Option<Res<ServiceClient>>,
-) {
-    let target_processes = resolve_terminal_input_targets(
-        targeted_terminals.iter().copied(),
-        !keyboard_targets.is_empty(),
-        focus.stack,
-        terminals
-            .iter()
-            .map(|(pid, child_of)| (child_of.get(), *pid)),
-        *mode,
-    );
-
-    if target_processes.is_empty() {
-        for _ in er.read() {}
-        return;
-    }
-    let Some(service) = service else {
-        for _ in er.read() {}
-        return;
-    };
-    for event in er.read() {
-        let lines = match event.unit {
-            MouseScrollUnit::Line => -event.y as i32,
-            MouseScrollUnit::Pixel => (-event.y / 20.0) as i32,
-        };
-        if lines == 0 {
-            continue;
-        }
-        // Send scroll as mouse button 64/65 SGR sequences
-        let button: u8 = if lines < 0 { 64 } else { 65 };
-        let count = lines.unsigned_abs();
-        let seq = sgr_mouse_sequence(button, 0, 0, 0, true);
-        for process_id in &target_processes {
-            for _ in 0..count {
-                service.0.send(ClientMessage::ProcessInput {
-                    process_id: *process_id,
-                    data: seq.clone(),
-                });
-            }
-        }
-    }
-}
-
 /// Encode a mouse event as an SGR escape sequence.
 fn sgr_mouse_sequence(button: u8, col: u16, row: u16, modifiers: u8, pressed: bool) -> Vec<u8> {
     let mut cb = button as u32;
@@ -2356,6 +2302,17 @@ fn on_term_mouse(
     let Some(service) = service else { return };
     let Ok(pid) = q.get(entity) else { return };
     let process_id = *pid;
+
+    if event.button == 64 || event.button == 65 {
+        service.0.send(ClientMessage::MouseWheel {
+            process_id,
+            up: event.button == 64,
+            col: event.col,
+            row: event.row,
+            modifiers: event.modifiers,
+        });
+        return;
+    }
 
     let mouse_capture = mode_map
         .modes


### PR DESCRIPTION
## Summary
Terminal panes did not scroll. Two gaps:
1. The terminal page (Dioxus/WASM, `page.rs`) forwarded clicks/drags to the host but **never the wheel**; in windowed browse mode the CEF page owns input, so winits wheel handler never fired.
2. Even when the wheel reached the host it was always baked into SGR and written to the PTY, so a plain shell (no mouse tracking) ignored it — there was no scrollback wiring.

Wire the wheel end-to-end and route it in the **service** (the emulator), matching xterm/alacritty:
- `page.rs`: `onwheel` emits `TermMouseEvent` button 64/65 at the cursor cell, accumulating pixel/line/page delta into notches (trackpad + wheel).
- `on_term_mouse`: forwards wheel to the service as `ClientMessage::MouseWheel`.
- service `handle_mouse_wheel` routes by terminal mode:
  - **mouse-tracking app** (e.g. Vibe) → SGR wheel report (unchanged behavior; it keeps its own scrollbar — standard for mouse-mode TUIs).
  - **alt-screen + alternate-scroll** (less/man/vim) → arrow keys, cursor-key-mode (DECCKM) aware.
  - **normal screen** (shell) → scroll the scrollback viewport (display offset); output/typing snaps back to bottom.
- drop the vestigial winit `handle_terminal_scroll` path (superseded; only fired in OSR mode and would double-scroll).
- enable `MouseEvent`/`WheelEvent` web-sys features.

An earlier revision added `NSEventMask::ScrollWheel` to the native wake monitor; that was the wrong layer and was reverted.

## Test plan
- [x] `cargo test -p vmux_service` — wheel routing unit tests (mouse-mode SGR, alt-screen arrows incl. app-cursor, alternate-scroll-disabled inert, normal-screen scrollback).
- [x] `cargo check -p vmux_desktop` (native) + `cargo check -p vmux_terminal --target wasm32-unknown-unknown` (frontend) + clippy on vmux_service.
- [ ] Manual: shell scrolls scrollback; Vibe scrolls (own scrollbar); `less`/`vim` scroll via arrows; trackpad + wheel both feel right.