### PR TITLE
fix(space): persist active space across restart

### DIFF
--- a/crates/vmux_space/src/model.rs
+++ b/crates/vmux_space/src/model.rs
@@ -20,6 +20,8 @@ impl Default for SpaceRecord {
 #[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct SpaceRegistry {
     pub spaces: Vec<SpaceRecord>,
+    #[serde(default)]
+    pub active: Option<String>,
 }
 
 pub fn bootstrap_space_record() -> SpaceRecord {
@@ -28,6 +30,16 @@ pub fn bootstrap_space_record() -> SpaceRecord {
         name: BOOTSTRAP_SPACE_NAME.to_string(),
         profile: BOOTSTRAP_PROFILE_NAME.to_string(),
     }
+}
+
+pub fn select_active_record(registry: &SpaceRegistry) -> SpaceRecord {
+    registry
+        .active
+        .as_deref()
+        .and_then(|id| registry.spaces.iter().find(|space| space.id == id))
+        .or_else(|| registry.spaces.first())
+        .cloned()
+        .unwrap_or_else(bootstrap_space_record)
 }
 
 pub fn registry_path(root: &Path) -> PathBuf {
@@ -135,5 +147,57 @@ mod tests {
             },
         ];
         assert_eq!(unique_space_id(&records, "Work"), "work-3");
+    }
+
+    fn record(id: &str) -> SpaceRecord {
+        SpaceRecord {
+            id: id.to_string(),
+            name: id.to_uppercase(),
+            profile: BOOTSTRAP_PROFILE_NAME.to_string(),
+        }
+    }
+
+    #[test]
+    fn select_active_uses_active_id_when_present() {
+        let registry = SpaceRegistry {
+            spaces: vec![record("a"), record("b")],
+            active: Some("b".to_string()),
+        };
+        assert_eq!(select_active_record(&registry).id, "b");
+    }
+
+    #[test]
+    fn select_active_falls_back_to_first_when_active_none() {
+        let registry = SpaceRegistry {
+            spaces: vec![record("a"), record("b")],
+            active: None,
+        };
+        assert_eq!(select_active_record(&registry).id, "a");
+    }
+
+    #[test]
+    fn select_active_falls_back_to_first_when_active_id_unknown() {
+        let registry = SpaceRegistry {
+            spaces: vec![record("a")],
+            active: Some("missing".to_string()),
+        };
+        assert_eq!(select_active_record(&registry).id, "a");
+    }
+
+    #[test]
+    fn select_active_uses_bootstrap_when_empty() {
+        let registry = SpaceRegistry {
+            spaces: vec![],
+            active: Some("anything".to_string()),
+        };
+        assert_eq!(select_active_record(&registry), bootstrap_space_record());
+    }
+
+    #[test]
+    fn registry_without_active_field_parses() {
+        let body = r#"(spaces: [(id: "a", name: "A", profile: "Personal")])"#;
+        let registry: SpaceRegistry = ron::de::from_str(body).expect("parse legacy registry");
+        assert_eq!(registry.active, None);
+        assert_eq!(registry.spaces.len(), 1);
     }
 }

--- a/crates/vmux_space/src/plugin.rs
+++ b/crates/vmux_space/src/plugin.rs
@@ -44,6 +44,7 @@ impl Plugin for SpacePlugin {
             .add_message::<SaveSpaceRequest>()
             .add_message::<SpaceCommandRequest>()
             .add_systems(Update, relay_space_command_requests)
+            .add_systems(Update, persist_active_space)
             .add_systems(Startup, ensure_space_registry)
             .add_systems(
                 Startup,
@@ -162,6 +163,19 @@ fn ensure_space_registry() {
         return;
     }
     write_space_registry_to(&root, &read_space_registry_from(&root));
+}
+
+fn persist_active_space(active: Res<ActiveSpace>) {
+    if !active.is_changed() {
+        return;
+    }
+    let root = profile::shared_data_dir();
+    let mut registry = read_space_registry_from(&root);
+    if registry.active.as_deref() == Some(active.record.id.as_str()) {
+        return;
+    }
+    registry.active = Some(active.record.id.clone());
+    write_space_registry_to(&root, &registry);
 }
 
 fn rename_space_record(registry: &mut SpaceRegistry, id: &str, name: &str) -> bool {
@@ -702,6 +716,7 @@ mod tests {
         };
         let registry = SpaceRegistry {
             spaces: vec![bootstrap_space_record(), active.record.clone()],
+            active: None,
         };
         let rows = space_rows(&active, &registry, 4);
         assert!(!rows[0].is_active);
@@ -737,6 +752,7 @@ mod tests {
                     profile: BOOTSTRAP_PROFILE_NAME.to_string(),
                 },
             ],
+            active: None,
         };
 
         let deleted = delete_space_record(&mut registry, "work").unwrap();
