### PR TITLE
fix(team): reuse open team page on avatar click

### DIFF
--- a/crates/vmux_team/src/plugin.rs
+++ b/crates/vmux_team/src/plugin.rs
@@ -9,9 +9,12 @@ use vmux_core::event::team::{
 };
 use vmux_core::page::PageReady;
 use vmux_core::team::{Agent, Profile, User};
-use vmux_core::{PageMetadata, PageOpenError, PageOpenHandled, PageOpenSet, PageOpenTask};
+use vmux_core::{
+    PageMetadata, PageOpenError, PageOpenHandled, PageOpenSet, PageOpenTask, focus_pane_entity,
+};
 use vmux_layout::cef::LayoutCef;
 use vmux_layout::space::{ActiveSpaceEntity, Space, space_of};
+use vmux_layout::stack::Stack;
 
 #[derive(Component)]
 struct Team;
@@ -274,12 +277,36 @@ fn reset_team_sent_on_page_ready(
     commands.entity(entity).remove::<TeamListSent>();
 }
 
+fn open_team_stack_in_space(
+    space: Entity,
+    stacks: &Query<(Entity, &PageMetadata), With<Stack>>,
+    child_of: &Query<&ChildOf>,
+    spaces: &Query<(), With<Space>>,
+) -> Option<Entity> {
+    stacks.iter().find_map(|(stack, meta)| {
+        (meta.url == TEAM_PAGE_URL && space_of(stack, child_of, spaces) == Some(space))
+            .then_some(stack)
+    })
+}
+
 fn on_team_command(
     _trigger: On<BinReceive<TeamCommandEvent>>,
     mut messages: ResMut<bevy::ecs::message::Messages<AppCommand>>,
     mut issued: ResMut<bevy::ecs::message::Messages<vmux_command::CommandIssued>>,
     user: Query<Entity, With<User>>,
+    active_space: Res<ActiveSpaceEntity>,
+    stacks: Query<(Entity, &PageMetadata), With<Stack>>,
+    child_of: Query<&ChildOf>,
+    spaces: Query<(), With<Space>>,
+    mut commands: Commands,
 ) {
+    if let Some(space) = active_space.0
+        && let Some(stack) = open_team_stack_in_space(space, &stacks, &child_of, &spaces)
+    {
+        focus_pane_entity(stack, &mut commands, &child_of);
+        return;
+    }
+
     let caller = user.single().unwrap_or(Entity::PLACEHOLDER);
     let cmd = AppCommand::Browser(BrowserCommand::Open(OpenCommand::InNewStack {
         url: Some(TEAM_PAGE_URL.to_string()),
@@ -289,4 +316,67 @@ fn on_team_command(
         command: cmd.clone(),
     });
     messages.write(cmd);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::ecs::system::RunSystemOnce;
+
+    fn spawn_team_stack(world: &mut World, space: Entity) -> Entity {
+        world
+            .spawn((
+                Stack::default(),
+                PageMetadata {
+                    url: TEAM_PAGE_URL.to_string(),
+                    ..default()
+                },
+                ChildOf(space),
+            ))
+            .id()
+    }
+
+    fn lookup(app: &mut App, space: Entity) -> Option<Entity> {
+        app.world_mut()
+            .run_system_once(
+                move |stacks: Query<(Entity, &PageMetadata), With<Stack>>,
+                      child_of: Query<&ChildOf>,
+                      spaces: Query<(), With<Space>>| {
+                    open_team_stack_in_space(space, &stacks, &child_of, &spaces)
+                },
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn finds_open_team_stack_in_active_space() {
+        let mut app = App::new();
+        let space = app.world_mut().spawn(Space).id();
+        let stack = spawn_team_stack(app.world_mut(), space);
+        assert_eq!(lookup(&mut app, space), Some(stack));
+    }
+
+    #[test]
+    fn ignores_team_stack_in_other_space() {
+        let mut app = App::new();
+        let active = app.world_mut().spawn(Space).id();
+        let other = app.world_mut().spawn(Space).id();
+        spawn_team_stack(app.world_mut(), other);
+        assert_eq!(lookup(&mut app, active), None);
+    }
+
+    #[test]
+    fn ignores_non_team_stack_in_active_space() {
+        let mut app = App::new();
+        let space = app.world_mut().spawn(Space).id();
+        app.world_mut().spawn((
+            Stack::default(),
+            PageMetadata {
+                url: "https://example.com".to_string(),
+                ..default()
+            },
+            ChildOf(space),
+        ));
+        assert_eq!(lookup(&mut app, space), None);
+    }
 }


### PR DESCRIPTION
## Summary
- Clicking the header profile/agent facepile (avatar) used to always issue `OpenCommand::InNewStack` for `vmux://team/`, so every click stacked a duplicate Team page.
- Now `on_team_command` first looks for a `Stack` whose `PageMetadata.url == TEAM_PAGE_URL` in the **active space**. If found, it activates that stack's full chain via `focus_pane_entity` (stack → pane → tab), bringing the existing page to the front. Only when no team page is open in the space does it fall back to opening a new stack.

## Changes
- `crates/vmux_team/src/plugin.rs`
  - Add `open_team_stack_in_space()` helper (matches team stack by URL within a space).
  - Branch `on_team_command` to activate-existing-or-open-new.
  - 3 unit tests: found in active space, ignored in other space, non-team stack ignored.

## Test plan
- [x] `cargo test -p vmux_team` — 3 passed
- [x] `cargo clippy -p vmux_team --all-targets` — clean
- [x] `cargo fmt -p vmux_team`
- [ ] Manual: in a space with a Team page open in a background tab, click the avatar → existing tab/page is activated (not duplicated). With no team page open, click → new team page opens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Team page navigation is now smarter about reusing existing pages. When you open the Team page, the system checks if one already exists in your current workspace. If found, it brings that page to focus instead of opening a duplicate. This streamlines navigation and reduces workspace clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->