### PR TITLE
fix(browser): keep inactive-tab pages full-size for instant switching

### DIFF
--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -628,20 +628,35 @@ fn sync_children_to_ui(
             continue;
         }
 
+        let is_cef_ui = status.is_some() || side_sheet.is_some() || modal.is_some();
+
+        let under_inactive_tab = parent != glass_entity
+            && !is_cef_ui
+            && match tab_ancestor(parent, &child_of_q, &tabs_q) {
+                Some(tab) => !active_tab_q.contains(tab),
+                None => false,
+            };
+
         let size_px = computed.size;
-        if !webview_layout_is_renderable(
+        let renderable = webview_layout_is_renderable(
             size_px,
             visibility,
             pending_webview_reveal || pending_command_bar_reveal,
-        ) {
-            tf.scale = Vec3::splat(1.0e-6);
-            if webview_size.0 != Vec2::ONE {
-                webview_size.0 = Vec2::ONE;
+        );
+        match hidden_webview_sizing(renderable, under_inactive_tab) {
+            HiddenWebviewSizing::Render => {}
+            HiddenWebviewSizing::HideKeepSize => {
+                tf.scale = Vec3::splat(1.0e-6);
+                continue;
             }
-            continue;
+            HiddenWebviewSizing::Collapse => {
+                tf.scale = Vec3::splat(1.0e-6);
+                if webview_size.0 != Vec2::ONE {
+                    webview_size.0 = Vec2::ONE;
+                }
+                continue;
+            }
         }
-
-        let is_cef_ui = status.is_some() || side_sheet.is_some() || modal.is_some();
 
         // Check if this browser's parent tab is the active tab in its pane
         let is_active_stack = if parent != glass_entity && !is_cef_ui {
@@ -658,12 +673,7 @@ fn sync_children_to_ui(
         let is_inactive_stack =
             parent != glass_entity && !is_cef_ui && !is_active_stack && !is_previous_stack;
 
-        let is_inactive_tab = parent != glass_entity
-            && !is_cef_ui
-            && match tab_ancestor(parent, &child_of_q, &tabs_q) {
-                Some(tab) => !active_tab_q.contains(tab),
-                None => false,
-            };
+        let is_inactive_tab = under_inactive_tab;
 
         let sx = size_px.x / glass_size_px.x;
         let sy = size_px.y / glass_size_px.y;
@@ -1759,6 +1769,23 @@ fn sync_osr_webview_focus(
         } else {
             browsers.set_osr_hidden(&e);
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HiddenWebviewSizing {
+    Render,
+    HideKeepSize,
+    Collapse,
+}
+
+fn hidden_webview_sizing(renderable: bool, under_inactive_tab: bool) -> HiddenWebviewSizing {
+    if renderable {
+        HiddenWebviewSizing::Render
+    } else if under_inactive_tab {
+        HiddenWebviewSizing::HideKeepSize
+    } else {
+        HiddenWebviewSizing::Collapse
     }
 }
 
@@ -3364,6 +3391,26 @@ mod tests {
             Some(&Visibility::Hidden),
             true
         ));
+    }
+
+    #[test]
+    fn inactive_tab_pages_keep_size_other_hidden_pages_collapse() {
+        assert_eq!(
+            hidden_webview_sizing(true, false),
+            HiddenWebviewSizing::Render
+        );
+        assert_eq!(
+            hidden_webview_sizing(true, true),
+            HiddenWebviewSizing::Render
+        );
+        assert_eq!(
+            hidden_webview_sizing(false, true),
+            HiddenWebviewSizing::HideKeepSize
+        );
+        assert_eq!(
+            hidden_webview_sizing(false, false),
+            HiddenWebviewSizing::Collapse
+        );
     }
 
     #[test]

--- a/crates/vmux_layout/src/space.rs
+++ b/crates/vmux_layout/src/space.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use moonshine_save::prelude::*;
+use vmux_command::ReadAppCommands;
 
 pub struct SpacePlugin;
 
@@ -24,7 +25,8 @@ impl Plugin for SpacePlugin {
                     crate::active::ensure_active_tab,
                     crate::active::ensure_active_stack,
                     crate::active::ensure_active_branch,
-                ),
+                )
+                    .after(ReadAppCommands),
             )
             .add_systems(
                 PostUpdate,

--- a/crates/vmux_layout/src/tab.rs
+++ b/crates/vmux_layout/src/tab.rs
@@ -706,4 +706,54 @@ mod tests {
         assert!(app.world().get_entity(other_tab).is_ok());
         assert!(app.world().resource::<LastTabCloseAt>().0.is_some());
     }
+
+    #[test]
+    fn tab_next_activates_and_reveals_target_in_a_single_update() {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, CommandPlugin, crate::space::SpacePlugin))
+            .add_message::<crate::TabLayoutSpawnRequest>()
+            .add_systems(Update, handle_tab_commands.in_set(ReadAppCommands))
+            .add_systems(PostUpdate, sync_tab_visibility.before(UiSystems::Layout));
+
+        app.world_mut().spawn(PrimaryWindow);
+        let main = app.world_mut().spawn(MainNode).id();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active, ChildOf(main)))
+            .id();
+        let tab_a = app
+            .world_mut()
+            .spawn((
+                tab_bundle(),
+                LastActivatedAt(2),
+                vmux_core::Active,
+                ChildOf(space),
+            ))
+            .id();
+        let tab_b = app
+            .world_mut()
+            .spawn((tab_bundle(), LastActivatedAt(1), ChildOf(space)))
+            .id();
+
+        app.world_mut()
+            .resource_mut::<Messages<AppCommand>>()
+            .write(AppCommand::Layout(LayoutCommand::Tab(TabCommand::Next)));
+
+        app.update();
+
+        assert!(
+            app.world().entity(tab_b).contains::<vmux_core::Active>(),
+            "target tab must become Active in the same update as the switch command"
+        );
+        assert_eq!(
+            app.world().get::<Node>(tab_b).unwrap().display,
+            Display::Flex,
+            "target tab must be revealed in the same update (no one-frame lag)"
+        );
+        assert_eq!(
+            app.world().get::<Node>(tab_a).unwrap().display,
+            Display::None,
+            "previously active tab must hide in the same update"
+        );
+    }
 }


