### PR TITLE
fix(bridge): restrict Bevy<->Dioxus IPC to vmux:// frames

### DIFF
--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -86,8 +86,12 @@ impl Plugin for BrowserPlugin {
                     embedded_hosts,
                     ..default()
                 },
-                BinEventEmitterPlugin::<(HeaderCommandEvent, SideSheetCommandEvent)>::default(),
-                BinEventEmitterPlugin::<(DebugUpdateReady, DebugUpdateClear)>::default(),
+                BinEventEmitterPlugin::<(HeaderCommandEvent, SideSheetCommandEvent)>::for_hosts(&[
+                    "layout",
+                ]),
+                BinEventEmitterPlugin::<(DebugUpdateReady, DebugUpdateClear)>::for_hosts(&[
+                    "debug",
+                ]),
             ))
             .add_observer(on_webview_ready_send_theme)
             .add_observer(on_header_command_emit)

--- a/crates/vmux_desktop/src/updater.rs
+++ b/crates/vmux_desktop/src/updater.rs
@@ -118,7 +118,9 @@ impl Plugin for UpdatePlugin {
         })
         .add_systems(Startup, init_update_checker)
         .add_systems(Update, poll_update_result)
-        .add_plugins(BinEventEmitterPlugin::<(RestartRequestEvent,)>::default())
+        .add_plugins(BinEventEmitterPlugin::<(RestartRequestEvent,)>::for_hosts(
+            &["debug", "layout"],
+        ))
         .add_observer(on_restart_request);
     }
 }

--- a/crates/vmux_history/src/plugin.rs
+++ b/crates/vmux_history/src/plugin.rs
@@ -30,16 +30,16 @@ impl Plugin for HistoryPlugin {
                 prune_history.run_if(on_timer(Duration::from_secs(3600))),
             )
             .add_systems(Startup, prune_history)
-            .add_plugins(
+            .add_plugins((
                 BinEventEmitterPlugin::<(
                     HistoryQueryRequest,
                     HistoryDeleteRequest,
                     HistoryClearAllRequest,
                     HistoryOpenRequest,
-                    HistorySuggestionsRequest,
                     HistoryChangedEvent,
-                )>::default(),
-            )
+                )>::for_hosts(&["history"]),
+                BinEventEmitterPlugin::<(HistorySuggestionsRequest,)>::for_hosts(&["command-bar"]),
+            ))
             .add_observer(on_history_query_request)
             .add_observer(on_history_delete_request)
             .add_observer(on_history_clear_all_request)

--- a/crates/vmux_layout/src/command_bar/handler.rs
+++ b/crates/vmux_layout/src/command_bar/handler.rs
@@ -98,7 +98,7 @@ impl Plugin for CommandBarInputPlugin {
                 CommandBarReadyEvent,
                 CommandBarRenderedEvent,
                 CommandBarSizeEvent,
-            )>::default())
+            )>::for_hosts(&["command-bar"]))
             .add_observer(on_command_bar_action)
             .add_observer(on_path_complete_request)
             .add_observer(on_command_bar_ready)

--- a/crates/vmux_layout/src/tab.rs
+++ b/crates/vmux_layout/src/tab.rs
@@ -27,7 +27,9 @@ impl Plugin for TabPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Tab>()
             .init_resource::<LastTabCloseAt>()
