### PR TITLE
fix(service): nest dev logs/services under Vmux/dev, move service log to logs

### DIFF
--- a/crates/vmux_service/src/launchd.rs
+++ b/crates/vmux_service/src/launchd.rs
@@ -51,6 +51,7 @@ pub fn generate_plist(profile: &str, binary_path: &Path, log_path: &Path) -> Str
 pub fn install(profile: &str, binary_path: &Path) -> std::io::Result<PathBuf> {
     let plist = crate::plist_path(profile);
     std::fs::create_dir_all(crate::service_dir())?;
+    std::fs::create_dir_all(crate::log_dir())?;
     let log = crate::log_path();
     reconcile_plist_at(&plist, profile, binary_path, &log)?;
     bootstrap(&plist)?;
@@ -135,6 +136,7 @@ pub fn kickstart(label: &str) -> std::io::Result<()> {
 /// `binary_path` is the daemon executable (resolved by the caller).
 pub fn ensure_running(profile: &str, binary_path: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(crate::service_dir())?;
+    std::fs::create_dir_all(crate::log_dir())?;
     let plist = crate::plist_path(profile);
     let log = crate::log_path();
     let rewrote = reconcile_plist_at(&plist, profile, binary_path, &log)?;

--- a/crates/vmux_service/src/paths.rs
+++ b/crates/vmux_service/src/paths.rs
@@ -1,15 +1,16 @@
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
+use vmux_core::profile::shared_data_dir;
 
 /// Profile this build was compiled for ("release", "local", or "dev").
 pub fn current_profile() -> &'static str {
     env!("VMUX_BUILD_PROFILE")
 }
 
-/// Directory for service runtime files (socket, pid, log).
+/// Directory for service runtime files (socket, pid, identity). Nested under the
+/// profile-specific data dir so `dev` builds stay isolated under `Vmux/dev`.
 pub fn service_dir() -> PathBuf {
-    let home = std::env::var_os("HOME").expect("HOME not set");
-    PathBuf::from(home).join("Library/Application Support/Vmux/services")
+    shared_data_dir().join("services")
 }
 
 fn profile_file(ext: &str) -> PathBuf {
@@ -31,15 +32,17 @@ pub fn identity_path() -> PathBuf {
     profile_file("identity")
 }
 
-/// Path to the per-profile service log file.
+/// Path to the per-profile service stdout/stderr capture log. Lives alongside
+/// the rotated application logs in `log_dir`, not in `service_dir`.
 pub fn log_path() -> PathBuf {
-    profile_file("log")
+    log_dir().join(format!("vmux-{}.log", current_profile()))
 }
 
-/// Directory for application log files (separate from runtime files in `service_dir`).
+/// Directory for application log files (separate from runtime files in
+/// `service_dir`). Nested under the profile-specific data dir so `dev` builds
+/// stay isolated under `Vmux/dev`.
 pub fn log_dir() -> PathBuf {
-    let home = std::env::var_os("HOME").expect("HOME not set");
-    PathBuf::from(home).join("Library/Application Support/Vmux/logs")
+    shared_data_dir().join("logs")
 }
 
 /// Path to today's unified log file. Matches the filename the tracing-appender
@@ -238,6 +241,24 @@ mod tests {
                 "expected {name} to start with {suffix}"
             );
         }
+    }
+
+    #[test]
+    fn service_and_log_dirs_nest_under_profile_data_dir() {
+        let base = vmux_core::profile::shared_data_dir();
+        assert_eq!(service_dir(), base.join("services"));
+        assert_eq!(log_dir(), base.join("logs"));
+    }
+
+    #[test]
+    fn log_path_lives_in_log_dir_not_service_dir() {
+        let p = log_path();
+        assert_eq!(p.parent().unwrap(), log_dir());
+        assert_ne!(p.parent().unwrap(), service_dir());
+        assert_eq!(
+            p.file_name().unwrap().to_string_lossy(),
+            format!("vmux-{}.log", current_profile())
+        );
     }
 
     #[test]

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -853,7 +853,7 @@ fn ensure_service_started() {
 #[cfg(unix)]
 fn spawn_detached_service(binary: &std::path::Path) {
     use std::os::unix::process::CommandExt;
-    let log_dir = vmux_service::service_dir();
+    let log_dir = vmux_service::log_dir();
     let _ = std::fs::create_dir_all(&log_dir);
     let stderr_cfg = match std::fs::File::create(vmux_service::log_path()) {
         Ok(f) => std::process::Stdio::from(f),


### PR DESCRIPTION
## Context

Dev builds were duplicating `logs/` and `services/` directories: instead of nesting under `Vmux/dev/` (like the dev profile dir already does), they landed at the top-level `Vmux/{logs,services}` next to the release data. `service_dir()` and `log_dir()` hardcoded the `Vmux/...` path and ignored the build profile.

## Implementation

- `service_dir()` / `log_dir()` now derive from `vmux_core::profile::shared_data_dir()`, which already encodes the profile suffix (`Vmux` for release/local, `Vmux/dev` for dev). This matches how `profile_dir()` is computed, so all per-build state stays together under `Vmux/dev/`.
- Moved the per-profile service stdout/stderr capture log (`vmux-{profile}.log`) out of `services/` and into `logs/`, alongside the rotated daily app logs. Filenames don't collide (no-date vs dated).
- Added `create_dir_all(log_dir())` at the sites that write that log via launchd plist / detached spawn (`launchd::install`, `launchd::ensure_running`, `terminal::spawn_detached_service`).

## Checks / QA

- Launch a dev build; confirm new files appear under `~/Library/Application Support/Vmux/dev/{logs,services}/` and nothing new is written to the top-level `Vmux/{logs,services}/`.
- Confirm the service log is now `Vmux/dev/logs/vmux-dev.log` (not under `services/`).
- Existing top-level `Vmux/{logs,services}` are stale leftovers from before this fix and can be deleted manually.
