### PR TITLE
fix(cef): defer windowed webview create until host window handle ready

### DIFF
--- a/patches/bevy_cef-0.5.2/src/webview.rs
+++ b/patches/bevy_cef-0.5.2/src/webview.rs
@@ -324,6 +324,9 @@ fn create_webview(
                     #[allow(deprecated)]
                     w.raw_window_handle().ok()
                 });
+            if windowed && host_window.is_none() {
+                continue;
+            }
             webview_debug_log(format!(
                 "create_webview entity={entity:?} uri={} size={:?} scale={device_scale_factor} transparent={transparent} host_window={} fps={windowless_frame_rate}",
                 uri.0,


### PR DESCRIPTION
## Context

At cold start the windowed (browse-mode) CEF browser can be created before winit finishes creating its OS window, so the parent native handle is . On macOS  then calls , which makes CEF spawn a **detached top-level window** (its own title bar / traffic lights) instead of a child view. Creation is one-shot, so it is never reparented — leaving a mis-placed black window that looks like a startup resize failure. More likely when a second window opens (its handle lags its content spawn).

## Implementation

Guard windowed creation on the parent handle being available; defer otherwise.  runs every frame and is -guarded, so the entity is picked up and attached as a proper child view as soon as the winit handle exists. OSR/offscreen webviews are unaffected (a null parent is fine offscreen).

## Checks / QA

- Cold-launch several times — including a saved space that opens two windows — and confirm no detached/black browser window appears.
- Browse-mode pages render inside their pane at the correct size/position from the first frame.
- Resize the host window and confirm content tracks the pane.