### PR TITLE
fix(persistence): preserve tab order across restart

### DIFF
--- a/crates/vmux_core/src/lib.rs
+++ b/crates/vmux_core/src/lib.rs
@@ -39,6 +39,7 @@ impl Plugin for CorePlugin {
             .register_type::<LastVisitedAt>()
             .register_type::<VisitedUrl>()
             .register_type::<TransitionType>()
+            .register_type::<Order>()
             .register_type::<Children>()
             .register_type::<ChildOf>();
     }
@@ -142,6 +143,13 @@ pub struct VisitCount(pub u32);
 #[require(Save)]
 #[type_path = "vmux_history"]
 pub struct LastVisitedAt(pub i64);
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Component, Clone, Copy, Debug, Reflect, Default, PartialEq, Eq)]
+#[reflect(Component, Default)]
+#[require(Save)]
+#[type_path = "vmux_core"]
+pub struct Order(pub u32);
 
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Component, Clone, Copy, Debug, Reflect)]

--- a/crates/vmux_desktop/src/persistence.rs
+++ b/crates/vmux_desktop/src/persistence.rs
@@ -6,7 +6,7 @@ use moonshine_save::prelude::*;
 use std::path::{Path, PathBuf};
 
 use vmux_browser::Browser;
-use vmux_core::PageMetadata;
+use vmux_core::{CreatedAt, Order, PageMetadata};
 use vmux_layout::event::SERVICES_PAGE_URL;
 use vmux_layout::event::TERMINAL_PAGE_URL;
 use vmux_layout::profile::Profile;
@@ -169,6 +169,7 @@ pub(crate) fn save_space_to_path(commands: &mut Commands, path: PathBuf) {
         .allow::<vmux_core::LastVisitedAt>()
         .allow::<vmux_core::VisitedUrl>()
         .allow::<vmux_core::TransitionType>()
+        .allow::<vmux_core::Order>()
         .allow::<vmux_terminal::launch::TerminalLaunch>();
     commands.trigger_save(save);
 }
@@ -261,12 +262,17 @@ fn page_metadata_urls(body: &str) -> Vec<&str> {
     urls
 }
 
