### PR TITLE
feat(service): OSC 133 command-lifecycle parsing (1/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9669,6 +9669,7 @@ dependencies = [
  "vmux_core",
  "vmux_layout",
  "vmux_ui",
+ "vte",
  "wasm-bindgen",
  "web-sys",
 ]

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -55,8 +55,13 @@ pub struct AgentExecutableOverride(pub std::collections::HashMap<AgentKind, bool
 /// pane). A bare `run` stacks new terminals into this pane instead of splitting
 /// the agent's own pane again; the first `run` creates it. Self-healing: a stale
 /// pane (closed) is replaced by a fresh split.
+/// `run_terminals` tracks each anchor's live run terminal so a default (`auto`)
+/// `run` reuses that one persistent shell instead of stacking a new terminal.
 #[derive(Resource, Default)]
-pub struct AgentTerminalRegions(pub std::collections::HashMap<ProcessId, Entity>);
+pub struct AgentTerminalRegions {
+    pub panes: std::collections::HashMap<ProcessId, Entity>,
+    pub run_terminals: std::collections::HashMap<ProcessId, ProcessId>,
+}
 
 fn resolve_agent_executable(
     kind: AgentKind,
@@ -687,6 +692,17 @@ fn handle_agent_self_commands(
                         AgentCommandResult::Text(pid.to_string())
                     }
                     None => 'spawn: {
+                        if beside.is_none()
+                            && *mode == vmux_service::protocol::PlacementMode::Auto
+                            && let Some(pid) = regions.run_terminals.get(anchor).copied()
+                            && term_pids.iter().any(|(_, p)| *p == pid)
+                        {
+                            service.0.send(ClientMessage::ProcessInput {
+                                process_id: pid,
+                                data,
+                            });
+                            break 'spawn AgentCommandResult::Text(pid.to_string());
+                        }
                         let Some((agent_term, self_pane)) =
                             resolve_self_pane(*anchor, &agent_terms, &child_of_q)
                         else {
@@ -727,7 +743,7 @@ fn handle_agent_self_commands(
                             // off the agent the first time (don't spawn a pane unless needed).
                             (None, _) => {
                                 let region = regions
-                                    .0
+                                    .panes
                                     .get(anchor)
                                     .copied()
                                     .filter(|p| panes.contains(*p));
@@ -745,7 +761,7 @@ fn handle_agent_self_commands(
                                 })
                             }
                         };
-                        regions.0.insert(*anchor, target_pane);
+                        regions.panes.insert(*anchor, target_pane);
                         let new_pid = ProcessId::new();
                         let agent_cwd = launch_q.get(agent_term).ok().map(|l| l.cwd.clone());
                         let cwd = run_terminal_cwd(agent_cwd.as_deref(), active_space.as_deref());
@@ -756,6 +772,10 @@ fn handle_agent_self_commands(
                             process_id: Some(new_pid),
                             activate: *focus,
                         });
+                        if beside.is_none() && *mode != vmux_service::protocol::PlacementMode::Split
+                        {
+                            regions.run_terminals.insert(*anchor, new_pid);
+                        }
                         AgentCommandResult::Text(new_pid.to_string())
                     }
                 }

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -942,9 +942,11 @@ fn handle_agent_queries(
                     result: AgentQueryResult::Spaces(json),
                 });
             }
-            // ReadTerminal/ReadTerminalFull are answered by the service directly;
-            // they never reach the GUI.
-            AgentQuery::ReadTerminal { .. } | AgentQuery::ReadTerminalFull { .. } => {}
+            // ReadTerminal/ReadTerminalFull/CommandExit are answered by the
+            // service directly; they never reach the GUI.
+            AgentQuery::ReadTerminal { .. }
+            | AgentQuery::ReadTerminalFull { .. }
+            | AgentQuery::CommandExit { .. } => {}
         }
     }
 }

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -55,8 +55,6 @@ pub struct AgentExecutableOverride(pub std::collections::HashMap<AgentKind, bool
 /// pane). A bare `run` stacks new terminals into this pane instead of splitting
 /// the agent's own pane again; the first `run` creates it. Self-healing: a stale
 /// pane (closed) is replaced by a fresh split.
-/// `run_terminals` tracks each anchor's live run terminal so a default (`auto`)
-/// `run` reuses that one persistent shell instead of stacking a new terminal.
 #[derive(Resource, Default)]
 pub struct AgentTerminalRegions {
     pub panes: std::collections::HashMap<ProcessId, Entity>,

--- a/crates/vmux_mcp/src/protocol.rs
+++ b/crates/vmux_mcp/src/protocol.rs
@@ -120,7 +120,6 @@ async fn tool_call_result(
             terminal,
             ..
         }) => {
-            let token = run_token();
             let run = AgentCommand::Run {
                 anchor,
                 command,
@@ -129,55 +128,22 @@ async fn tool_call_result(
                 beside,
                 mode,
                 terminal,
-                done_marker: Some(token.clone()),
+                done_marker: None,
             };
-            run_blocking(run, &token).await
+            run_blocking(run).await
         }
         crate::tools::DispatchTarget::Command(command) => run_agent_command(command).await,
         crate::tools::DispatchTarget::Query(query) => run_agent_query(query).await,
     }
 }
 
