### PR TITLE
fix(command-bar): open highlighted result on Enter for plain queries

### DIFF
--- a/crates/vmux_command/src/event.rs
+++ b/crates/vmux_command/src/event.rs
@@ -183,6 +183,18 @@ pub fn command_bar_open_should_ack(open_id: u64) -> bool {
     open_id != 0
 }
 
+pub fn should_open_typed_query_on_enter(
+    open_target: Option<crate::open_target::OpenTarget>,
+    nav_mode: bool,
+    query: &str,
+) -> bool {
+    matches!(open_target, Some(crate::open_target::OpenTarget::InPlace))
+        && !nav_mode
+        && !query.trim().is_empty()
+        && !query.trim_start().starts_with('>')
+        && looks_like_url(query.trim())
+}
+
 pub const PATH_COMPLETE_REQUEST: &str = "path-complete-request";
 pub const PATH_COMPLETE_RESPONSE: &str = "path-complete-response";
 
@@ -427,6 +439,51 @@ mod tests {
     fn command_bar_retried_open_payload_still_gets_ack() {
         assert!(command_bar_open_should_ack(7));
         assert!(!command_bar_open_should_ack(0));
+    }
+
+    #[test]
+    fn in_place_enter_opens_typed_query_without_nav_selection() {
+        assert!(should_open_typed_query_on_enter(
+            Some(crate::open_target::OpenTarget::InPlace),
+            false,
+            "https://example.com"
+        ));
+    }
+
+    #[test]
+    fn in_place_enter_keeps_explicit_nav_selection() {
+        assert!(!should_open_typed_query_on_enter(
+            Some(crate::open_target::OpenTarget::InPlace),
+            true,
+            "https://example.com"
+        ));
+    }
+
+    #[test]
+    fn command_query_enter_keeps_command_selection() {
+        assert!(!should_open_typed_query_on_enter(
+            Some(crate::open_target::OpenTarget::InPlace),
+            false,
+            "> close"
+        ));
+    }
+
+    #[test]
+    fn in_place_enter_keeps_highlighted_suggestion_for_plain_text_query() {
+        assert!(!should_open_typed_query_on_enter(
+            Some(crate::open_target::OpenTarget::InPlace),
+            false,
+            "terminal"
+        ));
+    }
+
+    #[test]
+    fn in_place_enter_opens_typed_domain_query() {
+        assert!(should_open_typed_query_on_enter(
+            Some(crate::open_target::OpenTarget::InPlace),
+            false,
+            "google.com"
+        ));
     }
 
     #[test]

--- a/crates/vmux_layout/src/command_bar/page.rs
+++ b/crates/vmux_layout/src/command_bar/page.rs
@@ -18,7 +18,7 @@ use vmux_command::event::{
     CommandBarRenderedEvent, CommandBarSizeEvent, HISTORY_SUGGESTIONS_RESPONSE_EVENT, HistoryEntry,
     HistorySuggestionsRequest, HistorySuggestionsResponse, PATH_COMPLETE_RESPONSE,
     PathCompleteRequest, PathCompleteResponse, PathEntry, command_bar_open_should_ack,
-    command_bar_open_should_reset_input, looks_like_url,
+    command_bar_open_should_reset_input, looks_like_url, should_open_typed_query_on_enter,
 };
 use vmux_ui::components::icon::Icon;
 use vmux_ui::favicon::Favicon;
@@ -656,19 +656,6 @@ fn page_icon(icon: &str) -> Element {
     }
 }
 
-fn should_open_typed_query_on_enter(
-    open_target: Option<vmux_command::open_target::OpenTarget>,
-    nav_mode: bool,
-    query: &str,
-) -> bool {
-    matches!(
-        open_target,
-        Some(vmux_command::open_target::OpenTarget::InPlace)
-    ) && !nav_mode
-        && !query.trim().is_empty()
-        && !query.trim_start().starts_with('>')
-}
-
 fn emit_action(action: &str, value: &str) {
     emit_action_with_target(action, value, None);
 }
@@ -1032,38 +1019,5 @@ fn dispatch_input_event(el: &web_sys::HtmlInputElement) {
     init.set_bubbles(true);
     if let Ok(evt) = web_sys::Event::new_with_event_init_dict("input", &init) {
         let _ = el.dispatch_event(&evt);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use vmux_command::open_target::OpenTarget;
-
-    #[test]
-    fn in_place_enter_opens_typed_query_without_nav_selection() {
-        assert!(should_open_typed_query_on_enter(
-            Some(OpenTarget::InPlace),
-            false,
-            "https://example.com"
-        ));
-    }
-
-    #[test]
-    fn in_place_enter_keeps_explicit_nav_selection() {
-        assert!(!should_open_typed_query_on_enter(
-            Some(OpenTarget::InPlace),
-            true,
-            "https://example.com"
-        ));
-    }
-
-    #[test]
-    fn command_query_enter_keeps_command_selection() {
-        assert!(!should_open_typed_query_on_enter(
-            Some(OpenTarget::InPlace),
-            false,
-            "> close"
-        ));
     }
 }

--- a/crates/vmux_layout/src/command_bar/style.rs
+++ b/crates/vmux_layout/src/command_bar/style.rs
@@ -264,8 +264,7 @@ mod tests {
     fn command_bar_in_place_enter_opens_typed_query_before_suggestions() {
         let source = include_str!("page.rs");
 
-        assert!(source.contains("fn should_open_typed_query_on_enter"));
-        assert!(source.contains("OpenTarget::InPlace"));
+        assert!(source.contains("should_open_typed_query_on_enter("));
         assert!(source.contains("emit_action_with_target(\"open\", &q, open_target)"));
     }
 


### PR DESCRIPTION
## Context

Clicking a command-bar result (e.g. the **Terminal** page suggestion) opened it, but pressing **Enter** on the same highlighted row instead ran a Google search for the typed text. In InPlace (address-bar) mode the Enter handler always treated a non-empty, non-command query as something to open directly as a URL/search, ignoring whatever result was highlighted.

## Implementation

`should_open_typed_query_on_enter` now additionally requires `looks_like_url(query)` before short-circuiting to "open the typed text". So the shortcut only fires for actual URLs/domains (`https://…`, `google.com`); plain search terms fall through to executing the selected result — identical to clicking it. Explicit arrow-key navigation and `>` command queries are unchanged.

The decision fn moved from the wasm-only `vmux_layout::command_bar::page` (whose `#[cfg(test)]` tests never ran in native CI) to `vmux_command::event`, beside `looks_like_url`, so the regression tests now run in CI.

## Checks / QA

Open the command bar in address-bar (InPlace) mode and, without arrowing:
- Type `terminal` → Enter opens the highlighted **Terminal** page (not a Google search).
- Type `https://example.com` or `google.com` → Enter navigates to the URL.
- Type `> ` command → Enter runs the selected command.
- Arrow down to a suggestion → Enter activates that suggestion.