@@ -756,6 +772,7 @@ mod tests {
                     profile: BOOTSTRAP_PROFILE_NAME.to_string(),
                 },
             ],
+            active: None,
         };
 
         assert!(rename_space_record(&mut registry, "work", "Client A"));
@@ -769,6 +786,7 @@ mod tests {
     fn rename_space_record_unknown_id_is_noop() {
         let mut registry = SpaceRegistry {
             spaces: vec![bootstrap_space_record()],
+            active: None,
         };
         assert!(!rename_space_record(&mut registry, "nope", "X"));
     }
@@ -777,12 +795,37 @@ mod tests {
     fn delete_space_keeps_last_space() {
         let mut registry = SpaceRegistry {
             spaces: vec![bootstrap_space_record()],
+            active: None,
         };
 
         let deleted = delete_space_record(&mut registry, "space-1");
 
         assert!(deleted.is_none());
         assert_eq!(registry.spaces, vec![bootstrap_space_record()]);
+    }
+
+    #[test]
+    fn active_space_change_persists_active_id_to_registry() {
+        let _home = HomeEnvGuard::use_temp_home("persist-active-id");
+        write_space_registry_to(
+            &profile::shared_data_dir(),
+            &SpaceRegistry {
+                spaces: vec![bootstrap_space_record(), work_space_record()],
+                active: None,
+            },
+        );
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .insert_resource(ActiveSpace {
+                record: work_space_record(),
+            })
+            .add_systems(Update, persist_active_space);
+        app.update();
+
+        let registry = read_space_registry_from(&profile::shared_data_dir());
+        assert_eq!(registry.active.as_deref(), Some("work"));
+        assert_eq!(registry.spaces.len(), 2);
     }
 
     #[test]
@@ -793,6 +836,7 @@ mod tests {
             &profile::shared_data_dir(),
             &SpaceRegistry {
                 spaces: vec![bootstrap_space_record(), active_record.clone()],
+                active: None,
             },
         );
         let mut app = App::new();
@@ -852,6 +896,7 @@ mod tests {
             &profile::shared_data_dir(),
             &SpaceRegistry {
                 spaces: vec![bootstrap_space_record(), active_record.clone()],
+                active: None,
             },
         );
         let mut app = App::new();
@@ -931,6 +976,7 @@ mod tests {
             &profile::shared_data_dir(),
             &SpaceRegistry {
                 spaces: vec![bootstrap_space_record()],
+                active: None,
             },
         );
         let mut app = App::new();
@@ -1066,6 +1112,7 @@ mod tests {
             &profile::shared_data_dir(),
             &SpaceRegistry {
                 spaces: vec![bootstrap_space_record()],
+                active: None,
             },
         );
         let mut app = App::new();

--- a/crates/vmux_space/src/spaces.rs
+++ b/crates/vmux_space/src/spaces.rs
@@ -8,7 +8,8 @@ use vmux_layout::cef::Browser;
 
 use crate::event::{SPACES_PAGE_URL, SpaceRow};
 use crate::model::{
-    SpaceRecord, SpaceRegistry, bootstrap_space_record, registry_path, space_layout_path_for,
+    SpaceRecord, SpaceRegistry, bootstrap_space_record, registry_path, select_active_record,
+    space_layout_path_for,
 };
 
 #[derive(Resource, Clone, Debug)]
@@ -19,12 +20,9 @@ pub struct ActiveSpace {
 impl Default for ActiveSpace {
     fn default() -> Self {
         let registry = read_space_registry_from(&profile::shared_data_dir());
-        let record = registry
-            .spaces
-            .first()
-            .cloned()
-            .unwrap_or_else(bootstrap_space_record);
-        Self { record }
+        Self {
+            record: select_active_record(&registry),
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

Space *names* persist fine (in `spaces.ron`), but the **active-space selection** does not. `ActiveSpace` is a runtime-only resource and `ActiveSpace::default()` always picked `registry.spaces.first()`. So every launch resets to the oldest surviving space, regardless of which one you were on when you quit — making it look like the space (and its name in the header) "reverted."

## Fix

- Add a persisted `active: Option<String>` to `SpaceRegistry` (`spaces.ron`), `#[serde(default)]` so existing files still parse.
- `select_active_record()` resolves the active id → record, falling back to first, then bootstrap.
- `ActiveSpace::default()` uses it on boot.
- `persist_active_space` system writes the active id back whenever `ActiveSpace` changes (read-modify-write, so the spaces list and CRUD writes are preserved; it is the sole writer of the `active` field).

## Tests

`cargo test -p vmux_space` — 23 pass, incl. 5 new selector/back-compat tests and `active_space_change_persists_active_id_to_registry`. fmt + clippy clean.

## Not in scope

The `Name` component baked into each `space.ron` still goes stale on rename (it is dead for display — names render from the registry). Left as a separate cleanup.