### PR TITLE
feat(layout): configurable 8px window padding + config cleanup

### DIFF
--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -1736,10 +1736,6 @@ mod tests {
                 radius: 0.0,
                 window: WindowSettings {
                     padding: 0.0,
-                    padding_top: None,
-                    padding_right: None,
-                    padding_bottom: None,
-                    padding_left: None,
                 },
                 pane: PaneSettings { gap: 0.0 },
                 side_sheet: SideSheetSettings::default(),

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -1734,9 +1734,7 @@ mod tests {
             },
             layout: LayoutSettings {
                 radius: 0.0,
-                window: WindowSettings {
-                    padding: 0.0,
-                },
+                window: WindowSettings { padding: 0.0 },
                 pane: PaneSettings { gap: 0.0 },
                 side_sheet: SideSheetSettings::default(),
                 focus_ring: FocusRingSettings::default(),

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -968,6 +968,7 @@ fn sync_windowed_frames(
     >,
     child_of_q: Query<&ChildOf>,
     pane_rect: Query<(&ComputedNode, &UiGlobalTransform), With<Pane>>,
+    header_rect: Query<(&ComputedNode, &UiGlobalTransform), (With<Header>, With<Open>)>,
     all_children: Query<&Children>,
     leaf_panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
     mut last_raised_frame: Local<std::collections::HashMap<Entity, (i32, i32, i32, i32)>>,
@@ -975,6 +976,9 @@ fn sync_windowed_frames(
 ) {
     let visible_pane_count =
         visible_pane_count_for_windowed_sync(focus.tab, &all_children, &leaf_panes);
+    let header_frame = header_rect
+        .iter()
+        .find_map(|(computed, ui_gt)| windowed_frame_rect_from_computed(computed, ui_gt));
     let force_raise = layout_hidden.is_changed();
     let mut hidden = Vec::new();
     let mut visible = Vec::new();
@@ -989,17 +993,30 @@ fn sync_windowed_frames(
         let (computed, ui_gt) = pane_rect
             .get(pane_entity)
             .unwrap_or((self_computed, self_ui_gt));
-        let size_px = computed.size;
-        let center = ui_gt.transform_point2(Vec2::ZERO);
-        let left = center.x - size_px.x * 0.5;
-        let top = center.y - size_px.y * 0.5;
+        let Some(pane_frame) = windowed_frame_rect_from_computed(computed, ui_gt) else {
+            continue;
+        };
         let scale = 1.0 / computed.inverse_scale_factor.max(1.0e-6);
+        let frame = windowed_page_frame_rect(
+            pane_frame,
+            header_frame,
+            layout_hidden.0,
+            visible_pane_count,
+            settings.layout.radius * scale * 0.25,
+        );
         let became_visible = !last_visible_pages.contains(&entity);
         if became_visible {
             browsers.set_windowed_hidden(&entity, false);
         }
-        browsers.set_windowed_frame(&entity, left, top, size_px.x, size_px.y, scale);
-        let all_corners = layout_hidden.0 || visible_pane_count > 1;
+        browsers.set_windowed_frame(
+            &entity,
+            frame.left,
+            frame.top,
+            frame.width,
+            frame.height,
+            scale,
+        );
+        let all_corners = windowed_page_all_corners(layout_hidden.0, visible_pane_count);
         browsers.set_windowed_corner_radius(
             &entity,
             settings.layout.radius * scale,
@@ -1028,10 +1045,10 @@ fn sync_windowed_frames(
         );
         if browsers.has_browser(entity) {
             let key = (
-                left.round() as i32,
-                top.round() as i32,
-                size_px.x.round() as i32,
-                size_px.y.round() as i32,
+                frame.left.round() as i32,
+                frame.top.round() as i32,
+                frame.width.round() as i32,
+                frame.height.round() as i32,
             );
             let changed = last_raised_frame.insert(entity, key) != Some(key);
             if force_raise || changed || became_visible {
@@ -1044,6 +1061,74 @@ fn sync_windowed_frames(
         browsers.set_windowed_hidden(&entity, true);
     }
     *last_visible_pages = visible;
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct WindowedFrameRect {
+    left: f32,
+    top: f32,
+    width: f32,
+    height: f32,
+}
+
+impl WindowedFrameRect {
+    fn right(self) -> f32 {
+        self.left + self.width
+    }
+
+    fn bottom(self) -> f32 {
+        self.top + self.height
+    }
+}
+
+fn windowed_frame_rect_from_computed(
+    computed: &ComputedNode,
+    ui_gt: &UiGlobalTransform,
+) -> Option<WindowedFrameRect> {
+    let size = computed.size;
+    if size.x <= 0.0 || size.y <= 0.0 || !size.x.is_finite() || !size.y.is_finite() {
+        return None;
+    }
+    let center = ui_gt.transform_point2(Vec2::ZERO);
+    Some(WindowedFrameRect {
+        left: center.x - size.x * 0.5,
+        top: center.y - size.y * 0.5,
+        width: size.x,
+        height: size.y,
+    })
+}
+
+fn windowed_page_frame_rect(
+    pane: WindowedFrameRect,
+    header: Option<WindowedFrameRect>,
+    layout_hidden: bool,
+    visible_pane_count: usize,
+    straight_edge_inset: f32,
+) -> WindowedFrameRect {
+    let Some(header) = header else {
+        return pane;
+    };
+    if layout_hidden || visible_pane_count != 1 {
+        return pane;
+    }
+    let inset = if straight_edge_inset.is_finite() {
+        straight_edge_inset.max(0.0).ceil()
+    } else {
+        0.0
+    };
+    let left = header.left.ceil() + inset;
+    let right = header.right().floor() - inset;
+    let top = header.bottom().ceil().max(pane.top.ceil());
+    let bottom = pane.bottom().floor();
+    if right <= left || bottom <= top {
+        return pane;
+    }
+    WindowedFrameRect {
+        left,
+        top,
+        width: right - left,
+        height: bottom - top,
+    }
 }
 
 fn visible_pane_count_for_windowed_sync(
@@ -1071,6 +1156,10 @@ fn windowed_pages_to_hide(
         .copied()
         .filter(|entity| prev_visible.contains(entity) || !ever_shown.contains(entity))
         .collect()
+}
+
+fn windowed_page_all_corners(layout_hidden: bool, visible_pane_count: usize) -> bool {
+    layout_hidden || visible_pane_count > 1
 }
 
 fn sync_windowed_layout(
@@ -1957,13 +2046,47 @@ fn layout_window_padding_from_settings(settings: &AppSettings) -> LayoutWindowPa
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct LayoutFixedOffsets {
+    left: f32,
+    top: f32,
+    right: f32,
+    height: f32,
+}
+
+fn layout_fixed_offsets_from_computed(
+    computed: &ComputedNode,
+    transform: &UiGlobalTransform,
+    window_width_px: f32,
+) -> Option<LayoutFixedOffsets> {
+    if computed.size.x <= 0.0 || computed.size.y <= 0.0 || window_width_px <= 0.0 {
+        return None;
+    }
+
+    let inverse_scale = computed.inverse_scale_factor.max(1.0e-6);
+    let size = computed.size * inverse_scale;
+    let center = transform.transform_point2(Vec2::ZERO) * inverse_scale;
+    let window_width = window_width_px * inverse_scale;
+    let left = center.x - size.x * 0.5;
+    let top = center.y - size.y * 0.5;
+    let right = window_width - (center.x + size.x * 0.5);
+
+    Some(LayoutFixedOffsets {
+        left,
+        top,
+        right,
+        height: size.y,
+    })
+}
+
 fn push_layout_state_emit(
     mut commands: Commands,
     browsers: NonSend<Browsers>,
     cef_q: Query<(Entity, Ref<PageReady>), With<LayoutCef>>,
-    header_q: Query<Has<Open>, With<Header>>,
+    header_q: Query<(Has<Open>, Option<&ComputedNode>, Option<&UiGlobalTransform>), With<Header>>,
     side_sheet_q: Query<(&SideSheetPosition, Has<Open>), With<SideSheet>>,
     window_q: Query<&Node, With<VmuxWindow>>,
+    windows: Query<&Window, With<PrimaryWindow>>,
     side_sheet_width: Res<SideSheetWidth>,
     settings: Res<AppSettings>,
     mut last: Local<String>,
@@ -1979,16 +2102,32 @@ fn push_layout_state_emit(
         .ok()
         .map(layout_window_padding_from_node)
         .unwrap_or_else(|| layout_window_padding_from_settings(&settings));
+    let header_open = header_q.iter().any(|(is_open, _, _)| is_open);
+    let window_width_px = windows
+        .single()
+        .ok()
+        .map(|window| window.resolution.physical_width() as f32)
+        .unwrap_or(0.0);
+    let header_offsets = header_q.iter().find_map(|(_, computed, transform)| {
+        let computed = computed?;
+        let transform = transform?;
+        layout_fixed_offsets_from_computed(computed, transform, window_width_px)
+    });
 
     let payload = LayoutStateEvent {
-        header_open: header_q.iter().any(|is_open| is_open),
+        header_open,
         side_sheet_open: side_sheet_q
             .iter()
             .any(|(pos, is_open)| *pos == SideSheetPosition::Left && is_open),
-        header_height: HEADER_HEIGHT_PX,
+        header_height: header_offsets
+            .map(|offsets| offsets.height)
+            .unwrap_or(HEADER_HEIGHT_PX),
         side_sheet_width: side_sheet_width.0,
         pane_gap: vmux_layout::event::PANE_GAP_PX,
         radius: settings.layout.radius,
+        header_left: header_offsets.map(|offsets| offsets.left),
+        header_top: header_offsets.map(|offsets| offsets.top),
+        header_right: header_offsets.map(|offsets| offsets.right),
         window_pad_top: window_padding.top,
         window_pad_right: window_padding.right,
         window_pad_bottom: window_padding.bottom,
@@ -3631,6 +3770,26 @@ mod tests {
     }
 
     #[test]
+    fn layout_fixed_offsets_use_computed_header_rect() {
+        let computed = ComputedNode {
+            size: Vec2::new(1_544.0, 168.0),
+            inverse_scale_factor: 0.5,
+            ..default()
+        };
+        let transform = UiGlobalTransform::from(bevy::math::Affine2::from_translation(Vec2::new(
+            788.0, 84.0,
+        )));
+
+        let offsets =
+            layout_fixed_offsets_from_computed(&computed, &transform, 1_600.0).expect("offsets");
+
+        assert_eq!(offsets.left, 8.0);
+        assert_eq!(offsets.top, 0.0);
+        assert_eq!(offsets.right, 20.0);
+        assert_eq!(offsets.height, 84.0);
+    }
+
+    #[test]
     fn windowed_content_mesh_material_is_hidden() {
         let mut material = WebviewExtendStandardMaterial::default();
 
@@ -3652,9 +3811,7 @@ mod tests {
             },
             layout: vmux_layout::settings::LayoutSettings {
                 radius,
-                window: vmux_layout::settings::WindowSettings {
-                    padding: 0.0,
-                },
+                window: vmux_layout::settings::WindowSettings { padding: 0.0 },
                 pane: vmux_layout::settings::PaneSettings { gap: 0.0 },
                 side_sheet: vmux_layout::settings::SideSheetSettings::default(),
                 focus_ring: vmux_layout::settings::FocusRingSettings::default(),
@@ -3804,7 +3961,7 @@ mod tests {
     }
 
     #[test]
-    fn windowed_page_sync_rounds_all_corners_from_visible_tab_leaf_count() {
+    fn windowed_page_sync_uses_native_corner_policy() {
         let source = include_str!("lib.rs");
         let sync_fn = source
             .split("fn sync_windowed_frames")
@@ -3813,7 +3970,88 @@ mod tests {
             .unwrap_or_default();
 
         assert!(sync_fn.contains("visible_pane_count_for_windowed_sync"));
-        assert!(sync_fn.contains("let all_corners = layout_hidden.0 || visible_pane_count > 1"));
+        assert!(sync_fn.contains("windowed_page_all_corners(layout_hidden.0, visible_pane_count)"));
+    }
+
+    #[test]
+    fn windowed_page_keeps_single_pane_top_edge_flat_under_header() {
+        assert!(!windowed_page_all_corners(false, 1));
+    }
+
+    #[test]
+    fn windowed_page_rounds_when_layout_hidden_or_split() {
+        assert!(windowed_page_all_corners(true, 1));
+        assert!(windowed_page_all_corners(false, 2));
+    }
+
+    #[test]
+    fn windowed_page_sync_aligns_single_pane_frame_to_header() {
+        let source = include_str!("lib.rs");
+        let sync_fn = source
+            .split("fn sync_windowed_frames")
+            .nth(1)
+            .and_then(|tail| tail.split("fn visible_pane_count_for_windowed_sync").next())
+            .unwrap_or_default();
+
+        assert!(sync_fn.contains("header_rect"));
+        assert!(sync_fn.contains("windowed_page_frame_rect("));
+        assert!(sync_fn.contains("settings.layout.radius * scale * 0.25"));
+    }
+
+    #[test]
+    fn single_pane_windowed_frame_uses_header_width_and_bottom_edge() {
+        let pane = WindowedFrameRect {
+            left: 60.2,
+            top: 84.0,
+            width: 150.6,
+            height: 300.0,
+        };
+        let header = WindowedFrameRect {
+            left: 72.1,
+            top: 0.0,
+            width: 130.8,
+            height: 84.2,
+        };
+
+        let frame = windowed_page_frame_rect(pane, Some(header), false, 1, 0.0);
+
+        assert_eq!(
+            frame,
+            WindowedFrameRect {
+                left: 73.0,
+                top: 85.0,
+                width: 129.0,
+                height: 299.0,
+            }
+        );
+    }
+
+    #[test]
+    fn single_pane_windowed_frame_insets_quarter_radius_to_header_visible_edge() {
+        let pane = WindowedFrameRect {
+            left: 60.2,
+            top: 84.0,
+            width: 150.6,
+            height: 300.0,
+        };
+        let header = WindowedFrameRect {
+            left: 72.1,
+            top: 0.0,
+            width: 130.8,
+            height: 84.2,
+        };
+
+        let frame = windowed_page_frame_rect(pane, Some(header), false, 1, 4.0);
+
+        assert_eq!(
+            frame,
+            WindowedFrameRect {
+                left: 77.0,
+                top: 85.0,
+                width: 121.0,
+                height: 299.0,
+            }
+        );
     }
 
     #[test]
@@ -4425,9 +4663,7 @@ mod tests {
                 },
                 layout: LayoutSettings {
                     radius: 0.0,
-                    window: WindowSettings {
-                        padding: 0.0,
-                    },
+                    window: WindowSettings { padding: 0.0 },
                     pane: PaneSettings { gap: 0.0 },
                     side_sheet: SideSheetSettings::default(),
                     focus_ring: FocusRingSettings::default(),

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -3654,10 +3654,6 @@ mod tests {
                 radius,
                 window: vmux_layout::settings::WindowSettings {
                     padding: 0.0,
-                    padding_top: None,
-                    padding_right: None,
-                    padding_bottom: None,
-                    padding_left: None,
                 },
                 pane: vmux_layout::settings::PaneSettings { gap: 0.0 },
                 side_sheet: vmux_layout::settings::SideSheetSettings::default(),
@@ -4431,10 +4427,6 @@ mod tests {
                     radius: 0.0,
                     window: WindowSettings {
                         padding: 0.0,
-                        padding_top: None,
-                        padding_right: None,
-                        padding_bottom: None,
-                        padding_left: None,
                     },
                     pane: PaneSettings { gap: 0.0 },
                     side_sheet: SideSheetSettings::default(),

--- a/crates/vmux_desktop/src/os_menu.rs
+++ b/crates/vmux_desktop/src/os_menu.rs
@@ -327,10 +327,6 @@ mod tests {
                 radius: 0.0,
                 window: WindowSettings {
                     padding: 0.0,
-                    padding_top: None,
-                    padding_right: None,
-                    padding_bottom: None,
-                    padding_left: None,
                 },
                 pane: PaneSettings { gap: 0.0 },
                 side_sheet: SideSheetSettings::default(),

--- a/crates/vmux_desktop/src/os_menu.rs
+++ b/crates/vmux_desktop/src/os_menu.rs
@@ -325,9 +325,7 @@ mod tests {
             },
             layout: LayoutSettings {
                 radius: 0.0,
-                window: WindowSettings {
-                    padding: 0.0,
-                },
+                window: WindowSettings { padding: 0.0 },
                 pane: PaneSettings { gap: 0.0 },
                 side_sheet: SideSheetSettings::default(),
                 focus_ring: FocusRingSettings::default(),

--- a/crates/vmux_desktop/src/persistence.rs
+++ b/crates/vmux_desktop/src/persistence.rs
@@ -661,9 +661,7 @@ mod tests {
             },
             layout: LayoutSettings {
                 radius: 0.0,
-                window: WindowSettings {
-                    padding: 0.0,
-                },
+                window: WindowSettings { padding: 0.0 },
                 pane: PaneSettings { gap: 0.0 },
                 side_sheet: SideSheetSettings::default(),
                 focus_ring: FocusRingSettings::default(),

--- a/crates/vmux_desktop/src/persistence.rs
+++ b/crates/vmux_desktop/src/persistence.rs
@@ -663,10 +663,6 @@ mod tests {
                 radius: 0.0,
                 window: WindowSettings {
                     padding: 0.0,
-                    padding_top: None,
-                    padding_right: None,
-                    padding_bottom: None,
-                    padding_left: None,
                 },
                 pane: PaneSettings { gap: 0.0 },
                 side_sheet: SideSheetSettings::default(),

--- a/crates/vmux_desktop/src/shortcut.rs
+++ b/crates/vmux_desktop/src/shortcut.rs
@@ -296,9 +296,7 @@ mod tests {
             },
             layout: LayoutSettings {
                 radius: 0.0,
-                window: WindowSettings {
-                    padding: 0.0,
-                },
+                window: WindowSettings { padding: 0.0 },
                 pane: PaneSettings { gap: 0.0 },
                 side_sheet: SideSheetSettings::default(),
                 focus_ring: FocusRingSettings::default(),

--- a/crates/vmux_desktop/src/shortcut.rs
+++ b/crates/vmux_desktop/src/shortcut.rs
@@ -298,10 +298,6 @@ mod tests {
                 radius: 0.0,
                 window: WindowSettings {
                     padding: 0.0,
-                    padding_top: None,
-                    padding_right: None,
-                    padding_bottom: None,
-                    padding_left: None,
                 },
                 pane: PaneSettings { gap: 0.0 },
                 side_sheet: SideSheetSettings::default(),

--- a/crates/vmux_layout/assets/index.css
+++ b/crates/vmux_layout/assets/index.css
@@ -10,7 +10,7 @@
 
   html,
   body {
-    @apply m-0 p-0 h-full w-full overflow-x-hidden;
+    @apply m-0 p-0 h-full w-full overflow-hidden;
     max-width: 100%;
   }
 

--- a/crates/vmux_layout/src/command_bar/style.rs
+++ b/crates/vmux_layout/src/command_bar/style.rs
@@ -323,10 +323,10 @@ mod tests {
     }
 
     #[test]
-    fn command_bar_document_disables_horizontal_overflow() {
+    fn command_bar_document_disables_document_overflow() {
         let css = include_str!("../../assets/index.css");
 
-        assert!(css.contains("overflow-x-hidden"));
+        assert!(css.contains("overflow-hidden"));
     }
 
     #[test]

--- a/crates/vmux_layout/src/event.rs
+++ b/crates/vmux_layout/src/event.rs
@@ -49,6 +49,12 @@ pub struct LayoutStateEvent {
     #[serde(default)]
     pub radius: f32,
     #[serde(default)]
+    pub header_left: Option<f32>,
+    #[serde(default)]
+    pub header_top: Option<f32>,
+    #[serde(default)]
+    pub header_right: Option<f32>,
+    #[serde(default)]
     pub window_pad_top: f32,
     #[serde(default = "default_window_pad")]
     pub window_pad_right: f32,
@@ -65,6 +71,18 @@ impl LayoutStateEvent {
         } else {
             self.window_pad_left
         }
+    }
+
+    pub fn header_left(&self) -> f32 {
+        self.header_left.unwrap_or_else(|| self.main_cef_left())
+    }
+
+    pub fn header_top(&self) -> f32 {
+        self.header_top.unwrap_or(self.window_pad_top)
+    }
+
+    pub fn header_right(&self) -> f32 {
+        self.header_right.unwrap_or(self.window_pad_right)
     }
 
     pub fn header_visible(&self) -> bool {
@@ -170,6 +188,27 @@ mod tests {
 
         assert_eq!(closed.main_cef_left(), 16.0);
         assert_eq!(open.main_cef_left(), 304.0);
+    }
+
+    #[test]
+    fn header_offsets_can_override_derived_window_padding() {
+        let state = LayoutStateEvent {
+            side_sheet_open: true,
+            side_sheet_width: 220.0,
+            pane_gap: 4.0,
+            window_pad_left: 8.0,
+            window_pad_top: 2.0,
+            window_pad_right: 8.0,
+            header_left: Some(230.0),
+            header_top: Some(1.0),
+            header_right: Some(9.0),
+            ..Default::default()
+        };
+
+        assert_eq!(state.main_cef_left(), 232.0);
+        assert_eq!(state.header_left(), 230.0);
+        assert_eq!(state.header_top(), 1.0);
+        assert_eq!(state.header_right(), 9.0);
     }
 
     #[test]

--- a/crates/vmux_layout/src/event.rs
+++ b/crates/vmux_layout/src/event.rs
@@ -116,8 +116,8 @@ pub const TRAFFIC_LIGHTS_PAD_PX: f32 = 80.0;
 /// strip is needed.
 pub const CEF_RESERVED_HEIGHT_PX: f32 = HEADER_HEIGHT_PX;
 
-/// Hardcoded window edge padding (px). Not user-configurable.
-pub const WINDOW_PAD_PX: f32 = 4.0;
+/// Default window edge padding (px). Overridable via `settings.layout.window.padding`.
+pub const WINDOW_PAD_PX: f32 = 8.0;
 
 /// Default page bg color for terminal-like stacks (terminals, processes,
 /// agent CLIs). Matches catppuccin-mocha `base` so the CEF URL row

--- a/crates/vmux_layout/src/focus_ring.rs
+++ b/crates/vmux_layout/src/focus_ring.rs
@@ -258,9 +258,7 @@ mod tests {
     fn test_layout_settings() -> LayoutSettings {
         LayoutSettings {
             radius: 0.0,
-            window: crate::settings::WindowSettings {
-                padding: 0.0,
-            },
+            window: crate::settings::WindowSettings { padding: 0.0 },
             pane: crate::settings::PaneSettings { gap: 0.0 },
             side_sheet: crate::settings::SideSheetSettings::default(),
             focus_ring: crate::settings::FocusRingSettings::default(),

--- a/crates/vmux_layout/src/focus_ring.rs
+++ b/crates/vmux_layout/src/focus_ring.rs
@@ -228,16 +228,12 @@ fn build_focus_ring_material(
     let r_o = (r_i + b).min(m_o * 0.5);
     let c = &settings.focus_ring.color;
     let border_color = Color::srgb(c.r, c.g, c.b).to_linear().to_vec4();
-    let g = &settings.focus_ring.gradient;
-    let accent = &g.accent;
-    let border_accent = Color::srgb(accent.r, accent.g, accent.b)
-        .to_linear()
-        .to_vec4();
-    let grad_on = if g.enabled { 1.0 } else { 0.0 };
-    let speed = if is_loading { g.speed * 3.0 } else { g.speed };
-    let gradient_params = Vec4::new(grad_on, speed, g.cycles.max(0.01), time_secs);
-    let spread = settings.focus_ring.glow.spread.max(0.5);
-    let intensity = settings.focus_ring.glow.intensity.max(0.0);
+    // Glow + gradient are no longer user-configurable; keep the tuned defaults.
+    let border_accent = Color::srgb(0.7, 0.7, 0.78).to_linear().to_vec4();
+    let speed = if is_loading { 1.8 } else { 0.6 };
+    let gradient_params = Vec4::new(1.0, speed, 1.0, time_secs);
+    let spread = 8.0;
+    let intensity = 0.45;
     let glow_on = if intensity > 1.0e-4 { 1.0 } else { 0.0 };
     FocusRingMaterial {
         pane_inner: Vec4::new(r_i, w_i, h_i, 0.0),
@@ -264,10 +260,6 @@ mod tests {
             radius: 0.0,
             window: crate::settings::WindowSettings {
                 padding: 0.0,
-                padding_top: None,
-                padding_right: None,
-                padding_bottom: None,
-                padding_left: None,
             },
             pane: crate::settings::PaneSettings { gap: 0.0 },
             side_sheet: crate::settings::SideSheetSettings::default(),

--- a/crates/vmux_layout/src/page.rs
+++ b/crates/vmux_layout/src/page.rs
@@ -115,9 +115,9 @@ pub fn Page() -> Element {
     );
     let header_vars = format!(
         "--vmux-header-top:{}px;--vmux-header-left:{}px;--vmux-header-right:{}px;--vmux-header-height:{}px;--vmux-tab-row-pad-left:{}px;",
-        state.window_pad_top,
-        state.main_cef_left(),
-        state.window_pad_right,
+        state.header_top(),
+        state.header_left(),
+        state.header_right(),
         state.header_height,
         state.tab_row_pad_left(),
     );

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -2161,9 +2161,7 @@ mod tests {
     fn test_settings() -> LayoutSettings {
         LayoutSettings {
             radius: 0.0,
-            window: WindowSettings {
-                padding: 0.0,
-            },
+            window: WindowSettings { padding: 0.0 },
             pane: PaneSettings { gap: 0.0 },
             side_sheet: SideSheetSettings::default(),
             focus_ring: FocusRingSettings::default(),

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -2163,10 +2163,6 @@ mod tests {
             radius: 0.0,
             window: WindowSettings {
                 padding: 0.0,
-                padding_top: None,
-                padding_right: None,
-                padding_bottom: None,
-                padding_left: None,
             },
             pane: PaneSettings { gap: 0.0 },
             side_sheet: SideSheetSettings::default(),

--- a/crates/vmux_layout/src/settings.rs
+++ b/crates/vmux_layout/src/settings.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 pub struct LayoutSettings {
     /// Corner radius (px) applied across the design system: pane corner clip,
     /// focus ring, and the CEF CSS `--radius` variable.
-    #[serde(default)]
+    #[serde(default = "default_radius")]
     pub radius: f32,
     #[serde(default)]
     pub window: WindowSettings,
@@ -53,31 +53,23 @@ fn default_side_sheet_width() -> f32 {
 pub struct WindowSettings {
     #[serde(default = "default_window_padding")]
     pub padding: f32,
-    #[serde(default)]
-    pub padding_top: Option<f32>,
-    #[serde(default)]
-    pub padding_right: Option<f32>,
-    #[serde(default)]
-    pub padding_bottom: Option<f32>,
-    #[serde(default)]
-    pub padding_left: Option<f32>,
 }
 
 impl WindowSettings {
     pub fn pad_top(&self) -> f32 {
-        self.padding_top.unwrap_or(self.padding)
+        self.padding
     }
 
     pub fn pad_right(&self) -> f32 {
-        self.padding_right.unwrap_or(self.padding)
+        self.padding
     }
 
     pub fn pad_bottom(&self) -> f32 {
-        self.padding_bottom.unwrap_or(self.padding)
+        self.padding
     }
 
     pub fn pad_left(&self) -> f32 {
-        self.padding_left.unwrap_or(self.padding)
+        self.padding
     }
 }
 
@@ -85,16 +77,16 @@ impl Default for WindowSettings {
     fn default() -> Self {
         Self {
             padding: default_window_padding(),
-            padding_top: None,
-            padding_right: None,
-            padding_bottom: None,
-            padding_left: None,
         }
     }
 }
 
 fn default_window_padding() -> f32 {
     crate::event::WINDOW_PAD_PX
+}
+
+fn default_radius() -> f32 {
+    8.0
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -115,55 +107,11 @@ impl Default for FocusRingColor {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct FocusRingGlow {
-    #[serde(default = "default_outline_glow_spread")]
-    pub spread: f32,
-    #[serde(default = "default_outline_glow_intensity")]
-    pub intensity: f32,
-}
-
-impl Default for FocusRingGlow {
-    fn default() -> Self {
-        Self {
-            spread: default_outline_glow_spread(),
-            intensity: default_outline_glow_intensity(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct FocusRingGradient {
-    #[serde(default = "default_outline_gradient_enabled")]
-    pub enabled: bool,
-    #[serde(default = "default_outline_gradient_speed")]
-    pub speed: f32,
-    #[serde(default = "default_outline_gradient_cycles")]
-    pub cycles: f32,
-    #[serde(default = "default_outline_gradient_accent")]
-    pub accent: FocusRingColor,
-}
-
-impl Default for FocusRingGradient {
-    fn default() -> Self {
-        Self {
-            enabled: default_outline_gradient_enabled(),
-            speed: default_outline_gradient_speed(),
-            cycles: default_outline_gradient_cycles(),
-            accent: default_outline_gradient_accent(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FocusRingSettings {
     #[serde(default = "default_focus_ring_width")]
     pub width: f32,
     #[serde(default = "default_focus_ring_color")]
     pub color: FocusRingColor,
-    #[serde(default)]
-    pub glow: FocusRingGlow,
-    #[serde(default)]
-    pub gradient: FocusRingGradient,
 }
 
 impl Default for FocusRingSettings {
@@ -171,8 +119,6 @@ impl Default for FocusRingSettings {
         Self {
             width: default_focus_ring_width(),
             color: default_focus_ring_color(),
-            glow: FocusRingGlow::default(),
-            gradient: FocusRingGradient::default(),
         }
     }
 }
@@ -183,34 +129,6 @@ fn default_focus_ring_width() -> f32 {
 
 fn default_focus_ring_color() -> FocusRingColor {
     FocusRingColor::default()
-}
-
-fn default_outline_glow_spread() -> f32 {
-    8.0
-}
-
-fn default_outline_glow_intensity() -> f32 {
-    0.45
-}
-
-fn default_outline_gradient_enabled() -> bool {
-    true
-}
-
-fn default_outline_gradient_speed() -> f32 {
-    0.6
-}
-
-fn default_outline_gradient_cycles() -> f32 {
-    1.0
-}
-
-fn default_outline_gradient_accent() -> FocusRingColor {
-    FocusRingColor {
-        r: 0.7,
-        g: 0.7,
-        b: 0.78,
-    }
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/crates/vmux_layout/src/stack.rs
+++ b/crates/vmux_layout/src/stack.rs
@@ -707,9 +707,7 @@ mod tests {
     fn test_settings() -> LayoutSettings {
         LayoutSettings {
             radius: 0.0,
-            window: WindowSettings {
-                padding: 0.0,
-            },
+            window: WindowSettings { padding: 0.0 },
             pane: PaneSettings { gap: 0.0 },
             side_sheet: SideSheetSettings::default(),
             focus_ring: FocusRingSettings::default(),

--- a/crates/vmux_layout/src/stack.rs
+++ b/crates/vmux_layout/src/stack.rs
@@ -709,10 +709,6 @@ mod tests {
             radius: 0.0,
             window: WindowSettings {
                 padding: 0.0,
-                padding_top: None,
-                padding_right: None,
-                padding_bottom: None,
-                padding_left: None,
             },
             pane: PaneSettings { gap: 0.0 },
             side_sheet: SideSheetSettings::default(),

--- a/crates/vmux_layout/src/tab.rs
+++ b/crates/vmux_layout/src/tab.rs
@@ -505,10 +505,6 @@ mod tests {
             radius: 0.0,
             window: WindowSettings {
                 padding: 0.0,
-                padding_top: None,
-                padding_right: None,
-                padding_bottom: None,
-                padding_left: None,
             },
             pane: PaneSettings { gap: 0.0 },
             side_sheet: SideSheetSettings::default(),

--- a/crates/vmux_layout/src/tab.rs
+++ b/crates/vmux_layout/src/tab.rs
@@ -503,9 +503,7 @@ mod tests {
     fn test_settings() -> LayoutSettings {
         LayoutSettings {
             radius: 0.0,
-            window: WindowSettings {
-                padding: 0.0,
-            },
+            window: WindowSettings { padding: 0.0 },
             pane: PaneSettings { gap: 0.0 },
             side_sheet: SideSheetSettings::default(),
             focus_ring: FocusRingSettings::default(),

--- a/crates/vmux_layout/src/toggle.rs
+++ b/crates/vmux_layout/src/toggle.rs
@@ -132,10 +132,6 @@ mod tests {
                 radius: 0.0,
                 window: WindowSettings {
                     padding: 16.0,
-                    padding_top: None,
-                    padding_right: None,
-                    padding_bottom: None,
-                    padding_left: None,
                 },
                 pane: PaneSettings { gap: 0.0 },
                 side_sheet: SideSheetSettings::default(),
@@ -167,10 +163,6 @@ mod tests {
                 radius: 0.0,
                 window: WindowSettings {
                     padding: 16.0,
-                    padding_top: None,
-                    padding_right: None,
-                    padding_bottom: None,
-                    padding_left: None,
                 },
                 pane: PaneSettings { gap: 0.0 },
                 side_sheet: SideSheetSettings::default(),

--- a/crates/vmux_layout/src/toggle.rs
+++ b/crates/vmux_layout/src/toggle.rs
@@ -2,9 +2,8 @@ use crate::Open;
 use crate::header::Header;
 use crate::settings::LayoutSettings;
 use crate::side_sheet::SideSheet;
-use crate::window::{VmuxWindow, window_uses_full_padding};
+use crate::window::VmuxWindow;
 use bevy::prelude::*;
-use bevy::window::{Monitor, PrimaryWindow};
 use vmux_command::{AppCommand, LayoutCommand, ReadAppCommands, ToggleLayoutCommand};
 
 /// Tracks whether the layout CEF shell (header + side sheet) is currently hidden.
@@ -31,15 +30,9 @@ impl Plugin for TogglePlugin {
 fn sync_window_padding_to_layout_hidden(
     hidden: Res<LayoutHidden>,
     settings: Res<LayoutSettings>,
-    primary_window: Query<&Window, With<PrimaryWindow>>,
-    monitors: Query<&Monitor>,
     mut window_q: Query<&mut Node, With<VmuxWindow>>,
 ) {
-    let fullscreen = primary_window
-        .single()
-        .ok()
-        .is_some_and(|window| window_uses_full_padding(window, &monitors));
-    let (top, left) = if hidden.0 || fullscreen {
+    let (top, left) = if hidden.0 {
         (settings.window.pad_top(), settings.window.pad_left())
     } else {
         (0.0, 0.0)
@@ -91,7 +84,7 @@ mod tests {
         },
         window::VmuxWindow,
     };
-    use bevy::window::{Monitor, MonitorSelection, WindowMode};
+    use bevy::window::{Monitor, MonitorSelection, PrimaryWindow, WindowMode};
 
     #[test]
     fn window_padding_sync_runs_before_ui_layout() {
@@ -124,15 +117,13 @@ mod tests {
     }
 
     #[test]
-    fn fullscreen_window_padding_uses_layout_window_settings() {
+    fn visible_fullscreen_layout_clears_top_left_padding() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .insert_resource(LayoutHidden(false))
             .insert_resource(LayoutSettings {
                 radius: 0.0,
-                window: WindowSettings {
-                    padding: 16.0,
-                },
+                window: WindowSettings { padding: 16.0 },
                 pane: PaneSettings { gap: 0.0 },
                 side_sheet: SideSheetSettings::default(),
                 focus_ring: FocusRingSettings::default(),
@@ -150,20 +141,18 @@ mod tests {
         app.update();
 
         let node = app.world().get::<Node>(root).expect("window node");
-        assert_eq!(node.padding.top, Val::Px(16.0));
-        assert_eq!(node.padding.left, Val::Px(16.0));
+        assert_eq!(node.padding.top, Val::Px(0.0));
+        assert_eq!(node.padding.left, Val::Px(0.0));
     }
 
     #[test]
-    fn maximized_window_padding_uses_layout_window_settings() {
+    fn visible_maximized_layout_clears_top_left_padding() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .insert_resource(LayoutHidden(false))
             .insert_resource(LayoutSettings {
                 radius: 0.0,
-                window: WindowSettings {
-                    padding: 16.0,
-                },
+                window: WindowSettings { padding: 16.0 },
                 pane: PaneSettings { gap: 0.0 },
                 side_sheet: SideSheetSettings::default(),
                 focus_ring: FocusRingSettings::default(),
@@ -185,6 +174,35 @@ mod tests {
             scale_factor: 1.0,
             video_modes: Vec::new(),
         });
+        let root = app.world_mut().spawn((VmuxWindow, Node::default())).id();
+
+        app.update();
+
+        let node = app.world().get::<Node>(root).expect("window node");
+        assert_eq!(node.padding.top, Val::Px(0.0));
+        assert_eq!(node.padding.left, Val::Px(0.0));
+    }
+
+    #[test]
+    fn hidden_layout_uses_top_left_padding() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .insert_resource(LayoutHidden(true))
+            .insert_resource(LayoutSettings {
+                radius: 0.0,
+                window: WindowSettings { padding: 16.0 },
+                pane: PaneSettings { gap: 0.0 },
+                side_sheet: SideSheetSettings::default(),
+                focus_ring: FocusRingSettings::default(),
+            })
+            .add_systems(Update, sync_window_padding_to_layout_hidden);
+        app.world_mut().spawn((
+            Window {
+                resolution: (1200, 800).into(),
+                ..default()
+            },
+            PrimaryWindow,
+        ));
         let root = app.world_mut().spawn((VmuxWindow, Node::default())).id();
 
         app.update();

--- a/crates/vmux_layout/src/window.rs
+++ b/crates/vmux_layout/src/window.rs
@@ -695,8 +695,8 @@ fn sync_window_layout_to_settings(
 
     // MainColumn row_gap (between Header and Main pane container) is
     // managed by sync_main_column_gap_to_pane_count, which keeps it 0
-    // when the active tab has a single pane and switches to PANE_GAP_PX
-    // when split. Don't override here.
+    // when the active tab has a single pane and switches to the window
+    // padding when split. Don't override here.
     let _ = main_column_q.single_mut();
 
     // Side sheet width resource: initialise from settings on first run.
@@ -728,10 +728,12 @@ fn sync_window_layout_to_settings(
 }
 
 /// Keep MainColumn's row_gap at 0 when the active tab has a single pane
-/// (so the url row sits flush against the pane content) and switch to
-/// PANE_GAP_PX when it's split (so panes visually separate from CEF shell).
+/// (so the url row sits flush against the pane content) and switch to the
+/// window's top padding when it's split (so the panes get a visible gap
+/// below the url bar, matching their outer padding).
 fn sync_main_column_gap_to_pane_count(
     focus: Res<crate::stack::FocusedStack>,
+    settings: Res<LayoutSettings>,
     all_children: Query<&Children>,
     leaf_panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
     mut main_column_q: Query<&mut Node, With<MainColumn>>,
@@ -745,7 +747,7 @@ fn sync_main_column_gap_to_pane_count(
         })
         .unwrap_or(0);
     let target = if pane_count > 1 {
-        crate::event::PANE_GAP_PX
+        settings.window.pad_top()
     } else {
         0.0
     };
@@ -975,10 +977,6 @@ mod tests {
             radius: 0.0,
             window: crate::settings::WindowSettings {
                 padding: 0.0,
-                padding_top: None,
-                padding_right: None,
-                padding_bottom: None,
-                padding_left: None,
             },
             pane: crate::settings::PaneSettings { gap },
             side_sheet: crate::settings::SideSheetSettings::default(),
@@ -1133,10 +1131,6 @@ mod tests {
                 radius: 0.0,
                 window: crate::settings::WindowSettings {
                     padding: 0.0,
-                    padding_top: None,
-                    padding_right: None,
-                    padding_bottom: None,
-                    padding_left: None,
                 },
                 pane: crate::settings::PaneSettings { gap: 0.0 },
                 side_sheet: crate::settings::SideSheetSettings::default(),
@@ -1169,10 +1163,6 @@ mod tests {
                 radius: 0.0,
                 window: crate::settings::WindowSettings {
                     padding: 0.0,
-                    padding_top: None,
-                    padding_right: None,
-                    padding_bottom: None,
-                    padding_left: None,
                 },
                 pane: crate::settings::PaneSettings { gap: 0.0 },
                 side_sheet: crate::settings::SideSheetSettings::default(),
@@ -1218,10 +1208,6 @@ mod tests {
                 radius: 0.0,
                 window: crate::settings::WindowSettings {
                     padding: 0.0,
-                    padding_top: None,
-                    padding_right: None,
-                    padding_bottom: None,
-                    padding_left: None,
                 },
                 pane: crate::settings::PaneSettings { gap: 0.0 },
                 side_sheet: crate::settings::SideSheetSettings::default(),
@@ -1280,10 +1266,6 @@ mod tests {
                 radius: 0.0,
                 window: crate::settings::WindowSettings {
                     padding: 16.0,
-                    padding_top: None,
-                    padding_right: None,
-                    padding_bottom: None,
-                    padding_left: None,
                 },
                 pane: crate::settings::PaneSettings { gap: 0.0 },
                 side_sheet: crate::settings::SideSheetSettings::default(),

--- a/crates/vmux_layout/src/window.rs
+++ b/crates/vmux_layout/src/window.rs
@@ -19,7 +19,7 @@ use bevy::{
     render::render_resource::AsBindGroup,
     shader::ShaderRef,
     ui::{FlexDirection, UiTargetCamera},
-    window::{Monitor, PrimaryWindow, WindowMode},
+    window::PrimaryWindow,
     winit::WINIT_WINDOWS,
 };
 use bevy_cef::prelude::*;
@@ -196,21 +196,6 @@ fn handle_window_commands(
     }
 }
 
-pub(crate) fn window_uses_full_padding(window: &Window, monitors: &Query<&Monitor>) -> bool {
-    matches!(
-        &window.mode,
-        WindowMode::BorderlessFullscreen(_) | WindowMode::Fullscreen(_, _)
-    ) || window_fills_monitor(window, monitors)
-}
-
-fn window_fills_monitor(window: &Window, monitors: &Query<&Monitor>) -> bool {
-    let size = window.resolution.physical_size();
-    monitors.iter().any(|monitor| {
-        let monitor_size = monitor.physical_size();
-        size.x >= monitor_size.x.saturating_sub(2) && size.y >= monitor_size.y.saturating_sub(2)
-    })
-}
-
 #[derive(Bundle)]
 struct WindowBundle<M>
 where
@@ -293,7 +278,7 @@ fn setup(
                     right: Val::Px(settings.window.pad_right()),
                     bottom: Val::Px(settings.window.pad_bottom()),
                 },
-                column_gap: Val::Px(0.0),
+                column_gap: Val::Px(crate::event::PANE_GAP_PX),
                 ..default()
             },
             ui_target: UiTargetCamera(*main_camera),
@@ -651,8 +636,6 @@ fn apply_webview_material_defaults(
 fn sync_window_layout_to_settings(
     settings: Res<LayoutSettings>,
     hidden: Option<Res<crate::toggle::LayoutHidden>>,
-    primary_window: Query<&Window, With<PrimaryWindow>>,
-    monitors: Query<&Monitor>,
     mut window_q: Query<&mut Node, (With<VmuxWindow>, Without<SideSheet>, Without<MainColumn>)>,
     mut main_column_q: Query<
         &mut Node,
@@ -674,11 +657,7 @@ fn sync_window_layout_to_settings(
     let pad_left = settings.window.pad_left();
     let gap = crate::event::PANE_GAP_PX;
     let cfg_width = crate::event::SIDE_SHEET_WIDTH_PX;
-    let full_padding = hidden.as_deref().is_some_and(|hidden| hidden.0)
-        || primary_window
-            .single()
-            .ok()
-            .is_some_and(|window| window_uses_full_padding(window, &monitors));
+    let full_padding = hidden.as_deref().is_some_and(|hidden| hidden.0);
 
     // Root window: padding + flex-row column gap. Top and left are flush
     // with the window so the CEF shell / pane meet the system edge; right
@@ -793,6 +772,7 @@ mod tests {
     use super::*;
     use crate::cef::LayoutCef;
     use bevy::ecs::relationship::Relationship;
+    use bevy::window::Monitor;
     use bevy_cef::prelude::WebviewExtendStandardMaterial;
 
     static HOME_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -975,9 +955,7 @@ mod tests {
     fn test_settings(gap: f32) -> LayoutSettings {
         LayoutSettings {
             radius: 0.0,
-            window: crate::settings::WindowSettings {
-                padding: 0.0,
-            },
+            window: crate::settings::WindowSettings { padding: 0.0 },
             pane: crate::settings::PaneSettings { gap },
             side_sheet: crate::settings::SideSheetSettings::default(),
             focus_ring: crate::settings::FocusRingSettings::default(),
@@ -1040,6 +1018,21 @@ mod tests {
             .count();
 
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn setup_window_gap_matches_header_layout_gap() {
+        let mut app = setup_window_app();
+        app.update();
+
+        let root = app
+            .world_mut()
+            .query_filtered::<Entity, With<VmuxWindow>>()
+            .single(app.world())
+            .expect("window root");
+        let node = app.world().get::<Node>(root).expect("window node");
+
+        assert_eq!(node.column_gap, Val::Px(crate::event::PANE_GAP_PX));
     }
 
     #[test]
@@ -1129,9 +1122,7 @@ mod tests {
             .add_message::<PageOpenRequest>()
             .insert_resource(LayoutSettings {
                 radius: 0.0,
-                window: crate::settings::WindowSettings {
-                    padding: 0.0,
-                },
+                window: crate::settings::WindowSettings { padding: 0.0 },
                 pane: crate::settings::PaneSettings { gap: 0.0 },
                 side_sheet: crate::settings::SideSheetSettings::default(),
                 focus_ring: crate::settings::FocusRingSettings::default(),
@@ -1161,9 +1152,7 @@ mod tests {
             .add_message::<PageOpenRequest>()
             .insert_resource(LayoutSettings {
                 radius: 0.0,
-                window: crate::settings::WindowSettings {
-                    padding: 0.0,
-                },
+                window: crate::settings::WindowSettings { padding: 0.0 },
                 pane: crate::settings::PaneSettings { gap: 0.0 },
                 side_sheet: crate::settings::SideSheetSettings::default(),
                 focus_ring: crate::settings::FocusRingSettings::default(),
@@ -1206,9 +1195,7 @@ mod tests {
             .add_message::<PageOpenRequest>()
             .insert_resource(LayoutSettings {
                 radius: 0.0,
-                window: crate::settings::WindowSettings {
-                    padding: 0.0,
-                },
+                window: crate::settings::WindowSettings { padding: 0.0 },
                 pane: crate::settings::PaneSettings { gap: 0.0 },
                 side_sheet: crate::settings::SideSheetSettings::default(),
                 focus_ring: crate::settings::FocusRingSettings::default(),
@@ -1258,15 +1245,13 @@ mod tests {
     }
 
     #[test]
-    fn fills_monitor_window_sync_applies_all_window_padding_edges() {
+    fn visible_fills_monitor_window_sync_clears_top_left_padding() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .insert_resource(crate::toggle::LayoutHidden(false))
             .insert_resource(LayoutSettings {
                 radius: 0.0,
-                window: crate::settings::WindowSettings {
-                    padding: 16.0,
-                },
+                window: crate::settings::WindowSettings { padding: 16.0 },
                 pane: crate::settings::PaneSettings { gap: 0.0 },
                 side_sheet: crate::settings::SideSheetSettings::default(),
                 focus_ring: crate::settings::FocusRingSettings::default(),
@@ -1294,8 +1279,8 @@ mod tests {
         app.update();
 
         let node = app.world().get::<Node>(root).expect("window node");
-        assert_eq!(node.padding.top, Val::Px(16.0));
-        assert_eq!(node.padding.left, Val::Px(16.0));
+        assert_eq!(node.padding.top, Val::Px(0.0));
+        assert_eq!(node.padding.left, Val::Px(0.0));
         assert_eq!(node.padding.right, Val::Px(16.0));
         assert_eq!(node.padding.bottom, Val::Px(16.0));
     }

--- a/crates/vmux_layout/tests/page_source.rs
+++ b/crates/vmux_layout/tests/page_source.rs
@@ -109,6 +109,21 @@ fn layout_page_offsets_header_and_side_sheet_by_window_padding() {
 }
 
 #[test]
+fn layout_page_uses_computed_header_right_offset() {
+    let source = include_str!("../src/page.rs");
+
+    assert!(source.contains("state.header_right()"));
+    assert!(source.contains("--vmux-header-right"));
+}
+
+#[test]
+fn layout_document_disables_both_scroll_axes() {
+    let css = include_str!("../assets/index.css");
+
+    assert!(css.contains("overflow-hidden"));
+}
+
+#[test]
 fn layout_page_gates_header_and_side_sheet_until_host_state_arrives() {
     let source = include_str!("../src/page.rs");
 

--- a/crates/vmux_setting/src/plugin/runtime.rs
+++ b/crates/vmux_setting/src/plugin/runtime.rs
@@ -966,9 +966,7 @@ mod tests {
             },
             layout: LayoutSettings {
                 radius: 0.0,
-                window: WindowSettings {
-                    padding: 0.0,
-                },
+                window: WindowSettings { padding: 0.0 },
                 pane: PaneSettings { gap: 0.0 },
                 side_sheet: SideSheetSettings::default(),
                 focus_ring: FocusRingSettings::default(),

--- a/crates/vmux_setting/src/plugin/runtime.rs
+++ b/crates/vmux_setting/src/plugin/runtime.rs
@@ -968,10 +968,6 @@ mod tests {
                 radius: 0.0,
                 window: WindowSettings {
                     padding: 0.0,
-                    padding_top: None,
-                    padding_right: None,
-                    padding_bottom: None,
-                    padding_left: None,
                 },
                 pane: PaneSettings { gap: 0.0 },
                 side_sheet: SideSheetSettings::default(),

--- a/crates/vmux_setting/src/plugin/view.rs
+++ b/crates/vmux_setting/src/plugin/view.rs
@@ -283,13 +283,7 @@ fn build_settings_schema() -> SettingsSchema {
                 "layout.window",
                 FieldSpec {
                     label: Some("Window".into()),
-                    order: vec![
-                        "padding".into(),
-                        "padding_top".into(),
-                        "padding_right".into(),
-                        "padding_bottom".into(),
-                        "padding_left".into(),
-                    ],
+                    order: vec!["padding".into()],
                     ..Default::default()
                 },
             ),
@@ -312,54 +306,7 @@ fn build_settings_schema() -> SettingsSchema {
                 "layout.focus_ring",
                 FieldSpec {
                     label: Some("Focus ring".into()),
-                    order: vec![
-                        "width".into(),
-                        "color".into(),
-                        "glow".into(),
-                        "gradient".into(),
-                    ],
-                    ..Default::default()
-                },
-            ),
-            field(
-                "layout.focus_ring.glow",
-                FieldSpec {
-                    label: Some("Glow".into()),
-                    order: vec!["spread".into(), "intensity".into()],
-                    ..Default::default()
-                },
-            ),
-            field(
-                "layout.focus_ring.gradient",
-                FieldSpec {
-                    label: Some("Gradient".into()),
-                    order: vec![
-                        "enabled".into(),
-                        "speed".into(),
-                        "cycles".into(),
-                        "accent".into(),
-                    ],
-                    ..Default::default()
-                },
-            ),
-            field(
-                "layout.focus_ring.glow.intensity",
-                FieldSpec {
-                    step: Some(0.05),
-                    ..Default::default()
-                },
-            ),
-            field(
-                "layout.focus_ring.gradient.speed",
-                FieldSpec {
-                    step: Some(0.1),
-                    ..Default::default()
-                },
-            ),
-            field(
-                "layout.focus_ring.gradient.cycles",
-                FieldSpec {
-                    step: Some(0.1),
+                    order: vec!["width".into(), "color".into()],
                     ..Default::default()
                 },
             ),

--- a/crates/vmux_setting/src/settings.ron
+++ b/crates/vmux_setting/src/settings.ron
@@ -3,7 +3,9 @@
         startup_url: "https://www.google.com",
     ),
     layout: (
-        radius: 8.0,
+        window: (
+            padding: 8.0,
+        ),
     ),
     shortcuts: (
         leader: (key: "b", ctrl: true),

--- a/crates/vmux_space/src/plugin.rs
+++ b/crates/vmux_space/src/plugin.rs
@@ -682,10 +682,6 @@ mod tests {
                 radius: 0.0,
                 window: WindowSettings {
                     padding: 0.0,
-                    padding_top: None,
-                    padding_right: None,
-                    padding_bottom: None,
-                    padding_left: None,
                 },
                 pane: PaneSettings { gap: 0.0 },
                 side_sheet: SideSheetSettings::default(),

--- a/crates/vmux_space/src/plugin.rs
+++ b/crates/vmux_space/src/plugin.rs
@@ -680,9 +680,7 @@ mod tests {
             },
             layout: LayoutSettings {
                 radius: 0.0,
-                window: WindowSettings {
-                    padding: 0.0,
-                },
+                window: WindowSettings { padding: 0.0 },
                 pane: PaneSettings { gap: 0.0 },
                 side_sheet: SideSheetSettings::default(),
                 focus_ring: FocusRingSettings::default(),

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -3091,9 +3091,7 @@ mod tests {
             },
             layout: LayoutSettings {
                 radius: 0.0,
-                window: WindowSettings {
-                    padding: 0.0,
-                },
+                window: WindowSettings { padding: 0.0 },
                 pane: PaneSettings { gap: 0.0 },
                 side_sheet: SideSheetSettings::default(),
                 focus_ring: FocusRingSettings::default(),

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -3093,10 +3093,6 @@ mod tests {
                 radius: 0.0,
                 window: WindowSettings {
                     padding: 0.0,
-                    padding_top: None,
-                    padding_right: None,
-                    padding_bottom: None,
-                    padding_left: None,
                 },
                 pane: PaneSettings { gap: 0.0 },
                 side_sheet: SideSheetSettings::default(),


### PR DESCRIPTION
## Summary
- **Window padding is now 8px and configurable** via `settings.layout.window.padding` (was a hardcoded 4px), applied uniformly through the existing maximized/hidden full-padding path.
- **Split tabs** get a visible gap between the url row and the panes (sized to the window padding); single-pane stays flush against the url row.
- **Slimmed the layout config surface:**
  - Removed the per-edge padding overrides (`padding_top/right/bottom/left`) — just `window.padding` now.
  - `radius` gains a serde default, so it's omittable from `settings.ron` (now just `layout: (window: (padding: 8.0))`).
  - `focus_ring` reduced to `width` + `color`; glow/gradient values are hardcoded (the ring is visually unchanged), dropping 8 config fields.

Net **−215 lines**. Rebased onto current `main`.

## Test plan
- [ ] Single / split / hidden layouts look right at 8px padding
- [ ] Split shows a gap between the url row and the panes
- [ ] Focus ring unchanged on the active split pane
- [ ] Settings page shows only `window.padding` and `focus_ring.{width,color}`
- [ ] App launches (embedded `settings.ron` parses)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated default window padding to **8px**, improving spacing across multi-pane layouts.
  * Header inset offsets are now computed from layout geometry and can override derived padding; when layout is not hidden, top/left padding is cleared for fullscreen/maximized behaviors.
  * Page rendering now uses header-driven CSS offsets for consistent header alignment.

* **Settings Updates**
  * `layout.window.padding` replaces the prior `layout.radius`-style setting.
  * Focus ring settings are limited to **width** and **color** only.

* **UI/Styling**
  * Global styles now disable both horizontal and vertical scrolling (`overflow-hidden`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->