### PR TITLE
chore: rename leftover "chrome" references to "layout"

### DIFF
--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -840,7 +840,7 @@ fn sync_windowed_content_mesh_materials(
     }
 }
 
-/// The layout chrome renders on the OSR mesh in both modes: a wgpu quad that resizes with the Bevy
+/// The layout renders on the OSR mesh in both modes: a wgpu quad that resizes with the Bevy
 /// frame, so it tracks a live window resize (a native overlay cannot — its frame only updates from a
 /// Bevy schedule the macOS resize loop starves). Keep the material visible.
 ///
@@ -3238,7 +3238,7 @@ mod tests {
         assert_eq!(
             mat.base.base_color.alpha(),
             1.0,
-            "User mode renders the layout chrome via the mesh (CPU OSR) so it tracks live resize"
+            "User mode renders the layout via the mesh (CPU OSR) so it tracks live resize"
         );
         assert_eq!(mat.base.alpha_mode, AlphaMode::Blend);
     }

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -353,11 +353,11 @@ fn event_location_in_window_physical_px(event: &objc2_app_kit::NSEvent) -> Optio
 /// `react_to_device_events` is off in browse (User) mode: native CEF views own scroll/input, so only
 /// Player mode's free camera consumes `AccumulatedMouseMotion`.
 ///
-/// At rest `react_to_window_events` is on so the layout chrome mesh + camera respond to window events
+/// At rest `react_to_window_events` is on so the layout mesh + camera respond to window events
 /// (sizing, focus). During a live resize it flips off and `wait` drops to ~16ms: the loop is paced by
 /// the timer at ~60Hz instead of rendering on every 120Hz `Resized`, capping the resize CPU spike.
 /// `Resized` still updates the `Window` on delivery, so the timer reads the latest size each tick and
-/// the chrome tracks the drag. `live_resize` is driven by [`install_live_resize_monitor`].
+/// the layout tracks the drag. `live_resize` is driven by [`install_live_resize_monitor`].
 pub(crate) fn foreground_winit_settings(player: bool, live_resize: bool) -> WinitSettings {
     let focused_mode = if live_resize {
         UpdateMode::Reactive {
@@ -634,7 +634,7 @@ mod tests {
             settings.unfocused_mode,
             UpdateMode::reactive_low_power(Duration::from_secs(1))
         );
-        // At rest, window-event wakes are on so the chrome mesh + camera respond to window events;
+        // At rest, window-event wakes are on so the layout mesh + camera respond to window events;
         // device-event wakes stay off in browse mode.
         assert!(!react_to_device_events);
         assert!(react_to_window_events);

--- a/patches/bevy_cef-0.5.2/src/common/components.rs
+++ b/patches/bevy_cef-0.5.2/src/common/components.rs
@@ -81,7 +81,7 @@ pub struct WebviewOpaqueWindowedBackground;
 pub struct WebviewWindowedNativeFocus;
 
 /// Caps an OSR webview's windowless frame rate (fps). `sync_windowless_frame_rate` clamps the
-/// monitor-derived rate to this value, so a mostly-static surface (e.g. layout chrome) repaints —
+/// monitor-derived rate to this value, so a mostly-static surface (e.g. the layout) repaints —
 /// and forces a Bevy re-render — far less often. No effect on windowed webviews.
 #[derive(Component, Debug, Clone, Copy, Reflect)]
 #[reflect(Component)]

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
@@ -1047,7 +1047,7 @@ impl Browsers {
     pub fn raise_windowed_to_front(&self, _: &Entity) {}
 
     /// Set the `zPosition` of a windowed browser's native view (the liquid-glass container when
-    /// present). The layout chrome composites as a sibling `CALayer` at `zPosition` 100, and a plain
+    /// present). The layout composites as a sibling `CALayer` at `zPosition` 100, and a plain
     /// windowed view sits at 0 — so `raise_windowed_to_front` (subview order) cannot lift the
     /// command-bar modal above the sidebar/header overlay. A higher `zPosition` can.
     #[cfg(target_os = "macos")]

--- a/website/src/landing/pillars.rs
+++ b/website/src/landing/pillars.rs
@@ -191,7 +191,7 @@ fn tab(icon: Element, title: &str, active: bool) -> Element {
     }
 }
 
-fn chrome(frame: &str, tabs: Element, address: &str, body: Element) -> Element {
+fn browser_frame(frame: &str, tabs: Element, address: &str, body: Element) -> Element {
     rsx! {
         div { class: "flex h-64 flex-col overflow-hidden rounded-lg border {frame}",
             div { class: "flex items-center gap-1 px-2 pt-2",
@@ -215,7 +215,7 @@ fn chrome(frame: &str, tabs: Element, address: &str, body: Element) -> Element {
 
 fn art(kind: Art) -> Element {
     match kind {
-        Art::Coworking => chrome(
+        Art::Coworking => browser_frame(
             "border-accent/20 bg-[#0d0d18] shadow-xl shadow-accent/20",
             rsx! {
                 {tab(icon_bot("h-3 w-3 text-aurora-violet"), "vibe", true)}
@@ -239,7 +239,7 @@ fn art(kind: Art) -> Element {
                 }
             },
         ),
-        Art::Browser => chrome(
+        Art::Browser => browser_frame(
             "border-aurora-cyan/20 bg-[#0b1418] shadow-xl shadow-aurora-cyan/20",
             rsx! {
                 {tab(icon_globe("h-3 w-3 text-aurora-cyan"), "New Tab", true)}
@@ -256,7 +256,7 @@ fn art(kind: Art) -> Element {
                 }
             },
         ),
-        Art::Terminal => chrome(
+        Art::Terminal => browser_frame(
             "border-aurora-violet/20 bg-[#120c1a] shadow-xl shadow-aurora-violet/20",
             rsx! {
                 {tab(icon_term("h-3 w-3 text-aurora-violet"), "pillars.rs", true)}


### PR DESCRIPTION
## Summary
The vmux UI is called the **layout**, never "chrome". Scrubbed the last stragglers.

- `vmux_desktop/src/background_lifecycle.rs` — 3 comments
- `vmux_browser/src/lib.rs` — doc comment + 1 test assertion message
- `patches/bevy_cef*/...` — 2 vmux-added comments
- `website/src/landing/pillars.rs` — renamed helper `fn chrome` → `browser_frame` (draws a generic browser-window frame mockup)

Comment/string/identifier-rename only — no behavior change. Legit references (Chromium, Chrome DevTools, `chrome.*` extension APIs, Chrome-parity, `chrome://`) left intact.

## Test plan
- [ ] CI: fmt, clippy, tests green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation and inline comments across multiple modules to improve terminology consistency and ensure technical descriptions align throughout the codebase for better clarity.

* **Refactor**
  * Renamed a website UI component helper function to enhance code clarity and improve maintainability across the website's visual components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->