### PR TITLE
feat(space): spaces as live directories backed by one store.ron

### DIFF
--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -681,7 +681,15 @@ fn handle_agent_queries(
     mut reader: MessageReader<AgentQueryRequest>,
     service: Option<Res<ServiceClient>>,
     settings: Res<AppSettings>,
-    active_space: Option<Res<ActiveSpace>>,
+    spaces: Query<
+        (
+            &vmux_layout::space::SpaceId,
+            &Name,
+            Has<vmux_layout::space::ActiveSpaceTag>,
+            Option<&vmux_core::Order>,
+        ),
+        With<vmux_layout::space::Space>,
+    >,
     mut layout_snapshot_writer: MessageWriter<vmux_layout::reconcile::LayoutSnapshotRequest>,
 ) {
     let Some(service) = service else { return };
@@ -703,22 +711,22 @@ fn handle_agent_queries(
                 });
             }
             AgentQuery::ListSpaces => {
-                let registry = vmux_space::spaces::read_space_registry_from(
-                    &vmux_core::profile::shared_data_dir(),
-                );
-                let active_id = active_space.as_ref().map(|a| a.record.id.clone());
-                let rows: Vec<serde_json::Value> = registry
-                    .spaces
+                let mut rows: Vec<(u32, serde_json::Value)> = spaces
                     .iter()
-                    .map(|space| {
-                        serde_json::json!({
-                            "id": space.id,
-                            "name": space.name,
-                            "profile": space.profile,
-                            "is_active": active_id.as_deref() == Some(space.id.as_str()),
-                        })
+                    .map(|(id, name, is_active, order)| {
+                        (
+                            order.map(|o| o.0).unwrap_or(u32::MAX),
+                            serde_json::json!({
+                                "id": id.0,
+                                "name": name.to_string(),
+                                "profile": vmux_space::model::BOOTSTRAP_PROFILE_NAME,
+                                "is_active": is_active,
+                            }),
+                        )
                     })
                     .collect();
+                rows.sort_by_key(|(order, _)| *order);
+                let rows: Vec<serde_json::Value> = rows.into_iter().map(|(_, row)| row).collect();
                 let json = serde_json::to_string(&rows).unwrap_or_else(|_| "[]".to_string());
                 service.0.send(ClientMessage::AgentQueryResponse {
                     request_id: request.request_id,

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -2204,6 +2204,7 @@ fn push_tabs_host_emit(
     cef_q: Query<(Entity, Ref<PageReady>), With<LayoutCef>>,
     tabs: Query<(Entity, &Tab, &LastActivatedAt)>,
     tab_q: Query<Entity, With<Tab>>,
+    tab_space: Query<&vmux_layout::space::SpaceId>,
     child_of_q: Query<&ChildOf>,
     all_children: Query<&Children>,
     leaf_pane_q: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
@@ -2222,8 +2223,14 @@ fn push_tabs_host_emit(
 
     let active_tab = tabs.iter().max_by_key(|(_, _, ts)| ts.0).map(|t| t.0);
 
-    let ordered = if let Some(any) = tabs.iter().next() {
-        vmux_layout::tab::active_tab_siblings(any.0, &child_of_q, &all_children, &tab_q)
+    let ordered = if let Some(anchor) = active_tab {
+        vmux_layout::tab::active_tab_siblings(
+            anchor,
+            &child_of_q,
+            &all_children,
+            &tab_q,
+            &tab_space,
+        )
     } else {
         Vec::new()
     };

--- a/crates/vmux_core/src/profile.rs
+++ b/crates/vmux_core/src/profile.rs
@@ -72,6 +72,9 @@ fn rename_space_dir_in(home: &std::path::Path, old_id: &str, new_id: &str) {
     if new.exists() {
         return;
     }
+    if let Some(parent) = new.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
     if old.exists() {
         let _ = std::fs::rename(&old, &new);
     } else {
@@ -145,6 +148,17 @@ mod tests {
         let _ = std::fs::remove_dir_all(&home);
         rename_space_dir_in(&home, "old", "new");
         assert!(space_dir_path(&home, "new").exists());
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn rename_space_dir_creates_nested_path() {
+        let home = std::env::temp_dir().join(format!("vmux-rndir-nest-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(space_dir_path(&home, "old")).unwrap();
+        rename_space_dir_in(&home, "old", "org/new");
+        assert!(!space_dir_path(&home, "old").exists());
+        assert!(space_dir_path(&home, "org/new").exists());
         let _ = std::fs::remove_dir_all(&home);
     }
 }

--- a/crates/vmux_core/src/profile.rs
+++ b/crates/vmux_core/src/profile.rs
@@ -47,14 +47,38 @@ pub fn default_space_dir() -> PathBuf {
     space_dir("space-1")
 }
 
+fn spaces_root(home: &std::path::Path) -> PathBuf {
+    home.join(".vmux").join("spaces")
+}
+
 fn space_dir_path(home: &std::path::Path, space_id: &str) -> PathBuf {
-    home.join(".vmux").join("spaces").join(space_id)
+    spaces_root(home).join(space_id)
 }
 
 fn home_dir() -> PathBuf {
     std::env::var_os("HOME")
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("/"))
+}
+
+fn is_empty_dir(path: &std::path::Path) -> bool {
+    std::fs::read_dir(path)
+        .map(|mut entries| entries.next().is_none())
+        .unwrap_or(false)
+}
+
+/// Remove `dir` and its now-empty ancestors, stopping at (and never removing)
+/// `root`.
+fn prune_empty_dirs_up(mut dir: PathBuf, root: &std::path::Path) {
+    while dir.as_path() != root && dir.starts_with(root) {
+        if !is_empty_dir(&dir) || std::fs::remove_dir(&dir).is_err() {
+            break;
+        }
+        match dir.parent() {
+            Some(parent) => dir = parent.to_path_buf(),
+            None => break,
+        }
+    }
 }
 
 pub fn space_dir(space_id: &str) -> PathBuf {
@@ -69,21 +93,66 @@ fn rename_space_dir_in(home: &std::path::Path, old_id: &str, new_id: &str) {
     }
     let old = space_dir_path(home, old_id);
     let new = space_dir_path(home, new_id);
-    if new.exists() {
+    if old == new {
         return;
     }
     if let Some(parent) = new.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
     if old.exists() {
-        let _ = std::fs::rename(&old, &new);
-    } else {
+        if is_empty_dir(&new) {
+            let _ = std::fs::remove_dir(&new);
+        }
+        if std::fs::rename(&old, &new).is_ok()
+            && let Some(parent) = old.parent()
+        {
+            prune_empty_dirs_up(parent.to_path_buf(), &spaces_root(home));
+        }
+    } else if !new.exists() {
         let _ = std::fs::create_dir_all(&new);
     }
 }
 
 pub fn rename_space_dir(old_id: &str, new_id: &str) {
     rename_space_dir_in(&home_dir(), old_id, new_id);
+}
+
+fn collect_subdirs(dir: &std::path::Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_subdirs(&path, out);
+            out.push(path);
+        }
+    }
+}
+
+/// Remove directories under `~/.vmux/spaces/` that no longer match a live space
+/// id and are empty. Folders that contain files (or back a live space) are kept.
+fn prune_orphan_space_dirs_in(home: &std::path::Path, live: &std::collections::HashSet<String>) {
+    let root = spaces_root(home);
+    let mut dirs = Vec::new();
+    collect_subdirs(&root, &mut dirs);
+    dirs.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
+    for dir in dirs {
+        let Ok(rel) = dir.strip_prefix(&root) else {
+            continue;
+        };
+        let rel_id = rel.to_string_lossy().replace('\\', "/");
+        if live.contains(&rel_id) {
+            continue;
+        }
+        if is_empty_dir(&dir) {
+            let _ = std::fs::remove_dir(&dir);
+        }
+    }
+}
+
+pub fn prune_orphan_space_dirs(live: &std::collections::HashSet<String>) {
+    prune_orphan_space_dirs_in(&home_dir(), live);
 }
 
 #[cfg(test)]
@@ -159,6 +228,41 @@ mod tests {
         rename_space_dir_in(&home, "old", "org/new");
         assert!(!space_dir_path(&home, "old").exists());
         assert!(space_dir_path(&home, "org/new").exists());
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn rename_prunes_empty_old_parent() {
+        let home = std::env::temp_dir().join(format!("vmux-rndir-prune-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(space_dir_path(&home, "org/old")).unwrap();
+        rename_space_dir_in(&home, "org/old", "elsewhere");
+        assert!(space_dir_path(&home, "elsewhere").is_dir());
+        assert!(!space_dir_path(&home, "org/old").exists());
+        // the now-empty `org` parent is pruned too
+        assert!(!space_dir_path(&home, "org").exists());
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn prune_removes_empty_orphans_keeps_live_and_files() {
+        let home = std::env::temp_dir().join(format!("vmux-prune-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(space_dir_path(&home, "org/live")).unwrap();
+        std::fs::create_dir_all(space_dir_path(&home, "org/orphan")).unwrap();
+        std::fs::create_dir_all(space_dir_path(&home, "solo")).unwrap();
+        std::fs::create_dir_all(space_dir_path(&home, "keep")).unwrap();
+        std::fs::write(space_dir_path(&home, "keep").join("f.txt"), b"x").unwrap();
+
+        let live: std::collections::HashSet<String> =
+            ["org/live".to_string()].into_iter().collect();
+        prune_orphan_space_dirs_in(&home, &live);
+
+        assert!(space_dir_path(&home, "org/live").is_dir());
+        assert!(space_dir_path(&home, "org").is_dir());
+        assert!(!space_dir_path(&home, "org/orphan").exists());
+        assert!(!space_dir_path(&home, "solo").exists());
+        assert!(space_dir_path(&home, "keep").is_dir());
         let _ = std::fs::remove_dir_all(&home);
     }
 }

--- a/crates/vmux_core/src/profile.rs
+++ b/crates/vmux_core/src/profile.rs
@@ -47,11 +47,15 @@ pub fn default_space_dir() -> PathBuf {
     space_dir("space-1")
 }
 
+fn space_dir_path(home: &std::path::Path, space_id: &str) -> PathBuf {
+    home.join(".vmux").join("spaces").join(space_id)
+}
+
 pub fn space_dir(space_id: &str) -> PathBuf {
     let home = std::env::var_os("HOME")
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("/"));
-    let dir = home.join(".vmux").join(space_id);
+    let dir = space_dir_path(&home, space_id);
     let _ = std::fs::create_dir_all(&dir);
     dir
 }
@@ -91,5 +95,13 @@ mod tests {
     #[test]
     fn shared_data_dir_ends_with_profile_suffix() {
         assert!(shared_data_dir().ends_with(data_dir_suffix()));
+    }
+
+    #[test]
+    fn space_dir_is_under_vmux_spaces() {
+        assert_eq!(
+            space_dir_path(std::path::Path::new("/home/u"), "work"),
+            PathBuf::from("/home/u/.vmux/spaces/work")
+        );
     }
 }

--- a/crates/vmux_core/src/profile.rs
+++ b/crates/vmux_core/src/profile.rs
@@ -51,27 +51,36 @@ fn space_dir_path(home: &std::path::Path, space_id: &str) -> PathBuf {
     home.join(".vmux").join("spaces").join(space_id)
 }
 
-pub fn space_dir(space_id: &str) -> PathBuf {
-    let home = std::env::var_os("HOME")
+fn home_dir() -> PathBuf {
+    std::env::var_os("HOME")
         .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("/"));
-    let dir = space_dir_path(&home, space_id);
+        .unwrap_or_else(|| PathBuf::from("/"))
+}
+
+pub fn space_dir(space_id: &str) -> PathBuf {
+    let dir = space_dir_path(&home_dir(), space_id);
     let _ = std::fs::create_dir_all(&dir);
     dir
 }
 
-pub fn rename_space_dir(old_id: &str, new_id: &str) {
+fn rename_space_dir_in(home: &std::path::Path, old_id: &str, new_id: &str) {
     if old_id == new_id {
         return;
     }
-    let home = std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("/"));
-    let old = space_dir_path(&home, old_id);
-    let new = space_dir_path(&home, new_id);
-    if old.exists() && !new.exists() {
-        let _ = std::fs::rename(&old, &new);
+    let old = space_dir_path(home, old_id);
+    let new = space_dir_path(home, new_id);
+    if new.exists() {
+        return;
     }
+    if old.exists() {
+        let _ = std::fs::rename(&old, &new);
+    } else {
+        let _ = std::fs::create_dir_all(&new);
+    }
+}
+
+pub fn rename_space_dir(old_id: &str, new_id: &str) {
+    rename_space_dir_in(&home_dir(), old_id, new_id);
 }
 
 #[cfg(test)]
@@ -117,5 +126,25 @@ mod tests {
             space_dir_path(std::path::Path::new("/home/u"), "work"),
             PathBuf::from("/home/u/.vmux/spaces/work")
         );
+    }
+
+    #[test]
+    fn rename_space_dir_moves_existing_folder() {
+        let home = std::env::temp_dir().join(format!("vmux-rndir-mv-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(space_dir_path(&home, "old")).unwrap();
+        rename_space_dir_in(&home, "old", "new");
+        assert!(!space_dir_path(&home, "old").exists());
+        assert!(space_dir_path(&home, "new").exists());
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn rename_space_dir_creates_folder_when_absent() {
+        let home = std::env::temp_dir().join(format!("vmux-rndir-new-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        rename_space_dir_in(&home, "old", "new");
+        assert!(space_dir_path(&home, "new").exists());
+        let _ = std::fs::remove_dir_all(&home);
     }
 }

--- a/crates/vmux_core/src/profile.rs
+++ b/crates/vmux_core/src/profile.rs
@@ -60,6 +60,20 @@ pub fn space_dir(space_id: &str) -> PathBuf {
     dir
 }
 
+pub fn rename_space_dir(old_id: &str, new_id: &str) {
+    if old_id == new_id {
+        return;
+    }
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/"));
+    let old = space_dir_path(&home, old_id);
+    let new = space_dir_path(&home, new_id);
+    if old.exists() && !new.exists() {
+        let _ = std::fs::rename(&old, &new);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/vmux_desktop/src/boot_status.rs
+++ b/crates/vmux_desktop/src/boot_status.rs
@@ -1,8 +1,33 @@
+use bevy::ecs::relationship::Relationship;
 use bevy::prelude::*;
 use vmux_core::page::PageReady;
 use vmux_layout::SpaceFilePresent;
 use vmux_layout::cef::LayoutCef;
+use vmux_layout::space::{ActiveSpaceId, SpaceId};
 use vmux_layout::stack::Stack;
+
+/// Walk up from a stack to its owning tab's `SpaceId`; `true` if it belongs to
+/// the active space (or there is no active space / no space ancestor).
+fn stack_in_active_space(
+    stack: Entity,
+    child_of_q: &Query<&ChildOf>,
+    tab_space_q: &Query<&SpaceId>,
+    active: Option<&str>,
+) -> bool {
+    let Some(active) = active else {
+        return true;
+    };
+    let mut entity = stack;
+    loop {
+        if let Ok(sid) = tab_space_q.get(entity) {
+            return sid.0 == active;
+        }
+        match child_of_q.get(entity) {
+            Ok(child_of) => entity = child_of.get(),
+            Err(_) => return true,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BootPhase {
@@ -77,14 +102,21 @@ pub fn compute_boot_status(
     space_present: Res<SpaceFilePresent>,
     restore: Res<RestoreComplete>,
     layout_q: Query<(), (With<LayoutCef>, With<PageReady>)>,
-    stacks_q: Query<Option<&Children>, With<Stack>>,
+    stacks_q: Query<(Entity, Option<&Children>), With<Stack>>,
     ready_q: Query<(), With<PageReady>>,
+    child_of_q: Query<&ChildOf>,
+    tab_space_q: Query<&SpaceId>,
+    active_id: Option<Res<ActiveSpaceId>>,
 ) {
+    let active_space = active_id.as_deref().and_then(|id| id.0.as_deref());
     let layout_ready = !layout_q.is_empty();
 
     let mut total_pages = 0usize;
     let mut ready_pages = 0usize;
-    for children in &stacks_q {
+    for (stack, children) in &stacks_q {
+        if !stack_in_active_space(stack, &child_of_q, &tab_space_q, active_space) {
+            continue;
+        }
         if let Some(c) = children.filter(|c| !c.is_empty()) {
             total_pages += 1;
             if c.iter().any(|e| ready_q.contains(e)) {

--- a/crates/vmux_desktop/src/persistence.rs
+++ b/crates/vmux_desktop/src/persistence.rs
@@ -10,7 +10,7 @@ use vmux_core::{CreatedAt, Order, PageMetadata};
 use vmux_layout::event::SERVICES_PAGE_URL;
 use vmux_layout::event::TERMINAL_PAGE_URL;
 use vmux_layout::profile::Profile;
-use vmux_layout::space::Space;
+use vmux_layout::space::{ActiveSpaceTag, Space, SpaceId};
 use vmux_layout::{
     LayoutStartupSet, Open, SpaceFilePresent,
     pane::{Pane, PaneSize, PaneSplit, PaneSplitDirection, pane_split_gaps},
@@ -94,8 +94,8 @@ struct AutoSave {
     dirty: bool,
 }
 
-pub(crate) fn space_path(active: &ActiveSpace) -> PathBuf {
-    active.layout_path()
+pub(crate) fn store_path() -> PathBuf {
+    vmux_core::profile::shared_data_dir().join("store.ron")
 }
 
 fn mark_dirty_on_change(
@@ -123,24 +123,19 @@ fn mark_dirty_on_change(
     }
 }
 
-fn auto_save_system(
-    time: Res<Time>,
-    mut auto_save: ResMut<AutoSave>,
-    active: Res<ActiveSpace>,
-    mut commands: Commands,
-) {
+fn auto_save_system(time: Res<Time>, mut auto_save: ResMut<AutoSave>, mut commands: Commands) {
     auto_save.periodic.tick(time.delta());
 
     if auto_save.dirty {
         auto_save.debounce.tick(time.delta());
         if auto_save.debounce.is_finished() {
-            save_space_to_path(&mut commands, space_path(&active));
+            save_space_to_path(&mut commands, store_path());
             auto_save.dirty = false;
         }
     }
 
     if auto_save.periodic.just_finished() {
-        save_space_to_path(&mut commands, space_path(&active));
+        save_space_to_path(&mut commands, store_path());
     }
 }
 
@@ -163,6 +158,8 @@ pub(crate) fn save_space_to_path(commands: &mut Commands, path: PathBuf) {
         .allow::<PaneSplit>()
         .allow::<PaneSize>()
         .allow::<Space>()
+        .allow::<SpaceId>()
+        .allow::<ActiveSpaceTag>()
         .allow::<Profile>()
         .allow::<Open>()
         .allow::<PageMetadata>()
@@ -185,7 +182,7 @@ pub(crate) fn load_space_on_startup(
     mut restore: ResMut<crate::boot_status::RestoreComplete>,
     mut commands: Commands,
 ) {
-    let path = space_path(&active);
+    let path = store_path();
     let removed_stale = remove_stale_space_if_needed(&path);
     let exists = path.exists() && !removed_stale;
     commands.insert_resource(SpaceFilePresent(exists));
@@ -205,12 +202,8 @@ fn remove_stale_space_if_needed(path: &Path) -> bool {
     if !space_is_stale(&body) {
         return false;
     }
-    warn!("Removing stale space from {:?}", path);
-    if let Some(dir) = path.parent() {
-        let _ = std::fs::remove_dir_all(dir);
-    } else {
-        let _ = std::fs::remove_file(path);
-    }
+    warn!("Removing stale store from {:?}", path);
+    let _ = std::fs::remove_file(path);
     true
 }
 
@@ -906,6 +899,6 @@ mod tests {
 
         assert!(remove_stale_space_if_needed(&path));
         assert!(!path.exists());
-        assert!(!space_dir.exists());
+        assert!(space_dir.exists());
     }
 }

--- a/crates/vmux_layout/src/reconcile.rs
+++ b/crates/vmux_layout/src/reconcile.rs
@@ -653,6 +653,7 @@ fn active_space_id(world: &World) -> Option<String> {
         .and_then(|active| active.0.clone())
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn collect_ids_recursive(world: &World, entity: Entity, out: &mut ApplyHashSet<String>) {
     let Ok(entity_ref) = world.get_entity(entity) else {
         return;
@@ -677,6 +678,7 @@ fn collect_ids_recursive(world: &World, entity: Entity, out: &mut ApplyHashSet<S
 /// Existing ids the reconcile diff may add/remove. Scoped to the active space's
 /// tab subtrees so `update_layout` can never despawn another space's content.
 /// When there is no active space, all tabs are included (global behavior).
+#[cfg(not(target_arch = "wasm32"))]
 fn collect_existing_ids(world: &mut World) -> ApplyHashSet<String> {
     let active = active_space_id(world);
     let mut tab_q =

--- a/crates/vmux_layout/src/reconcile.rs
+++ b/crates/vmux_layout/src/reconcile.rs
@@ -332,12 +332,15 @@ pub fn serve_snapshot_requests(
     zoomed_q: Query<&crate::pane::Zoomed>,
     focused: Res<crate::stack::FocusedStack>,
     process_ids: Query<(&vmux_core::ProcessId, &ChildOf)>,
+    tab_space_q: Query<&crate::space::SpaceId>,
+    active_id: Option<Res<crate::space::ActiveSpaceId>>,
     mut writer: MessageWriter<LayoutSnapshotResponse>,
 ) {
     let pid_by_stack: HashMap<u64, String> = process_ids
         .iter()
         .map(|(pid, co)| (co.get().to_bits(), pid.to_string()))
         .collect();
+    let active_space = active_id.as_deref().and_then(|id| id.0.clone());
     for request in reader.read() {
         let self_stack = request.anchor.and_then(|anchor| {
             process_ids
@@ -355,6 +358,20 @@ pub fn serve_snapshot_requests(
             &focused,
             self_stack,
         );
+        if let Some(active) = active_space.as_deref() {
+            snapshot.tabs.retain(|tab| {
+                tab.id
+                    .as_deref()
+                    .and_then(|id| crate::protocol::parse_id(id).ok())
+                    .map(|(_, bits)| {
+                        tab_space_q
+                            .get(Entity::from_bits(bits))
+                            .map(|sid| sid.0 == active)
+                            .unwrap_or(true)
+                    })
+                    .unwrap_or(true)
+            });
+        }
         for tab in &mut snapshot.tabs {
             fill_process_ids(&mut tab.root, &pid_by_stack);
         }
@@ -630,23 +647,48 @@ fn apply_close(world: &mut World, id: &str) {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+fn active_space_id(world: &World) -> Option<String> {
+    world
+        .get_resource::<crate::space::ActiveSpaceId>()
+        .and_then(|active| active.0.clone())
+}
+
+fn collect_ids_recursive(world: &World, entity: Entity, out: &mut ApplyHashSet<String>) {
+    let Ok(entity_ref) = world.get_entity(entity) else {
+        return;
+    };
+    if entity_ref.contains::<LayoutTab>() {
+        out.insert(format_id(NodeKind::Tab, entity.to_bits()));
+    } else if entity_ref.contains::<PaneSplit>() {
+        out.insert(format_id(NodeKind::Split, entity.to_bits()));
+    } else if entity_ref.contains::<Pane>() {
+        out.insert(format_id(NodeKind::Pane, entity.to_bits()));
+    } else if entity_ref.contains::<Stack>() {
+        out.insert(format_id(NodeKind::Stack, entity.to_bits()));
+    }
+    if let Some(children) = entity_ref.get::<Children>() {
+        let kids: Vec<Entity> = children.iter().collect();
+        for child in kids {
+            collect_ids_recursive(world, child, out);
+        }
+    }
+}
+
+/// Existing ids the reconcile diff may add/remove. Scoped to the active space's
+/// tab subtrees so `update_layout` can never despawn another space's content.
+/// When there is no active space, all tabs are included (global behavior).
 fn collect_existing_ids(world: &mut World) -> ApplyHashSet<String> {
+    let active = active_space_id(world);
+    let mut tab_q =
+        world.query_filtered::<(Entity, Option<&crate::space::SpaceId>), With<LayoutTab>>();
+    let tabs: Vec<Entity> = tab_q
+        .iter(world)
+        .filter(|(_, sid)| crate::space::in_active_space(*sid, active.as_deref()))
+        .map(|(entity, _)| entity)
+        .collect();
     let mut out = ApplyHashSet::new();
-    let mut q_tab = world.query_filtered::<Entity, With<LayoutTab>>();
-    for e in q_tab.iter(world) {
-        out.insert(format_id(NodeKind::Tab, e.to_bits()));
-    }
-    let mut q_split = world.query_filtered::<Entity, (With<Pane>, With<PaneSplit>)>();
-    for e in q_split.iter(world) {
-        out.insert(format_id(NodeKind::Split, e.to_bits()));
-    }
-    let mut q_pane = world.query_filtered::<Entity, (With<Pane>, Without<PaneSplit>)>();
-    for e in q_pane.iter(world) {
-        out.insert(format_id(NodeKind::Pane, e.to_bits()));
-    }
-    let mut q_tab = world.query_filtered::<Entity, With<Stack>>();
-    for e in q_tab.iter(world) {
-        out.insert(format_id(NodeKind::Stack, e.to_bits()));
+    for tab in tabs {
+        collect_ids_recursive(world, tab, &mut out);
     }
     out
 }
@@ -812,6 +854,27 @@ fn node_entity(node: &proto::LayoutNode) -> Option<Entity> {
 mod tests {
     use super::*;
     use crate::protocol::{SplitDirection, Tab as TabDto};
+
+    #[test]
+    fn collect_existing_ids_scoped_to_active_space() {
+        let mut world = World::new();
+        world.insert_resource(crate::space::ActiveSpaceId(Some("a".to_string())));
+        let tab_a = world
+            .spawn((
+                crate::tab::Tab::default(),
+                crate::space::SpaceId("a".to_string()),
+            ))
+            .id();
+        let tab_b = world
+            .spawn((
+                crate::tab::Tab::default(),
+                crate::space::SpaceId("b".to_string()),
+            ))
+            .id();
+        let ids = collect_existing_ids(&mut world);
+        assert!(ids.contains(&format_id(NodeKind::Tab, tab_a.to_bits())));
+        assert!(!ids.contains(&format_id(NodeKind::Tab, tab_b.to_bits())));
+    }
 
     fn pane(id: Option<&str>, stacks: Vec<StackDto>) -> LayoutNode {
         LayoutNode::Pane {

--- a/crates/vmux_layout/src/space.rs
+++ b/crates/vmux_layout/src/space.rs
@@ -97,6 +97,13 @@ pub fn assign_orphan_tabs_to_active_space(
     }
 }
 
+pub fn same_space(candidate: Option<&SpaceId>, active: Option<&SpaceId>) -> bool {
+    match (candidate, active) {
+        (Some(candidate), Some(active)) => candidate == active,
+        _ => true,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/vmux_layout/src/space.rs
+++ b/crates/vmux_layout/src/space.rs
@@ -9,9 +9,15 @@ impl Plugin for SpacePlugin {
             .register_type::<SpaceId>()
             .register_type::<ActiveSpaceTag>()
             .init_resource::<ActiveSpaceEntity>()
+            .init_resource::<ActiveSpaceId>()
             .add_systems(
                 Update,
-                (ensure_active_space_tagged, sync_active_space_entity).chain(),
+                (
+                    ensure_active_space_tagged,
+                    sync_active_space_entity,
+                    sync_active_space_id,
+                )
+                    .chain(),
             );
     }
 }
@@ -37,6 +43,9 @@ pub struct ActiveSpaceTag;
 #[derive(Resource, Default, Debug, PartialEq, Eq)]
 pub struct ActiveSpaceEntity(pub Option<Entity>);
 
+#[derive(Resource, Default, Debug, PartialEq, Eq)]
+pub struct ActiveSpaceId(pub Option<String>);
+
 pub fn sync_active_space_entity(
     tagged: Query<Entity, With<ActiveSpaceTag>>,
     mut active: ResMut<ActiveSpaceEntity>,
@@ -57,6 +66,20 @@ pub fn ensure_active_space_tagged(
     }
     if let Some(entity) = spaces.iter().next() {
         commands.entity(entity).insert(ActiveSpaceTag);
+    }
+}
+
+pub fn sync_active_space_id(
+    active: Res<ActiveSpaceEntity>,
+    ids: Query<&SpaceId>,
+    mut active_id: ResMut<ActiveSpaceId>,
+) {
+    let current = active
+        .0
+        .and_then(|entity| ids.get(entity).ok())
+        .map(|id| id.0.clone());
+    if active_id.0 != current {
+        active_id.0 = current;
     }
 }
 
@@ -101,6 +124,24 @@ mod tests {
         app.update();
         assert!(app.world().entity(space).contains::<ActiveSpaceTag>());
         assert_eq!(app.world().resource::<ActiveSpaceEntity>().0, Some(space));
+    }
+
+    #[test]
+    fn active_space_id_tracks_active_entity() {
+        let mut app = App::new();
+        app.init_resource::<ActiveSpaceEntity>()
+            .init_resource::<ActiveSpaceId>()
+            .add_systems(
+                Update,
+                (sync_active_space_entity, sync_active_space_id).chain(),
+            );
+        app.world_mut()
+            .spawn((Space, SpaceId("work".to_string()), ActiveSpaceTag));
+        app.update();
+        assert_eq!(
+            app.world().resource::<ActiveSpaceId>().0.as_deref(),
+            Some("work")
+        );
     }
 
     #[test]

--- a/crates/vmux_layout/src/space.rs
+++ b/crates/vmux_layout/src/space.rs
@@ -5,7 +5,11 @@ pub struct SpacePlugin;
 
 impl Plugin for SpacePlugin {
     fn build(&self, app: &mut App) {
-        app.register_type::<Space>();
+        app.register_type::<Space>()
+            .register_type::<SpaceId>()
+            .register_type::<ActiveSpaceTag>()
+            .init_resource::<ActiveSpaceEntity>()
+            .add_systems(Update, sync_active_space_entity);
     }
 }
 
@@ -14,3 +18,56 @@ impl Plugin for SpacePlugin {
 #[type_path = "vmux_desktop::space"]
 #[require(Save)]
 pub struct Space;
+
+#[derive(Component, Reflect, Default, Clone, PartialEq, Eq)]
+#[reflect(Component)]
+#[type_path = "vmux_desktop::space"]
+#[require(Save)]
+pub struct SpaceId(pub String);
+
+#[derive(Component, Reflect, Default)]
+#[reflect(Component)]
+#[type_path = "vmux_desktop::space"]
+#[require(Save)]
+pub struct ActiveSpaceTag;
+
+#[derive(Resource, Default, Debug, PartialEq, Eq)]
+pub struct ActiveSpaceEntity(pub Option<Entity>);
+
+pub fn sync_active_space_entity(
+    tagged: Query<Entity, With<ActiveSpaceTag>>,
+    mut active: ResMut<ActiveSpaceEntity>,
+) {
+    let current = tagged.iter().next();
+    if active.0 != current {
+        active.0 = current;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn active_space_entity_tracks_tagged_space() {
+        let mut app = App::new();
+        app.init_resource::<ActiveSpaceEntity>()
+            .add_systems(Update, sync_active_space_entity);
+        let space = app
+            .world_mut()
+            .spawn((Space, SpaceId("default".to_string()), ActiveSpaceTag))
+            .id();
+        app.update();
+        assert_eq!(app.world().resource::<ActiveSpaceEntity>().0, Some(space));
+    }
+
+    #[test]
+    fn active_space_entity_clears_when_no_tag() {
+        let mut app = App::new();
+        app.init_resource::<ActiveSpaceEntity>()
+            .add_systems(Update, sync_active_space_entity);
+        app.insert_resource(ActiveSpaceEntity(Some(Entity::from_bits(42))));
+        app.update();
+        assert_eq!(app.world().resource::<ActiveSpaceEntity>().0, None);
+    }
+}

--- a/crates/vmux_layout/src/space.rs
+++ b/crates/vmux_layout/src/space.rs
@@ -104,6 +104,16 @@ pub fn same_space(candidate: Option<&SpaceId>, active: Option<&SpaceId>) -> bool
     }
 }
 
+/// Whether a tab/entity carrying `candidate` belongs to the active space id.
+/// Unknown ids (no `SpaceId`, or no active space) are treated as in-scope so
+/// callers degrade to global behavior instead of hiding everything.
+pub fn in_active_space(candidate: Option<&SpaceId>, active: Option<&str>) -> bool {
+    match (candidate, active) {
+        (Some(candidate), Some(active)) => candidate.0 == active,
+        _ => true,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/vmux_layout/src/space.rs
+++ b/crates/vmux_layout/src/space.rs
@@ -9,7 +9,10 @@ impl Plugin for SpacePlugin {
             .register_type::<SpaceId>()
             .register_type::<ActiveSpaceTag>()
             .init_resource::<ActiveSpaceEntity>()
-            .add_systems(Update, sync_active_space_entity);
+            .add_systems(
+                Update,
+                (ensure_active_space_tagged, sync_active_space_entity).chain(),
+            );
     }
 }
 
@@ -44,6 +47,19 @@ pub fn sync_active_space_entity(
     }
 }
 
+pub fn ensure_active_space_tagged(
+    tagged: Query<(), With<ActiveSpaceTag>>,
+    spaces: Query<Entity, With<Space>>,
+    mut commands: Commands,
+) {
+    if !tagged.is_empty() {
+        return;
+    }
+    if let Some(entity) = spaces.iter().next() {
+        commands.entity(entity).insert(ActiveSpaceTag);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -69,5 +85,38 @@ mod tests {
         app.insert_resource(ActiveSpaceEntity(Some(Entity::from_bits(42))));
         app.update();
         assert_eq!(app.world().resource::<ActiveSpaceEntity>().0, None);
+    }
+
+    #[test]
+    fn ensure_active_space_tagged_tags_sole_untagged_space() {
+        let mut app = App::new();
+        app.init_resource::<ActiveSpaceEntity>().add_systems(
+            Update,
+            (ensure_active_space_tagged, sync_active_space_entity).chain(),
+        );
+        let space = app
+            .world_mut()
+            .spawn((Space, SpaceId("default".to_string())))
+            .id();
+        app.update();
+        assert!(app.world().entity(space).contains::<ActiveSpaceTag>());
+        assert_eq!(app.world().resource::<ActiveSpaceEntity>().0, Some(space));
+    }
+
+    #[test]
+    fn ensure_active_space_tagged_is_noop_when_already_tagged() {
+        let mut app = App::new();
+        app.add_systems(Update, ensure_active_space_tagged);
+        let a = app
+            .world_mut()
+            .spawn((Space, SpaceId("a".to_string()), ActiveSpaceTag))
+            .id();
+        let b = app
+            .world_mut()
+            .spawn((Space, SpaceId("b".to_string())))
+            .id();
+        app.update();
+        assert!(app.world().entity(a).contains::<ActiveSpaceTag>());
+        assert!(!app.world().entity(b).contains::<ActiveSpaceTag>());
     }
 }

--- a/crates/vmux_layout/src/space.rs
+++ b/crates/vmux_layout/src/space.rs
@@ -16,6 +16,7 @@ impl Plugin for SpacePlugin {
                     ensure_active_space_tagged,
                     sync_active_space_entity,
                     sync_active_space_id,
+                    assign_orphan_tabs_to_active_space,
                 )
                     .chain(),
             );
@@ -28,7 +29,7 @@ impl Plugin for SpacePlugin {
 #[require(Save)]
 pub struct Space;
 
-#[derive(Component, Reflect, Default, Clone, PartialEq, Eq)]
+#[derive(Component, Reflect, Default, Clone, Debug, PartialEq, Eq)]
 #[reflect(Component)]
 #[type_path = "vmux_desktop::space"]
 #[require(Save)]
@@ -80,6 +81,19 @@ pub fn sync_active_space_id(
         .map(|id| id.0.clone());
     if active_id.0 != current {
         active_id.0 = current;
+    }
+}
+
+pub fn assign_orphan_tabs_to_active_space(
+    active_id: Res<ActiveSpaceId>,
+    orphans: Query<Entity, (With<crate::tab::Tab>, Without<SpaceId>)>,
+    mut commands: Commands,
+) {
+    let Some(id) = active_id.0.as_deref() else {
+        return;
+    };
+    for tab in &orphans {
+        commands.entity(tab).insert(SpaceId(id.to_string()));
     }
 }
 
@@ -141,6 +155,19 @@ mod tests {
         assert_eq!(
             app.world().resource::<ActiveSpaceId>().0.as_deref(),
             Some("work")
+        );
+    }
+
+    #[test]
+    fn orphan_tabs_get_active_space_id() {
+        let mut app = App::new();
+        app.insert_resource(ActiveSpaceId(Some("work".to_string())))
+            .add_systems(Update, assign_orphan_tabs_to_active_space);
+        let tab = app.world_mut().spawn(crate::tab::Tab::default()).id();
+        app.update();
+        assert_eq!(
+            app.world().entity(tab).get::<SpaceId>(),
+            Some(&SpaceId("work".to_string()))
         );
     }
 

--- a/crates/vmux_layout/src/stack.rs
+++ b/crates/vmux_layout/src/stack.rs
@@ -139,6 +139,8 @@ pub fn focused_stack(
 
 fn compute_focused_stack(
     mut cached: ResMut<FocusedStack>,
+    active_id: Option<Res<crate::space::ActiveSpaceId>>,
+    tab_space: Query<&crate::space::SpaceId>,
     tabs: Query<(Entity, &LastActivatedAt), With<Tab>>,
     all_children: Query<&Children>,
     leaf_panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
@@ -146,14 +148,12 @@ fn compute_focused_stack(
     pane_children: Query<&Children, With<Pane>>,
     stack_ts: Query<(Entity, &LastActivatedAt), With<Stack>>,
 ) {
-    let (tab, pane, stack) = focused_stack(
-        &tabs,
-        &all_children,
-        &leaf_panes,
-        &pane_ts,
-        &pane_children,
-        &stack_ts,
-    );
+    let active_space = active_id.as_deref().and_then(|id| id.0.as_deref());
+    let tab = active_among(tabs.iter().filter(|(entity, _)| {
+        crate::space::in_active_space(tab_space.get(*entity).ok(), active_space)
+    }));
+    let pane = tab.and_then(|t| active_pane_in_tab(t, &all_children, &leaf_panes, &pane_ts));
+    let stack = pane.and_then(|p| active_stack_in_pane(p, &pane_children, &stack_ts));
     cached.tab = tab;
     cached.pane = pane;
     cached.stack = stack;

--- a/crates/vmux_layout/src/tab.rs
+++ b/crates/vmux_layout/src/tab.rs
@@ -256,13 +256,25 @@ fn pick_after_close(active: Entity, siblings: &[Entity]) -> Option<Entity> {
 }
 
 fn sync_tab_visibility(
-    mut tabs: Query<(Entity, &LastActivatedAt, &mut Node, &mut Visibility), With<Tab>>,
+    active_id: Option<Res<crate::space::ActiveSpaceId>>,
+    mut tabs: Query<
+        (
+            Entity,
+            &LastActivatedAt,
+            Option<&crate::space::SpaceId>,
+            &mut Node,
+            &mut Visibility,
+        ),
+        With<Tab>,
+    >,
 ) {
+    let active_space = active_id.as_deref().and_then(|id| id.0.as_deref());
     let active = tabs
         .iter()
-        .max_by_key(|(_, ts, _, _)| ts.0)
-        .map(|(e, _, _, _)| e);
-    for (entity, _, mut node, mut vis) in &mut tabs {
+        .filter(|(_, _, sid, _, _)| crate::space::in_active_space(*sid, active_space))
+        .max_by_key(|(_, ts, _, _, _)| ts.0)
+        .map(|(e, _, _, _, _)| e);
+    for (entity, _, _, mut node, mut vis) in &mut tabs {
         let is_active = Some(entity) == active;
         let target_display = if is_active {
             Display::Flex

--- a/crates/vmux_layout/src/tab.rs
+++ b/crates/vmux_layout/src/tab.rs
@@ -75,6 +75,7 @@ fn handle_tab_commands(
     mut reader: MessageReader<AppCommand>,
     tabs: Query<(Entity, &LastActivatedAt), With<Tab>>,
     tab_q: Query<Entity, With<Tab>>,
+    tab_space: Query<&crate::space::SpaceId>,
     main_q: Query<Entity, With<MainNode>>,
     primary_window: Single<Entity, With<PrimaryWindow>>,
     child_of_q: Query<&ChildOf>,
@@ -115,7 +116,8 @@ fn handle_tab_commands(
             AppCommand::Layout(LayoutCommand::Tab(tab_cmd)) => match tab_cmd {
                 TabCommand::Close => {
                     let Some(active) = active_tab else { continue };
-                    let siblings = active_tab_siblings(active, &child_of_q, &all_children, &tab_q);
+                    let siblings =
+                        active_tab_siblings(active, &child_of_q, &all_children, &tab_q, &tab_space);
                     if siblings.len() <= 1 {
                         let Ok(main) = main_q.single() else { continue };
                         layout_requests.write(TabLayoutSpawnRequest {
@@ -133,7 +135,8 @@ fn handle_tab_commands(
                 }
                 TabCommand::Next | TabCommand::Previous => {
                     let Some(active) = active_tab else { continue };
-                    let siblings = active_tab_siblings(active, &child_of_q, &all_children, &tab_q);
+                    let siblings =
+                        active_tab_siblings(active, &child_of_q, &all_children, &tab_q, &tab_space);
                     if siblings.len() <= 1 {
                         continue;
                     }
@@ -161,7 +164,8 @@ fn handle_tab_commands(
                 | TabCommand::SelectIndex8
                 | TabCommand::SelectLast => {
                     let Some(active) = active_tab else { continue };
-                    let siblings = active_tab_siblings(active, &child_of_q, &all_children, &tab_q);
+                    let siblings =
+                        active_tab_siblings(active, &child_of_q, &all_children, &tab_q, &tab_space);
                     if siblings.is_empty() {
                         continue;
                     }
@@ -224,6 +228,7 @@ pub fn active_tab_siblings(
     child_of_q: &Query<&ChildOf>,
     all_children: &Query<&Children>,
     tab_q: &Query<Entity, With<Tab>>,
+    tab_space: &Query<&crate::space::SpaceId>,
 ) -> Vec<Entity> {
     let Ok(co) = child_of_q.get(active) else {
         return vec![active];
@@ -232,9 +237,11 @@ pub fn active_tab_siblings(
     let Ok(children) = all_children.get(parent) else {
         return vec![active];
     };
+    let active_space = tab_space.get(active).ok();
     children
         .iter()
         .filter(|e| tab_q.contains(*e))
+        .filter(|e| crate::space::same_space(tab_space.get(*e).ok(), active_space))
         .collect::<Vec<_>>()
 }
 
@@ -279,15 +286,21 @@ fn sync_tab_visibility(
 fn sync_tab_order(
     main_children: Query<&Children, (With<MainNode>, Changed<Children>)>,
     tab_q: Query<(), With<Tab>>,
+    tab_space: Query<&crate::space::SpaceId>,
     mut order_q: Query<&mut Order>,
     mut commands: Commands,
 ) {
     for children in &main_children {
-        let mut idx = 0u32;
+        let mut counters: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
         for child in children.iter() {
             if !tab_q.contains(child) {
                 continue;
             }
+            let key = tab_space
+                .get(child)
+                .map(|space| space.0.clone())
+                .unwrap_or_default();
+            let idx = *counters.get(&key).unwrap_or(&0);
             match order_q.get_mut(child) {
                 Ok(mut order) => {
                     if order.0 != idx {
@@ -298,7 +311,7 @@ fn sync_tab_order(
                     commands.entity(child).insert(Order(idx));
                 }
             }
-            idx += 1;
+            counters.insert(key, idx + 1);
         }
     }
 }
@@ -307,6 +320,7 @@ fn on_tabs_command_emit(
     trigger: On<BinReceive<TabsCommandEvent>>,
     tabs: Query<(Entity, &LastActivatedAt), With<Tab>>,
     tab_q: Query<Entity, With<Tab>>,
+    tab_space: Query<&crate::space::SpaceId>,
     main_q: Query<Entity, With<MainNode>>,
     primary_window: Single<Entity, With<PrimaryWindow>>,
     child_of_q: Query<&ChildOf>,
@@ -329,7 +343,8 @@ fn on_tabs_command_emit(
             let target = tab_target(evt.tab_id.as_deref(), tabs.iter().map(|(entity, _)| entity))
                 .or(active_tab);
             let Some(target) = target else { return };
-            let siblings = active_tab_siblings(target, &child_of_q, &all_children, &tab_q);
+            let siblings =
+                active_tab_siblings(target, &child_of_q, &all_children, &tab_q, &tab_space);
             if siblings.len() <= 1 {
                 let Ok(main) = main_q.single() else { return };
                 layout_requests.write(TabLayoutSpawnRequest {
@@ -385,6 +400,53 @@ mod tests {
         let id = target.to_bits().to_string();
 
         assert_eq!(tab_target(Some(&id), [other, target]), Some(target));
+    }
+
+    #[test]
+    fn active_tab_siblings_scopes_to_space() {
+        use bevy::ecs::system::RunSystemOnce;
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        let main = app.world_mut().spawn(MainNode).id();
+        let a1 = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                crate::space::SpaceId("a".into()),
+                ChildOf(main),
+            ))
+            .id();
+        let a2 = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                crate::space::SpaceId("a".into()),
+                ChildOf(main),
+            ))
+            .id();
+        let b1 = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                crate::space::SpaceId("b".into()),
+                ChildOf(main),
+            ))
+            .id();
+        let siblings = app
+            .world_mut()
+            .run_system_once(
+                move |child_of_q: Query<&ChildOf>,
+                      all_children: Query<&Children>,
+                      tab_q: Query<Entity, With<Tab>>,
+                      tab_space: Query<&crate::space::SpaceId>| {
+                    active_tab_siblings(a1, &child_of_q, &all_children, &tab_q, &tab_space)
+                },
+            )
+            .unwrap();
+        assert_eq!(siblings.len(), 2);
+        assert!(siblings.contains(&a1));
+        assert!(siblings.contains(&a2));
+        assert!(!siblings.contains(&b1));
     }
 
     #[test]

--- a/crates/vmux_layout/src/window.rs
+++ b/crates/vmux_layout/src/window.rs
@@ -477,6 +477,7 @@ pub fn spawn_requested_tab_layouts(
     mut new_stack_ctx: ResMut<crate::NewStackContext>,
     mut page_open_requests: MessageWriter<PageOpenRequest>,
     mut focus: Option<ResMut<crate::stack::FocusedStack>>,
+    active_space_id: Option<Res<crate::space::ActiveSpaceId>>,
     mut commands: Commands,
 ) {
     for request in reader.read() {
@@ -490,6 +491,11 @@ pub fn spawn_requested_tab_layouts(
             .id();
         if let Some(name) = request.name.clone() {
             commands.entity(tab_e).insert(Tab { name });
+        }
+        if let Some(space_id) = active_space_id.as_deref().and_then(|active| active.0.clone()) {
+            commands
+                .entity(tab_e)
+                .insert(crate::space::SpaceId(space_id));
         }
 
         let gap = pane_split_gaps(PaneSplitDirection::Row, settings.pane.gap);

--- a/crates/vmux_layout/src/window.rs
+++ b/crates/vmux_layout/src/window.rs
@@ -492,7 +492,10 @@ pub fn spawn_requested_tab_layouts(
         if let Some(name) = request.name.clone() {
             commands.entity(tab_e).insert(Tab { name });
         }
-        if let Some(space_id) = active_space_id.as_deref().and_then(|active| active.0.clone()) {
+        if let Some(space_id) = active_space_id
+            .as_deref()
+            .and_then(|active| active.0.clone())
+        {
             commands
                 .entity(tab_e)
                 .insert(crate::space::SpaceId(space_id));

--- a/crates/vmux_space/src/model.rs
+++ b/crates/vmux_space/src/model.rs
@@ -1,5 +1,3 @@
-use std::path::{Path, PathBuf};
-
 pub const BOOTSTRAP_PROFILE_NAME: &str = "Personal";
 pub const BOOTSTRAP_SPACE_ID: &str = "space-1";
 pub const BOOTSTRAP_SPACE_NAME: &str = "Space 1";
@@ -17,29 +15,12 @@ impl Default for SpaceRecord {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct SpaceRegistry {
-    pub spaces: Vec<SpaceRecord>,
-}
-
 pub fn bootstrap_space_record() -> SpaceRecord {
     SpaceRecord {
         id: BOOTSTRAP_SPACE_ID.to_string(),
         name: BOOTSTRAP_SPACE_NAME.to_string(),
         profile: BOOTSTRAP_PROFILE_NAME.to_string(),
     }
-}
-
-pub fn registry_path(root: &Path) -> PathBuf {
-    root.join("spaces.ron")
-}
-
-pub fn space_layout_path_for(root: &Path, space_id: &str, profile: &str) -> PathBuf {
-    root.join("profiles")
-        .join(normalize_space_id(profile))
-        .join("spaces")
-        .join(space_id)
-        .join("space.ron")
 }
 
 pub fn normalize_space_id(input: &str) -> String {
@@ -63,21 +44,14 @@ pub fn normalize_space_id(input: &str) -> String {
     }
 }
 
-pub fn unique_space_id<'a>(
-    records: impl IntoIterator<Item = &'a SpaceRecord>,
-    name: &str,
-) -> String {
+pub fn unique_space_id_among(existing: &std::collections::HashSet<String>, name: &str) -> String {
     let base = normalize_space_id(name);
-    let existing: std::collections::HashSet<&str> = records
-        .into_iter()
-        .map(|record| record.id.as_str())
-        .collect();
-    if !existing.contains(base.as_str()) {
+    if !existing.contains(&base) {
         return base;
     }
     for idx in 2usize.. {
         let candidate = format!("{base}-{idx}");
-        if !existing.contains(candidate.as_str()) {
+        if !existing.contains(&candidate) {
             return candidate;
         }
     }
@@ -89,51 +63,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn space_layouts_are_scoped_under_profiles() {
-        let root = PathBuf::from("/tmp/vmux");
-        assert_eq!(
-            space_layout_path_for(&root, "space-1", "Personal"),
-            root.join("profiles")
-                .join("personal")
-                .join("spaces")
-                .join("space-1")
-                .join("space.ron")
-        );
-    }
-
-    #[test]
-    fn named_space_is_scoped_under_attached_profile() {
-        let root = PathBuf::from("/tmp/vmux");
-        assert_eq!(
-            space_layout_path_for(&root, "work", "client-a"),
-            root.join("profiles")
-                .join("client-a")
-                .join("spaces")
-                .join("work")
-                .join("space.ron")
-        );
-    }
-
-    #[test]
     fn space_ids_are_slugged() {
         assert_eq!(normalize_space_id("Client A!"), "client-a");
         assert_eq!(normalize_space_id("  "), "space");
     }
 
     #[test]
-    fn space_ids_are_unique() {
-        let records = vec![
-            SpaceRecord {
-                id: "work".to_string(),
-                name: "Work".to_string(),
-                profile: BOOTSTRAP_PROFILE_NAME.to_string(),
-            },
-            SpaceRecord {
-                id: "work-2".to_string(),
-                name: "Work 2".to_string(),
-                profile: BOOTSTRAP_PROFILE_NAME.to_string(),
-            },
-        ];
-        assert_eq!(unique_space_id(&records, "Work"), "work-3");
+    fn unique_space_id_skips_existing() {
+        let existing: std::collections::HashSet<String> =
+            ["work".to_string(), "work-2".to_string()]
+                .into_iter()
+                .collect();
+        assert_eq!(unique_space_id_among(&existing, "Work"), "work-3");
     }
 }

--- a/crates/vmux_space/src/model.rs
+++ b/crates/vmux_space/src/model.rs
@@ -1,6 +1,6 @@
 pub const BOOTSTRAP_PROFILE_NAME: &str = "Personal";
 pub const BOOTSTRAP_SPACE_ID: &str = "space-1";
-pub const BOOTSTRAP_SPACE_NAME: &str = "Space 1";
+pub const BOOTSTRAP_SPACE_NAME: &str = "space-1";
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct SpaceRecord {

--- a/crates/vmux_space/src/model.rs
+++ b/crates/vmux_space/src/model.rs
@@ -23,7 +23,7 @@ pub fn bootstrap_space_record() -> SpaceRecord {
     }
 }
 
-pub fn normalize_space_id(input: &str) -> String {
+fn slug_segment(input: &str) -> String {
     let mut out = String::new();
     let mut pending_dash = false;
     for ch in input.chars().flat_map(char::to_lowercase) {
@@ -37,10 +37,21 @@ pub fn normalize_space_id(input: &str) -> String {
             pending_dash = true;
         }
     }
-    if out.is_empty() {
+    out
+}
+
+/// Slugs a space name into a filesystem-relative id, preserving `/` as a
+/// nested-directory separator (each segment is slugged independently).
+pub fn normalize_space_id(input: &str) -> String {
+    let segments: Vec<String> = input
+        .split('/')
+        .map(slug_segment)
+        .filter(|segment| !segment.is_empty())
+        .collect();
+    if segments.is_empty() {
         "space".to_string()
     } else {
-        out
+        segments.join("/")
     }
 }
 
@@ -66,6 +77,13 @@ mod tests {
     fn space_ids_are_slugged() {
         assert_eq!(normalize_space_id("Client A!"), "client-a");
         assert_eq!(normalize_space_id("  "), "space");
+    }
+
+    #[test]
+    fn normalize_keeps_slash_as_nested_separator() {
+        assert_eq!(normalize_space_id("vmux-ai/vmux"), "vmux-ai/vmux");
+        assert_eq!(normalize_space_id("Org Name/Repo!"), "org-name/repo");
+        assert_eq!(normalize_space_id("a//b/"), "a/b");
     }
 
     #[test]

--- a/crates/vmux_space/src/plugin.rs
+++ b/crates/vmux_space/src/plugin.rs
@@ -1,8 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use bevy::{ecs::message::MessageReader, prelude::*, window::PrimaryWindow};
 use bevy_cef::prelude::*;
-use moonshine_save::prelude::TriggerLoad;
 use vmux_core::page::PageReady;
 use vmux_core::profile;
 use vmux_core::{
@@ -15,11 +14,7 @@ use vmux_layout::{TabLayoutSpawnContent, TabLayoutSpawnRequest};
 use crate::event::{
     SPACES_LIST_EVENT, SPACES_PAGE_URL, SpaceCommandEvent, SpaceRow, SpacesListEvent,
 };
-use crate::model::{
-    SpaceRecord, SpaceRegistry, bootstrap_space_record, registry_path, space_layout_path_for,
-    unique_space_id,
-};
-use crate::spaces::{ActiveSpace, Spaces, read_space_registry_from, space_profile_bundle};
+use crate::spaces::{ActiveSpace, Spaces};
 
 #[derive(Message, Clone)]
 pub struct SaveSpaceRequest {
@@ -44,7 +39,7 @@ impl Plugin for SpacePlugin {
             .add_message::<SaveSpaceRequest>()
             .add_message::<SpaceCommandRequest>()
             .add_systems(Update, relay_space_command_requests)
-            .add_systems(Startup, ensure_space_registry)
+            .add_systems(Update, sync_active_space_record)
             .add_systems(
                 Startup,
                 update_effective_startup_url
@@ -68,10 +63,7 @@ impl Plugin for SpacePlugin {
                 Update,
                 handle_open_in_new_space.in_set(vmux_command::ReadAppCommands),
             )
-            .add_systems(
-                Update,
-                (apply_pending_space_switch, broadcast_spaces_to_views).chain(),
-            )
+            .add_systems(Update, broadcast_spaces_to_views)
             .add_systems(
                 Update,
                 crate::snapshot_updater::update_spaces_snapshot
@@ -145,83 +137,57 @@ fn reset_spaces_sent_marker_on_page_ready(
     commands.entity(entity).remove::<SpacesListSent>();
 }
 
-fn write_space_registry_to(root: &Path, registry: &SpaceRegistry) {
-    let path = registry_path(root);
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    if let Ok(body) = ron::ser::to_string_pretty(registry, ron::ser::PrettyConfig::default()) {
-        let _ = std::fs::write(path, body);
-    }
-}
-
-fn ensure_space_registry() {
-    let root = profile::shared_data_dir();
-    let path = registry_path(&root);
-    if path.exists() {
-        return;
-    }
-    write_space_registry_to(&root, &read_space_registry_from(&root));
-}
-
-fn rename_space_record(registry: &mut SpaceRegistry, id: &str, name: &str) -> bool {
-    if let Some(space) = registry.spaces.iter_mut().find(|space| space.id == id) {
-        space.name = name.to_string();
-        true
-    } else {
-        false
+fn sync_active_space_record(
+    tagged: Query<(&vmux_layout::space::SpaceId, &Name), With<vmux_layout::space::ActiveSpaceTag>>,
+    mut active: ResMut<ActiveSpace>,
+) {
+    if let Some((id, name)) = tagged.iter().next()
+        && (active.record.id != id.0 || active.record.name != name.as_str())
+    {
+        active.record.id = id.0.clone();
+        active.record.name = name.to_string();
     }
 }
 
-fn delete_space_record(registry: &mut SpaceRegistry, id: &str) -> Option<SpaceRecord> {
-    if registry.spaces.len() <= 1 {
-        return None;
-    }
-    let idx = registry.spaces.iter().position(|space| space.id == id)?;
-    Some(registry.spaces.remove(idx))
-}
+type SpaceListQuery<'w, 's> = Query<
+    'w,
+    's,
+    (
+        &'static vmux_layout::space::SpaceId,
+        &'static Name,
+        Has<vmux_layout::space::ActiveSpaceTag>,
+        Option<&'static vmux_core::Order>,
+    ),
+    With<vmux_layout::space::Space>,
+>;
 
-fn delete_space_layout(root: &Path, record: &SpaceRecord) {
-    let path = space_layout_path_for(root, &record.id, &record.profile);
-    if let Some(dir) = path.parent() {
-        let _ = std::fs::remove_dir_all(dir);
-    }
-}
-
-fn space_rows(
-    active: &ActiveSpace,
-    registry: &SpaceRegistry,
-    active_stack_count: usize,
+fn space_rows_from_world(
+    spaces: &SpaceListQuery,
+    tab_spaces: &Query<&vmux_layout::space::SpaceId, With<vmux_layout::tab::Tab>>,
 ) -> Vec<SpaceRow> {
-    registry
-        .spaces
+    let mut rows: Vec<(u32, SpaceRow)> = spaces
         .iter()
-        .map(|space| {
-            let is_active = space.id == active.record.id;
-            SpaceRow {
-                id: space.id.clone(),
-                name: space.name.clone(),
-                profile: space.profile.clone(),
-                is_active,
-                tab_count: if is_active {
-                    active_stack_count as u32
-                } else {
-                    0
+        .map(|(sid, name, is_active, order)| {
+            let tab_count = tab_spaces.iter().filter(|s| s.0 == sid.0).count() as u32;
+            (
+                order.map(|o| o.0).unwrap_or(u32::MAX),
+                SpaceRow {
+                    id: sid.0.clone(),
+                    name: name.to_string(),
+                    profile: crate::model::BOOTSTRAP_PROFILE_NAME.to_string(),
+                    is_active,
+                    tab_count,
                 },
-            }
+            )
         })
-        .collect()
-}
-
-#[derive(Resource)]
-struct PendingSpaceSwitch {
-    from_id: String,
-    record: SpaceRecord,
-    delay_frames: u8,
+        .collect();
+    rows.sort_by_key(|(order, _)| *order);
+    rows.into_iter().map(|(_, row)| row).collect()
 }
 
 fn broadcast_spaces_to_views(
-    active: Res<ActiveSpace>,
+    spaces: SpaceListQuery,
+    tab_spaces: Query<&vmux_layout::space::SpaceId, With<vmux_layout::tab::Tab>>,
     pending_spaces: Query<Entity, (With<Spaces>, With<PageReady>, Without<SpacesListSent>)>,
     sent_spaces: Query<Entity, (With<Spaces>, With<PageReady>, With<SpacesListSent>)>,
     pending_cef: Query<
@@ -241,7 +207,6 @@ fn broadcast_spaces_to_views(
         ),
     >,
     browsers: NonSend<Browsers>,
-    tabs: Query<(), With<Stack>>,
     mut last_body: Local<String>,
     mut commands: Commands,
 ) {
@@ -250,9 +215,8 @@ fn broadcast_spaces_to_views(
     if pending_total == 0 && sent_total == 0 {
         return;
     }
-    let registry = read_space_registry_from(&profile::shared_data_dir());
     let payload = SpacesListEvent {
-        spaces: space_rows(&active, &registry, tabs.iter().count()),
+        spaces: space_rows_from_world(&spaces, &tab_spaces),
     };
     let body = ron::ser::to_string(&payload).unwrap_or_default();
     let body_changed = body != *last_body;
@@ -282,59 +246,6 @@ fn broadcast_spaces_to_views(
     }
 }
 
-fn apply_pending_space_switch(
-    pending: Option<ResMut<PendingSpaceSwitch>>,
-    mut active: ResMut<ActiveSpace>,
-    space_entities: Query<
-        Entity,
-        Or<(
-            With<vmux_layout::space::Space>,
-            With<vmux_layout::tab::Tab>,
-            With<vmux_history::Visit>,
-        )>,
-    >,
-    main_q: Query<Entity, With<vmux_layout::window::Main>>,
-    primary_window: Single<Entity, With<PrimaryWindow>>,
-    mut layout_requests: MessageWriter<TabLayoutSpawnRequest>,
-    mut commands: Commands,
-) {
-    let Some(mut pending) = pending else {
-        return;
-    };
-    if pending.delay_frames > 0 {
-        pending.delay_frames -= 1;
-        return;
-    }
-    let record = pending.record.clone();
-    let from_id = pending.from_id.clone();
-    commands.remove_resource::<PendingSpaceSwitch>();
-    if from_id != active.record.id {
-        return;
-    }
-    active.record = record.clone();
-    let target_path =
-        space_layout_path_for(&profile::shared_data_dir(), &record.id, &record.profile);
-    if target_path.exists() {
-        commands.trigger_load(moonshine_save::prelude::LoadWorld::default_from_file(
-            target_path,
-        ));
-    } else {
-        for entity in &space_entities {
-            commands.entity(entity).try_despawn();
-        }
-        commands.spawn(space_profile_bundle(&record));
-        let Ok(main) = main_q.single() else { return };
-        layout_requests.write(TabLayoutSpawnRequest {
-            main,
-            primary_window: *primary_window,
-            name: None,
-            content: TabLayoutSpawnContent::StartupUrlOrPrompt,
-            clear_pending_stack: false,
-            focus: true,
-        });
-    }
-}
-
 fn relay_space_command_requests(
     mut reader: MessageReader<SpaceCommandRequest>,
     mut commands: Commands,
@@ -351,30 +262,68 @@ fn relay_space_command_requests(
     }
 }
 
+type SpaceQuery<'w, 's> = Query<
+    'w,
+    's,
+    (
+        Entity,
+        &'static vmux_layout::space::SpaceId,
+        Has<vmux_layout::space::ActiveSpaceTag>,
+        Option<&'static vmux_core::Order>,
+    ),
+    With<vmux_layout::space::Space>,
+>;
+
+type SpaceTabQuery<'w, 's> = Query<
+    'w,
+    's,
+    (
+        Entity,
+        &'static vmux_layout::space::SpaceId,
+        &'static vmux_history::LastActivatedAt,
+    ),
+    With<vmux_layout::tab::Tab>,
+>;
+
+fn bump_space_tab(tabs: &SpaceTabQuery, space_id: &str, commands: &mut Commands) {
+    if let Some((tab, _, _)) = tabs
+        .iter()
+        .filter(|(_, sid, _)| sid.0 == space_id)
+        .max_by_key(|(_, _, ts)| ts.0)
+    {
+        commands
+            .entity(tab)
+            .insert(vmux_history::LastActivatedAt::now());
+    }
+}
+
+fn deactivate_all_spaces(spaces: &SpaceQuery, commands: &mut Commands) {
+    for (entity, _, is_active, _) in spaces.iter() {
+        if is_active {
+            commands
+                .entity(entity)
+                .remove::<vmux_layout::space::ActiveSpaceTag>();
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 fn on_space_command(
     trigger: On<BinReceive<SpaceCommandEvent>>,
-    mut active: ResMut<ActiveSpace>,
-    space_entities: Query<
-        Entity,
-        Or<(
-            With<vmux_layout::space::Space>,
-            With<vmux_layout::tab::Tab>,
-            With<vmux_history::Visit>,
-        )>,
-    >,
+    spaces: SpaceQuery,
+    tabs: SpaceTabQuery,
     main_q: Query<Entity, With<vmux_layout::window::Main>>,
     primary_window: Single<Entity, With<PrimaryWindow>>,
-    focus: Option<ResMut<vmux_layout::stack::FocusedStack>>,
+    focus: Option<Res<vmux_layout::stack::FocusedStack>>,
     mut spawn_requests: Option<MessageWriter<PageOpenRequest>>,
-    mut save_requests: MessageWriter<SaveSpaceRequest>,
     mut layout_requests: MessageWriter<TabLayoutSpawnRequest>,
+    mut active_id: ResMut<vmux_layout::space::ActiveSpaceId>,
     stack_q: Query<(Entity, &PageMetadata), With<Stack>>,
     child_of_q: Query<&ChildOf>,
     mut commands: Commands,
 ) {
-    let root = profile::shared_data_dir();
-    let mut registry = read_space_registry_from(&root);
     let evt = &trigger.event().payload;
+
     if evt.command == "open_page" {
         if let Some((existing, _)) = stack_q.iter().find(|(_, meta)| meta.url == SPACES_PAGE_URL) {
             vmux_core::focus_pane_entity(existing, &mut commands, &child_of_q);
@@ -403,32 +352,6 @@ fn on_space_command(
         });
         return;
     }
-    if evt.command == "delete" {
-        let Some(id) = evt.space_id.as_deref() else {
-            return;
-        };
-        let Some(deleted) = delete_space_record(&mut registry, id) else {
-            return;
-        };
-        let deleted_active = deleted.id == active.record.id;
-        let target = registry
-            .spaces
-            .first()
-            .cloned()
-            .unwrap_or_else(bootstrap_space_record);
-        write_space_registry_to(&root, &registry);
-        delete_space_layout(&root, &deleted);
-        if !deleted_active {
-            return;
-        }
-        let from_id = active.record.id.clone();
-        commands.insert_resource(PendingSpaceSwitch {
-            from_id,
-            record: target,
-            delay_frames: 1,
-        });
-        return;
-    }
 
     if evt.command == "rename" {
         let Some(id) = evt.space_id.as_deref() else {
@@ -437,92 +360,112 @@ fn on_space_command(
         let Some(name) = evt.name.as_deref().map(str::trim).filter(|n| !n.is_empty()) else {
             return;
         };
-        if rename_space_record(&mut registry, id, name) {
-            write_space_registry_to(&root, &registry);
-            if active.record.id == id {
-                active.record.name = name.to_string();
-            }
+        if let Some((entity, _, _, _)) = spaces.iter().find(|(_, sid, _, _)| sid.0 == id) {
+            commands.entity(entity).insert(Name::new(name.to_string()));
         }
         return;
     }
 
-    let (target, open_spaces_page) = match evt.command.as_str() {
+    if evt.command == "delete" {
+        let Some(id) = evt.space_id.as_deref() else {
+            return;
+        };
+        if spaces.iter().count() <= 1 {
+            return;
+        }
+        let Some((entity, _, was_active, _)) = spaces.iter().find(|(_, sid, _, _)| sid.0 == id)
+        else {
+            return;
+        };
+        commands.entity(entity).despawn();
+        for (tab, sid, _) in tabs.iter() {
+            if sid.0 == id {
+                commands.entity(tab).despawn();
+            }
+        }
+        if was_active
+            && let Some((target_entity, target_id)) = spaces
+                .iter()
+                .filter(|(_, sid, _, _)| sid.0 != id)
+                .min_by_key(|(_, _, _, order)| order.map(|o| o.0).unwrap_or(u32::MAX))
+                .map(|(entity, sid, _, _)| (entity, sid.0.clone()))
+        {
+            commands
+                .entity(target_entity)
+                .insert(vmux_layout::space::ActiveSpaceTag);
+            active_id.0 = Some(target_id.clone());
+            bump_space_tab(&tabs, &target_id, &mut commands);
+        }
+        return;
+    }
+
+    match evt.command.as_str() {
         "attach" => {
             let Some(id) = evt.space_id.as_deref() else {
                 return;
             };
-            let Some(record) = registry.spaces.iter().find(|space| space.id == id) else {
+            let Some((entity, _, is_active, _)) = spaces.iter().find(|(_, sid, _, _)| sid.0 == id)
+            else {
                 return;
             };
-            (record.clone(), false)
+            if is_active {
+                return;
+            }
+            deactivate_all_spaces(&spaces, &mut commands);
+            commands
+                .entity(entity)
+                .insert(vmux_layout::space::ActiveSpaceTag);
+            active_id.0 = Some(id.to_string());
+            bump_space_tab(&tabs, id, &mut commands);
         }
         "new" => {
+            let count = spaces.iter().count();
             let name = evt
                 .name
                 .clone()
-                .unwrap_or_else(|| format!("Space {}", registry.spaces.len() + 1));
-            let id = unique_space_id(&registry.spaces, &name);
-            let record = SpaceRecord {
-                id,
-                name,
-                profile: active.record.profile.clone(),
-            };
-            registry.spaces.push(record.clone());
-            write_space_registry_to(&root, &registry);
-            (record, true)
+                .filter(|n| !n.trim().is_empty())
+                .unwrap_or_else(|| format!("Space {}", count + 1));
+            let existing: std::collections::HashSet<String> =
+                spaces.iter().map(|(_, sid, _, _)| sid.0.clone()).collect();
+            let id = crate::model::unique_space_id_among(&existing, &name);
+            let order = spaces
+                .iter()
+                .filter_map(|(_, _, _, order)| order.map(|o| o.0))
+                .max()
+                .map(|max| max + 1)
+                .unwrap_or(0);
+            deactivate_all_spaces(&spaces, &mut commands);
+            commands.spawn((
+                vmux_layout::space::Space,
+                vmux_layout::space::SpaceId(id.clone()),
+                Name::new(name),
+                vmux_core::Order(order),
+                vmux_layout::space::ActiveSpaceTag,
+            ));
+            active_id.0 = Some(id.clone());
+            let _ = profile::space_dir(&id);
+            let Ok(main) = main_q.single() else { return };
+            layout_requests.write(TabLayoutSpawnRequest {
+                main,
+                primary_window: *primary_window,
+                name: None,
+                content: TabLayoutSpawnContent::Url(SPACES_PAGE_URL.to_string()),
+                clear_pending_stack: true,
+                focus: true,
+            });
         }
-        _ => return,
-    };
-
-    if target.id == active.record.id {
-        return;
-    }
-
-    let current_path = active.layout_path();
-    save_requests.write(SaveSpaceRequest { path: current_path });
-    active.record = target;
-    let target_path = active.layout_path();
-    if target_path.exists() {
-        commands.trigger_load(moonshine_save::prelude::LoadWorld::default_from_file(
-            target_path,
-        ));
-    } else {
-        for entity in &space_entities {
-            commands.entity(entity).try_despawn();
-        }
-        commands.spawn(space_profile_bundle(&active.record));
-        let Ok(main) = main_q.single() else { return };
-        layout_requests.write(TabLayoutSpawnRequest {
-            main,
-            primary_window: *primary_window,
-            name: None,
-            content: if open_spaces_page {
-                TabLayoutSpawnContent::Url(SPACES_PAGE_URL.to_string())
-            } else {
-                TabLayoutSpawnContent::StartupUrlOrPrompt
-            },
-            clear_pending_stack: true,
-            focus: true,
-        });
+        _ => {}
     }
 }
 
 #[allow(clippy::too_many_arguments)]
 fn handle_open_in_new_space(
     mut reader: MessageReader<vmux_command::AppCommand>,
-    mut active: ResMut<ActiveSpace>,
-    space_entities: Query<
-        Entity,
-        Or<(
-            With<vmux_layout::space::Space>,
-            With<vmux_layout::tab::Tab>,
-            With<vmux_history::Visit>,
-        )>,
-    >,
+    spaces: SpaceQuery,
     main_q: Query<Entity, With<vmux_layout::window::Main>>,
     primary_window: Single<Entity, With<PrimaryWindow>>,
     effective_startup_url: Option<Res<vmux_layout::settings::EffectiveStartupUrl>>,
-    mut save_requests: MessageWriter<SaveSpaceRequest>,
+    mut active_id: ResMut<vmux_layout::space::ActiveSpaceId>,
     mut layout_requests: MessageWriter<TabLayoutSpawnRequest>,
     mut commands: Commands,
 ) {
@@ -534,25 +477,28 @@ fn handle_open_in_new_space(
             continue;
         };
 
-        let root = profile::shared_data_dir();
-        let mut registry = read_space_registry_from(&root);
-        let name = format!("Space {}", registry.spaces.len() + 1);
-        let record = SpaceRecord {
-            id: unique_space_id(&registry.spaces, &name),
-            name,
-            profile: active.record.profile.clone(),
-        };
-        registry.spaces.push(record.clone());
-        write_space_registry_to(&root, &registry);
-        save_requests.write(SaveSpaceRequest {
-            path: active.layout_path(),
-        });
-        active.record = record;
-        for entity in &space_entities {
-            commands.entity(entity).try_despawn();
-        }
+        let count = spaces.iter().count();
+        let name = format!("Space {}", count + 1);
+        let existing: std::collections::HashSet<String> =
+            spaces.iter().map(|(_, sid, _, _)| sid.0.clone()).collect();
+        let id = crate::model::unique_space_id_among(&existing, &name);
+        let order = spaces
+            .iter()
+            .filter_map(|(_, _, _, order)| order.map(|o| o.0))
+            .max()
+            .map(|max| max + 1)
+            .unwrap_or(0);
+        deactivate_all_spaces(&spaces, &mut commands);
+        commands.spawn((
+            vmux_layout::space::Space,
+            vmux_layout::space::SpaceId(id.clone()),
+            Name::new(name),
+            vmux_core::Order(order),
+            vmux_layout::space::ActiveSpaceTag,
+        ));
+        active_id.0 = Some(id.clone());
+        let _ = profile::space_dir(&id);
         let Ok(main) = main_q.single() else { continue };
-        commands.spawn(space_profile_bundle(&active.record));
         let content = url
             .as_deref()
             .filter(|url| !url.is_empty())
@@ -591,55 +537,13 @@ fn respond_spaces_spawn(
 }
 
 #[cfg(test)]
-static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-#[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::BOOTSTRAP_PROFILE_NAME;
-    use vmux_history::LastActivatedAt;
+    use crate::model::{BOOTSTRAP_PROFILE_NAME, SpaceRecord};
     use vmux_layout::settings::{
         FocusRingSettings, LayoutSettings, PaneSettings, SideSheetSettings, WindowSettings,
     };
-    use vmux_layout::{NewStackContext, pane::Pane, stack::Stack, tab::Tab, window::Main};
     use vmux_setting::{AppSettings, BrowserSettings, ShortcutSettings};
-
-    struct HomeEnvGuard {
-        _guard: std::sync::MutexGuard<'static, ()>,
-        old_home: Option<std::ffi::OsString>,
-    }
-
-    impl HomeEnvGuard {
-        fn use_temp_home(name: &str) -> Self {
-            let guard = super::ENV_LOCK
-                .lock()
-                .unwrap_or_else(|err| err.into_inner());
-            let old_home = std::env::var_os("HOME");
-            let home =
-                std::env::temp_dir().join(format!("vmux-test-{name}-{}", std::process::id()));
-            let _ = std::fs::remove_dir_all(&home);
-            std::fs::create_dir_all(&home).expect("create temp home");
-            unsafe {
-                std::env::set_var("HOME", &home);
-            }
-            Self {
-                _guard: guard,
-                old_home,
-            }
-        }
-    }
-
-    impl Drop for HomeEnvGuard {
-        fn drop(&mut self) {
-            unsafe {
-                if let Some(home) = &self.old_home {
-                    std::env::set_var("HOME", home);
-                } else {
-                    std::env::remove_var("HOME");
-                }
-            }
-        }
-    }
 
     fn test_settings() -> AppSettings {
         AppSettings {
@@ -675,41 +579,6 @@ mod tests {
         }
     }
 
-    fn resolve_stack_page_open_requests(
-        mut reader: MessageReader<PageOpenRequest>,
-        mut commands: Commands,
-    ) {
-        for request in reader.read() {
-            if let PageOpenTarget::Stack(stack) = request.target {
-                commands.spawn(PageOpenTask {
-                    id: vmux_core::PageOpenId::new(),
-                    stack,
-                    url: request.url.clone(),
-                    request_id: request.request_id,
-                });
-            }
-        }
-    }
-
-    #[test]
-    fn rows_mark_active_space_and_profile() {
-        let active = ActiveSpace {
-            record: SpaceRecord {
-                id: "work".to_string(),
-                name: "Work".to_string(),
-                profile: BOOTSTRAP_PROFILE_NAME.to_string(),
-            },
-        };
-        let registry = SpaceRegistry {
-            spaces: vec![bootstrap_space_record(), active.record.clone()],
-        };
-        let rows = space_rows(&active, &registry, 4);
-        assert!(!rows[0].is_active);
-        assert!(rows[1].is_active);
-        assert_eq!(rows[1].profile, BOOTSTRAP_PROFILE_NAME);
-        assert_eq!(rows[1].tab_count, 4);
-    }
-
     #[test]
     fn registers_spaces_host_before_cef_embedded_hosts_are_read() {
         let mut app = App::new();
@@ -724,308 +593,6 @@ mod tests {
 
         let entry = hosts.entry_for_host("spaces").unwrap();
         assert_eq!(entry.default_document, "spaces/index.html");
-    }
-
-    #[test]
-    fn delete_space_removes_named_space_from_registry() {
-        let mut registry = SpaceRegistry {
-            spaces: vec![
-                bootstrap_space_record(),
-                SpaceRecord {
-                    id: "work".to_string(),
-                    name: "Work".to_string(),
-                    profile: BOOTSTRAP_PROFILE_NAME.to_string(),
-                },
-            ],
-        };
-
-        let deleted = delete_space_record(&mut registry, "work").unwrap();
-
-        assert_eq!(deleted.id, "work");
-        assert_eq!(registry.spaces, vec![bootstrap_space_record()]);
-    }
-
-    #[test]
-    fn rename_space_record_changes_name_keeps_id() {
-        let mut registry = SpaceRegistry {
-            spaces: vec![
-                bootstrap_space_record(),
-                SpaceRecord {
-                    id: "work".to_string(),
-                    name: "Work".to_string(),
-                    profile: BOOTSTRAP_PROFILE_NAME.to_string(),
-                },
-            ],
-        };
-
-        assert!(rename_space_record(&mut registry, "work", "Client A"));
-
-        let renamed = registry.spaces.iter().find(|s| s.id == "work").unwrap();
-        assert_eq!(renamed.name, "Client A");
-        assert_eq!(renamed.id, "work");
-    }
-
-    #[test]
-    fn rename_space_record_unknown_id_is_noop() {
-        let mut registry = SpaceRegistry {
-            spaces: vec![bootstrap_space_record()],
-        };
-        assert!(!rename_space_record(&mut registry, "nope", "X"));
-    }
-
-    #[test]
-    fn delete_space_keeps_last_space() {
-        let mut registry = SpaceRegistry {
-            spaces: vec![bootstrap_space_record()],
-        };
-
-        let deleted = delete_space_record(&mut registry, "space-1");
-
-        assert!(deleted.is_none());
-        assert_eq!(registry.spaces, vec![bootstrap_space_record()]);
-    }
-
-    #[test]
-    fn delete_active_space_defers_current_layout_teardown() {
-        let _home = HomeEnvGuard::use_temp_home("delete-active-space-defers-layout");
-        let active_record = work_space_record();
-        write_space_registry_to(
-            &profile::shared_data_dir(),
-            &SpaceRegistry {
-                spaces: vec![bootstrap_space_record(), active_record.clone()],
-            },
-        );
-        let mut app = App::new();
-        app.add_plugins(MinimalPlugins)
-            .add_message::<SaveSpaceRequest>()
-            .add_message::<vmux_layout::TabLayoutSpawnRequest>()
-            .add_observer(on_space_command)
-            .insert_resource(ActiveSpace {
-                record: active_record,
-            })
-            .insert_resource(test_settings())
-            .insert_resource(test_settings().layout)
-            .init_resource::<NewStackContext>()
-            .init_resource::<Assets<Mesh>>()
-            .init_resource::<Assets<WebviewExtendStandardMaterial>>();
-
-        app.world_mut().spawn(PrimaryWindow);
-        let main = app.world_mut().spawn(Main).id();
-        let space = app.world_mut().spawn((Tab::default(), ChildOf(main))).id();
-        let pane = app.world_mut().spawn((Pane, ChildOf(space))).id();
-        let tab = app
-            .world_mut()
-            .spawn((
-                Stack::default(),
-                PageMetadata {
-                    title: "Spaces".to_string(),
-                    url: SPACES_PAGE_URL.to_string(),
-                    favicon_url: String::new(),
-                    bg_color: None,
-                },
-                ChildOf(pane),
-            ))
-            .id();
-        let webview = app.world_mut().spawn((Spaces, ChildOf(tab))).id();
-
-        app.world_mut()
-            .entity_mut(webview)
-            .trigger(|webview| BinReceive {
-                webview,
-                payload: SpaceCommandEvent {
-                    command: "delete".to_string(),
-                    space_id: Some("work".to_string()),
-                    name: None,
-                },
-            });
-        app.update();
-
-        assert!(app.world().get_entity(space).is_ok());
-        assert_eq!(app.world().resource::<ActiveSpace>().record.id, "work");
-    }
-
-    #[test]
-    fn deferred_active_space_delete_spawns_target_layout() {
-        let _home = HomeEnvGuard::use_temp_home("deferred-active-space-delete-switches");
-        let active_record = work_space_record();
-        write_space_registry_to(
-            &profile::shared_data_dir(),
-            &SpaceRegistry {
-                spaces: vec![bootstrap_space_record(), active_record.clone()],
-            },
-        );
-        let mut app = App::new();
-        app.add_plugins(MinimalPlugins)
-            .add_message::<SaveSpaceRequest>()
-            .add_message::<vmux_layout::TabLayoutSpawnRequest>()
-            .add_message::<PageOpenRequest>()
-            .add_observer(on_space_command)
-            .add_systems(
-                Update,
-                (
-                    apply_pending_space_switch,
-                    vmux_layout::window::spawn_requested_tab_layouts,
-                )
-                    .chain(),
-            )
-            .insert_resource(ActiveSpace {
-                record: active_record,
-            })
-            .insert_resource(test_settings())
-            .insert_resource(test_settings().layout)
-            .init_resource::<NewStackContext>()
-            .init_resource::<Assets<Mesh>>()
-            .init_resource::<Assets<WebviewExtendStandardMaterial>>();
-
-        app.world_mut().spawn(PrimaryWindow);
-        let main = app.world_mut().spawn(Main).id();
-        let space = app.world_mut().spawn((Tab::default(), ChildOf(main))).id();
-        let pane = app.world_mut().spawn((Pane, ChildOf(space))).id();
-        let tab = app
-            .world_mut()
-            .spawn((
-                Stack::default(),
-                PageMetadata {
-                    title: "Spaces".to_string(),
-                    url: SPACES_PAGE_URL.to_string(),
-                    favicon_url: String::new(),
-                    bg_color: None,
-                },
-                ChildOf(pane),
-            ))
-            .id();
-        let webview = app.world_mut().spawn((Spaces, ChildOf(tab))).id();
-
-        app.world_mut()
-            .entity_mut(webview)
-            .trigger(|webview| BinReceive {
-                webview,
-                payload: SpaceCommandEvent {
-                    command: "delete".to_string(),
-                    space_id: Some("work".to_string()),
-                    name: None,
-                },
-            });
-        app.update();
-        assert!(app.world().get_entity(space).is_ok());
-
-        for _ in 0..3 {
-            app.update();
-            if app.world().get_entity(space).is_err() {
-                break;
-            }
-        }
-        assert!(app.world().get_entity(space).is_err());
-        assert_eq!(
-            app.world().resource::<ActiveSpace>().record,
-            bootstrap_space_record()
-        );
-        let mut tab_query = app.world_mut().query::<&Tab>();
-        assert_eq!(tab_query.iter(app.world()).count(), 1);
-    }
-
-    #[test]
-    fn new_space_spawns_spaces_page_layout() {
-        let _home = HomeEnvGuard::use_temp_home("new-space-spawns-spaces-page");
-        write_space_registry_to(
-            &profile::shared_data_dir(),
-            &SpaceRegistry {
-                spaces: vec![bootstrap_space_record()],
-            },
-        );
-        let mut app = App::new();
-        app.add_plugins(MinimalPlugins)
-            .add_message::<SaveSpaceRequest>()
-            .add_message::<vmux_layout::TabLayoutSpawnRequest>()
-            .add_message::<PageOpenRequest>()
-            .add_observer(on_space_command)
-            .add_systems(
-                Update,
-                (
-                    vmux_layout::window::spawn_requested_tab_layouts,
-                    resolve_stack_page_open_requests,
-                    handle_spaces_page_open,
-                )
-                    .chain(),
-            )
-            .insert_resource(vmux_layout::stack::FocusedStack::default())
-            .insert_resource(ActiveSpace {
-                record: bootstrap_space_record(),
-            })
-            .insert_resource(test_settings())
-            .insert_resource(test_settings().layout)
-            .init_resource::<NewStackContext>()
-            .init_resource::<Assets<Mesh>>()
-            .init_resource::<Assets<WebviewExtendStandardMaterial>>();
-
-        app.world_mut().spawn(PrimaryWindow);
-        let main = app.world_mut().spawn(Main).id();
-        let old_tab = app.world_mut().spawn((Tab::default(), ChildOf(main))).id();
-        let pane = app.world_mut().spawn((Pane, ChildOf(old_tab))).id();
-        let tab = app
-            .world_mut()
-            .spawn((
-                Stack::default(),
-                PageMetadata {
-                    title: "Spaces".to_string(),
-                    url: SPACES_PAGE_URL.to_string(),
-                    favicon_url: String::new(),
-                    bg_color: None,
-                },
-                ChildOf(pane),
-            ))
-            .id();
-        let webview = app.world_mut().spawn((Spaces, ChildOf(tab))).id();
-        *app.world_mut()
-            .resource_mut::<vmux_layout::stack::FocusedStack>() =
-            vmux_layout::stack::FocusedStack {
-                tab: Some(old_tab),
-                pane: Some(pane),
-                stack: Some(tab),
-            };
-
-        app.world_mut()
-            .entity_mut(webview)
-            .trigger(|webview| BinReceive {
-                webview,
-                payload: SpaceCommandEvent {
-                    command: "new".to_string(),
-                    space_id: None,
-                    name: Some("Client A".to_string()),
-                },
-            });
-        app.update();
-
-        assert!(app.world().get_entity(old_tab).is_err());
-        assert_eq!(app.world().resource::<ActiveSpace>().record.id, "client-a");
-        assert!(!app.world().resource::<NewStackContext>().needs_open);
-        assert!(app.world().resource::<NewStackContext>().stack.is_none());
-
-        let mut tab_query = app.world_mut().query::<&Tab>();
-        assert_eq!(tab_query.iter(app.world()).count(), 1);
-
-        let tabs = {
-            let mut tab_q = app
-                .world_mut()
-                .query_filtered::<(Entity, &PageMetadata, &Children), With<Stack>>();
-            tab_q
-                .iter(app.world())
-                .map(|(entity, meta, children)| {
-                    let has_spaces_view = children
-                        .iter()
-                        .any(|child| app.world().get::<Spaces>(child).is_some());
-                    (entity, meta.url.clone(), has_spaces_view)
-                })
-                .collect::<Vec<_>>()
-        };
-        assert_eq!(tabs.len(), 1);
-        assert_eq!(tabs[0].1, SPACES_PAGE_URL);
-        assert!(tabs[0].2);
-        let focus = app.world().resource::<vmux_layout::stack::FocusedStack>();
-        assert_ne!(focus.tab, Some(old_tab));
-        assert!(focus.tab.is_some());
-        assert!(focus.pane.is_some());
-        assert!(focus.stack.is_some());
     }
 
     #[test]
@@ -1057,82 +624,5 @@ mod tests {
                 .0,
             "https://work.example"
         );
-    }
-
-    #[test]
-    fn ipc_new_space_focuses_spaces_page_layout_in_same_update() {
-        let _home = HomeEnvGuard::use_temp_home("ipc-new-space-focuses-layout");
-        write_space_registry_to(
-            &profile::shared_data_dir(),
-            &SpaceRegistry {
-                spaces: vec![bootstrap_space_record()],
-            },
-        );
-        let mut app = App::new();
-        app.add_plugins((
-            MinimalPlugins,
-            vmux_command::CommandPlugin,
-            bevy_cef::prelude::JsEmitEventPlugin::<SpaceCommandEvent>::default(),
-            vmux_layout::stack::StackPlugin,
-        ))
-        .add_message::<vmux_layout::LayoutSpawnRequest>()
-        .add_message::<vmux_layout::TabLayoutSpawnRequest>()
-        .add_message::<PageOpenRequest>()
-        .add_message::<SaveSpaceRequest>()
-        .add_observer(on_space_command)
-        .add_systems(Update, vmux_layout::window::spawn_requested_tab_layouts)
-        .init_resource::<vmux_layout::pane::PendingCursorWarp>()
-        .init_resource::<bevy_cef::prelude::IpcEventRawBuffer>()
-        .insert_resource(ActiveSpace {
-            record: bootstrap_space_record(),
-        })
-        .insert_resource(test_settings())
-        .insert_resource(test_settings().layout)
-        .init_resource::<NewStackContext>()
-        .init_resource::<Assets<Mesh>>()
-        .init_resource::<Assets<WebviewExtendStandardMaterial>>();
-
-        app.world_mut().spawn(PrimaryWindow);
-        let main = app.world_mut().spawn(Main).id();
-        let old_tab = app
-            .world_mut()
-            .spawn((Tab::default(), LastActivatedAt::now(), ChildOf(main)))
-            .id();
-        let pane = app
-            .world_mut()
-            .spawn((Pane, LastActivatedAt::now(), ChildOf(old_tab)))
-            .id();
-        let tab = app
-            .world_mut()
-            .spawn((
-                Stack::default(),
-                LastActivatedAt::now(),
-                PageMetadata {
-                    title: "Spaces".to_string(),
-                    url: SPACES_PAGE_URL.to_string(),
-                    favicon_url: String::new(),
-                    bg_color: None,
-                },
-                ChildOf(pane),
-            ))
-            .id();
-        let webview = app.world_mut().spawn((Spaces, ChildOf(tab))).id();
-        let payload = serde_json::to_string(&SpaceCommandEvent {
-            command: "new".to_string(),
-            space_id: None,
-            name: Some("Client A".to_string()),
-        })
-        .unwrap();
-        app.world_mut()
-            .resource_mut::<bevy_cef::prelude::IpcEventRawBuffer>()
-            .0
-            .push(bevy_cef_core::prelude::IpcEventRaw { webview, payload });
-
-        app.update();
-
-        let focus = app.world().resource::<vmux_layout::stack::FocusedStack>();
-        assert!(focus.tab.is_some());
-        assert!(focus.pane.is_some());
-        assert!(focus.stack.is_some());
     }
 }

--- a/crates/vmux_space/src/plugin.rs
+++ b/crates/vmux_space/src/plugin.rs
@@ -41,6 +41,7 @@ impl Plugin for SpacePlugin {
             .add_systems(Update, relay_space_command_requests)
             .add_systems(Update, sync_active_space_record)
             .add_systems(Update, sync_space_name_to_id)
+            .add_systems(Update, prune_orphan_space_dirs)
             .add_systems(
                 Startup,
                 update_effective_startup_url
@@ -322,6 +323,25 @@ fn sync_space_name_to_id(
             *name = Name::new(id.0.clone());
         }
     }
+}
+
+fn prune_orphan_space_dirs(
+    spaces: Query<&vmux_layout::space::SpaceId, With<vmux_layout::space::Space>>,
+    changed: Query<
+        (),
+        (
+            With<vmux_layout::space::Space>,
+            Changed<vmux_layout::space::SpaceId>,
+        ),
+    >,
+    mut removed: RemovedComponents<vmux_layout::space::Space>,
+) {
+    let any_removed = removed.read().count() > 0;
+    if changed.is_empty() && !any_removed {
+        return;
+    }
+    let live: std::collections::HashSet<String> = spaces.iter().map(|id| id.0.clone()).collect();
+    profile::prune_orphan_space_dirs(&live);
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/vmux_space/src/plugin.rs
+++ b/crates/vmux_space/src/plugin.rs
@@ -586,6 +586,46 @@ mod tests {
     };
     use vmux_setting::{AppSettings, BrowserSettings, ShortcutSettings};
 
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct HomeEnvGuard {
+        _guard: std::sync::MutexGuard<'static, ()>,
+        old_home: Option<std::ffi::OsString>,
+        home: std::path::PathBuf,
+    }
+
+    impl HomeEnvGuard {
+        fn use_temp_home(name: &str) -> Self {
+            let guard = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+            let old_home = std::env::var_os("HOME");
+            let home =
+                std::env::temp_dir().join(format!("vmux-test-{name}-{}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&home);
+            std::fs::create_dir_all(&home).expect("create temp home");
+            unsafe {
+                std::env::set_var("HOME", &home);
+            }
+            Self {
+                _guard: guard,
+                old_home,
+                home,
+            }
+        }
+    }
+
+    impl Drop for HomeEnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                if let Some(home) = &self.old_home {
+                    std::env::set_var("HOME", home);
+                } else {
+                    std::env::remove_var("HOME");
+                }
+            }
+            let _ = std::fs::remove_dir_all(&self.home);
+        }
+    }
+
     fn test_settings() -> AppSettings {
         AppSettings {
             browser: BrowserSettings {
@@ -668,7 +708,8 @@ mod tests {
     }
 
     #[test]
-    fn rename_reslugs_space_id_and_retags_tabs() {
+    fn rename_reslugs_space_id_retags_tabs_and_nests_folder() {
+        let home = HomeEnvGuard::use_temp_home("rename-slash");
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .add_message::<TabLayoutSpawnRequest>()
@@ -698,7 +739,7 @@ mod tests {
             payload: SpaceCommandEvent {
                 command: "rename".to_string(),
                 space_id: Some("rename-src-test".to_string()),
-                name: Some("Rename Dst Test".to_string()),
+                name: Some("Vmux Ai/Vmux".to_string()),
             },
         });
         app.update();
@@ -707,24 +748,25 @@ mod tests {
             app.world()
                 .get::<vmux_layout::space::SpaceId>(space)
                 .map(|s| s.0.clone()),
-            Some("rename-dst-test".to_string())
+            Some("vmux-ai/vmux".to_string())
         );
         assert_eq!(
             app.world().get::<Name>(space).map(|n| n.to_string()),
-            Some("rename-dst-test".to_string())
+            Some("vmux-ai/vmux".to_string())
         );
         assert_eq!(
             app.world()
                 .get::<vmux_layout::space::SpaceId>(tab)
                 .map(|s| s.0.clone()),
-            Some("rename-dst-test".to_string())
+            Some("vmux-ai/vmux".to_string())
         );
         assert_eq!(
             app.world()
                 .resource::<vmux_layout::space::ActiveSpaceId>()
                 .0
                 .as_deref(),
-            Some("rename-dst-test")
+            Some("vmux-ai/vmux")
         );
+        assert!(home.home.join(".vmux/spaces/vmux-ai/vmux").is_dir());
     }
 }

--- a/crates/vmux_space/src/plugin.rs
+++ b/crates/vmux_space/src/plugin.rs
@@ -40,6 +40,7 @@ impl Plugin for SpacePlugin {
             .add_message::<SpaceCommandRequest>()
             .add_systems(Update, relay_space_command_requests)
             .add_systems(Update, sync_active_space_record)
+            .add_systems(Update, sync_space_name_to_id)
             .add_systems(
                 Startup,
                 update_effective_startup_url
@@ -307,6 +308,22 @@ fn deactivate_all_spaces(spaces: &SpaceQuery, commands: &mut Commands) {
     }
 }
 
+fn sync_space_name_to_id(
+    mut spaces: Query<
+        (&vmux_layout::space::SpaceId, &mut Name),
+        (
+            With<vmux_layout::space::Space>,
+            Changed<vmux_layout::space::SpaceId>,
+        ),
+    >,
+) {
+    for (id, mut name) in &mut spaces {
+        if name.as_str() != id.0 {
+            *name = Name::new(id.0.clone());
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn on_space_command(
     trigger: On<BinReceive<SpaceCommandEvent>>,
@@ -364,13 +381,13 @@ fn on_space_command(
         else {
             return;
         };
-        commands.entity(entity).insert(Name::new(name.to_string()));
         let existing: std::collections::HashSet<String> = spaces
             .iter()
             .filter(|(_, sid, _, _)| sid.0 != id)
             .map(|(_, sid, _, _)| sid.0.clone())
             .collect();
         let new_id = crate::model::unique_space_id_among(&existing, name);
+        commands.entity(entity).insert(Name::new(new_id.clone()));
         if new_id != id {
             commands
                 .entity(entity)
@@ -462,7 +479,7 @@ fn on_space_command(
             commands.spawn((
                 vmux_layout::space::Space,
                 vmux_layout::space::SpaceId(id.clone()),
-                Name::new(name),
+                Name::new(id.clone()),
                 vmux_core::Order(order),
                 vmux_layout::space::ActiveSpaceTag,
             ));
@@ -516,7 +533,7 @@ fn handle_open_in_new_space(
         commands.spawn((
             vmux_layout::space::Space,
             vmux_layout::space::SpaceId(id.clone()),
-            Name::new(name),
+            Name::new(id.clone()),
             vmux_core::Order(order),
             vmux_layout::space::ActiveSpaceTag,
         ));
@@ -694,7 +711,7 @@ mod tests {
         );
         assert_eq!(
             app.world().get::<Name>(space).map(|n| n.to_string()),
-            Some("Rename Dst Test".to_string())
+            Some("rename-dst-test".to_string())
         );
         assert_eq!(
             app.world()

--- a/crates/vmux_space/src/plugin.rs
+++ b/crates/vmux_space/src/plugin.rs
@@ -360,8 +360,32 @@ fn on_space_command(
         let Some(name) = evt.name.as_deref().map(str::trim).filter(|n| !n.is_empty()) else {
             return;
         };
-        if let Some((entity, _, _, _)) = spaces.iter().find(|(_, sid, _, _)| sid.0 == id) {
-            commands.entity(entity).insert(Name::new(name.to_string()));
+        let Some((entity, _, is_active, _)) = spaces.iter().find(|(_, sid, _, _)| sid.0 == id)
+        else {
+            return;
+        };
+        commands.entity(entity).insert(Name::new(name.to_string()));
+        let existing: std::collections::HashSet<String> = spaces
+            .iter()
+            .filter(|(_, sid, _, _)| sid.0 != id)
+            .map(|(_, sid, _, _)| sid.0.clone())
+            .collect();
+        let new_id = crate::model::unique_space_id_among(&existing, name);
+        if new_id != id {
+            commands
+                .entity(entity)
+                .insert(vmux_layout::space::SpaceId(new_id.clone()));
+            for (tab, sid, _) in tabs.iter() {
+                if sid.0 == id {
+                    commands
+                        .entity(tab)
+                        .insert(vmux_layout::space::SpaceId(new_id.clone()));
+                }
+            }
+            profile::rename_space_dir(id, &new_id);
+            if is_active {
+                active_id.0 = Some(new_id.clone());
+            }
         }
         return;
     }
@@ -623,6 +647,67 @@ mod tests {
                 .resource::<vmux_layout::settings::EffectiveStartupUrl>()
                 .0,
             "https://work.example"
+        );
+    }
+
+    #[test]
+    fn rename_reslugs_space_id_and_retags_tabs() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<TabLayoutSpawnRequest>()
+            .init_resource::<vmux_layout::space::ActiveSpaceId>()
+            .add_observer(on_space_command);
+        app.world_mut().spawn(bevy::window::PrimaryWindow);
+        let space = app
+            .world_mut()
+            .spawn((
+                vmux_layout::space::Space,
+                vmux_layout::space::SpaceId("rename-src-test".to_string()),
+                Name::new("rename-src-test"),
+                vmux_layout::space::ActiveSpaceTag,
+            ))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                vmux_layout::tab::Tab::default(),
+                vmux_layout::space::SpaceId("rename-src-test".to_string()),
+                vmux_history::LastActivatedAt::now(),
+            ))
+            .id();
+
+        app.world_mut().trigger(BinReceive {
+            webview: Entity::PLACEHOLDER,
+            payload: SpaceCommandEvent {
+                command: "rename".to_string(),
+                space_id: Some("rename-src-test".to_string()),
+                name: Some("Rename Dst Test".to_string()),
+            },
+        });
+        app.update();
+
+        assert_eq!(
+            app.world()
+                .get::<vmux_layout::space::SpaceId>(space)
+                .map(|s| s.0.clone()),
+            Some("rename-dst-test".to_string())
+        );
+        assert_eq!(
+            app.world().get::<Name>(space).map(|n| n.to_string()),
+            Some("Rename Dst Test".to_string())
+        );
+        assert_eq!(
+            app.world()
+                .get::<vmux_layout::space::SpaceId>(tab)
+                .map(|s| s.0.clone()),
+            Some("rename-dst-test".to_string())
+        );
+        assert_eq!(
+            app.world()
+                .resource::<vmux_layout::space::ActiveSpaceId>()
+                .0
+                .as_deref(),
+            Some("rename-dst-test")
         );
     }
 }

--- a/crates/vmux_space/src/snapshot_updater.rs
+++ b/crates/vmux_space/src/snapshot_updater.rs
@@ -1,24 +1,38 @@
 use bevy::prelude::*;
 use vmux_command::snapshot::{CommandBarSpacesSnapshot, SpaceSummary};
+use vmux_core::Order;
+use vmux_layout::space::{ActiveSpaceId, ActiveSpaceTag, Space, SpaceId};
 
 use crate::event::SPACES_PAGE_URL;
-use crate::spaces::{ActiveSpace, registry_space_summaries};
 
 pub fn update_spaces_snapshot(
-    active: Res<ActiveSpace>,
+    spaces: Query<(&SpaceId, &Name, Option<&Order>), With<Space>>,
+    active_id: Res<ActiveSpaceId>,
+    active_name: Query<&Name, With<ActiveSpaceTag>>,
     mut snapshot: ResMut<CommandBarSpacesSnapshot>,
 ) {
-    let active_changed = active.is_changed() || active.is_added();
-    if !active_changed && !snapshot.spaces_page_url.is_empty() {
-        return;
-    }
-
-    snapshot.spaces = registry_space_summaries()
-        .into_iter()
-        .map(|(id, name, profile)| SpaceSummary { id, name, profile })
+    let mut rows: Vec<(u32, SpaceSummary)> = spaces
+        .iter()
+        .map(|(id, name, order)| {
+            (
+                order.map(|o| o.0).unwrap_or(u32::MAX),
+                SpaceSummary {
+                    id: id.0.clone(),
+                    name: name.to_string(),
+                    profile: crate::model::BOOTSTRAP_PROFILE_NAME.to_string(),
+                },
+            )
+        })
         .collect();
-    snapshot.active_space_id = active.record.id.clone();
-    snapshot.active_space_name = active.record.name.clone();
+    rows.sort_by_key(|(order, _)| *order);
+
+    snapshot.spaces = rows.into_iter().map(|(_, summary)| summary).collect();
+    snapshot.active_space_id = active_id.0.clone().unwrap_or_default();
+    snapshot.active_space_name = active_name
+        .iter()
+        .next()
+        .map(|name| name.to_string())
+        .unwrap_or_default();
     snapshot.spaces_page_url = SPACES_PAGE_URL.to_string();
 }
 
@@ -30,11 +44,19 @@ mod tests {
     fn writes_active_name_and_url() {
         let mut app = App::new();
         app.init_resource::<CommandBarSpacesSnapshot>()
-            .init_resource::<ActiveSpace>()
+            .insert_resource(ActiveSpaceId(Some("space-1".to_string())))
             .add_systems(Update, update_spaces_snapshot);
+        app.world_mut().spawn((
+            Space,
+            SpaceId("space-1".to_string()),
+            Name::new("Space 1"),
+            ActiveSpaceTag,
+        ));
         app.update();
         let snap = app.world().resource::<CommandBarSpacesSnapshot>();
         assert_eq!(snap.spaces_page_url, SPACES_PAGE_URL);
-        assert!(!snap.active_space_id.is_empty());
+        assert_eq!(snap.active_space_id, "space-1");
+        assert_eq!(snap.active_space_name, "Space 1");
+        assert_eq!(snap.spaces.len(), 1);
     }
 }

--- a/crates/vmux_space/src/spaces.rs
+++ b/crates/vmux_space/src/spaces.rs
@@ -52,6 +52,7 @@ pub fn read_space_registry_from(root: &Path) -> SpaceRegistry {
 pub fn space_profile_bundle(record: &SpaceRecord) -> impl Bundle {
     (
         vmux_layout::space::Space,
+        vmux_layout::space::SpaceId(record.id.clone()),
         vmux_layout::profile::Profile {
             name: record.profile.clone(),
         },
@@ -138,20 +139,25 @@ impl Spaces {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{BOOTSTRAP_PROFILE_NAME, BOOTSTRAP_SPACE_NAME, bootstrap_space_record};
+    use crate::model::{
+        BOOTSTRAP_PROFILE_NAME, BOOTSTRAP_SPACE_ID, BOOTSTRAP_SPACE_NAME, bootstrap_space_record,
+    };
 
     #[test]
-    fn space_profile_bundle_spawns_space_name_and_profile_name() {
+    fn space_profile_bundle_spawns_space_name_profile_and_id() {
         let mut app = App::new();
         app.world_mut()
             .spawn(space_profile_bundle(&bootstrap_space_record()));
 
-        let mut query = app
-            .world_mut()
-            .query_filtered::<(&Name, &vmux_layout::profile::Profile), With<vmux_layout::space::Space>>();
-        let (name, profile) = query.single(app.world()).unwrap();
+        let mut query = app.world_mut().query_filtered::<(
+            &Name,
+            &vmux_layout::profile::Profile,
+            &vmux_layout::space::SpaceId,
+        ), With<vmux_layout::space::Space>>();
+        let (name, profile, space_id) = query.single(app.world()).unwrap();
 
         assert_eq!(name.as_str(), BOOTSTRAP_SPACE_NAME);
         assert_eq!(profile.name, BOOTSTRAP_PROFILE_NAME);
+        assert_eq!(space_id.0, BOOTSTRAP_SPACE_ID);
     }
 }

--- a/crates/vmux_space/src/spaces.rs
+++ b/crates/vmux_space/src/spaces.rs
@@ -4,19 +4,11 @@ use vmux_core::PageMetadata;
 use vmux_layout::cef::Browser;
 
 use crate::event::SPACES_PAGE_URL;
-use crate::model::{SpaceRecord, bootstrap_space_record};
+use crate::model::SpaceRecord;
 
-#[derive(Resource, Clone, Debug)]
+#[derive(Resource, Clone, Debug, Default)]
 pub struct ActiveSpace {
     pub record: SpaceRecord,
-}
-
-impl Default for ActiveSpace {
-    fn default() -> Self {
-        Self {
-            record: bootstrap_space_record(),
-        }
-    }
 }
 
 pub fn space_profile_bundle(record: &SpaceRecord) -> impl Bundle {

--- a/crates/vmux_space/src/spaces.rs
+++ b/crates/vmux_space/src/spaces.rs
@@ -1,15 +1,10 @@
-use std::path::{Path, PathBuf};
-
 use bevy::{picking::Pickable, prelude::*};
 use bevy_cef::prelude::*;
 use vmux_core::PageMetadata;
-use vmux_core::profile;
 use vmux_layout::cef::Browser;
 
-use crate::event::{SPACES_PAGE_URL, SpaceRow};
-use crate::model::{
-    SpaceRecord, SpaceRegistry, bootstrap_space_record, registry_path, space_layout_path_for,
-};
+use crate::event::SPACES_PAGE_URL;
+use crate::model::{SpaceRecord, bootstrap_space_record};
 
 #[derive(Resource, Clone, Debug)]
 pub struct ActiveSpace {
@@ -18,35 +13,10 @@ pub struct ActiveSpace {
 
 impl Default for ActiveSpace {
     fn default() -> Self {
-        let registry = read_space_registry_from(&profile::shared_data_dir());
-        let record = registry
-            .spaces
-            .first()
-            .cloned()
-            .unwrap_or_else(bootstrap_space_record);
-        Self { record }
+        Self {
+            record: bootstrap_space_record(),
+        }
     }
-}
-
-impl ActiveSpace {
-    pub fn layout_path(&self) -> PathBuf {
-        space_layout_path_for(
-            &profile::shared_data_dir(),
-            &self.record.id,
-            &self.record.profile,
-        )
-    }
-}
-
-pub fn read_space_registry_from(root: &Path) -> SpaceRegistry {
-    let mut registry = std::fs::read_to_string(registry_path(root))
-        .ok()
-        .and_then(|body| ron::de::from_str::<SpaceRegistry>(&body).ok())
-        .unwrap_or_default();
-    if registry.spaces.is_empty() {
-        registry.spaces.push(bootstrap_space_record());
-    }
-    registry
 }
 
 pub fn space_profile_bundle(record: &SpaceRecord) -> impl Bundle {
@@ -58,37 +28,6 @@ pub fn space_profile_bundle(record: &SpaceRecord) -> impl Bundle {
         },
         Name::new(record.name.clone()),
     )
-}
-
-pub fn registry_space_summaries() -> Vec<(String, String, String)> {
-    let registry = read_space_registry_from(&profile::shared_data_dir());
-    registry
-        .spaces
-        .into_iter()
-        .map(|space| (space.id, space.name, space.profile))
-        .collect()
-}
-
-pub fn active_space_rows(active: &ActiveSpace, active_stack_count: usize) -> Vec<SpaceRow> {
-    let registry = read_space_registry_from(&profile::shared_data_dir());
-    registry
-        .spaces
-        .into_iter()
-        .map(|space| {
-            let is_active = space.id == active.record.id;
-            SpaceRow {
-                id: space.id.clone(),
-                name: space.name.clone(),
-                profile: space.profile.clone(),
-                is_active,
-                tab_count: if is_active {
-                    active_stack_count as u32
-                } else {
-                    0
-                },
-            }
-        })
-        .collect()
 }
 
 #[derive(Component)]

--- a/docs/specs/2026-06-18-spaces-store-redesign-design.md
+++ b/docs/specs/2026-06-18-spaces-store-redesign-design.md
@@ -1,0 +1,205 @@
+# Spaces as Live Directories, One `store.ron`
+
+## Problem
+
+Spaces persistence is split across many files and only ever holds **one** space in
+the ECS world at a time:
+
+- `spaces.ron` — a registry of `{id, name, profile}` records.
+- `…/Application Support/Vmux/<profile>/profiles/<p>/spaces/<id>/space.ron` — one
+  moonshine scene **per space** (its layout).
+- Switching a space **saves** the active scene to its file, **despawns** the active
+  tab tree, and **loads** the target file (`on_space_command`, three duplicated
+  save→despawn→load blocks).
+
+Consequences:
+
+- The active-space selection wasn't persisted (always reset to the first record).
+- The display name is duplicated (registry `name` + a stale `Name` component baked
+  into each `space.ron`).
+- Inactive spaces don't exist in the world, so their terminals/agents/browsers are
+  torn down on switch — unlike tmux, where detached sessions keep running.
+
+## Goal
+
+Model spaces like **tmux sessions**: every space stays **live** (its terminals,
+agents, and browser pages keep running), switching only changes what is **rendered
+and focused**, and all non-settings state lives in **one** `store.ron`.
+
+- **`store.ron`** (single moonshine scene) holds **all** saved state except
+  settings: every space and its full layout (tabs/panes/stacks), plus browsing
+  history. Active space and ordering are **components in the scene**, not a side file.
+- A space's **working directory** is a real folder under `~/.vmux/spaces/<id>/`.
+- Switching is **in-memory** — no file IO, nothing despawned.
+
+## Non-goals
+
+- No migration. Fresh start: existing `spaces.ron` / per-space `space.ron` are
+  ignored (left on disk, harmless).
+- Profiles: collapse to a single profile. CEF/chromium browser data stays shared in
+  Application Support (unchanged).
+- The Spaces web page UI and MCP/agent space tools keep their current surface
+  (`new`/`attach`/`delete`/`rename` events); MCP/automation continues to see the
+  **active** space only.
+
+## Storage layout
+
+```
+~/Library/Application Support/Vmux/<profile>/
+  settings.ron        # settings — separate, unchanged
+  store.ron           # ALL other saved state (scene: spaces + layouts + history)
+  <CEF chromium data…> # unchanged, shared across spaces
+
+~/.vmux/spaces/
+  default/            # cwd for the "default" space (terminals/agents start here)
+  work/               # cwd for the "work" space
+```
+
+- `store.ron` path = `vmux_core::profile::shared_data_dir().join("store.ron")` (the
+  same dir as `settings.ron`).
+- Space cwd = `space_dir(id)` → `~/.vmux/spaces/<id>` (today it is `~/.vmux/<id>`; add
+  the `spaces/` segment).
+
+## `store.ron` contents (the scene model)
+
+One moonshine scene. New/affected components on the **Space entity**:
+
+- `Space` (existing marker), `Save` (existing).
+- `SpaceId(String)` — **new**. Stable slug; names the cwd folder. Survives rename.
+- `Name` (Bevy) — display name (pretty; may contain spaces/caps). Rename edits this,
+  not `SpaceId`.
+- `Order` (existing component, reused) — space ordering in the strip/list.
+- `ActiveSpaceTag` — **new** zero-field marker on exactly one Space entity = the
+  persisted active space.
+- `Profile` — dropped from the model (single profile).
+
+Each Space entity **owns its tab subtree** (see hierarchy). History entities
+(`Url`/`Visit`) remain top-level in the same scene. The save allowlist
+(`save_space_to_path`) gains `SpaceId` and `ActiveSpaceTag`; drops `Profile`.
+
+`Main` (the window node) is **not** saved, so top-level `ChildOf(Main)` references
+can't persist — same as today. On load we re-parent loaded **Space** entities to the
+live `Main`; tab→Space references are intra-scene and persist as-is.
+
+## ECS hierarchy change
+
+Today: `Main → Tab → Pane(split) → Pane(leaf) → Stack → Browser`, and `Space` is a
+standalone marker unrelated to the tab tree.
+
+New: insert Space into the hierarchy.
+
+```
+Main → Space → Tab → Pane(split) → Pane(leaf) → Stack → Browser
+```
+
+- Tabs spawn `ChildOf(active Space)` instead of `ChildOf(Main)`
+  (`spawn_requested_tab_layouts`, window.rs).
+- Inactive Space nodes get `Visibility::Hidden`; Bevy cascades it, hiding the whole
+  subtree in **one** place. The page/process keeps running; it just doesn't paint.
+
+## Active-space scoping
+
+Introduce `ActiveSpaceEntity(Entity)` (resource) pointing at the active Space; it is
+recomputed whenever `ActiveSpaceTag` moves. The existing `ActiveSpace { record }`
+resource stays as a derived id/name cache for cwd resolution and snapshots.
+
+The following currently-global systems must scope to **children of the active
+Space** (today they assume one space's worth of tabs in the world):
+
+- `sync_tab_visibility` (tab.rs) — candidates = active space's tabs; inactive spaces
+  already hidden via their Space node.
+- `compute_focused_stack` / `focused_stack` (stack.rs) — widest blast radius; scope
+  the `active_among` set to the active space.
+- `push_tabs_host_emit` + `active_tab_siblings` (vmux_browser/lib.rs, tab.rs) — the
+  tab strip lists the active space's tabs only.
+- `handle_tab_commands`, `sync_tab_order` (tab.rs) — Next/Prev/Close/SelectIndex and
+  ordering scoped to the active space.
+- `build_layout_snapshot` + reconcile apply (snapshot.rs, reconcile.rs) — MCP/
+  automation reads/writes the active space only.
+- `request_default_layout` (window.rs) — "any tabs?" check scoped to active space.
+- `rebuild_space_views`, `mark_dirty_on_change` (vmux_desktop/persistence.rs) —
+  rebuild views for all loaded spaces; re-parent Space→Main; dirty-tracking spans all
+  spaces (one combined file).
+- `compute_boot_status` stack count (boot_status.rs); Spaces-page `tab_count`
+  (`broadcast_spaces_to_views`, `space_rows`, vmux_space/plugin.rs) — count the
+  active space's stacks.
+
+## Lifecycle: fully live (tmux semantics)
+
+- Inactive spaces keep **all** processes alive: terminals, agent CLIs, and CEF
+  webviews are **not** despawned on switch.
+- Rendering: only the active space paints. Hidden Space subtree ⇒ `Visibility::Hidden`
+  ⇒ no UI/mesh draw. Hidden CEF webviews must stop painting and **not** wake the event
+  loop (respect the `no_continuous_update_mode` rule; route real wakeups through
+  `EventLoopProxy`, never `UpdateMode::Continuous`).
+
+## Switching & CRUD (in-memory, no file IO)
+
+- **attach(id)**: move `ActiveSpaceTag` to the target Space; set
+  `ActiveSpaceEntity`; flip Visibility (hide previous, show target); recompute
+  `FocusedStack` from the target's tabs. Debounced `store.ron` save.
+- **new(name)**: slug → `SpaceId`; spawn `Space` (`ChildOf(Main)`) + an initial Tab
+  subtree (startup url / prompt); `mkdir ~/.vmux/spaces/<id>`; make active.
+- **delete(id)**: despawn that Space's subtree; refuse if it is the last space;
+  reassign active to another Space. **Keep** the cwd folder on disk (it holds the
+  user's files).
+- **rename(id, name)**: set `Name` on the Space entity. cwd folder unchanged.
+- **save**: one debounced `SaveWorld` → `store.ron` (all Space subtrees + history).
+- **load (startup)**: `LoadWorld` `store.ron` → spawn all spaces; rebuild views for
+  all; set active from `ActiveSpaceTag` (fallback: first by `Order`, else bootstrap).
+
+## Bootstrap (fresh start)
+
+On startup, if `store.ron` is absent or has no Space entities: spawn a single default
+Space (`SpaceId("default")`, `Name "default"`, `ActiveSpaceTag`), `mkdir
+~/.vmux/spaces/default`, and an initial tab. Old `spaces.ron` and per-space
+`space.ron` files are ignored.
+
+## Removed
+
+- `SpaceRegistry` / `spaces.ron`; the `read/write_space_registry_from/to` path.
+- The Application Support per-space layout tree (`profiles/<p>/spaces/<id>/space.ron`)
+  and `space_layout_path_for`.
+- The per-space `profile` field; `Profile` from the scene.
+- The three save→despawn→load switch blocks (`on_space_command` attach/new,
+  `apply_pending_space_switch`, `handle_open_in_new_space`) → replaced by in-memory
+  activation.
+
+## Phasing
+
+Each phase compiles, passes tests, and is independently reviewable.
+
+**Phase A — Structural (single space, behavior unchanged).** Add `SpaceId`,
+`ActiveSpaceTag`, `ActiveSpaceEntity`. Window setup spawns a Space node under `Main`;
+tabs spawn `ChildOf(active Space)`. Re-scope every system in *Active-space scoping*.
+Keep current persistence working. Verify the app behaves identically with one space.
+This is the bulk of the risk (≈15 systems).
+
+**Phase B — Persistence + multi-space.** `store.ron` at `shared_data_dir()`;
+`SaveWorld`/`LoadWorld` of all spaces + history; allowlist updates. In-memory
+switching; `new`/`delete`/`rename` operate on Space entities; cwd folders at
+`~/.vmux/spaces/<id>`; fully-live inactive spaces; fresh-start bootstrap.
+
+**Phase C — Cleanup.** Delete the registry/index/per-space-file/profile code and the
+old switch blocks. Verify hidden live CEF respects the wake/idle-CPU rule.
+
+## Risks
+
+- **Idle CPU**: N live hidden CEF webviews must be throttled; guard against
+  `Continuous` regressions (existing `no_continuous_update_mode` test).
+- **Scoping regressions**: ~15 systems convert from global to active-space; Phase A
+  behavior-preservation tests are the safety net.
+- **Load re-parenting**: Space→`Main` must re-parent on load (Main isn't saved);
+  tab→Space must round-trip.
+
+## Testing
+
+- Unit: `SpaceId` slugging; active-selection fallback (tag → first-by-order →
+  bootstrap).
+- System (Bevy app): two Space subtrees in one world → only the active space's tab is
+  visible; focus is scoped; tab strip lists only active space tabs; MCP snapshot
+  returns active space only; tab Next/Prev stays within the active space.
+- Persistence: `store.ron` round-trip with multiple spaces preserves layouts, order,
+  and active; reload re-parents Space→Main.
+- Lifecycle: switching does **not** despawn an inactive space's terminal entity
+  (process stays alive).

--- a/docs/specs/2026-06-18-spaces-store-redesign-design.md
+++ b/docs/specs/2026-06-18-spaces-store-redesign-design.md
@@ -203,3 +203,36 @@ old switch blocks. Verify hidden live CEF respects the wake/idle-CPU rule.
   and active; reload re-parents Space→Main.
 - Lifecycle: switching does **not** despawn an inactive space's terminal entity
   (process stays alive).
+
+## As-built deviations
+
+The shipped implementation differs from the design above in a few deliberate ways:
+
+- **No `Main → Space → Tab` re-parent.** Tabs stay `ChildOf(Main)` and carry a
+  `SpaceId(String)` tag (the active space id; spawned-tagged + backfilled). `Space`
+  entities remain standalone markers holding `SpaceId` + `Name` + `Order` +
+  `ActiveSpaceTag`. This avoids a large, fragile cross-crate re-parent and lets the
+  scoping land incrementally. Scoping is done by filtering on `SpaceId == ActiveSpaceId`
+  rather than relying on a Bevy `Visibility` cascade from a Space node.
+- **`ActiveSpaceId` resource** (string) mirrors the `ActiveSpaceTag`ged space and is the
+  single value the scoping systems compare against; `ActiveSpace` (vmux_space) is a
+  derived id/name cache synced from the tagged entity.
+- **name === folder.** A space's name *is* its slug id; `Name` is kept equal to
+  `SpaceId` by a sync system. `/` is preserved as a **nested folder separator** so
+  `org/repo` → `~/.vmux/spaces/org/repo` (each segment slugged). The folder path mirrors
+  the name exactly.
+- **Self-cleaning folders.** Rename moves the folder (creating nested parents, removing
+  an empty target first) and prunes empty old parents; a reconcile system removes
+  empty, unreferenced dirs under `~/.vmux/spaces/` (never folders containing files).
+- **Focus scoping is at the source.** `compute_focused_stack` (the `FocusedStack`
+  resource) and `sync_tab_visibility` filter to the active space; the on-demand
+  `focused_stack()` helper used by some command handlers stays global (acceptable —
+  the resource + visibility drive all rendering; command targeting rides on
+  `LastActivatedAt` + the switch bump).
+- **#4 (hidden CEF throttle) needed no new code.** Because inactive-space tabs are now
+  `Display::None`/`Visibility::Hidden`, the pre-existing windowed/OSR hide systems
+  (`set_windowed_hidden` / `set_osr_hidden`, keyed off mesh scale / node size /
+  active-stack) already stop their paint while the page stays alive.
+- **MCP scoping.** `read_layout` filters its tab list to the active space, and
+  `update_layout`'s `collect_existing_ids` is scoped to the active space's tab subtrees
+  so a reconcile can never despawn another space's content.


### PR DESCRIPTION
## Summary

Reworks spaces to behave like **tmux sessions** and consolidates persistence.

- **All spaces live in the ECS at once**, persisted in a single `~/Library/Application Support/Vmux/<profile>/store.ron` (active + order are scene components). Switching is **in-memory** — no despawn, no per-space file IO. Inactive spaces' terminals/agents/browsers keep running; hidden webviews stop painting via the existing OSR/windowed hide path.
- **A space's name *is* its folder.** `Name == SpaceId` (a slug); the cwd lives at `~/.vmux/spaces/<id>`. `/` is preserved as a **nested** separator: `org/repo` → `~/.vmux/spaces/org/repo`. Rename re-slugs, re-tags the space's tabs, and moves the folder (creating nested parents, removing an empty target). Empty orphaned space folders are pruned (folders with files are never touched).
- **Removed** the `spaces.ron` registry and the per-space Application Support layout tree; the spaces list, command bar, and MCP `list_spaces` now enumerate from the ECS.
- **Active-space scoping:** focus ring + tab visibility, MCP `read_layout`, `update_layout` reconcile (can't despawn other spaces), tab strip/commands/ordering, and the splash boot-status page count are all scoped to the active space.

Tabs stay `ChildOf(Main)` and carry a `SpaceId` tag (no big `Main→Space→Tab` re-parent — see the as-built notes in the spec). Fresh-start only: pre-existing `spaces.ron`/per-space layouts are ignored (left on disk).

Spec: `docs/specs/2026-06-18-spaces-store-redesign-design.md` (incl. an "As-built deviations" section).

## Test plan

- [ ] Create / switch / delete / rename spaces, including `org/repo` names
- [ ] Restart → spaces and the active space persist
- [ ] Switch away from a space → its terminal/agent keeps running
- [ ] Ask an agent to rename a *different* space → its `~/.vmux/spaces/` folder follows
- [ ] `~/.vmux/spaces/` ends up matching the live spaces (no empty orphans)
- [ ] `make lint` + `make test` green (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)