### PR TITLE
feat(website): illustrated landing sections, docs nav, and renames

### DIFF
--- a/docs/architecture/agent-first.md
+++ b/docs/architecture/agent-first.md
@@ -1,9 +1,32 @@
-# Agent-first: the workspace is an API
+# Vmux MCP: the workspace is an API
 
 > Part of the [Vmux Architecture](../architecture.md) overview.
 
-Vmux exposes its runtime to agents through an **MCP** server
-(`crates/vmux_mcp/src/tools.rs`), from atomic mutations to declarative reconciliation:
+Every action you can take in Vmux — open a page, split a pane, run a command,
+reshape the layout — is also an **MCP tool**. Vmux ships a standard
+[Model Context Protocol](https://modelcontextprotocol.io) server, so any
+MCP-capable agent drives the workspace exactly the way a person does. The
+flagship client is the **vibe** CLI; Claude, Codex, or anything that speaks MCP
+connect the same way.
+
+## How an agent connects
+
+Vmux exposes a stdio MCP server — line-delimited JSON-RPC (`tools/list`,
+`tools/call`) in `crates/vmux_mcp`. Point an agent at the `vmux mcp` command and
+it gets the full tool surface; that's all the vibe CLI is wired to under the hood.
+
+The server is a thin front end: it connects to the `vmux_service` daemon over its
+Unix socket and forwards each call as a typed protocol message. The daemon — not
+the agent — owns the PTYs, terminals, and sessions, so work keeps running even if
+the agent process exits.
+
+Every agent is launched **anchored to its own Space** (`vmux mcp --anchor <id>`).
+Tool calls resolve relative to that anchor, so a background agent spawns its pages
+and terminals in its own space and can't read or disrupt the one you're looking at.
+
+## The tool surface
+
+From atomic mutations to declarative reconciliation:
 
 - **Atomic** — `browser_navigate`, `terminal_send`, `select_tab`, `create_space`,
   `update_settings`.
@@ -16,18 +39,17 @@ Vmux exposes its runtime to agents through an **MCP** server
   graph and reconciles **React-style** — add panes, move stacks, shift focus, in one
   atomic transaction.
 
-Agents are anchored in their own Space, so a background agent can't read or disrupt the
-space you're looking at.
-
 ## Persistence via a daemon
 
 Commands route through a `launchd`-supervised background daemon (`crates/vmux_service`)
 that owns the PTYs and agent sessions. Because it outlives the window, shells, long
-builds, and agent routines persist across app restarts.
+builds, and agent routines persist across app restarts — an agent can kick off a build,
+the app can close, and the output is still waiting when it reopens.
 
 ## A privileged bridge behind a scheme gate
 
-"The workspace is an API" invites the obvious question — can a random website drive it? No.
+Agents reach Vmux over MCP. Web pages reach it over a second, tightly gated path — and
+"the workspace is an API" invites the obvious question: can a random website drive it? No.
 
 The host bridge (`window.cef` — the messaging that lets a page read or command the
 workspace) only works for **trusted frames**: a page is trusted *iff* its URL is
@@ -38,7 +60,7 @@ no web page can ever *be* at a `vmux://` URL — an unforgeable boundary, checke
 the browser process with a defense-in-depth check in the renderer.
 
 A second layer adds **least privilege** among trusted pages: each message type is bound to
-the page that may emit it (`for_hosts(&["history"])`, …), so a compromised vmux page can't
+the page that may emit it (`for_hosts(&["history"])`, …), so a compromised Vmux page can't
 pivot to another's handlers — and the full Bevy Remote Protocol is locked to the `debug`
 page alone. The predicate lives in the patched `bevy_cef_core` (`url_is_trusted_embedded_page`),
 unit-tested against `https://evil.com`, `about:blank`, and bare `vmux://`.

--- a/docs/architecture/built-to-scale.md
+++ b/docs/architecture/built-to-scale.md
@@ -1,4 +1,4 @@
-# Built to scale
+# ECS: Build to scale
 
 > Part of the [Vmux Architecture](../architecture.md) overview.
 

--- a/docs/architecture/layout-model.md
+++ b/docs/architecture/layout-model.md
@@ -1,4 +1,4 @@
-# The layout model: Space → Tab → Pane → Stack
+# Vmux Layout: Space → Tab → Pane → Stack
 
 > Part of the [Vmux Architecture](../architecture.md) overview.
 

--- a/docs/architecture/render-stack.md
+++ b/docs/architecture/render-stack.md
@@ -1,4 +1,4 @@
-# The render stack: one window, many web surfaces
+# 2D / 3D renderer: one window, many web surfaces
 
 > Part of the [Vmux Architecture](../architecture.md) overview.
 

--- a/docs/experience.md
+++ b/docs/experience.md
@@ -36,20 +36,19 @@ layout you imagine.
 
 ---
 
-## Input: talk, type, click
+## Input: Talk › Type › Click
 
 Vmux orders interaction from abstract delegation down to mechanical control.
 
-1. **Agent prompts — type or talk.** *First priority.* Direct the whole workspace in
-   natural language. **Type** for silent, high-precision tasks; **talk** for hands-free
-   speed and live layout manipulation.
-2. **Keyboard shortcuts.** *Second priority.* High-velocity control with near-zero
-   learning curve, split intentionally to avoid friction:
+1. **Talk.** *First priority.* Direct the whole workspace in natural language —
+   hands-free and conversational. Just say what you want and watch it happen.
+2. **Type.** *Second priority.* Keyboard shortcuts — high-velocity control with
+   near-zero learning curve, split intentionally to avoid friction:
    - **Chrome-style** — standard browser actions (open tabs, navigate history, refresh)
      use the native shortcuts you already know by heart.
    - **Tmux-style** — layout commands (split panes, switch windows, cycle layouts) use a
      powerful `<leader>`-prefixed scheme built for terminal efficiency.
-3. **Mouse.** *Third priority.* Plain, intuitive point-and-click that keeps Vmux
+3. **Click.** *Third priority.* Plain, intuitive point-and-click that keeps Vmux
    grounded in predictable browser behavior.
 
 ---

--- a/website/Cargo.toml
+++ b/website/Cargo.toml
@@ -30,6 +30,7 @@ web-sys = { version = "0.3", features = [
     "DomRect",
     "Element",
     "EventTarget",
+    "History",
     "HtmlAnchorElement",
     "HtmlElement",
     "MediaQueryList",

--- a/website/src/docs.rs
+++ b/website/src/docs.rs
@@ -32,25 +32,25 @@ pub const DOCS: &[Doc] = &[
     },
     Doc {
         slug: "built-to-scale",
-        title: "Built to scale",
+        title: "ECS: Build to scale",
         group: "Architecture",
         content: include_str!("../../docs/architecture/built-to-scale.md"),
     },
     Doc {
         slug: "agent-first",
-        title: "Agent-first API",
+        title: "Vmux MCP",
         group: "Architecture",
         content: include_str!("../../docs/architecture/agent-first.md"),
     },
     Doc {
         slug: "layout-model",
-        title: "The layout model",
+        title: "Vmux Layout",
         group: "Architecture",
         content: include_str!("../../docs/architecture/layout-model.md"),
     },
     Doc {
         slug: "render-stack",
-        title: "The render stack",
+        title: "2D / 3D renderer",
         group: "Architecture",
         content: include_str!("../../docs/architecture/render-stack.md"),
     },
@@ -58,6 +58,16 @@ pub const DOCS: &[Doc] = &[
 
 pub fn find(slug: &str) -> Option<&'static Doc> {
     DOCS.iter().find(|d| d.slug == slug)
+}
+
+pub fn neighbors(slug: &str) -> (Option<&'static Doc>, Option<&'static Doc>) {
+    match DOCS.iter().position(|d| d.slug == slug) {
+        Some(i) => {
+            let prev = if i > 0 { Some(&DOCS[i - 1]) } else { None };
+            (prev, DOCS.get(i + 1))
+        }
+        None => (None, None),
+    }
 }
 
 pub fn groups() -> Vec<(&'static str, Vec<usize>)> {

--- a/website/src/landing/agents.rs
+++ b/website/src/landing/agents.rs
@@ -7,6 +7,10 @@ struct Addr {
 
 const ADDRS: &[Addr] = &[
     Addr {
+        url: "vmux://agent/claude/8d1f2c…",
+        hot: true,
+    },
+    Addr {
         url: "vmux://agent/codex/4f3a91…",
         hot: true,
     },
@@ -36,6 +40,14 @@ const TOOLS: &[&str] = &[
     "create_space",
 ];
 
+fn key(label: &str, cls: &str) -> Element {
+    rsx! {
+        kbd { class: "inline-flex items-center justify-center rounded-md border border-white/20 bg-gradient-to-b from-white/[0.14] to-white/[0.03] font-semibold text-text shadow-[0_1px_2px_rgba(0,0,0,0.4)] {cls}",
+            "{label}"
+        }
+    }
+}
+
 #[component]
 pub fn Agents() -> Element {
     rsx! {
@@ -43,14 +55,21 @@ pub fn Agents() -> Element {
             div { class: "grid grid-cols-1 md:grid-cols-2 gap-10 items-center",
                 div { class: "reveal",
                     p { class: "text-sm uppercase tracking-[0.2em] text-accent mb-3", "Agents" }
-                    h2 { class: "text-3xl sm:text-4xl font-bold tracking-tight mb-4",
-                        "The workspace is an API."
+                    h2 { class: "mb-5",
+                        span { class: "block text-3xl sm:text-4xl font-bold tracking-tight",
+                            "Every agent has a home."
+                        }
+                        span { class: "mt-3 flex flex-wrap items-center gap-2 text-lg sm:text-xl font-medium text-text-muted",
+                            "Hit"
+                            {key("⌘ L", "h-6 px-2 text-sm")}
+                            "to visit."
+                        }
                     }
                     p { class: "text-text-muted leading-relaxed mb-4",
-                        "Agents drive Vmux over MCP — browse, run commands in a terminal you can watch and take over, and reshape the layout declaratively."
+                        "Every agent, terminal, and space lives at its own address, ready to share or jump back to. A background run stays anchored in its own space, so it never disrupts the one you're in."
                     }
                     p { class: "text-text-muted leading-relaxed",
-                        "Every agent session is a first-class, addressable surface — anchored in its own space, so a background run never disrupts the one you're in."
+                        "Under the hood, agents drive Vmux over MCP: browse, run commands in a terminal you can watch and take over, and reshape the layout declaratively."
                     }
                     div { class: "mt-6 flex flex-wrap gap-2",
                         for t in TOOLS.iter() {
@@ -69,7 +88,10 @@ pub fn Agents() -> Element {
                         span { class: "h-2.5 w-2.5 rounded-full bg-white/15" }
                         span { class: "h-2.5 w-2.5 rounded-full bg-white/15" }
                         span { class: "h-2.5 w-2.5 rounded-full bg-white/15" }
-                        span { class: "ml-2 text-[11px] text-text-muted", "addressable surfaces" }
+                        span { class: "ml-2 flex items-center gap-1.5 text-[11px] text-text-muted",
+                            {key("⌘ L", "h-4 px-1.5 text-[10px]")}
+                            "to visit"
+                        }
                     }
                     div { class: "flex flex-col gap-2.5",
                         for a in ADDRS.iter() {

--- a/website/src/landing/hero.rs
+++ b/website/src/landing/hero.rs
@@ -2,7 +2,7 @@ use dioxus::prelude::*;
 use dioxus_primitives::toast::{ToastOptions, use_toast};
 
 use crate::hooks::{use_clipboard_copy, use_dmg_download, use_is_mac};
-use crate::landing::{GITHUB_URL, ICON, INSTALL_CMD};
+use crate::landing::{ICON, INSTALL_CMD};
 
 #[component]
 pub fn Hero() -> Element {
@@ -30,14 +30,25 @@ pub fn Hero() -> Element {
                     "Vmux"
                 }
                 p { class: "text-lg sm:text-2xl text-text mb-3 max-w-2xl mx-auto",
-                    "The workspace that bridges chat and IDE."
+                    "The browser that bridges chat and IDE."
                 }
                 p { class: "text-base sm:text-lg text-text-muted mb-10 max-w-xl mx-auto",
                     "An agent co-working space with a browser and IDE built in — people and agents, side by side."
                 }
-                div { class: "flex flex-wrap justify-center gap-3 mb-6",
+                div { class: "inline-flex flex-col sm:flex-row items-center gap-2 sm:gap-3 bg-code-bg/80 backdrop-blur border border-border rounded-lg px-4 py-3 text-sm sm:text-base mb-6",
+                    code { class: "font-mono text-accent", "{INSTALL_CMD}" }
                     button {
-                        class: "inline-flex items-center px-6 py-3 rounded-lg text-base font-semibold border border-transparent bg-accent text-black cursor-pointer transition-colors hover:bg-accent-hover",
+                        class: "bg-accent text-black border-0 rounded px-3 py-1.5 text-sm font-semibold cursor-pointer transition-colors hover:bg-accent-hover",
+                        onclick: move |_| {
+                            copy(INSTALL_CMD.to_string());
+                            toast_api.success("Copied!".to_string(), ToastOptions::new());
+                        },
+                        "Copy"
+                    }
+                }
+                div { class: "flex justify-center",
+                    button {
+                        class: "inline-flex items-center px-7 py-3.5 rounded-lg text-base font-semibold border border-transparent bg-accent text-black cursor-pointer transition-colors hover:bg-accent-hover",
                         onclick: move |_| {
                             if is_mac {
                                 download(());
@@ -52,26 +63,8 @@ pub fn Hero() -> Element {
                         },
                         "Download .dmg"
                     }
-                    a {
-                        class: "inline-flex items-center px-6 py-3 rounded-lg text-base font-semibold no-underline border border-border bg-transparent text-text transition-colors hover:border-accent hover:text-accent",
-                        href: GITHUB_URL,
-                        target: "_blank",
-                        rel: "noopener noreferrer",
-                        "GitHub"
-                    }
                 }
-                div { class: "inline-flex flex-col sm:flex-row items-center gap-2 sm:gap-3 bg-code-bg/80 backdrop-blur border border-border rounded-lg px-4 py-3 text-sm sm:text-base mb-4",
-                    code { class: "font-mono text-accent", "{INSTALL_CMD}" }
-                    button {
-                        class: "bg-accent text-black border-0 rounded px-3 py-1.5 text-sm font-semibold cursor-pointer transition-colors hover:bg-accent-hover",
-                        onclick: move |_| {
-                            copy(INSTALL_CMD.to_string());
-                            toast_api.success("Copied!".to_string(), ToastOptions::new());
-                        },
-                        "Copy"
-                    }
-                }
-                p { class: "text-sm text-text-muted", "Requires macOS 13.0 (Ventura) or later." }
+                p { class: "mt-5 text-sm text-text-muted", "Requires macOS 13.0 (Ventura) or later." }
             }
         }
     }

--- a/website/src/landing/pillars.rs
+++ b/website/src/landing/pillars.rs
@@ -1,22 +1,33 @@
 use dioxus::prelude::*;
 
+#[derive(Clone, Copy)]
+enum Art {
+    Coworking,
+    Browser,
+    Terminal,
+}
+
 struct Pillar {
     title: &'static str,
     body: &'static str,
+    art: Art,
 }
 
 const PILLARS: &[Pillar] = &[
     Pillar {
         title: "Co-working",
         body: "People and agents work in one shared space — from hands-on pairing to full autonomy. Watch a run and grab the keyboard, or turn agents loose.",
+        art: Art::Coworking,
     },
     Pillar {
         title: "Known by heart",
         body: "It looks and acts like a standard web browser. No learning curve — everyone already knows how to use it.",
+        art: Art::Browser,
     },
     Pillar {
         title: "IDE power",
         body: "Beneath the surface: advanced tools, keyboard-driven workflows, and deep environment control for when you want it.",
+        art: Art::Terminal,
     },
 ];
 
@@ -27,19 +38,286 @@ pub fn Pillars() -> Element {
             p { class: "text-center text-sm uppercase tracking-[0.2em] text-accent mb-3",
                 "Two worlds, one workspace"
             }
-            h2 { class: "text-center text-3xl sm:text-4xl font-bold tracking-tight mb-14 max-w-2xl mx-auto",
+            h2 { class: "text-center text-3xl sm:text-4xl font-bold tracking-tight mb-16 sm:mb-20 max-w-2xl mx-auto",
                 "Vmux bridges chat-first tools and developer IDEs."
             }
-            div { class: "grid grid-cols-1 md:grid-cols-3 gap-5",
+            div { class: "flex flex-col gap-16 sm:gap-24",
                 for (i , p) in PILLARS.iter().enumerate() {
                     div {
-                        class: "rounded-2xl border border-white/10 bg-white/5 backdrop-blur p-7 reveal",
-                        style: "transition-delay: {i * 120}ms",
-                        h3 { class: "text-lg font-semibold text-accent mb-2", "{p.title}" }
-                        p { class: "text-sm text-text-muted leading-relaxed", "{p.body}" }
+                        key: "{p.title}",
+                        class: "grid grid-cols-1 items-center gap-8 md:grid-cols-2 md:gap-12 reveal",
+                        div { class: if i % 2 == 1 { "md:order-2" } else { "" },
+                            h3 { class: "text-2xl sm:text-3xl font-bold tracking-tight text-accent mb-3", "{p.title}" }
+                            p { class: "text-base sm:text-lg text-text-muted leading-relaxed", "{p.body}" }
+                        }
+                        div { class: if i % 2 == 1 { "md:order-1" } else { "" },
+                            {art(p.art)}
+                        }
                     }
                 }
             }
         }
+    }
+}
+
+fn svg_icon(class: &str, body: Element) -> Element {
+    rsx! {
+        svg {
+            view_box: "0 0 24 24",
+            fill: "none",
+            stroke: "currentColor",
+            stroke_width: "2",
+            stroke_linecap: "round",
+            stroke_linejoin: "round",
+            class: "{class}",
+            {body}
+        }
+    }
+}
+
+fn icon_globe(class: &str) -> Element {
+    svg_icon(
+        class,
+        rsx! {
+            circle { cx: "12", cy: "12", r: "10" }
+            path { d: "M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" }
+            path { d: "M2 12h20" }
+        },
+    )
+}
+
+fn icon_term(class: &str) -> Element {
+    svg_icon(
+        class,
+        rsx! {
+            path { d: "M4 17 10 11 4 5" }
+            path { d: "M12 19h8" }
+        },
+    )
+}
+
+fn icon_search(class: &str) -> Element {
+    svg_icon(
+        class,
+        rsx! {
+            circle { cx: "11", cy: "11", r: "8" }
+            path { d: "m21 21-4.3-4.3" }
+        },
+    )
+}
+
+fn icon_mic(class: &str) -> Element {
+    svg_icon(
+        class,
+        rsx! {
+            rect { x: "9", y: "2", width: "6", height: "12", rx: "3" }
+            path { d: "M19 10v1a7 7 0 0 1-14 0v-1" }
+            path { d: "M12 18v4" }
+            path { d: "M8 22h8" }
+        },
+    )
+}
+
+fn icon_person(class: &str) -> Element {
+    svg_icon(
+        class,
+        rsx! {
+            path { d: "M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" }
+            circle { cx: "12", cy: "7", r: "4" }
+        },
+    )
+}
+
+fn icon_bot(class: &str) -> Element {
+    svg_icon(
+        class,
+        rsx! {
+            path { d: "M12 8V4H8" }
+            rect { width: "16", height: "12", x: "4", y: "8", rx: "2" }
+            path { d: "M2 14h2" }
+            path { d: "M20 14h2" }
+            path { d: "M15 13v2" }
+            path { d: "M9 13v2" }
+        },
+    )
+}
+
+fn avatar_you() -> Element {
+    rsx! {
+        div { class: "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-accent/40 bg-accent/15 text-accent",
+            {icon_person("h-3 w-3")}
+        }
+    }
+}
+
+fn avatar_bot() -> Element {
+    rsx! {
+        div { class: "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-aurora-violet/40 bg-aurora-violet/15 text-aurora-violet",
+            {icon_bot("h-3 w-3")}
+        }
+    }
+}
+
+fn nav_icon(paths: &[&str]) -> Element {
+    rsx! {
+        span { class: "flex h-5 w-5 shrink-0 items-center justify-center rounded text-text-muted",
+            svg {
+                view_box: "0 0 24 24",
+                fill: "none",
+                stroke: "currentColor",
+                stroke_width: "2",
+                stroke_linecap: "round",
+                stroke_linejoin: "round",
+                class: "h-3 w-3",
+                for d in paths.iter() {
+                    path { key: "{d}", d: "{d}" }
+                }
+            }
+        }
+    }
+}
+
+fn tab(icon: Element, title: &str, active: bool) -> Element {
+    let class = if active {
+        "flex items-center gap-1.5 rounded-md bg-white/[0.06] border border-white/10 px-2 py-1 text-[10px] text-text"
+    } else {
+        "flex items-center gap-1.5 rounded-md px-2 py-1 text-[10px] text-text-muted"
+    };
+    rsx! {
+        div { class: "{class}",
+            {icon}
+            span { class: "max-w-[72px] truncate", "{title}" }
+        }
+    }
+}
+
+fn chrome(frame: &str, tabs: Element, address: &str, body: Element) -> Element {
+    rsx! {
+        div { class: "flex h-64 flex-col overflow-hidden rounded-lg border {frame}",
+            div { class: "flex items-center gap-1 px-2 pt-2",
+                {tabs}
+                {nav_icon(&["M5 12h14", "M12 5v14"])}
+            }
+            div { class: "flex items-center gap-1.5 border-b border-t border-white/10 bg-white/[0.03] px-2 py-1.5",
+                {nav_icon(&["M19 12H5", "M12 19l-7-7 7-7"])}
+                {nav_icon(&["M5 12h14", "M12 5l7 7-7 7"])}
+                {nav_icon(&["M21 12a9 9 0 11-3-6.7L21 8", "M21 3v5h-5"])}
+                div { class: "ml-1 flex h-6 min-w-0 flex-1 items-center rounded-md border border-white/10 bg-black/40 px-2",
+                    span { class: "truncate font-mono text-[10px] text-text-muted", "{address}" }
+                }
+            }
+            div { class: "min-h-0 flex-1 overflow-hidden",
+                {body}
+            }
+        }
+    }
+}
+
+fn art(kind: Art) -> Element {
+    match kind {
+        Art::Coworking => chrome(
+            "border-accent/20 bg-[#0d0d18] shadow-xl shadow-accent/20",
+            rsx! {
+                {tab(icon_bot("h-3 w-3 text-aurora-violet"), "vibe", true)}
+                {tab(icon_globe("h-3 w-3"), "example.com", false)}
+            },
+            "vmux://agent/vibe/2c80e7…",
+            rsx! {
+                div { class: "flex h-full flex-col justify-center gap-3 p-4",
+                    div { class: "flex items-end gap-2",
+                        {avatar_bot()}
+                        div { class: "rounded-xl rounded-bl-sm bg-white/10 px-3 py-2 text-[11px] leading-snug text-text",
+                            "Tests pass — ship it?"
+                        }
+                    }
+                    div { class: "flex items-end justify-end gap-2",
+                        div { class: "rounded-xl rounded-br-sm border border-accent/30 bg-accent/25 px-3 py-2 text-[11px] leading-snug text-text",
+                            "Ship it."
+                        }
+                        {avatar_you()}
+                    }
+                }
+            },
+        ),
+        Art::Browser => chrome(
+            "border-aurora-cyan/20 bg-[#0b1418] shadow-xl shadow-aurora-cyan/20",
+            rsx! {
+                {tab(icon_globe("h-3 w-3 text-aurora-cyan"), "New Tab", true)}
+                {tab(icon_globe("h-3 w-3"), "docs", false)}
+            },
+            "Search or enter address",
+            rsx! {
+                div { class: "flex h-full flex-col items-center justify-center p-4",
+                    div { class: "flex w-full items-center gap-3 rounded-full border border-white/20 bg-white/[0.08] px-5 py-3.5",
+                        {icon_search("h-4 w-4 shrink-0 text-text-muted")}
+                        span { class: "flex-1 text-left text-[12px] text-text-muted", "Search the web" }
+                        {icon_mic("h-4 w-4 shrink-0 text-aurora-cyan/70")}
+                    }
+                }
+            },
+        ),
+        Art::Terminal => chrome(
+            "border-aurora-violet/20 bg-[#120c1a] shadow-xl shadow-aurora-violet/20",
+            rsx! {
+                {tab(icon_term("h-3 w-3 text-aurora-violet"), "pillars.rs", true)}
+            },
+            "file://.worktrees/website-agents-section/…/pillars.rs",
+            rsx! {
+                div { class: "flex h-full gap-2 overflow-hidden p-3",
+                    div { class: "flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-md border border-accent/30 bg-accent/[0.04] font-mono text-[9px] leading-relaxed shadow-lg shadow-accent/10",
+                        div { class: "flex items-center gap-1.5 border-b border-white/10 px-2 py-1 text-text-muted",
+                            {icon_bot("h-2.5 w-2.5 text-accent")}
+                            span { "vibe" }
+                        }
+                        div { class: "flex-1 space-y-1 p-2",
+                            div {
+                                span { class: "text-accent", "› " }
+                                span { class: "text-text", "add agents section" }
+                            }
+                            div { class: "text-text-muted", "● editing pillars.rs" }
+                            div { class: "text-text-muted", "  + alternating rows" }
+                            div { class: "text-aurora-cyan/80", "✓ done" }
+                            div {
+                                span { class: "text-accent", "› " }
+                                span { class: "inline-block w-1.5 h-2.5 align-middle bg-accent animate-pulse motion-reduce:animate-none" }
+                            }
+                        }
+                    }
+                    div { class: "flex w-1/2 min-h-0 flex-col gap-2",
+                        div { class: "flex min-h-0 flex-[1.6] flex-col overflow-hidden rounded-md border border-aurora-violet/30 bg-[#0d0d18] font-mono text-[9px] leading-relaxed",
+                            div { class: "border-b border-white/10 px-2 py-1 text-text-muted", "pillars.rs" }
+                            div { class: "flex-1 p-2",
+                                div {
+                                    span { class: "text-aurora-violet", "fn " }
+                                    span { class: "text-accent", "art" }
+                                    span { class: "text-text-muted", "(kind) {{" }
+                                }
+                                div { class: "pl-2",
+                                    span { class: "text-aurora-violet", "match " }
+                                    span { class: "text-text", "kind" }
+                                    span { class: "text-text-muted", " {{ … }}" }
+                                }
+                                div {
+                                    span { class: "text-text-muted", "}}" }
+                                }
+                            }
+                        }
+                        div { class: "flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border border-white/10 bg-black/30 font-mono text-[9px]",
+                            div { class: "border-b border-white/10 px-2 py-1 text-text-muted", "zsh" }
+                            div { class: "flex-1 p-2",
+                                div {
+                                    span { class: "text-text-muted", "$ " }
+                                    span { class: "text-text", "dx serve" }
+                                }
+                                div {
+                                    span { class: "text-text-muted", "$ " }
+                                    span { class: "inline-block w-1.5 h-2.5 align-middle bg-aurora-violet animate-pulse motion-reduce:animate-none" }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        ),
     }
 }

--- a/website/src/landing/scenes.rs
+++ b/website/src/landing/scenes.rs
@@ -151,57 +151,194 @@ fn terminal_pane() -> Element {
     }
 }
 
+#[derive(Clone, Copy)]
+enum InputArt {
+    Talk,
+    Type,
+    Click,
+}
+
 struct Tier {
     rank: &'static str,
     title: &'static str,
     body: &'static str,
+    art: InputArt,
 }
 
 const TIERS: &[Tier] = &[
     Tier {
         rank: "01",
-        title: "Talk or type",
-        body: "Direct the whole workspace in natural language. Type for precision, talk for hands-free speed.",
+        title: "Talk",
+        body: "Direct the whole workspace in natural language — hands-free and conversational. Just say what you want and watch it happen.",
+        art: InputArt::Talk,
     },
     Tier {
         rank: "02",
-        title: "Keyboard shortcuts",
-        body: "Chrome-style for browsing, tmux-style <leader> commands for layout. High velocity, near-zero learning curve.",
+        title: "Type",
+        body: "Chrome-style shortcuts for browsing, tmux-style <leader> commands for layout. High velocity, near-zero learning curve.",
+        art: InputArt::Type,
     },
     Tier {
         rank: "03",
-        title: "Mouse",
+        title: "Click",
         body: "Plain, intuitive point-and-click that keeps everything grounded in predictable browser behavior.",
+        art: InputArt::Click,
     },
 ];
 
 #[component]
 pub fn InputScene() -> Element {
     rsx! {
-        section { class: "relative max-w-3xl mx-auto px-6 py-24 sm:py-32",
-            div { class: "text-center mb-12 reveal",
+        section { class: "relative max-w-5xl mx-auto px-6 py-24 sm:py-32",
+            div { class: "text-center mb-16 sm:mb-20 reveal",
                 p { class: "text-sm uppercase tracking-[0.2em] text-accent mb-3", "Input" }
                 h2 { class: "text-3xl sm:text-5xl font-bold tracking-tight mb-4",
-                    "Talk, type, click."
+                    "Talk › Type › Click"
                 }
-                p { class: "text-text-muted leading-relaxed",
+                p { class: "text-text-muted leading-relaxed max-w-2xl mx-auto",
                     "Interaction ordered from abstract delegation down to mechanical control."
                 }
             }
-            div { class: "flex flex-col gap-4 reveal",
+            div { class: "flex flex-col gap-16 sm:gap-24",
                 for (i , t) in TIERS.iter().enumerate() {
                     div {
                         key: "{t.rank}",
-                        class: "relative flex items-start gap-4 rounded-xl border border-white/10 bg-white/5 backdrop-blur p-5 pl-6 overflow-hidden",
-                        div {
-                            class: "absolute left-0 top-0 h-full w-1 bg-accent animate-cue motion-reduce:animate-none",
-                            style: "animation-delay: {i}s",
+                        class: "grid grid-cols-1 items-center gap-8 md:grid-cols-2 md:gap-12 reveal",
+                        div { class: if i % 2 == 1 { "md:order-2" } else { "" },
+                            div { class: "mb-3 flex items-baseline gap-3",
+                                span { class: "font-mono text-sm text-accent", "{t.rank}" }
+                                h3 { class: "text-2xl sm:text-3xl font-bold tracking-tight text-text", "{t.title}" }
+                            }
+                            p { class: "text-base sm:text-lg text-text-muted leading-relaxed", "{t.body}" }
                         }
-                        span { class: "text-accent font-mono text-sm pt-0.5", "{t.rank}" }
-                        div {
-                            h3 { class: "font-semibold mb-1", "{t.title}" }
-                            p { class: "text-sm text-text-muted leading-relaxed", "{t.body}" }
+                        div { class: if i % 2 == 1 { "md:order-1" } else { "" },
+                            {input_art(t.art)}
                         }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn input_art(kind: InputArt) -> Element {
+    match kind {
+        InputArt::Talk => talk_art(),
+        InputArt::Type => type_art(),
+        InputArt::Click => click_art(),
+    }
+}
+
+fn talk_art() -> Element {
+    rsx! {
+        div { class: "relative flex h-64 items-center justify-center overflow-hidden rounded-2xl border border-accent/20 bg-[#0d0d18] shadow-xl shadow-accent/20",
+            div { class: "pointer-events-none absolute left-1/2 top-1/2 h-40 w-40 -translate-x-1/2 -translate-y-1/2 rounded-full bg-accent/15 blur-[60px]" }
+            div { class: "relative flex flex-col items-center gap-6",
+                div { class: "relative flex h-20 w-20 items-center justify-center",
+                    span { class: "absolute inset-0 rounded-full border border-accent/25 animate-ping motion-reduce:animate-none" }
+                    span { class: "absolute inset-2 rounded-full border border-accent/20" }
+                    div { class: "flex h-16 w-16 items-center justify-center rounded-full border border-accent/40 bg-gradient-to-br from-accent/40 to-accent/5 text-accent shadow-lg shadow-accent/40",
+                        svg {
+                            view_box: "0 0 24 24",
+                            fill: "none",
+                            stroke: "currentColor",
+                            stroke_width: "2",
+                            stroke_linecap: "round",
+                            stroke_linejoin: "round",
+                            class: "h-7 w-7",
+                            rect { x: "9", y: "2", width: "6", height: "12", rx: "3" }
+                            path { d: "M19 10v1a7 7 0 0 1-14 0v-1" }
+                            path { d: "M12 18v4" }
+                            path { d: "M8 22h8" }
+                        }
+                    }
+                }
+                div { class: "flex h-10 items-center gap-1.5",
+                    {bar("h-3", "0ms")}
+                    {bar("h-6", "120ms")}
+                    {bar("h-9", "240ms")}
+                    {bar("h-5", "360ms")}
+                    {bar("h-10", "180ms")}
+                    {bar("h-4", "300ms")}
+                    {bar("h-7", "60ms")}
+                    {bar("h-3", "420ms")}
+                    {bar("h-6", "200ms")}
+                }
+            }
+        }
+    }
+}
+
+fn bar(h: &str, delay: &str) -> Element {
+    rsx! {
+        span {
+            class: "w-1.5 rounded-full bg-accent/70 animate-pulse motion-reduce:animate-none {h}",
+            style: "animation-delay: {delay}",
+        }
+    }
+}
+
+fn type_art() -> Element {
+    rsx! {
+        div { class: "relative flex h-64 items-center justify-center overflow-hidden rounded-2xl border border-aurora-violet/20 bg-[#120c1a] shadow-xl shadow-aurora-violet/20",
+            div { class: "pointer-events-none absolute left-1/2 top-1/2 h-40 w-40 -translate-x-1/2 -translate-y-1/2 rounded-full bg-aurora-violet/15 blur-[60px]" }
+            div { class: "relative flex flex-col items-center gap-4",
+                div { class: "rounded-md border border-aurora-violet/40 bg-aurora-violet/15 px-2.5 py-1 font-mono text-[11px] text-text shadow-lg shadow-aurora-violet/20",
+                    "⌘ K"
+                }
+                div { class: "flex flex-col items-center gap-1.5",
+                    div { class: "flex gap-1.5",
+                        {cap(false)}
+                        {cap(false)}
+                        {cap(false)}
+                        {cap(false)}
+                        {cap(false)}
+                        {cap(false)}
+                    }
+                    div { class: "flex gap-1.5",
+                        {cap(false)}
+                        {cap(false)}
+                        {cap(true)}
+                        {cap(true)}
+                        {cap(false)}
+                        {cap(false)}
+                    }
+                    div { class: "flex justify-center",
+                        span { class: "h-6 w-32 rounded-md border border-white/15 bg-gradient-to-b from-white/[0.12] to-white/[0.03] shadow-[0_1px_2px_rgba(0,0,0,0.4)]" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn cap(highlight: bool) -> Element {
+    let extra = if highlight {
+        "border-aurora-violet/50 bg-aurora-violet/25"
+    } else {
+        "border-white/15 bg-gradient-to-b from-white/[0.12] to-white/[0.03]"
+    };
+    rsx! {
+        span { class: "h-6 w-6 rounded-md border shadow-[0_1px_2px_rgba(0,0,0,0.4)] {extra}" }
+    }
+}
+
+fn click_art() -> Element {
+    rsx! {
+        div { class: "relative flex h-64 items-center justify-center overflow-hidden rounded-2xl border border-aurora-cyan/20 bg-[#0b1418] shadow-xl shadow-aurora-cyan/20",
+            div { class: "pointer-events-none absolute left-1/2 top-1/2 h-40 w-40 -translate-x-1/2 -translate-y-1/2 rounded-full bg-aurora-cyan/15 blur-[60px]" }
+            div { class: "relative",
+                div { class: "flex h-10 items-center rounded-lg border border-aurora-cyan/40 bg-aurora-cyan/10 px-5 shadow-lg shadow-aurora-cyan/20",
+                    div { class: "h-1.5 w-16 rounded-full bg-aurora-cyan/60" }
+                }
+                div { class: "absolute -bottom-3 -right-3 flex h-10 w-10 items-center justify-center",
+                    span { class: "absolute inset-0 rounded-full border border-aurora-cyan/50 animate-ping motion-reduce:animate-none" }
+                    span { class: "absolute inset-2 rounded-full bg-aurora-cyan/20" }
+                    svg {
+                        view_box: "0 0 24 24",
+                        fill: "currentColor",
+                        class: "relative h-7 w-7 text-text drop-shadow-lg",
+                        path { d: "M5 3l14 7-6 2-2 6z" }
                     }
                 }
             }

--- a/website/src/main.rs
+++ b/website/src/main.rs
@@ -177,6 +177,7 @@ fn toc_item(h: &markdown::Heading, effective: &str) -> Element {
 mod spy {
     use dioxus::prelude::*;
     use wasm_bindgen::JsCast;
+    use wasm_bindgen::JsValue;
     use wasm_bindgen::prelude::Closure;
 
     pub fn setup(mut active: Signal<String>) {
@@ -194,20 +195,36 @@ mod spy {
             let Ok(list) = scope.query_selector_all("h2[id], h3[id]") else {
                 return;
             };
-            let top = scope.get_bounding_client_rect().top();
+            let rect = scope.get_bounding_client_rect();
+            let line = rect.top() + rect.height() * 0.3;
             let mut current = String::new();
             for i in 0..list.length() {
-                if let Some(node) = list.item(i) {
-                    if let Some(el) = node.dyn_ref::<web_sys::Element>() {
-                        if el.get_bounding_client_rect().top() - top <= 96.0 {
-                            current = el.id();
-                        }
+                if let Some(el) = list
+                    .item(i)
+                    .and_then(|n| n.dyn_into::<web_sys::Element>().ok())
+                {
+                    if el.get_bounding_client_rect().top() <= line {
+                        current = el.id();
                     }
                 }
             }
-            let changed = *active.peek() != current;
-            if !current.is_empty() && changed {
-                active.set(current);
+            let at_bottom = f64::from(scope.scroll_top()) + f64::from(scope.client_height())
+                >= f64::from(scope.scroll_height()) - 8.0;
+            if at_bottom && list.length() > 0 {
+                if let Some(el) = list
+                    .item(list.length() - 1)
+                    .and_then(|n| n.dyn_into::<web_sys::Element>().ok())
+                {
+                    current = el.id();
+                }
+            }
+            if current.is_empty() || *active.peek() == current {
+                return;
+            }
+            active.set(current.clone());
+            if let Ok(history) = win.history() {
+                let _ =
+                    history.replace_state_with_url(&JsValue::NULL, "", Some(&format!("#{current}")));
             }
         };
         update();
@@ -219,19 +236,62 @@ mod spy {
 
 #[component]
 fn DocsIndex() -> Element {
+    use_effect(|| {
+        #[cfg(target_arch = "wasm32")]
+        scroll_doc_top();
+    });
     doc_body("experience")
 }
 
 #[component]
 fn DocPage(slug: String) -> Element {
+    let s = slug.clone();
+    use_effect(use_reactive!(|s| {
+        let _ = &s;
+        #[cfg(target_arch = "wasm32")]
+        scroll_doc_top();
+    }));
     doc_body(&slug)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn scroll_doc_top() {
+    if let Some(el) = web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.get_element_by_id("doc-main"))
+    {
+        el.set_scroll_top(0);
+    }
 }
 
 fn doc_body(slug: &str) -> Element {
     match docs::find(slug) {
-        Some(d) => rsx! {
-            markdown::Markdown { content: d.content.to_string() }
-        },
+        Some(d) => {
+            let (prev, next) = docs::neighbors(d.slug);
+            rsx! {
+                markdown::Markdown { content: d.content.to_string() }
+                nav { class: "mt-16 grid grid-cols-2 gap-4 border-t border-border pt-8",
+                    if let Some(p) = prev {
+                        Link {
+                            class: "group flex flex-col gap-1 rounded-lg border border-border px-4 py-3 no-underline transition-colors hover:border-accent",
+                            to: Route::DocPage { slug: p.slug.to_string() },
+                            span { class: "text-xs text-text-muted", "← Previous" }
+                            span { class: "text-sm font-medium text-text group-hover:text-accent", "{p.title}" }
+                        }
+                    } else {
+                        span {}
+                    }
+                    if let Some(n) = next {
+                        Link {
+                            class: "group col-start-2 flex flex-col items-end gap-1 rounded-lg border border-border px-4 py-3 text-right no-underline transition-colors hover:border-accent",
+                            to: Route::DocPage { slug: n.slug.to_string() },
+                            span { class: "text-xs text-text-muted", "Next →" }
+                            span { class: "text-sm font-medium text-text group-hover:text-accent", "{n.title}" }
+                        }
+                    }
+                }
+            }
+        }
         None => rsx! {
             div { class: "py-12 text-center text-text-muted",
                 h1 { class: "text-2xl font-bold text-text mb-2", "Not found" }

--- a/website/src/markdown.rs
+++ b/website/src/markdown.rs
@@ -260,7 +260,7 @@ fn render_node(n: &Node) -> Element {
         },
         Node::Text(t) => rsx! { "{t}" },
         Node::Code(t) => rsx! {
-            code { class: "font-mono text-[0.85em] bg-code-bg text-accent rounded px-1.5 py-0.5", "{t}" }
+            code { class: "font-mono text-[0.85em] bg-code-bg text-accent rounded-md border border-border px-1.5 py-0.5", "{t}" }
         },
         Node::Strong(ch) => rsx! { strong { class: "font-semibold text-text", {render_nodes(ch)} } },
         Node::Emphasis(ch) => rsx! { em { class: "italic", {render_nodes(ch)} } },


### PR DESCRIPTION
## Summary
- **Agents** section: "Every agent has a home." with a `⌘ L` keycap and the addressable-URL panel (`⌘ L to visit`).
- **Two worlds** pillars: alternating full-width illustrated rows — vibe chat / generic search / IDE split (editor + zsh) — each in realistic vmux browser chrome with themed glow.
- **Input** section: `Talk › Type › Click` illustrated rows (mic + waveform, keyboard + ⌘K chip, button + click ripple).
- **Hero**: removed the GitHub button; matches the Install section layout.
- **Docs**: scroll-spy that activates earlier and syncs the URL `#hash`; prev/next footer nav; scroll-to-top on doc navigation; inline code rendered as bordered chips.
- **Docs renames**: Agent-first API → **Vmux MCP** (rewritten around agent exposure / vibe CLI), The render stack → **2D / 3D renderer**, Built to scale → **ECS: Build to scale**, The layout model → **Vmux Layout**.

## Test plan
- [ ] `cargo check` (host + `wasm32-unknown-unknown`) — both green
- [ ] Landing renders: Agents, pillars, Input rows, hero
- [ ] Docs: sidebar highlight + URL hash follow scroll; prev/next links; top reset on nav

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured and retitled architecture documentation with clearer focus on API design and system persistence
  * Updated interaction priority framework with improved visual labels

* **New Features**
  * Added "Previous" and "Next" navigation links to documentation pages

* **Style**
  * Redesigned landing page layouts including hero section, feature pillars, and interaction models
  * Updated visual styling and typography across documentation pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->