### PR TITLE
feat(agent): run terminals join the type-stack spiral

### DIFF
--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -54,13 +54,8 @@ const BUILTIN_AGENT_PROVIDERS: &[AgentKind] =
 #[derive(Resource, Clone, Default)]
 pub struct AgentExecutableOverride(pub std::collections::HashMap<AgentKind, bool>);
 
-/// The terminal "region" pane each agent's `run` terminals live in (anchor →
-/// pane). A bare `run` stacks new terminals into this pane instead of splitting
-/// the agent's own pane again; the first `run` creates it. Self-healing: a stale
-/// pane (closed) is replaced by a fresh split.
 #[derive(Resource, Default)]
 pub struct AgentTerminalRegions {
-    pub panes: std::collections::HashMap<ProcessId, Entity>,
     pub run_terminals: std::collections::HashMap<ProcessId, ProcessId>,
 }
 
@@ -679,12 +674,8 @@ fn handle_agent_self_commands(
     mut reader: MessageReader<AgentCommandRequest>,
     agent_terms: Query<(Entity, &ProcessId, &ChildOf), With<AgentSession>>,
     term_pids: Query<(Entity, &ProcessId), With<Terminal>>,
-    child_of_q: Query<&ChildOf>,
     launch_q: Query<&TerminalLaunch>,
-    pane_children: Query<&Children, With<Pane>>,
-    panes: Query<Entity, With<Pane>>,
-    split_dir_q: Query<&PaneSplit>,
-    tab_filter: Query<Entity, With<vmux_layout::stack::Stack>>,
+    ctx: vmux_layout::pane::PlacementCtx,
     mut open_beside_writer: MessageWriter<vmux_layout::OpenBesideRequest>,
     mut terminal_stack_spawn_writer: MessageWriter<TerminalStackSpawnRequest>,
     mut commands: Commands,
@@ -709,7 +700,7 @@ fn handle_agent_self_commands(
                 direction,
                 url,
                 focus,
-            } => match resolve_self_pane(*anchor, &agent_terms, &child_of_q) {
+            } => match resolve_self_pane(*anchor, &agent_terms, &ctx.child_of_q) {
                 None => AgentCommandResult::Error("self process not found".to_string()),
                 Some((_, pane)) => {
                     open_beside_writer.write(vmux_layout::OpenBesideRequest {
@@ -756,7 +747,7 @@ fn handle_agent_self_commands(
                             break 'spawn AgentCommandResult::Text(pid.to_string());
                         }
                         let Some((agent_term, self_pane)) =
-                            resolve_self_pane(*anchor, &agent_terms, &child_of_q)
+                            resolve_self_pane(*anchor, &agent_terms, &ctx.child_of_q)
                         else {
                             break 'spawn AgentCommandResult::Error(
                                 "self process not found".to_string(),
@@ -765,7 +756,7 @@ fn handle_agent_self_commands(
                         // Resolve an explicit `beside` anchor up front (errors if stale).
                         let beside_pane = match beside {
                             Some(pid) => {
-                                match resolve_pane_for_pid(*pid, &term_pids, &child_of_q) {
+                                match resolve_pane_for_pid(*pid, &term_pids, &ctx.child_of_q) {
                                     Some(pane) => Some(pane),
                                     None => {
                                         break 'spawn AgentCommandResult::Error(format!(
@@ -784,36 +775,21 @@ fn handle_agent_self_commands(
                                 anchor.unwrap_or(self_pane),
                                 direction,
                                 *focus,
-                                &pane_children,
-                                &tab_filter,
-                                &split_dir_q,
+                                &ctx.pane_children,
+                                &ctx.tab_filter,
+                                &ctx.split_dir_q,
                                 &mut split_this_batch,
                             ),
-                            // Stack into the given page's pane.
                             (Some(pane), _) => pane,
-                            // No anchor: reuse the agent's terminal region, else split one
-                            // off the agent the first time (don't spawn a pane unless needed).
-                            (None, _) => {
-                                let region = regions
-                                    .panes
-                                    .get(anchor)
-                                    .copied()
-                                    .filter(|p| panes.contains(*p));
-                                region.unwrap_or_else(|| {
-                                    split_pane_off(
-                                        &mut commands,
-                                        self_pane,
-                                        direction,
-                                        *focus,
-                                        &pane_children,
-                                        &tab_filter,
-                                        &split_dir_q,
-                                        &mut split_this_batch,
-                                    )
-                                })
-                            }
+                            (None, _) => vmux_layout::pane::resolve_spiral_pane(
+                                &mut commands,
+                                self_pane,
+                                TERMINAL_PAGE_URL,
+                                *focus,
+                                &mut split_this_batch,
+                                &ctx,
+                            ),
                         };
-                        regions.panes.insert(*anchor, target_pane);
                         let new_pid = ProcessId::new();
                         let agent_cwd = launch_q.get(agent_term).ok().map(|l| l.cwd.clone());
                         let cwd = run_terminal_cwd(agent_cwd.as_deref(), active_space.as_deref());

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -1145,6 +1145,55 @@ fn find_reuse_in_space(
     None
 }
 
+#[derive(bevy::ecs::system::SystemParam)]
+pub struct PlacementCtx<'w, 's> {
+    pub child_of_q: Query<'w, 's, &'static ChildOf>,
+    pub tab_q: Query<'w, 's, Entity, With<Tab>>,
+    pub all_children: Query<'w, 's, &'static Children>,
+    pub leaf_panes: Query<'w, 's, Entity, (With<Pane>, Without<PaneSplit>)>,
+    pub pane_children: Query<'w, 's, &'static Children, With<Pane>>,
+    pub split_dir_q: Query<'w, 's, &'static PaneSplit>,
+    pub tab_filter: Query<'w, 's, Entity, With<Stack>>,
+    pub seq_q: Query<'w, 's, &'static SpawnSeq>,
+    pub node_q: Query<'w, 's, &'static ComputedNode>,
+    pub page_q: Query<'w, 's, &'static vmux_core::PageMetadata, With<Stack>>,
+}
+
+pub fn resolve_spiral_pane(
+    commands: &mut Commands,
+    anchor_pane: Entity,
+    url: &str,
+    focus: bool,
+    split_batch: &mut std::collections::HashSet<Entity>,
+    ctx: &PlacementCtx,
+) -> Entity {
+    let Some(tab) = tab_of_pane(anchor_pane, &ctx.child_of_q, &ctx.tab_q) else {
+        return anchor_pane;
+    };
+    let leaves = collect_leaf_infos(
+        tab,
+        &ctx.all_children,
+        &ctx.leaf_panes,
+        &ctx.pane_children,
+        &ctx.seq_q,
+        &ctx.node_q,
+        &ctx.page_q,
+    );
+    match crate::placement::resolve_placement(url, None, &leaves, anchor_pane) {
+        crate::placement::Placement::AddTab { pane } => pane,
+        crate::placement::Placement::Spiral { anchor, axis } => {
+            let existing_tabs: Vec<Entity> = ctx
+                .pane_children
+                .get(anchor)
+                .map(|c| c.iter().filter(|&e| ctx.tab_filter.contains(e)).collect())
+                .unwrap_or_default();
+            let already_split = !split_batch.insert(anchor) || ctx.split_dir_q.contains(anchor);
+            split_or_extend(commands, anchor, axis, &existing_tabs, focus, already_split)
+        }
+        crate::placement::Placement::Focus { .. } => anchor_pane,
+    }
+}
+
 fn is_after_direction(direction: &PaneDirection) -> bool {
     matches!(direction, PaneDirection::Right | PaneDirection::Bottom)
 }
@@ -2499,6 +2548,116 @@ mod tests {
         assert!(
             app.world().get::<PaneSplit>(browser_pane).is_none(),
             "reuse must not split"
+        );
+    }
+
+    #[derive(Resource)]
+    struct SpiralInput {
+        anchor: Entity,
+        url: String,
+    }
+    #[derive(Resource, Default)]
+    struct SpiralOut(Option<Entity>);
+
+    fn spiral_test_sys(
+        input: Res<SpiralInput>,
+        mut commands: Commands,
+        ctx: PlacementCtx,
+        mut out: ResMut<SpiralOut>,
+    ) {
+        let mut batch = std::collections::HashSet::new();
+        out.0 = Some(resolve_spiral_pane(
+            &mut commands,
+            input.anchor,
+            &input.url,
+            false,
+            &mut batch,
+            &ctx,
+        ));
+    }
+
+    fn spiral_app(anchor_url: &str, other: Option<(&str, u64, Vec2)>) -> (App, Entity) {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<SpiralOut>()
+            .add_systems(Update, spiral_test_sys);
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                vmux_core::Active,
+                LastActivatedAt::now(),
+                ChildOf(space),
+            ))
+            .id();
+        let agent = place_pane_with_url(&mut app, tab, 1, Vec2::new(800.0, 900.0), anchor_url);
+        if let Some((url, seq, size)) = other {
+            place_pane_with_url(&mut app, tab, seq, size, url);
+        }
+        (app, agent)
+    }
+
+    #[test]
+    fn run_terminal_spirals_off_newest_nonagent_leaf() {
+        let (mut app, agent) = spiral_app(
+            "vmux://agent/vibe/x",
+            Some(("https://a.com", 9, Vec2::new(1600.0, 900.0))),
+        );
+        let browser = app
+            .world_mut()
+            .query_filtered::<Entity, (With<Pane>, Without<PaneSplit>)>()
+            .iter(app.world())
+            .find(|&e| e != agent)
+            .unwrap();
+        app.world_mut().insert_resource(SpiralInput {
+            anchor: agent,
+            url: "vmux://terminal/".into(),
+        });
+        app.update();
+
+        let split = app
+            .world()
+            .get::<PaneSplit>(browser)
+            .expect("newest non-agent (browser) leaf must split for the new terminal type");
+        assert_eq!(split.direction, PaneSplitDirection::Row, "wide => Row");
+        assert!(
+            app.world().get::<PaneSplit>(agent).is_none(),
+            "agent pane untouched"
+        );
+        let out = app.world().resource::<SpiralOut>().0.unwrap();
+        assert_ne!(out, browser, "returns the new leaf, not the split node");
+    }
+
+    #[test]
+    fn run_terminal_adds_tab_to_existing_terminal_stack() {
+        let (mut app, agent) = spiral_app(
+            "vmux://agent/vibe/x",
+            Some(("vmux://terminal/7", 9, Vec2::new(1600.0, 900.0))),
+        );
+        let term_pane = app
+            .world_mut()
+            .query_filtered::<Entity, (With<Pane>, Without<PaneSplit>)>()
+            .iter(app.world())
+            .find(|&e| e != agent)
+            .unwrap();
+        app.world_mut().insert_resource(SpiralInput {
+            anchor: agent,
+            url: "vmux://terminal/".into(),
+        });
+        app.update();
+
+        assert!(
+            app.world().get::<PaneSplit>(term_pane).is_none(),
+            "existing terminal stack must not split"
+        );
+        assert_eq!(
+            app.world().resource::<SpiralOut>().0,
+            Some(term_pane),
+            "new terminal tabs into the existing terminal pane"
         );
     }
 


### PR DESCRIPTION
## Summary
Follow-up to #135 (Plan B): **`run` terminals now join the same type-stack spiral** as `open_page`/`open_file`.

- In `Auto` mode with no `beside`, a new `run` terminal is placed by the shared resolver instead of a bespoke per-agent region: it tabs into the existing **terminal** stack if one exists, else spiral-splits the most-recently-created non-agent leaf along its longer side. The **agent pane stays protected** (never the spiral anchor; split at most once to bootstrap).
- **Persistent-shell reuse is unchanged**: `run_terminals` still reuses one shell per agent so cwd/env persist across calls. Explicit `mode=split` / `mode=stack` / `beside` are unchanged.
- Removed the now-redundant `AgentTerminalRegions.panes` region map — the resolver finds the terminal stack each call.
- New reusable `vmux_layout::pane::PlacementCtx` + `resolve_spiral_pane` (reuse-free placement), shared by the `run` path.

## Test plan
- [x] `cargo test -p vmux_layout` (290 tests, incl. 2 new `resolve_spiral_pane` tests: spiral-off-newest-non-agent, add-tab-to-existing-terminal) + `vmux_agent` green
- [x] clippy clean; `cargo build -p vmux_desktop` ok
- [ ] Runtime: agent `run` opens a terminal that spirals into the layout next to file/browser/agent stacks (one unified spiral, not a separate region); a second `run` reuses the same shell; the agent pane keeps its width.

Completes the terminal half of the spiral design (`docs/specs/2026-06-23-auto-type-stack-spiral-placement-design.md`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized terminal placement state tracking and management in agent operations
  * Refactored pane resolution logic for improved resource efficiency

* **Tests**
  * Extended test coverage for spiral placement behavior
  * Added test coverage for terminal stack management scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->