### PR TITLE
feat(splash): show Vmux title and live startup status

### DIFF
--- a/crates/vmux_desktop/Cargo.toml
+++ b/crates/vmux_desktop/Cargo.toml
@@ -72,8 +72,12 @@ objc2-app-kit = { version = "0.3", features = [
     "NSProgressIndicator",
     "NSScreen",
     "NSAnimation",
+    "NSControl",
+    "NSText",
+    "NSTextField",
+    "NSFont",
 ] }
-objc2-foundation = { version = "0.3", features = ["NSGeometry", "NSData"] }
+objc2-foundation = { version = "0.3", features = ["NSGeometry", "NSData", "NSString"] }
 objc2-quartz-core = { version = "0.3", features = ["CALayer", "objc2-core-foundation"] }
 objc2-core-graphics = { version = "0.3", features = ["CGEvent", "CGEventTypes"] }
 objc2-core-foundation = { version = "0.3", features = [

--- a/crates/vmux_desktop/src/boot_status.rs
+++ b/crates/vmux_desktop/src/boot_status.rs
@@ -1,0 +1,320 @@
+use std::time::{Duration, Instant};
+
+use bevy::prelude::*;
+use vmux_core::page::PageReady;
+use vmux_layout::SpaceFilePresent;
+use vmux_layout::cef::LayoutCef;
+use vmux_layout::stack::{FocusedStack, Stack};
+
+/// How long to wait for the active page after the layout page is ready before
+/// revealing the window anyway, so a slow/hanging page cannot stall startup.
+pub const ACTIVE_PAGE_BUDGET: Duration = Duration::from_secs(8);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BootPhase {
+    Starting,
+    RestoringSpace,
+    LoadingInterface,
+    LoadingPages { ready: usize, total: usize },
+}
+
+impl BootPhase {
+    pub fn display(self) -> String {
+        match self {
+            BootPhase::Starting => "Starting...".to_string(),
+            BootPhase::RestoringSpace => "Restoring space...".to_string(),
+            BootPhase::LoadingInterface => "Loading interface...".to_string(),
+            BootPhase::LoadingPages { ready, total } => {
+                format!("Loading page {ready}/{total}...")
+            }
+        }
+    }
+}
+
+#[derive(Resource)]
+pub struct SplashStatus {
+    pub phase: BootPhase,
+    pub reveal_ready: bool,
+}
+
+impl Default for SplashStatus {
+    fn default() -> Self {
+        Self {
+            phase: BootPhase::Starting,
+            reveal_ready: false,
+        }
+    }
+}
+
+/// Set once the saved space has been restored (or immediately when there is no
+/// saved space). Owned here, written by the persistence plugin.
+#[derive(Resource, Default)]
+pub struct RestoreComplete(pub bool);
+
+pub struct BootInputs {
+    pub space_present: bool,
+    pub restore_complete: bool,
+    pub layout_ready: bool,
+    pub total_pages: usize,
+    pub ready_pages: usize,
+    pub active_page_ready: bool,
+    pub has_active_page: bool,
+    pub elapsed_since_layout: Option<Duration>,
+}
+
+pub fn compute(i: BootInputs) -> (BootPhase, bool) {
+    let budget_expired = i
+        .elapsed_since_layout
+        .is_some_and(|e| e >= ACTIVE_PAGE_BUDGET);
+    let reveal_ready =
+        i.layout_ready && (i.active_page_ready || !i.has_active_page || budget_expired);
+
+    let phase = if i.layout_ready && i.total_pages > 0 {
+        BootPhase::LoadingPages {
+            ready: i.ready_pages,
+            total: i.total_pages,
+        }
+    } else if i.layout_ready || i.restore_complete {
+        BootPhase::LoadingInterface
+    } else if i.space_present {
+        BootPhase::RestoringSpace
+    } else {
+        BootPhase::Starting
+    };
+
+    (phase, reveal_ready)
+}
+
+pub fn compute_boot_status(
+    mut status: ResMut<SplashStatus>,
+    space_present: Res<SpaceFilePresent>,
+    restore: Res<RestoreComplete>,
+    layout_q: Query<(), (With<LayoutCef>, With<PageReady>)>,
+    stacks_q: Query<Option<&Children>, With<Stack>>,
+    ready_q: Query<(), With<PageReady>>,
+    focused: Res<FocusedStack>,
+    mut layout_ready_at: Local<Option<Instant>>,
+) {
+    let layout_ready = !layout_q.is_empty();
+    if layout_ready && layout_ready_at.is_none() {
+        *layout_ready_at = Some(Instant::now());
+    }
+    let elapsed_since_layout = layout_ready_at.map(|t| t.elapsed());
+
+    // (is_content_stack, has_a_ready_page)
+    let inspect = |children: Option<&Children>| -> (bool, bool) {
+        match children {
+            Some(c) if !c.is_empty() => (true, c.iter().any(|e| ready_q.contains(e))),
+            _ => (false, false),
+        }
+    };
+
+    let mut total_pages = 0usize;
+    let mut ready_pages = 0usize;
+    for children in &stacks_q {
+        let (is_content, ready) = inspect(children);
+        if is_content {
+            total_pages += 1;
+            if ready {
+                ready_pages += 1;
+            }
+        }
+    }
+
+    let (has_active_page, active_page_ready) = match focused.stack {
+        Some(stack) => match stacks_q.get(stack) {
+            Ok(children) => inspect(children),
+            Err(_) => (false, false),
+        },
+        None => (false, false),
+    };
+
+    let (phase, reveal_ready) = compute(BootInputs {
+        space_present: space_present.0,
+        restore_complete: restore.0,
+        layout_ready,
+        total_pages,
+        ready_pages,
+        active_page_ready,
+        has_active_page,
+        elapsed_since_layout,
+    });
+
+    if status.phase != phase {
+        info!("boot: {}", phase.display());
+    }
+    status.phase = phase;
+    status.reveal_ready = reveal_ready;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inputs() -> BootInputs {
+        BootInputs {
+            space_present: false,
+            restore_complete: false,
+            layout_ready: false,
+            total_pages: 0,
+            ready_pages: 0,
+            active_page_ready: false,
+            has_active_page: false,
+            elapsed_since_layout: None,
+        }
+    }
+
+    #[test]
+    fn starting_when_nothing_ready() {
+        let (phase, reveal) = compute(inputs());
+        assert_eq!(phase, BootPhase::Starting);
+        assert!(!reveal);
+    }
+
+    #[test]
+    fn restoring_space_when_present_and_not_complete() {
+        let (phase, _) = compute(BootInputs {
+            space_present: true,
+            ..inputs()
+        });
+        assert_eq!(phase, BootPhase::RestoringSpace);
+    }
+
+    #[test]
+    fn loading_interface_after_restore_complete() {
+        let (phase, _) = compute(BootInputs {
+            space_present: true,
+            restore_complete: true,
+            ..inputs()
+        });
+        assert_eq!(phase, BootPhase::LoadingInterface);
+    }
+
+    #[test]
+    fn loading_interface_on_fresh_boot_once_complete() {
+        let (phase, _) = compute(BootInputs {
+            restore_complete: true,
+            ..inputs()
+        });
+        assert_eq!(phase, BootPhase::LoadingInterface);
+    }
+
+    #[test]
+    fn loading_pages_counts_when_layout_ready() {
+        let (phase, _) = compute(BootInputs {
+            layout_ready: true,
+            total_pages: 5,
+            ready_pages: 2,
+            ..inputs()
+        });
+        assert_eq!(phase, BootPhase::LoadingPages { ready: 2, total: 5 });
+    }
+
+    #[test]
+    fn not_revealed_until_layout_ready() {
+        let (_, reveal) = compute(BootInputs {
+            layout_ready: false,
+            has_active_page: true,
+            active_page_ready: true,
+            ..inputs()
+        });
+        assert!(!reveal);
+    }
+
+    #[test]
+    fn revealed_when_layout_and_active_page_ready() {
+        let (_, reveal) = compute(BootInputs {
+            layout_ready: true,
+            has_active_page: true,
+            active_page_ready: true,
+            ..inputs()
+        });
+        assert!(reveal);
+    }
+
+    #[test]
+    fn not_revealed_while_active_page_pending() {
+        let (_, reveal) = compute(BootInputs {
+            layout_ready: true,
+            has_active_page: true,
+            active_page_ready: false,
+            ..inputs()
+        });
+        assert!(!reveal);
+    }
+
+    #[test]
+    fn revealed_via_budget_when_active_page_hangs() {
+        let (_, reveal) = compute(BootInputs {
+            layout_ready: true,
+            has_active_page: true,
+            active_page_ready: false,
+            elapsed_since_layout: Some(Duration::from_secs(8)),
+            ..inputs()
+        });
+        assert!(reveal);
+    }
+
+    #[test]
+    fn revealed_when_no_content_pages() {
+        let (_, reveal) = compute(BootInputs {
+            layout_ready: true,
+            has_active_page: false,
+            ..inputs()
+        });
+        assert!(reveal);
+    }
+
+    #[test]
+    fn display_strings() {
+        assert_eq!(BootPhase::Starting.display(), "Starting...");
+        assert_eq!(BootPhase::RestoringSpace.display(), "Restoring space...");
+        assert_eq!(
+            BootPhase::LoadingInterface.display(),
+            "Loading interface..."
+        );
+        assert_eq!(
+            BootPhase::LoadingPages { ready: 2, total: 5 }.display(),
+            "Loading page 2/5..."
+        );
+    }
+
+    #[test]
+    fn system_reports_loading_pages_and_reveals_on_active_ready() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<SplashStatus>()
+            .init_resource::<RestoreComplete>()
+            .init_resource::<FocusedStack>()
+            .insert_resource(SpaceFilePresent(true))
+            .add_systems(Update, compute_boot_status);
+
+        app.world_mut().spawn((LayoutCef, PageReady {}));
+        let stack = app.world_mut().spawn(Stack::default()).id();
+        app.world_mut().spawn((PageReady {}, ChildOf(stack)));
+        app.world_mut().resource_mut::<FocusedStack>().stack = Some(stack);
+
+        app.update();
+
+        let status = app.world().resource::<SplashStatus>();
+        assert_eq!(status.phase, BootPhase::LoadingPages { ready: 1, total: 1 });
+        assert!(status.reveal_ready);
+    }
+
+    #[test]
+    fn system_reports_restoring_space_before_layout_ready() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<SplashStatus>()
+            .init_resource::<RestoreComplete>()
+            .init_resource::<FocusedStack>()
+            .insert_resource(SpaceFilePresent(true))
+            .add_systems(Update, compute_boot_status);
+
+        app.update();
+
+        let status = app.world().resource::<SplashStatus>();
+        assert_eq!(status.phase, BootPhase::RestoringSpace);
+        assert!(!status.reveal_ready);
+    }
+}

