### PR TITLE
ci: skip rust lint/test on non-code PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,11 @@ jobs:
           echo "Resolved CEF version: $version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-  lint:
-    name: Lint
+  lint-rust:
+    name: Lint (rust)
     runs-on: ubuntu-latest
-    needs: cef-version
+    needs: [cef-version, changes]
+    if: needs.changes.outputs.code == 'true'
     env:
       CEF_VERSION: ${{ needs.cef-version.outputs.version }}
     steps:
@@ -141,10 +142,11 @@ jobs:
       - name: Clippy
         run: env -u CEF_PATH cargo clippy ${{ steps.pkgs.outputs.args }} --all-targets -- -D warnings
 
-  test:
-    name: Test
+  test-rust:
+    name: Test (rust)
     runs-on: ubuntu-latest
-    needs: cef-version
+    needs: [cef-version, changes]
+    if: needs.changes.outputs.code == 'true'
     env:
       CEF_VERSION: ${{ needs.cef-version.outputs.version }}
     steps:
@@ -235,12 +237,21 @@ jobs:
     outputs:
       website: ${{ steps.filter.outputs.website }}
       packaging: ${{ steps.filter.outputs.packaging }}
+      code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
+            code:
+              - 'crates/**'
+              - 'patches/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - 'scripts/**'
+              - '.github/workflows/ci.yml'
             website:
               - 'website/**'
             packaging:
@@ -252,6 +263,40 @@ jobs:
               - 'Cargo.lock'
               - '.github/workflows/release.yml'
               - '.github/workflows/ci.yml'
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs: [changes, lint-rust]
+    if: always()
+    steps:
+      - name: Gate
+        env:
+          CODE: ${{ needs.changes.outputs.code }}
+          RESULT: ${{ needs.lint-rust.result }}
+        run: |
+          if [ "$CODE" = "true" ] && [ "$RESULT" != "success" ]; then
+            echo "::error::Lint (rust) result: $RESULT"
+            exit 1
+          fi
+          echo "Lint gate ok (code=$CODE rust=$RESULT)"
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: [changes, test-rust]
+    if: always()
+    steps:
+      - name: Gate
+        env:
+          CODE: ${{ needs.changes.outputs.code }}
+          RESULT: ${{ needs.test-rust.result }}
+        run: |
+          if [ "$CODE" = "true" ] && [ "$RESULT" != "success" ]; then
+            echo "::error::Test (rust) result: $RESULT"
+            exit 1
+          fi
+          echo "Test gate ok (code=$CODE rust=$RESULT)"
 
   website:
     name: Website Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,9 +272,14 @@ jobs:
     steps:
       - name: Gate
         env:
+          CHANGES: ${{ needs.changes.result }}
           CODE: ${{ needs.changes.outputs.code }}
           RESULT: ${{ needs.lint-rust.result }}
         run: |
+          if [ "$CHANGES" != "success" ]; then
+            echo "::error::Detect Changes did not succeed ($CHANGES)"
+            exit 1
+          fi
           if [ "$CODE" = "true" ] && [ "$RESULT" != "success" ]; then
             echo "::error::Lint (rust) result: $RESULT"
             exit 1
@@ -289,9 +294,14 @@ jobs:
     steps:
       - name: Gate
         env:
+          CHANGES: ${{ needs.changes.result }}
           CODE: ${{ needs.changes.outputs.code }}
           RESULT: ${{ needs.test-rust.result }}
         run: |
+          if [ "$CHANGES" != "success" ]; then
+            echo "::error::Detect Changes did not succeed ($CHANGES)"
+            exit 1
+          fi
           if [ "$CODE" = "true" ] && [ "$RESULT" != "success" ]; then
             echo "::error::Test (rust) result: $RESULT"
             exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,15 @@ When taking a Linear issue (e.g. "take VMX-XX"), immediately move it to **In Pro
 
 Worktree directory: `.worktrees/` (already in `.gitignore`).
 
+## Merging
+
+Before merging any PR:
+
+1. **Check review comments.** Read all review feedback — CodeRabbit and human reviewers — and address or explicitly triage every item. A green status check is not enough; unresolved review comments must be handled first.
+2. **Check CI.** Confirm all required checks are green on the PR's head commit.
+
+After merging, clean up: remove the worktree (`git worktree remove .worktrees/<name>`) and delete the branch (`gh pr merge --delete-branch` for the remote; delete the local branch too if it lingers).
+
 ## Documentation
 
 - Save design specs to `docs/specs/YYYY-MM-DD-<topic>-design.md` (not `docs/superpowers/specs/`).


### PR DESCRIPTION
## Why

Branch protection on `main` requires the `Lint` and `Test` checks. Today both run on **every** PR — including config/doc-only changes like #113 (`.coderabbit.yaml`), which waited on the full Rust toolchain for no reason. GitHub matches required checks by name globally, so you can't simply skip them on irrelevant paths: a skipped required check never reports and blocks merge.

## What

Aggregator pattern (no branch-protection changes needed):

- `changes` job gains a `code` paths-filter: `crates/**`, `patches/**`, `Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`, `scripts/**`, `.github/workflows/ci.yml`.
- Heavy jobs renamed `Lint (rust)` / `Test (rust)`, gated `if: code == 'true'`.
- New thin jobs **named** `Lint` / `Test` (`if: always()`) satisfy the required contexts: pass instantly when no code changed, else mirror the rust job's result.

Net: non-code PRs report `Lint`/`Test` green in seconds; code PRs are unchanged.

## Test plan

- [x] This PR touches `ci.yml` (in the `code` filter) → `Lint (rust)`/`Test (rust)` run, validating the code path
- [ ] After merge, rebase #113 (config-only) and confirm `Lint`/`Test` go green without running the rust jobs (validates the skip path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI to run Rust linting and testing only when relevant Rust-related changes are detected.
  * Broadened change-detection coverage to include Rust workspace components, manifests/lockfiles, tooling, scripts, and the CI configuration itself.
  * Added always-running CI gate jobs to ensure Rust check failures are surfaced correctly when code changes are present.
* **Documentation**
  * Updated merge guidance with a new “Merging” section, including a pre-merge checklist and post-merge cleanup steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->