### PR TITLE
fix(layout): truncate dir path titles at start, not end

### DIFF
--- a/crates/vmux_layout/src/page.rs
+++ b/crates/vmux_layout/src/page.rs
@@ -371,6 +371,14 @@ fn NavButton(
     }
 }
 
+fn dir_truncate_class(title: &str) -> &'static str {
+    if title.starts_with('/') || title.starts_with("~/") {
+        "truncate-start"
+    } else {
+        "truncate"
+    }
+}
+
 #[component]
 fn Tab(tab: TabRow) -> Element {
     let id_switch = tab.id.clone();
@@ -399,11 +407,12 @@ fn Tab(tab: TabRow) -> Element {
         after:[background:radial-gradient(circle_at_top_right,transparent_0,transparent_8px,var(--tab-bg)_8px)]";
     let tab_box_classes = "group flex h-10 w-52 min-w-52 max-w-52 basis-52 shrink-0 grow-0 -mb-[3px] pb-[3px] cursor-pointer items-center gap-2 px-3.5";
 
+    let trunc = dir_truncate_class(&display_title);
     let (tab_style, tab_class, title_class, close_class) = if is_active {
         (
             "--tab-bg:var(--glass);".to_string(),
             format!("{skirt_classes} {tab_box_classes} glass rounded-t-md border-b-0"),
-            "min-w-0 flex-1 truncate text-ui font-medium text-foreground".to_string(),
+            format!("min-w-0 flex-1 {trunc} text-ui font-medium text-foreground"),
             "flex h-4 w-4 cursor-pointer shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 hover:bg-foreground/10".to_string(),
         )
     } else {
@@ -412,7 +421,7 @@ fn Tab(tab: TabRow) -> Element {
             format!(
                 "{tab_box_classes} rounded-md text-muted-foreground hover:bg-glass-hover hover:px-4 hover:text-foreground"
             ),
-            "min-w-0 flex-1 truncate text-ui".to_string(),
+            format!("min-w-0 flex-1 {trunc} text-ui"),
             "flex h-4 w-4 cursor-pointer shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 hover:bg-foreground/10".to_string(),
         )
     };
@@ -630,9 +639,9 @@ fn SideSheetStackRow(stack: StackNode, pane_id: u64) -> Element {
             StackIcon { url: stack.url.clone(), title: stack.title.clone(), favicon_src: icon, favicon_error: icon_error }
             span {
                 class: if is_active {
-                    "min-w-0 flex-1 truncate text-ui font-medium text-foreground"
+                    format!("min-w-0 flex-1 {} text-ui font-medium text-foreground", dir_truncate_class(&stack.title))
                 } else {
-                    "min-w-0 flex-1 truncate text-ui"
+                    format!("min-w-0 flex-1 {} text-ui", dir_truncate_class(&stack.title))
                 },
                 "{stack.title}"
             }

--- a/crates/vmux_layout/tests/page_source.rs
+++ b/crates/vmux_layout/tests/page_source.rs
@@ -53,7 +53,8 @@ fn header_tabs_use_same_fixed_width_for_active_and_inactive_states() {
     assert!(tab.contains("before:-left-2"));
     assert!(tab.contains("after:-right-2"));
     assert!(tab.contains("class: \"flex min-w-0 flex-1 items-center gap-2.5 overflow-hidden\""));
-    assert!(tab.contains("min-w-0 flex-1 truncate text-ui"));
+    assert!(tab.contains("min-w-0 flex-1 {trunc} text-ui"));
+    assert!(tab.contains("dir_truncate_class(&display_title)"));
 }
 
 #[test]
@@ -149,6 +150,26 @@ fn command_bar_page_installs_document_pointer_dismiss_listener() {
     assert!(source.contains("command-bar-shell"));
     assert!(source.contains("shell.contains"));
     assert!(source.contains("emit_action(\"dismiss\", \"\")"));
+}
+
+#[test]
+fn dir_path_titles_truncate_at_start() {
+    let source = include_str!("../src/page.rs");
+
+    assert!(source.contains("fn dir_truncate_class(title: &str) -> &'static str"));
+    assert!(source.contains("title.starts_with('/') || title.starts_with(\"~/\")"));
+    assert!(source.contains("\"truncate-start\""));
+    assert!(source.contains("dir_truncate_class(&display_title)"));
+    assert!(source.contains("dir_truncate_class(&stack.title)"));
+
+    let theme = include_str!("../../vmux_ui/assets/theme.css");
+    assert!(theme.contains(".truncate-start"));
+    assert!(theme.contains("direction: rtl"));
+    assert!(theme.contains("text-overflow: ellipsis"));
+
+    let server_css = include_str!("../../vmux_server/assets/index.css");
+    assert!(server_css.contains("../../vmux_ui/assets/theme.css"));
+    assert!(server_css.contains("@source \"../../vmux_layout/src\""));
 }
 
 fn tab_component_source() -> &'static str {

--- a/crates/vmux_ui/assets/theme.css
+++ b/crates/vmux_ui/assets/theme.css
@@ -278,3 +278,15 @@
   -webkit-backdrop-filter: blur(20px) saturate(1.4);
   backdrop-filter: blur(20px) saturate(1.4);
 }
+
+.truncate-start {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  direction: rtl;
+  text-align: left;
+}
+
+.truncate-start::before {
+  content: "\200E";
+}


### PR DESCRIPTION
## Context

Tab and stack titles that are directory paths were truncated at the end (e.g. `~/Projects/githu…`), hiding the meaningful trailing segment. The useful part of a path is the tail, so it should stay visible.

## Implementation

Added a shared `.truncate-start` utility to `vmux_ui/assets/theme.css` (imported by every webview host, alongside `.glass`): `direction: rtl; text-align: left` puts the ellipsis on the left while keeping the path tail visible, and a `::before` LRM (U+200E) keeps short paths in correct LTR order. `dir_truncate_class` applies it only to path-like titles (starting with `/` or `~/`); everything else keeps end-truncation.

The rule lives in `theme.css` rather than `vmux_layout/assets/index.css` because the served layout UI is compiled from `vmux_server/assets/index.css` (which `@source`s the layout crate), not the layout crate's own stylesheet — so a rule placed there never reached the running CSS.

## Checks / QA

- Open a space with a terminal stack whose cwd is a deep path; confirm the tab title and side-sheet stack row show a leading `…` with the tail (e.g. `…/vmux-ai/vmux`) on a single line, no wrapping.
- Confirm non-path titles (web page titles, "New Stack", space names) still truncate at the end.
- Hover the tab to confirm the tooltip shows the full path.
