### PR TITLE
feat(team): click agent avatar to focus its open page

### DIFF
--- a/crates/vmux_layout/src/page.rs
+++ b/crates/vmux_layout/src/page.rs
@@ -520,16 +520,17 @@ fn TeamFacepile(members: Vec<TeamMemberRow>) -> Element {
     let overflow = agents.len().saturating_sub(max);
     rsx! {
         div {
-            class: "flex shrink-0 items-center gap-2 pl-3 pr-3 cursor-pointer transition-opacity hover:opacity-80",
-            title: "Team",
-            onclick: move |_| {
-                let _ = try_cef_bin_emit_rkyv(&TeamCommandEvent {
-                    command: "open".to_string(),
-                    member_id: None,
-                });
-            },
+            class: "flex shrink-0 items-center gap-2 pl-3 pr-3",
             if let Some(user) = user {
-                div { class: "flex items-center gap-1.5 rounded-full bg-foreground/10 py-0.5 pl-0.5 pr-2.5",
+                div {
+                    class: "flex items-center gap-1.5 rounded-full bg-foreground/10 py-0.5 pl-0.5 pr-2.5 cursor-pointer transition-opacity hover:opacity-80",
+                    title: "Team",
+                    onclick: move |_| {
+                        let _ = try_cef_bin_emit_rkyv(&TeamCommandEvent {
+                            command: "open".to_string(),
+                            member_id: None,
+                        });
+                    },
                     div {
                         class: "inline-flex size-5 items-center justify-center rounded-full text-[9px] font-semibold text-white",
                         style: "background:{user.color}",
@@ -544,12 +545,19 @@ fn TeamFacepile(members: Vec<TeamMemberRow>) -> Element {
                         {
                             let src = favicon_src_for_url(&m.icon, &m.url);
                             let bg = if src.is_some() { String::new() } else { format!("background:{}", m.color) };
+                            let id = m.id.clone();
                             rsx! {
                                 div {
                                     key: "{m.id}",
                                     title: "{m.name}",
-                                    class: "relative inline-flex size-5 items-center justify-center overflow-hidden rounded-full ring-2 ring-background text-[9px] font-semibold text-white",
+                                    class: "relative inline-flex size-5 items-center justify-center overflow-hidden rounded-full ring-2 ring-background text-[9px] font-semibold text-white cursor-pointer transition-opacity hover:opacity-80",
                                     style: "{bg}",
+                                    onclick: move |_| {
+                                        let _ = try_cef_bin_emit_rkyv(&TeamCommandEvent {
+                                            command: "focus".to_string(),
+                                            member_id: Some(id.clone()),
+                                        });
+                                    },
                                     if let Some(src) = src.as_ref() {
                                         img { class: "size-full object-cover", src: "{src}" }
                                     } else {
@@ -564,7 +572,14 @@ fn TeamFacepile(members: Vec<TeamMemberRow>) -> Element {
                     }
                     if overflow > 0 {
                         div {
-                            class: "relative inline-flex size-5 items-center justify-center rounded-full ring-2 ring-background bg-muted text-[9px] font-medium text-muted-foreground",
+                            class: "relative inline-flex size-5 items-center justify-center rounded-full ring-2 ring-background bg-muted text-[9px] font-medium text-muted-foreground cursor-pointer transition-opacity hover:opacity-80",
+                            title: "Team",
+                            onclick: move |_| {
+                                let _ = try_cef_bin_emit_rkyv(&TeamCommandEvent {
+                                    command: "open".to_string(),
+                                    member_id: None,
+                                });
+                            },
                             "+{overflow}"
                         }
                     }

--- a/crates/vmux_team/src/plugin.rs
+++ b/crates/vmux_team/src/plugin.rs
@@ -289,17 +289,32 @@ fn open_team_stack_in_space(
     })
 }
 
+fn parse_member_entity(member_id: &str) -> Option<Entity> {
+    let bits = member_id.parse::<u64>().ok()?;
+    Entity::try_from_bits(bits)
+}
+
 fn on_team_command(
-    _trigger: On<BinReceive<TeamCommandEvent>>,
+    trigger: On<BinReceive<TeamCommandEvent>>,
     mut messages: ResMut<bevy::ecs::message::Messages<AppCommand>>,
     mut issued: ResMut<bevy::ecs::message::Messages<vmux_command::CommandIssued>>,
     user: Query<Entity, With<User>>,
     active_space: Res<ActiveSpaceEntity>,
     stacks: Query<(Entity, &PageMetadata), With<Stack>>,
+    agents: Query<Entity, With<Agent>>,
     child_of: Query<&ChildOf>,
     spaces: Query<(), With<Space>>,
     mut commands: Commands,
 ) {
+    if let Some(member_id) = trigger.event().payload.member_id.as_deref() {
+        if let Some(entity) = parse_member_entity(member_id)
+            && agents.get(entity).is_ok()
+        {
+            focus_pane_entity(entity, &mut commands, &child_of);
+        }
+        return;
+    }
+
     if let Some(space) = active_space.0
         && let Some(stack) = open_team_stack_in_space(space, &stacks, &child_of, &spaces)
     {
@@ -322,6 +337,8 @@ fn on_team_command(
 mod tests {
     use super::*;
     use bevy::ecs::system::RunSystemOnce;
+    use vmux_core::LastActivatedAt;
+    use vmux_core::agent::AgentKind;
 
     fn spawn_team_stack(world: &mut World, space: Entity) -> Entity {
         world
@@ -378,5 +395,72 @@ mod tests {
             ChildOf(space),
         ));
         assert_eq!(lookup(&mut app, space), None);
+    }
+
+    #[test]
+    fn parse_member_entity_roundtrips_and_rejects_garbage() {
+        let mut app = App::new();
+        let entity = app.world_mut().spawn_empty().id();
+        let bits = entity.to_bits().to_string();
+        assert_eq!(parse_member_entity(&bits), Some(entity));
+        assert_eq!(parse_member_entity("not-a-number"), None);
+        assert_eq!(parse_member_entity(""), None);
+    }
+
+    fn command_app() -> App {
+        let mut app = App::new();
+        app.add_message::<AppCommand>()
+            .add_message::<vmux_command::CommandIssued>()
+            .add_observer(on_team_command);
+        app
+    }
+
+    #[test]
+    fn agent_avatar_click_focuses_agent_stack() {
+        let mut app = command_app();
+        let space = app.world_mut().spawn(Space).id();
+        app.insert_resource(ActiveSpaceEntity(Some(space)));
+        let stack = app
+            .world_mut()
+            .spawn((
+                Stack::default(),
+                Agent {
+                    sid: "s".to_string(),
+                    kind: AgentKind::Claude,
+                },
+                ChildOf(space),
+            ))
+            .id();
+
+        app.world_mut().trigger(BinReceive::<TeamCommandEvent> {
+            webview: Entity::PLACEHOLDER,
+            payload: TeamCommandEvent {
+                command: "focus".to_string(),
+                member_id: Some(stack.to_bits().to_string()),
+            },
+        });
+        app.world_mut().flush();
+
+        assert!(app.world().get::<LastActivatedAt>(stack).is_some());
+        assert_eq!(lookup(&mut app, space), None);
+    }
+
+    #[test]
+    fn user_click_reuses_open_team_stack() {
+        let mut app = command_app();
+        let space = app.world_mut().spawn(Space).id();
+        app.insert_resource(ActiveSpaceEntity(Some(space)));
+        let team = spawn_team_stack(app.world_mut(), space);
+
+        app.world_mut().trigger(BinReceive::<TeamCommandEvent> {
+            webview: Entity::PLACEHOLDER,
+            payload: TeamCommandEvent {
+                command: "open".to_string(),
+                member_id: None,
+            },
+        });
+        app.world_mut().flush();
+
+        assert!(app.world().get::<LastActivatedAt>(team).is_some());
     }
 }


### PR DESCRIPTION
## Context

Clicking anywhere on the top-right facepile opened the team page — the whole strip was a single click target with no per-avatar action. Clicking a specific agent should instead jump to the page that agent has open.

## Implementation

- Facepile (`vmux_layout/src/page.rs`): moved the click handler off the container and onto each element. Agent avatars emit `TeamCommandEvent { member_id: Some(entity_bits) }`; the user pill and `+N` overflow chip keep emitting `member_id: None`.
- Handler (`vmux_team/src/plugin.rs`): `on_team_command` now reads `member_id`. A live `Agent` entity is focused via `focus_pane_entity` (stamps the stack + ancestors, bringing that page to front and switching the active tab); this works for both layouts — page-agent (entity is the stack) and CLI-agent (entity is a child of the stack). `None` keeps the open/reuse-team-page flow; a stale/invalid id is a no-op so it never surprise-opens the team page.

## Checks / QA

- Click an agent avatar in the facepile → its page comes to the front and the active tab switches to it.
- Click the user ("You") pill → team page opens/reuses (unchanged).
- Click the `+N` overflow chip → team page opens.
- Click an agent in a stack that is not currently frontmost → it is revealed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Team member avatars are now fully interactive; clicking an avatar focuses on that specific team member within the team view
  * The overflow member indicator (displaying the count of additional members) is now clickable with interactive behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->