### PR TITLE
feat(agent): reliable run, terminal placement, and layout fixes

### DIFF
--- a/crates/vmux_agent/src/client/cli/vibe.rs
+++ b/crates/vmux_agent/src/client/cli/vibe.rs
@@ -33,7 +33,11 @@ impl CliAgentStrategy for VibeStrategy {
     }
 
     fn build_args(&self, _mcp: &McpServerConfig, session_id: Option<&str>) -> Vec<String> {
-        let mut args = Vec::new();
+        // vmux launches vibe non-interactively, so the folder-trust prompt can't
+        // be answered. Without trust, vibe runs restricted and ignores the user
+        // config (falling back to default models). `--trust` trusts the working
+        // directory for this invocation (vibe's documented automation flag).
+        let mut args = vec!["--trust".to_string()];
         if let Some(sid) = session_id {
             args.push("--resume".to_string());
             args.push(sid.to_string());
@@ -178,6 +182,22 @@ pub(crate) fn discover_vibe_session_id(
 mod tests {
     use super::*;
     use std::time::Duration;
+
+    #[test]
+    fn build_args_trusts_workdir_and_resumes_when_given() {
+        let mcp = McpServerConfig {
+            command: "vmux".to_string(),
+            args: vec![],
+            cwd: None,
+        };
+        // Non-interactive launches must pass --trust so vibe loads the user
+        // config instead of falling back to default models.
+        assert_eq!(VibeStrategy.build_args(&mcp, None), vec!["--trust"]);
+        assert_eq!(
+            VibeStrategy.build_args(&mcp, Some("sid-1")),
+            vec!["--trust", "--resume", "sid-1"]
+        );
+    }
 
     fn write_meta(
         dir: &Path,

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -51,12 +51,12 @@ const BUILTIN_AGENT_PROVIDERS: &[AgentKind] =
 #[derive(Resource, Clone, Default)]
 pub struct AgentExecutableOverride(pub std::collections::HashMap<AgentKind, bool>);
 
-/// Tracks the terminal a `run` opened for each agent (anchor → run-terminal
-/// `ProcessId`), so a later `run` without an explicit `terminal` reuses it
-/// instead of opening a new split. Stale entries self-heal: if the tracked
-/// terminal is gone, `run` opens a new one and overwrites the entry.
+/// The terminal "region" pane each agent's `run` terminals live in (anchor →
+/// pane). A bare `run` stacks new terminals into this pane instead of splitting
+/// the agent's own pane again; the first `run` creates it. Self-healing: a stale
+/// pane (closed) is replaced by a fresh split.
 #[derive(Resource, Default)]
-pub struct AgentRunTerminals(pub std::collections::HashMap<ProcessId, ProcessId>);
+pub struct AgentTerminalRegions(pub std::collections::HashMap<ProcessId, Entity>);
 
 fn resolve_agent_executable(
     kind: AgentKind,
@@ -99,7 +99,7 @@ impl Plugin for AgentPlugin {
 
         app.insert_resource(strategies)
             .init_resource::<AgentSessionToEntity>()
-            .init_resource::<AgentRunTerminals>()
+            .init_resource::<AgentTerminalRegions>()
             .init_resource::<AgentSessionDirty>()
             .add_message::<AgentCommandRequest>()
             .add_message::<AgentQueryRequest>()
@@ -478,6 +478,49 @@ fn resolve_self_pane(
     Some((term, pane))
 }
 
+/// The pane containing the terminal whose `ProcessId` is `pid` (its stack's
+/// parent pane). Used to anchor a `run` next to an existing terminal page.
+fn resolve_pane_for_pid(
+    pid: ProcessId,
+    term_pids: &Query<(Entity, &ProcessId), With<Terminal>>,
+    child_of_q: &Query<&ChildOf>,
+) -> Option<Entity> {
+    use bevy::ecs::relationship::Relationship;
+    let (term, _) = term_pids.iter().find(|(_, p)| **p == pid)?;
+    let stack = child_of_q.get(term).ok()?.get();
+    let pane = child_of_q.get(stack).ok()?.get();
+    Some(pane)
+}
+
+/// Split `pane` and return the new leaf pane. Batches several splits of the same
+/// pane in one tick (extend an existing split instead of re-splitting the leaf).
+#[allow(clippy::too_many_arguments)]
+fn split_pane_off(
+    commands: &mut Commands,
+    pane: Entity,
+    direction: &vmux_service::protocol::AgentPaneDirection,
+    focus: bool,
+    pane_children: &Query<&Children, With<Pane>>,
+    tab_filter: &Query<Entity, With<vmux_layout::stack::Stack>>,
+    split_dir_q: &Query<&PaneSplit>,
+    split_this_batch: &mut std::collections::HashSet<Entity>,
+) -> Entity {
+    let existing_tabs: Vec<Entity> = pane_children
+        .get(pane)
+        .map(|c| c.iter().filter(|&e| tab_filter.contains(e)).collect())
+        .unwrap_or_default();
+    let split_dir = vmux_layout::pane::direction_to_split(&to_pane_direction(direction));
+    let already_split = !split_this_batch.insert(pane) || split_dir_q.contains(pane);
+    vmux_layout::pane::split_or_extend(
+        commands,
+        pane,
+        split_dir,
+        &existing_tabs,
+        focus,
+        already_split,
+    )
+}
+
 fn to_pane_direction(
     d: &vmux_service::protocol::AgentPaneDirection,
 ) -> vmux_command::open::PaneDirection {
@@ -541,9 +584,12 @@ fn run_terminal_cwd(agent_launch_cwd: Option<&str>, active_space: Option<&Active
 fn handle_agent_self_commands(
     mut reader: MessageReader<AgentCommandRequest>,
     agent_terms: Query<(Entity, &ProcessId, &ChildOf), With<AgentSession>>,
+    term_pids: Query<(Entity, &ProcessId), With<Terminal>>,
     child_of_q: Query<&ChildOf>,
     launch_q: Query<&TerminalLaunch>,
     pane_children: Query<&Children, With<Pane>>,
+    panes: Query<Entity, With<Pane>>,
+    split_dir_q: Query<&PaneSplit>,
     tab_filter: Query<Entity, With<vmux_layout::stack::Stack>>,
     mut open_beside_writer: MessageWriter<vmux_layout::OpenBesideRequest>,
     mut terminal_stack_spawn_writer: MessageWriter<TerminalStackSpawnRequest>,
@@ -551,14 +597,17 @@ fn handle_agent_self_commands(
     service: Option<Res<ServiceClient>>,
     active_space: Option<Res<ActiveSpace>>,
     settings: Res<AppSettings>,
-    live_terms: Query<&ProcessId, (With<Terminal>, Without<ProcessExited>)>,
-    mut run_terminals: ResMut<AgentRunTerminals>,
+    mut regions: ResMut<AgentTerminalRegions>,
 ) {
     use vmux_service::protocol::{AgentCommandResult, ClientMessage};
     let Some(service) = service else {
         for _ in reader.read() {}
         return;
     };
+    // Anchors split during this batch. Several `run`s dispatched in one tick all
+    // resolve to the same agent pane; the first splits it, the rest must extend
+    // that split rather than re-split the leaf (which would orphan empty panes).
+    let mut split_this_batch: std::collections::HashSet<Entity> = std::collections::HashSet::new();
     for request in reader.read() {
         let result = match &request.command {
             ServiceAgentCommand::OpenBeside {
@@ -584,6 +633,8 @@ fn handle_agent_self_commands(
                 command,
                 direction,
                 focus,
+                beside,
+                mode,
                 terminal,
                 done_marker,
             } => {
@@ -598,61 +649,77 @@ fn handle_agent_self_commands(
                         });
                         AgentCommandResult::Text(pid.to_string())
                     }
-                    None => {
-                        // Reuse this agent's existing run-terminal if it's still
-                        // alive; otherwise open a new one and remember it.
-                        let reuse = run_terminals
-                            .0
-                            .get(anchor)
-                            .copied()
-                            .filter(|pid| live_terms.iter().any(|p| p == pid));
-                        match reuse {
+                    None => 'spawn: {
+                        let Some((agent_term, self_pane)) =
+                            resolve_self_pane(*anchor, &agent_terms, &child_of_q)
+                        else {
+                            break 'spawn AgentCommandResult::Error(
+                                "self process not found".to_string(),
+                            );
+                        };
+                        // Resolve an explicit `beside` anchor up front (errors if stale).
+                        let beside_pane = match beside {
                             Some(pid) => {
-                                service.0.send(ClientMessage::ProcessInput {
-                                    process_id: pid,
-                                    data,
-                                });
-                                AgentCommandResult::Text(pid.to_string())
+                                match resolve_pane_for_pid(*pid, &term_pids, &child_of_q) {
+                                    Some(pane) => Some(pane),
+                                    None => {
+                                        break 'spawn AgentCommandResult::Error(format!(
+                                            "run.beside page not found: {pid}"
+                                        ));
+                                    }
+                                }
                             }
-                            None => match resolve_self_pane(*anchor, &agent_terms, &child_of_q) {
-                                None => {
-                                    AgentCommandResult::Error("self process not found".to_string())
-                                }
-                                Some((term, pane)) => {
-                                    let existing_tabs: Vec<Entity> = pane_children
-                                        .get(pane)
-                                        .map(|c| {
-                                            c.iter().filter(|&e| tab_filter.contains(e)).collect()
-                                        })
-                                        .unwrap_or_default();
-                                    let split_dir = vmux_layout::pane::direction_to_split(
-                                        &to_pane_direction(direction),
-                                    );
-                                    let p2 = vmux_layout::pane::split_leaf_into_two(
+                            None => None,
+                        };
+                        use vmux_service::protocol::PlacementMode;
+                        let target_pane = match (beside_pane, *mode) {
+                            // Explicit split: a new pane off the given page's pane (or self).
+                            (anchor, PlacementMode::Split) => split_pane_off(
+                                &mut commands,
+                                anchor.unwrap_or(self_pane),
+                                direction,
+                                *focus,
+                                &pane_children,
+                                &tab_filter,
+                                &split_dir_q,
+                                &mut split_this_batch,
+                            ),
+                            // Stack into the given page's pane.
+                            (Some(pane), _) => pane,
+                            // No anchor: reuse the agent's terminal region, else split one
+                            // off the agent the first time (don't spawn a pane unless needed).
+                            (None, _) => {
+                                let region = regions
+                                    .0
+                                    .get(anchor)
+                                    .copied()
+                                    .filter(|p| panes.contains(*p));
+                                region.unwrap_or_else(|| {
+                                    split_pane_off(
                                         &mut commands,
-                                        pane,
-                                        split_dir,
-                                        &existing_tabs,
+                                        self_pane,
+                                        direction,
                                         *focus,
-                                    );
-                                    let new_pid = ProcessId::new();
-                                    let agent_cwd = launch_q.get(term).ok().map(|l| l.cwd.clone());
-                                    let cwd = run_terminal_cwd(
-                                        agent_cwd.as_deref(),
-                                        active_space.as_deref(),
-                                    );
-                                    terminal_stack_spawn_writer.write(TerminalStackSpawnRequest {
-                                        pane: p2,
-                                        cwd: Some(cwd),
-                                        pending_input: Some(data),
-                                        process_id: Some(new_pid),
-                                        activate: *focus,
-                                    });
-                                    run_terminals.0.insert(*anchor, new_pid);
-                                    AgentCommandResult::Text(new_pid.to_string())
-                                }
-                            },
-                        }
+                                        &pane_children,
+                                        &tab_filter,
+                                        &split_dir_q,
+                                        &mut split_this_batch,
+                                    )
+                                })
+                            }
+                        };
+                        regions.0.insert(*anchor, target_pane);
+                        let new_pid = ProcessId::new();
+                        let agent_cwd = launch_q.get(agent_term).ok().map(|l| l.cwd.clone());
+                        let cwd = run_terminal_cwd(agent_cwd.as_deref(), active_space.as_deref());
+                        terminal_stack_spawn_writer.write(TerminalStackSpawnRequest {
+                            pane: target_pane,
+                            cwd: Some(cwd),
+                            pending_input: Some(data),
+                            process_id: Some(new_pid),
+                            activate: *focus,
+                        });
+                        AgentCommandResult::Text(new_pid.to_string())
                     }
                 }
             }

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -13,7 +13,7 @@ use vmux_core::{
 };
 use vmux_layout::event::TERMINAL_PAGE_URL;
 use vmux_layout::{
-    pane::{Pane, PaneSplit},
+    pane::{ForcePaneClose, Pane, PaneSplit},
     stack::FocusedStack,
 };
 use vmux_service::client::ServiceClient;
@@ -23,9 +23,11 @@ use vmux_service::protocol::{
 };
 use vmux_setting::AppSettings;
 use vmux_space::ActiveSpace;
-use vmux_terminal::ProcessExited;
 use vmux_terminal::launch::TerminalLaunch;
-use vmux_terminal::{ServiceMessageSet, TerminalStackSpawnRequest, new_terminal_bundle_with_cwd};
+use vmux_terminal::{
+    ProcessExited, ServiceMessageSet, Terminal, TerminalStackSpawnRequest,
+    new_terminal_bundle_with_cwd,
+};
 
 use crate::AgentVariant;
 use crate::client::cli::claude::ClaudeStrategy;
@@ -48,6 +50,13 @@ const BUILTIN_AGENT_PROVIDERS: &[AgentKind] =
 /// without depending on which CLIs are installed on the host.
 #[derive(Resource, Clone, Default)]
 pub struct AgentExecutableOverride(pub std::collections::HashMap<AgentKind, bool>);
+
+/// Tracks the terminal a `run` opened for each agent (anchor → run-terminal
+/// `ProcessId`), so a later `run` without an explicit `terminal` reuses it
+/// instead of opening a new split. Stale entries self-heal: if the tracked
+/// terminal is gone, `run` opens a new one and overwrites the entry.
+#[derive(Resource, Default)]
+pub struct AgentRunTerminals(pub std::collections::HashMap<ProcessId, ProcessId>);
 
 fn resolve_agent_executable(
     kind: AgentKind,
@@ -90,6 +99,7 @@ impl Plugin for AgentPlugin {
 
         app.insert_resource(strategies)
             .init_resource::<AgentSessionToEntity>()
+            .init_resource::<AgentRunTerminals>()
             .init_resource::<AgentSessionDirty>()
             .add_message::<AgentCommandRequest>()
             .add_message::<AgentQueryRequest>()
@@ -504,7 +514,7 @@ fn command_with_marker(shell: &str, command: &str, token: &str) -> String {
         .unwrap_or(shell);
     match base {
         "nu" | "nushell" => format!(
-            "try {{ {command}; print \"\\n__VMUX_DONE_{token}_0__\" }} catch {{ |e| print $\"\\n__VMUX_DONE_{token}_($e.exit_code? | default 1)__\" }}"
+            "try {{ {command}; print $\"\\n__VMUX_DONE_{token}_($env.LAST_EXIT_CODE)__\" }} catch {{ |e| print $\"\\n__VMUX_DONE_{token}_($e.exit_code? | default 1)__\" }}"
         ),
         "fish" => format!("{command}; printf '\\n__VMUX_DONE_{token}_%s__\\n' $status"),
         _ => format!("{command}; printf '\\n__VMUX_DONE_{token}_%s__\\n' \"$?\""),
@@ -541,6 +551,8 @@ fn handle_agent_self_commands(
     service: Option<Res<ServiceClient>>,
     active_space: Option<Res<ActiveSpace>>,
     settings: Res<AppSettings>,
+    live_terms: Query<&ProcessId, (With<Terminal>, Without<ProcessExited>)>,
+    mut run_terminals: ResMut<AgentRunTerminals>,
 ) {
     use vmux_service::protocol::{AgentCommandResult, ClientMessage};
     let Some(service) = service else {
@@ -586,37 +598,62 @@ fn handle_agent_self_commands(
                         });
                         AgentCommandResult::Text(pid.to_string())
                     }
-                    None => match resolve_self_pane(*anchor, &agent_terms, &child_of_q) {
-                        None => AgentCommandResult::Error("self process not found".to_string()),
-                        Some((term, pane)) => {
-                            let existing_tabs: Vec<Entity> = pane_children
-                                .get(pane)
-                                .map(|c| c.iter().filter(|&e| tab_filter.contains(e)).collect())
-                                .unwrap_or_default();
-                            let split_dir = vmux_layout::pane::direction_to_split(
-                                &to_pane_direction(direction),
-                            );
-                            let p2 = vmux_layout::pane::split_leaf_into_two(
-                                &mut commands,
-                                pane,
-                                split_dir,
-                                &existing_tabs,
-                                *focus,
-                            );
-                            let new_pid = ProcessId::new();
-                            let agent_cwd = launch_q.get(term).ok().map(|l| l.cwd.clone());
-                            let cwd =
-                                run_terminal_cwd(agent_cwd.as_deref(), active_space.as_deref());
-                            terminal_stack_spawn_writer.write(TerminalStackSpawnRequest {
-                                pane: p2,
-                                cwd: Some(cwd),
-                                pending_input: Some(data),
-                                process_id: Some(new_pid),
-                                activate: *focus,
-                            });
-                            AgentCommandResult::Text(new_pid.to_string())
+                    None => {
+                        // Reuse this agent's existing run-terminal if it's still
+                        // alive; otherwise open a new one and remember it.
+                        let reuse = run_terminals
+                            .0
+                            .get(anchor)
+                            .copied()
+                            .filter(|pid| live_terms.iter().any(|p| p == pid));
+                        match reuse {
+                            Some(pid) => {
+                                service.0.send(ClientMessage::ProcessInput {
+                                    process_id: pid,
+                                    data,
+                                });
+                                AgentCommandResult::Text(pid.to_string())
+                            }
+                            None => match resolve_self_pane(*anchor, &agent_terms, &child_of_q) {
+                                None => {
+                                    AgentCommandResult::Error("self process not found".to_string())
+                                }
+                                Some((term, pane)) => {
+                                    let existing_tabs: Vec<Entity> = pane_children
+                                        .get(pane)
+                                        .map(|c| {
+                                            c.iter().filter(|&e| tab_filter.contains(e)).collect()
+                                        })
+                                        .unwrap_or_default();
+                                    let split_dir = vmux_layout::pane::direction_to_split(
+                                        &to_pane_direction(direction),
+                                    );
+                                    let p2 = vmux_layout::pane::split_leaf_into_two(
+                                        &mut commands,
+                                        pane,
+                                        split_dir,
+                                        &existing_tabs,
+                                        *focus,
+                                    );
+                                    let new_pid = ProcessId::new();
+                                    let agent_cwd = launch_q.get(term).ok().map(|l| l.cwd.clone());
+                                    let cwd = run_terminal_cwd(
+                                        agent_cwd.as_deref(),
+                                        active_space.as_deref(),
+                                    );
+                                    terminal_stack_spawn_writer.write(TerminalStackSpawnRequest {
+                                        pane: p2,
+                                        cwd: Some(cwd),
+                                        pending_input: Some(data),
+                                        process_id: Some(new_pid),
+                                        activate: *focus,
+                                    });
+                                    run_terminals.0.insert(*anchor, new_pid);
+                                    AgentCommandResult::Text(new_pid.to_string())
+                                }
+                            },
                         }
-                    },
+                    }
                 }
             }
             _ => continue,
@@ -684,21 +721,40 @@ pub fn detect_agent_session_process_exit(
         (Entity, Option<&vmux_terminal::pid::Pid>, &mut PageMetadata),
         (With<AgentSession>, With<ProcessExited>),
     >,
+    child_of: Query<&ChildOf>,
 ) {
+    use bevy::ecs::relationship::Relationship;
     for (entity, pid, mut meta) in &mut q {
         commands
             .entity(entity)
             .remove::<AgentSession>()
             .remove::<SessionId>()
             .remove::<PendingAgentSession>();
-        let next = match pid {
-            Some(vmux_terminal::pid::Pid(p)) => {
-                format!("{}{p}", vmux_terminal::event::TERMINAL_PAGE_URL)
+        // A vibe agent terminal that exits should close its pane entirely, not
+        // linger as a shell/terminal. The terminal is a child of a stack, which
+        // is a child of a pane; mark that pane for a no-dialog force close. If
+        // the pane can't be resolved, fall back to converting to a terminal.
+        let pane = child_of
+            .get(entity)
+            .ok()
+            .map(Relationship::get)
+            .and_then(|stack| child_of.get(stack).ok())
+            .map(Relationship::get);
+        match pane {
+            Some(pane) => {
+                commands.entity(pane).insert(ForcePaneClose);
             }
-            None => vmux_terminal::event::TERMINAL_PAGE_URL.to_string(),
-        };
-        if meta.url != next {
-            meta.url = next;
+            None => {
+                let next = match pid {
+                    Some(vmux_terminal::pid::Pid(p)) => {
+                        format!("{}{p}", vmux_terminal::event::TERMINAL_PAGE_URL)
+                    }
+                    None => vmux_terminal::event::TERMINAL_PAGE_URL.to_string(),
+                };
+                if meta.url != next {
+                    meta.url = next;
+                }
+            }
         }
         writer.write(AgentSessionExited { entity });
     }
@@ -1711,10 +1767,12 @@ mod tests {
     #[test]
     fn command_with_marker_is_shell_aware() {
         // nushell aborts `;` on failure, so it wraps in try/catch and reads the
-        // exit code from the caught error.
+        // exit code from the caught error. Success uses `($env.LAST_EXIT_CODE)`
+        // (not a literal digit) so the echoed command line can't be matched as a
+        // completion marker.
         assert_eq!(
             command_with_marker("/opt/homebrew/bin/nu", "ls", "abc"),
-            "try { ls; print \"\\n__VMUX_DONE_abc_0__\" } catch { |e| print $\"\\n__VMUX_DONE_abc_($e.exit_code? | default 1)__\" }"
+            "try { ls; print $\"\\n__VMUX_DONE_abc_($env.LAST_EXIT_CODE)__\" } catch { |e| print $\"\\n__VMUX_DONE_abc_($e.exit_code? | default 1)__\" }"
         );
         assert_eq!(
             command_with_marker("/usr/local/bin/fish", "ls", "abc"),

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -481,11 +481,58 @@ fn to_pane_direction(
     }
 }
 
+fn agent_terminal_shell(settings: &AppSettings) -> String {
+    settings
+        .terminal
+        .as_ref()
+        .map(|t| t.resolve_theme(&t.default_theme).shell)
+        .unwrap_or_else(|| std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string()))
+}
+
+/// Wrap a `run` command so the shell prints a completion marker carrying the
+/// exit code once the command finishes (success OR failure). `token` is a unique
+/// per-run id; the printed marker is `__VMUX_DONE_<token>_<exit_code>__`.
+///
+/// posix/fish chain with `;` (which continues after a non-zero command). nushell
+/// aborts the rest of a `;` line when an external command fails, so it needs a
+/// `try`/`catch` wrapper to always print the marker and recover the exit code
+/// from the caught error.
+fn command_with_marker(shell: &str, command: &str, token: &str) -> String {
+    let base = std::path::Path::new(shell)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(shell);
+    match base {
+        "nu" | "nushell" => format!(
+            "try {{ {command}; print \"\\n__VMUX_DONE_{token}_0__\" }} catch {{ |e| print $\"\\n__VMUX_DONE_{token}_($e.exit_code? | default 1)__\" }}"
+        ),
+        "fish" => format!("{command}; printf '\\n__VMUX_DONE_{token}_%s__\\n' $status"),
+        _ => format!("{command}; printf '\\n__VMUX_DONE_{token}_%s__\\n' \"$?\""),
+    }
+}
+
+fn run_command_line(command: &str, token: Option<&str>, settings: &AppSettings) -> String {
+    match token {
+        Some(token) => command_with_marker(&agent_terminal_shell(settings), command, token),
+        None => command.to_string(),
+    }
+}
+
+fn run_terminal_cwd(agent_launch_cwd: Option<&str>, active_space: Option<&ActiveSpace>) -> PathBuf {
+    if let Some(Ok(Some(path))) = agent_launch_cwd.map(valid_cwd) {
+        return path;
+    }
+    active_space
+        .map(|s| space_dir(&s.record.id))
+        .unwrap_or_else(default_space_dir)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn handle_agent_self_commands(
     mut reader: MessageReader<AgentCommandRequest>,
     agent_terms: Query<(Entity, &ProcessId, &ChildOf), With<AgentSession>>,
     child_of_q: Query<&ChildOf>,
+    launch_q: Query<&TerminalLaunch>,
     pane_children: Query<&Children, With<Pane>>,
     tab_filter: Query<Entity, With<vmux_layout::stack::Stack>>,
     mut open_beside_writer: MessageWriter<vmux_layout::OpenBesideRequest>,
@@ -493,6 +540,7 @@ fn handle_agent_self_commands(
     mut commands: Commands,
     service: Option<Res<ServiceClient>>,
     active_space: Option<Res<ActiveSpace>>,
+    settings: Res<AppSettings>,
 ) {
     use vmux_service::protocol::{AgentCommandResult, ClientMessage};
     let Some(service) = service else {
@@ -525,8 +573,10 @@ fn handle_agent_self_commands(
                 direction,
                 focus,
                 terminal,
+                done_marker,
             } => {
-                let mut data = command.clone().into_bytes();
+                let mut data =
+                    run_command_line(command, done_marker.as_deref(), &settings).into_bytes();
                 data.push(b'\r');
                 match terminal {
                     Some(pid) => {
@@ -538,7 +588,7 @@ fn handle_agent_self_commands(
                     }
                     None => match resolve_self_pane(*anchor, &agent_terms, &child_of_q) {
                         None => AgentCommandResult::Error("self process not found".to_string()),
-                        Some((_, pane)) => {
+                        Some((term, pane)) => {
                             let existing_tabs: Vec<Entity> = pane_children
                                 .get(pane)
                                 .map(|c| c.iter().filter(|&e| tab_filter.contains(e)).collect())
@@ -554,10 +604,9 @@ fn handle_agent_self_commands(
                                 *focus,
                             );
                             let new_pid = ProcessId::new();
-                            let cwd = active_space
-                                .as_deref()
-                                .map(|s| space_dir(&s.record.id))
-                                .unwrap_or_else(default_space_dir);
+                            let agent_cwd = launch_q.get(term).ok().map(|l| l.cwd.clone());
+                            let cwd =
+                                run_terminal_cwd(agent_cwd.as_deref(), active_space.as_deref());
                             terminal_stack_spawn_writer.write(TerminalStackSpawnRequest {
                                 pane: p2,
                                 cwd: Some(cwd),
@@ -733,8 +782,9 @@ fn handle_agent_queries(
                     result: AgentQueryResult::Spaces(json),
                 });
             }
-            // ReadTerminal is answered by the service directly; it never reaches the GUI.
-            AgentQuery::ReadTerminal { .. } => {}
+            // ReadTerminal/ReadTerminalFull are answered by the service directly;
+            // they never reach the GUI.
+            AgentQuery::ReadTerminal { .. } | AgentQuery::ReadTerminalFull { .. } => {}
         }
     }
 }
@@ -1641,5 +1691,57 @@ mod tests {
             spawns[0].cwd, dir,
             "claude page cwd resolves to space startup_dir"
         );
+    }
+
+    #[test]
+    fn run_terminal_cwd_inherits_agent_launch_dir() {
+        let dir = std::env::temp_dir().join(format!("vmux-run-cwd-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let got = run_terminal_cwd(Some(&dir.to_string_lossy()), None);
+        let _ = std::fs::remove_dir_all(&dir);
+        assert_eq!(got, dir);
+    }
+
+    #[test]
+    fn run_terminal_cwd_falls_back_when_agent_cwd_missing() {
+        assert_eq!(run_terminal_cwd(Some(""), None), default_space_dir());
+        assert_eq!(run_terminal_cwd(None, None), default_space_dir());
+    }
+
+    #[test]
+    fn command_with_marker_is_shell_aware() {
+        // nushell aborts `;` on failure, so it wraps in try/catch and reads the
+        // exit code from the caught error.
+        assert_eq!(
+            command_with_marker("/opt/homebrew/bin/nu", "ls", "abc"),
+            "try { ls; print \"\\n__VMUX_DONE_abc_0__\" } catch { |e| print $\"\\n__VMUX_DONE_abc_($e.exit_code? | default 1)__\" }"
+        );
+        assert_eq!(
+            command_with_marker("/usr/local/bin/fish", "ls", "abc"),
+            "ls; printf '\\n__VMUX_DONE_abc_%s__\\n' $status"
+        );
+        assert_eq!(
+            command_with_marker("/bin/zsh", "ls", "abc"),
+            "ls; printf '\\n__VMUX_DONE_abc_%s__\\n' \"$?\""
+        );
+        // Unknown shells fall back to posix syntax.
+        assert_eq!(
+            command_with_marker("/bin/bash", "ls", "abc"),
+            "ls; printf '\\n__VMUX_DONE_abc_%s__\\n' \"$?\""
+        );
+    }
+
+    #[test]
+    fn run_command_line_noop_when_token_absent() {
+        let settings = test_settings();
+        assert_eq!(run_command_line("ls -la", None, &settings), "ls -la");
+    }
+
+    #[test]
+    fn run_command_line_embeds_marker_when_token_present() {
+        let settings = test_settings();
+        let out = run_command_line("ls -la", Some("tok9"), &settings);
+        assert!(out.contains("ls -la"), "got: {out}");
+        assert!(out.contains("__VMUX_DONE_tok9_"), "got: {out}");
     }
 }

--- a/crates/vmux_core/src/profile.rs
+++ b/crates/vmux_core/src/profile.rs
@@ -29,6 +29,54 @@ pub fn shared_data_dir() -> PathBuf {
     }
 }
 
+/// User config directory: `~/.vmux`. Holds `settings.ron` (and per-build
+/// overrides), separate from the profile-isolated [`shared_data_dir`].
+pub fn config_dir() -> PathBuf {
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/"));
+    home.join(".vmux")
+}
+
+/// Per-build config subdir, or `None` for the shared (release) settings.
+fn config_suffix() -> Option<&'static str> {
+    match env!("VMUX_BUILD_PROFILE") {
+        "release" | "local" => None,
+        other => Some(other),
+    }
+}
+
+fn settings_candidates_in(base: &std::path::Path, suffix: Option<&str>) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(suffix) = suffix {
+        candidates.push(base.join(suffix).join("settings.ron"));
+    }
+    candidates.push(base.join("settings.ron"));
+    candidates
+}
+
+/// Settings files in priority order: the per-build override first (e.g.
+/// `~/.vmux/dev/settings.ron`), then the shared `~/.vmux/settings.ron`.
+pub fn settings_path_candidates() -> Vec<PathBuf> {
+    settings_candidates_in(&config_dir(), config_suffix())
+}
+
+/// The settings file to read/write: the first candidate that exists, falling
+/// back to the shared `~/.vmux/settings.ron` when none exist yet.
+pub fn settings_path() -> PathBuf {
+    let candidates = settings_path_candidates();
+    candidates
+        .iter()
+        .find(|path| path.exists())
+        .cloned()
+        .unwrap_or_else(|| {
+            candidates
+                .last()
+                .cloned()
+                .expect("settings candidates always include the shared path")
+        })
+}
+
 pub fn profile_dir() -> PathBuf {
     shared_data_dir()
         .join("profiles")
@@ -264,5 +312,31 @@ mod tests {
         assert!(!space_dir_path(&home, "solo").exists());
         assert!(space_dir_path(&home, "keep").is_dir());
         let _ = std::fs::remove_dir_all(&home);
+    }
+    #[test]
+    fn settings_live_in_dot_vmux_not_data_dir() {
+        // Settings live under ~/.vmux, separate from the profile-isolated data dir.
+        for candidate in settings_path_candidates() {
+            assert!(candidate.starts_with(config_dir()));
+            assert!(!candidate.starts_with(shared_data_dir()));
+        }
+    }
+
+    #[test]
+    fn settings_candidates_prefer_per_build_override_then_shared() {
+        let base = PathBuf::from("/base");
+        // Release/local: shared file only.
+        assert_eq!(
+            settings_candidates_in(&base, None),
+            vec![base.join("settings.ron")]
+        );
+        // Dev: per-build override first, then the shared file.
+        assert_eq!(
+            settings_candidates_in(&base, Some("dev")),
+            vec![
+                base.join("dev").join("settings.ron"),
+                base.join("settings.ron"),
+            ]
+        );
     }
 }

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -575,10 +575,30 @@ fn handle_pane_commands(
                 let Ok(siblings) = pane_children.get(parent) else {
                     continue;
                 };
-                let sibling = siblings
+                let pane_siblings: Vec<Entity> = siblings
                     .iter()
-                    .find(|&e| e != active && (leaf_panes.contains(e) || split_dir_q.contains(e)));
-                let Some(sibling) = sibling else {
+                    .filter(|&e| e != active && (leaf_panes.contains(e) || split_dir_q.contains(e)))
+                    .collect();
+
+                if pane_siblings.len() >= 2 {
+                    commands.entity(active).despawn();
+                    let new_active_pane = pane_siblings
+                        .iter()
+                        .copied()
+                        .max_by_key(|&e| pane_ts.get(e).map(|(_, t)| t.0).unwrap_or(0))
+                        .unwrap_or(pane_siblings[0]);
+                    let focus_leaf =
+                        first_leaf_descendant(new_active_pane, &pane_children, &leaf_panes);
+                    commands.entity(focus_leaf).insert(LastActivatedAt::now());
+                    if let Some(stack) = active_stack_in_pane(focus_leaf, &pane_children, &stack_ts)
+                        .or_else(|| first_stack_in_pane(focus_leaf, &pane_children, &tab_filter))
+                    {
+                        commands.entity(stack).insert(LastActivatedAt::now());
+                    }
+                    continue;
+                }
+
+                let Some(sibling) = pane_siblings.into_iter().next() else {
                     continue;
                 };
 
@@ -821,6 +841,39 @@ pub fn split_leaf_into_two(
     p2
 }
 
+/// Return a fresh empty leaf pane beside `anchor`, to host an agent-spawned
+/// terminal. When `anchor` is still a leaf (`already_split == false`), it is
+/// split in two via [`split_leaf_into_two`] (its stacks move into the first
+/// child, the returned pane is the second). When `anchor` is already a split —
+/// either from a previous frame, or from an earlier call in the *same* command
+/// buffer — the new leaf is appended as another child of that split.
+///
+/// Calling [`split_leaf_into_two`] repeatedly on the same leaf within one
+/// command buffer (e.g. several agent `run`s dispatched in one tick) would wrap
+/// it again on each call and orphan an empty `pane1` every time; routing the
+/// 2nd+ split through here keeps the result a clean N-ary split with no empties.
+pub fn split_or_extend(
+    commands: &mut Commands,
+    anchor: Entity,
+    split_dir: PaneSplitDirection,
+    existing_tabs: &[Entity],
+    activate_new: bool,
+    already_split: bool,
+) -> Entity {
+    if already_split {
+        let ts = if activate_new {
+            LastActivatedAt::now()
+        } else {
+            LastActivatedAt(0)
+        };
+        commands
+            .spawn((leaf_pane_bundle(), ts, ChildOf(anchor)))
+            .id()
+    } else {
+        split_leaf_into_two(commands, anchor, split_dir, existing_tabs, activate_new)
+    }
+}
+
 #[derive(Message, Clone)]
 pub struct OpenBesideRequest {
     pub pane: Entity,
@@ -835,23 +888,30 @@ pub struct OpenBesideRequest {
 pub fn handle_open_beside_requests(
     mut reader: MessageReader<OpenBesideRequest>,
     pane_children: Query<&Children, With<Pane>>,
+    split_dir_q: Query<&PaneSplit>,
     tab_filter: Query<Entity, With<Stack>>,
     mut commands: Commands,
     mut page_open_requests: MessageWriter<PageOpenRequest>,
     mut new_stack_ctx: ResMut<NewStackContext>,
 ) {
+    // Anchors split during this batch: several `open_page`s dispatched in one
+    // tick all resolve to the same agent pane; the first splits it, the rest must
+    // extend that split rather than re-split the leaf (which orphans empties).
+    let mut split_this_batch: std::collections::HashSet<Entity> = std::collections::HashSet::new();
     for req in reader.read() {
         let existing_tabs: Vec<Entity> = pane_children
             .get(req.pane)
             .map(|c| c.iter().filter(|&e| tab_filter.contains(e)).collect())
             .unwrap_or_default();
         let split_dir = direction_to_split(&req.direction);
-        let p2 = split_leaf_into_two(
+        let already_split = !split_this_batch.insert(req.pane) || split_dir_q.contains(req.pane);
+        let p2 = split_or_extend(
             &mut commands,
             req.pane,
             split_dir,
             &existing_tabs,
             req.focus,
+            already_split,
         );
         let stack_ts = if req.focus {
             LastActivatedAt::now()
@@ -2358,6 +2418,105 @@ mod tests {
     }
 
     #[test]
+    fn closing_one_of_three_siblings_keeps_split_intact() {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, CommandPlugin))
+            .init_resource::<PaneHoverIntent>()
+            .init_resource::<PendingCursorWarp>()
+            .init_resource::<NewStackContext>()
+            .init_resource::<ConfirmCloseSettings>()
+            .add_message::<PageOpenRequest>()
+            .insert_resource(test_settings())
+            .add_systems(Update, handle_pane_commands.in_set(WriteAppCommands));
+
+        let _window = app.world_mut().spawn(PrimaryWindow).id();
+        let tab_e = app
+            .world_mut()
+            .spawn((Tab::default(), LastActivatedAt::now()))
+            .id();
+        let root = app
+            .world_mut()
+            .spawn((
+                Pane,
+                PaneSplit {
+                    direction: PaneSplitDirection::Row,
+                },
+                Node {
+                    flex_direction: FlexDirection::Row,
+                    ..default()
+                },
+                ChildOf(tab_e),
+            ))
+            .id();
+        let a = place_pane(
+            &mut app,
+            root,
+            Vec2::new(200.0, 400.0),
+            Vec2::new(400.0, 800.0),
+        );
+        let b = place_pane(
+            &mut app,
+            root,
+            Vec2::new(600.0, 400.0),
+            Vec2::new(400.0, 800.0),
+        );
+        let c = place_pane(
+            &mut app,
+            root,
+            Vec2::new(1000.0, 400.0),
+            Vec2::new(400.0, 800.0),
+        );
+
+        app.world_mut().entity_mut(a).insert(LastActivatedAt(10));
+        app.world_mut().entity_mut(c).insert(LastActivatedAt(20));
+        app.world_mut().entity_mut(b).insert(LastActivatedAt(30));
+        app.world_mut()
+            .resource_mut::<Messages<AppCommand>>()
+            .write(AppCommand::Layout(LayoutCommand::Pane(PaneCommand::Close)));
+        app.update();
+
+        assert!(
+            app.world().get_entity(b).is_err(),
+            "the closed middle pane must be despawned"
+        );
+        let split = app
+            .world()
+            .get::<PaneSplit>(root)
+            .expect("a 3-way split must stay a split after one pane closes");
+        assert_eq!(
+            split.direction,
+            PaneSplitDirection::Row,
+            "surviving split keeps its direction"
+        );
+        let children: Vec<Entity> = app
+            .world()
+            .get::<Children>(root)
+            .expect("root has children")
+            .iter()
+            .collect();
+        assert_eq!(
+            children.len(),
+            2,
+            "root keeps exactly the two surviving leaves directly under it"
+        );
+        assert!(
+            children.contains(&a) && children.contains(&c),
+            "both survivors remain direct children of the split"
+        );
+        assert!(
+            app.world().get_entity(a).is_ok() && app.world().get_entity(c).is_ok(),
+            "survivors are not despawned"
+        );
+        for survivor in [a, c] {
+            let has_stack = app
+                .world()
+                .get::<Children>(survivor)
+                .is_some_and(|ch| ch.iter().any(|e| app.world().get::<Stack>(e).is_some()));
+            assert!(has_stack, "survivor keeps its own stack");
+        }
+    }
+
+    #[test]
     fn split_gap_only_applies_on_split_axis() {
         let row = pane_split_gaps(PaneSplitDirection::Row, 8.0);
         let column = pane_split_gaps(PaneSplitDirection::Column, 8.0);
@@ -3245,6 +3404,93 @@ mod tests {
     }
 
     #[test]
+    fn split_or_extend_batched_runs_make_no_empty_panes() {
+        use bevy_ecs::system::RunSystemOnce;
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        let tab = app
+            .world_mut()
+            .spawn((Tab::default(), LastActivatedAt::now()))
+            .id();
+        let anchor = app
+            .world_mut()
+            .spawn((leaf_pane_bundle(), LastActivatedAt::now(), ChildOf(tab)))
+            .id();
+        let agent_stack = app
+            .world_mut()
+            .spawn((stack_bundle(), LastActivatedAt::now(), ChildOf(anchor)))
+            .id();
+
+        // Two agent runs splitting the same anchor in ONE command buffer: the
+        // first really splits, the second extends the now-split anchor.
+        let (p2a, p2b) = app
+            .world_mut()
+            .run_system_once(move |mut commands: Commands| {
+                let existing = [agent_stack];
+                let p2a = split_or_extend(
+                    &mut commands,
+                    anchor,
+                    PaneSplitDirection::Row,
+                    &existing,
+                    false,
+                    false,
+                );
+                let p2b = split_or_extend(
+                    &mut commands,
+                    anchor,
+                    PaneSplitDirection::Row,
+                    &existing,
+                    false,
+                    true,
+                );
+                (p2a, p2b)
+            })
+            .unwrap();
+
+        let children: Vec<Entity> = app
+            .world()
+            .get::<Children>(anchor)
+            .expect("anchor has children")
+            .iter()
+            .collect();
+        assert_eq!(
+            children.len(),
+            3,
+            "anchor holds exactly the stack-holder + two terminal leaves (no orphaned empty pane)"
+        );
+        assert!(
+            children.contains(&p2a) && children.contains(&p2b),
+            "both new terminal leaves are direct children of the split"
+        );
+        let stack_holders = children
+            .iter()
+            .filter(|&&c| {
+                app.world()
+                    .get::<Children>(c)
+                    .is_some_and(|cc| cc.iter().any(|e| app.world().get::<Stack>(e).is_some()))
+            })
+            .count();
+        assert_eq!(
+            stack_holders, 1,
+            "the agent stack lives in exactly one child"
+        );
+        let empty_leaves = children
+            .iter()
+            .filter(|&&c| {
+                app.world()
+                    .get::<Children>(c)
+                    .map(|cc| cc.iter().count())
+                    .unwrap_or(0)
+                    == 0
+            })
+            .count();
+        assert_eq!(
+            empty_leaves, 2,
+            "exactly the two terminal-host leaves are empty; no orphan leftover"
+        );
+    }
+
+    #[test]
     fn open_beside_splits_the_given_pane() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
@@ -3311,6 +3557,68 @@ mod tests {
             unactivated, 1,
             "focus:false leaves exactly the new stack un-activated (ts 0) so focus stays put"
         );
+    }
+
+    #[test]
+    fn batched_open_beside_makes_no_empty_panes() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<OpenBesideRequest>()
+            .add_message::<PageOpenRequest>()
+            .init_resource::<NewStackContext>()
+            .add_systems(Update, handle_open_beside_requests);
+        let tab = app.world_mut().spawn(crate::tab::tab_bundle()).id();
+        let anchor_pane = app
+            .world_mut()
+            .spawn((leaf_pane_bundle(), LastActivatedAt::now(), ChildOf(tab)))
+            .id();
+        app.world_mut()
+            .spawn((stack_bundle(), LastActivatedAt::now(), ChildOf(anchor_pane)));
+
+        // Three open_page calls in one tick, all anchored to the same pane (as
+        // the agent does for "open a few terminals beside me").
+        for direction in [
+            PaneDirection::Right,
+            PaneDirection::Bottom,
+            PaneDirection::Left,
+        ] {
+            app.world_mut()
+                .resource_mut::<Messages<OpenBesideRequest>>()
+                .write(OpenBesideRequest {
+                    pane: anchor_pane,
+                    direction,
+                    url: "vmux://terminal/".into(),
+                    request_id: [0u8; 16],
+                    focus: false,
+                });
+        }
+        app.update();
+
+        assert!(
+            app.world().get::<PaneSplit>(anchor_pane).is_some(),
+            "anchor becomes a split"
+        );
+        let children: Vec<Entity> = app
+            .world()
+            .get::<Children>(anchor_pane)
+            .expect("anchor has children")
+            .iter()
+            .collect();
+        assert_eq!(
+            children.len(),
+            4,
+            "anchor holds the stack-holder + three terminal leaves, with no orphaned empty panes"
+        );
+        for child in children {
+            let has_stack = app
+                .world()
+                .get::<Children>(child)
+                .is_some_and(|cc| cc.iter().any(|e| app.world().get::<Stack>(e).is_some()));
+            assert!(
+                has_stack,
+                "every child pane has a stack; none is an empty orphan"
+            );
+        }
     }
 
     #[test]

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -31,6 +31,12 @@ use vmux_history::LastActivatedAt;
 #[derive(Component)]
 pub struct PendingPaneClose;
 
+/// Marker: close this pane immediately, without a confirmation dialog. Used when
+/// the pane's process has already exited (e.g. an agent CLI quit), so there is
+/// nothing to confirm and the pane should be removed + the split collapsed.
+#[derive(Component)]
+pub struct ForcePaneClose;
+
 pub struct PanePlugin;
 
 #[cfg_attr(target_os = "macos", allow(dead_code))]
@@ -67,6 +73,7 @@ impl Plugin for PanePlugin {
                     click_pane_in_player_mode,
                     pane_gap_drag_resize,
                     process_pending_pane_closes,
+                    process_force_pane_closes,
                     process_pending_stack_closes,
                 ),
             )
@@ -1754,6 +1761,48 @@ fn process_pending_pane_closes(world: &mut World) {
     }
 }
 
+/// Exclusive system: force-close panes marked [`ForcePaneClose`] with no
+/// confirmation dialog. Mirrors [`process_pending_pane_closes`] (activate the
+/// pane + its tab, mark `CloseConfirmed`, dispatch `PaneCommand::Close`) but
+/// skips the prompt, since the process has already exited. Being exclusive, the
+/// activation lands before the dispatched command is read.
+fn process_force_pane_closes(world: &mut World) {
+    let pending: Vec<Entity> = world
+        .query_filtered::<Entity, (With<ForcePaneClose>, With<Pane>)>()
+        .iter(world)
+        .collect();
+
+    if pending.is_empty() {
+        return;
+    }
+
+    for pane in pending {
+        let Ok(mut entity_mut) = world.get_entity_mut(pane) else {
+            continue;
+        };
+        entity_mut.remove::<ForcePaneClose>();
+        entity_mut.insert((CloseConfirmed, LastActivatedAt::now()));
+
+        let mut current = pane;
+        for _ in 0..10 {
+            if world.get_entity(current).is_ok_and(|e| e.contains::<Tab>()) {
+                if let Ok(mut entity_mut) = world.get_entity_mut(current) {
+                    entity_mut.insert(LastActivatedAt::now());
+                }
+                break;
+            }
+            if let Some(co) = world.get::<ChildOf>(current) {
+                current = co.get();
+            } else {
+                break;
+            }
+        }
+        world
+            .resource_mut::<Messages<AppCommand>>()
+            .write(AppCommand::Layout(LayoutCommand::Pane(PaneCommand::Close)));
+    }
+}
+
 fn process_pending_stack_closes(world: &mut World) {
     let pending: Vec<Entity> = world
         .query_filtered::<Entity, (With<PendingStackClose>, With<Stack>)>()
@@ -1865,6 +1914,44 @@ mod tests {
         app.world_mut()
             .spawn((Stack::default(), LastActivatedAt::now(), ChildOf(id)));
         id
+    }
+
+    #[test]
+    fn force_pane_close_dispatches_pane_close_without_dialog() {
+        use vmux_command::CommandPlugin;
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, CommandPlugin));
+        let tab = app
+            .world_mut()
+            .spawn((Tab::default(), LastActivatedAt::now()))
+            .id();
+        let pane = app
+            .world_mut()
+            .spawn((Pane, LastActivatedAt::now(), ChildOf(tab), ForcePaneClose))
+            .id();
+
+        process_force_pane_closes(app.world_mut());
+
+        assert!(
+            app.world().get::<ForcePaneClose>(pane).is_none(),
+            "ForcePaneClose marker should be consumed"
+        );
+        assert!(
+            app.world().get::<CloseConfirmed>(pane).is_some(),
+            "pane should be marked CloseConfirmed so the close skips the dialog"
+        );
+        let closes: Vec<_> = app
+            .world_mut()
+            .resource_mut::<Messages<AppCommand>>()
+            .drain()
+            .filter(|c| {
+                matches!(
+                    c,
+                    AppCommand::Layout(LayoutCommand::Pane(PaneCommand::Close))
+                )
+            })
+            .collect();
+        assert_eq!(closes.len(), 1, "exactly one PaneCommand::Close dispatched");
     }
 
     #[test]

--- a/crates/vmux_layout/src/reconcile.rs
+++ b/crates/vmux_layout/src/reconcile.rs
@@ -499,6 +499,21 @@ pub fn apply_with_existing(
     for tab in &snapshot.tabs {
         apply_tab(world, tab);
     }
+    // Honor the snapshot's active tab: make it the most-recently-activated tab so
+    // the timestamp-based active-tab selection (windowed-browser visibility, focus
+    // ring) follows `is_active` instead of defaulting to whichever tab was just
+    // spawned — otherwise a newly created tab steals "active" and its windowed
+    // browser covers the layout.
+    if let Some((_, active_entity)) = materialized.iter().find(|(t, _)| t.is_active) {
+        let newest = materialized
+            .iter()
+            .filter_map(|(_, e)| world.get::<LastActivatedAt>(*e).map(|l| l.0))
+            .max()
+            .unwrap_or(0);
+        if let Ok(mut e) = world.get_entity_mut(*active_entity) {
+            e.insert(LastActivatedAt(newest + 1));
+        }
+    }
     let rescued: ApplyHashSet<String> = new_entities
         .iter()
         .filter_map(|(ptr, &entity)| {
@@ -1371,6 +1386,79 @@ mod tests {
         assert!(
             s_grandparent.is_some() && s_grandparent != Some(tab),
             "moved stack's pane should live under the new tab, not the original"
+        );
+    }
+
+    #[test]
+    fn snapshot_active_tab_becomes_most_recently_activated() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<crate::LayoutSpawnRequest>()
+            .add_message::<PageOpenRequest>();
+        let active_tab = app
+            .world_mut()
+            .spawn((LayoutTab { name: "A".into() }, LastActivatedAt(1)))
+            .id();
+        let active_pane = app.world_mut().spawn((Pane, ChildOf(active_tab))).id();
+
+        // Keep the existing tab (is_active) and add a NEW tab that must NOT steal active.
+        let snap = LayoutSnapshot {
+            tabs: vec![
+                proto::Tab {
+                    id: Some(format_id(NodeKind::Tab, active_tab.to_bits())),
+                    name: "A".into(),
+                    is_active: true,
+                    root: proto::LayoutNode::Pane {
+                        id: Some(format_id(NodeKind::Pane, active_pane.to_bits())),
+                        is_zoomed: false,
+                        stacks: vec![],
+                    },
+                },
+                proto::Tab {
+                    id: None,
+                    name: "New".into(),
+                    is_active: false,
+                    root: proto::LayoutNode::Pane {
+                        id: None,
+                        is_zoomed: false,
+                        stacks: vec![proto::Stack {
+                            id: None,
+                            url: "https://example.com".into(),
+                            kind: "browser".into(),
+                            ..Default::default()
+                        }],
+                    },
+                },
+            ],
+            focused: proto::Focus::default(),
+        };
+        let existing: std::collections::HashSet<String> = [
+            format_id(NodeKind::Tab, active_tab.to_bits()),
+            format_id(NodeKind::Pane, active_pane.to_bits()),
+        ]
+        .into_iter()
+        .collect();
+
+        apply_with_existing(app.world_mut(), &snap, &existing).unwrap();
+
+        let mut q = app
+            .world_mut()
+            .query_filtered::<(Entity, &LastActivatedAt), With<LayoutTab>>();
+        let ts: Vec<(Entity, i64)> = q.iter(app.world()).map(|(e, l)| (e, l.0)).collect();
+        let active_ts = ts
+            .iter()
+            .find(|(e, _)| *e == active_tab)
+            .map(|(_, t)| *t)
+            .expect("active tab has a timestamp");
+        let max_other = ts
+            .iter()
+            .filter(|(e, _)| *e != active_tab)
+            .map(|(_, t)| *t)
+            .max()
+            .expect("a new tab exists");
+        assert!(
+            active_ts > max_other,
+            "is_active tab ({active_ts}) must out-rank other tabs ({max_other})"
         );
     }
 

--- a/crates/vmux_layout/src/reconcile.rs
+++ b/crates/vmux_layout/src/reconcile.rs
@@ -467,6 +467,10 @@ pub fn apply_with_existing(
 
     let mut new_entities: std::collections::HashMap<*const proto::LayoutNode, Entity> =
         std::collections::HashMap::new();
+    // Resolve (or create) each tab's entity once and keep the pairing, so the
+    // structure pass reparents existing nodes into NEW tabs too (e.g. moving a
+    // stack to a brand-new tab) — not only into tabs that already have an id.
+    let mut materialized: Vec<(&proto::Tab, Entity)> = Vec::with_capacity(snapshot.tabs.len());
     for tab in &snapshot.tabs {
         let tab_entity = match &tab.id {
             Some(id) => match parse_id(id) {
@@ -486,15 +490,11 @@ pub fn apply_with_existing(
             }
         };
         materialize_descendants(world, tab_entity, &tab.root, &mut new_entities);
+        materialized.push((tab, tab_entity));
     }
 
-    for tab in &snapshot.tabs {
-        if let Some(id) = &tab.id
-            && let Ok((_, value)) = parse_id(id)
-        {
-            let tab_entity = Entity::from_bits(value);
-            apply_structure(world, Some(tab_entity), &tab.root, &new_entities);
-        }
+    for (tab, tab_entity) in &materialized {
+        apply_structure(world, Some(*tab_entity), &tab.root, &new_entities);
     }
     for tab in &snapshot.tabs {
         apply_tab(world, tab);
@@ -1307,6 +1307,71 @@ mod tests {
         apply(app.world_mut(), &snap).unwrap();
         let parent = app.world().get::<ChildOf>(moved).map(|p| p.parent());
         assert_eq!(parent, Some(split_b));
+    }
+
+    #[test]
+    fn moves_stack_to_new_tab_reparents_it() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<crate::LayoutSpawnRequest>()
+            .add_message::<PageOpenRequest>();
+        let tab = app.world_mut().spawn(LayoutTab { name: "S".into() }).id();
+        let pane = app.world_mut().spawn((Pane, ChildOf(tab))).id();
+        let stack = app.world_mut().spawn(ChildOf(pane)).id();
+
+        // Move the existing stack out of its pane into a brand-new tab (id: None).
+        let snap = LayoutSnapshot {
+            tabs: vec![
+                proto::Tab {
+                    id: Some(format_id(NodeKind::Tab, tab.to_bits())),
+                    name: "S".into(),
+                    is_active: false,
+                    root: proto::LayoutNode::Pane {
+                        id: Some(format_id(NodeKind::Pane, pane.to_bits())),
+                        is_zoomed: false,
+                        stacks: vec![],
+                    },
+                },
+                proto::Tab {
+                    id: None,
+                    name: "YouTube".into(),
+                    is_active: true,
+                    root: proto::LayoutNode::Pane {
+                        id: None,
+                        is_zoomed: false,
+                        stacks: vec![proto::Stack {
+                            id: Some(format_id(NodeKind::Stack, stack.to_bits())),
+                            ..Default::default()
+                        }],
+                    },
+                },
+            ],
+            focused: proto::Focus::default(),
+        };
+        let existing: std::collections::HashSet<String> = [
+            format_id(NodeKind::Tab, tab.to_bits()),
+            format_id(NodeKind::Pane, pane.to_bits()),
+            format_id(NodeKind::Stack, stack.to_bits()),
+        ]
+        .into_iter()
+        .collect();
+
+        apply_with_existing(app.world_mut(), &snap, &existing).unwrap();
+
+        let s_parent = app
+            .world()
+            .get::<ChildOf>(stack)
+            .map(|p| p.parent())
+            .expect("moved stack still has a parent");
+        assert_ne!(
+            s_parent, pane,
+            "stack should be reparented out of the original pane"
+        );
+        let s_grandparent = app.world().get::<ChildOf>(s_parent).map(|p| p.parent());
+        assert!(
+            s_grandparent.is_some() && s_grandparent != Some(tab),
+            "moved stack's pane should live under the new tab, not the original"
+        );
     }
 
     #[test]

--- a/crates/vmux_layout/src/reconcile.rs
+++ b/crates/vmux_layout/src/reconcile.rs
@@ -291,7 +291,7 @@ use bevy::prelude::*;
 #[cfg(not(target_arch = "wasm32"))]
 use vmux_core::{PageMetadata, PageOpenRequest, PageOpenTarget};
 #[cfg(not(target_arch = "wasm32"))]
-use vmux_history::LastActivatedAt;
+use vmux_history::{CreatedAt, LastActivatedAt};
 
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Message, Clone)]
@@ -471,6 +471,15 @@ pub fn apply_with_existing(
     // structure pass reparents existing nodes into NEW tabs too (e.g. moving a
     // stack to a brand-new tab) — not only into tabs that already have an id.
     let mut materialized: Vec<(&proto::Tab, Entity)> = Vec::with_capacity(snapshot.tabs.len());
+    // The container existing tabs hang off, so new tabs can be spawned as their
+    // siblings (the tab strip only shows same-parent, same-space siblings).
+    let tab_parent: Option<Entity> = snapshot
+        .tabs
+        .iter()
+        .filter_map(|t| t.id.as_deref())
+        .filter_map(|id| parse_id(id).ok())
+        .map(|(_, v)| Entity::from_bits(v))
+        .find_map(|e| world.get::<ChildOf>(e).map(|c| c.parent()));
     for tab in &snapshot.tabs {
         let tab_entity = match &tab.id {
             Some(id) => match parse_id(id) {
@@ -479,8 +488,24 @@ pub fn apply_with_existing(
             },
             None => {
                 let entity = world
-                    .spawn((crate::tab::tab_bundle(), LastActivatedAt::now()))
+                    .spawn((
+                        crate::tab::tab_bundle(),
+                        LastActivatedAt::now(),
+                        CreatedAt::now(),
+                    ))
                     .id();
+                // Match canonical tab creation: parent the new tab to the same
+                // container as existing tabs and tag it with the active space.
+                // Otherwise the sibling-grouped, space-scoped tab strip filters it
+                // out and it never shows, even though it exists in the tree.
+                if let Some(parent) = tab_parent {
+                    world.entity_mut(entity).insert(ChildOf(parent));
+                }
+                if let Some(space) = active_space_id(world) {
+                    world
+                        .entity_mut(entity)
+                        .insert(crate::space::SpaceId(space));
+                }
                 if !tab.name.is_empty()
                     && let Some(mut layout_tab) = world.get_mut::<LayoutTab>(entity)
                 {
@@ -1459,6 +1484,88 @@ mod tests {
         assert!(
             active_ts > max_other,
             "is_active tab ({active_ts}) must out-rank other tabs ({max_other})"
+        );
+    }
+
+    #[test]
+    fn new_tab_inherits_active_space_and_parent() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<crate::LayoutSpawnRequest>()
+            .add_message::<PageOpenRequest>()
+            .insert_resource(crate::space::ActiveSpaceId(Some("space-1".to_string())));
+        let main = app.world_mut().spawn_empty().id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                LayoutTab { name: "A".into() },
+                crate::space::SpaceId("space-1".to_string()),
+                ChildOf(main),
+            ))
+            .id();
+        let pane = app.world_mut().spawn((Pane, ChildOf(tab))).id();
+
+        let snap = LayoutSnapshot {
+            tabs: vec![
+                proto::Tab {
+                    id: Some(format_id(NodeKind::Tab, tab.to_bits())),
+                    name: "A".into(),
+                    is_active: true,
+                    root: proto::LayoutNode::Pane {
+                        id: Some(format_id(NodeKind::Pane, pane.to_bits())),
+                        is_zoomed: false,
+                        stacks: vec![],
+                    },
+                },
+                proto::Tab {
+                    id: None,
+                    name: "New".into(),
+                    is_active: false,
+                    root: proto::LayoutNode::Pane {
+                        id: None,
+                        is_zoomed: false,
+                        stacks: vec![proto::Stack {
+                            id: None,
+                            url: "https://example.com".into(),
+                            kind: "browser".into(),
+                            ..Default::default()
+                        }],
+                    },
+                },
+            ],
+            focused: proto::Focus::default(),
+        };
+        let existing: std::collections::HashSet<String> = [
+            format_id(NodeKind::Tab, tab.to_bits()),
+            format_id(NodeKind::Pane, pane.to_bits()),
+        ]
+        .into_iter()
+        .collect();
+
+        apply_with_existing(app.world_mut(), &snap, &existing).unwrap();
+
+        let mut q = app.world_mut().query_filtered::<(
+            Entity,
+            Option<&crate::space::SpaceId>,
+            Option<&ChildOf>,
+        ), With<LayoutTab>>();
+        let rows: Vec<(Entity, Option<String>, Option<Entity>)> = q
+            .iter(app.world())
+            .map(|(e, s, c)| (e, s.map(|s| s.0.clone()), c.map(|c| c.parent())))
+            .collect();
+        let (_, space, parent) = rows
+            .iter()
+            .find(|(e, _, _)| *e != tab)
+            .expect("new tab exists");
+        assert_eq!(
+            space.as_deref(),
+            Some("space-1"),
+            "new tab should inherit the active space id"
+        );
+        assert_eq!(
+            *parent,
+            Some(main),
+            "new tab should be a sibling of the existing tab (same parent)"
         );
     }
 

--- a/crates/vmux_layout/src/stack.rs
+++ b/crates/vmux_layout/src/stack.rs
@@ -310,10 +310,39 @@ fn handle_stack_commands(
                         let Ok(siblings) = pane_children.get(parent) else {
                             continue;
                         };
-                        let sibling = siblings.iter().find(|&e| {
-                            e != pane && (leaf_panes.contains(e) || split_dir_q.contains(e))
-                        });
-                        let Some(sibling) = sibling else {
+                        let pane_siblings: Vec<Entity> = siblings
+                            .iter()
+                            .filter(|&e| {
+                                e != pane && (leaf_panes.contains(e) || split_dir_q.contains(e))
+                            })
+                            .collect();
+
+                        if pane_siblings.len() >= 2 {
+                            commands.entity(pane).despawn();
+                            let new_active_pane = pane_siblings
+                                .iter()
+                                .copied()
+                                .max_by_key(|&e| pane_ts.get(e).map(|(_, t)| t.0).unwrap_or(0))
+                                .unwrap_or(pane_siblings[0]);
+                            let focus_leaf =
+                                first_leaf_descendant(new_active_pane, &pane_children, &leaf_panes);
+                            commands.entity(focus_leaf).insert(LastActivatedAt::now());
+                            if let Some(t) =
+                                active_stack_in_pane(focus_leaf, &pane_children, &stack_ts).or_else(
+                                    || first_stack_in_pane(focus_leaf, &pane_children, &stack_q),
+                                )
+                            {
+                                commands.entity(t).insert(LastActivatedAt::now());
+                            }
+                            if new_stack_ctx.stack == Some(active) {
+                                new_stack_ctx.stack = None;
+                            }
+                            new_stack_ctx.previous_stack = None;
+                            new_stack_ctx.needs_open = false;
+                            continue;
+                        }
+
+                        let Some(sibling) = pane_siblings.into_iter().next() else {
                             continue;
                         };
                         let sibling_children: Vec<Entity> = pane_children
@@ -837,6 +866,101 @@ mod tests {
         assert!(!app.world().entity(split).contains::<PaneSplit>());
         assert_eq!(app.world().resource::<NewStackContext>().stack, None);
         assert!(!app.world().resource::<NewStackContext>().needs_open);
+    }
+
+    #[test]
+    fn closing_stack_in_three_way_split_keeps_split_and_does_not_respawn_startup() {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, CommandPlugin))
+            .add_message::<PageOpenRequest>()
+            .init_resource::<NewStackContext>()
+            .init_resource::<PendingCursorWarp>()
+            .insert_resource(test_settings())
+            .insert_resource(crate::settings::EffectiveStartupUrl(
+                "vmux://agent/vibe/".to_string(),
+            ))
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+            .add_systems(Update, handle_stack_commands.in_set(WriteAppCommands));
+
+        let tab = app
+            .world_mut()
+            .spawn((Tab::default(), LastActivatedAt::now()))
+            .id();
+        let split = app
+            .world_mut()
+            .spawn((
+                crate::pane::split_root_bundle(crate::pane::PaneSplitDirection::Row),
+                ChildOf(tab),
+            ))
+            .id();
+        let active_pane = app
+            .world_mut()
+            .spawn((Pane, LastActivatedAt(3), ChildOf(split)))
+            .id();
+        let p2 = app
+            .world_mut()
+            .spawn((Pane, LastActivatedAt(2), ChildOf(split)))
+            .id();
+        let p3 = app
+            .world_mut()
+            .spawn((Pane, LastActivatedAt(1), ChildOf(split)))
+            .id();
+        let active_stack = app
+            .world_mut()
+            .spawn((Stack::default(), LastActivatedAt(3), ChildOf(active_pane)))
+            .id();
+        let s2 = app
+            .world_mut()
+            .spawn((Stack::default(), LastActivatedAt(2), ChildOf(p2)))
+            .id();
+        let s3 = app
+            .world_mut()
+            .spawn((Stack::default(), LastActivatedAt(1), ChildOf(p3)))
+            .id();
+
+        app.world_mut()
+            .resource_mut::<Messages<AppCommand>>()
+            .write(AppCommand::Layout(LayoutCommand::Stack(
+                StackCommand::Close,
+            )));
+        app.update();
+
+        assert!(
+            app.world().get_entity(active_pane).is_err(),
+            "closed terminal pane is despawned"
+        );
+        assert!(
+            app.world().get_entity(active_stack).is_err(),
+            "closed terminal stack is despawned"
+        );
+        assert!(
+            app.world().entity(split).contains::<PaneSplit>(),
+            "a 3-way split must stay a split after one terminal closes (tree not corrupted)"
+        );
+        let children: Vec<Entity> = app
+            .world()
+            .get::<Children>(split)
+            .expect("split has children")
+            .iter()
+            .collect();
+        assert_eq!(children, vec![p2, p3], "exactly the two survivors remain");
+        assert!(app.world().get_entity(s2).is_ok() && app.world().get_entity(s3).is_ok());
+        let mut stacks = app.world_mut().query_filtered::<Entity, With<Stack>>();
+        assert_eq!(
+            stacks.iter(app.world()).count(),
+            2,
+            "no replacement startup (Vibe) stack spawned"
+        );
+        let reqs: Vec<_> = app
+            .world_mut()
+            .resource_mut::<Messages<PageOpenRequest>>()
+            .drain()
+            .collect();
+        assert!(
+            reqs.is_empty(),
+            "closing a terminal in an N-ary split must not open the startup URL"
+        );
     }
 
     #[test]

--- a/crates/vmux_layout/src/window.rs
+++ b/crates/vmux_layout/src/window.rs
@@ -134,7 +134,11 @@ impl Plugin for WindowPlugin {
             )
             .add_systems(
                 Startup,
-                (request_default_layout, spawn_requested_tab_layouts)
+                (
+                    request_default_layout,
+                    spawn_requested_tab_layouts,
+                    discard_startup_tab_layout_requests,
+                )
                     .chain()
                     .in_set(LayoutStartupSet::DefaultTab),
             )
@@ -468,6 +472,10 @@ fn request_default_layout(
         clear_pending_stack: false,
         focus: true,
     });
+}
+
+fn discard_startup_tab_layout_requests(mut requests: ResMut<Messages<TabLayoutSpawnRequest>>) {
+    requests.clear();
 }
 
 pub fn spawn_requested_tab_layouts(
@@ -1159,6 +1167,54 @@ mod tests {
         let ctx = app.world().resource::<crate::NewStackContext>();
         assert!(ctx.stack.is_some());
         assert!(ctx.needs_open);
+    }
+
+    #[test]
+    fn cold_start_seeds_exactly_one_default_tab() {
+        let _home = HomeEnvGuard::use_temp_home("cold-start-one-tab");
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<crate::NewStackContext>()
+            .add_message::<crate::TabLayoutSpawnRequest>()
+            .add_message::<PageOpenRequest>()
+            .insert_resource(LayoutSettings {
+                radius: 0.0,
+                window: crate::settings::WindowSettings {
+                    padding: 0.0,
+                    padding_top: None,
+                    padding_right: None,
+                    padding_bottom: None,
+                    padding_left: None,
+                },
+                pane: crate::settings::PaneSettings { gap: 0.0 },
+                side_sheet: crate::settings::SideSheetSettings::default(),
+                focus_ring: crate::settings::FocusRingSettings::default(),
+            })
+            .insert_resource(crate::settings::EffectiveStartupUrl(
+                "vmux://agent/vibe/".to_string(),
+            ))
+            .add_systems(
+                Startup,
+                (
+                    request_default_layout,
+                    spawn_requested_tab_layouts,
+                    discard_startup_tab_layout_requests,
+                )
+                    .chain(),
+            )
+            .add_systems(Update, spawn_requested_tab_layouts);
+
+        app.world_mut().spawn(PrimaryWindow);
+        app.world_mut().spawn(Main);
+
+        app.update();
+
+        let mut tabs = app.world_mut().query_filtered::<Entity, With<Tab>>();
+        assert_eq!(
+            tabs.iter(app.world()).count(),
+            1,
+            "cold start must seed exactly one default tab; the Startup-written request must not be re-read by the Update consumer"
+        );
     }
 
     #[test]

--- a/crates/vmux_mcp/src/protocol.rs
+++ b/crates/vmux_mcp/src/protocol.rs
@@ -450,6 +450,14 @@ mod tests {
             marker_code("__VMUX_DONE_tok_($env.LAST_EXIT_CODE)__", "tok"),
             None
         );
+        // nushell catch-branch echo (interpolated expr, not digits) must not match.
+        assert_eq!(
+            marker_code(
+                "print $\"__VMUX_DONE_tok_($e.exit_code? | default 1)__\"",
+                "tok"
+            ),
+            None
+        );
         // Wrong token never matches.
         assert_eq!(marker_code("__VMUX_DONE_other_0__", "tok"), None);
     }

--- a/crates/vmux_mcp/src/protocol.rs
+++ b/crates/vmux_mcp/src/protocol.rs
@@ -115,6 +115,8 @@ async fn tool_call_result(
             command,
             direction,
             focus,
+            beside,
+            mode,
             terminal,
             ..
         }) => {
@@ -124,6 +126,8 @@ async fn tool_call_result(
                 command,
                 direction,
                 focus,
+                beside,
+                mode,
                 terminal,
                 done_marker: Some(token.clone()),
             };

--- a/crates/vmux_mcp/src/protocol.rs
+++ b/crates/vmux_mcp/src/protocol.rs
@@ -1,6 +1,18 @@
 use serde_json::{Value, json};
 use std::io::{self, BufRead, Write};
-use vmux_service::protocol::{AgentCommand, ClientMessage, ServiceMessage};
+use std::time::{Duration, Instant};
+use vmux_service::protocol::{
+    AgentCommand, AgentQuery, AgentQueryResult, AgentRequestId, ClientMessage, ServiceMessage,
+};
+
+/// How long `run` waits for a command to finish before returning a partial
+/// result. Kept under vibe's 60s default MCP tool timeout.
+const RUN_BLOCK_TIMEOUT: Duration = Duration::from_secs(50);
+/// Interval between terminal reads while waiting for the completion marker.
+const RUN_POLL_INTERVAL: Duration = Duration::from_millis(200);
+/// Grace period for the terminal to be created before a "process not found"
+/// read is treated as a real error.
+const RUN_CREATE_GRACE: Duration = Duration::from_secs(3);
 
 pub fn read_json_line(reader: &mut impl BufRead) -> io::Result<Option<Value>> {
     let mut line = String::new();
@@ -98,8 +110,190 @@ async fn tool_call_result(
         .unwrap_or_else(|| json!({}));
 
     match crate::tools::dispatch_with_anchor(name, arguments, anchor)? {
+        crate::tools::DispatchTarget::Command(AgentCommand::Run {
+            anchor,
+            command,
+            direction,
+            focus,
+            terminal,
+            ..
+        }) => {
+            let token = run_token();
+            let run = AgentCommand::Run {
+                anchor,
+                command,
+                direction,
+                focus,
+                terminal,
+                done_marker: Some(token.clone()),
+            };
+            run_blocking(run, &token).await
+        }
         crate::tools::DispatchTarget::Command(command) => run_agent_command(command).await,
         crate::tools::DispatchTarget::Query(query) => run_agent_query(query).await,
+    }
+}
+
+fn run_token() -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("v{nanos:x}")
+}
+
+/// Parse the exit code from a line containing `__VMUX_DONE_<token>_<digits>__`.
+/// Returns `None` for the echoed command line (which carries the unresolved
+/// `%s`/`($env...)` placeholder rather than digits).
+fn marker_code(line: &str, token: &str) -> Option<i32> {
+    let prefix = format!("__VMUX_DONE_{token}_");
+    let start = line.find(&prefix)? + prefix.len();
+    let rest = &line[start..];
+    let end = rest.find("__")?;
+    rest[..end].parse::<i32>().ok()
+}
+
+/// Find the resolved completion marker anywhere in `text` and return its exit code.
+fn parse_done_marker(text: &str, token: &str) -> Option<i32> {
+    text.lines().rev().find_map(|line| marker_code(line, token))
+}
+
+/// Extract command output from the full terminal buffer: the lines between the
+/// echoed command (the first line carrying the token) and the resolved marker
+/// line, with both boundary lines removed.
+fn clean_run_output(text: &str, token: &str) -> String {
+    let token_pat = format!("__VMUX_DONE_{token}");
+    let lines: Vec<&str> = text.lines().collect();
+    let end = lines
+        .iter()
+        .position(|line| marker_code(line, token).is_some())
+        .unwrap_or(lines.len());
+    let start = lines[..end]
+        .iter()
+        .rposition(|line| line.contains(&token_pat))
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    lines[start..end].join("\n").trim_end().to_string()
+}
+
+fn run_result(pid: &str, exit: Option<i32>, output: &str, timed_out: bool) -> Value {
+    let mut text = format!("terminal: {pid}\n");
+    match exit {
+        Some(code) => text.push_str(&format!("exit: {code}\n")),
+        None if timed_out => text.push_str(&format!(
+            "note: still running after {}s; call read_terminal({pid}) to read more\n",
+            RUN_BLOCK_TIMEOUT.as_secs()
+        )),
+        None => {}
+    }
+    text.push_str("output:\n");
+    text.push_str(output);
+    json!({ "content": [{"type": "text", "text": text}] })
+}
+
+/// Send `run`, then block (polling the full terminal buffer) until the command's
+/// completion marker appears, returning the output + exit code in one response.
+async fn run_blocking(run: AgentCommand, token: &str) -> Result<Value, String> {
+    let connection = vmux_service::client::ServiceConnection::connect()
+        .await
+        .map_err(|error| format!("cannot connect to vmux_service: {error}"))?;
+
+    let request_id = AgentRequestId::new();
+    connection
+        .send(&ClientMessage::AgentCommand {
+            request_id,
+            command: run,
+        })
+        .await
+        .map_err(|error| format!("cannot send run command: {error}"))?;
+
+    let pid = loop {
+        let Some(message) = connection
+            .recv()
+            .await
+            .map_err(|error| format!("cannot read service response: {error}"))?
+        else {
+            return Err("vmux_service disconnected".to_string());
+        };
+        match message {
+            ServiceMessage::AgentCommandResult {
+                request_id: received,
+                result,
+            } if received == request_id => {
+                use vmux_service::protocol::AgentCommandResult;
+                match result {
+                    AgentCommandResult::Text(pid) => break pid,
+                    AgentCommandResult::Error(message) => return Err(message),
+                    other => return Err(format!("run: unexpected result: {other:?}")),
+                }
+            }
+            ServiceMessage::Error { message } => return Err(message),
+            _ => {}
+        }
+    };
+
+    let process_id = pid
+        .parse::<vmux_service::protocol::ProcessId>()
+        .map_err(|_| format!("run: service returned an invalid terminal id: {pid}"))?;
+
+    let start = Instant::now();
+    let deadline = start + RUN_BLOCK_TIMEOUT;
+    let mut last_text = String::new();
+    let mut got_text = false;
+    loop {
+        let query_id = AgentRequestId::new();
+        connection
+            .send(&ClientMessage::AgentQuery {
+                request_id: query_id,
+                query: AgentQuery::ReadTerminalFull { process_id },
+            })
+            .await
+            .map_err(|error| format!("cannot poll terminal: {error}"))?;
+
+        let read = loop {
+            let Some(message) = connection
+                .recv()
+                .await
+                .map_err(|error| format!("cannot read terminal poll: {error}"))?
+            else {
+                return Err("vmux_service disconnected".to_string());
+            };
+            match message {
+                ServiceMessage::AgentQueryResult {
+                    request_id: received,
+                    result,
+                } if received == query_id => break result,
+                ServiceMessage::Error { message } => {
+                    return Err(message);
+                }
+                _ => {}
+            }
+        };
+
+        match read {
+            AgentQueryResult::Text(text) => {
+                got_text = true;
+                last_text = text;
+                if let Some(code) = parse_done_marker(&last_text, token) {
+                    let output = clean_run_output(&last_text, token);
+                    return Ok(run_result(&pid, Some(code), &output, false));
+                }
+            }
+            AgentQueryResult::Error(message) => {
+                // The terminal may not be created yet; tolerate "process not
+                // found" during the grace window, but surface a persistent error.
+                if !got_text && start.elapsed() > RUN_CREATE_GRACE {
+                    return Err(message);
+                }
+            }
+            other => return Err(format!("run: unexpected terminal read: {other:?}")),
+        }
+
+        if Instant::now() >= deadline {
+            let output = clean_run_output(&last_text, token);
+            return Ok(run_result(&pid, None, &output, true));
+        }
+        tokio::time::sleep(RUN_POLL_INTERVAL).await;
     }
 }
 
@@ -238,5 +432,61 @@ mod tests {
         let request = read_json_line(&mut lines).unwrap().unwrap();
 
         assert_eq!(request["method"], "tools/list");
+    }
+
+    #[test]
+    fn marker_code_parses_resolved_exit_only() {
+        assert_eq!(marker_code("__VMUX_DONE_tok_0__", "tok"), Some(0));
+        assert_eq!(
+            marker_code("prefix __VMUX_DONE_tok_130__ suffix", "tok"),
+            Some(130)
+        );
+        // Echoed command line carries the unresolved placeholder, not digits.
+        assert_eq!(
+            marker_code("ls; printf '__VMUX_DONE_tok_%s__' \"$?\"", "tok"),
+            None
+        );
+        assert_eq!(
+            marker_code("__VMUX_DONE_tok_($env.LAST_EXIT_CODE)__", "tok"),
+            None
+        );
+        // Wrong token never matches.
+        assert_eq!(marker_code("__VMUX_DONE_other_0__", "tok"), None);
+    }
+
+    #[test]
+    fn parse_done_marker_finds_code_ignoring_echo() {
+        let text =
+            "$ ls; printf '__VMUX_DONE_tok_%s__' \"$?\"\nfile_a\nfile_b\n__VMUX_DONE_tok_0__\n$ ";
+        assert_eq!(parse_done_marker(text, "tok"), Some(0));
+        assert_eq!(parse_done_marker("nothing here", "tok"), None);
+    }
+
+    #[test]
+    fn clean_run_output_strips_echo_and_marker() {
+        let text =
+            "$ ls; printf '__VMUX_DONE_tok_%s__' \"$?\"\nfile_a\nfile_b\n__VMUX_DONE_tok_0__\n$ ";
+        assert_eq!(clean_run_output(text, "tok"), "file_a\nfile_b");
+    }
+
+    #[test]
+    fn clean_run_output_timeout_keeps_output_after_echo() {
+        // No resolved marker yet (command still running).
+        let text = "$ sleep 9; printf '__VMUX_DONE_tok_%s__' \"$?\"\nworking...";
+        assert_eq!(clean_run_output(text, "tok"), "working...");
+    }
+
+    #[test]
+    fn run_result_shapes_text() {
+        let done = run_result("pid7", Some(1), "boom", false);
+        let text = done["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("terminal: pid7"));
+        assert!(text.contains("exit: 1"));
+        assert!(text.contains("output:\nboom"));
+
+        let timeout = run_result("pid7", None, "partial", true);
+        let text = timeout["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("still running"));
+        assert!(text.contains("read_terminal(pid7)"));
     }
 }

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -183,6 +183,7 @@ Recipes: \
 - Close a pane/stack: omit it from the submitted tree. \
 - Resize a split: change flex_weights on the parent split. \
 - Equalize a split: set all flex_weights to the same value. \
+- Group an agent's parallel terminals (keep the agent's own pane readable): make the tab root a row split with two children - the agent's own pane on one side, and on the other either a split holding the terminal panes (when there are a few, so all are visible) or a single pane whose stacks are all the terminals (tabs, when there are many). Move existing terminal stacks by id into the grouped pane(s) rather than recreating them, and set flex_weights so the agent keeps a fair share (e.g. [1, 1] or [2, 3]). \
 - Change focus: set the top-level focused triple. \
 - Toggle zoom: flip the pane's is_zoomed flag. \
 \
@@ -297,16 +298,26 @@ fn run_definition() -> ToolDefinition {
     ToolDefinition {
         name: "run".into(),
         description:
-            "Run a shell command in a visible terminal the user can watch live and take over. \
+            "Run a shell command in a visible terminal pane the user can watch live and take over. \
 Blocks until the command finishes and returns its full output plus the exit code \
 (`terminal: <id>`, `exit: <code>`, `output: ...`). If it has not finished within ~50s, returns the \
 output so far with a note to call read_terminal for the rest. \
-By default opens a new terminal in a pane beside YOUR pane; pass `terminal` (a terminal id from a \
-previous run or from read_layout's process_id) to run in that existing terminal instead — reuse the \
-id instead of opening a new terminal for every command. \
-direction|focus apply only when opening a new terminal (direction default right; \
-focus default false = keep focus on your own pane). \
-The command is typed into an interactive shell, so the terminal stays usable afterwards."
+\
+PLACEMENT — by DEFAULT you don't need to think about this: a bare `run` reuses your one terminal region \
+(new terminals stack into a single pane beside you), so your own pane never keeps shrinking and the \
+layout stays tidy. The first `run` opens that region; later ones stack into it. Rule of thumb: don't \
+open a new pane unless you actually need one. \
+Override only when you mean to: \
+- `mode`: `auto` (default, reuse your region) | `split` (force a NEW pane) | `stack` (force a stacked \
+tab into the anchor's pane). \
+- `beside`: anchor to a specific page — a terminal id a previous run returned, or \"self\" for your own \
+pane. With `beside` set, `stack` tabs into that page's pane and `split` splits off it. \
+- `direction`: which side for `split` (right|left|top|bottom, default right). \
+- `terminal: <id>`: instead of opening anything, run IN that existing terminal (best for dependent / \
+sequential steps that share one shell, in order). \
+\
+`focus` (default false = keep focus on your own pane) applies when opening a new terminal. The command \
+is typed into an interactive shell, so the terminal stays usable afterwards."
                 .into(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -315,6 +326,8 @@ The command is typed into an interactive shell, so the terminal stays usable aft
             "properties": {
                 "command": {"type": "string"},
                 "terminal": {"type": "string"},
+                "beside": {"type": "string"},
+                "mode": {"enum": ["auto", "split", "stack"]},
                 "direction": {"enum": ["right", "left", "top", "bottom"]},
                 "focus": {"type": "boolean"}
             }
@@ -428,11 +441,30 @@ pub fn dispatch_with_anchor(
             ),
             _ => None,
         };
+        let beside = match arguments.get("beside").and_then(Value::as_str) {
+            Some(s) if !s.is_empty() && s != "self" => Some(
+                s.parse::<vmux_service::protocol::ProcessId>()
+                    .map_err(|_| format!("run.beside is not a valid page id: {s}"))?,
+            ),
+            _ => None,
+        };
+        let mode = match arguments
+            .get("mode")
+            .and_then(Value::as_str)
+            .unwrap_or("auto")
+        {
+            "auto" => vmux_service::protocol::PlacementMode::Auto,
+            "split" => vmux_service::protocol::PlacementMode::Split,
+            "stack" => vmux_service::protocol::PlacementMode::Stack,
+            other => return Err(format!("unknown mode: {other}")),
+        };
         return Ok(DispatchTarget::Command(AgentCommand::Run {
             anchor,
             command,
             direction,
             focus,
+            beside,
+            mode,
             terminal,
             done_marker: None,
         }));
@@ -784,6 +816,70 @@ mod tests {
                 "run",
                 serde_json::json!({"command": "ls", "terminal": "nope"}),
                 Some(anchor)
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn run_beside_and_mode_dispatch() {
+        use vmux_service::protocol::PlacementMode;
+        let anchor = vmux_service::protocol::ProcessId::new();
+        let beside = vmux_service::protocol::ProcessId::new();
+
+        // beside=<id> + mode=stack carries through.
+        let target = dispatch_with_anchor(
+            "run",
+            serde_json::json!({"command": "ls", "beside": beside.to_string(), "mode": "stack"}),
+            Some(anchor),
+        )
+        .unwrap();
+        match target {
+            DispatchTarget::Command(AgentCommand::Run {
+                beside: Some(b),
+                mode,
+                ..
+            }) => {
+                assert_eq!(b, beside);
+                assert_eq!(mode, PlacementMode::Stack);
+            }
+            other => panic!("expected Run with beside+stack, got {other:?}"),
+        }
+
+        // beside="self" => None; mode defaults to Auto (reuse the region).
+        let target = dispatch_with_anchor(
+            "run",
+            serde_json::json!({"command": "ls", "beside": "self"}),
+            Some(anchor),
+        )
+        .unwrap();
+        match target {
+            DispatchTarget::Command(AgentCommand::Run {
+                beside: None, mode, ..
+            }) => assert_eq!(mode, PlacementMode::Auto),
+            other => panic!("expected Run with self+auto, got {other:?}"),
+        }
+
+        // explicit mode=split is honored.
+        let target = dispatch_with_anchor(
+            "run",
+            serde_json::json!({"command": "ls", "mode": "split"}),
+            Some(anchor),
+        )
+        .unwrap();
+        match target {
+            DispatchTarget::Command(AgentCommand::Run { mode, .. }) => {
+                assert_eq!(mode, PlacementMode::Split)
+            }
+            other => panic!("expected Run with split, got {other:?}"),
+        }
+
+        // unknown mode errors.
+        assert!(
+            dispatch_with_anchor(
+                "run",
+                serde_json::json!({"command": "ls", "mode": "nope"}),
+                Some(anchor),
             )
             .is_err()
         );

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -298,12 +298,15 @@ fn run_definition() -> ToolDefinition {
         name: "run".into(),
         description:
             "Run a shell command in a visible terminal the user can watch live and take over. \
+Blocks until the command finishes and returns its full output plus the exit code \
+(`terminal: <id>`, `exit: <code>`, `output: ...`). If it has not finished within ~50s, returns the \
+output so far with a note to call read_terminal for the rest. \
 By default opens a new terminal in a pane beside YOUR pane; pass `terminal` (a terminal id from a \
-previous run or from read_layout's process_id) to run in that existing terminal instead. \
+previous run or from read_layout's process_id) to run in that existing terminal instead — reuse the \
+id instead of opening a new terminal for every command. \
 direction|focus apply only when opening a new terminal (direction default right; \
 focus default false = keep focus on your own pane). \
-The command is typed into an interactive shell, so the terminal stays usable afterwards. \
-Returns the terminal's id; pass it to read_terminal to read the output, or to run again."
+The command is typed into an interactive shell, so the terminal stays usable afterwards."
                 .into(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -431,6 +434,7 @@ pub fn dispatch_with_anchor(
             direction,
             focus,
             terminal,
+            done_marker: None,
         }));
     }
     if name == "read_terminal" {

--- a/crates/vmux_service/src/process.rs
+++ b/crates/vmux_service/src/process.rs
@@ -1323,6 +1323,30 @@ impl Process {
         }
     }
 
+    /// Full terminal text: scrollback history plus the visible screen, joined by
+    /// `\n` with trailing spaces stripped per line and trailing blank lines
+    /// removed. Reads the rendered alacritty grid, so the text carries no ANSI.
+    pub fn full_text(&self) -> String {
+        let grid = self.term.grid();
+        let num_cols = grid.columns();
+        let top = grid.topmost_line().0;
+        let bottom = grid.bottommost_line().0;
+
+        let mut lines: Vec<String> = Vec::new();
+        for line_idx in top..=bottom {
+            let row = &grid[Line(line_idx)];
+            let mut text = String::with_capacity(num_cols);
+            for col in 0..num_cols {
+                text.push(row[Column(col)].c);
+            }
+            lines.push(text.trim_end().to_string());
+        }
+        while lines.last().is_some_and(|line| line.is_empty()) {
+            lines.pop();
+        }
+        lines.join("\n")
+    }
+
     pub fn info(&self) -> ProcessInfo {
         ProcessInfo {
             id: self.id,
@@ -1646,6 +1670,47 @@ mod tests {
 
         assert!(text.contains(&cwd));
         assert!(!text.contains(&format!("cd {cwd}")));
+    }
+
+    #[test]
+    fn full_text_includes_scrolled_off_history() {
+        let (wake_tx, _) = mpsc::unbounded_channel();
+        let mut process = Process::new_with_wake(
+            ProcessId::new(),
+            "/bin/sh".to_string(),
+            vec![],
+            String::new(),
+            Vec::new(),
+            80,
+            24,
+            wake_tx,
+        )
+        .expect("process should spawn");
+
+        drain_process_output(&mut process, Duration::from_millis(300));
+        // Screen is 24 rows; printing ~60 lines scrolls FIRSTLINE into history.
+        process.write_input(
+            b"echo FIRSTLINE; for i in $(seq 1 60); do echo pad_$i; done; echo LASTLINE\r",
+        );
+        let _ = wait_for_snapshot_text(&mut process, "LASTLINE");
+        drain_process_output(&mut process, Duration::from_millis(200));
+
+        let visible = snapshot_text(process.snapshot());
+        let full = process.full_text();
+        process.kill();
+
+        assert!(
+            full.contains("LASTLINE"),
+            "full_text should include last line"
+        );
+        assert!(
+            full.contains("FIRSTLINE"),
+            "full_text should include scrolled-off first line; full=\n{full}"
+        );
+        assert!(
+            !visible.contains("FIRSTLINE"),
+            "visible snapshot should not include scrolled-off line; visible=\n{visible}"
+        );
     }
 
     fn drain_process_output(process: &mut Process, duration: Duration) {

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -103,6 +103,10 @@ pub enum AgentCommand {
         /// Run in this existing terminal (its `ProcessId`); `None` opens a new
         /// terminal beside the agent.
         terminal: Option<ProcessId>,
+        /// When set, the GUI appends a shell-aware completion print using this
+        /// token so the caller can detect command completion + exit code in the
+        /// terminal output. `None` keeps the legacy fire-and-forget behavior.
+        done_marker: Option<String>,
     },
 }
 
@@ -120,8 +124,18 @@ pub enum AgentCommandResult {
 
 #[derive(Debug, Clone, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum AgentQuery {
-    ReadLayout { anchor: Option<ProcessId> },
-    ReadTerminal { process_id: ProcessId },
+    ReadLayout {
+        anchor: Option<ProcessId>,
+    },
+    ReadTerminal {
+        process_id: ProcessId,
+    },
+    /// Like `ReadTerminal` but returns the full scrollback history plus the
+    /// visible screen as plain text (used to capture a command's complete
+    /// output, not just the current viewport).
+    ReadTerminalFull {
+        process_id: ProcessId,
+    },
     GetSettings,
     ListSpaces,
 }

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -38,6 +38,19 @@ pub enum AgentPaneDirection {
     Left,
 }
 
+/// How a spawned page is placed relative to its anchor pane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub enum PlacementMode {
+    /// Default: don't spawn a new pane unless necessary. Reuse the agent's
+    /// existing terminal region (stack the new terminal into it); split one pane
+    /// off the agent only when no region exists yet.
+    Auto,
+    /// New pane split off the anchor pane (X/Y), in the given direction.
+    Split,
+    /// New stack added to the anchor pane itself (Z); the pane keeps its size.
+    Stack,
+}
+
 #[derive(Debug, Clone, PartialEq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum AgentCommand {
     AppCommand {
@@ -100,6 +113,14 @@ pub enum AgentCommand {
         command: String,
         direction: AgentPaneDirection,
         focus: bool,
+        /// Anchor a newly opened terminal next to this page (a terminal's
+        /// `ProcessId`); `None` anchors to the agent's own page. Ignored when
+        /// `terminal` is set (reuse).
+        beside: Option<ProcessId>,
+        /// How a newly opened terminal is placed relative to its anchor pane
+        /// (split into a new pane, or stacked into the anchor pane). Ignored when
+        /// `terminal` is set.
+        mode: PlacementMode,
         /// Run in this existing terminal (its `ProcessId`); `None` opens a new
         /// terminal beside the agent.
         terminal: Option<ProcessId>,

--- a/crates/vmux_service/src/server.rs
+++ b/crates/vmux_service/src/server.rs
@@ -553,6 +553,23 @@ async fn handle_client(
                         write_message!(&mut *w, &resp)?;
                         continue;
                     }
+                    crate::protocol::AgentQuery::ReadTerminalFull { process_id } => {
+                        let result = {
+                            let mgr = manager.lock().await;
+                            match mgr.processes.get(&process_id) {
+                                Some(process) => {
+                                    crate::protocol::AgentQueryResult::Text(process.full_text())
+                                }
+                                None => crate::protocol::AgentQueryResult::Error(format!(
+                                    "process not found: {process_id}"
+                                )),
+                            }
+                        };
+                        let resp = ServiceMessage::AgentQueryResult { request_id, result };
+                        let mut w = writer.lock().await;
+                        write_message!(&mut *w, &resp)?;
+                        continue;
+                    }
                     other => other,
                 };
                 if agent_tx.receiver_count() == 0 {

--- a/crates/vmux_setting/src/page.rs
+++ b/crates/vmux_setting/src/page.rs
@@ -71,7 +71,7 @@ pub fn Page() -> Element {
                     div { class: "mb-8 lg:hidden",
                         h1 { class: "text-xl font-semibold tracking-tight", "Settings" }
                         p { class: "mt-1 text-sm text-muted-foreground",
-                            "Stored in ~/Library/Application Support/Vmux/settings.ron"
+                            "Stored in ~/.vmux/settings.ron"
                         }
                     }
                     div { class: "flex flex-col gap-8",

--- a/crates/vmux_setting/src/plugin/runtime.rs
+++ b/crates/vmux_setting/src/plugin/runtime.rs
@@ -368,17 +368,6 @@ pub(crate) struct SettingsWatcher {
     _watcher: RecommendedWatcher,
 }
 
-fn data_dir() -> Option<std::path::PathBuf> {
-    #[cfg(target_os = "macos")]
-    {
-        std::env::var_os("HOME").map(|_| vmux_core::profile::shared_data_dir())
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        Some(vmux_core::profile::shared_data_dir())
-    }
-}
-
 #[derive(Deserialize, Default)]
 struct PartialAppSettings {
     #[serde(default)]
@@ -433,26 +422,27 @@ fn parse_settings(text: &str) -> Result<AppSettings, ron::error::SpannedError> {
 }
 
 pub fn load_settings(mut commands: Commands) {
-    let (settings, config_path) = if let Some(dir) = data_dir() {
-        if std::fs::create_dir_all(&dir).is_err() {
-            (load_embedded_settings(), None)
-        } else {
-            let path = dir.join("settings.ron");
-            let s = match std::fs::read_to_string(&path) {
-                Ok(text) => match parse_settings(&text) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        bevy::log::warn!(
-                            "Ignoring invalid config {}: {e}; using embedded defaults",
-                            path.display()
-                        );
-                        load_embedded_settings()
-                    }
-                },
-                Err(_) => load_embedded_settings(),
-            };
-            (s, Some(path))
-        }
+    // Resolve the active settings file: per-build override (~/.vmux/<profile>/
+    // settings.ron) if present, else the shared ~/.vmux/settings.ron.
+    let path = vmux_core::profile::settings_path();
+    let parent_ready = path
+        .parent()
+        .is_some_and(|parent| std::fs::create_dir_all(parent).is_ok());
+    let (settings, config_path) = if parent_ready {
+        let s = match std::fs::read_to_string(&path) {
+            Ok(text) => match parse_settings(&text) {
+                Ok(s) => s,
+                Err(e) => {
+                    bevy::log::warn!(
+                        "Ignoring invalid config {}: {e}; using embedded defaults",
+                        path.display()
+                    );
+                    load_embedded_settings()
+                }
+            },
+            Err(_) => load_embedded_settings(),
+        };
+        (s, Some(path))
     } else {
         (load_embedded_settings(), None)
     };

--- a/crates/vmux_terminal/src/lib.rs
+++ b/crates/vmux_terminal/src/lib.rs
@@ -25,6 +25,8 @@ pub mod plugin;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod processes_monitor;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod shell_env;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod shell_input;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod snapshot_updater;

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -987,6 +987,13 @@ struct PollServiceWriters<'w> {
     osc_title: MessageWriter<'w, OscTitleChanged>,
 }
 
+/// True when a rendered line carries any non-whitespace text. Used to decide
+/// when a shell has actually drawn its prompt (vs. a blank pre-prompt frame), so
+/// pending `run` input is flushed only once the line editor is ready.
+fn line_has_content(line: &vmux_core::event::TermLine) -> bool {
+    line.spans.iter().any(|s| !s.text.trim().is_empty())
+}
+
 fn poll_service_messages(
     pending_create: Query<
         (Entity, &ProcessId, &crate::launch::TerminalLaunch),
@@ -1089,7 +1096,9 @@ fn poll_service_messages(
             } => {
                 for (entity, pid, _) in &terminals {
                     if *pid == process_id {
-                        if !output_seen.contains(entity) {
+                        if !output_seen.contains(entity)
+                            && changed_lines.iter().any(|(_, l)| line_has_content(l))
+                        {
                             commands.entity(entity).insert(ShellOutputSeen);
                         }
                         if !browsers.has_browser(entity) || !browsers.host_emit_ready(&entity) {
@@ -1142,7 +1151,7 @@ fn poll_service_messages(
             } => {
                 for (entity, pid, _) in &terminals {
                     if *pid == process_id {
-                        if !output_seen.contains(entity) {
+                        if !output_seen.contains(entity) && lines.iter().any(line_has_content) {
                             commands.entity(entity).insert(ShellOutputSeen);
                         }
                         if !browsers.has_browser(entity) || !browsers.host_emit_ready(&entity) {

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -748,6 +748,13 @@ pub struct PendingTerminalInput {
     pub data: Vec<u8>,
 }
 
+/// Marker: the terminal's process has produced output at least once (i.e. the
+/// shell has drawn its prompt). Used to defer flushing [`PendingTerminalInput`]
+/// until the shell is reading input, so a `run` command isn't raw-echoed above
+/// the prompt before the shell renders it.
+#[derive(Component)]
+struct ShellOutputSeen;
+
 /// Marker: CreateProcess was sent, waiting for ProcessCreated response.
 #[derive(Component)]
 struct AwaitingProcessCreated;
@@ -1008,18 +1015,27 @@ fn poll_service_messages(
     settings: Res<AppSettings>,
     launches: Query<&crate::launch::TerminalLaunch>,
     agent_sessions: Query<&vmux_core::agent::AgentSession>,
+    output_seen: Query<(), With<ShellOutputSeen>>,
 ) {
     let Some(service) = service else { return };
 
     // Handle pending creates — send CreateProcess, wait for ProcessCreated
     // response which will carry the real process ID.
     for (entity, process_id, launch) in &pending_create {
+        // Agents run as bare executables and don't load the user's shell config
+        // the way a terminal does, so merge in the login-shell env (API keys
+        // etc.). Done here (at spawn) rather than at launch-build time so it
+        // also covers agents restored from a persisted space or restarted.
+        let mut env = launch.env.clone();
+        if agent_sessions.contains(entity) {
+            crate::shell_env::merge_login_shell_env(&mut env, &terminal_shell(&settings));
+        }
         service.0.send(ClientMessage::CreateProcess {
             process_id: *process_id,
             command: launch.command.clone(),
             args: launch.args.clone(),
             cwd: launch.cwd.clone(),
-            env: launch.env.clone(),
+            env,
             cols: 80,
             rows: 24,
         });
@@ -1073,6 +1089,9 @@ fn poll_service_messages(
             } => {
                 for (entity, pid, _) in &terminals {
                     if *pid == process_id {
+                        if !output_seen.contains(entity) {
+                            commands.entity(entity).insert(ShellOutputSeen);
+                        }
                         if !browsers.has_browser(entity) || !browsers.host_emit_ready(&entity) {
                             continue;
                         }
@@ -1123,6 +1142,9 @@ fn poll_service_messages(
             } => {
                 for (entity, pid, _) in &terminals {
                     if *pid == process_id {
+                        if !output_seen.contains(entity) {
+                            commands.entity(entity).insert(ShellOutputSeen);
+                        }
                         if !browsers.has_browser(entity) || !browsers.host_emit_ready(&entity) {
                             continue;
                         }
@@ -1162,7 +1184,7 @@ fn poll_service_messages(
                             .insert(ProcessExited)
                             .remove::<CloseRequiresConfirmation>()
                             .remove::<AgentLoading>();
-                        if let Ok(session) = agent_sessions.get(entity) {
+                        let is_agent = if let Ok(session) = agent_sessions.get(entity) {
                             commands.trigger(BinHostEmitEvent::from_rkyv(
                                 entity,
                                 TERM_LOADING_EVENT,
@@ -1171,14 +1193,23 @@ fn poll_service_messages(
                                     label: session.kind.display_name().to_string(),
                                 },
                             ));
+                            true
+                        } else {
+                            false
+                        };
+                        // Plain terminals close their stack on exit. Agent
+                        // terminals are closed by the agent crate (it
+                        // force-closes the whole pane), so skip the stack close
+                        // here to avoid a double close collapsing the wrong pane.
+                        if !is_agent {
+                            let tab = child_of.get();
+                            commands.entity(tab).insert(LastActivatedAt::now());
+                            writers
+                                .app_commands
+                                .write(AppCommand::Layout(LayoutCommand::Stack(
+                                    StackCommand::Close,
+                                )));
                         }
-                        let tab = child_of.get();
-                        commands.entity(tab).insert(LastActivatedAt::now());
-                        writers
-                            .app_commands
-                            .write(AppCommand::Layout(LayoutCommand::Stack(
-                                StackCommand::Close,
-                            )));
                         break;
                     }
                 }
@@ -1273,6 +1304,7 @@ fn flush_pending_terminal_input(
         (Entity, &ProcessId, &PendingTerminalInput),
         (
             With<Terminal>,
+            With<ShellOutputSeen>,
             Without<PendingServiceCreate>,
             Without<AwaitingProcessCreated>,
             Without<ProcessExited>,

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -334,7 +334,6 @@ fn add_terminal_update_systems(app: &mut App) -> &mut App {
         .add_message::<OscTitleChanged>()
         .add_systems(Update, apply_osc_title.after(poll_service_messages))
         .add_systems(Update, clear_osc_title_on_exit.after(poll_service_messages))
-        .add_systems(Update, respawn_shell_on_vibe_exit)
         .add_systems(
             Update,
             handle_terminal_page_open.in_set(PageOpenSet::HandleKnownPages),
@@ -2844,48 +2843,6 @@ pub fn clear_osc_title_on_exit(
     }
 }
 
-fn respawn_shell_on_agent_exit_for_entity(
-    commands: &mut Commands,
-    entity: Entity,
-    shell: &str,
-    cwd: String,
-) {
-    let new_id = ProcessId::new();
-    let mut ec = commands.entity(entity);
-    ec.remove::<vmux_core::agent::AgentSession>();
-    ec.remove::<vmux_core::agent::SessionId>();
-    ec.remove::<vmux_core::agent::PendingAgentSession>();
-    ec.insert(new_id);
-    ec.insert(PendingServiceCreate);
-    ec.insert(crate::launch::TerminalLaunch {
-        command: shell.to_string(),
-        args: vec![],
-        cwd,
-        env: vec![],
-        kind: crate::launch::TerminalKind::Plain,
-    });
-}
-
-pub fn respawn_shell_on_vibe_exit(
-    mut commands: Commands,
-    mut exited: MessageReader<ProcessExitedEvent>,
-    q: Query<
-        (Entity, &ProcessId, &crate::launch::TerminalLaunch),
-        With<vmux_core::agent::AgentSession>,
-    >,
-    settings: Res<AppSettings>,
-) {
-    for ev in exited.read() {
-        let Some((entity, _pid, launch)) = q.iter().find(|(_, pid, _)| **pid == ev.process_id)
-        else {
-            continue;
-        };
-        let shell = terminal_shell(&settings);
-        let cwd = launch.cwd.clone();
-        respawn_shell_on_agent_exit_for_entity(&mut commands, entity, &shell, cwd);
-    }
-}
-
 fn update_local_copy_mode_for_mouse_action(
     local_copy_mode: &mut LocalCopyModeState,
     process_id: ProcessId,
@@ -3706,57 +3663,6 @@ mod tests {
         assert!(app.world().get::<AwaitingProcessCreated>(entity).is_none());
         let stored_process_id = app.world().get::<ProcessId>(entity).unwrap();
         assert_eq!(*stored_process_id, id);
-    }
-
-    #[test]
-    fn respawn_shell_on_agent_exit_swaps_kind_and_drops_agent() {
-        use crate::launch::{TerminalKind, TerminalLaunch};
-
-        let mut app = bevy::prelude::App::new();
-        let original_id = ProcessId::new();
-        let entity = app
-            .world_mut()
-            .spawn((
-                Terminal,
-                original_id,
-                vmux_core::agent::AgentSession {
-                    kind: vmux_core::agent::AgentKind::Vibe,
-                },
-                vmux_core::agent::SessionId("abc-123".into()),
-                TerminalLaunch {
-                    command: "/usr/local/bin/vibe".into(),
-                    args: vec!["--trust".into()],
-                    cwd: "/work".into(),
-                    env: vec![("VIBE_MCP_SERVERS".into(), "[]".into())],
-                    kind: TerminalKind::Vibe,
-                },
-            ))
-            .id();
-
-        app.world_mut()
-            .run_system_cached_with(
-                |In((entity, shell, cwd)): In<(Entity, String, String)>, mut commands: Commands| {
-                    respawn_shell_on_agent_exit_for_entity(&mut commands, entity, &shell, cwd);
-                },
-                (entity, "/bin/zsh".to_string(), "/work".to_string()),
-            )
-            .unwrap();
-
-        let world = app.world();
-        assert!(
-            world
-                .get::<vmux_core::agent::AgentSession>(entity)
-                .is_none()
-        );
-        assert!(world.get::<vmux_core::agent::SessionId>(entity).is_none());
-        let launch = world.get::<TerminalLaunch>(entity).unwrap();
-        assert_eq!(launch.kind, TerminalKind::Plain);
-        assert_eq!(launch.command, "/bin/zsh");
-        assert_eq!(launch.cwd, "/work");
-        assert!(launch.args.is_empty());
-        let new_id = world.get::<ProcessId>(entity).copied().unwrap();
-        assert_ne!(new_id, original_id);
-        assert!(world.get::<PendingServiceCreate>(entity).is_some());
     }
 
     #[test]

--- a/crates/vmux_terminal/src/shell_env.rs
+++ b/crates/vmux_terminal/src/shell_env.rs
@@ -1,0 +1,120 @@
+//! Capture the user's login-shell environment so agent processes inherit it.
+//!
+//! A vmux terminal runs the user's shell, which sources its config (`env.nu`,
+//! `.zshrc`, …) and thus has the user's exported vars (API keys, etc.). An
+//! *agent* (vibe/claude/codex) is launched as a bare executable, so it only
+//! inherits the daemon's environment — which is missing those vars when the
+//! daemon was started by launchd rather than from a shell. We capture the login
+//! shell's exported environment once and merge it into agent spawns.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::sync::OnceLock;
+
+/// The environment the user's login shell exports, captured once per process.
+pub fn login_shell_env(shell: &str) -> &'static [(String, String)] {
+    static CACHE: OnceLock<Vec<(String, String)>> = OnceLock::new();
+    CACHE
+        .get_or_init(|| capture_login_shell_env(shell))
+        .as_slice()
+}
+
+/// Merge the login-shell env into `env` (shell values win), then drop duplicate
+/// keys keeping the last. Use when spawning an agent so it gets the same
+/// environment a terminal would, regardless of how the daemon was launched.
+pub fn merge_login_shell_env(env: &mut Vec<(String, String)>, shell: &str) {
+    env.extend(login_shell_env(shell).iter().cloned());
+    dedup_env_keep_last(env);
+}
+
+/// Run the login shell so it sources its config (where exports live), then dump
+/// the environment it hands to child processes. Shell-specific flags: nushell
+/// auto-loads `env.nu` with a plain `-c` (and `-l -i` can suppress it), while
+/// POSIX-style shells (bash/zsh) and fish need `-l -i` to source their login +
+/// interactive config. Returns empty on any failure (callers keep their env).
+fn capture_login_shell_env(shell: &str) -> Vec<(String, String)> {
+    let base = Path::new(shell)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(shell);
+    let args: &[&str] = match base {
+        "nu" | "nushell" => &["-c", "/usr/bin/env"],
+        _ => &["-l", "-i", "-c", "/usr/bin/env"],
+    };
+    let Ok(output) = Command::new(shell)
+        .args(args)
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+    else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    parse_env(&output.stdout)
+}
+
+/// Parse `KEY=VALUE` lines from `env` output. Splits on the first `=` and skips
+/// lines without one (e.g. wrapped multi-line values).
+fn parse_env(bytes: &[u8]) -> Vec<(String, String)> {
+    String::from_utf8_lossy(bytes)
+        .lines()
+        .filter_map(|line| line.split_once('='))
+        .filter(|(key, _)| !key.is_empty())
+        .map(|(key, value)| (key.to_string(), value.to_string()))
+        .collect()
+}
+
+/// Keep only the last occurrence of each key, preserving order.
+fn dedup_env_keep_last(env: &mut Vec<(String, String)>) {
+    let mut seen = HashSet::new();
+    let mut deduped = Vec::with_capacity(env.len());
+    for (key, value) in std::mem::take(env).into_iter().rev() {
+        if seen.insert(key.clone()) {
+            deduped.push((key, value));
+        }
+    }
+    deduped.reverse();
+    *env = deduped;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_env_splits_on_first_equals() {
+        let out = b"PATH=/usr/bin:/bin\nKEY=a=b=c\nEMPTY=\nnovalue\n=novalue\n";
+        assert_eq!(
+            parse_env(out),
+            vec![
+                ("PATH".to_string(), "/usr/bin:/bin".to_string()),
+                ("KEY".to_string(), "a=b=c".to_string()),
+                ("EMPTY".to_string(), String::new()),
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_overrides_existing_keys_keeping_order() {
+        // Simulate a base env (daemon) merged with a login env via dedup.
+        let mut env = vec![
+            ("VIBE_MCP_SERVERS".to_string(), "[...]".to_string()),
+            ("ANTHROPIC_FOUNDRY_API_KEY".to_string(), "stale".to_string()),
+            // login env appended (would come from login_shell_env):
+            ("ANTHROPIC_FOUNDRY_API_KEY".to_string(), "fresh".to_string()),
+            ("PATH".to_string(), "/login/bin".to_string()),
+        ];
+        dedup_env_keep_last(&mut env);
+        assert_eq!(
+            env,
+            vec![
+                ("VIBE_MCP_SERVERS".to_string(), "[...]".to_string()),
+                ("ANTHROPIC_FOUNDRY_API_KEY".to_string(), "fresh".to_string()),
+                ("PATH".to_string(), "/login/bin".to_string()),
+            ]
+        );
+    }
+}

--- a/docs/specs/2026-06-19-agent-layout-api-design.md
+++ b/docs/specs/2026-06-19-agent-layout-api-design.md
@@ -1,0 +1,211 @@
+# Agent Layout API Design
+
+## Summary
+
+Give the agent a real, id-addressed layout API by generalizing vmux's existing
+command enums with a `target`/`Anchor` parameter — default the focused element,
+or a specific `pane:`/`stack:`/`tab:` id — and un-skipping them for MCP. The same
+command and the same handler serve the keyboard/menu (Active target) and the
+agent (id target): one implementation, no duplicate verbs or messages. Page
+placement happens **at spawn time** via the generalized `InPane` command, so the
+agent's terminals/pages are born in the right spot instead of popping up
+scattered and being rearranged afterward.
+
+## Problem
+
+The agent's only structural layout tool today is `update_layout` (submit a
+complete tree, reconciled). Every per-op layout verb a human uses (split, move
+stack, equalize, close pane) is `#[mcp(skip)]` on `AppCommand::Layout`
+(`command.rs:22`) and is focus-relative + parameterless — `close_pane` closes the
+*focused* pane, with no id.
+
+So to arrange anything, the agent must hand-build a complete, correct tree, which
+it will not do reliably. Observed: asked to run five parallel commands, the agent
+self-split its own pane five times into unreadable slivers, never Z-stacked, never
+reused a terminal, and never called `update_layout` to tidy — even with the policy
+spelled out in the tool descriptions. Two description-only iterations failed. Root
+cause: there are no id-addressed mid-level layout ops, and spawning (`run` /
+`open_page`) always splits the agent's own pane.
+
+## Goals
+
+- The agent places each page (terminal or browser) where it wants **at spawn
+  time**, so the layout is tidy as pages appear — no flicker-then-rearrange.
+- The agent drives layout decisions; no vmux auto-magic or pooling.
+- Layout ops are **id-addressed** (`pane:`/`stack:`/`tab:` ids from `read_layout`).
+- Keyboard/menu and agent **share one command + one handler** — no duplicated
+  logic — via Bevy systems + messages (the existing `AppCommand` message), per the
+  project's bevy-way rule.
+- Generalizes to the roadmap: the same verbs arrange browser pages (search, docs),
+  not just terminals.
+
+## Non-goals
+
+- No vmux-side terminal pool / auto-grouping (rejected: the agent drives).
+- No high-level `group_terminals` / `arrange_pages` verb (rejected: spawn-time
+  placement replaces post-hoc tidy).
+- `update_layout` / `reconcile` stay unchanged (the declarative whole-tree path
+  remains the escape hatch).
+- No helper-function sharing layer (rejected: share via systems + messages).
+- Navigation/selection commands (SelectLeft/Right, rotate, …) are not exposed to
+  the agent.
+
+## Terminology
+
+- **Pane** = a spatial tile; **splits** divide a tab on the **X/Y** plane.
+- **Stack** = a page (terminal or browser) inside a pane, on the **Z** axis. A
+  pane holds several stacks; one is visible, switched via the in-pane stack strip.
+- **split** arrangement = N panes (X/Y), one stack each. **stack** arrangement =
+  one pane, N stacks (Z).
+- **Anchor** (new) = a command's target: `Active` (focused) or a specific id.
+
+## Design
+
+### 1. The `Anchor` target
+
+New type in `vmux_command`:
+
+```rust
+enum Anchor { Active, Pane(u64), Stack(u64), Tab(u64) } // default: Active
+```
+
+- Keyboard / menu / command-bar construct commands with `Anchor::Active`.
+- The agent supplies an id. The MCP wire form is an optional `target` string
+  (e.g. `"pane:7"`), parsed via the existing `parse_id`; absent ⇒ `Active`.
+- One resolver maps `Anchor` → `Entity`: `Active` → `FocusedStack`; an id → the
+  same id↔entity map `read_layout` / `reconcile` already use.
+
+### 2. Generalize the structural layout commands
+
+Add `target: Anchor` to the structural commands the agent needs and remove
+`#[mcp(skip)]` from them, so `McpTool` generates id-addressed tools from the same
+enum that drives menus and shortcuts:
+
+- `PaneCommand::Close` → close the `target` pane.
+- `StackCommand::MoveToPane` → carries a destination-pane `Anchor` (move the
+  `target` stack into a pane).
+- A new `SetWeights { target: split, weights }` op — absolute weights, which the
+  agent can compute, vs. the incremental `Resize*` commands.
+- `OpenCommand::InPane` (already fielded with `direction` / `target` / `mode` /
+  `url`, `open.rs:54`) → change its `target` from the focus-relative `PaneTarget`
+  to an `Anchor` id, and un-skip. This is the **spawn-placement** verb: open a
+  page as a `split` (new pane, X/Y) or `stack` (Z) relative to an anchor pane.
+
+Navigation/selection (`SelectLeft/Right/Up/Down`, `Toggle`, rotate) keep
+`Anchor::Active` semantics and stay `mcp(skip)` — the agent does not move focus.
+
+### 3. Spawn-time placement (`run` / `open_page`)
+
+- `run` keeps its own tool (it needs blocking + the done-marker + output). It
+  gains placement params that map onto the shared split/stack path:
+  `beside: <page-id|self>`, `mode: split|stack`, `direction`. The new terminal is
+  born at the anchor. `terminal: <id>` reuse stays for sequential steps.
+- `open_page` becomes a thin self-relative convenience over the same path
+  (`beside: self`); see open question in Risks.
+- Spawns return the **landing pane id** (alongside the page/terminal id) so the
+  agent can anchor the next page to it (e.g. `beside: <pane>, mode: stack`).
+
+### 4. One handler, target-aware
+
+`handle_pane_commands` (`pane.rs:485`) stops doing focus-relative work inline. It
+resolves `target` (Active → focused; id → entity) and performs the op via the
+existing helpers (`split_leaf_into_two` / `split_or_extend`, plus the close / move
+/ weights bodies and a `stack_into_pane` insert). Both the keyboard
+(`AppCommand::Layout { target: Active, … }`) and the agent
+(`AppCommand::Layout { target: Id, … }`) flow through it.
+
+The agent path: `dispatch_*` (`tools.rs`) parses the tool + ids and emits
+`AppCommand::Layout { target, … }` — i.e. `AgentCommand` routes onto the *same*
+`AppCommand` bus the keyboard uses (valid now that the command carries a target).
+Spawn placement routes to the InPane/split path.
+
+### 5. Discovery
+
+`read_layout` already returns per-stack `is_self`, `process_id`, `kind`, and
+`pane:`/`stack:` ids (`protocol.rs:62-81`) — enough for the agent to find itself
+and address targets. (Optional later: an `is_busy` flag for reuse hints.)
+
+## Data flow
+
+```
+keyboard/menu ─► AppCommand::Layout{ target: Active, command }
+                       │
+agent (MCP) ─► tool → AppCommand::Layout{ target: Id, command }
+                       ▼
+        handle_* system: resolve target → entity → op (shared helpers/messages)
+                       ▼
+                  ECS layout mutated
+
+spawn: run/open_page → InPane(split|stack, anchor)
+                       → split_leaf_into_two / stack_into_pane
+```
+
+## Implementation surface
+
+- `vmux_command/src/open.rs` — define `Anchor`; `InPane.target: Anchor`; un-skip
+  `InPane`.
+- `vmux_command/src/command.rs` — `target: Anchor` on `PaneCommand::Close`,
+  `StackCommand::MoveToPane`, new `SetWeights`; remove `#[mcp(skip)]` from these
+  (keep it on navigation/selection).
+- `vmux_macro` — derive support: default the `Anchor` field to `Active` for
+  `OsMenu` / `DefaultShortcuts` / `CommandBar` construction; `McpTool` emits
+  `target` as an optional id-string param.
+- `vmux_layout/src/pane.rs` — generalize `handle_pane_commands` to resolve
+  `Anchor`; reuse `split_leaf_into_two` / `split_or_extend`; add close / move /
+  weights bodies and a `stack_into_pane` insert; add the `Anchor`→`Entity`
+  resolver (reuse the id map + `parse_id`).
+- `vmux_mcp/src/tools.rs` — `run` / `open_page` gain `beside` / `mode` /
+  `direction`; dispatch parses ids and emits the generalized commands; drop the
+  hand-written layout verbs (now generated from the un-skipped enum); spawns
+  return the landing pane id.
+- `vmux_agent/src/plugin.rs` — route layout ops to `AppCommand::Layout { target }`
+  (bus) and spawn placement to the InPane/split path; return the pane id.
+- `vmux_service/src/protocol.rs` — extend `Run` / `OpenBeside` (or an InPane
+  variant) with `beside` / `mode` / `direction`; spawn responses carry the pane id.
+
+## Testing (bevy way)
+
+- Send `AppCommand::Layout { target: Id(...), Close / MoveToPane / SetWeights }`
+  into a test `App`, run the schedule, assert the resulting ECS layout state.
+  Repeat with `target: Active`.
+- Spawn placement: emit `InPane(split|stack, anchor)`, assert the new pane/stack
+  lands at the anchor and does **not** split the agent's pane.
+- dispatch / id-parse tests in `tools.rs` for the new params; tool-presence tests
+  for the now-generated layout tools; assert navigation commands keep `mcp(skip)`.
+- Macro: a generated tool includes `target`; menu/shortcut paths construct with
+  `Active`.
+
+## Risks / open questions
+
+1. **Macro work is the main cost/risk.** The custom derives must handle a
+   defaulted `Anchor` field. `InPane` proves that fielded layout commands already
+   work across `McpTool` / menu / shortcut (`open.rs:31-64`), but those set fields
+   explicitly; defaulting `Anchor::Active` for menu/shortcut/command-bar
+   construction may need new macro support. Validate early on one command
+   (`Close`) before converting the rest.
+2. **`open_page` vs. generalized `InPane`.** Fold `open_page` into
+   `InPane(target = self)` or keep it as a thin alias? Lean: keep `open_page` as
+   the self-relative convenience, implemented via the same path.
+3. **Anchor representation.** `Anchor` enum vs. a `target: Option<String>` field on
+   the wire. The enum is clearer; `Option<String>` is derive-simpler. Recommend
+   the enum, parsed at the MCP boundary.
+4. **Parallel stacking race.** For N concurrent terminals stacked into one pane,
+   the first spawn creates the pane and the rest anchor to it
+   (`beside: <pane>, mode: stack`). The agent must do first-then-rest, not a blind
+   concurrent burst — document this in `run`'s description.
+5. **Anchor-kind validation.** A pane command given a `stack:` id (or vice-versa):
+   resolve to the containing pane where sensible, otherwise return an error.
+
+## Scope for first implementation
+
+- `Anchor` + resolver; generalize + un-skip `Close` and `InPane`; `run` /
+  `open_page` placement params; refactor `handle_pane_commands` to resolve
+  `target` for `Close`; tests. Prove the pattern on `Close` + `InPane` first.
+- Then: `MoveToPane`, `SetWeights`, and the remaining structural commands.
+
+## Out of scope
+
+- `update_layout` / `reconcile` changes.
+- vmux-side pooling / auto-arrange / high-level group verb.
+- `is_busy` / idle tracking (later, if reuse needs it).
+- Navigation/selection MCP exposure.

--- a/patches/moonshine-save-0.6.1/src/load.rs
+++ b/patches/moonshine-save-0.6.1/src/load.rs
@@ -342,7 +342,7 @@ fn load_world<E: LoadEvent>(mut event: E, world: &mut World) -> LoadResult {
             let mut deserializer = ron::Deserializer::from_bytes(&bytes)?;
             let type_registry = &world.resource::<AppTypeRegistry>().read();
             let scene_deserializer = SceneDeserializer { type_registry };
-            scene_deserializer.deserialize(&mut deserializer).unwrap()
+            scene_deserializer.deserialize(&mut deserializer)?
         }
         LoadInput::Stream(mut stream) => {
             let mut bytes = Vec::new();


### PR DESCRIPTION
## Context

Driving the agent (vibe) inside vmux surfaced a chain of problems: the injected `run` tool looped (no output, no completion signal), spawned a terminal per command (slivers), echoed the wrapped command twice, and the agent's own pane kept shrinking; moving a page into a new tab broke the layout entirely. This PR makes `run` reliable, gives the agent sensible terminal placement, and fixes the underlying layout/reconcile bugs — plus lands the design spec for a fuller agent layout API.

## Implementation

- **Blocking `run`** — blocks until the command finishes and returns `terminal` / `exit` / `output` in one MCP response (50s cap → partial output + `read_terminal(<id>)` hint). Completion/exit detected via a shell-aware marker (nushell `try/catch`; posix/fish `;` + `$?`/`$status`); full output read from the rendered `alacritty_terminal` grid (`AgentQuery::ReadTerminalFull` / `Process::full_text`).
- **Terminal placement** — `run` defaults to a reused **region**: new terminals stack into one pane beside the agent instead of re-splitting its pane (so it never shrinks to a sliver). `beside` + `mode` (`auto` | `split` | `stack`) give explicit control; `terminal=<id>` reuses an existing one for sequential steps.
- **Prompt echo** — a `run`'s input is flushed only once the shell has drawn its prompt, so the wrapped command no longer raw-echoes above the prompt (shows once).
- **Reconcile fixes** — `apply_structure` now runs for newly created tabs, so moving an existing stack into a new tab reparents it instead of stranding it (was: empty new tab + broken layout); and the snapshot's `is_active` tab is made the most-recently-activated, so a freshly spawned tab can't steal "active" and cover the layout with its windowed browser.
- **Env / config** — agent terminals inherit the login-shell env; `settings.ron` moves to `~/.vmux` with a per-build override.
- **Spec** — `docs/specs/2026-06-19-agent-layout-api-design.md`: id-addressed layout verbs via an `Anchor` target so keyboard and agent share one command + handler.
- Builds on the in-progress layout `split_or_extend` batch-split helper.

## Checks / QA

- vibe in a worktree with `.vibe/config.toml` (`disabled_tools=["bash"]`): run `echo hi` (exit 0), `false` (exit 1), `sleep 3; echo done` (blocks then returns) — each completes in one call with no per-command terminal spawn.
- Ask for several commands in a row → they stack as tabs in one terminal region; the agent pane stays full-width. The wrapped command appears once at the prompt.
- "Open youtube.com beside you, then move it into a new tab of its own" → the page lands in a new (inactive) tab and hides; the agent pane stays visible; no collapse to an empty layout.