-            .add_plugins(BinEventEmitterPlugin::<(TabsCommandEvent,)>::default())
+            .add_plugins(BinEventEmitterPlugin::<(TabsCommandEvent,)>::for_hosts(&[
+                "layout",
+            ]))
             .add_observer(on_tabs_command_emit)
             .add_systems(
                 Update,

--- a/crates/vmux_setting/src/plugin.rs
+++ b/crates/vmux_setting/src/plugin.rs
@@ -43,7 +43,9 @@ impl Plugin for SettingsPlugin {
             )
             .add_message::<vmux_core::page::SettingsPageSpawnRequest>()
             .add_systems(Update, respond_settings_spawn.in_set(ReadAppCommands))
-            .add_plugins(BinEventEmitterPlugin::<(SettingsCommandEvent,)>::default())
+            .add_plugins(BinEventEmitterPlugin::<(SettingsCommandEvent,)>::for_hosts(
+                &["settings"],
+            ))
             .add_observer(on_settings_command)
             .add_observer(reset_sent_markers_on_page_ready)
             .add_systems(

--- a/crates/vmux_space/src/plugin.rs
+++ b/crates/vmux_space/src/plugin.rs
@@ -58,7 +58,9 @@ impl Plugin for SpacePlugin {
                 Update,
                 handle_spaces_page_open.in_set(PageOpenSet::HandleKnownPages),
             )
-            .add_plugins(BinEventEmitterPlugin::<(SpaceCommandEvent,)>::default())
+            .add_plugins(BinEventEmitterPlugin::<(SpaceCommandEvent,)>::for_hosts(&[
+                "spaces", "layout",
+            ]))
             .add_observer(on_space_command)
             .add_observer(reset_spaces_sent_marker_on_page_ready)
             .add_systems(

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -265,7 +265,7 @@ impl Plugin for TerminalPlugin {
                 TermResizeEvent,
                 TermMouseEvent,
                 TermKeyEvent,
-            )>::default())
+            )>::for_hosts(&["terminal"]))
             .add_systems(
                 PreUpdate,
                 handle_terminal_keyboard

--- a/crates/vmux_terminal/src/processes_monitor.rs
+++ b/crates/vmux_terminal/src/processes_monitor.rs
@@ -82,7 +82,7 @@ impl Plugin for ProcessesMonitorPlugin {
                 ProcessNavigateEvent,
                 ProcessKillEvent,
                 ProcessKillAllEvent,
-            )>::default())
+            )>::for_hosts(&["services"]))
             .add_systems(
                 Update,
                 (request_process_list, broadcast_to_monitors).chain(),

--- a/crates/vmux_vibe_setup/src/plugin.rs
+++ b/crates/vmux_vibe_setup/src/plugin.rs
@@ -7,8 +7,10 @@ pub struct VibeSetupPlugin;
 impl Plugin for VibeSetupPlugin {
     fn build(&self, app: &mut App) {
         app.world_mut().spawn(crate::PAGE_MANIFEST);
-        app.add_plugins(BinEventEmitterPlugin::<(VibeInstallRunRequest,)>::default())
-            .add_observer(on_vibe_install_run);
+        app.add_plugins(BinEventEmitterPlugin::<(VibeInstallRunRequest,)>::for_hosts(
+            &["agent"],
+        ))
+        .add_observer(on_vibe_install_run);
     }
 }
 

--- a/docs/specs/2026-06-19-bridge-scheme-gate-design.md
+++ b/docs/specs/2026-06-19-bridge-scheme-gate-design.md
@@ -1,0 +1,91 @@
+# Bridge scheme gate — restrict the Bevy↔Dioxus bridge to `vmux://` frames
+
+Date: 2026-06-19
+
+## Problem / threat model
+
+The `window.cef` bridge (`brp` / `emit` / `binEmit` / `listen` / `binListen`) is injected
+into **every** CEF frame as a global V8 extension (`v8/bevy-cef-api`, registered in
+`on_web_kit_initialized`). Nothing checks the source frame's URL. So untrusted web content
+loaded in a browse tab (or an iframe inside any page) can drive the bridge:
+
+- `window.cef.brp({...})` proxies the **full Bevy Remote Protocol** → arbitrary ECS
+  read/write (history, spaces, settings, terminals). Info theft + manipulation.
+- `window.cef.binEmit("…RestartRequestEvent", …)` / `HistoryClearAllRequest` /
+  `ProcessKillAllEvent` fire global observers that ignore the source entity.
+
+Inbound messages are only loosely scoped: the browser process stamps the source `Entity`
+and observers *may* read `trigger.event_target()`, but several global-action observers
+ignore it entirely, and the decode step keys purely on the rkyv type-name id — never on the
+origin scheme.
+
+A page is **trusted iff its frame URL is `vmux://<known-host>/`**. The `vmux://` scheme is a
+registered custom scheme served only from bundled assets, so a web page can never *be* at a
+`vmux://` URL — scheme is a sound trust boundary. Per-frame URL means an `evil.com` iframe
+inside a vmux page is correctly rejected.
+
+No production code calls `window.cef` from http(s)/browse pages, so gating breaks nothing
+legitimate. All bridge-using vmux pages are served from `vmux://<host>/`.
+
+## Shared predicate (`bevy_cef_core/src/util.rs`)
+
+Pure, unit-tested, explicit-arg core + thin wrappers over `resolved_cef_embedded_page_config()`:
+
+```rust
+pub fn url_has_embedded_scheme(url: &str, scheme_prefix: &str) -> bool;          // scheme-only
+pub fn url_is_trusted_embedded_page(url, scheme_prefix, hosts) -> bool;          // scheme + host allowlist
+pub fn has_embedded_scheme(url: &str) -> bool;                                   // render wrapper
+pub fn is_trusted_embedded_page(url: &str) -> bool;                              // browser wrapper
+```
+
+Host is parsed as the segment after the prefix up to the first `/`, `?`, or `#`. Empty
+prefix → always false.
+
+| url | `has_embedded_scheme` | `is_trusted_embedded_page` |
+|---|---|---|
+| `vmux://history/` | ✓ | ✓ |
+| `vmux://history/sub?x=1` | ✓ | ✓ |
+| `vmux://history?x=1` | ✓ | ✓ |
+| `vmux://unknown/` | ✓ | ✗ (allowlist) |
+| `vmux://` (bare) | ✓ | ✗ |
+| `vmux:evil` (no `//`) | ✗ | ✗ |
+| `https://evil.com/` | ✗ | ✗ |
+| `about:blank` / `""` | ✗ | ✗ |
+
+Browser process (A1, A2) uses the host allowlist (`CefEmbeddedHosts` populated there).
+Render process (B1, B2, B2b) uses scheme-only — the host list is not populated in the render
+process, and the browser side enforces hosts authoritatively.
+
+## Gate map (all in `bevy_cef_core`)
+
+### Inbound — page → Bevy
+- **A1 — browser, authoritative.** `browser_process/client_handler.rs::on_process_message_received`:
+  resolve `frame.url()`; if `!is_trusted_embedded_page`, `webview_debug_log` and return without
+  dispatching. One chokepoint covering `bin_emit` / `js_emit` / `brp` handlers.
+- **B1 — render, defense in depth.** `render_process/cef_api_handler.rs` `execute_emit` /
+  `execute_bin_emit` / `execute_brp`: after `context.frame()`, no-op if `!has_embedded_scheme`.
+
+### Outbound — Bevy → page (the listener side)
+- **A2 — browser, authoritative.** `browser_process/browsers.rs` `emit_event` /
+  `emit_event_raw_json` / `emit_event_bytes`: each resolves `browser.client.main_frame()`;
+  skip `send_process_message` if that frame's URL is not trusted. Mirror of A1.
+- **B2 — render, defense in depth (delivery chokepoint).** `render_process/render_process_handler.rs::on_process_message_received`:
+  has the destination `frame`; drop `handle_listen_message` / `handle_bin_listen_message` /
+  brp-response delivery if `!has_embedded_scheme`.
+- **B2b — render, registration.** `cef_api_handler.rs::execute_listen`: look up the current
+  frame; no-op registering a listener on an untrusted frame.
+
+BRP is fully covered inbound at A1 (no accepted request ⇒ no response). Outbound is already
+entity-targeted; A2/B2 are defense in depth against future mis-targeting.
+
+## Non-goals
+- No change to per-entity routing of legitimate messages.
+- No change to outbound targeting logic (Bevy still chooses target entities).
+
+## Tests
+- Unit (`cargo test -p bevy_cef_core`): the predicate table above (explicit-arg forms, no CEF
+  runtime needed) — mirrors the existing `decode_bin_event` tests.
+- Manual (runtime): `VMUX_WEBVIEW_DEBUG=1`, open a browse tab → devtools console →
+  `window.cef.brp({...})` / `window.cef.binEmit(...)` → confirm debug log shows the drop and
+  there is no ECS effect. Then confirm command-bar, history, settings, terminal, spaces still
+  work normally.

--- a/docs/specs/2026-06-19-bridge-scheme-gate-design.md
+++ b/docs/specs/2026-06-19-bridge-scheme-gate-design.md
@@ -78,6 +78,42 @@ process, and the browser side enforces hosts authoritatively.
 BRP is fully covered inbound at A1 (no accepted request ⇒ no response). Outbound is already
 entity-targeted; A2/B2 are defense in depth against future mis-targeting.
 
+## Per-page message ownership (least privilege)
+
+The scheme/host gate above lets *any* trusted `vmux://` page emit *any* registered message
+type. A second layer binds each message type to the page(s) that legitimately emit it, so a
+compromised vmux page cannot pivot to another page's handlers (e.g. a history page triggering
+`RestartRequestEvent`).
+
+Mechanism:
+- `BinIpcEventRaw` carries the source `host` (stamped in `bin_emit_event_handler` from
+  `frame.url()`).
+- `BinEventEmitterPlugin::for_hosts(&["..."])` declares owner host(s); `receive_bin_events`
+  drops a decoded event whose `host` is not in the owner set. No owner set (`default()` /
+  `with_id`) = unrestricted (shared types like `PageReady`).
+
+Owner is the *emitting* page, derived from the `try_cef_bin_emit_rkyv` call sites:
+
+| Owner host(s) | Types |
+|---|---|
+| settings | `SettingsCommandEvent` |
+| agent | `VibeInstallRunRequest` |
+| spaces, layout | `SpaceCommandEvent` |
+| terminal | `TermResizeEvent`, `TermMouseEvent`, `TermKeyEvent` |
+| services | `ProcessNavigateEvent`, `ProcessKillEvent`, `ProcessKillAllEvent` |
+| debug, layout | `RestartRequestEvent` |
+| layout | `HeaderCommandEvent`, `SideSheetCommandEvent`, `TabsCommandEvent` |
+| debug | `DebugUpdateReady`, `DebugUpdateClear` |
+| command-bar | `CommandBarActionEvent`, `PathCompleteRequest`, `CommandBarReadyEvent`, `CommandBarRenderedEvent`, `CommandBarSizeEvent`, `HistorySuggestionsRequest` |
+| history | `HistoryQueryRequest`, `HistoryDeleteRequest`, `HistoryClearAllRequest`, `HistoryOpenRequest`, `HistoryChangedEvent` |
+| (unrestricted) | `PageReady`, `AgentToast` |
+
+`HistorySuggestionsRequest` is emitted by the command-bar page, so it is split out of the
+history registration into its own command-bar-owned registration.
+
+BRP lockdown: A1 additionally drops `PROCESS_MESSAGE_BRP` from any host other than `debug`
+(no production page uses `window.cef.brp`).
+
 ## Non-goals
 - No change to per-entity routing of legitimate messages.
 - No change to outbound targeting logic (Bevy still chooses target entities).