-fn run_token() -> String {
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    format!("v{nanos:x}")
-}
-
-/// Parse the exit code from a line containing `__VMUX_DONE_<token>_<digits>__`.
-/// Returns `None` for the echoed command line (which carries the unresolved
-/// `%s`/`($env...)` placeholder rather than digits).
-fn marker_code(line: &str, token: &str) -> Option<i32> {
-    let prefix = format!("__VMUX_DONE_{token}_");
-    let start = line.find(&prefix)? + prefix.len();
-    let rest = &line[start..];
-    let end = rest.find("__")?;
-    rest[..end].parse::<i32>().ok()
-}
-
-/// Find the resolved completion marker anywhere in `text` and return its exit code.
-fn parse_done_marker(text: &str, token: &str) -> Option<i32> {
-    text.lines().rev().find_map(|line| marker_code(line, token))
-}
-
-/// Extract command output from the full terminal buffer: the lines between the
-/// echoed command (the first line carrying the token) and the resolved marker
-/// line, with both boundary lines removed.
-fn clean_run_output(text: &str, token: &str) -> String {
-    let token_pat = format!("__VMUX_DONE_{token}");
-    let lines: Vec<&str> = text.lines().collect();
-    let end = lines
-        .iter()
-        .position(|line| marker_code(line, token).is_some())
-        .unwrap_or(lines.len());
-    let start = lines[..end]
-        .iter()
-        .rposition(|line| line.contains(&token_pat))
-        .map(|i| i + 1)
-        .unwrap_or(0);
-    lines[start..end].join("\n").trim_end().to_string()
+fn output_since(baseline: &str, final_text: &str) -> String {
+    final_text
+        .strip_prefix(baseline)
+        .unwrap_or(final_text)
+        .trim_matches('\n')
+        .trim_end()
+        .to_string()
 }
 
 fn run_result(pid: &str, exit: Option<i32>, output: &str, timed_out: bool) -> Value {
@@ -197,7 +163,7 @@ fn run_result(pid: &str, exit: Option<i32>, output: &str, timed_out: bool) -> Va
 
 /// Send `run`, then block (polling the full terminal buffer) until the command's
 /// completion marker appears, returning the output + exit code in one response.
-async fn run_blocking(run: AgentCommand, token: &str) -> Result<Value, String> {
+async fn run_blocking(run: AgentCommand) -> Result<Value, String> {
     let connection = vmux_service::client::ServiceConnection::connect()
         .await
         .map_err(|error| format!("cannot connect to vmux_service: {error}"))?;
@@ -241,63 +207,76 @@ async fn run_blocking(run: AgentCommand, token: &str) -> Result<Value, String> {
         .map_err(|_| format!("run: service returned an invalid terminal id: {pid}"))?;
 
     let start = Instant::now();
-    let deadline = start + RUN_BLOCK_TIMEOUT;
-    let mut last_text = String::new();
-    let mut got_text = false;
-    loop {
-        let query_id = AgentRequestId::new();
-        connection
-            .send(&ClientMessage::AgentQuery {
-                request_id: query_id,
-                query: AgentQuery::ReadTerminalFull { process_id },
-            })
-            .await
-            .map_err(|error| format!("cannot poll terminal: {error}"))?;
-
-        let read = loop {
-            let Some(message) = connection
-                .recv()
-                .await
-                .map_err(|error| format!("cannot read terminal poll: {error}"))?
-            else {
-                return Err("vmux_service disconnected".to_string());
-            };
-            match message {
-                ServiceMessage::AgentQueryResult {
-                    request_id: received,
-                    result,
-                } if received == query_id => break result,
-                ServiceMessage::Error { message } => {
-                    return Err(message);
-                }
-                _ => {}
-            }
-        };
-
-        match read {
-            AgentQueryResult::Text(text) => {
-                got_text = true;
-                last_text = text;
-                if let Some(code) = parse_done_marker(&last_text, token) {
-                    let output = clean_run_output(&last_text, token);
-                    return Ok(run_result(&pid, Some(code), &output, false));
-                }
-            }
+    let baseline_seq = loop {
+        match agent_query(&connection, AgentQuery::CommandExit { process_id }).await? {
+            AgentQueryResult::CommandExit { seq, .. } => break seq,
             AgentQueryResult::Error(message) => {
-                // The terminal may not be created yet; tolerate "process not
-                // found" during the grace window, but surface a persistent error.
-                if !got_text && start.elapsed() > RUN_CREATE_GRACE {
+                if start.elapsed() > RUN_CREATE_GRACE {
                     return Err(message);
                 }
+                tokio::time::sleep(RUN_POLL_INTERVAL).await;
             }
-            other => return Err(format!("run: unexpected terminal read: {other:?}")),
+            other => return Err(format!("run: unexpected command-exit result: {other:?}")),
         }
+    };
+    let baseline_text = read_full_text(&connection, process_id).await;
 
+    let deadline = start + RUN_BLOCK_TIMEOUT;
+    loop {
+        match agent_query(&connection, AgentQuery::CommandExit { process_id }).await? {
+            AgentQueryResult::CommandExit { seq, exit } if seq > baseline_seq => {
+                let final_text = read_full_text(&connection, process_id).await;
+                let output = output_since(&baseline_text, &final_text);
+                return Ok(run_result(&pid, exit, &output, false));
+            }
+            AgentQueryResult::CommandExit { .. } => {}
+            AgentQueryResult::Error(message) => return Err(message),
+            other => return Err(format!("run: unexpected command-exit result: {other:?}")),
+        }
         if Instant::now() >= deadline {
-            let output = clean_run_output(&last_text, token);
+            let final_text = read_full_text(&connection, process_id).await;
+            let output = output_since(&baseline_text, &final_text);
             return Ok(run_result(&pid, None, &output, true));
         }
         tokio::time::sleep(RUN_POLL_INTERVAL).await;
+    }
+}
+
+async fn agent_query(
+    connection: &vmux_service::client::ServiceConnection,
+    query: AgentQuery,
+) -> Result<AgentQueryResult, String> {
+    let request_id = AgentRequestId::new();
+    connection
+        .send(&ClientMessage::AgentQuery { request_id, query })
+        .await
+        .map_err(|error| format!("cannot send query: {error}"))?;
+    loop {
+        let Some(message) = connection
+            .recv()
+            .await
+            .map_err(|error| format!("cannot read query response: {error}"))?
+        else {
+            return Err("vmux_service disconnected".to_string());
+        };
+        match message {
+            ServiceMessage::AgentQueryResult {
+                request_id: received,
+                result,
+            } if received == request_id => return Ok(result),
+            ServiceMessage::Error { message } => return Err(message),
+            _ => {}
+        }
+    }
+}
+
+async fn read_full_text(
+    connection: &vmux_service::client::ServiceConnection,
+    process_id: vmux_service::protocol::ProcessId,
+) -> String {
+    match agent_query(connection, AgentQuery::ReadTerminalFull { process_id }).await {
+        Ok(AgentQueryResult::Text(text)) => text,
+        _ => String::new(),
     }
 }
 
@@ -405,6 +384,11 @@ fn query_result_to_mcp_response(result: vmux_service::protocol::AgentQueryResult
                 "content": [{"type": "text", "text": json_str}]
             })
         }
+        AgentQueryResult::CommandExit { seq, exit } => {
+            json!({
+                "content": [{"type": "text", "text": format!("seq={seq} exit={exit:?}")}]
+            })
+        }
         AgentQueryResult::Error(message) => {
             json!({
                 "isError": true,
@@ -439,53 +423,20 @@ mod tests {
     }
 
     #[test]
-    fn marker_code_parses_resolved_exit_only() {
-        assert_eq!(marker_code("__VMUX_DONE_tok_0__", "tok"), Some(0));
+    fn output_since_returns_appended_tail() {
+        let baseline = "prompt$ ";
+        let final_text = "prompt$ ls\nfile_a\nfile_b\nprompt$ ";
         assert_eq!(
-            marker_code("prefix __VMUX_DONE_tok_130__ suffix", "tok"),
-            Some(130)
+            output_since(baseline, final_text),
+            "ls\nfile_a\nfile_b\nprompt$"
         );
-        // Echoed command line carries the unresolved placeholder, not digits.
-        assert_eq!(
-            marker_code("ls; printf '__VMUX_DONE_tok_%s__' \"$?\"", "tok"),
-            None
-        );
-        assert_eq!(
-            marker_code("__VMUX_DONE_tok_($env.LAST_EXIT_CODE)__", "tok"),
-            None
-        );
-        // nushell catch-branch echo (interpolated expr, not digits) must not match.
-        assert_eq!(
-            marker_code(
-                "print $\"__VMUX_DONE_tok_($e.exit_code? | default 1)__\"",
-                "tok"
-            ),
-            None
-        );
-        // Wrong token never matches.
-        assert_eq!(marker_code("__VMUX_DONE_other_0__", "tok"), None);
     }
 
     #[test]
-    fn parse_done_marker_finds_code_ignoring_echo() {
-        let text =
-            "$ ls; printf '__VMUX_DONE_tok_%s__' \"$?\"\nfile_a\nfile_b\n__VMUX_DONE_tok_0__\n$ ";
-        assert_eq!(parse_done_marker(text, "tok"), Some(0));
-        assert_eq!(parse_done_marker("nothing here", "tok"), None);
-    }
-
-    #[test]
-    fn clean_run_output_strips_echo_and_marker() {
-        let text =
-            "$ ls; printf '__VMUX_DONE_tok_%s__' \"$?\"\nfile_a\nfile_b\n__VMUX_DONE_tok_0__\n$ ";
-        assert_eq!(clean_run_output(text, "tok"), "file_a\nfile_b");
-    }
-
-    #[test]
-    fn clean_run_output_timeout_keeps_output_after_echo() {
-        // No resolved marker yet (command still running).
-        let text = "$ sleep 9; printf '__VMUX_DONE_tok_%s__' \"$?\"\nworking...";
-        assert_eq!(clean_run_output(text, "tok"), "working...");
+    fn output_since_falls_back_to_full_when_prefix_shifted() {
+        let baseline = "old prompt$ ";
+        let final_text = "different\noutput here";
+        assert_eq!(output_since(baseline, final_text), "different\noutput here");
     }
 
     #[test]

--- a/crates/vmux_mcp/src/protocol.rs
+++ b/crates/vmux_mcp/src/protocol.rs
@@ -385,8 +385,9 @@ fn query_result_to_mcp_response(result: vmux_service::protocol::AgentQueryResult
             })
         }
         AgentQueryResult::CommandExit { seq, exit } => {
+            let exit = exit.map_or_else(|| "null".to_string(), |code| code.to_string());
             json!({
-                "content": [{"type": "text", "text": format!("seq={seq} exit={exit:?}")}]
+                "content": [{"type": "text", "text": format!("{{\"seq\":{seq},\"exit\":{exit}}}")}]
             })
         }
         AgentQueryResult::Error(message) => {

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -303,13 +303,13 @@ Blocks until the command finishes and returns its full output plus the exit code
 (`terminal: <id>`, `exit: <code>`, `output: ...`). If it has not finished within ~50s, returns the \
 output so far with a note to call read_terminal for the rest. \
 \
-PLACEMENT — by DEFAULT you don't need to think about this: a bare `run` reuses your one terminal region \
-(new terminals stack into a single pane beside you), so your own pane never keeps shrinking and the \
-layout stays tidy. The first `run` opens that region; later ones stack into it. Rule of thumb: don't \
-open a new pane unless you actually need one. \
+PLACEMENT — by DEFAULT you don't need to think about this: a bare `run` reuses ONE persistent terminal \
+beside you — the SAME shell across calls, so its working directory and environment persist. Do NOT `cd` \
+into your project on every run; the shell stays where it was. The first `run` opens it; later ones run \
+in that same shell. Rule of thumb: don't open a new pane unless you actually need one. \
 Override only when you mean to: \
-- `mode`: `auto` (default, reuse your region) | `split` (force a NEW pane) | `stack` (force a stacked \
-tab into the anchor's pane). \
+- `mode`: `auto` (default, reuse your one persistent shell) | `split` (force a NEW pane) | `stack` \
+(force a new stacked terminal in the anchor's pane). \
 - `beside`: anchor to a specific page — a terminal id a previous run returned, or \"self\" for your own \
 pane. With `beside` set, `stack` tabs into that page's pane and `split` splits off it. \
 - `direction`: which side for `split` (right|left|top|bottom, default right). \

--- a/crates/vmux_service/Cargo.toml
+++ b/crates/vmux_service/Cargo.toml
@@ -29,6 +29,7 @@ libc = "0.2"
 uuid = { workspace = true }
 tokio = { workspace = true }
 alacritty_terminal = { workspace = true }
+vte = "0.15"
 portable-pty = { workspace = true }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/crates/vmux_service/src/lib.rs
+++ b/crates/vmux_service/src/lib.rs
@@ -26,6 +26,8 @@ pub mod launchd;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod message;
 #[cfg(not(target_arch = "wasm32"))]
+mod osc133;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod plugin;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod process;

--- a/crates/vmux_service/src/lib.rs
+++ b/crates/vmux_service/src/lib.rs
@@ -41,6 +41,8 @@ pub mod registry;
 pub mod server;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod service;
+#[cfg(not(target_arch = "wasm32"))]
+mod shell_integration;
 #[cfg(all(target_os = "macos", not(target_arch = "wasm32")))]
 pub mod sm_app_service;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/vmux_service/src/osc133.rs
+++ b/crates/vmux_service/src/osc133.rs
@@ -60,7 +60,10 @@ mod tests {
     #[test]
     fn detects_command_start() {
         let mut s = Osc133Scanner::new();
-        assert_eq!(s.feed(&esc("\\e]133;C\\a")), vec![Osc133Event::CommandStart]);
+        assert_eq!(
+            s.feed(&esc("\\e]133;C\\a")),
+            vec![Osc133Event::CommandStart]
+        );
     }
 
     #[test]
@@ -98,7 +101,10 @@ mod tests {
     fn reassembles_sequence_split_across_feeds() {
         let mut s = Osc133Scanner::new();
         assert_eq!(s.feed(&esc("\\e]133;D")), vec![]);
-        assert_eq!(s.feed(&esc(";0\\a")), vec![Osc133Event::CommandEnd(Some(0))]);
+        assert_eq!(
+            s.feed(&esc(";0\\a")),
+            vec![Osc133Event::CommandEnd(Some(0))]
+        );
     }
 
     #[test]

--- a/crates/vmux_service/src/osc133.rs
+++ b/crates/vmux_service/src/osc133.rs
@@ -1,0 +1,118 @@
+use vte::{Parser, Perform};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Osc133Event {
+    CommandStart,
+    CommandEnd(Option<i32>),
+}
+
+pub struct Osc133Scanner {
+    parser: Parser,
+}
+
+impl Osc133Scanner {
+    pub fn new() -> Self {
+        Self {
+            parser: Parser::new(),
+        }
+    }
+
+    pub fn feed(&mut self, bytes: &[u8]) -> Vec<Osc133Event> {
+        let mut collector = Collector::default();
+        self.parser.advance(&mut collector, bytes);
+        collector.events
+    }
+}
+
+#[derive(Default)]
+struct Collector {
+    events: Vec<Osc133Event>,
+}
+
+impl Perform for Collector {
+    fn osc_dispatch(&mut self, params: &[&[u8]], _bell_terminated: bool) {
+        if params.first().copied() != Some(b"133".as_slice()) {
+            return;
+        }
+        let kind = params.get(1).copied();
+        if kind == Some(b"C".as_slice()) {
+            self.events.push(Osc133Event::CommandStart);
+        } else if kind == Some(b"D".as_slice()) {
+            let exit = params
+                .get(2)
+                .and_then(|p| std::str::from_utf8(p).ok())
+                .and_then(|s| s.trim().parse::<i32>().ok());
+            self.events.push(Osc133Event::CommandEnd(exit));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn esc(seq: &str) -> Vec<u8> {
+        seq.replace("\\e", "\u{1b}")
+            .replace("\\a", "\u{07}")
+            .into_bytes()
+    }
+
+    #[test]
+    fn detects_command_start() {
+        let mut s = Osc133Scanner::new();
+        assert_eq!(s.feed(&esc("\\e]133;C\\a")), vec![Osc133Event::CommandStart]);
+    }
+
+    #[test]
+    fn detects_command_end_with_exit_code() {
+        let mut s = Osc133Scanner::new();
+        assert_eq!(
+            s.feed(&esc("\\e]133;D;0\\a")),
+            vec![Osc133Event::CommandEnd(Some(0))]
+        );
+        assert_eq!(
+            s.feed(&esc("\\e]133;D;130\\a")),
+            vec![Osc133Event::CommandEnd(Some(130))]
+        );
+    }
+
+    #[test]
+    fn command_end_without_code_is_none() {
+        let mut s = Osc133Scanner::new();
+        assert_eq!(
+            s.feed(&esc("\\e]133;D\\a")),
+            vec![Osc133Event::CommandEnd(None)]
+        );
+    }
+
+    #[test]
+    fn accepts_st_terminator() {
+        let mut s = Osc133Scanner::new();
+        assert_eq!(
+            s.feed(&esc("\\e]133;D;0\\e\\")),
+            vec![Osc133Event::CommandEnd(Some(0))]
+        );
+    }
+
+    #[test]
+    fn reassembles_sequence_split_across_feeds() {
+        let mut s = Osc133Scanner::new();
+        assert_eq!(s.feed(&esc("\\e]133;D")), vec![]);
+        assert_eq!(s.feed(&esc(";0\\a")), vec![Osc133Event::CommandEnd(Some(0))]);
+    }
+
+    #[test]
+    fn ignores_other_osc_and_plain_text() {
+        let mut s = Osc133Scanner::new();
+        assert_eq!(s.feed(&esc("\\e]0;my title\\ahello world\n")), vec![]);
+    }
+
+    #[test]
+    fn emits_start_then_end_in_order() {
+        let mut s = Osc133Scanner::new();
+        assert_eq!(
+            s.feed(&esc("\\e]133;C\\als -la\n\\e]133;D;0\\a")),
+            vec![Osc133Event::CommandStart, Osc133Event::CommandEnd(Some(0))]
+        );
+    }
+}

--- a/crates/vmux_service/src/paths.rs
+++ b/crates/vmux_service/src/paths.rs
@@ -45,6 +45,12 @@ pub fn log_dir() -> PathBuf {
     shared_data_dir().join("logs")
 }
 
+/// Directory holding the generated per-shell OSC 133 integration snippets that
+/// spawned shells source at startup.
+pub fn shell_integration_dir() -> PathBuf {
+    shared_data_dir().join("shell-integration")
+}
+
 /// Path to today's unified log file. Matches the filename the tracing-appender
 /// DAILY rotation writes (`vmux-{profile}.{YYYY-MM-DD}.log`, UTC date), so the
 /// daemon, the desktop file layer, and the panic hook all target the same file.

--- a/crates/vmux_service/src/paths.rs
+++ b/crates/vmux_service/src/paths.rs
@@ -45,8 +45,6 @@ pub fn log_dir() -> PathBuf {
     shared_data_dir().join("logs")
 }
 
-/// Directory holding the generated per-shell OSC 133 integration snippets that
-/// spawned shells source at startup.
 pub fn shell_integration_dir() -> PathBuf {
     shared_data_dir().join("shell-integration")
 }

--- a/crates/vmux_service/src/process.rs
+++ b/crates/vmux_service/src/process.rs
@@ -231,13 +231,19 @@ impl Process {
     pub fn new_with_wake(
         id: ProcessId,
         command: String,
-        args: Vec<String>,
+        mut args: Vec<String>,
         cwd: String,
-        env: Vec<(String, String)>,
+        mut env: Vec<(String, String)>,
         cols: u16,
         rows: u16,
         wake_tx: mpsc::UnboundedSender<ProcessId>,
     ) -> Result<Self, String> {
+        crate::shell_integration::inject(
+            &command,
+            &mut args,
+            &mut env,
+            &crate::paths::shell_integration_dir(),
+        );
         let pty_system = NativePtySystem::default();
         let pair = pty_system
             .openpty(PtySize {

--- a/crates/vmux_service/src/process.rs
+++ b/crates/vmux_service/src/process.rs
@@ -76,6 +76,7 @@ pub struct Process {
     pub created_at: Instant,
     term: Term<ServiceEventProxy>,
     processor: Processor,
+    osc133: crate::osc133::Osc133Scanner,
     pty_writer: PtyInputWriter,
     master: Box<dyn portable_pty::MasterPty + Send>,
     child: Box<dyn portable_pty::Child + Send + Sync>,
@@ -320,6 +321,7 @@ impl Process {
             created_at: Instant::now(),
             term,
             processor: Processor::new(),
+            osc133: crate::osc133::Osc133Scanner::new(),
             pty_writer: writer,
             master: pair.master,
             child,
@@ -1177,6 +1179,20 @@ impl Process {
                 break;
             };
             self.processor.advance(&mut self.term, &data);
+            for event in self.osc133.feed(&data) {
+                let kind = match event {
+                    crate::osc133::Osc133Event::CommandStart => {
+                        crate::protocol::CommandLifecycleKind::Started
+                    }
+                    crate::osc133::Osc133Event::CommandEnd(exit_code) => {
+                        crate::protocol::CommandLifecycleKind::Ended { exit_code }
+                    }
+                };
+                let _ = self.patch_tx.send(ServiceMessage::CommandLifecycle {
+                    process_id: self.id,
+                    kind,
+                });
+            }
             got_data = true;
         }
         if got_data && self.copy_mode.is_none() && self.selection.is_some() {
@@ -1720,6 +1736,41 @@ mod tests {
             process.poll();
             std::thread::sleep(Duration::from_millis(10));
         }
+    }
+
+    #[test]
+    fn poll_broadcasts_command_lifecycle_from_osc133() {
+        let (wake_tx, _wake_rx) = mpsc::unbounded_channel();
+        let mut process = Process::new_with_wake(
+            ProcessId::new(),
+            "/bin/sh".to_string(),
+            vec!["-c".to_string(), "printf '\\033]133;D;0\\007'".to_string()],
+            String::new(),
+            vec![],
+            80,
+            24,
+            wake_tx,
+        )
+        .expect("spawn");
+        let mut rx = process.subscribe();
+
+        drain_process_output(&mut process, Duration::from_secs(2));
+
+        let mut saw_end = false;
+        while let Ok(msg) = rx.try_recv() {
+            if let ServiceMessage::CommandLifecycle {
+                kind: crate::protocol::CommandLifecycleKind::Ended { exit_code },
+                ..
+            } = msg
+            {
+                assert_eq!(exit_code, Some(0));
+                saw_end = true;
+            }
+        }
+        assert!(
+            saw_end,
+            "expected a CommandLifecycle Ended broadcast from OSC 133;D;0"
+        );
     }
 
     fn wait_for_snapshot_text(process: &mut Process, needle: &str) -> String {

--- a/crates/vmux_service/src/process.rs
+++ b/crates/vmux_service/src/process.rs
@@ -77,6 +77,8 @@ pub struct Process {
     term: Term<ServiceEventProxy>,
     processor: Processor,
     osc133: crate::osc133::Osc133Scanner,
+    command_ended_seq: u64,
+    last_command_exit: Option<i32>,
     pty_writer: PtyInputWriter,
     master: Box<dyn portable_pty::MasterPty + Send>,
     child: Box<dyn portable_pty::Child + Send + Sync>,
@@ -328,6 +330,8 @@ impl Process {
             term,
             processor: Processor::new(),
             osc133: crate::osc133::Osc133Scanner::new(),
+            command_ended_seq: 0,
+            last_command_exit: None,
             pty_writer: writer,
             master: pair.master,
             child,
@@ -345,6 +349,13 @@ impl Process {
 
     pub fn subscribe(&self) -> broadcast::Receiver<ServiceMessage> {
         self.patch_tx.subscribe()
+    }
+
+    /// Monotonic count of completed commands (OSC 133;D seen) and the most
+    /// recent command's exit code. A `run` captures the count as a baseline,
+    /// then waits for it to advance to learn its command finished.
+    pub fn command_status(&self) -> (u64, Option<i32>) {
+        (self.command_ended_seq, self.last_command_exit)
     }
 
     pub fn write_input(&self, data: &[u8]) {
@@ -1191,6 +1202,8 @@ impl Process {
                         crate::protocol::CommandLifecycleKind::Started
                     }
                     crate::osc133::Osc133Event::CommandEnd(exit_code) => {
+                        self.command_ended_seq = self.command_ended_seq.wrapping_add(1);
+                        self.last_command_exit = exit_code;
                         crate::protocol::CommandLifecycleKind::Ended { exit_code }
                     }
                 };
@@ -1776,6 +1789,11 @@ mod tests {
         assert!(
             saw_end,
             "expected a CommandLifecycle Ended broadcast from OSC 133;D;0"
+        );
+        assert_eq!(
+            process.command_status(),
+            (1, Some(0)),
+            "command_status must record one completed command with its exit code"
         );
     }
 

--- a/crates/vmux_service/src/process.rs
+++ b/crates/vmux_service/src/process.rs
@@ -351,9 +351,6 @@ impl Process {
         self.patch_tx.subscribe()
     }
 
-    /// Monotonic count of completed commands (OSC 133;D seen) and the most
-    /// recent command's exit code. A `run` captures the count as a baseline,
-    /// then waits for it to advance to learn its command finished.
     pub fn command_status(&self) -> (u64, Option<i32>) {
         (self.command_ended_seq, self.last_command_exit)
     }

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -429,6 +429,12 @@ pub enum CopyModeKey {
 }
 
 /// Messages sent from the service to the GUI client.
+#[derive(Debug, Clone, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub enum CommandLifecycleKind {
+    Started,
+    Ended { exit_code: Option<i32> },
+}
+
 #[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum ServiceMessage {
     ProcessCreated {
@@ -460,6 +466,10 @@ pub enum ServiceMessage {
     ProcessTitle {
         process_id: ProcessId,
         title: String,
+    },
+    CommandLifecycle {
+        process_id: ProcessId,
+        kind: CommandLifecycleKind,
     },
     ProcessList {
         processes: Vec<ProcessInfo>,

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -159,6 +159,12 @@ pub enum AgentQuery {
     ReadTerminalFull {
         process_id: ProcessId,
     },
+    /// Lifecycle status of a process: the count of completed commands (OSC
+    /// 133;D) and the most recent exit code. Used by `run` to detect when its
+    /// command finished without a sentinel marker in the command line.
+    CommandExit {
+        process_id: ProcessId,
+    },
     GetSettings,
     ListSpaces,
 }
@@ -169,6 +175,7 @@ pub enum AgentQueryResult {
     Text(String),
     Settings(String),
     Spaces(String),
+    CommandExit { seq: u64, exit: Option<i32> },
     Error(String),
 }
 

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -159,9 +159,6 @@ pub enum AgentQuery {
     ReadTerminalFull {
         process_id: ProcessId,
     },
-    /// Lifecycle status of a process: the count of completed commands (OSC
-    /// 133;D) and the most recent exit code. Used by `run` to detect when its
-    /// command finished without a sentinel marker in the command line.
     CommandExit {
         process_id: ProcessId,
     },

--- a/crates/vmux_service/src/server.rs
+++ b/crates/vmux_service/src/server.rs
@@ -175,6 +175,9 @@ fn query_result_to_content(result: crate::protocol::AgentQueryResult) -> (String
         AgentQueryResult::Text(text) => (text, false),
         AgentQueryResult::Settings(json) => (json, false),
         AgentQueryResult::Spaces(json) => (json, false),
+        AgentQueryResult::CommandExit { seq, exit } => {
+            (format!("{{\"seq\":{seq},\"exit\":{exit:?}}}"), false)
+        }
         AgentQueryResult::Error(message) => (message, true),
     }
 }
@@ -563,6 +566,24 @@ async fn handle_client(
                             match mgr.processes.get(&process_id) {
                                 Some(process) => {
                                     crate::protocol::AgentQueryResult::Text(process.full_text())
+                                }
+                                None => crate::protocol::AgentQueryResult::Error(format!(
+                                    "process not found: {process_id}"
+                                )),
+                            }
+                        };
+                        let resp = ServiceMessage::AgentQueryResult { request_id, result };
+                        let mut w = writer.lock().await;
+                        write_message!(&mut *w, &resp)?;
+                        continue;
+                    }
+                    crate::protocol::AgentQuery::CommandExit { process_id } => {
+                        let result = {
+                            let mgr = manager.lock().await;
+                            match mgr.processes.get(&process_id) {
+                                Some(process) => {
+                                    let (seq, exit) = process.command_status();
+                                    crate::protocol::AgentQueryResult::CommandExit { seq, exit }
                                 }
                                 None => crate::protocol::AgentQueryResult::Error(format!(
                                     "process not found: {process_id}"

--- a/crates/vmux_service/src/server.rs
+++ b/crates/vmux_service/src/server.rs
@@ -176,7 +176,8 @@ fn query_result_to_content(result: crate::protocol::AgentQueryResult) -> (String
         AgentQueryResult::Settings(json) => (json, false),
         AgentQueryResult::Spaces(json) => (json, false),
         AgentQueryResult::CommandExit { seq, exit } => {
-            (format!("{{\"seq\":{seq},\"exit\":{exit:?}}}"), false)
+            let exit = exit.map_or_else(|| "null".to_string(), |code| code.to_string());
+            (format!("{{\"seq\":{seq},\"exit\":{exit}}}"), false)
         }
         AgentQueryResult::Error(message) => (message, true),
     }

--- a/crates/vmux_service/src/shell_integration.rs
+++ b/crates/vmux_service/src/shell_integration.rs
@@ -1,0 +1,243 @@
+use std::path::Path;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Shell {
+    Bash,
+    Zsh,
+    Fish,
+    Nu,
+}
+
+pub fn detect_shell(command: &str) -> Option<Shell> {
+    let base = Path::new(command).file_name()?.to_str()?;
+    match base {
+        "bash" => Some(Shell::Bash),
+        "zsh" => Some(Shell::Zsh),
+        "fish" => Some(Shell::Fish),
+        "nu" | "nushell" => Some(Shell::Nu),
+        _ => None,
+    }
+}
+
+const BASH_RC: &str = r#"[ -r "$HOME/.bashrc" ] && . "$HOME/.bashrc"
+if [[ $- == *i* ]]; then
+  __vmux_at_prompt=1
+  __vmux_preexec() { [ -n "$__vmux_at_prompt" ] || return; __vmux_at_prompt=; printf '\033]133;C\007'; }
+  __vmux_precmd() { local s=$?; printf '\033]133;D;%s\007' "$s"; __vmux_at_prompt=1; }
+  trap '__vmux_preexec' DEBUG
+  PROMPT_COMMAND='__vmux_precmd'"${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
+fi
+"#;
+
+const ZSH_ZSHENV: &str = r#"ZDOTDIR="${__VMUX_ZDOTDIR_ORIG:-$HOME}"
+[ -r "$ZDOTDIR/.zshenv" ] && source "$ZDOTDIR/.zshenv"
+"#;
+
+const ZSH_ZSHRC: &str = r#"ZDOTDIR="${__VMUX_ZDOTDIR_ORIG:-$HOME}"
+[ -r "$ZDOTDIR/.zshrc" ] && source "$ZDOTDIR/.zshrc"
+autoload -Uz add-zsh-hook 2>/dev/null
+__vmux_pe() { printf '\033]133;C\007' }
+__vmux_pc() { printf '\033]133;D;%s\007' "$?" }
+add-zsh-hook preexec __vmux_pe 2>/dev/null
+add-zsh-hook precmd __vmux_pc 2>/dev/null
+"#;
+
+const FISH_INIT: &str = "function __vmux_pe --on-event fish_preexec; printf '\\033]133;C\\007'; end; function __vmux_pc --on-event fish_postexec; printf '\\033]133;D;%s\\007' $status; end";
+
+const NU_HOOKS: &str = r#"$env.config.hooks.pre_execution = ($env.config.hooks.pre_execution? | default [] | append {|| print -rn $"\u{1b}]133;C\u{7}" })
+$env.config.hooks.pre_prompt = ($env.config.hooks.pre_prompt? | default [] | append {|| print -rn $"\u{1b}]133;D;($env.LAST_EXIT_CODE)\u{7}" })
+"#;
+
+fn set_env(env: &mut Vec<(String, String)>, key: &str, value: String) {
+    if let Some(entry) = env.iter_mut().find(|(k, _)| k == key) {
+        entry.1 = value;
+    } else {
+        env.push((key.to_string(), value));
+    }
+}
+
+fn prepend_args(args: &mut Vec<String>, mut head: Vec<String>) {
+    head.append(args);
+    *args = head;
+}
+
+/// Resolve the user's nushell config dir so the generated config can re-source it.
+fn nu_config_dir() -> Option<std::path::PathBuf> {
+    if let Some(dir) = std::env::var_os("NU_CONFIG_DIR") {
+        return Some(std::path::PathBuf::from(dir));
+    }
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+        return Some(std::path::PathBuf::from(xdg).join("nushell"));
+    }
+    let home = std::env::var_os("HOME")?;
+    Some(std::path::PathBuf::from(home).join("Library/Application Support/nushell"))
+}
+
+fn nu_config() -> String {
+    let mut out = String::new();
+    if let Some(user) = nu_config_dir().map(|d| d.join("config.nu")) {
+        if user.exists() {
+            out.push_str(&format!("source \"{}\"\n", user.display()));
+        }
+    }
+    out.push_str(NU_HOOKS);
+    out
+}
+
+/// Augment `args`/`env` so the spawned shell emits OSC 133 command-lifecycle
+/// markers. No-op for unrecognized shells and for one-shot `-c` invocations
+/// (those are command executions, not interactive prompt loops). Snippet files
+/// are written under `dir`.
+pub fn inject(command: &str, args: &mut Vec<String>, env: &mut Vec<(String, String)>, dir: &Path) {
+    if args.iter().any(|a| a == "-c") {
+        return;
+    }
+    let Some(shell) = detect_shell(command) else {
+        return;
+    };
+    let _ = std::fs::create_dir_all(dir);
+    match shell {
+        Shell::Bash => {
+            let rc = dir.join("bashrc");
+            if std::fs::write(&rc, BASH_RC).is_ok() {
+                prepend_args(
+                    args,
+                    vec!["--rcfile".to_string(), rc.to_string_lossy().into_owned()],
+                );
+            }
+        }
+        Shell::Zsh => {
+            let zdir = dir.join("zsh");
+            if std::fs::create_dir_all(&zdir).is_ok()
+                && std::fs::write(zdir.join(".zshenv"), ZSH_ZSHENV).is_ok()
+                && std::fs::write(zdir.join(".zshrc"), ZSH_ZSHRC).is_ok()
+            {
+                let orig = env
+                    .iter()
+                    .find(|(k, _)| k == "ZDOTDIR")
+                    .map(|(_, v)| v.clone())
+                    .or_else(|| std::env::var("ZDOTDIR").ok())
+                    .or_else(|| std::env::var("HOME").ok())
+                    .unwrap_or_default();
+                set_env(env, "__VMUX_ZDOTDIR_ORIG", orig);
+                set_env(env, "ZDOTDIR", zdir.to_string_lossy().into_owned());
+            }
+        }
+        Shell::Fish => {
+            prepend_args(
+                args,
+                vec!["--init-command".to_string(), FISH_INIT.to_string()],
+            );
+        }
+        Shell::Nu => {
+            let cfg = dir.join("config.nu");
+            if std::fs::write(&cfg, nu_config()).is_ok() {
+                prepend_args(
+                    args,
+                    vec!["--config".to_string(), cfg.to_string_lossy().into_owned()],
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_known_shells_by_basename() {
+        assert_eq!(detect_shell("/bin/bash"), Some(Shell::Bash));
+        assert_eq!(detect_shell("/usr/bin/zsh"), Some(Shell::Zsh));
+        assert_eq!(detect_shell("/opt/homebrew/bin/fish"), Some(Shell::Fish));
+        assert_eq!(detect_shell("/opt/homebrew/bin/nu"), Some(Shell::Nu));
+        assert_eq!(detect_shell("nu"), Some(Shell::Nu));
+        assert_eq!(detect_shell("/bin/sh"), None);
+        assert_eq!(detect_shell("/usr/bin/python3"), None);
+    }
+
+    #[test]
+    fn skips_one_shot_dash_c_invocations() {
+        let dir = std::env::temp_dir().join("vmux-si-test-dashc");
+        let mut args = vec!["-c".to_string(), "echo hi".to_string()];
+        let mut env = vec![];
+        inject("/bin/bash", &mut args, &mut env, &dir);
+        assert_eq!(args, vec!["-c".to_string(), "echo hi".to_string()]);
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn skips_unknown_shell() {
+        let dir = std::env::temp_dir().join("vmux-si-test-unknown");
+        let mut args: Vec<String> = vec![];
+        let mut env = vec![];
+        inject("/bin/sh", &mut args, &mut env, &dir);
+        assert!(args.is_empty());
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn bash_injects_rcfile_arg() {
+        let dir = std::env::temp_dir().join(format!("vmux-si-bash-{}", std::process::id()));
+        let mut args: Vec<String> = vec![];
+        let mut env = vec![];
+        inject("/bin/bash", &mut args, &mut env, &dir);
+        assert_eq!(args.first().map(String::as_str), Some("--rcfile"));
+        assert!(args[1].ends_with("bashrc"));
+        assert!(
+            std::fs::read_to_string(dir.join("bashrc"))
+                .unwrap()
+                .contains("133;C")
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn zsh_sets_zdotdir_env_and_preserves_original() {
+        let dir = std::env::temp_dir().join(format!("vmux-si-zsh-{}", std::process::id()));
+        let mut args: Vec<String> = vec![];
+        let mut env = vec![("ZDOTDIR".to_string(), "/user/zdot".to_string())];
+        inject("/usr/bin/zsh", &mut args, &mut env, &dir);
+        assert!(args.is_empty());
+        let zdot = env.iter().find(|(k, _)| k == "ZDOTDIR").unwrap();
+        assert!(zdot.1.ends_with("zsh"));
+        let orig = env
+            .iter()
+            .find(|(k, _)| k == "__VMUX_ZDOTDIR_ORIG")
+            .unwrap();
+        assert_eq!(orig.1, "/user/zdot");
+        assert!(
+            std::fs::read_to_string(dir.join("zsh/.zshrc"))
+                .unwrap()
+                .contains("add-zsh-hook")
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn fish_injects_inline_init_command() {
+        let dir = std::env::temp_dir().join("vmux-si-fish");
+        let mut args: Vec<String> = vec![];
+        let mut env = vec![];
+        inject("/opt/homebrew/bin/fish", &mut args, &mut env, &dir);
+        assert_eq!(args.first().map(String::as_str), Some("--init-command"));
+        assert!(args[1].contains("fish_preexec"));
+        assert!(args[1].contains("133;C"));
+    }
+
+    #[test]
+    fn nu_injects_config_arg() {
+        let dir = std::env::temp_dir().join(format!("vmux-si-nu-{}", std::process::id()));
+        let mut args: Vec<String> = vec![];
+        let mut env = vec![];
+        inject("/opt/homebrew/bin/nu", &mut args, &mut env, &dir);
+        assert_eq!(args.first().map(String::as_str), Some("--config"));
+        assert!(args[1].ends_with("config.nu"));
+        assert!(
+            std::fs::read_to_string(dir.join("config.nu"))
+                .unwrap()
+                .contains("pre_prompt")
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/vmux_service/src/shell_integration.rs
+++ b/crates/vmux_service/src/shell_integration.rs
@@ -61,7 +61,6 @@ fn prepend_args(args: &mut Vec<String>, mut head: Vec<String>) {
     *args = head;
 }
 
-/// Resolve the user's nushell config dir so the generated config can re-source it.
 fn nu_config_dir() -> Option<std::path::PathBuf> {
     if let Some(dir) = std::env::var_os("NU_CONFIG_DIR") {
         return Some(std::path::PathBuf::from(dir));
@@ -75,19 +74,15 @@ fn nu_config_dir() -> Option<std::path::PathBuf> {
 
 fn nu_config() -> String {
     let mut out = String::new();
-    if let Some(user) = nu_config_dir().map(|d| d.join("config.nu")) {
-        if user.exists() {
-            out.push_str(&format!("source \"{}\"\n", user.display()));
-        }
+    if let Some(user) = nu_config_dir().map(|d| d.join("config.nu"))
+        && user.exists()
+    {
+        out.push_str(&format!("source \"{}\"\n", user.display()));
     }
     out.push_str(NU_HOOKS);
     out
 }
 
-/// Augment `args`/`env` so the spawned shell emits OSC 133 command-lifecycle
-/// markers. No-op for unrecognized shells and for one-shot `-c` invocations
-/// (those are command executions, not interactive prompt loops). Snippet files
-/// are written under `dir`.
 pub fn inject(command: &str, args: &mut Vec<String>, env: &mut Vec<(String, String)>, dir: &Path) {
     if args.iter().any(|a| a == "-c") {
         return;

--- a/crates/vmux_service/src/shell_integration.rs
+++ b/crates/vmux_service/src/shell_integration.rs
@@ -68,8 +68,13 @@ fn nu_config_dir() -> Option<std::path::PathBuf> {
     if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
         return Some(std::path::PathBuf::from(xdg).join("nushell"));
     }
-    let home = std::env::var_os("HOME")?;
-    Some(std::path::PathBuf::from(home).join("Library/Application Support/nushell"))
+    let home = std::path::PathBuf::from(std::env::var_os("HOME")?);
+    let base = if cfg!(target_os = "macos") {
+        home.join("Library/Application Support")
+    } else {
+        home.join(".config")
+    };
+    Some(base.join("nushell"))
 }
 
 fn nu_config() -> String {

--- a/docs/plans/2026-06-21-shell-integration-osc133-parsing.md
+++ b/docs/plans/2026-06-21-shell-integration-osc133-parsing.md
@@ -12,7 +12,7 @@
 
 ---
 
-### Task 1: Add the `vte` dependency
+## Task 1: Add the `vte` dependency
 
 **Files:**
 - Modify: `crates/vmux_service/Cargo.toml`
@@ -44,7 +44,7 @@ git commit -m "build(service): add vte dependency for OSC 133 parsing"
 
 ---
 
-### Task 2: Add the `CommandLifecycle` message
+## Task 2: Add the `CommandLifecycle` message
 
 **Files:**
 - Modify: `crates/vmux_service/src/protocol.rs` (the `ServiceMessage` enum begins at line 433; `ProcessTitle` at 460 is the template)
@@ -89,7 +89,7 @@ git commit -m "feat(service): add CommandLifecycle service message"
 
 ---
 
-### Task 3: OSC 133 scanner (pure, unit-tested)
+## Task 3: OSC 133 scanner (pure, unit-tested)
 
 **Files:**
 - Create: `crates/vmux_service/src/osc133.rs`
@@ -257,7 +257,7 @@ git commit -m "feat(service): OSC 133 scanner over a parallel vte parser"
 
 ---
 
-### Task 4: Wire the scanner into `Process` and broadcast lifecycle events
+## Task 4: Wire the scanner into `Process` and broadcast lifecycle events
 
 **Files:**
 - Modify: `crates/vmux_service/src/process.rs` (struct at line 69, `new_with_wake` init around line 304-327, drain `poll()` at 1173-1198)

--- a/docs/plans/2026-06-21-shell-integration-osc133-parsing.md
+++ b/docs/plans/2026-06-21-shell-integration-osc133-parsing.md
@@ -1,0 +1,382 @@
+# Shell Integration — Plan 1: OSC 133 parse foundation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `vmux_service` detect OSC 133 command-lifecycle markers (`C` = command start, `D;<exit>` = command end) in PTY output and broadcast them as a new `ServiceMessage::CommandLifecycle`, without changing any existing behavior.
+
+**Architecture:** The service parses PTY bytes with `alacritty_terminal`'s vte, whose high-level `Handler` ignores OSC 133. Rather than hand-roll a byte scanner, run a second, tiny `vte::Parser` per `Process` whose `Perform` only inspects `osc_dispatch` for `133`. vte handles ESC/OSC framing, `ST` vs `BEL`, and chunk-split reassembly. The drain loop feeds this scanner the same bytes it feeds alacritty and broadcasts a `CommandLifecycle` for each event. Nothing consumes the new message yet (additive, safe to ship).
+
+**Tech Stack:** Rust, `vte` 0.15 (already a transitive dep via `alacritty_terminal`), `tokio::sync::broadcast`, `rkyv` (wire serialization for `ServiceMessage`).
+
+**Spec:** `docs/specs/2026-06-21-shell-integration-command-lifecycle-design.md`
+
+---
+
+### Task 1: Add the `vte` dependency
+
+**Files:**
+- Modify: `crates/vmux_service/Cargo.toml`
+
+- [ ] **Step 1: Add the dependency**
+
+In `crates/vmux_service/Cargo.toml`, under `[dependencies]` (next to `alacritty_terminal`), add:
+
+```toml
+vte = "0.15"
+```
+
+- [ ] **Step 2: Verify it resolves to the same version alacritty uses**
+
+Run: `cargo tree -p vmux_service -i vte`
+Expected: a single `vte v0.15.x` (no duplicate versions). If a second version appears, pin `vte` to the exact version printed under `alacritty_terminal`.
+
+- [ ] **Step 3: Verify it builds**
+
+Run: `cargo build -p vmux_service`
+Expected: builds with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/vmux_service/Cargo.toml Cargo.lock
+git commit -m "build(service): add vte dependency for OSC 133 parsing"
+```
+
+---
+
+### Task 2: Add the `CommandLifecycle` message
+
+**Files:**
+- Modify: `crates/vmux_service/src/protocol.rs` (the `ServiceMessage` enum begins at line 433; `ProcessTitle` at 460 is the template)
+
+- [ ] **Step 1: Add the kind enum**
+
+Immediately above `pub enum ServiceMessage` (line 433), add a new enum with the same derives:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub enum CommandLifecycleKind {
+    /// OSC 133;C — a command began executing.
+    Started,
+    /// OSC 133;D;<exit> — a command finished; `exit_code` is None if the shell
+    /// omitted it.
+    Ended { exit_code: Option<i32> },
+}
+```
+
+- [ ] **Step 2: Add the message variant**
+
+Inside `pub enum ServiceMessage`, after the `ProcessTitle { .. }` variant (ends line 463), add:
+
+```rust
+    CommandLifecycle {
+        process_id: ProcessId,
+        kind: CommandLifecycleKind,
+    },
+```
+
+- [ ] **Step 3: Verify it builds**
+
+Run: `cargo build -p vmux_service`
+Expected: builds. (Any `match` on `ServiceMessage` that is non-exhaustive will fail to compile — if so, add a `ServiceMessage::CommandLifecycle { .. } => {}` arm wherever the compiler points, since no existing code consumes it yet.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/vmux_service/src/protocol.rs
+git commit -m "feat(service): add CommandLifecycle service message"
+```
+
+---
+
+### Task 3: OSC 133 scanner (pure, unit-tested)
+
+**Files:**
+- Create: `crates/vmux_service/src/osc133.rs`
+- Modify: `crates/vmux_service/src/lib.rs` (add `mod osc133;` — check the file for how sibling modules like `process` and `protocol` are declared and match that style)
+
+- [ ] **Step 1: Declare the module**
+
+In `crates/vmux_service/src/lib.rs`, add alongside the other `mod` declarations:
+
+```rust
+mod osc133;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `crates/vmux_service/src/osc133.rs` with the test module only (the types it references don't exist yet, so it won't compile — that is the "failing" state for this pure unit):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn esc(seq: &str) -> Vec<u8> {
+        seq.replace("\\e", "\u{1b}")
+            .replace("\\a", "\u{07}")
+            .into_bytes()
+    }
+
+    #[test]
+    fn detects_command_start() {
+        let mut s = Osc133Scanner::new();
+        assert_eq!(s.feed(&esc("\\e]133;C\\a")), vec![Osc133Event::CommandStart]);
+    }
+
+    #[test]
+    fn detects_command_end_with_exit_code() {
+        let mut s = Osc133Scanner::new();
+        assert_eq!(
+            s.feed(&esc("\\e]133;D;0\\a")),
+            vec![Osc133Event::CommandEnd(Some(0))]
+        );
+        assert_eq!(
+            s.feed(&esc("\\e]133;D;130\\a")),
+            vec![Osc133Event::CommandEnd(Some(130))]
+        );
+    }
+
+    #[test]
+    fn command_end_without_code_is_none() {
+        let mut s = Osc133Scanner::new();
+        assert_eq!(
+            s.feed(&esc("\\e]133;D\\a")),
+            vec![Osc133Event::CommandEnd(None)]
+        );
+    }
+
+    #[test]
+    fn accepts_st_terminator() {
+        let mut s = Osc133Scanner::new();
+        assert_eq!(
+            s.feed(&esc("\\e]133;D;0\\e\\")),
+            vec![Osc133Event::CommandEnd(Some(0))]
+        );
+    }
+
+    #[test]
+    fn reassembles_sequence_split_across_feeds() {
+        let mut s = Osc133Scanner::new();
+        assert_eq!(s.feed(&esc("\\e]133;D")), vec![]);
+        assert_eq!(s.feed(&esc(";0\\a")), vec![Osc133Event::CommandEnd(Some(0))]);
+    }
+
+    #[test]
+    fn ignores_other_osc_and_plain_text() {
+        let mut s = Osc133Scanner::new();
+        // OSC 0 (title) + normal text must yield nothing.
+        assert_eq!(s.feed(&esc("\\e]0;my title\\ahello world\n")), vec![]);
+    }
+
+    #[test]
+    fn emits_start_then_end_in_order() {
+        let mut s = Osc133Scanner::new();
+        assert_eq!(
+            s.feed(&esc("\\e]133;C\\als -la\n\\e]133;D;0\\a")),
+            vec![Osc133Event::CommandStart, Osc133Event::CommandEnd(Some(0))]
+        );
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `cargo test -p vmux_service osc133 2>&1 | head -20`
+Expected: compile error — `Osc133Scanner`/`Osc133Event` not found.
+
+- [ ] **Step 4: Write the implementation**
+
+At the **top** of `crates/vmux_service/src/osc133.rs` (above the `#[cfg(test)] mod tests`), add:
+
+```rust
+use vte::{Parser, Perform};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Osc133Event {
+    /// OSC 133;C
+    CommandStart,
+    /// OSC 133;D;<exit>
+    CommandEnd(Option<i32>),
+}
+
+/// Watches a PTY byte stream for OSC 133 semantic-prompt markers, reusing vte's
+/// state machine so split chunks and `ST`/`BEL` terminators are handled for us.
+pub struct Osc133Scanner {
+    parser: Parser,
+}
+
+impl Osc133Scanner {
+    pub fn new() -> Self {
+        Self { parser: Parser::new() }
+    }
+
+    /// Feed a chunk of PTY output; returns any OSC 133 events completed by it.
+    pub fn feed(&mut self, bytes: &[u8]) -> Vec<Osc133Event> {
+        let mut collector = Collector::default();
+        self.parser.advance(&mut collector, bytes);
+        collector.events
+    }
+}
+
+#[derive(Default)]
+struct Collector {
+    events: Vec<Osc133Event>,
+}
+
+impl Perform for Collector {
+    fn osc_dispatch(&mut self, params: &[&[u8]], _bell_terminated: bool) {
+        if params.first().copied() != Some(b"133".as_slice()) {
+            return;
+        }
+        let kind = params.get(1).copied();
+        if kind == Some(b"C".as_slice()) {
+            self.events.push(Osc133Event::CommandStart);
+        } else if kind == Some(b"D".as_slice()) {
+            let exit = params
+                .get(2)
+                .and_then(|p| std::str::from_utf8(p).ok())
+                .and_then(|s| s.trim().parse::<i32>().ok());
+            self.events.push(Osc133Event::CommandEnd(exit));
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test -p vmux_service osc133`
+Expected: all 7 tests pass, output pristine.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/vmux_service/src/osc133.rs crates/vmux_service/src/lib.rs
+git commit -m "feat(service): OSC 133 scanner over a parallel vte parser"
+```
+
+---
+
+### Task 4: Wire the scanner into `Process` and broadcast lifecycle events
+
+**Files:**
+- Modify: `crates/vmux_service/src/process.rs` (struct at line 69, `new_with_wake` init around line 304-327, drain `poll()` at 1173-1198)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add this test to the existing `#[cfg(test)] mod tests` in `crates/vmux_service/src/process.rs` (use the existing `drain_process_output` helper at line 1717 and the `subscribe()` pattern from `proxy_broadcasts_process_title_on_term_title_event`):
+
+```rust
+    #[test]
+    fn poll_broadcasts_command_lifecycle_from_osc133() {
+        let (wake_tx, _wake_rx) = mpsc::unbounded_channel();
+        let mut process = Process::new_with_wake(
+            ProcessId::new(),
+            "/bin/sh".to_string(),
+            vec![
+                "-c".to_string(),
+                // Emit an OSC 133;D;0 sequence, then exit.
+                "printf '\\033]133;D;0\\007'".to_string(),
+            ],
+            String::new(),
+            vec![],
+            80,
+            24,
+            wake_tx,
+        )
+        .expect("spawn");
+        let mut rx = process.subscribe();
+
+        drain_process_output(&mut process, std::time::Duration::from_secs(2));
+
+        let mut saw_end = false;
+        while let Ok(msg) = rx.try_recv() {
+            if let ServiceMessage::CommandLifecycle {
+                kind: crate::protocol::CommandLifecycleKind::Ended { exit_code },
+                ..
+            } = msg
+            {
+                assert_eq!(exit_code, Some(0));
+                saw_end = true;
+            }
+        }
+        assert!(saw_end, "expected a CommandLifecycle Ended broadcast from OSC 133;D;0");
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p vmux_service poll_broadcasts_command_lifecycle_from_osc133 -- --nocapture`
+Expected: FAIL — no `CommandLifecycle` is ever broadcast (and `Process` has no scanner field yet, so this may be a compile error first; either failure is acceptable for RED).
+
+- [ ] **Step 3: Add the scanner field to `Process`**
+
+In the `Process` struct (line 69), after the `processor: Processor,` field (line 78), add:
+
+```rust
+    osc133: crate::osc133::Osc133Scanner,
+```
+
+- [ ] **Step 4: Initialize it in `new_with_wake`**
+
+In the struct literal returned by `new_with_wake` (the block initializing `processor: Processor::new(),` around line 322), add:
+
+```rust
+            osc133: crate::osc133::Osc133Scanner::new(),
+```
+
+- [ ] **Step 5: Feed the scanner + broadcast in `poll()`**
+
+In `poll()` (line 1173), replace the drain body that currently reads:
+
+```rust
+            self.processor.advance(&mut self.term, &data);
+            got_data = true;
+```
+
+with:
+
+```rust
+            self.processor.advance(&mut self.term, &data);
+            for event in self.osc133.feed(&data) {
+                let kind = match event {
+                    crate::osc133::Osc133Event::CommandStart => {
+                        crate::protocol::CommandLifecycleKind::Started
+                    }
+                    crate::osc133::Osc133Event::CommandEnd(exit_code) => {
+                        crate::protocol::CommandLifecycleKind::Ended { exit_code }
+                    }
+                };
+                let _ = self.patch_tx.send(ServiceMessage::CommandLifecycle {
+                    process_id: self.id,
+                    kind,
+                });
+            }
+            got_data = true;
+```
+
+- [ ] **Step 6: Run the integration test to verify it passes**
+
+Run: `cargo test -p vmux_service poll_broadcasts_command_lifecycle_from_osc133`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full crate test suite to check for regressions**
+
+Run: `cargo test -p vmux_service`
+Expected: all pass, output pristine.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/vmux_service/src/process.rs
+git commit -m "feat(service): broadcast CommandLifecycle from PTY OSC 133 markers"
+```
+
+---
+
+## Out of scope (later plans)
+
+- **Plan 2 — Emit + inject:** per-shell OSC 133 snippets (bash/zsh/fish/nu) shipped in the app bundle, injected at PTY spawn via each shell's native init (`--rcfile`, `ZDOTDIR`, `--init-command`, nu config) with no dotfile edits.
+- **Plan 3 — Consume + cleanup:** rewire MCP `run` (`vmux_mcp/src/protocol.rs`) to wait on `CommandLifecycle::Ended` instead of scraping `__VMUX_DONE_`; delete the `run_command_line` wrapper (`vmux_agent/src/plugin.rs:582`) and the sentinel parser; add the unknown-shell fallback.
+
+These depend on Plan 1's `CommandLifecycle` API and are written once Plan 1 lands.

--- a/docs/specs/2026-06-21-shell-integration-command-lifecycle-design.md
+++ b/docs/specs/2026-06-21-shell-integration-command-lifecycle-design.md
@@ -1,0 +1,156 @@
+# Shell integration: systematic command lifecycle via OSC 133
+
+Date: 2026-06-21
+Status: draft (pending review)
+
+## Problem
+
+`vmux run` (agent/MCP command execution) learns when an injected command finishes,
+and its exit code, by **rewriting the command**. `run_command_line`
+(`vmux_agent/src/plugin.rs:582`) wraps every command per shell:
+
+- nu: `try { <cmd>; print "\n__VMUX_DONE_<token>_($env.LAST_EXIT_CODE)__" } catch { |e| print "\n__VMUX_DONE_<token>_($e.exit_code? | default 1)__" }`
+- fish: `<cmd>; printf '\n__VMUX_DONE_<token>_%s__\n' $status`
+- bash/zsh/other: `<cmd>; printf '\n__VMUX_DONE_<token>_%s__\n' "$?"`
+
+`vmux_mcp/src/protocol.rs` then polls the terminal output and scrapes
+`__VMUX_DONE_<token>_<exit>__` to detect completion + exit code.
+
+Problems:
+
+- **The user sees the wrapper, not their command.** The instrumented line is what is
+  typed into the shell, shown in the viewport, and stored in shell history. Re-running
+  from history re-runs the wrapper.
+- **Fragile.** try/catch + per-shell exit-code extraction; nu needs special-casing; any
+  shell whose `$?` / `$status` / `LAST_EXIT_CODE` semantics differ breaks it.
+- **Per-command cost, no general signal.** Every run pays the wrapping, and the rest of
+  vmux has no notion of "a command started / ended" (for UI status, output capture, etc.).
+
+## Goals
+
+- The user types, sees, re-runs, and gets shell history of **exactly their command** — no
+  wrapper, no sentinel.
+- Command **start / end + exit code** are detected systematically for **every** command in
+  a terminal, not just `vmux run`.
+- Native support for the shells vmux targets: **bash, zsh, fish, nu**.
+- No permanent edits to the user's dotfiles.
+
+## Non-goals
+
+- Capturing / segmenting per-command output ranges for the UI (the lifecycle events make
+  this possible later; not built here).
+- Shells beyond the big four — those get a fallback (below), not native integration.
+- Changing the interactive terminal renderer.
+
+## Decisions (from brainstorming)
+
+- **Markers:** standard **OSC 133** semantic-prompt sequences (FinalTerm; same family as
+  iTerm2 / VSCode / WezTerm), so they are invisible escape codes and interoperable.
+- **Scope:** every command (full shell integration), installed once per session.
+- **Injection:** at PTY spawn, via each shell's native init mechanism — no dotfile edits.
+- **Parsing:** in `vmux_service`, by scanning the PTY byte stream for OSC 133 (alacritty
+  already ignores it, so nothing leaks into the grid).
+- **Fallback:** unknown / unsupported shell → keep a minimal `__VMUX_DONE_` sentinel (or
+  bash wrapper) for `run`, accepting command-mangling only there.
+
+## Architecture
+
+### OSC 133 markers
+
+The shell emits, around each prompt / command:
+
+- `OSC 133 ; A ST` — prompt start
+- `OSC 133 ; B ST` — prompt end / command start
+- `OSC 133 ; C ST` — pre-execution (command is running)
+- `OSC 133 ; D ; <exit> ST` — command end, with exit code
+
+(`OSC` = `ESC ]`, `ST` = `ESC \` or `BEL`.) vmux only needs `C` (a command started) and
+`D;<exit>` (it ended with code). `A` / `B` are emitted for interop and future use.
+
+### Per-shell emission (injected snippets)
+
+Small native snippets, shipped + versioned by vmux. Sketches:
+
+- **bash** — `trap ... DEBUG` (preexec) + `PROMPT_COMMAND` (precmd), or bash-preexec: emit
+  `C` before a command and `D;$?` before the next prompt. Adapt the well-known VSCode / iTerm
+  bash integration.
+- **zsh** — `preexec` / `precmd` hooks emit `C` and `D;$?`.
+- **fish** — `fish_preexec` / `fish_postexec` events emit `C` and `D;$status`.
+- **nu** — `$env.config.hooks.pre_execution` emits `C`; `pre_prompt` emits
+  `D;($env.LAST_EXIT_CODE)`.
+
+### Injection at PTY spawn (no dotfile edits)
+
+`Process::new_with_wake` (`vmux_service/src/process.rs:250`) already controls the shell
+`command`, `args`, and `env`. Inject the integration via each shell's native,
+non-persistent init:
+
+- **bash** — `--rcfile <vmux-snippet>`; the snippet first sources the user's `~/.bashrc`,
+  then installs hooks.
+- **zsh** — set `ZDOTDIR` to a temp dir whose `.zshrc` sources the user's, then installs
+  hooks.
+- **fish** — `--init-command 'source <vmux-snippet>'` (or a `conf.d` entry).
+- **nu** — source the snippet via nu's config / env-file flag. Highest risk: nu replaces
+  rather than layers config, so the snippet must source the user's config, then append hooks.
+
+Snippets ship inside the vmux app bundle; injection selects one by the shell basename. The
+user's own config still loads — vmux only appends hooks.
+
+### Parsing in vmux_service
+
+`Process` feeds PTY bytes to `alacritty_terminal`'s vte (`process.rs:359` / `:1179`).
+alacritty ignores OSC 133 (no grid output), and its `EventListener` does not surface it
+(only `TermEvent::Title` etc. today).
+
+Add an **OSC 133 scanner** over the raw `data` in the drain loop, alongside
+`processor.advance`:
+
+- Scan for `ESC ] 133 ; … (ST | BEL)`; keep a small bounded carry-over buffer so a sequence
+  split across `read()` chunks is reassembled.
+- On `C`: emit "command started". On `D;<exit>`: emit "command ended, exit = <n>".
+- Broadcast a new `ServiceMessage` (e.g. `CommandLifecycle { process_id, kind, exit_code }`)
+  on the existing `patch_tx` channel, next to `ViewportPatch` / `ProcessTitle`.
+
+alacritty keeps rendering the stream unchanged; OSC 133 never appears in the viewport.
+
+### Consumption
+
+- **MCP `run`** (`vmux_mcp/src/protocol.rs`): send the user's clean command; wait for the
+  next `D;<exit>` lifecycle event for that process instead of scraping `__VMUX_DONE_`.
+  Correlate by sequencing (`run` sends one command, waits for the subsequent `C` → `D`).
+  Return output + exit.
+- **Remove the wrapper**: delete `run_command_line` instrumentation
+  (`vmux_agent/src/plugin.rs:582-600`) and the `__VMUX_DONE_` parse machinery in
+  `protocol.rs` for supported shells.
+- **(Future)** lifecycle events become available to the UI (per-command status, spinners) —
+  out of scope here.
+
+### Fallback for unknown shells
+
+If the shell basename is not one of bash / zsh / fish / nu (or snippet injection fails),
+fall back to the current `__VMUX_DONE_` sentinel / bash wrapper for `run`. Those commands
+stay mangled / visible — only for unrecognized shells. No lifecycle events for typed
+commands there.
+
+## Testing
+
+- Per-shell snippet emits the expected OSC 133 bytes: spawn each shell with injection, run a
+  command, assert `C` and `D;<code>` (including non-zero exit) appear in the raw PTY stream
+  and are absent from the rendered grid.
+- OSC 133 scanner: unit tests for whole + chunk-split sequences, `BEL` vs `ST` terminators,
+  interleaving with normal output, and ignoring non-133 OSC.
+- `run` correlation: a clean command returns correct output + exit via lifecycle events;
+  a concurrent typed command does not confuse the wait.
+- Injection layers user config (the user's rc still runs) and makes no dotfile edits.
+- Fallback path still works for an unknown shell.
+
+## Risks
+
+- **nu** is the highest-risk target (config layering + hook semantics). Validate first; if
+  non-viable, nu temporarily uses the fallback.
+- **Split OSC sequences** across read chunks — the scanner must buffer; bound it so a
+  malformed stream cannot grow it without limit.
+- **Snippet drift** vs upstream shells — vendor + version the snippets; cover with the
+  emission tests.
+- **History / rc interactions** — `--rcfile` / `ZDOTDIR` must source the user's config or the
+  user loses their environment; tested explicitly.

--- a/docs/specs/2026-06-21-shell-integration-command-lifecycle-design.md
+++ b/docs/specs/2026-06-21-shell-integration-command-lifecycle-design.md
@@ -98,20 +98,24 @@ user's own config still loads — vmux only appends hooks.
 
 ### Parsing in vmux_service
 
-`Process` feeds PTY bytes to `alacritty_terminal`'s vte (`process.rs:359` / `:1179`).
-alacritty ignores OSC 133 (no grid output), and its `EventListener` does not surface it
-(only `TermEvent::Title` etc. today).
+`Process` feeds PTY bytes to `alacritty_terminal`'s ansi processor
+(`process.rs:359` / `:1179`). alacritty's high-level `Handler` does **not** expose OSC 133
+(its "semantic" API is word-selection chars, unrelated), and its `EventListener` only
+surfaces `TermEvent::Title` etc. — OSC 133 falls through as an unhandled OSC: ignored, no
+grid output.
 
-Add an **OSC 133 scanner** over the raw `data` in the drain loop, alongside
-`processor.advance`:
+Rather than hand-roll a byte scanner, ride alacritty's own parser library: run a second,
+tiny **`vte::Parser`** in the drain loop, fed the same `data`, with a custom `Perform` that
+implements only `osc_dispatch`. vte's state machine handles ESC/OSC framing, `ST` vs `BEL`
+terminators, and sequences split across `read()` chunks — correct reassembly for free.
 
-- Scan for `ESC ] 133 ; … (ST | BEL)`; keep a small bounded carry-over buffer so a sequence
-  split across `read()` chunks is reassembled.
-- On `C`: emit "command started". On `D;<exit>`: emit "command ended, exit = <n>".
+- In `osc_dispatch`, match `params[0] == b"133"`; on `C` emit "command started", on
+  `D;<exit>` parse `params[2]` and emit "command ended, exit = <n>". Ignore all other OSC.
 - Broadcast a new `ServiceMessage` (e.g. `CommandLifecycle { process_id, kind, exit_code }`)
   on the existing `patch_tx` channel, next to `ViewportPatch` / `ProcessTitle`.
 
 alacritty keeps rendering the stream unchanged; OSC 133 never appears in the viewport.
+(`vte` is already a transitive dep via `alacritty_terminal`; add it as a direct dep.)
 
 ### Consumption
 
@@ -137,8 +141,9 @@ commands there.
 - Per-shell snippet emits the expected OSC 133 bytes: spawn each shell with injection, run a
   command, assert `C` and `D;<code>` (including non-zero exit) appear in the raw PTY stream
   and are absent from the rendered grid.
-- OSC 133 scanner: unit tests for whole + chunk-split sequences, `BEL` vs `ST` terminators,
-  interleaving with normal output, and ignoring non-133 OSC.
+- OSC 133 `Perform`: feed a persistent `vte::Parser` whole + chunk-split sequences, `BEL` vs
+  `ST` terminators, interleaving with normal output, and non-133 OSC; assert the right
+  lifecycle events fire and nothing else does.
 - `run` correlation: a clean command returns correct output + exit via lifecycle events;
   a concurrent typed command does not confuse the wait.
 - Injection layers user config (the user's rc still runs) and makes no dotfile edits.
@@ -148,8 +153,9 @@ commands there.
 
 - **nu** is the highest-risk target (config layering + hook semantics). Validate first; if
   non-viable, nu temporarily uses the fallback.
-- **Split OSC sequences** across read chunks — the scanner must buffer; bound it so a
-  malformed stream cannot grow it without limit.
+- **Parser state across chunks** — handled by vte's state machine (the `Perform` runs in a
+  persistent `Parser` per process); no hand-rolled buffering. The second parser only inspects
+  OSC, so per-byte cost is negligible.
 - **Snippet drift** vs upstream shells — vendor + version the snippets; cover with the
   emission tests.
 - **History / rc interactions** — `--rcfile` / `ZDOTDIR` must source the user's config or the


### PR DESCRIPTION
## Summary

Foundation for shell integration (1 of 3 plans). Adds command-lifecycle detection to `vmux_service`, **additive and behavior-preserving** — nothing emits OSC 133 yet, so no runtime change.

- New `ServiceMessage::CommandLifecycle` (`Started` / `Ended { exit_code }`).
- A second, tiny `vte::Parser` per `Process` whose `Perform` only inspects `osc_dispatch` for OSC `133;C` (command start) and `133;D;<exit>` (command end). vte handles ESC/OSC framing, `ST`/`BEL`, and chunk-split reassembly; alacritty already ignores OSC 133 so nothing leaks to the grid.
- `poll()` feeds the scanner the same PTY bytes it feeds alacritty and broadcasts a `CommandLifecycle` per event.

Design: `docs/specs/2026-06-21-shell-integration-command-lifecycle-design.md`
Plan: `docs/plans/2026-06-21-shell-integration-osc133-parsing.md`

Follow-ups: **Plan 2** ships per-shell OSC 133 snippets (bash/zsh/fish/nu) + non-invasive injection at PTY spawn; **Plan 3** rewires MCP `run` to lifecycle events and removes the `__VMUX_DONE_` wrapper/sentinel.

## Test plan

- [ ] `cargo test -p vmux_service` (108 lib tests) green
- [ ] osc133 unit tests: whole/split/`BEL`/`ST`/non-133 + start-then-end ordering
- [ ] integration: a process emitting `OSC 133;D;0` broadcasts `CommandLifecycle::Ended(Some(0))`
- [ ] clippy + fmt clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OSC 133 command lifecycle tracking, emitting command started/ended events and capturing exit codes when available.
  * Implemented shell integration injection for Bash, Zsh, Fish, and Nushell to enable OSC 133 markers.
  * Added command-exit agent querying and propagated lifecycle/exit status to the GUI and MCP layers.
* **Documentation**
  * Added new plan and design specs for OSC 133 shell integration.
* **Tests**
  * Added unit/integration coverage for OSC 133 parsing and lifecycle end handling (with/without exit codes).
* **Other**
  * Updated MCP `run` completion detection to rely on command exit status instead of the prior done marker, and clarified placement wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->