+fn sort_tabs_by_order(mut tabs: Vec<(Entity, Option<u32>, Option<i64>)>) -> Vec<Entity> {
+    tabs.sort_by_key(|(_, order, created)| (order.unwrap_or(u32::MAX), created.unwrap_or(0)));
+    tabs.into_iter().map(|(entity, _, _)| entity).collect()
+}
+
 /// Rebuild view components (Node, Transform, Browser, etc.) for entities
 /// that were loaded from space.ron. Loaded entities only have model
 /// components; this system adds the visual layer.
 pub(crate) fn rebuild_space_views(
     main_q: Query<Entity, With<Main>>,
-    tabs_need_view: Query<Entity, (With<Tab>, Without<Node>)>,
+    tabs_need_view: Query<(Entity, Option<&Order>, Option<&CreatedAt>), (With<Tab>, Without<Node>)>,
     splits_need_view: Query<(Entity, &PaneSplit), Without<Node>>,
     panes_need_view: Query<Entity, (With<Pane>, Without<PaneSplit>, Without<Node>)>,
     stacks_need_view: Query<
@@ -300,7 +306,11 @@ pub(crate) fn rebuild_space_views(
     let Ok(main) = main_q.single() else { return };
     let pw = *primary_window;
 
-    for tab_e in &tabs_need_view {
+    let saved_tab_order: Vec<(Entity, Option<u32>, Option<i64>)> = tabs_need_view
+        .iter()
+        .map(|(entity, order, created)| (entity, order.map(|o| o.0), created.map(|c| c.0)))
+        .collect();
+    for tab_e in sort_tabs_by_order(saved_tab_order) {
         commands.entity(tab_e).insert((
             Transform::default(),
             GlobalTransform::default(),
@@ -523,6 +533,40 @@ mod tests {
         FocusRingSettings, LayoutSettings, PaneSettings, SideSheetSettings, WindowSettings,
     };
     use vmux_setting::{AppSettings, BrowserSettings, ShortcutSettings};
+
+    #[test]
+    fn sort_tabs_orders_by_order_field() {
+        let a = Entity::from_bits(10);
+        let b = Entity::from_bits(11);
+        let c = Entity::from_bits(12);
+        let input = vec![
+            (a, Some(2u32), Some(100i64)),
+            (b, Some(0), Some(200)),
+            (c, Some(1), Some(50)),
+        ];
+        assert_eq!(sort_tabs_by_order(input), vec![b, c, a]);
+    }
+
+    #[test]
+    fn sort_tabs_legacy_falls_back_to_created_at() {
+        let a = Entity::from_bits(10);
+        let b = Entity::from_bits(11);
+        let c = Entity::from_bits(12);
+        let input = vec![
+            (a, None, Some(2i64)),
+            (b, None, Some(3)),
+            (c, None, Some(1)),
+        ];
+        assert_eq!(sort_tabs_by_order(input), vec![c, a, b]);
+    }
+
+    #[test]
+    fn sort_tabs_ordered_before_unordered() {
+        let ordered = Entity::from_bits(1);
+        let legacy = Entity::from_bits(2);
+        let input = vec![(legacy, None, Some(0i64)), (ordered, Some(5u32), Some(999))];
+        assert_eq!(sort_tabs_by_order(input), vec![ordered, legacy]);
+    }
 
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 

--- a/crates/vmux_layout/src/tab.rs
+++ b/crates/vmux_layout/src/tab.rs
@@ -15,6 +15,7 @@ use moonshine_save::prelude::*;
 use std::time::Instant;
 use vmux_command::open::OpenCommand;
 use vmux_command::{AppCommand, BrowserCommand, LayoutCommand, ReadAppCommands, TabCommand};
+use vmux_core::Order;
 use vmux_history::LastActivatedAt;
 
 pub struct TabPlugin;
@@ -34,7 +35,8 @@ impl Plugin for TabPlugin {
                     .in_set(ReadAppCommands)
                     .in_set(TabCommandSet),
             )
-            .add_systems(PostUpdate, sync_tab_visibility.before(UiSystems::Layout));
+            .add_systems(PostUpdate, sync_tab_visibility.before(UiSystems::Layout))
+            .add_systems(PostUpdate, sync_tab_order);
     }
 }
 
@@ -274,6 +276,33 @@ fn sync_tab_visibility(
     }
 }
 
+fn sync_tab_order(
+    main_children: Query<&Children, (With<MainNode>, Changed<Children>)>,
+    tab_q: Query<(), With<Tab>>,
+    mut order_q: Query<&mut Order>,
+    mut commands: Commands,
+) {
+    for children in &main_children {
+        let mut idx = 0u32;
+        for child in children.iter() {
+            if !tab_q.contains(child) {
+                continue;
+            }
+            match order_q.get_mut(child) {
+                Ok(mut order) => {
+                    if order.0 != idx {
+                        order.0 = idx;
+                    }
+                }
+                Err(_) => {
+                    commands.entity(child).insert(Order(idx));
+                }
+            }
+            idx += 1;
+        }
+    }
+}
+
 fn on_tabs_command_emit(
     trigger: On<BinReceive<TabsCommandEvent>>,
     tabs: Query<(Entity, &LastActivatedAt), With<Tab>>,
@@ -368,6 +397,70 @@ mod tests {
             .unwrap_or_default();
 
         assert!(plugin.contains("sync_tab_visibility.before(UiSystems::Layout)"));
+    }
+
+    fn order_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_systems(Update, sync_tab_order);
+        app
+    }
+
+    #[test]
+    fn sync_tab_order_stamps_children_index() {
+        let mut app = order_app();
+        let main = app.world_mut().spawn(MainNode).id();
+        let a = app
+            .world_mut()
+            .spawn((Tab { name: "a".into() }, ChildOf(main)))
+            .id();
+        let b = app
+            .world_mut()
+            .spawn((Tab { name: "b".into() }, ChildOf(main)))
+            .id();
+        let c = app
+            .world_mut()
+            .spawn((Tab { name: "c".into() }, ChildOf(main)))
+            .id();
+
+        app.update();
+
+        assert_eq!(app.world().get::<Order>(a), Some(&Order(0)));
+        assert_eq!(app.world().get::<Order>(b), Some(&Order(1)));
+        assert_eq!(app.world().get::<Order>(c), Some(&Order(2)));
+    }
+
+    #[test]
+    fn sync_tab_order_updates_after_reorder() {
+        let mut app = order_app();
+        let main = app.world_mut().spawn(MainNode).id();
+        let a = app
+            .world_mut()
+            .spawn((Tab { name: "a".into() }, ChildOf(main)))
+            .id();
+        let b = app
+            .world_mut()
+            .spawn((Tab { name: "b".into() }, ChildOf(main)))
+            .id();
+        let c = app
+            .world_mut()
+            .spawn((Tab { name: "c".into() }, ChildOf(main)))
+            .id();
+
+        app.update();
+
+        for e in [a, b, c] {
+            app.world_mut().entity_mut(e).remove::<ChildOf>();
+        }
+        for e in [c, a, b] {
+            app.world_mut().entity_mut(e).insert(ChildOf(main));
+        }
+
+        app.update();
+
+        assert_eq!(app.world().get::<Order>(c), Some(&Order(0)));
+        assert_eq!(app.world().get::<Order>(a), Some(&Order(1)));
+        assert_eq!(app.world().get::<Order>(b), Some(&Order(2)));
     }
 
     fn test_settings() -> LayoutSettings {


### PR DESCRIPTION
## Context

After quitting and relaunching vmux, tabs came back in a different order than the user left them. Tab arrangement — including manual cmd-swap reordering — was never written to disk, so it could not be restored.

## Implementation

Tab order lived only in `Main.Children` (ECS table order) at runtime, but `Main` is a UI-shell entity excluded from the persistence allowlist. So neither `Main.Children` nor a valid tab→parent reference was serialized, and on load tabs were re-parented to the live `Main` in arbitrary ECS query order.

- New persisted `Order(u32)` component in `vmux_core` (reflected + allowlisted).
- `sync_tab_order` stamps `Order = sibling index` whenever `Main.Children` changes; create/close/swap all rewrite `Main.Children`, so swaps are captured.
- On restore, `rebuild_space_views` sorts tabs by `(Order, CreatedAt)` before re-parenting. Legacy spaces without `Order` fall back to creation order, then get stamped on the next save.

## Checks / QA

- Open 3+ tabs, cmd-swap into a custom order, quit, relaunch → order preserved.
- A `space.ron` predating this change has no `Order`: the first relaunch restores creation order; arrange/swap once (triggers a save), then subsequent relaunches preserve the arrangement.
- Close a middle tab, reopen, restart → no scramble.