### PR TITLE
chore: add .coderabbit.yaml to enable PR reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  auto_review:
+    enabled: true
+    base_branches:
+      - "^main$"


### PR DESCRIPTION
## Why

CodeRabbit skipped review on #112 with *\"Auto reviews are disabled on base/target branches other than the default branch.\"* CodeRabbit was set up via the website (no repo config), so it ran with `Configuration used: defaults`. On a fresh install its default-branch gate skipped a PR that targeted `main`.

No prior PR (#90, #105, #108, #109, #110) ever received a CodeRabbit comment — #112 is the first, confirming this is initial-setup behavior, not PR-specific.

## Fix

Add `.coderabbit.yaml` with an explicit `reviews.auto_review.base_branches`. Listing `^main$` makes CodeRabbit review every PR targeting `main` regardless of its default-branch detection. `enabled: true` is explicit for clarity.

```yaml
reviews:
  auto_review:
    enabled: true
    base_branches:
      - "^main$"
```

`base_branches` accepts regex (per CodeRabbit schema). Swap `^main$` for `.*` later if we want stacked PRs (base != main) reviewed too.

## Test plan

- [ ] After merge, open/push a PR to `main` and confirm CodeRabbit posts a review summary instead of "Review skipped"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Chores**
  * Updated internal code review configuration settings.

---

**Note:** This release contains internal infrastructure updates with no user-facing changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->