--- a/patches/bevy_cef-0.5.2/src/common/ipc/bin_js_emit.rs
+++ b/patches/bevy_cef-0.5.2/src/common/ipc/bin_js_emit.rs
@@ -46,11 +46,16 @@ where
 }
 
 pub trait BinEventList {
-    fn register_events(app: &mut App, id_override: Option<&'static str>);
+    fn register_events(
+        app: &mut App,
+        id_override: Option<&'static str>,
+        owner_hosts: Option<&'static [&'static str]>,
+    );
 }
 
 pub struct BinEventEmitterPlugin<T> {
     id: Option<&'static str>,
+    owner_hosts: Option<&'static [&'static str]>,
     marker: PhantomData<T>,
 }
 
@@ -58,6 +63,17 @@ impl<E> BinEventEmitterPlugin<(E,)> {
     pub const fn with_id(id: &'static str) -> Self {
         Self {
             id: Some(id),
+            owner_hosts: None,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<T> BinEventEmitterPlugin<T> {
+    pub const fn for_hosts(owner_hosts: &'static [&'static str]) -> Self {
+        Self {
+            id: None,
+            owner_hosts: Some(owner_hosts),
             marker: PhantomData,
         }
     }
@@ -67,6 +83,7 @@ impl<T> Default for BinEventEmitterPlugin<T> {
     fn default() -> Self {
         Self {
             id: None,
+            owner_hosts: None,
             marker: PhantomData,
         }
     }
@@ -77,11 +94,18 @@ where
     T: BinEventList + Send + Sync + 'static,
 {
     fn build(&self, app: &mut App) {
-        T::register_events(app, self.id);
+        T::register_events(app, self.id, self.owner_hosts);
     }
 }
 
-fn register_event<E>(app: &mut App, id: &'static str)
+fn host_allowed(owner_hosts: Option<&[&str]>, host: &str) -> bool {
+    match owner_hosts {
+        None => true,
+        Some(list) => list.contains(&host),
+    }
+}
+
+fn register_event<E>(app: &mut App, id: &'static str, owner_hosts: Option<&'static [&'static str]>)
 where
     E: rkyv::Archive + Send + Sync + 'static,
     E::Archived: rkyv::Deserialize<E, rkyv::api::high::HighDeserializer<rkyv::rancor::Error>>
@@ -90,7 +114,7 @@ where
     app.add_systems(
         Update,
         (move |commands: Commands, buffer: Res<BinIpcEventRawBuffer>| {
-            receive_bin_events::<E>(commands, buffer, id);
+            receive_bin_events::<E>(commands, buffer, id, owner_hosts);
         })
         .after(drain_bin_ipc_events),
     );
@@ -109,11 +133,15 @@ macro_rules! impl_bin_event_list {
                     + for<'a> CheckBytes<rkyv::api::high::HighValidator<'a, rkyv::rancor::Error>>,
             )*
         {
-            fn register_events(app: &mut App, id_override: Option<&'static str>) {
+            fn register_events(
+                app: &mut App,
+                id_override: Option<&'static str>,
+                owner_hosts: Option<&'static [&'static str]>,
+            ) {
                 let head_id = id_override.unwrap_or_else(bin_ipc_event_id::<$head>);
-                register_event::<$head>(app, head_id);
+                register_event::<$head>(app, head_id, owner_hosts);
                 $(
-                    register_event::<$tail>(app, bin_ipc_event_id::<$tail>());
+                    register_event::<$tail>(app, bin_ipc_event_id::<$tail>(), owner_hosts);
                 )*
             }
         }
@@ -149,14 +177,25 @@ where
     rkyv::from_bytes::<E, rkyv::rancor::Error>(&event.payload).ok()
 }
 
-fn receive_bin_events<E>(mut commands: Commands, buffer: Res<BinIpcEventRawBuffer>, id: &str)
-where
+fn receive_bin_events<E>(
+    mut commands: Commands,
+    buffer: Res<BinIpcEventRawBuffer>,
+    id: &str,
+    owner_hosts: Option<&'static [&'static str]>,
+) where
     E: rkyv::Archive + Send + Sync + 'static,
     E::Archived: rkyv::Deserialize<E, rkyv::api::high::HighDeserializer<rkyv::rancor::Error>>
         + for<'a> CheckBytes<rkyv::api::high::HighValidator<'a, rkyv::rancor::Error>>,
 {
     for event in &buffer.0 {
         if let Some(payload) = decode_bin_event::<E>(event, id) {
+            if !host_allowed(owner_hosts, &event.host) {
+                webview_debug_log(format!(
+                    "ipc: dropped '{}' from host '{}' (owner {:?})",
+                    id, event.host, owner_hosts
+                ));
+                continue;
+            }
             commands.trigger(BinReceive {
                 webview: event.webview,
                 payload,
@@ -205,6 +244,7 @@ mod tests {
             .into_vec();
         let raw = BinIpcEventRaw {
             webview: Entity::PLACEHOLDER,
+            host: String::new(),
             id: bin_ipc_event_id::<BetaEvent>().to_string(),
             payload: bytes,
         };
@@ -220,6 +260,7 @@ mod tests {
             .into_vec();
         let raw = BinIpcEventRaw {
             webview: Entity::PLACEHOLDER,
+            host: String::new(),
             id: bin_ipc_event_id::<AlphaEvent>().to_string(),
             payload: bytes,
         };
@@ -228,5 +269,21 @@ mod tests {
             decode_bin_event::<AlphaEvent>(&raw, bin_ipc_event_id::<AlphaEvent>()).unwrap();
 
         assert_eq!(decoded, payload);
+    }
+
+    #[test]
+    fn host_allowed_without_owner_accepts_any_host() {
+        assert!(host_allowed(None, "history"));
+        assert!(host_allowed(None, ""));
+    }
+
+    #[test]
+    fn host_allowed_restricts_to_owner_hosts() {
+        assert!(host_allowed(Some(&["history"]), "history"));
+        assert!(!host_allowed(Some(&["history"]), "command-bar"));
+        assert!(host_allowed(Some(&["debug", "layout"]), "layout"));
+        assert!(host_allowed(Some(&["debug", "layout"]), "debug"));
+        assert!(!host_allowed(Some(&["debug", "layout"]), "terminal"));
+        assert!(!host_allowed(Some(&[]), "history"));
     }
 }

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
@@ -575,6 +575,7 @@ impl Browsers {
             && let Some(argument_list) = process_message.argument_list()
             && let Some(browser) = self.browsers.get(webview)
             && let Some(frame) = browser.client.main_frame()
+            && crate::util::is_trusted_embedded_page(&frame.url().into_string())
         {
             argument_list.set_string(0, Some(&id.into().as_str().into()));
             argument_list.set_string(1, Some(&event.to_string().as_str().into()));
@@ -592,6 +593,7 @@ impl Browsers {
             && let Some(argument_list) = process_message.argument_list()
             && let Some(browser) = self.browsers.get(webview)
             && let Some(frame) = browser.client.main_frame()
+            && crate::util::is_trusted_embedded_page(&frame.url().into_string())
         {
             argument_list.set_string(0, Some(&id.into().as_str().into()));
             argument_list.set_string(1, Some(&json_body.into()));
@@ -609,6 +611,7 @@ impl Browsers {
             && let Some(argument_list) = process_message.argument_list()
             && let Some(browser) = self.browsers.get(webview)
             && let Some(frame) = browser.client.main_frame()
+            && crate::util::is_trusted_embedded_page(&frame.url().into_string())
         {
             argument_list.set_string(0, Some(&id.into().as_str().into()));
             // CEF's BinaryValue rejects zero-length data. For unit-shaped payloads

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/client_handler.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/client_handler.rs
@@ -8,8 +8,9 @@ use crate::prelude::IntoString;
 use cef::rc::{Rc, RcImpl};
 use cef::{
     Browser, Client, ContextMenuHandler, DisplayHandler, FocusHandler, FocusSource, Frame,
-    ImplClient, ImplFocusHandler, ImplProcessMessage, LifeSpanHandler, ListValue, LoadHandler,
-    ProcessId, ProcessMessage, RenderHandler, RequestHandler, WrapClient, WrapFocusHandler, sys,
+    ImplClient, ImplFocusHandler, ImplFrame, ImplProcessMessage, LifeSpanHandler, ListValue,
+    LoadHandler, ProcessId, ProcessMessage, RenderHandler, RequestHandler, WrapClient,
+    WrapFocusHandler, sys,
 };
 use std::os::raw::c_int;
 
@@ -224,19 +225,26 @@ impl ImplClient for ClientHandlerBuilder {
         if let Some(message) = message
             && let Some(browser) = browser
             && let Some(frame) = frame
-            && let Some(name) = Some(message.name().into_string())
-            && let Some(handler) = self
+        {
+            let name = message.name().into_string();
+            let url = frame.url().into_string();
+            if !crate::util::is_trusted_embedded_page(&url) {
+                crate::util::webview_debug_log(format!(
+                    "ipc: dropped inbound '{name}' from untrusted url={url}"
+                ));
+                return 1;
+            }
+            if let Some(handler) = self
                 .message_handlers
                 .iter()
                 .find(|h| h.process_name() == name.as_str())
-        {
             {
                 let args = message.argument_list();
                 handler.handle_message(browser, frame, args);
-            }
-            // Wake Bevy so it drains the IPC channel this frame instead of on the next idle tick.
-            if let Some(wake) = &self.wake {
-                wake();
+                // Wake Bevy so it drains the IPC channel this frame instead of on the next idle tick.
+                if let Some(wake) = &self.wake {
+                    wake();
+                }
             }
         };
         1

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/client_handler.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/client_handler.rs
@@ -234,6 +234,14 @@ impl ImplClient for ClientHandlerBuilder {
                 ));
                 return 1;
             }
+            if name == crate::prelude::PROCESS_MESSAGE_BRP
+                && crate::util::embedded_page_host_of(&url).as_deref() != Some("debug")
+            {
+                crate::util::webview_debug_log(format!(
+                    "ipc: dropped BRP from non-debug url={url}"
+                ));
+                return 1;
+            }
             if let Some(handler) = self
                 .message_handlers
                 .iter()

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/client_handler/bin_emit_event_handler.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/client_handler/bin_emit_event_handler.rs
@@ -3,11 +3,12 @@ use crate::prelude::PROCESS_MESSAGE_BIN_JS_EMIT;
 use crate::util::IntoString;
 use async_channel::Sender;
 use bevy::prelude::Entity;
-use cef::{Browser, Frame, ImplBinaryValue, ImplListValue, ListValue};
+use cef::{Browser, Frame, ImplBinaryValue, ImplFrame, ImplListValue, ListValue};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BinIpcEventRaw {
     pub webview: Entity,
+    pub host: String,
     pub id: String,
     pub payload: Vec<u8>,
 }
@@ -76,10 +77,12 @@ impl ProcessMessageHandler for BinEmitEventHandler {
         PROCESS_MESSAGE_BIN_JS_EMIT
     }
 
-    fn handle_message(&self, _browser: &mut Browser, _frame: &mut Frame, args: Option<ListValue>) {
+    fn handle_message(&self, _browser: &mut Browser, frame: &mut Frame, args: Option<ListValue>) {
         let Some(args) = args else {
             return;
         };
+        let host =
+            crate::util::embedded_page_host_of(&frame.url().into_string()).unwrap_or_default();
         let id = args.string(0).into_string();
         let payload_index = if id.is_empty() { 0 } else { 1 };
         let payload = match args.binary(payload_index) {
@@ -104,6 +107,7 @@ impl ProcessMessageHandler for BinEmitEventHandler {
         ));
         let _ = self.sender.send_blocking(BinIpcEventRaw {
             webview: self.webview,
+            host,
             id,
             payload,
         });
@@ -121,10 +125,12 @@ mod tests {
         let payload = vec![1, 2, 3, 4];
         let raw = BinIpcEventRaw {
             webview,
+            host: "history".to_string(),
             id: "test-id".to_string(),
             payload: payload.clone(),
         };
         assert_eq!(raw.webview, webview);
+        assert_eq!(raw.host, "history");
         assert_eq!(raw.id, "test-id");
         assert_eq!(raw.payload, payload);
     }

--- a/patches/bevy_cef_core-0.5.2/src/render_process/cef_api_handler.rs
+++ b/patches/bevy_cef_core-0.5.2/src/render_process/cef_api_handler.rs
@@ -99,6 +99,9 @@ impl CefApiHandler {
         let Some(frame) = context.frame() else {
             return 0;
         };
+        if !crate::util::has_embedded_scheme(&frame.url().into_string()) {
+            return 1;
+        }
 
         if let Some(mut process) = process_message_create(Some(&PROCESS_MESSAGE_BRP.into()))
             && let Some(promise) = v8_value_create_promise()
@@ -136,6 +139,9 @@ impl CefApiHandler {
         let Some(frame) = context.frame() else {
             return 0;
         };
+        if !crate::util::has_embedded_scheme(&frame.url().into_string()) {
+            return 1;
+        }
 
         if let Some(mut process) = process_message_create(Some(&PROCESS_MESSAGE_JS_EMIT.into()))
             && let Some(arguments_list) = process.argument_list()
@@ -161,6 +167,9 @@ impl CefApiHandler {
         let Some(frame) = context.frame() else {
             return 0;
         };
+        if !crate::util::has_embedded_scheme(&frame.url().into_string()) {
+            return 1;
+        }
 
         if let Some(mut process) = process_message_create(Some(&PROCESS_MESSAGE_BIN_JS_EMIT.into()))
             && let Some(arguments_list) = process.argument_list()
@@ -218,6 +227,15 @@ impl CefApiHandler {
     }
 
     fn execute_listen(&self, arguments: Option<&[Option<V8Value>]>) -> c_int {
+        let Some(context) = v8_context_get_current_context() else {
+            return 1;
+        };
+        let Some(frame) = context.frame() else {
+            return 1;
+        };
+        if !crate::util::has_embedded_scheme(&frame.url().into_string()) {
+            return 1;
+        }
         if let Some(arguments) = arguments
             && let Some(Some(id)) = arguments.first()
             && id.is_string().is_positive()

--- a/patches/bevy_cef_core-0.5.2/src/render_process/render_process_handler.rs
+++ b/patches/bevy_cef_core-0.5.2/src/render_process/render_process_handler.rs
@@ -138,6 +138,7 @@ impl ImplRenderProcessHandler for RenderProcessHandlerBuilder {
     ) -> c_int {
         if let Some(message) = message
             && let Some(frame) = frame
+            && crate::util::has_embedded_scheme(&frame.url().into_string())
             && let Some(ctx) = frame.v8_context()
         {
             match message.name().into_string().as_str() {

--- a/patches/bevy_cef_core-0.5.2/src/util.rs
+++ b/patches/bevy_cef_core-0.5.2/src/util.rs
@@ -126,19 +126,28 @@ pub fn url_has_embedded_scheme(url: &str, scheme_prefix: &str) -> bool {
     !scheme_prefix.is_empty() && url.starts_with(scheme_prefix)
 }
 
+pub fn embedded_page_host(url: &str, scheme_prefix: &str) -> Option<String> {
+    if scheme_prefix.is_empty() {
+        return None;
+    }
+    let rest = url.strip_prefix(scheme_prefix)?;
+    let host = rest.split(['/', '?', '#']).next().unwrap_or("");
+    if host.is_empty() {
+        None
+    } else {
+        Some(host.to_string())
+    }
+}
+
 pub fn url_is_trusted_embedded_page(
     url: &str,
     scheme_prefix: &str,
     hosts: &CefEmbeddedHosts,
 ) -> bool {
-    if scheme_prefix.is_empty() {
-        return false;
+    match embedded_page_host(url, scheme_prefix) {
+        Some(host) => hosts.entry_for_host(&host).is_some(),
+        None => false,
     }
-    let Some(rest) = url.strip_prefix(scheme_prefix) else {
-        return false;
-    };
-    let host = rest.split(['/', '?', '#']).next().unwrap_or("");
-    !host.is_empty() && hosts.entry_for_host(host).is_some()
 }
 
 pub fn has_embedded_scheme(url: &str) -> bool {
@@ -148,6 +157,10 @@ pub fn has_embedded_scheme(url: &str) -> bool {
 pub fn is_trusted_embedded_page(url: &str) -> bool {
     let config = resolved_cef_embedded_page_config();
     url_is_trusted_embedded_page(url, config.scheme_prefix(), &config.hosts)
+}
+
+pub fn embedded_page_host_of(url: &str) -> Option<String> {
+    embedded_page_host(url, resolved_cef_embedded_page_config().scheme_prefix())
 }
 
 pub fn webview_debug_log_enabled() -> bool {
@@ -413,6 +426,25 @@ mod tests {
         ));
         assert!(!url_is_trusted_embedded_page("", "vmux://", &hosts));
         assert!(!url_is_trusted_embedded_page("vmux://history/", "", &hosts));
+    }
+
+    #[test]
+    fn embedded_page_host_parses_host_segment() {
+        assert_eq!(
+            embedded_page_host("vmux://history/", "vmux://").as_deref(),
+            Some("history")
+        );
+        assert_eq!(
+            embedded_page_host("vmux://agent/vibe/setup", "vmux://").as_deref(),
+            Some("agent")
+        );
+        assert_eq!(
+            embedded_page_host("vmux://command-bar?x=1", "vmux://").as_deref(),
+            Some("command-bar")
+        );
+        assert_eq!(embedded_page_host("vmux://", "vmux://"), None);
+        assert_eq!(embedded_page_host("https://evil.com/", "vmux://"), None);
+        assert_eq!(embedded_page_host("vmux://history/", ""), None);
     }
 }
 

--- a/patches/bevy_cef_core-0.5.2/src/util.rs
+++ b/patches/bevy_cef_core-0.5.2/src/util.rs
@@ -122,6 +122,34 @@ pub fn resolved_cef_embedded_page_config() -> Arc<CefEmbeddedPageConfig> {
         .unwrap_or_else(|| Arc::new(CefEmbeddedPageConfig::default()))
 }
 
+pub fn url_has_embedded_scheme(url: &str, scheme_prefix: &str) -> bool {
+    !scheme_prefix.is_empty() && url.starts_with(scheme_prefix)
+}
+
+pub fn url_is_trusted_embedded_page(
+    url: &str,
+    scheme_prefix: &str,
+    hosts: &CefEmbeddedHosts,
+) -> bool {
+    if scheme_prefix.is_empty() {
+        return false;
+    }
+    let Some(rest) = url.strip_prefix(scheme_prefix) else {
+        return false;
+    };
+    let host = rest.split(['/', '?', '#']).next().unwrap_or("");
+    !host.is_empty() && hosts.entry_for_host(host).is_some()
+}
+
+pub fn has_embedded_scheme(url: &str) -> bool {
+    url_has_embedded_scheme(url, resolved_cef_embedded_page_config().scheme_prefix())
+}
+
+pub fn is_trusted_embedded_page(url: &str) -> bool {
+    let config = resolved_cef_embedded_page_config();
+    url_is_trusted_embedded_page(url, config.scheme_prefix(), &config.hosts)
+}
+
 pub fn webview_debug_log_enabled() -> bool {
     std::env::var_os("VMUX_WEBVIEW_DEBUG").is_some()
 }
@@ -303,6 +331,88 @@ mod tests {
             webview_debug_log_path(),
             PathBuf::from("/tmp/vmux_webview_debug.log")
         );
+    }
+
+    fn allowlisted_hosts() -> CefEmbeddedHosts {
+        CefEmbeddedHosts(vec![
+            CefEmbeddedHost {
+                host: "history".to_string(),
+                default_document: "index.html".to_string(),
+            },
+            CefEmbeddedHost {
+                host: "terminal".to_string(),
+                default_document: "index.html".to_string(),
+            },
+        ])
+    }
+
+    #[test]
+    fn embedded_scheme_matches_only_exact_scheme_prefix() {
+        assert!(url_has_embedded_scheme("vmux://history/", "vmux://"));
+        assert!(url_has_embedded_scheme("vmux://anything/at/all", "vmux://"));
+        assert!(!url_has_embedded_scheme("https://evil.com/", "vmux://"));
+        assert!(!url_has_embedded_scheme("about:blank", "vmux://"));
+        assert!(!url_has_embedded_scheme("vmux:evil", "vmux://"));
+        assert!(!url_has_embedded_scheme("", "vmux://"));
+    }
+
+    #[test]
+    fn embedded_scheme_rejects_empty_prefix() {
+        assert!(!url_has_embedded_scheme("vmux://history/", ""));
+        assert!(!url_has_embedded_scheme("anything", ""));
+    }
+
+    #[test]
+    fn trusted_page_requires_scheme_and_allowlisted_host() {
+        let hosts = allowlisted_hosts();
+        assert!(url_is_trusted_embedded_page(
+            "vmux://history/",
+            "vmux://",
+            &hosts
+        ));
+        assert!(url_is_trusted_embedded_page(
+            "vmux://history/sub/path?x=1",
+            "vmux://",
+            &hosts
+        ));
+        assert!(url_is_trusted_embedded_page(
+            "vmux://history?x=1",
+            "vmux://",
+            &hosts
+        ));
+        assert!(url_is_trusted_embedded_page(
+            "vmux://terminal/",
+            "vmux://",
+            &hosts
+        ));
+    }
+
+    #[test]
+    fn trusted_page_rejects_unknown_host_and_untrusted_origins() {
+        let hosts = allowlisted_hosts();
+        assert!(!url_is_trusted_embedded_page(
+            "vmux://unknown/",
+            "vmux://",
+            &hosts
+        ));
+        assert!(!url_is_trusted_embedded_page("vmux://", "vmux://", &hosts));
+        assert!(!url_is_trusted_embedded_page(
+            "vmux:evil",
+            "vmux://",
+            &hosts
+        ));
+        assert!(!url_is_trusted_embedded_page(
+            "https://evil.com/",
+            "vmux://",
+            &hosts
+        ));
+        assert!(!url_is_trusted_embedded_page(
+            "about:blank",
+            "vmux://",
+            &hosts
+        ));
+        assert!(!url_is_trusted_embedded_page("", "vmux://", &hosts));
+        assert!(!url_is_trusted_embedded_page("vmux://history/", "", &hosts));
     }
 }
 


### PR DESCRIPTION
## Context

`window.cef` (`brp` / `emit` / `binEmit` / `listen`) is injected into **every** CEF frame as a global V8 extension, with no check on the source frame's origin. Untrusted web content in a browse tab or iframe could therefore drive the full Bevy Remote Protocol (arbitrary ECS read/write) and global IPC handlers (history wipe, app restart, kill-all). This locks the bridge to trusted `vmux://` pages only.

## Implementation

Every bridge message is gated on the source frame URL via a shared predicate in `bevy_cef_core::util` (`url_has_embedded_scheme` / `url_is_trusted_embedded_page`).

- **Browser process (authoritative)** requires `vmux://` + an allowlisted host (the existing `CefEmbeddedHosts` derived from page manifests): inbound dispatch is dropped in `client_handler`, outbound host-emit is skipped in `browsers`.
- **Render process (defense in depth)** uses scheme-only checks (its config override is unset, so it has no host list): `execute_emit/bin_emit/brp/listen` no-op and host-emit/brp delivery is dropped for non-`vmux://` frames.

The `vmux://` scheme only serves bundled assets, so scheme is a sound trust boundary; checking per-frame URL means an untrusted iframe inside a vmux page is also rejected. No production code calls `window.cef` from web pages, so nothing legitimate is affected. Drops are logged via `webview_debug_log`.

## Checks / QA

- `VMUX_WEBVIEW_DEBUG=1`, run the app, open a browse tab to any https site. In devtools console call `window.cef.brp({method:"world.get_components",params:{}})` and `window.cef.binEmit("x", new ArrayBuffer(0))` → `/tmp/vmux_webview_debug.log` shows `ipc: dropped inbound ... untrusted` and there is no ECS effect.
- Confirm command-bar, history, settings, terminal, and spaces still load and function (PageReady, command palette, list population, terminal input).