### PR TITLE
chore(release): v0.0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9398,7 +9398,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9429,7 +9429,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_browser"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9450,7 +9450,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -9462,7 +9462,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9477,7 +9477,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9492,7 +9492,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9544,7 +9544,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9565,7 +9565,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -9599,7 +9599,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "muda",
  "proc-macro2",
@@ -9609,7 +9609,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "serde",
  "serde_json",
@@ -9621,7 +9621,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_server"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "dioxus",
  "regex",
@@ -9640,7 +9640,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "alacritty_terminal",
  "bevy",
@@ -9675,7 +9675,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9698,7 +9698,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9723,7 +9723,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9753,7 +9753,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "dioxus",
  "dioxus-primitives",
@@ -9770,7 +9770,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_vibe_setup"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "bevy",
  "bevy_cef",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.15"
+version = "0.0.16"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "MIT"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.15"
-  sha256 "8a3008023718b16d623937e8a8b174e6a138fbaad50a092725ff17306ea5afbf"
+  version "0.0.16"
+  sha256 "9473cd939a92c274edf5995dc47e59a7a2a9dab82320ee446bac1015a3ba956b"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.15/Vmux_0.0.15_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.16/Vmux_0.0.16_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai/"

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.15",
-  "pub_date": "2026-06-12T13:20:03Z",
+  "version": "v0.0.16",
+  "pub_date": "2026-06-19T03:42:14Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.15/Vmux-v0.0.15-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzZ4K2tyeXY3RXYvSmhVeXA3cHNtTnBxVDRMOVB3OU1JNFcyZmV1YXo1V3FUYW81dHIwd0VYNHJrdldhY0Y2RGZzejlpVlRGSlh3aTJrcW1ZM1o2TkEwPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgxMjcwMTcwCWZpbGU6Vm11eC12MC4wLjE1LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKejZXZVpJVTN3TEo0UkozRzkwdjlaTGpsam05cDloSjVWWktJOEdiM1pZLy9YUjduelJEQ0pvRG9pY0pZdWxKNU9WcWMwRXhCcC9FVnNmeDNhVFpiQ1E9PQo=",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.16/Vmux-v0.0.16-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HT3l1YzNYUnJIWXZRMVcyZTV4cFVKVE1NSGtXcmR2NDZLNlVyNWwxU2NLbWJXSkhrdXlxVU85SVlmUjF5VmhMdHc4Wk9YZG1oMzZ4TnhjakJqUXQvM2dVPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgxODM5NzYyCWZpbGU6Vm11eC12MC4wLjE2LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKS0NkZUFXRmtOQkplMUVNQVFRZjRzc0xOZnlKZFkyV3BpY01YQ3c5SmZhM0ptZkhkc1ZSZTdaOGpQUEVMZkd4cWgvRWxiTGNlUkFEY3VPY1dLZW94QlE9PQo=",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.15/Vmux_0.0.15_aarch64.dmg",
-      "filename": "Vmux_0.0.15_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.16/Vmux_0.0.16_aarch64.dmg",
+      "filename": "Vmux_0.0.16_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
Patch release. Bumps workspace version 0.0.15 -> 0.0.16. Releases on merge.