### PR TITLE
fix(layout): render chrome on the wgpu mesh in User mode so it tracks live resize

### DIFF
--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -844,15 +844,10 @@ fn sync_windowed_content_mesh_materials(
 /// overlay. Keeping the entity visible (only the material transparent) leaves OSR running. Alpha
 /// mode stays `Blend` so Player keeps its transparency (pages show through the layout).
 fn sync_layout_mesh_visibility(
-    mode: Res<vmux_layout::scene::InteractionMode>,
     layout_q: Query<&MeshMaterial3d<WebviewExtendStandardMaterial>, With<LayoutCef>>,
     mut materials: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
-    let want_alpha = if *mode == vmux_layout::scene::InteractionMode::User {
-        0.0
-    } else {
-        1.0
-    };
+    let want_alpha = 1.0;
     for mat_handle in &layout_q {
         let Some(mut material) = materials.get_mut(mat_handle.id()) else {
             continue;
@@ -878,9 +873,7 @@ fn sync_cef_backend_for_interaction_mode(world: &mut World) {
     )>();
     let entities: Vec<(Entity, bool, bool)> = query.iter(world).collect();
     let target_windowed = |_entity: Entity, is_layout: bool| base_windowed && !is_layout;
-    let target_native_overlay = |is_layout: bool| {
-        cfg!(target_os = "macos") && mode == vmux_layout::scene::InteractionMode::User && is_layout
-    };
+    let target_native_overlay = |_is_layout: bool| false;
     let mut recreate = Vec::new();
     {
         let browsers = world.non_send::<Browsers>();

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -834,15 +834,14 @@ fn sync_windowed_content_mesh_materials(
     }
 }
 
-/// In User mode the layout chrome is presented by the native overlay (accelerated, with glass), but
-/// the OSR mesh still holds the last Player-mode (cpu-painted) frame and would draw it on top of the
-/// page views — the duplicate. Make the mesh render invisible in User; in Player the overlay is
-/// hidden and the mesh presents the (transparent) 3D layout, so render it.
+/// The layout chrome renders on the OSR mesh in both modes: a wgpu quad that resizes with the Bevy
+/// frame, so it tracks a live window resize (a native overlay cannot — its frame only updates from a
+/// Bevy schedule the macOS resize loop starves). Keep the material visible.
 ///
-/// This toggles the material's alpha rather than `Visibility`: the OSR focus pipeline treats a
-/// `Visibility::Hidden` webview as hidden and tells CEF to stop rendering it, which would starve the
-/// overlay. Keeping the entity visible (only the material transparent) leaves OSR running. Alpha
-/// mode stays `Blend` so Player keeps its transparency (pages show through the layout).
+/// This drives the material's alpha rather than `Visibility`: the OSR focus pipeline treats a
+/// `Visibility::Hidden` webview as hidden and tells CEF to stop rendering it. Keeping the entity
+/// visible leaves OSR running. Alpha mode stays `Blend` so pages show through the layout's
+/// transparent areas.
 fn sync_layout_mesh_visibility(
     layout_q: Query<&MeshMaterial3d<WebviewExtendStandardMaterial>, With<LayoutCef>>,
     mut materials: ResMut<Assets<WebviewExtendStandardMaterial>>,
@@ -3192,12 +3191,12 @@ mod tests {
     }
 
     #[test]
-    fn user_mode_makes_layout_mesh_invisible() {
-        let mat = layout_material_after_mode(vmux_layout::scene::InteractionMode::User, 1.0);
+    fn user_mode_makes_layout_mesh_visible() {
+        let mat = layout_material_after_mode(vmux_layout::scene::InteractionMode::User, 0.0);
         assert_eq!(
             mat.base.base_color.alpha(),
-            0.0,
-            "User mode hides the layout OSR mesh (the overlay presents the chrome) so it does not duplicate"
+            1.0,
+            "User mode renders the layout chrome via the mesh (CPU OSR) so it tracks live resize"
         );
         assert_eq!(mat.base.alpha_mode, AlphaMode::Blend);
     }
@@ -3855,10 +3854,7 @@ mod tests {
         sync_cef_backend_for_interaction_mode(app.world_mut());
 
         assert!(app.world().get::<WebviewWindowed>(layout).is_none());
-        assert_eq!(
-            app.world().get::<WebviewNativeOverlay>(layout).is_some(),
-            cfg!(target_os = "macos")
-        );
+        assert!(app.world().get::<WebviewNativeOverlay>(layout).is_none());
         assert_eq!(
             app.world().get::<WebviewWindowed>(terminal).is_some(),
             cfg!(target_os = "macos")

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -293,16 +293,12 @@ fn event_location_in_window_physical_px(event: &objc2_app_kit::NSEvent) -> Optio
     }
 }
 
-/// In browse (User) mode the focused-window update mode is fully native-wake-driven: winit's content
-/// view is first responder and emits `CursorMoved` on every move (CEF keeps `acceptsMouseMovedEvents`
-/// on for in-page hover), so leaving `react_to_window_events` on would tick Bevy ~display-refresh
-/// times per second while the mouse moves. Instead both `react_to_device_events` and
-/// `react_to_window_events` are off in User mode, and the native NSEvent monitors
-/// ([`install_native_mouse_wake_monitor`], native keyboard) wake the loop for the input that matters
-/// (clicks, keys, and pane-crossing hover). Player mode keeps both on for the free camera.
-/// every raw HID report. In browse (User) mode native CEF views own scroll/input, so Bevy must NOT
-/// wake on those — only Player mode's free camera consumes `AccumulatedMouseMotion`. Window events
-/// (resize/focus, OSR layout hover) and user events (CEF texture wake) stay on in both modes.
+/// `react_to_device_events` is off in browse (User) mode: native CEF views own scroll/input, so only
+/// Player mode's free camera consumes `AccumulatedMouseMotion`. `react_to_window_events` is on in
+/// both modes so the layout chrome mesh + camera track a live window resize (`Resized` fires during
+/// the macOS resize loop; the native mouse monitor never sees edge-drag events). The cost is that
+/// `CursorMoved` also wakes Bevy while the mouse moves — to be gated to live-resize only as a
+/// follow-up. The native NSEvent monitors still wake the loop for clicks/keys/pane-crossing hover.
 pub(crate) fn foreground_winit_settings(player: bool) -> WinitSettings {
     WinitSettings {
         focused_mode: UpdateMode::Reactive {
@@ -565,11 +561,11 @@ mod tests {
             settings.unfocused_mode,
             UpdateMode::reactive_low_power(Duration::from_secs(1))
         );
-        // Browse mode is fully native-wake-driven: both raw device-event and window-event wakes are
-        // off so the mouse moving (winit `CursorMoved`) does not tick Bevy. Player mode keeps both on
-        // for the free camera.
+        // Window-event wakes are on so the layout chrome mesh + camera track a live window resize
+        // (`Resized` fires during the macOS resize loop; the native mouse monitor never sees
+        // edge-drag events). Device-event wakes stay off in browse mode.
         assert!(!react_to_device_events);
-        assert!(!react_to_window_events);
+        assert!(react_to_window_events);
         let player = foreground_winit_settings(true);
         let UpdateMode::Reactive {
             react_to_device_events: player_device,

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -309,7 +309,7 @@ pub(crate) fn foreground_winit_settings(player: bool) -> WinitSettings {
             wait: FOCUSED_FRAME_INTERVAL,
             react_to_device_events: player,
             react_to_user_events: true,
-            react_to_window_events: player,
+            react_to_window_events: true,
         },
         unfocused_mode: UpdateMode::reactive_low_power(UNFOCUSED_FRAME_INTERVAL),
     }

--- a/crates/vmux_desktop/src/glass.rs
+++ b/crates/vmux_desktop/src/glass.rs
@@ -16,7 +16,13 @@ impl Plugin for GlassPlugin {
             .init_non_send::<LayoutOverlay>()
             .init_non_send::<CommandBarOverlay>()
             .add_systems(PreUpdate, install_window_glass)
-            .add_systems(Update, sync_window_glass_visibility)
+            .add_systems(
+                Update,
+                (
+                    sync_window_glass_visibility,
+                    keep_window_surface_layer_transparent,
+                ),
+            )
             .add_systems(
                 Update,
                 handle_toggle_fullscreen_command.in_set(vmux_command::ReadAppCommands),
@@ -318,6 +324,29 @@ fn primary_content_view_ptr(entity: Entity) -> Option<*mut core::ffi::c_void> {
             _ => None,
         }
     })
+}
+
+fn keep_window_surface_layer_transparent(window: Query<Entity, With<bevy::window::PrimaryWindow>>) {
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::{NSColor, NSView};
+
+    if MainThreadMarker::new().is_none() {
+        return;
+    }
+    let Ok(entity) = window.single() else {
+        return;
+    };
+    let Some(ns_view) = primary_content_view_ptr(entity) else {
+        return;
+    };
+    let content: &NSView = unsafe { &*ns_view.cast::<NSView>() };
+    content.setWantsLayer(true);
+    let Some(layer) = content.layer() else {
+        return;
+    };
+    let clear_color = NSColor::clearColor();
+    layer.setOpaque(false);
+    layer.setBackgroundColor(Some(&clear_color.CGColor()));
 }
 
 fn sync_layout_overlay(
@@ -707,5 +736,30 @@ mod tests {
             .unwrap_or_default();
 
         assert!(build.contains("ensure_window_active_after_reveal"));
+    }
+
+    #[test]
+    fn surface_transparency_system_is_registered() {
+        let source = include_str!("glass.rs");
+        let build = source
+            .split("fn build(&self, app: &mut App)")
+            .nth(1)
+            .and_then(|tail| tail.split("#[derive(Default)]").next())
+            .unwrap_or_default();
+
+        assert!(build.contains("keep_window_surface_layer_transparent"));
+    }
+
+    #[test]
+    fn surface_layer_kept_non_opaque_and_clear() {
+        let source = include_str!("glass.rs");
+        let func = source
+            .split("fn keep_window_surface_layer_transparent")
+            .nth(1)
+            .and_then(|tail| tail.split("fn sync_layout_overlay").next())
+            .unwrap_or_default();
+
+        assert!(func.contains("layer.setOpaque(false)"));
+        assert!(func.contains("layer.setBackgroundColor(Some(&clear_color.CGColor()))"));
     }
 }


### PR DESCRIPTION
## Summary

The User-mode layout chrome (sidebar/header/tabs/pane frames) was composited as a single full-window native `CALayer` overlay fed by CEF's **accelerated** (IOSurface) OSR. During a macOS **live-resize drag**, that overlay froze at the old size — its frame is only updated from a Bevy schedule, which the macOS resize tracking run loop starves — showing an opaque block / desync that trailed the glass.

This routes the layout through the **wgpu mesh path (CPU OSR)** in User mode, exactly like Player mode already does. The mesh is a quad that resizes *with* the Bevy frame, so it tracks the drag (the stale texture stretches, snapping crisp on release). Transparency works because CPU paint preserves alpha — the accelerated path blits transparent surfaces to black, which is the reason the native overlay existed in the first place.

## Changes
- `sync_cef_backend_for_interaction_mode`: the layout never takes the native overlay → it stays on the CPU-mesh path (the `shared_texture` decision then auto-selects CPU paint).
- `sync_layout_mesh_visibility`: keep the layout mesh visible in User mode.
- `foreground_winit_settings`: `react_to_window_events: true` so the mesh + camera follow the live-resize drag (`Resized` fires during the tracking loop; the native mouse monitor never sees edge-drag events).

## Known follow-up
- Resize is correct but CPU spikes *while actively dragging* (full render + CEF reflow per frame). Next: a ~60Hz frame cap during `inLiveResize` (suppress layout repaint / let the mesh stretch, throttle windowed-page reflow), which will also gate the `react_to_window_events` mouse-move wake to resize-only.

## Test plan
- [x] `cargo clippy -p vmux_browser -p vmux_desktop --all-targets -- -D warnings`
- [x] `cargo test -p vmux_browser -p vmux_desktop` (210 passed)
- [x] Manual: live-resize the window in browse mode — chrome tracks the drag, no opaque block, no mid-drag freeze; pages line up; glass intact.