--- a/crates/vmux_desktop/src/glass.rs
+++ b/crates/vmux_desktop/src/glass.rs
@@ -1,5 +1,4 @@
 use bevy::prelude::*;
-use vmux_core::page::PageReady;
 use vmux_layout::cef::LayoutCef;
 use vmux_layout::scene::InteractionMode;
 
@@ -131,9 +130,9 @@ fn install_window_glass(
 fn reveal_window_after_layout_ready(
     mut state: NonSendMut<GlassState>,
     mut window: Query<(Entity, &mut Window), With<bevy::window::PrimaryWindow>>,
-    layout_ready: Query<(), (With<LayoutCef>, With<PageReady>)>,
+    status: Res<crate::boot_status::SplashStatus>,
 ) {
-    if state.revealed || !state.installed || layout_ready.is_empty() {
+    if state.revealed || !state.installed || !status.reveal_ready {
         return;
     }
     let Ok((entity, mut window)) = window.single_mut() else {
@@ -557,7 +556,7 @@ mod tests {
         assert!(overlay.contains("layer.setBackgroundColor(Some(&clear_color.CGColor()))"));
     }
 
-    fn reveal_test_app(layout_ready: bool) -> App {
+    fn reveal_test_app(reveal_ready: bool) -> App {
         let mut app = App::new();
         app.add_systems(Update, reveal_window_after_layout_ready);
         app.world_mut().insert_non_send(GlassState {
@@ -571,15 +570,15 @@ mod tests {
             },
             bevy::window::PrimaryWindow,
         ));
-        let mut layout = app.world_mut().spawn((LayoutCef,));
-        if layout_ready {
-            layout.insert(PageReady::default());
-        }
+        app.insert_resource(crate::boot_status::SplashStatus {
+            phase: crate::boot_status::BootPhase::Starting,
+            reveal_ready,
+        });
         app
     }
 
     #[test]
-    fn startup_window_stays_hidden_until_layout_ready() {
+    fn startup_window_stays_hidden_until_reveal_ready() {
         let mut app = reveal_test_app(false);
 
         app.update();
@@ -593,7 +592,7 @@ mod tests {
     }
 
     #[test]
-    fn startup_window_reveals_after_layout_ready() {
+    fn startup_window_reveals_after_reveal_ready() {
         let mut app = reveal_test_app(true);
 
         app.update();

--- a/crates/vmux_desktop/src/lib.rs
+++ b/crates/vmux_desktop/src/lib.rs
@@ -6,6 +6,7 @@
 )]
 
 mod background_lifecycle;
+mod boot_status;
 #[cfg(target_os = "macos")]
 mod event_tap;
 #[cfg(target_os = "macos")]
@@ -111,6 +112,13 @@ impl Plugin for VmuxPlugin {
                 background_lifecycle::BackgroundLifecyclePlugin,
                 tray::TrayPlugin,
             ));
+
+        app.init_resource::<boot_status::SplashStatus>()
+            .init_resource::<boot_status::RestoreComplete>()
+            .add_systems(
+                Update,
+                boot_status::compute_boot_status.after(vmux_layout::stack::ComputeFocusSet),
+            );
 
         #[cfg(target_os = "macos")]
         app.add_plugins((glass::GlassPlugin, splash::SplashPlugin))

--- a/crates/vmux_desktop/src/persistence.rs
+++ b/crates/vmux_desktop/src/persistence.rs
@@ -35,6 +35,7 @@ impl Plugin for PersistencePlugin {
             periodic: Timer::from_seconds(60.0, TimerMode::Repeating),
             dirty: false,
         })
+        .init_resource::<crate::boot_status::RestoreComplete>()
         .add_message::<vmux_core::agent::SpawnAgentInStackRequest>()
         .add_message::<vmux_space::SaveSpaceRequest>()
         .add_observer(save_on_default_event)
@@ -78,7 +79,11 @@ fn mark_space_views_need_rebuild(_trigger: On<Loaded>, mut commands: Commands) {
     commands.insert_resource(SpaceViewsNeedRebuild);
 }
 
-fn clear_space_views_need_rebuild(mut commands: Commands) {
+fn clear_space_views_need_rebuild(
+    mut restore: ResMut<crate::boot_status::RestoreComplete>,
+    mut commands: Commands,
+) {
+    restore.0 = true;
     commands.remove_resource::<SpaceViewsNeedRebuild>();
 }
 
@@ -174,7 +179,11 @@ pub(crate) fn save_space_to_path(commands: &mut Commands, path: PathBuf) {
 }
 
 /// Check if a space file exists and trigger load on startup.
-pub(crate) fn load_space_on_startup(active: Res<ActiveSpace>, mut commands: Commands) {
+pub(crate) fn load_space_on_startup(
+    active: Res<ActiveSpace>,
+    mut restore: ResMut<crate::boot_status::RestoreComplete>,
+    mut commands: Commands,
+) {
     let path = space_path(&active);
     let removed_stale = remove_stale_space_if_needed(&path);
     let exists = path.exists() && !removed_stale;
@@ -183,6 +192,7 @@ pub(crate) fn load_space_on_startup(active: Res<ActiveSpace>, mut commands: Comm
         info!("Loading space from {:?}", path);
         commands.trigger_load(LoadWorld::default_from_file(path));
     } else {
+        restore.0 = true;
         commands.spawn(vmux_space::spaces::space_profile_bundle(&active.record));
     }
 }

--- a/crates/vmux_desktop/src/splash.rs
+++ b/crates/vmux_desktop/src/splash.rs
@@ -30,6 +30,7 @@ fn splash_decision(visible: bool, dismissed: bool, elapsed: Duration) -> SplashA
 #[derive(Default)]
 struct SplashState {
     window: Option<Retained<NSPanel>>,
+    status_label: Option<Retained<objc2_app_kit::NSTextField>>,
     shown: bool,
     dismissed: bool,
     created_at: Option<Instant>,
@@ -42,20 +43,20 @@ impl Plugin for SplashPlugin {
     fn build(&self, app: &mut App) {
         app.init_non_send::<SplashState>()
             .add_systems(Startup, show_splash)
-            .add_systems(Last, dismiss_splash);
+            .add_systems(Last, (update_splash_text, dismiss_splash).chain());
     }
 }
 
 fn show_splash(mut state: NonSendMut<SplashState>) {
-    use objc2::{AnyThread, ClassType, MainThreadMarker, MainThreadOnly, runtime::AnyClass};
+    use objc2::{ClassType, MainThreadMarker, MainThreadOnly, runtime::AnyClass};
     use objc2_app_kit::{
-        NSAutoresizingMaskOptions, NSBackingStoreType, NSColor, NSGlassEffectView,
-        NSGlassEffectViewStyle, NSImage, NSImageScaling, NSImageView, NSProgressIndicator,
-        NSProgressIndicatorStyle, NSScreen, NSView, NSVisualEffectBlendingMode,
-        NSVisualEffectMaterial, NSVisualEffectState, NSVisualEffectView, NSWindow,
-        NSWindowCollectionBehavior, NSWindowStyleMask,
+        NSAutoresizingMaskOptions, NSBackingStoreType, NSColor, NSFont, NSGlassEffectView,
+        NSGlassEffectViewStyle, NSProgressIndicator, NSProgressIndicatorStyle, NSScreen,
+        NSTextAlignment, NSTextField, NSView, NSVisualEffectBlendingMode, NSVisualEffectMaterial,
+        NSVisualEffectState, NSVisualEffectView, NSWindow, NSWindowCollectionBehavior,
+        NSWindowStyleMask,
     };
-    use objc2_foundation::{NSData, NSPoint, NSRect, NSSize};
+    use objc2_foundation::{NSPoint, NSRect, NSSize, NSString};
 
     if state.shown {
         return;
@@ -127,18 +128,16 @@ fn show_splash(mut state: NonSendMut<SplashState>) {
         container.addSubview(view);
     }
 
-    let bytes: &[u8] = include_bytes!("../../../packaging/macos/vmux-icon.png");
-    let data = NSData::with_bytes(bytes);
-    if let Some(image) = NSImage::initWithData(NSImage::alloc(), &data) {
-        const LOGO: f64 = 96.0;
-        let logo = NSImageView::imageViewWithImage(&image, mtm);
-        logo.setFrame(NSRect::new(
-            NSPoint::new((W - LOGO) / 2.0, (H - LOGO) / 2.0 + 24.0),
-            NSSize::new(LOGO, LOGO),
-        ));
-        logo.setImageScaling(NSImageScaling::ScaleProportionallyUpOrDown);
-        container.addSubview(&logo);
-    }
+    const TITLE_H: f64 = 40.0;
+    let title = NSTextField::labelWithString(&NSString::from_str("Vmux"), mtm);
+    title.setFrame(NSRect::new(
+        NSPoint::new(0.0, (H - TITLE_H) / 2.0 + 40.0),
+        NSSize::new(W, TITLE_H),
+    ));
+    title.setAlignment(NSTextAlignment::Center);
+    title.setFont(Some(&NSFont::boldSystemFontOfSize(28.0)));
+    title.setTextColor(Some(&NSColor::labelColor()));
+    container.addSubview(&title);
 
     const SPIN: f64 = 32.0;
     let spinner = NSProgressIndicator::initWithFrame(
@@ -152,6 +151,18 @@ fn show_splash(mut state: NonSendMut<SplashState>) {
     spinner.setIndeterminate(true);
     unsafe { spinner.startAnimation(None) };
     container.addSubview(&spinner);
+
+    const STATUS_H: f64 = 20.0;
+    let status = NSTextField::labelWithString(&NSString::from_str("Starting..."), mtm);
+    status.setFrame(NSRect::new(
+        NSPoint::new(0.0, (H - STATUS_H) / 2.0 - 96.0),
+        NSSize::new(W, STATUS_H),
+    ));
+    status.setAlignment(NSTextAlignment::Center);
+    status.setFont(Some(&NSFont::systemFontOfSize(12.0)));
+    status.setTextColor(Some(&NSColor::secondaryLabelColor()));
+    container.addSubview(&status);
+    state.status_label = Some(status);
 
     window.setContentView(Some(&container));
     window.orderFrontRegardless();
@@ -195,6 +206,13 @@ fn dismiss_splash(
             state.dismissed = true;
             state.fade_started = Some(Instant::now());
         }
+    }
+}
+
+fn update_splash_text(state: NonSend<SplashState>, status: Res<crate::boot_status::SplashStatus>) {
+    use objc2_foundation::NSString;
+    if let Some(label) = &state.status_label {
+        label.setStringValue(&NSString::from_str(&status.phase.display()));
     }
 }
 
@@ -254,10 +272,12 @@ mod tests {
     }
 
     #[test]
-    fn splash_embeds_logo() {
+    fn splash_shows_title_and_status_label() {
         let source = include_str!("splash.rs");
-        assert!(source.contains("include_bytes!"));
-        assert!(source.contains("vmux-icon.png"));
+        assert!(source.contains("NSTextField"));
+        assert!(source.contains("\"Vmux\""));
+        assert!(source.contains("SplashStatus"));
+        assert!(source.contains("update_splash_text"));
     }
 
     #[test]
@@ -273,7 +293,7 @@ mod tests {
         let manifest = include_str!("../Cargo.toml");
         assert!(manifest.contains("\"NSProgressIndicator\""));
         assert!(manifest.contains("\"NSVisualEffectView\""));
-        assert!(manifest.contains("\"NSImageView\""));
-        assert!(manifest.contains("\"NSData\""));
+        assert!(manifest.contains("\"NSTextField\""));
+        assert!(manifest.contains("\"NSFont\""));
     }
 }

--- a/docs/specs/2026-06-16-startup-status-splash-design.md
+++ b/docs/specs/2026-06-16-startup-status-splash-design.md
@@ -1,0 +1,208 @@
+# Startup status splash — design
+
+Date: 2026-06-16
+
+## Problem
+
+The startup splash (`crates/vmux_desktop/src/splash.rs`) shows a logo and an
+**indeterminate spinner** only. Users wait through a long, opaque loading screen
+with no indication of what the app is doing or how far along it is.
+
+## Findings: what gates the splash today
+
+- The splash is a native AppKit `NSPanel`, shown in `Startup` (`show_splash`) and
+  faded in `Last` (`dismiss_splash`) once the primary window becomes `visible`
+  (20s force-dismiss backstop).
+- On macOS the primary window starts hidden (`visible: false`,
+  `lib.rs:primary_window_config`). It is revealed by
+  `reveal_window_after_layout_ready` (`glass.rs`) the moment the **layout page**
+  entity has both `LayoutCef` and `PageReady`.
+- That single gate means the splash duration ≈ CEF cold-start (helper subprocess
+  spawn + framework dylib load) + layout-page bundle load. **Content pages** (browser
+  tabs, terminals, agents) are spawned during space restore
+  (`persistence.rs:rebuild_space_views`) but load *after* the window is revealed —
+  they do not affect splash length today.
+
+Consequence: a truthful, live "page N/M" requires changing *when* the window
+reveals, because per-page readiness currently happens post-reveal.
+
+## Decision
+
+- Show **detailed status text with counts** in the splash, keeping the spinner.
+- **Wait for the active page**: the window reveal additionally gates on the
+  active/foreground page of the active space reporting ready (with a timeout).
+  Background tabs still lazy-load. The window appears slightly later, but the
+  focused tab is never blank on reveal.
+
+## Phase sequence shown in the splash
+
+1. `Starting…` — early init, before restore begins (or no saved space).
+2. `Restoring space…` — a saved space exists and views are being rebuilt. No
+   count here (restore is fast and the total isn't final until rebuild
+   completes). Skipped entirely when no saved space exists.
+3. `Loading interface…` — restore done (or nothing to restore), waiting on
+   the layout page's `PageReady` (the CEF cold-start long pole).
+4. `Loading page N/M…` — the layout page is up; `M` = content stacks in the active space,
+   `N` = those whose webview child has `PageReady`. Reveal gates on the
+   **active** stack specifically.
+
+These read as a sequence because the real signal order is monotonic: restore
+(filesystem + ECS spawn) completes well before the layout page's `PageReady` (CEF cold
+start). The narrative never regresses because each underlying signal flips
+false→true exactly once.
+
+## Architecture
+
+### 1. `boot_status.rs` (new, `crates/vmux_desktop/src/`)
+
+Pure ECS, no AppKit, so it compiles/tests cross-platform.
+
+```rust
+pub enum BootPhase {
+    Starting,
+    RestoringSpace,
+    LoadingInterface,
+    LoadingPages { ready: usize, total: usize },
+}
+
+#[derive(Resource)]
+pub struct SplashStatus {
+    pub phase: BootPhase,
+    pub reveal_ready: bool,
+}
+```
+
+Default = `{ phase: Starting, reveal_ready: false }`.
+
+A **pure function** carries all logic so it is unit-testable without ECS or
+AppKit:
+
+```rust
+struct BootInputs {
+    space_present: bool,        // saved space file exists
+    restore_complete: bool,     // space deserialized + views rebuilt (true immediately when no saved space)
+    layout_ready: bool,         // LayoutCef entity has PageReady
+    total_pages: usize,         // M: content stacks in the active space (valid once restore_complete)
+    ready_pages: usize,         // N: those whose webview child has PageReady
+    active_page_ready: bool,    // FocusedStack.stack's webview child has PageReady
+    has_active_page: bool,      // an active content stack exists
+    elapsed_since_layout: Option<Duration>, // since layout_ready first became true
+}
+
+fn compute(inputs: BootInputs) -> (BootPhase, bool); // (phase, reveal_ready)
+```
+
+Reveal:
+
+```
+reveal_ready = layout_ready && (active_page_ready || !has_active_page || budget_expired)
+budget_expired = elapsed_since_layout >= ACTIVE_PAGE_BUDGET   // 8s
+```
+
+Phase precedence (first match wins — monotonic given the signal order):
+
+```
+if layout_ready && total_pages > 0 => LoadingPages { ready_pages, total_pages }
+else if layout_ready               => LoadingInterface   // up, no content; reveal imminent
+else if restore_complete           => LoadingInterface   // restore done (or nothing to restore), layout page still loading
+else if space_present              => RestoringSpace
+else                               => Starting
+```
+
+`Starting` therefore shows only the first frame(s) before restore runs. A
+saved-space boot reads `Starting → RestoringSpace → LoadingInterface →
+LoadingPages`; a fresh boot reads `Starting → LoadingInterface` (no
+`RestoringSpace`).
+
+`BootPhase` renders to a display string:
+- `Starting…`
+- `Restoring space…`
+- `Loading interface…`
+- `Loading page {ready}/{total}…`
+
+### 2. `compute_boot_status` system
+
+Scheduled in `Update`, **after `ComputeFocusSet`** (so `FocusedStack` is current).
+Reads:
+
+- `SpaceFilePresent` resource → `space_present`
+- restore completion → `restore_complete`. Derived from `SpaceFilePresent`: if
+  no saved space, `true` immediately; otherwise `true` once `rebuild_space_views`
+  has run for the loaded space (e.g. observe the `Loaded` event / absence of
+  `Stack` entities still missing their `Node` view). A small marker resource set
+  when rebuild first completes is acceptable.
+- `LayoutCef` + `PageReady` query → `layout_ready`
+- content stacks in the active space and their webview children's `PageReady`
+  → `total_pages` (M) and `ready_pages` (N). Content stack = `Stack` with a
+  webview child (`Browser`/`Terminal`/agent/etc.), excluding the layout-page
+  `LayoutCef`.
+- `FocusedStack.stack`'s webview child `PageReady` → `active_page_ready` /
+  `has_active_page`
+
+Tracks `layout_ready_at: Option<Instant>` (set on first frame the layout page is
+ready) to derive `elapsed_since_layout`. Writes `SplashStatus { phase, reveal_ready }`.
+
+Optional: `info!` on each phase transition to record per-phase durations — gives
+an empirical answer to "what took so long" going forward.
+
+### 3. Reveal gate change (`glass.rs`)
+
+`reveal_window_after_layout_ready` reveals the window when
+`SplashStatus.reveal_ready` is true (single source of truth) instead of querying
+`LayoutCef` + `PageReady` directly. The 20s splash backstop in
+`dismiss_splash` is retained; the 8s active-page budget guarantees reveal well
+inside it even if a page hangs.
+
+### 4. Splash labels (`splash.rs`)
+
+- Replace the logo image (`NSImageView` + the `vmux-icon.png` `include_bytes!`)
+  with a **"Vmux" title** `NSTextField` (large, bold, centered) at the top.
+- Add a second `NSTextField` (non-editable, non-bordered, centered, secondary
+  color) below the spinner for the status line.
+- New `update_splash_text` system (`Last`, before/with `dismiss_splash`) reads
+  `SplashStatus` and sets the status label's string. Spinner stays.
+- Drop the obsolete `splash_embeds_logo` test; update
+  `desktop_enables_splash_appkit_features` (no longer needs `NSImageView`/`NSData`
+  for the logo; now needs `NSTextField`).
+
+### 5. Registration (`lib.rs`)
+
+- `mod boot_status;`
+- `init_resource::<SplashStatus>()` (Default = `Starting`, `reveal_ready: false`)
+- add `compute_boot_status` to `Update` after `ComputeFocusSet`.
+
+## Files
+
+- `crates/vmux_desktop/src/boot_status.rs` — new: enum, resource, `compute`,
+  display, system, tests
+- `crates/vmux_desktop/src/glass.rs` — reveal reads `reveal_ready`
+- `crates/vmux_desktop/src/splash.rs` — `NSTextField` + `update_splash_text`
+- `crates/vmux_desktop/src/lib.rs` — register module/resource/system
+
+## Testing (TDD)
+
+Pure-logic unit tests on `compute()` and the display formatter (mirrors the
+existing `splash_decision` test style):
+
+- `Starting` when `!restore_complete && !space_present && !layout_ready`
+- `RestoringSpace` when `space_present && !restore_complete && !layout_ready`
+- `LoadingInterface` when `restore_complete && !layout_ready` (covers both the
+  saved-space and fresh-boot paths)
+- `LoadingPages { ready, total }` when `layout_ready && total_pages > 0`
+- `reveal_ready` false until `layout_ready`
+- `reveal_ready` only when `layout_ready && active_page_ready`
+- `reveal_ready` via budget timeout when the active page hangs
+  (`elapsed_since_layout >= 8s`)
+- `reveal_ready` when `layout_ready && !has_active_page` (no content pages)
+- display strings, incl. `Loading page 2/5`
+
+ECS / source-scrape tests (match existing conventions):
+
+- glass: window reveals only when `SplashStatus.reveal_ready`
+- splash: source contains `NSTextField` and reads `SplashStatus`
+
+## Out of scope
+
+- Waiting for *all* pages (only the active page gates reveal).
+- Per-step progress *inside* CEF cold-start or the layout-page bundle load (opaque).
+- Reducing startup time itself (separate effort; timing logs will inform it).


### PR DESCRIPTION
## Summary
- Replace the startup splash logo with a **"Vmux"** title and a **live status line** that reflects boot progress: `Starting… → Restoring space… → Loading interface… → Loading page N/M…`.
- Add a cross-platform `boot_status` module: a `SplashStatus` resource computed each frame by a pure, unit-tested `compute()` from ECS signals (space-present, restore-complete, layout-page ready, content-page counts, active-page ready, elapsed).
- Gate the window reveal on the **active page** being ready (with an 8s budget so a slow/hanging page can't stall startup), so the focused tab is painted before the window appears — no blank-tab flash.
- `boot:` phase transitions are logged, giving an empirical read on where startup time goes.

## Details
- `crates/vmux_desktop/src/boot_status.rs` (new) — `BootPhase`, `SplashStatus`, `RestoreComplete`, `compute()`, `compute_boot_status`.
- `glass.rs` — `reveal_window_after_layout_ready` now reveals on `SplashStatus.reveal_ready`.
- `persistence.rs` — sets `RestoreComplete` (no-save path + after each rebuild).
- `splash.rs` — `NSTextField` title + status label, `update_splash_text` system.
- `Cargo.toml` — objc2-app-kit `NSTextField`/`NSFont`/`NSText`/`NSControl` + objc2-foundation `NSString`.
- Spec: `docs/specs/2026-06-16-startup-status-splash-design.md`.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy -p vmux_desktop --all-targets -- -D warnings` (clean)
- [x] `cargo test -p vmux_desktop` (107 pass: boot_status logic + ECS, glass reveal, splash)
- [ ] `make dev` — visually confirm phase sequence and that the focused tab is painted on reveal (golden path + fresh profile, no 8s stall)
