### PR TITLE
fix(profile): isolate non-release builds in a profile-suffixed data dir

### DIFF
--- a/crates/vmux_core/build.rs
+++ b/crates/vmux_core/build.rs
@@ -1,0 +1,6 @@
+#[path = "../build_git_env.rs"]
+mod build_git_env;
+
+fn main() {
+    build_git_env::emit();
+}

--- a/crates/vmux_core/src/profile.rs
+++ b/crates/vmux_core/src/profile.rs
@@ -4,15 +4,28 @@ pub fn active_profile_name() -> &'static str {
     "personal"
 }
 
+fn data_dir_suffix_for(profile: &str) -> PathBuf {
+    match profile {
+        "release" | "local" => PathBuf::from("Vmux"),
+        other => PathBuf::from("Vmux").join(other),
+    }
+}
+
+fn data_dir_suffix() -> PathBuf {
+    data_dir_suffix_for(env!("VMUX_BUILD_PROFILE"))
+}
+
 pub fn shared_data_dir() -> PathBuf {
     #[cfg(target_os = "macos")]
     {
         let home = std::env::var_os("HOME").expect("HOME not set");
-        PathBuf::from(home).join("Library/Application Support/Vmux")
+        PathBuf::from(home)
+            .join("Library/Application Support")
+            .join(data_dir_suffix())
     }
     #[cfg(not(target_os = "macos"))]
     {
-        std::env::temp_dir().join("Vmux")
+        std::env::temp_dir().join(data_dir_suffix())
     }
 }
 
@@ -41,4 +54,42 @@ pub fn space_dir(space_id: &str) -> PathBuf {
     let dir = home.join(".vmux").join(space_id);
     let _ = std::fs::create_dir_all(&dir);
     dir
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn data_dir_suffix_maps_each_profile() {
+        assert_eq!(data_dir_suffix_for("release"), PathBuf::from("Vmux"));
+        assert_eq!(data_dir_suffix_for("local"), PathBuf::from("Vmux"));
+        assert_eq!(
+            data_dir_suffix_for("dev"),
+            PathBuf::from("Vmux").join("dev")
+        );
+        assert_eq!(
+            data_dir_suffix_for("custom"),
+            PathBuf::from("Vmux").join("custom"),
+        );
+    }
+
+    #[test]
+    fn local_and_release_share_one_space() {
+        assert_eq!(data_dir_suffix_for("local"), data_dir_suffix_for("release"));
+    }
+
+    #[test]
+    fn dev_lives_under_the_release_space() {
+        let release = data_dir_suffix_for("release");
+        let dev = data_dir_suffix_for("dev");
+        assert!(dev.starts_with(&release));
+        assert_ne!(dev, release);
+        assert_eq!(dev.file_name().unwrap(), "dev");
+    }
+
+    #[test]
+    fn shared_data_dir_ends_with_profile_suffix() {
+        assert!(shared_data_dir().ends_with(data_dir_suffix()));
+    }
 }

--- a/crates/vmux_setting/src/plugin/runtime.rs
+++ b/crates/vmux_setting/src/plugin/runtime.rs
@@ -370,12 +370,11 @@ pub(crate) struct SettingsWatcher {
 fn data_dir() -> Option<std::path::PathBuf> {
     #[cfg(target_os = "macos")]
     {
-        std::env::var_os("HOME")
-            .map(|home| std::path::PathBuf::from(home).join("Library/Application Support/Vmux"))
+        std::env::var_os("HOME").map(|_| vmux_core::profile::shared_data_dir())
     }
     #[cfg(not(target_os = "macos"))]
     {
-        Some(std::env::temp_dir().join("Vmux"))
+        Some(vmux_core::profile::shared_data_dir())
     }
 }
 


### PR DESCRIPTION
## Summary
- Non-release/local builds (dev + any custom profile) now resolve their shared data dir to `Vmux/<profile>` instead of the bare `Vmux` dir used by the released app. This stops dev builds from sharing the released app's profile dir — the cause of stale `space.ron` startup panics.
- Add `crates/vmux_core/build.rs` so `VMUX_BUILD_PROFILE` is available to `profile.rs`.
- Route the `vmux_setting` settings-watcher dir through `vmux_core::profile::shared_data_dir()` so it follows the same suffix.

Profile → data dir:
- `release` / `local` → `Vmux`
- `dev` → `Vmux/dev`
- `<other>` → `Vmux/<other>`

## Test plan
- [x] `cargo test -p vmux_core profile` (5 passed)
- [ ] CI: fmt, clippy, tests