### PR DESCRIPTION
## Context

Switching tabs felt laggy compared to switching stacks — the page visibly reflowed on every tab switch, while stack switches were instant. Same UI affordance, very different feel.

## Implementation

Inactive tabs hide via `Display::None` (`tab.rs` `sync_tab_visibility`), which zeroes the descendant pane's `ComputedNode`. That tripped the not-renderable early-out in `sync_children_to_ui` (`vmux_browser/src/lib.rs`), which shrinks every page under the tab to `WebviewSize = 1×1`. On switch, CEF had to resize the surface 1px→full and reflow/repaint the whole page — the lag. Inactive *stacks* share a still-laid-out pane, so they keep full size and only toggle z-index → instant.

A small pure helper, `hidden_webview_sizing(renderable, under_inactive_tab)`, now distinguishes the cases:
- **Render** — normal sizing.
- **HideKeepSize** — hidden only because the tab is inactive → keep the last full `WebviewSize`, so reactivation needs no CEF resize (parity with inactive stacks).
- **Collapse** — genuine zero-size/hidden → still shrink to 1×1.

Tradeoff: backgrounded tabs now retain full-size CEF surfaces (CEF throttles hidden windowed views). This is the same memory/CPU profile stacks already accept.

## Checks / QA

- Switch between several used tabs — content should appear instantly, no resize/reflow flash.
- Confirm stack switching is unchanged.
- Open several tabs, leave them backgrounded, and watch idle CPU/memory — verify no regression from retained surfaces.
- Verify first-ever activation of a never-shown (e.g. restored) tab still sizes correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved webview visibility and scaling behavior for inactive tabs and other non-renderable content, yielding more consistent rendering.

* **Bug Fixes**
  * Ensured “Tab Next” activates the target tab and updates its UI visibility immediately within the same update cycle (no one-frame delay).

* **Tests**
  * Added/extended unit tests to validate webview sizing across renderable/inactive-tab cases and to confirm correct tab activation + visibility syncing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->