### PR TITLE
feat(window): persist window position, size & fullscreen

### DIFF
--- a/crates/vmux_desktop/src/glass.rs
+++ b/crates/vmux_desktop/src/glass.rs
@@ -31,6 +31,7 @@ impl Plugin for GlassPlugin {
                 Last,
                 (
                     reveal_window_after_layout_ready,
+                    restore_fullscreen_after_reveal,
                     ensure_window_active_after_reveal,
                     sync_layout_overlay,
                     sync_command_bar_overlay,
@@ -158,6 +159,34 @@ fn reveal_window_after_layout_ready(
     state.revealed_at = Some(Instant::now());
 }
 
+/// After reveal, apply the persisted fullscreen intent once: enter native
+/// fullscreen if it was saved, then mark restore complete so geometry capture
+/// can begin. Consumes [`crate::window_state::PendingFullscreenRestore`].
+fn restore_fullscreen_after_reveal(
+    state: NonSend<GlassState>,
+    pending: Option<Res<crate::window_state::PendingFullscreenRestore>>,
+    mut commands: Commands,
+) {
+    use objc2_app_kit::NSWindowStyleMask;
+
+    let Some(pending) = pending else {
+        return;
+    };
+    if !state.revealed {
+        return;
+    }
+    if pending.0
+        && let Some(parent_window) = &state._parent_window
+        && !parent_window
+            .styleMask()
+            .contains(NSWindowStyleMask::FullScreen)
+    {
+        parent_window.toggleFullScreen(None);
+    }
+    commands.remove_resource::<crate::window_state::PendingFullscreenRestore>();
+    commands.insert_resource(crate::window_state::WindowRestoreComplete);
+}
+
 fn should_attempt_activation(
     revealed: bool,
     active_confirmed: bool,
@@ -233,6 +262,7 @@ fn sync_window_glass_visibility(
         (&Node, Has<bevy_cef::prelude::CefKeyboardTarget>),
         With<vmux_layout::window::Modal>,
     >,
+    mut window_fullscreen: ResMut<crate::window_state::WindowFullscreen>,
 ) {
     use objc2::ClassType;
     use objc2_app_kit::NSWindowStyleMask;
@@ -252,6 +282,10 @@ fn sync_window_glass_visibility(
         .as_ref()
         .is_some_and(|w| w.styleMask().contains(NSWindowStyleMask::FullScreen));
     let fullscreen = bevy_fullscreen || native_fullscreen;
+
+    if window_fullscreen.0 != fullscreen {
+        window_fullscreen.0 = fullscreen;
+    }
 
     let [r, g, b] = vmux_layout::window::WINDOW_BACKGROUND_SRGB;
     let want_clear = if fullscreen {

--- a/crates/vmux_desktop/src/lib.rs
+++ b/crates/vmux_desktop/src/lib.rs
@@ -27,9 +27,13 @@ mod splash;
 pub(crate) mod shortcut;
 mod tray;
 pub mod updater;
+mod window_state;
 use bevy::asset::io::web::WebAssetPlugin;
 use bevy::prelude::*;
-use bevy::window::{CompositeAlphaMode, ExitCondition, Window as NativeWindow, WindowPlugin};
+use bevy::window::{
+    CompositeAlphaMode, ExitCondition, MonitorSelection, Window as NativeWindow, WindowPlugin,
+    WindowPosition, WindowResolution,
+};
 
 use {
     os_menu::OsMenuPlugin, persistence::PersistencePlugin, shortcut::ShortcutPlugin,
@@ -42,6 +46,11 @@ use {
 use vmux_agent::AgentPlugin;
 
 pub struct VmuxPlugin;
+
+/// First-launch window size (logical px) when no geometry is persisted in
+/// `store.ron`. Restored geometry overrides this after load.
+const DEFAULT_WINDOW_WIDTH: u32 = 1280;
+const DEFAULT_WINDOW_HEIGHT: u32 = 800;
 
 fn primary_window_config(title: String) -> NativeWindow {
     NativeWindow {
@@ -57,6 +66,8 @@ fn primary_window_config(title: String) -> NativeWindow {
         fullsize_content_view: true,
         ime_enabled: true,
         visible: !cfg!(target_os = "macos"),
+        position: WindowPosition::Centered(MonitorSelection::Primary),
+        resolution: WindowResolution::new(DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT),
         ..default()
     }
 }
@@ -114,6 +125,7 @@ impl Plugin for VmuxPlugin {
                 background_lifecycle::BackgroundLifecyclePlugin,
                 tray::TrayPlugin,
                 display::DisplayPlugin,
+                window_state::WindowStatePlugin,
             ));
 
         app.init_resource::<boot_status::SplashStatus>()
@@ -145,6 +157,18 @@ mod tests {
         let window = primary_window_config("Vmux".to_string());
 
         assert_eq!(window.visible, !cfg!(target_os = "macos"));
+    }
+
+    #[test]
+    fn primary_window_defaults_to_centered_default_size() {
+        let window = primary_window_config("Vmux".to_string());
+
+        assert!(matches!(
+            window.position,
+            WindowPosition::Centered(MonitorSelection::Primary)
+        ));
+        assert_eq!(window.resolution.physical_width(), DEFAULT_WINDOW_WIDTH);
+        assert_eq!(window.resolution.physical_height(), DEFAULT_WINDOW_HEIGHT);
     }
 
     #[test]

--- a/crates/vmux_desktop/src/persistence.rs
+++ b/crates/vmux_desktop/src/persistence.rs
@@ -16,7 +16,7 @@ use vmux_layout::{
     pane::{Pane, PaneSize, PaneSplit, PaneSplitDirection, pane_split_gaps},
     stack::Stack,
     tab::Tab,
-    window::Main,
+    window::{Main, WindowGeometry},
 };
 use vmux_setting::AppSettings;
 use vmux_setting::Settings;
@@ -108,6 +108,7 @@ fn mark_dirty_on_change(
     changed_meta: Query<(), (Changed<PageMetadata>, With<Stack>)>,
     changed_size: Query<(), Changed<PaneSize>>,
     changed_children: Query<(), Changed<Children>>,
+    changed_geometry: Query<(), Changed<WindowGeometry>>,
 ) {
     if !added_stacks.is_empty()
         || !added_panes.is_empty()
@@ -117,6 +118,7 @@ fn mark_dirty_on_change(
         || !changed_meta.is_empty()
         || !changed_size.is_empty()
         || !changed_children.is_empty()
+        || !changed_geometry.is_empty()
     {
         auto_save.dirty = true;
         auto_save.debounce.reset();
@@ -160,6 +162,7 @@ pub(crate) fn save_space_to_path(commands: &mut Commands, path: PathBuf) {
         .allow::<Space>()
         .allow::<SpaceId>()
         .allow::<ActiveSpaceTag>()
+        .allow::<WindowGeometry>()
         .allow::<Profile>()
         .allow::<Open>()
         .allow::<PageMetadata>()
@@ -767,6 +770,57 @@ mod tests {
             .next()
             .expect("TransitionType not round-tripped");
         assert_eq!(*tt, vmux_core::TransitionType::Typed);
+    }
+
+    #[test]
+    fn window_geometry_round_trips_through_store() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("store.ron");
+
+        let mut app_save = App::new();
+        app_save.add_plugins(MinimalPlugins);
+        app_save.add_plugins(vmux_core::CorePlugin);
+        app_save
+            .register_type::<WindowGeometry>()
+            .register_type::<Option<IVec2>>()
+            .register_type::<Option<Vec2>>();
+        app_save.add_observer(save_on_default_event);
+        app_save.world_mut().spawn((
+            Save,
+            WindowGeometry {
+                fullscreen: true,
+                position: Some(IVec2::new(11, 22)),
+                size: Some(Vec2::new(640.0, 480.0)),
+            },
+        ));
+
+        save_space_to_path(&mut app_save.world_mut().commands(), path.clone());
+        app_save.update();
+        assert!(path.exists(), "store file should exist");
+
+        let mut app_load = App::new();
+        app_load.add_plugins(MinimalPlugins);
+        app_load.add_plugins(vmux_core::CorePlugin);
+        app_load
+            .register_type::<WindowGeometry>()
+            .register_type::<Option<IVec2>>()
+            .register_type::<Option<Vec2>>();
+        app_load.add_observer(load_on_default_event);
+        app_load.update();
+        app_load
+            .world_mut()
+            .commands()
+            .trigger_load(LoadWorld::default_from_file(path));
+        app_load.update();
+
+        let geom = app_load
+            .world_mut()
+            .query::<&WindowGeometry>()
+            .single(app_load.world())
+            .expect("WindowGeometry not round-tripped");
+        assert!(geom.fullscreen);
+        assert_eq!(geom.position, Some(IVec2::new(11, 22)));
+        assert_eq!(geom.size, Some(Vec2::new(640.0, 480.0)));
     }
 
     #[test]

--- a/crates/vmux_desktop/src/window_state.rs
+++ b/crates/vmux_desktop/src/window_state.rs
@@ -1,0 +1,252 @@
+use bevy::prelude::*;
+use bevy::window::{PrimaryWindow, WindowPosition};
+use vmux_layout::window::WindowGeometry;
+
+#[cfg(not(target_os = "macos"))]
+use bevy::window::{MonitorSelection, WindowMode};
+
+/// Captures below this logical size are treated as transient and ignored.
+const MIN_WINDOW_SIZE: f32 = 100.0;
+
+/// Live fullscreen signal. macOS writes it from `glass.rs` (NSWindow styleMask);
+/// other platforms derive it from `window.mode`.
+#[derive(Resource, Default, Debug)]
+pub struct WindowFullscreen(pub bool);
+
+/// Loaded fullscreen intent awaiting application. Inserted by
+/// `apply_geometry_on_load`, consumed by the platform fullscreen-restore system
+/// (post-reveal on macOS), which then sets [`WindowRestoreComplete`].
+#[derive(Resource, Debug)]
+pub struct PendingFullscreenRestore(pub bool);
+
+/// Set once startup geometry restore is finished. Capture is gated on this so
+/// the transient windowed startup state can't overwrite a saved `fullscreen`.
+#[derive(Resource, Default, Debug)]
+pub struct WindowRestoreComplete;
+
+pub(crate) struct WindowStatePlugin;
+
+impl Plugin for WindowStatePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<WindowFullscreen>().add_systems(
+            Update,
+            (
+                ensure_geometry_singleton,
+                apply_geometry_on_load,
+                capture_window_geometry.run_if(resource_exists::<WindowRestoreComplete>),
+            )
+                .chain(),
+        );
+        #[cfg(not(target_os = "macos"))]
+        app.add_systems(
+            Update,
+            (
+                sync_fullscreen_signal_from_mode,
+                restore_fullscreen_non_macos,
+            ),
+        );
+    }
+}
+
+/// Spawn the persisted geometry singleton if none was loaded from `store.ron`
+/// (first run, or an older store predating this feature). Gated on restore
+/// completion so it never races the scene load into a duplicate.
+fn ensure_geometry_singleton(
+    restore: Res<crate::boot_status::RestoreComplete>,
+    existing: Query<(), With<WindowGeometry>>,
+    mut commands: Commands,
+) {
+    if !restore.0 || !existing.is_empty() {
+        return;
+    }
+    commands.spawn(WindowGeometry::default());
+}
+
+/// Apply a freshly loaded (or spawned) `WindowGeometry` to the primary window
+/// once. Windowed frame is applied immediately (window is hidden until reveal on
+/// macOS, so flicker-free); fullscreen intent is deferred via
+/// [`PendingFullscreenRestore`].
+fn apply_geometry_on_load(
+    geometry: Query<&WindowGeometry, Added<WindowGeometry>>,
+    mut window: Query<&mut Window, With<PrimaryWindow>>,
+    pending: Option<Res<PendingFullscreenRestore>>,
+    restore_done: Option<Res<WindowRestoreComplete>>,
+    mut commands: Commands,
+) {
+    let Some(geom) = geometry.iter().next().copied() else {
+        return;
+    };
+    if let Ok(mut window) = window.single_mut() {
+        if let Some(pos) = geom.position {
+            window.position = WindowPosition::At(pos);
+        }
+        if let Some(size) = geom.size {
+            window.resolution.set(size.x, size.y);
+        }
+    }
+    if pending.is_none() && restore_done.is_none() {
+        commands.insert_resource(PendingFullscreenRestore(geom.fullscreen));
+    }
+}
+
+/// Sync the live window frame into the persisted `WindowGeometry`, marking the
+/// scene dirty (via `Changed<WindowGeometry>`) for the debounced auto-save.
+/// Position/size track the windowed frame only; while fullscreen they are left
+/// untouched so exiting fullscreen lands on the prior frame.
+fn capture_window_geometry(
+    fullscreen: Res<WindowFullscreen>,
+    window: Query<&Window, With<PrimaryWindow>>,
+    mut geometry: Query<&mut WindowGeometry>,
+) {
+    let Ok(window) = window.single() else {
+        return;
+    };
+    let Ok(mut geom) = geometry.single_mut() else {
+        return;
+    };
+
+    let mut next = *geom;
+    next.fullscreen = fullscreen.0;
+    if !fullscreen.0 {
+        if let WindowPosition::At(p) = window.position {
+            next.position = Some(p);
+        }
+        let size = window.resolution.size();
+        if size.x >= MIN_WINDOW_SIZE && size.y >= MIN_WINDOW_SIZE {
+            next.size = Some(size);
+        }
+    }
+    if next != *geom {
+        *geom = next;
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn sync_fullscreen_signal_from_mode(
+    window: Query<&Window, With<PrimaryWindow>>,
+    mut fullscreen: ResMut<WindowFullscreen>,
+) {
+    let Ok(window) = window.single() else {
+        return;
+    };
+    let is_fullscreen = matches!(
+        window.mode,
+        WindowMode::BorderlessFullscreen(_) | WindowMode::Fullscreen(..)
+    );
+    if fullscreen.0 != is_fullscreen {
+        fullscreen.0 = is_fullscreen;
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn restore_fullscreen_non_macos(
+    pending: Option<Res<PendingFullscreenRestore>>,
+    mut window: Query<&mut Window, With<PrimaryWindow>>,
+    mut commands: Commands,
+) {
+    let Some(pending) = pending else {
+        return;
+    };
+    if pending.0
+        && let Ok(mut window) = window.single_mut()
+    {
+        window.mode = WindowMode::BorderlessFullscreen(MonitorSelection::Primary);
+    }
+    commands.remove_resource::<PendingFullscreenRestore>();
+    commands.insert_resource(WindowRestoreComplete);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<WindowFullscreen>();
+        app.world_mut().spawn((
+            Window {
+                resolution: (1200, 800).into(),
+                position: WindowPosition::At(IVec2::new(40, 60)),
+                ..default()
+            },
+            PrimaryWindow,
+        ));
+        app
+    }
+
+    #[test]
+    fn apply_geometry_sets_window_position_and_size() {
+        let mut app = app();
+        app.add_systems(Update, apply_geometry_on_load);
+        app.world_mut().spawn(WindowGeometry {
+            fullscreen: false,
+            position: Some(IVec2::new(123, 456)),
+            size: Some(Vec2::new(640.0, 480.0)),
+        });
+        app.update();
+
+        let window = app
+            .world_mut()
+            .query_filtered::<&Window, With<PrimaryWindow>>()
+            .single(app.world())
+            .unwrap();
+        assert!(matches!(window.position, WindowPosition::At(p) if p == IVec2::new(123, 456)));
+        assert_eq!(window.resolution.physical_width(), 640);
+        assert_eq!(window.resolution.physical_height(), 480);
+    }
+
+    #[test]
+    fn apply_geometry_inserts_pending_fullscreen_intent() {
+        let mut app = app();
+        app.add_systems(Update, apply_geometry_on_load);
+        app.world_mut().spawn(WindowGeometry {
+            fullscreen: true,
+            position: None,
+            size: None,
+        });
+        app.update();
+
+        let pending = app.world().get_resource::<PendingFullscreenRestore>();
+        assert!(pending.is_some_and(|p| p.0));
+    }
+
+    #[test]
+    fn capture_records_windowed_frame_when_not_fullscreen() {
+        let mut app = app();
+        app.world_mut().spawn(WindowGeometry::default());
+        app.add_systems(Update, capture_window_geometry);
+        app.update();
+
+        let geom = app
+            .world_mut()
+            .query::<&WindowGeometry>()
+            .single(app.world())
+            .unwrap();
+        assert_eq!(geom.position, Some(IVec2::new(40, 60)));
+        assert_eq!(geom.size, Some(Vec2::new(1200.0, 800.0)));
+        assert!(!geom.fullscreen);
+    }
+
+    #[test]
+    fn capture_preserves_windowed_frame_while_fullscreen() {
+        let mut app = app();
+        app.insert_resource(WindowFullscreen(true));
+        app.world_mut().spawn(WindowGeometry {
+            fullscreen: false,
+            position: Some(IVec2::new(7, 8)),
+            size: Some(Vec2::new(900.0, 600.0)),
+        });
+        app.add_systems(Update, capture_window_geometry);
+        app.update();
+
+        let geom = app
+            .world_mut()
+            .query::<&WindowGeometry>()
+            .single(app.world())
+            .unwrap();
+        assert!(geom.fullscreen);
+        assert_eq!(geom.position, Some(IVec2::new(7, 8)));
+        assert_eq!(geom.size, Some(Vec2::new(900.0, 600.0)));
+    }
+}

--- a/crates/vmux_layout/src/toggle.rs
+++ b/crates/vmux_layout/src/toggle.rs
@@ -2,7 +2,7 @@ use crate::Open;
 use crate::header::Header;
 use crate::settings::LayoutSettings;
 use crate::side_sheet::SideSheet;
-use crate::window::{ScreenMaximized, VmuxWindow, window_uses_full_padding};
+use crate::window::{VmuxWindow, window_uses_full_padding};
 use bevy::prelude::*;
 use bevy::window::{Monitor, PrimaryWindow};
 use vmux_command::{AppCommand, LayoutCommand, ReadAppCommands, ToggleLayoutCommand};
@@ -31,16 +31,14 @@ impl Plugin for TogglePlugin {
 fn sync_window_padding_to_layout_hidden(
     hidden: Res<LayoutHidden>,
     settings: Res<LayoutSettings>,
-    screen_maximized: Option<Res<ScreenMaximized>>,
     primary_window: Query<&Window, With<PrimaryWindow>>,
     monitors: Query<&Monitor>,
     mut window_q: Query<&mut Node, With<VmuxWindow>>,
 ) {
-    let fullscreen = screen_maximized.is_some()
-        || primary_window
-            .single()
-            .ok()
-            .is_some_and(|window| window_uses_full_padding(window, &monitors));
+    let fullscreen = primary_window
+        .single()
+        .ok()
+        .is_some_and(|window| window_uses_full_padding(window, &monitors));
     let (top, left) = if hidden.0 || fullscreen {
         (settings.window.pad_top(), settings.window.pad_left())
     } else {
@@ -202,17 +200,5 @@ mod tests {
         let node = app.world().get::<Node>(root).expect("window node");
         assert_eq!(node.padding.top, Val::Px(16.0));
         assert_eq!(node.padding.left, Val::Px(16.0));
-    }
-
-    #[test]
-    fn startup_maximized_window_padding_does_not_depend_on_monitor_query() {
-        let source = include_str!("toggle.rs");
-        let sync_fn = source
-            .split("fn sync_window_padding_to_layout_hidden")
-            .nth(1)
-            .and_then(|tail| tail.split("fn handle_toggle").next())
-            .unwrap_or_default();
-
-        assert!(sync_fn.contains("ScreenMaximized"));
     }
 }

--- a/crates/vmux_layout/src/window.rs
+++ b/crates/vmux_layout/src/window.rs
@@ -23,6 +23,7 @@ use bevy::{
     winit::WINIT_WINDOWS,
 };
 use bevy_cef::prelude::*;
+use moonshine_save::prelude::*;
 use vmux_command::{AppCommand, LayoutCommand, ReadAppCommands, WindowCommand};
 use vmux_core::page::ServerEmbedSet;
 use vmux_core::{PageOpenRequest, PageOpenSet, PageOpenTarget};
@@ -125,6 +126,9 @@ impl Plugin for WindowPlugin {
         load_internal_asset!(app, WINDOW_SHADER_HANDLE, "window.wgsl", Shader::from_wgsl);
 
         app.add_plugins(MaterialPlugin::<WindowMaterial>::default())
+            .register_type::<WindowGeometry>()
+            .register_type::<Option<IVec2>>()
+            .register_type::<Option<Vec2>>()
             .add_systems(
                 Startup,
                 setup
@@ -161,7 +165,6 @@ impl Plugin for WindowPlugin {
             .add_systems(
                 Update,
                 (
-                    maximize_window_to_screen.run_if(not(resource_exists::<ScreenMaximized>)),
                     crate::stack::open_startup_url_if_no_stacks.before(PageOpenSet::ResolveTarget),
                     spawn_requested_tab_layouts
                         .after(ReadAppCommands)
@@ -189,10 +192,6 @@ fn handle_window_commands(
     }
 }
 
-/// One-shot resource: window has been sized to fill the screen.
-#[derive(Resource)]
-pub(crate) struct ScreenMaximized;
-
 pub(crate) fn window_uses_full_padding(window: &Window, monitors: &Query<&Monitor>) -> bool {
     matches!(
         &window.mode,
@@ -206,30 +205,6 @@ fn window_fills_monitor(window: &Window, monitors: &Query<&Monitor>) -> bool {
         let monitor_size = monitor.physical_size();
         size.x >= monitor_size.x.saturating_sub(2) && size.y >= monitor_size.y.saturating_sub(2)
     })
-}
-
-/// Size the window to fill the current monitor (runs once at startup).
-fn maximize_window_to_screen(
-    mut window_q: Query<(Entity, &mut Window), With<PrimaryWindow>>,
-    mut commands: Commands,
-) {
-    let Ok((entity, mut window)) = window_q.single_mut() else {
-        return;
-    };
-    WINIT_WINDOWS.with_borrow(|winit_windows| {
-        let Some(winit_win) = winit_windows.get_window(entity) else {
-            return;
-        };
-        let Some(monitor) = winit_win.current_monitor() else {
-            return;
-        };
-        let size = monitor.size();
-        let scale = monitor.scale_factor() as f32;
-        let logical_w = size.width as f32 / scale;
-        let logical_h = size.height as f32 / scale;
-        window.resolution.set(logical_w, logical_h);
-        commands.insert_resource(ScreenMaximized);
-    });
 }
 
 #[derive(Bundle)]
@@ -260,6 +235,19 @@ pub struct Modal;
 
 #[derive(Component)]
 pub struct WindowSurface;
+
+/// Persisted primary-window geometry, saved as a singleton entity in `store.ron`.
+/// `position`/`size` always describe the windowed frame, even while `fullscreen`,
+/// so exiting fullscreen lands on a sane frame.
+#[derive(Component, Reflect, Clone, Copy, Debug, Default, PartialEq)]
+#[reflect(Component)]
+#[type_path = "vmux_desktop::layout::window"]
+#[require(Save)]
+pub struct WindowGeometry {
+    pub fullscreen: bool,
+    pub position: Option<IVec2>,
+    pub size: Option<Vec2>,
+}
 
 fn setup(
     window: Single<&Window, With<PrimaryWindow>>,
@@ -653,7 +641,6 @@ fn apply_webview_material_defaults(
 fn sync_window_layout_to_settings(
     settings: Res<LayoutSettings>,
     hidden: Option<Res<crate::toggle::LayoutHidden>>,
-    screen_maximized: Option<Res<ScreenMaximized>>,
     primary_window: Query<&Window, With<PrimaryWindow>>,
     monitors: Query<&Monitor>,
     mut window_q: Query<&mut Node, (With<VmuxWindow>, Without<SideSheet>, Without<MainColumn>)>,
@@ -678,7 +665,6 @@ fn sync_window_layout_to_settings(
     let gap = crate::event::PANE_GAP_PX;
     let cfg_width = crate::event::SIDE_SHEET_WIDTH_PX;
     let full_padding = hidden.as_deref().is_some_and(|hidden| hidden.0)
-        || screen_maximized.is_some()
         || primary_window
             .single()
             .ok()
@@ -1177,11 +1163,10 @@ mod tests {
     }
 
     #[test]
-    fn screen_maximized_window_sync_applies_all_window_padding_edges() {
+    fn fills_monitor_window_sync_applies_all_window_padding_edges() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .insert_resource(crate::toggle::LayoutHidden(false))
-            .insert_resource(ScreenMaximized)
             .insert_resource(LayoutSettings {
                 radius: 0.0,
                 window: crate::settings::WindowSettings {
@@ -1204,6 +1189,15 @@ mod tests {
             },
             PrimaryWindow,
         ));
+        app.world_mut().spawn(Monitor {
+            name: None,
+            physical_width: 1200,
+            physical_height: 800,
+            physical_position: IVec2::ZERO,
+            refresh_rate_millihertz: None,
+            scale_factor: 1.0,
+            video_modes: Vec::new(),
+        });
         let root = app.world_mut().spawn((VmuxWindow, Node::default())).id();
 
         app.update();
@@ -1213,5 +1207,26 @@ mod tests {
         assert_eq!(node.padding.left, Val::Px(16.0));
         assert_eq!(node.padding.right, Val::Px(16.0));
         assert_eq!(node.padding.bottom, Val::Px(16.0));
+    }
+
+    #[test]
+    fn window_geometry_round_trips_position_size_fullscreen() {
+        let g = WindowGeometry {
+            fullscreen: true,
+            position: Some(IVec2::new(100, 200)),
+            size: Some(Vec2::new(1280.0, 800.0)),
+        };
+        assert_eq!(g, g);
+        assert_eq!(g.position, Some(IVec2::new(100, 200)));
+        assert_eq!(g.size, Some(Vec2::new(1280.0, 800.0)));
+        assert!(g.fullscreen);
+        assert_eq!(
+            WindowGeometry::default(),
+            WindowGeometry {
+                fullscreen: false,
+                position: None,
+                size: None,
+            }
+        );
     }
 }

--- a/docs/specs/2026-06-19-window-position-size-persistence-design.md
+++ b/docs/specs/2026-06-19-window-position-size-persistence-design.md
@@ -1,0 +1,204 @@
+# Persist Window Position, Size & Fullscreen
+
+## Problem
+
+The OS window does not remember its geometry. Every launch runs
+`maximize_window_to_screen` (window.rs), which sizes the window to fill the current
+monitor once at startup (gated by the one-shot `ScreenMaximized` resource). Position
+is never read or saved; size is always "fill the monitor". Quitting a moved,
+resized, or fullscreen window and relaunching loses that state.
+
+## Goal
+
+Persist and restore the primary window's geometry across launches:
+
+- **Windowed frame**: position + size.
+- **Fullscreen / maximized**: if the window was native-fullscreen (macOS green-button
+  / `toggleFullScreen`) or otherwise screen-filling at quit, restore it.
+- **First launch** (no saved geometry): open a **centered** window at a default size
+  (`1280x800`), not maximized.
+
+Geometry lives in the existing **`store.ron`** moonshine scene
+(`shared_data_dir()/store.ron`) as a saved ECS component — reusing the debounced
+`AutoSave` save pipeline — not a new file and not in hand-edited `settings.ron`.
+
+## Non-goals
+
+- No separate windowed "maximized" (zoom) state distinct from fullscreen. vmux hides
+  the native window buttons; the green button maps to native fullscreen, and a
+  manually screen-filling window is reproduced by its saved size. So "maximized" ==
+  fullscreen for restore purposes.
+- No multi-window / per-space geometry. There is one OS window; geometry is global
+  (one singleton entity in the scene).
+- No migration. Absent/again-stale `store.ron` ⇒ first-launch defaults.
+
+## Storage: a saved component in `store.ron`
+
+`store.ron` is a single moonshine scene saved by `save_space_to_path`
+(persistence.rs) via a component allowlist and debounced `AutoSave`
+(`mark_dirty_on_change` → 0.5s debounce; 60s periodic), loaded on startup via
+`LoadWorld`. Window geometry becomes one more saved component on a **singleton
+entity**.
+
+New component (in `vmux_layout`, next to `Main`/`VmuxWindow`, mirroring `PaneSize`):
+
+```rust
+#[derive(Component, Reflect, Clone, Copy, Debug, Default)]
+#[reflect(Component)]
+#[type_path = "vmux_desktop::layout::window"]
+#[require(Save)]
+pub struct WindowGeometry {
+    pub fullscreen: bool,
+    pub position: Option<IVec2>, // physical, the WINDOWED outer position
+    pub size: Option<Vec2>,      // logical w,h, the WINDOWED size
+}
+```
+
+- Registered with `app.register_type::<WindowGeometry>()` in the layout plugin (so
+  moonshine reflection can (de)serialize it).
+- Stable `#[type_path = "vmux_desktop::layout::window"]` — scene files store
+  fully-qualified type paths; a stable path avoids the stale-load crash class
+  (cf. `stale_space_save_crash`).
+- `position`/`size` **always track the windowed frame**, even while fullscreen, so
+  exiting fullscreen lands on a sane frame.
+- Added to the `save_space_to_path` allowlist: `.allow::<WindowGeometry>()`.
+
+`rebuild_space_views`, stale-detection (`space_is_prompt_only_empty_url`,
+`space_contains_stale_agent_url`), and multi-space scoping ignore this entity (no
+Tab/Pane/Stack/PageMetadata), so it does not interfere.
+
+## Save (capture)
+
+A `WindowFullscreen(bool)` resource carries the live fullscreen signal:
+
+- **macOS**: `glass.rs::sync_window_glass_visibility` already computes
+  `fullscreen = bevy_fullscreen || native_fullscreen` (the latter from NSWindow
+  `styleMask().contains(FullScreen)`). It writes that value into `WindowFullscreen`.
+- **Linux** (`#[cfg(not(macos))]`): a small system sets `WindowFullscreen` from
+  `window.mode` (`BorderlessFullscreen`/`Fullscreen`).
+
+A capture system (poll-and-diff, event-independent) keeps `WindowGeometry` in sync
+with the live window and marks the scene dirty:
+
+- Set `WindowGeometry.fullscreen = WindowFullscreen.0`.
+- If **not** fullscreen: when `window.position == WindowPosition::At(p)` and
+  `window.resolution` differ from the stored values (beyond epsilon), update
+  `position`/`size`. While fullscreen, leave `position`/`size` untouched.
+- Guards: ignore captures with logical width/height `< 100` (transient); only read
+  `At(_)` positions (skip `Centered`/`Automatic` before winit reports a real frame).
+- Mutating `WindowGeometry` triggers `Changed<WindowGeometry>`, which is added to
+  `mark_dirty_on_change` so the existing `AutoSave` writes `store.ron`.
+
+The capture system runs only after restore is complete (see gating) so the startup
+restore can't be clobbered.
+
+## Restore (load)
+
+**1. First-launch default (create time).** `primary_window_config` sets
+`position: WindowPosition::Centered(MonitorSelection::Primary)` and
+`resolution: 1280x800`. With `maximize_window_to_screen` removed, this is the
+first-run window. (Window is hidden until splash reveal on macOS, so no flicker.)
+
+**2. Ensure singleton.** A startup/update system spawns one `WindowGeometry` (default)
+if none exists, so first-run geometry is captured and saved. After a load there is
+exactly one (dedupe if a load + spawn ever race).
+
+**3. Apply windowed frame (post-load).** When a `WindowGeometry` is `Added` (loaded
+from the scene), apply it to the primary window once:
+- `position = Some(p)` ⇒ `window.position = WindowPosition::At(p)`.
+- `size = Some(s)` ⇒ `window.resolution.set(s.x, s.y)`.
+- `None` fields leave the create-time centered default in place (first run).
+- If `fullscreen == true`, insert resource `PendingFullscreenRestore` (consumed in
+  step 4). Window stays hidden until reveal, so this is flicker-free on macOS.
+
+**4. Restore fullscreen (post-reveal, one-shot).**
+- **macOS** (`glass.rs`, owns the NSWindow): after reveal, if `PendingFullscreenRestore`
+  exists and the window is not already native-fullscreen, call
+  `parent_window.toggleFullScreen(None)`; remove the resource; set
+  `WindowRestoreComplete`.
+- **Linux**: a system sets `window.mode = BorderlessFullscreen(Primary)`, removes the
+  resource, sets `WindowRestoreComplete`.
+- If no `PendingFullscreenRestore`, `WindowRestoreComplete` is set immediately after
+  the windowed-frame apply.
+
+**Gating.** The capture system runs only once `WindowRestoreComplete` is set,
+preventing the transient windowed startup state (before native fullscreen engages)
+from overwriting a saved `fullscreen = true`.
+
+The existing `relocate_window_to_live_display` (display.rs) already recenters a
+window stranded off all monitors, so restoring an off-screen position on a changed
+monitor layout is self-healing.
+
+## Remove launch-maximize
+
+Delete `maximize_window_to_screen` and the `ScreenMaximized` resource. The
+"screen-filling ⇒ full padding" decision then relies solely on
+`window_uses_full_padding` (window.rs), which already covers:
+- Bevy fullscreen `WindowMode` (Linux), and
+- native fullscreen + manual maximize via `window_fills_monitor` (the fullscreen/
+  filled window's `resolution.physical_size()` equals the monitor size).
+
+Consumers updated to drop the `ScreenMaximized` param:
+- `sync_window_layout_to_settings` (window.rs:~648,672).
+- `sync_window_padding_to_layout_hidden` (toggle.rs:34,39).
+
+(macOS native fullscreen is also already handled at runtime by `glass.rs`, which sets
+the clear-color backdrop based on the styleMask signal.)
+
+## Platform gating
+
+- NSWindow / `toggleFullScreen` / styleMask paths are `#[cfg(target_os = "macos")]`
+  (in `glass.rs`, which already holds the `_parent_window` handle).
+- Linux uses Bevy `WindowMode` for both the fullscreen signal and restore.
+- On Linux the window is visible from creation (no splash), so apply-on-load may
+  produce a brief centered→restored resize. CI-only; acceptable.
+
+## Module layout
+
+- `WindowGeometry` component + `register_type`: `vmux_layout` (window.rs).
+- `WindowFullscreen`, `PendingFullscreenRestore`, `WindowRestoreComplete`,
+  ensure-singleton / capture / apply-on-load systems, allowlist entry: new module
+  `crates/vmux_desktop/src/window_state.rs` (`WindowStatePlugin`), wired in
+  `vmux_desktop/src/lib.rs`. Filename-based module (no mod.rs).
+- Fullscreen capture/restore hooks: `glass.rs` (macOS) + Linux system in
+  `window_state.rs`.
+
+## Removed / changed
+
+- `maximize_window_to_screen` system + `ScreenMaximized` resource (window.rs).
+- `ScreenMaximized` usage in toggle.rs and window.rs padding systems.
+- `primary_window_config` gains centered + `1280x800` defaults.
+
+## Risks
+
+- **Fullscreen detection on macOS** is via NSWindow styleMask, not Bevy `WindowMode`
+  (verified in glass.rs). Capture/restore must use the same signal; runtime-verify.
+- **Startup ordering**: windowed apply before reveal (flicker-free), fullscreen
+  restore after reveal (brief windowed→fullscreen animation — inherent to macOS).
+- **store.ron staleness**: if the whole file is wiped by stale-detection, geometry
+  resets to first-launch defaults (rare; acceptable).
+- **Padding refactor** removing `ScreenMaximized` touches two crates + three tests;
+  behavior must stay identical for fullscreen/maximized windows.
+
+## Testing
+
+- Unit: `WindowGeometry` reflection round-trips through a moonshine save/load
+  (position/size/fullscreen preserved); capture rules (skip pos/size while
+  fullscreen; min-size guard; ignore non-`At` positions).
+- System (Bevy app): apply-on-load sets `window.position`/`resolution` from a loaded
+  `WindowGeometry`; `fullscreen = true` inserts `PendingFullscreenRestore`; capture
+  gated until `WindowRestoreComplete`.
+- Padding: replace the `ScreenMaximized`-based tests with fullscreen-mode /
+  fills-monitor equivalents in toggle.rs and window.rs.
+- `primary_window_config` default-size/centered test.
+- Runtime (manual, macOS): move+resize+quit+relaunch restores frame; fullscreen+quit
+  +relaunch restores fullscreen; fresh profile opens centered 1280x800.
+
+## Open implementation checks (verify during build, not assumed)
+
+- Bevy reflects `Option<IVec2>` / `Option<Vec2>` through moonshine the same way it
+  reflects `Option<String>` (`PageMetadata.bg_color`); if not, fall back to explicit
+  scalar fields with sentinels.
+- Whether `Added<WindowGeometry>` is the right trigger for apply-on-load given
+  moonshine's spawn timing, vs. a `Loaded`-triggered pass like
+  `mark_space_views_need_rebuild`.


### PR DESCRIPTION
## Context

The OS window never remembered its geometry. Every launch ran `maximize_window_to_screen`, filling the current monitor; position was never saved. Quitting a moved, resized, or fullscreen window and relaunching lost that state. This persists and restores the primary window's position, size, and fullscreen across launches.

## Implementation

- Geometry is a `WindowGeometry` singleton component (`fullscreen`, `position` physical, `size` logical) saved in the existing `store.ron` moonshine scene, reusing the debounced `AutoSave` pipeline (added to the save allowlist + `mark_dirty_on_change`). `position`/`size` always track the *windowed* frame, even while fullscreen, so exiting fullscreen lands on a sane frame.
- Restore: the windowed frame is applied on scene load while the window is still hidden (flicker-free); fullscreen is re-entered post-reveal. macOS fullscreen is native AppKit (`toggleFullScreen` / NSWindow styleMask), so `glass.rs` owns capture + restore; non-macOS uses Bevy `WindowMode`.
- Capture is gated on a restore-complete flag so the transient windowed startup state can't overwrite a saved `fullscreen = true`.
- First launch (no saved geometry) now opens a centered 1280x800 window. `maximize_window_to_screen` and the `ScreenMaximized` resource are removed; full-padding now derives solely from `window_uses_full_padding` (fullscreen mode or fills-monitor).

## Checks / QA

- Fresh profile (no `store.ron`): window opens centered at 1280x800, not maximized.
- Move + resize + quit + relaunch: window restores to the same frame.
- Enter fullscreen (Ctrl+Cmd+F) + quit + relaunch: window restores to fullscreen (note: windowed->fullscreen animates after reveal, inherent to macOS Spaces).
- Existing users with a pre-feature `store.ron`: upgrades gracefully (centered default, then captures going forward).
