### PR TITLE
feat: agent-done OS notification + avatar indicator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6592,7 +6592,7 @@ dependencies = [
  "bitflags 2.11.1",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-core-location",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
 ]
 
@@ -6725,6 +6725,16 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -6983,13 +6993,13 @@ dependencies = [
  "objc2-cloud-kit 0.2.2",
  "objc2-core-data 0.2.2",
  "objc2-core-image 0.2.2",
- "objc2-core-location",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
  "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers 0.2.2",
- "objc2-user-notifications",
+ "objc2-user-notifications 0.2.2",
 ]
 
 [[package]]
@@ -7022,8 +7032,21 @@ dependencies = [
  "bitflags 2.11.1",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-core-location",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-core-location 0.3.2",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -9729,6 +9752,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "objc2-quartz-core 0.3.2",
  "objc2-screen-capture-kit",
+ "objc2-user-notifications 0.3.2",
  "parking_lot",
  "raw-window-handle",
  "rfd",

--- a/crates/vmux_agent/src/launch.rs
+++ b/crates/vmux_agent/src/launch.rs
@@ -18,6 +18,7 @@ pub fn build_agent_launch(
     let args = strategy.build_args(&mcp_cfg, session_id);
     let mut env: Vec<(String, String)> = std::env::vars().collect();
     env.extend(strategy.build_env(&mcp_cfg));
+    env.push(("VMUX_ANCHOR".to_string(), anchor.to_string()));
     Ok(TerminalLaunch {
         command: exe_path.to_string_lossy().to_string(),
         args,

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -121,7 +121,16 @@ impl Plugin for AgentPlugin {
             .add_message::<TerminalStackSpawnRequest>()
             .add_message::<ProcessStackSpawnRequest>()
             .add_message::<RestartAgentPty>()
+            .add_message::<vmux_core::notify::BellReceived>()
+            .add_message::<vmux_core::notify::AgentAttention>()
+            .add_message::<vmux_core::notify::OsNotify>()
             .init_resource::<bevy::ecs::message::Messages<vmux_layout::OpenBesideRequest>>()
+            .add_systems(
+                Update,
+                (agent_bell_to_attention, mark_agent_done, clear_agent_done)
+                    .chain()
+                    .after(vmux_layout::stack::ComputeFocusSet),
+            )
             .add_systems(Startup, session::start_agent_session_watchers)
             .add_systems(
                 Update,
@@ -300,6 +309,7 @@ struct AgentSpaceWriters<'w, 's> {
     layout_apply: MessageWriter<'w, vmux_layout::reconcile::LayoutApplyRequest>,
     space_command: MessageWriter<'w, vmux_space::SpaceCommandRequest>,
     issued: MessageWriter<'w, vmux_command::CommandIssued>,
+    attention: MessageWriter<'w, vmux_core::notify::AgentAttention>,
     agents: Query<
         'w,
         's,
@@ -347,6 +357,135 @@ fn handle_agent_tool_calls(
                     });
                 }
             }
+        }
+    }
+}
+
+fn agent_bell_to_attention(
+    mut reader: MessageReader<vmux_core::notify::BellReceived>,
+    mut attention: MessageWriter<vmux_core::notify::AgentAttention>,
+    agents: Query<(Entity, &vmux_service::protocol::ProcessId), With<vmux_core::team::Agent>>,
+) {
+    for ev in reader.read() {
+        if let Some((entity, _)) = agents.iter().find(|(_, pid)| **pid == ev.process_id) {
+            attention.write(vmux_core::notify::AgentAttention {
+                entity,
+                title: None,
+                body: None,
+            });
+        }
+    }
+}
+
+const DONE_DEDUP_WINDOW_SECS: f64 = 3.0;
+
+fn window_foreground(windows: &Query<&Window, With<bevy::window::PrimaryWindow>>) -> bool {
+    windows
+        .iter()
+        .next()
+        .map(|w| w.focused && w.visible)
+        .unwrap_or(false)
+}
+
+fn agent_is_viewed(
+    entity: Entity,
+    foreground: bool,
+    focused: &vmux_layout::stack::FocusedStack,
+    child_of: &Query<&ChildOf>,
+) -> bool {
+    let stack = child_of.get(entity).ok().map(|c| c.parent());
+    foreground && focused.stack.is_some() && focused.stack == stack
+}
+
+fn mark_agent_done(
+    mut reader: MessageReader<vmux_core::notify::AgentAttention>,
+    mut notify: MessageWriter<vmux_core::notify::OsNotify>,
+    windows: Query<&Window, With<bevy::window::PrimaryWindow>>,
+    focused: Res<vmux_layout::stack::FocusedStack>,
+    child_of: Query<&ChildOf>,
+    meta: Query<(
+        &vmux_core::team::Profile,
+        Option<&SessionId>,
+        Option<&vmux_core::team::Agent>,
+    )>,
+    time: Res<Time>,
+    mut last_notify: Local<std::collections::HashMap<Entity, f64>>,
+    mut commands: Commands,
+) {
+    let foreground = window_foreground(&windows);
+    for att in reader.read() {
+        commands
+            .entity(att.entity)
+            .insert(vmux_core::notify::AgentDoneUnseen);
+        if agent_is_viewed(att.entity, foreground, &focused, &child_of) {
+            continue;
+        }
+        let now = time.elapsed_secs_f64();
+        if last_notify
+            .get(&att.entity)
+            .is_some_and(|t| now - t < DONE_DEDUP_WINDOW_SECS)
+        {
+            continue;
+        }
+        last_notify.insert(att.entity, now);
+        let (name, sid) = match meta.get(att.entity) {
+            Ok((profile, session, agent)) => {
+                let sid = session
+                    .map(|s| s.0.clone())
+                    .filter(|s| !s.is_empty())
+                    .or_else(|| agent.map(|a| a.sid.clone()).filter(|s| !s.is_empty()))
+                    .unwrap_or_default();
+                (profile.name.clone(), sid)
+            }
+            Err(_) => ("Agent".to_string(), String::new()),
+        };
+        let short_sid: String = sid.chars().take(8).collect();
+        let title = att
+            .title
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| format!("{name} finished"));
+        let body = att
+            .body
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| {
+                if short_sid.is_empty() {
+                    String::new()
+                } else {
+                    format!("session {short_sid}")
+                }
+            });
+        notify.write(vmux_core::notify::OsNotify { title, body });
+    }
+}
+
+fn clear_agent_done(
+    done: Query<Entity, With<vmux_core::notify::AgentDoneUnseen>>,
+    windows: Query<&Window, With<bevy::window::PrimaryWindow>>,
+    focused: Res<vmux_layout::stack::FocusedStack>,
+    child_of: Query<&ChildOf>,
+    mut prev_focused: Local<Option<Entity>>,
+    mut commands: Commands,
+) {
+    let foreground = window_foreground(&windows);
+    let current = if foreground { focused.stack } else { None };
+    if current == *prev_focused {
+        return;
+    }
+    *prev_focused = current;
+    let Some(stack) = current else {
+        return;
+    };
+    for entity in &done {
+        if child_of.get(entity).ok().map(|c| c.parent()) == Some(stack) {
+            commands
+                .entity(entity)
+                .remove::<vmux_core::notify::AgentDoneUnseen>();
         }
     }
 }
@@ -489,6 +628,17 @@ fn handle_agent_commands(
                 });
                 AgentCommandResult::Ok
             }
+            ServiceAgentCommand::Notify { title, body } => match caller {
+                Some(caller) => {
+                    writers.attention.write(vmux_core::notify::AgentAttention {
+                        entity: caller,
+                        title: title.clone(),
+                        body: body.clone(),
+                    });
+                    AgentCommandResult::Ok
+                }
+                None => AgentCommandResult::Error("notify: caller not found".to_string()),
+            },
             ServiceAgentCommand::UpdateSettings { path, value_json } => {
                 match serde_json::from_str::<serde_json::Value>(value_json) {
                     Ok(value) => {
@@ -1760,6 +1910,173 @@ mod tests {
     };
     use vmux_setting::{BrowserSettings, ShortcutSettings};
     use vmux_terminal::Terminal;
+
+    fn bell_test_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<vmux_core::notify::BellReceived>()
+            .add_message::<vmux_core::notify::AgentAttention>()
+            .add_systems(Update, agent_bell_to_attention);
+        app
+    }
+
+    fn spawn_agent_with_pid(app: &mut App, pid: vmux_service::protocol::ProcessId) -> Entity {
+        app.world_mut()
+            .spawn((
+                vmux_core::team::Agent {
+                    sid: "s".to_string(),
+                    kind: vmux_core::agent::AgentKind::Claude,
+                },
+                pid,
+            ))
+            .id()
+    }
+
+    fn attentions(app: &App) -> Vec<Entity> {
+        let messages = app
+            .world()
+            .resource::<bevy::ecs::message::Messages<vmux_core::notify::AgentAttention>>();
+        let mut cursor = messages.get_cursor();
+        cursor.read(messages).map(|a| a.entity).collect()
+    }
+
+    #[test]
+    fn bell_resolves_to_agent_attention() {
+        use vmux_service::protocol::ProcessId;
+        let mut app = bell_test_app();
+        let pid = ProcessId::new();
+        let agent = spawn_agent_with_pid(&mut app, pid);
+        app.world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<vmux_core::notify::BellReceived>>()
+            .write(vmux_core::notify::BellReceived { process_id: pid });
+        app.update();
+        assert_eq!(attentions(&app), vec![agent]);
+    }
+
+    #[test]
+    fn bell_unknown_process_id_emits_nothing() {
+        use vmux_service::protocol::ProcessId;
+        let mut app = bell_test_app();
+        let _agent = spawn_agent_with_pid(&mut app, ProcessId::new());
+        app.world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<vmux_core::notify::BellReceived>>()
+            .write(vmux_core::notify::BellReceived {
+                process_id: ProcessId::new(),
+            });
+        app.update();
+        assert!(attentions(&app).is_empty());
+    }
+
+    fn done_test_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<vmux_core::notify::AgentAttention>()
+            .add_message::<vmux_core::notify::OsNotify>()
+            .init_resource::<vmux_layout::stack::FocusedStack>()
+            .add_systems(Update, (mark_agent_done, clear_agent_done));
+        app
+    }
+
+    fn spawn_agent_in_stack(app: &mut App) -> (Entity, Entity) {
+        let stack = app.world_mut().spawn_empty().id();
+        let agent = app
+            .world_mut()
+            .spawn((
+                vmux_core::team::Profile::agent(vmux_core::agent::AgentKind::Claude),
+                ChildOf(stack),
+            ))
+            .id();
+        (agent, stack)
+    }
+
+    fn set_window(app: &mut App, focused: bool) {
+        app.world_mut().spawn((
+            Window {
+                focused,
+                visible: true,
+                ..default()
+            },
+            bevy::window::PrimaryWindow,
+        ));
+    }
+
+    fn os_notify_count(app: &App) -> usize {
+        let messages = app
+            .world()
+            .resource::<bevy::ecs::message::Messages<vmux_core::notify::OsNotify>>();
+        let mut cursor = messages.get_cursor();
+        cursor.read(messages).count()
+    }
+
+    fn send_attention(app: &mut App, entity: Entity) {
+        app.world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<vmux_core::notify::AgentAttention>>()
+            .write(vmux_core::notify::AgentAttention {
+                entity,
+                title: None,
+                body: None,
+            });
+    }
+
+    #[test]
+    fn done_notifies_and_marks_when_backgrounded() {
+        let mut app = done_test_app();
+        let (agent, _stack) = spawn_agent_in_stack(&mut app);
+        set_window(&mut app, false);
+        send_attention(&mut app, agent);
+        app.update();
+        assert!(
+            app.world()
+                .get::<vmux_core::notify::AgentDoneUnseen>(agent)
+                .is_some()
+        );
+        assert_eq!(os_notify_count(&app), 1);
+    }
+
+    #[test]
+    fn no_banner_when_foreground_but_dot_still_set() {
+        let mut app = done_test_app();
+        let (agent, stack) = spawn_agent_in_stack(&mut app);
+        set_window(&mut app, true);
+        app.world_mut()
+            .resource_mut::<vmux_layout::stack::FocusedStack>()
+            .stack = Some(stack);
+        app.update();
+        send_attention(&mut app, agent);
+        app.update();
+        assert!(
+            app.world()
+                .get::<vmux_core::notify::AgentDoneUnseen>(agent)
+                .is_some(),
+            "dot shows even when foreground"
+        );
+        assert_eq!(os_notify_count(&app), 0, "no banner when foreground");
+    }
+
+    #[test]
+    fn clear_removes_marker_on_focus_transition() {
+        let mut app = done_test_app();
+        let (agent, stack) = spawn_agent_in_stack(&mut app);
+        set_window(&mut app, true);
+        app.world_mut()
+            .entity_mut(agent)
+            .insert(vmux_core::notify::AgentDoneUnseen);
+        app.update();
+        assert!(
+            app.world()
+                .get::<vmux_core::notify::AgentDoneUnseen>(agent)
+                .is_some()
+        );
+        app.world_mut()
+            .resource_mut::<vmux_layout::stack::FocusedStack>()
+            .stack = Some(stack);
+        app.update();
+        assert!(
+            app.world()
+                .get::<vmux_core::notify::AgentDoneUnseen>(agent)
+                .is_none()
+        );
+    }
 
     #[test]
     fn screenshot_response_maps_ok_and_err() {

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -550,6 +550,23 @@ fn sync_keyboard_target(
     }
 }
 
+fn tab_of(
+    start: Entity,
+    child_of_q: &Query<&ChildOf>,
+    tab_q: &Query<Entity, With<Tab>>,
+) -> Option<Entity> {
+    let mut e = start;
+    loop {
+        if tab_q.contains(e) {
+            return Some(e);
+        }
+        match child_of_q.get(e) {
+            Ok(co) => e = co.get(),
+            Err(_) => return None,
+        }
+    }
+}
+
 fn tab_ancestor(
     start: Entity,
     child_of_q: &Query<&ChildOf>,
@@ -2376,6 +2393,7 @@ fn push_tabs_host_emit(
     stack_ts: Query<(Entity, &LastActivatedAt), With<Stack>>,
     stack_children: Query<&Children>,
     browser_meta: Query<(&PageMetadata, Option<&OscTitle>), With<Browser>>,
+    done_agents: Query<Entity, With<vmux_core::notify::AgentDoneUnseen>>,
     mut last: Local<String>,
 ) {
     let Ok((cef_e, page_ready)) = cef_q.single() else {
@@ -2386,6 +2404,11 @@ fn push_tabs_host_emit(
     }
 
     let active_tab = active_tab_param.get();
+
+    let done_tabs: std::collections::HashSet<Entity> = done_agents
+        .iter()
+        .filter_map(|agent| tab_of(agent, &child_of_q, &tab_q))
+        .collect();
 
     let ordered = if let Some(anchor) = active_tab {
         vmux_layout::tab::active_tab_siblings(anchor, &child_of_q, &all_children, &tab_q)
@@ -2431,6 +2454,7 @@ fn push_tabs_host_emit(
                 title,
                 url,
                 favicon_url,
+                is_done_unseen: done_tabs.contains(&entity),
             }
         })
         .collect();

--- a/crates/vmux_cli/src/commands.rs
+++ b/crates/vmux_cli/src/commands.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, Subcommand};
 
 pub mod mcp;
+pub mod notify;
 pub mod open;
 pub mod service;
 
@@ -14,6 +15,14 @@ pub struct Cli {
 #[derive(Debug, Subcommand)]
 pub enum Command {
     Mcp {
+        #[arg(long)]
+        anchor: Option<String>,
+    },
+    Notify {
+        #[arg(long)]
+        title: Option<String>,
+        #[arg(long)]
+        body: Option<String>,
         #[arg(long)]
         anchor: Option<String>,
     },

--- a/crates/vmux_cli/src/commands/notify.rs
+++ b/crates/vmux_cli/src/commands/notify.rs
@@ -1,0 +1,65 @@
+use std::io;
+
+use vmux_service::client::ServiceConnection;
+use vmux_service::protocol::{
+    AGENT_COMMAND_TIMEOUT, AgentCommand, AgentCommandResult, AgentRequestId, ClientMessage,
+    ProcessId, ServiceMessage,
+};
+
+pub async fn run(
+    title: Option<String>,
+    body: Option<String>,
+    anchor: Option<String>,
+) -> io::Result<()> {
+    let anchor = match anchor {
+        Some(raw) => Some(raw.parse::<ProcessId>().map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid --anchor: {raw}"),
+            )
+        })?),
+        None => std::env::var("VMUX_ANCHOR")
+            .ok()
+            .and_then(|s| s.parse::<ProcessId>().ok()),
+    };
+
+    let connection = match ServiceConnection::connect().await {
+        Ok(connection) => connection,
+        Err(error) => {
+            eprintln!("vmux notify: cannot connect to vmux service: {error}");
+            return Ok(());
+        }
+    };
+
+    let request_id = AgentRequestId::new();
+    if let Err(error) = connection
+        .send(&ClientMessage::AgentCommand {
+            request_id,
+            anchor,
+            command: AgentCommand::Notify { title, body },
+        })
+        .await
+    {
+        eprintln!("vmux notify: failed to send: {error}");
+        return Ok(());
+    }
+
+    let _ = tokio::time::timeout(AGENT_COMMAND_TIMEOUT, async {
+        while let Ok(Some(message)) = connection.recv().await {
+            if let ServiceMessage::AgentCommandResult {
+                request_id: received,
+                result,
+            } = message
+                && received == request_id
+            {
+                if let AgentCommandResult::Error(message) = result {
+                    eprintln!("vmux notify: {message}");
+                }
+                break;
+            }
+        }
+    })
+    .await;
+
+    Ok(())
+}

--- a/crates/vmux_cli/src/main.rs
+++ b/crates/vmux_cli/src/main.rs
@@ -9,6 +9,11 @@ async fn main() -> std::io::Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Some(Command::Mcp { anchor }) => commands::mcp::run(anchor).await,
+        Some(Command::Notify {
+            title,
+            body,
+            anchor,
+        }) => commands::notify::run(title, body, anchor).await,
         Some(Command::Service(args)) => {
             let code = commands::service::run(args)?;
             std::process::exit(code);

--- a/crates/vmux_core/src/event/team.rs
+++ b/crates/vmux_core/src/event/team.rs
@@ -44,6 +44,8 @@ pub struct TeamMemberRow {
     pub sid: String,
     pub is_user: bool,
     pub is_running: bool,
+    #[serde(default)]
+    pub is_done_unseen: bool,
 }
 
 #[derive(
@@ -81,6 +83,7 @@ mod tests {
             sid: String::new(),
             is_user: false,
             is_running: true,
+            is_done_unseen: false,
         };
         assert!(row.is_running && !row.is_user);
     }
@@ -99,6 +102,7 @@ mod tests {
                 sid: "021fb65c".to_string(),
                 is_user: true,
                 is_running: false,
+                is_done_unseen: true,
             }],
         };
         let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&original).expect("serialize");

--- a/crates/vmux_core/src/lib.rs
+++ b/crates/vmux_core/src/lib.rs
@@ -16,9 +16,13 @@ pub mod agent;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod archive;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod notify;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod team;
 #[cfg(not(target_arch = "wasm32"))]
 pub use archive::{ArchivedPage, PageArchiveRequest};
+#[cfg(not(target_arch = "wasm32"))]
+pub use notify::{AgentAttention, AgentDoneUnseen, BellReceived, OsNotify};
 #[cfg(not(target_arch = "wasm32"))]
 pub use page_open::{
     CefPageAttachRequest, PageOpenError, PageOpenHandled, PageOpenId, PageOpenRequest, PageOpenSet,

--- a/crates/vmux_core/src/notify.rs
+++ b/crates/vmux_core/src/notify.rs
@@ -1,0 +1,40 @@
+use bevy::prelude::*;
+
+use crate::ProcessId;
+
+#[derive(Message, Clone)]
+pub struct BellReceived {
+    pub process_id: ProcessId,
+}
+
+#[derive(Message, Clone)]
+pub struct AgentAttention {
+    pub entity: Entity,
+    pub title: Option<String>,
+    pub body: Option<String>,
+}
+
+#[derive(Message, Clone)]
+pub struct OsNotify {
+    pub title: String,
+    pub body: String,
+}
+
+#[derive(Component)]
+pub struct AgentDoneUnseen;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_attention_carries_optional_text() {
+        let a = AgentAttention {
+            entity: Entity::PLACEHOLDER,
+            title: Some("done".into()),
+            body: None,
+        };
+        assert_eq!(a.title.as_deref(), Some("done"));
+        assert!(a.body.is_none());
+    }
+}

--- a/crates/vmux_desktop/Cargo.toml
+++ b/crates/vmux_desktop/Cargo.toml
@@ -85,6 +85,7 @@ objc2-app-kit = { version = "0.3", features = [
     "NSFont",
 ] }
 objc2-foundation = { version = "0.3", features = [
+    "NSBundle",
     "NSGeometry",
     "NSData",
     "NSString",
@@ -116,6 +117,14 @@ objc2-av-foundation = { version = "0.3", features = ["objc2-core-media"] }
 objc2-core-media = "0.3"
 objc2-core-video = "0.3"
 dispatch2 = "0.3"
+objc2-user-notifications = { version = "0.3", features = [
+    "UNNotificationContent",
+    "UNNotificationRequest",
+    "UNNotificationSound",
+    "UNNotificationTrigger",
+    "UNUserNotificationCenter",
+    "block2",
+] }
 block2 = "0.6"
 raw-window-handle = "0.6"
 

--- a/crates/vmux_desktop/src/lib.rs
+++ b/crates/vmux_desktop/src/lib.rs
@@ -17,6 +17,7 @@ mod glass;
 mod log_forward;
 #[cfg(target_os = "macos")]
 mod native_keyboard;
+mod notify;
 mod os_menu;
 pub mod panic_hook;
 mod persistence;
@@ -158,7 +159,9 @@ impl Plugin for VmuxPlugin {
                 )
                     .chain()
                     .after(WriteAppCommands),
-            );
+            )
+            .add_systems(Startup, notify::request_notification_auth)
+            .add_systems(Update, notify::post_os_notifications);
 
         #[cfg(target_os = "macos")]
         app.add_plugins((glass::GlassPlugin, splash::SplashPlugin))

--- a/crates/vmux_desktop/src/notify.rs
+++ b/crates/vmux_desktop/src/notify.rs
@@ -1,0 +1,100 @@
+use bevy::prelude::*;
+use vmux_core::notify::OsNotify;
+
+#[cfg(target_os = "macos")]
+pub fn request_notification_auth() {
+    use block2::RcBlock;
+    use objc2::runtime::Bool;
+    use objc2_foundation::NSError;
+    use objc2_user_notifications::UNAuthorizationOptions;
+
+    let Some(center) = current_center() else {
+        return;
+    };
+    let handler = RcBlock::new(|_granted: Bool, _error: *mut NSError| {});
+    center.requestAuthorizationWithOptions_completionHandler(
+        UNAuthorizationOptions::Alert | UNAuthorizationOptions::Sound,
+        &handler,
+    );
+}
+
+#[cfg(target_os = "macos")]
+fn current_center()
+-> Option<objc2::rc::Retained<objc2_user_notifications::UNUserNotificationCenter>> {
+    use objc2_foundation::NSBundle;
+    use objc2_user_notifications::UNUserNotificationCenter;
+
+    NSBundle::mainBundle().bundleIdentifier()?;
+    Some(UNUserNotificationCenter::currentNotificationCenter())
+}
+
+#[cfg(target_os = "macos")]
+pub fn post_os_notifications(mut reader: MessageReader<OsNotify>) {
+    let events: Vec<OsNotify> = reader.read().cloned().collect();
+    if events.is_empty() {
+        return;
+    }
+    match current_center() {
+        Some(center) => post_native(&center, &events),
+        None => {
+            for ev in &events {
+                osascript_notify(&ev.title, &ev.body);
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn post_native(center: &objc2_user_notifications::UNUserNotificationCenter, events: &[OsNotify]) {
+    use objc2_foundation::NSString;
+    use objc2_user_notifications::{
+        UNMutableNotificationContent, UNNotificationRequest, UNNotificationSound,
+    };
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NOTIF_SEQ: AtomicU64 = AtomicU64::new(0);
+    for ev in events {
+        let content = UNMutableNotificationContent::new();
+        content.setTitle(&NSString::from_str(&ev.title));
+        if !ev.body.is_empty() {
+            content.setBody(&NSString::from_str(&ev.body));
+        }
+        content.setSound(Some(&UNNotificationSound::defaultSound()));
+        let seq = NOTIF_SEQ.fetch_add(1, Ordering::Relaxed);
+        let id = NSString::from_str(&format!("vmux-{seq}"));
+        let request =
+            UNNotificationRequest::requestWithIdentifier_content_trigger(&id, &content, None);
+        center.addNotificationRequest_withCompletionHandler(&request, None);
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn osascript_notify(title: &str, body: &str) {
+    fn esc(s: &str) -> String {
+        s.replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .replace('\n', " ")
+    }
+    let script = format!(
+        "display notification \"{}\" with title \"{}\" sound name \"default\"",
+        esc(body),
+        esc(title)
+    );
+    if let Ok(mut child) = std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(script)
+        .spawn()
+    {
+        std::thread::spawn(move || {
+            let _ = child.wait();
+        });
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn request_notification_auth() {}
+
+#[cfg(not(target_os = "macos"))]
+pub fn post_os_notifications(mut reader: MessageReader<OsNotify>) {
+    for _ in reader.read() {}
+}

--- a/crates/vmux_layout/src/event.rs
+++ b/crates/vmux_layout/src/event.rs
@@ -363,6 +363,8 @@ pub struct TabRow {
     pub url: String,
     #[serde(default)]
     pub favicon_url: String,
+    #[serde(default)]
+    pub is_done_unseen: bool,
 }
 
 #[derive(

--- a/crates/vmux_layout/src/page.rs
+++ b/crates/vmux_layout/src/page.rs
@@ -461,6 +461,9 @@ fn Tab(tab: TabRow) -> Element {
                 }
                 span { class: "{title_class}", "{display_title}" }
             }
+            if tab.is_done_unseen {
+                span { class: "size-2 shrink-0 rounded-full bg-amber-400 ring-2 ring-background animate-pulse" }
+            }
             button {
                 r#type: "button",
                 aria_label: "Close tab",
@@ -550,21 +553,26 @@ fn TeamFacepile(members: Vec<TeamMemberRow>) -> Element {
                                 div {
                                     key: "{m.id}",
                                     title: "{m.name}",
-                                    class: "relative inline-flex size-5 items-center justify-center overflow-hidden rounded-full ring-2 ring-background text-[9px] font-semibold text-white cursor-pointer transition-opacity hover:opacity-80",
-                                    style: "{bg}",
+                                    class: "relative inline-flex size-5 shrink-0 cursor-pointer transition-opacity hover:opacity-80",
                                     onclick: move |_| {
                                         let _ = try_cef_bin_emit_rkyv(&TeamCommandEvent {
                                             command: "focus".to_string(),
                                             member_id: Some(id.clone()),
                                         });
                                     },
-                                    if let Some(src) = src.as_ref() {
-                                        img { class: "size-full object-cover", src: "{src}" }
-                                    } else {
-                                        "{m.initials}"
+                                    div {
+                                        class: "inline-flex size-5 items-center justify-center overflow-hidden rounded-full ring-2 ring-background text-[9px] font-semibold text-white",
+                                        style: "{bg}",
+                                        if let Some(src) = src.as_ref() {
+                                            img { class: "size-full object-cover", src: "{src}" }
+                                        } else {
+                                            "{m.initials}"
+                                        }
                                     }
                                     if m.is_running {
                                         span { class: "absolute -bottom-0.5 -right-0.5 size-1.5 rounded-full bg-emerald-400 ring-2 ring-background" }
+                                    } else if m.is_done_unseen {
+                                        span { class: "absolute -bottom-0.5 -right-0.5 size-2 rounded-full bg-amber-400 ring-2 ring-background animate-pulse" }
                                     }
                                 }
                             }

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -58,6 +58,13 @@ pub enum McpParamTool {
     RenameSpace { space_id: String, name: String },
     #[mcp(description = "Delete a space by id. Use vmux_list_spaces to discover ids.")]
     DeleteSpace { space_id: String },
+    #[mcp(
+        description = "Notify the user that you (this agent) need their attention - typically that you have finished your turn. Shows a macOS notification when they are not looking at your page, and a dot on your avatar in the team facepile until they view it. Optional `title` and `body` customize the message; with neither, a default \"<agent> finished\" is shown."
+    )]
+    Notify {
+        title: Option<String>,
+        body: Option<String>,
+    },
 }
 
 impl McpParamTool {
@@ -144,6 +151,7 @@ impl McpParamTool {
                     name: None,
                 })
             }
+            McpParamTool::Notify { title, body } => Ok(AgentCommand::Notify { title, body }),
         }
     }
 }
@@ -840,6 +848,39 @@ mod tests {
     #[test]
     fn unknown_tool_returns_error() {
         assert!(dispatch_from_tool_call("nope_not_a_tool", serde_json::json!({})).is_err());
+    }
+
+    #[test]
+    fn list_tools_includes_notify() {
+        assert!(tool_names().contains(&"vmux_notify".to_string()));
+    }
+
+    #[test]
+    fn notify_dispatches_to_notify_command() {
+        let command = dispatch_command(
+            "notify",
+            serde_json::json!({"title": "done", "body": "built X"}),
+        )
+        .unwrap();
+        assert_eq!(
+            command,
+            AgentCommand::Notify {
+                title: Some("done".to_string()),
+                body: Some("built X".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn notify_allows_empty_args() {
+        let command = dispatch_command("notify", serde_json::json!({})).unwrap();
+        assert_eq!(
+            command,
+            AgentCommand::Notify {
+                title: None,
+                body: None,
+            }
+        );
     }
 
     #[test]

--- a/crates/vmux_service/src/process.rs
+++ b/crates/vmux_service/src/process.rs
@@ -43,6 +43,11 @@ impl TermEventListener for ServiceEventProxy {
                     title,
                 });
             }
+            TermEvent::Bell => {
+                let _ = self.patch_tx.send(ServiceMessage::Bell {
+                    process_id: self.process_id,
+                });
+            }
             _ => {}
         }
     }
@@ -98,7 +103,7 @@ pub struct Process {
     /// Last copy-mode value emitted in a viewport patch.
     last_viewport_copy_mode: Option<bool>,
     /// Last broadcast (mouse_capture, copy_mode, alt_screen) flags.
-    last_terminal_mode: Option<(bool, bool, bool)>,
+    last_terminal_mode: Option<(bool, bool, bool, bool)>,
     /// Active copy-mode state (cursor, anchor, visual state). None when not in copy mode.
     copy_mode: Option<CopyModeState>,
 }
@@ -560,13 +565,15 @@ impl Process {
         }
     }
 
-    /// Broadcast TerminalMode whenever mouse-capture, copy-mode, or alt-screen changes.
+    /// Broadcast TerminalMode whenever mouse-capture, copy-mode, alt-screen, or
+    /// focus-reporting changes.
     fn maybe_broadcast_mode(&mut self) {
         use alacritty_terminal::term::TermMode;
         let mouse_capture = self.term.mode().intersects(TermMode::MOUSE_MODE);
         let copy_mode = self.copy_mode.is_some();
         let alt_screen = self.term.mode().contains(TermMode::ALT_SCREEN);
-        let cur = (mouse_capture, copy_mode, alt_screen);
+        let focus_reporting = self.term.mode().contains(TermMode::FOCUS_IN_OUT);
+        let cur = (mouse_capture, copy_mode, alt_screen, focus_reporting);
         if self.last_terminal_mode != Some(cur) {
             self.last_terminal_mode = Some(cur);
             let _ = self.patch_tx.send(ServiceMessage::TerminalMode {
@@ -574,6 +581,7 @@ impl Process {
                 mouse_capture,
                 copy_mode,
                 alt_screen,
+                focus_reporting,
             });
         }
     }
@@ -2089,6 +2097,28 @@ mod tests {
                 assert_eq!(title, "hello-osc");
             }
             other => panic!("expected ProcessTitle, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn proxy_broadcasts_bell_on_term_bell_event() {
+        use std::io;
+
+        let (tx, mut rx) = broadcast::channel::<ServiceMessage>(8);
+        let writer: PtyInputWriter = Arc::new(Mutex::new(Box::new(io::sink())));
+        let process_id = ProcessId::new();
+        let proxy = ServiceEventProxy {
+            process_id,
+            pty_writer: writer,
+            patch_tx: tx,
+        };
+
+        proxy.send_event(TermEvent::Bell);
+
+        let msg = rx.try_recv().expect("Bell should be broadcast");
+        match msg {
+            ServiceMessage::Bell { process_id: got_id } => assert_eq!(got_id, process_id),
+            other => panic!("expected Bell, got {other:?}"),
         }
     }
 }

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -129,6 +129,10 @@ pub enum AgentCommand {
         /// terminal output. `None` keeps the legacy fire-and-forget behavior.
         done_marker: Option<String>,
     },
+    Notify {
+        title: Option<String>,
+        body: Option<String>,
+    },
 }
 
 pub const AGENT_QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
@@ -531,6 +535,7 @@ pub enum ServiceMessage {
         mouse_capture: bool,
         copy_mode: bool,
         alt_screen: bool,
+        focus_reporting: bool,
     },
     AgentCommand {
         request_id: AgentRequestId,
@@ -548,6 +553,9 @@ pub enum ServiceMessage {
     AgentCommandResult {
         request_id: AgentRequestId,
         result: AgentCommandResult,
+    },
+    Bell {
+        process_id: ProcessId,
     },
     AgentDelta {
         sid: String,
@@ -712,6 +720,31 @@ mod tests {
         let back: AgentQueryResult =
             rkyv::from_bytes::<AgentQueryResult, rkyv::rancor::Error>(&bytes).unwrap();
         assert_eq!(back, r);
+    }
+
+    #[test]
+    fn notify_command_rkyv_roundtrip() {
+        let cmd = AgentCommand::Notify {
+            title: Some("done".to_string()),
+            body: None,
+        };
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&cmd).unwrap();
+        let back: AgentCommand =
+            rkyv::from_bytes::<AgentCommand, rkyv::rancor::Error>(&bytes).unwrap();
+        assert_eq!(cmd, back);
+    }
+
+    #[test]
+    fn bell_service_message_rkyv_roundtrip() {
+        let pid = ProcessId::new();
+        let msg = ServiceMessage::Bell { process_id: pid };
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&msg).unwrap();
+        let back: ServiceMessage =
+            rkyv::from_bytes::<ServiceMessage, rkyv::rancor::Error>(&bytes).unwrap();
+        match back {
+            ServiceMessage::Bell { process_id } => assert_eq!(process_id, pid),
+            _ => panic!("expected ServiceMessage::Bell"),
+        }
     }
 
     #[test]

--- a/crates/vmux_team/src/page.rs
+++ b/crates/vmux_team/src/page.rs
@@ -109,6 +109,11 @@ fn TeamRow(member: TeamMemberRow) -> Element {
                             span { class: "size-1.5 rounded-full bg-emerald-400 animate-pulse" }
                             "running"
                         }
+                    } else if member.is_done_unseen {
+                        span { class: "flex shrink-0 items-center gap-1.5 rounded-full bg-amber-500/15 px-2 py-0.5 text-[11px] font-medium text-amber-400",
+                            span { class: "size-1.5 rounded-full bg-amber-400 animate-pulse" }
+                            "done"
+                        }
                     }
                 }
                 if let Some(subtitle) = subtitle {
@@ -145,6 +150,8 @@ fn TeamAvatar(member: TeamMemberRow, size: u32) -> Element {
             }
             if member.is_running {
                 span { class: "absolute -bottom-0.5 -right-0.5 size-3 rounded-full bg-emerald-400 ring-2 ring-background animate-pulse" }
+            } else if member.is_done_unseen {
+                span { class: "absolute -bottom-0.5 -right-0.5 size-3 rounded-full bg-amber-400 ring-2 ring-background animate-pulse" }
             }
         }
     }

--- a/crates/vmux_team/src/plugin.rs
+++ b/crates/vmux_team/src/plugin.rs
@@ -72,6 +72,7 @@ fn team_member_row(
     sid: String,
     is_user: bool,
     is_running: bool,
+    is_done_unseen: bool,
 ) -> TeamMemberRow {
     TeamMemberRow {
         id: entity.to_bits().to_string(),
@@ -84,6 +85,7 @@ fn team_member_row(
         sid,
         is_user,
         is_running,
+        is_done_unseen,
     }
 }
 
@@ -133,6 +135,7 @@ fn build_team_members(
         &Agent,
         Option<&AgentRunState>,
         Option<&SessionId>,
+        Option<&vmux_core::notify::AgentDoneUnseen>,
     )>,
     child_of: &Query<&ChildOf>,
     space_marker: &Query<(), With<Space>>,
@@ -152,12 +155,14 @@ fn build_team_members(
             String::new(),
             true,
             false,
+            false,
         ));
     }
     if let Some(active) = active {
-        for (entity, profile, agent, run, session) in agent_q {
+        for (entity, profile, agent, run, session, done) in agent_q {
             if space_of(entity, child_of, space_marker) == Some(active) {
                 let is_running = matches!(run, Some(AgentRunState::Streaming));
+                let is_done_unseen = done.is_some();
                 let (icon, title) = agent_page(entity, meta_q, children_q, child_of);
                 let url = agent.kind.cli_url_prefix();
                 let sid = session
@@ -165,7 +170,15 @@ fn build_team_members(
                     .filter(|s| !s.is_empty())
                     .unwrap_or_else(|| agent.sid.clone());
                 members.push(team_member_row(
-                    entity, profile, icon, url, title, sid, false, is_running,
+                    entity,
+                    profile,
+                    icon,
+                    url,
+                    title,
+                    sid,
+                    false,
+                    is_running,
+                    is_done_unseen,
                 ));
             }
         }
@@ -187,6 +200,7 @@ fn emit_team(
         &Agent,
         Option<&AgentRunState>,
         Option<&SessionId>,
+        Option<&vmux_core::notify::AgentDoneUnseen>,
     )>,
     child_of: Query<&ChildOf>,
     space_marker: Query<(), With<Space>>,
@@ -363,6 +377,22 @@ mod tests {
                 },
             )
             .unwrap()
+    }
+
+    #[test]
+    fn done_unseen_sets_row_flag() {
+        let row = team_member_row(
+            Entity::PLACEHOLDER,
+            &Profile::agent(AgentKind::Claude),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            false,
+            false,
+            true,
+        );
+        assert!(row.is_done_unseen);
     }
 
     #[test]

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -146,7 +146,11 @@ pub struct TerminalModeFlags {
     pub mouse_capture: bool,
     pub copy_mode: bool,
     pub alt_screen: bool,
+    pub focus_reporting: bool,
 }
+
+#[derive(Component)]
+pub struct AgentFocusBlurred;
 
 const AGENT_LOADING_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
@@ -332,8 +336,10 @@ fn on_terminal_removed(
 fn add_terminal_update_systems(app: &mut App) -> &mut App {
     app.add_message::<ProcessExitedEvent>()
         .add_message::<OscTitleChanged>()
+        .add_message::<vmux_core::notify::BellReceived>()
         .add_systems(Update, apply_osc_title.after(poll_service_messages))
         .add_systems(Update, clear_osc_title_on_exit.after(poll_service_messages))
+        .add_systems(Update, blur_focus_aware_agents.after(poll_service_messages))
         .add_systems(
             Update,
             handle_terminal_page_open.in_set(PageOpenSet::HandleKnownPages),
@@ -1011,6 +1017,7 @@ struct PollServiceWriters<'w> {
     page_agent_snapshot: MessageWriter<'w, vmux_service::agent_events::PageAgentSnapshot>,
     process_exited: MessageWriter<'w, ProcessExitedEvent>,
     osc_title: MessageWriter<'w, OscTitleChanged>,
+    bell: MessageWriter<'w, vmux_core::notify::BellReceived>,
 }
 
 /// True when a rendered line carries any non-whitespace text. Used to decide
@@ -1018,6 +1025,34 @@ struct PollServiceWriters<'w> {
 /// pending `run` input is flushed only once the line editor is ready.
 fn line_has_content(line: &vmux_core::event::TermLine) -> bool {
     line.spans.iter().any(|s| !s.text.trim().is_empty())
+}
+
+fn blur_focus_aware_agents(
+    agents: Query<
+        (Entity, &ProcessId),
+        (
+            With<vmux_core::agent::AgentSession>,
+            Without<AgentFocusBlurred>,
+        ),
+    >,
+    mode_map: Res<TerminalModeMap>,
+    service: Option<Res<ServiceClient>>,
+    mut commands: Commands,
+) {
+    let Some(service) = service else { return };
+    for (entity, process_id) in &agents {
+        if mode_map
+            .modes
+            .get(process_id)
+            .is_some_and(|m| m.focus_reporting)
+        {
+            service.0.send(ClientMessage::ProcessInput {
+                process_id: *process_id,
+                data: b"\x1b[O".to_vec(),
+            });
+            commands.entity(entity).insert(AgentFocusBlurred);
+        }
+    }
 }
 
 fn poll_service_messages(
@@ -1159,6 +1194,11 @@ fn poll_service_messages(
                         break;
                     }
                 }
+            }
+            ServiceMessage::Bell { process_id } => {
+                writers
+                    .bell
+                    .write(vmux_core::notify::BellReceived { process_id });
             }
             ServiceMessage::ProcessTitle { process_id, title } => {
                 writers.osc_title.write(OscTitleChanged {
@@ -1308,6 +1348,7 @@ fn poll_service_messages(
                 mouse_capture,
                 copy_mode,
                 alt_screen,
+                focus_reporting,
             } => {
                 mode_map.modes.insert(
                     process_id,
@@ -1315,6 +1356,7 @@ fn poll_service_messages(
                         mouse_capture,
                         copy_mode,
                         alt_screen,
+                        focus_reporting,
                     },
                 );
                 set_local_copy_mode(&mut local_copy_mode, process_id, copy_mode);
@@ -3679,6 +3721,7 @@ mod tests {
                 mouse_capture: false,
                 copy_mode: false,
                 alt_screen: false,
+                focus_reporting: false,
             },
         );
         set_local_copy_mode(&mut local_copy_mode, process_id, false);
@@ -3882,6 +3925,7 @@ mod tests {
                     mouse_capture: false,
                     copy_mode: false,
                     alt_screen: true,
+                    focus_reporting: false,
                 },
             );
         app.update();

--- a/docs/specs/2026-06-23-agent-done-notification-design.md
+++ b/docs/specs/2026-06-23-agent-done-notification-design.md
@@ -1,0 +1,280 @@
+# Agent-Done Notification + Avatar Indicator — Design
+
+Date: 2026-06-23
+Status: Approved (pending spec review)
+
+## Goal
+
+When a CLI agent (claude / codex / vibe running in a vmux terminal) wants
+attention — typically because it finished its turn — surface it two ways:
+
+1. **OS notification** — a native macOS notification, but only when the user is
+   *not currently looking at that agent's page* (vmux window unfocused, or a
+   different stack/tab is active).
+2. **Avatar indicator** — a "done" dot on that agent's avatar in the top-right
+   facepile, which persists until the user views the agent's page, then clears.
+
+Two triggers feed one shared downstream:
+
+- **Terminal bell (BEL)** — automatic, passive. Fires with no agent cooperation
+  if the agent rings the bell on completion. Coarse (no message text).
+- **`vmux_notify` MCP tool** — intentional, rich. The agent calls it with an
+  optional title/body. Won't fire automatically at turn end (the model must
+  choose to call it), but gives a real message and is on-brand with vmux's
+  self-testing MCP tools (screenshot, read_layout).
+
+## How the triggers resolve to an agent entity
+
+A CLI agent entity (spawned at `crates/vmux_agent/src/plugin.rs:1419-1439`)
+carries, together: the `Terminal` bundle, a `ProcessId` (its PTY id),
+`AgentSession`, `vmux_core::team::Profile`, `vmux_core::team::Agent`, and
+`ChildOf(stack)`. Both triggers resolve to this same entity via its `ProcessId`:
+
+- **Bell** carries the PTY `process_id`. The app already matches `process_id`
+  against terminal entities in `poll_service_messages`
+  (`crates/vmux_terminal/src/plugin.rs:1135`).
+- **MCP** rides the existing `AgentCommand` path, which threads an
+  `anchor: Option<ProcessId>` end-to-end (each MCP server is spawned with
+  `--anchor <ProcessId>` = the agent's own PTY id,
+  `crates/vmux_agent/src/mcp.rs:19-27`). The GUI command handler resolves the
+  caller by matching `anchor` against each agent's `ProcessId` component
+  (`crates/vmux_agent/src/plugin.rs:374-381`). (Note: the `AgentQuery` path used
+  by `screenshot` does NOT carry identity — it broadcasts — which is why
+  `vmux_notify` uses the `AgentCommand` path instead.)
+
+## Why the terminal bell (and not run-state)
+
+CLI agents have **no per-turn run-state**: `AgentRunState`
+(`crates/vmux_agent/src/run_state.rs`) is only populated for in-app *Page* agents
+(`client/page/plugin.rs:176`), so the facepile "running" dot is always off for
+CLI agents. The cross-agent completion signal that already exists is the
+terminal **bell** (BEL, `0x07`). Every PTY runs through `alacritty_terminal`,
+whose event listener delivers `TermEvent::Bell` on a real bell. BELs that merely
+terminate an OSC sequence are consumed by the parser and surface separately
+(`osc_dispatch(.., bell_terminated:true)`), so they do **not** raise
+`TermEvent::Bell` — no false positives.
+
+**Dependency / caveat:** the bell path *surfaces* bells; it does not make agents
+ring. Whether claude/codex/vibe ring on completion is each agent's own config —
+out of scope. The `vmux_notify` tool exists precisely for agents that prefer an
+explicit signal.
+
+Platform scope: the OS notification is **macOS only**; non-macOS builds compile
+the notify system to a no-op (the avatar dot works everywhere).
+
+## Shared types (live in `vmux_core`)
+
+`vmux_agent` depends on `vmux_terminal`, so the shared types cannot live in
+`vmux_agent` (the bell producer is `vmux_terminal`). They live in
+`vmux_core` (everyone depends on it), in a new `crates/vmux_core/src/notify.rs`:
+
+```rust
+#[derive(Message, Clone)]
+pub struct BellReceived { pub process_id: ProcessId }   // bell, pre-resolution
+
+#[derive(Message, Clone)]
+pub struct AgentAttention {
+    pub entity: Entity,
+    pub title: Option<String>,
+    pub body: Option<String>,
+}
+
+#[derive(Message, Clone)]
+pub struct OsNotify { pub title: String, pub body: String }
+
+#[derive(Component)]
+pub struct AgentDoneUnseen;   // no `Save` → never persisted across restarts
+```
+
+The three messages are registered once in `AgentPlugin` (`add_message`). The
+component needs no registration.
+
+`BellReceived` keeps `vmux_terminal` dumb: `poll_service_messages` is a giant
+multi-`SystemParam` system that is impractical to unit-test, so it only does a
+trivial re-emit. The testable `process_id → agent entity` resolution lives in
+`vmux_agent` (`agent_bell_to_attention`), which naturally filters non-agent
+terminal bells (their `process_id` matches no `team::Agent` entity).
+
+## Flow
+
+```
+TRIGGER A — bell:
+  agent PTY emits BEL
+   → alacritty → ServiceEventProxy::send_event(TermEvent::Bell)   [process.rs:33]
+   → ServiceMessage::Bell { process_id }                          [protocol.rs:456, IPC → app]
+   → poll_service_messages re-emits BellReceived{process_id}      [trivial passthrough]
+   → agent_bell_to_attention: find team::Agent entity whose ProcessId == process_id
+        → AgentAttention{entity, None, None}  (non-agent bells match nothing → dropped)
+
+TRIGGER B — MCP:
+  agent calls vmux_notify{title?,body?}
+   → McpParamTool::Notify → AgentCommand::Notify{title,body}
+   → ClientMessage::AgentCommand{request_id, anchor, command}     [carries anchor]
+   → broker → ServiceMessage::AgentCommand{request_id, anchor, command}
+   → GUI relay → AgentCommandRequest{origin: Agent{anchor}}
+   → handle_agent_commands: resolve caller via ProcessId(anchor)
+        → AgentAttention{entity: caller, title, body}; reply AgentCommandResult::Ok → MCP "ok"
+
+SHARED downstream:
+  AgentAttention
+   → mark_agent_done:
+       foreground? = window.focused && window.visible
+                     && FocusedStack.stack == agent's ChildOf(stack)
+       ├─ foreground → nothing (user already sees it)
+       └─ background →
+            insert AgentDoneUnseen (idempotent)
+            + if no OsNotify for this entity within DEDUP_WINDOW → send OsNotify{title,body}
+                ├─ OsNotify → vmux_desktop post_os_notifications → UNUserNotification
+                └─ AgentDoneUnseen → emit_team sets TeamMemberRow.is_done_unseen
+                     → TeamEvent → facepile amber dot                [page.rs:566]
+
+CLEAR:
+  clear_agent_done: for each AgentDoneUnseen entity, if
+  window.focused && FocusedStack.stack == agent's stack → remove AgentDoneUnseen
+   → emit_team re-broadcasts → dot disappears
+```
+
+`DEDUP_WINDOW` (~3 s) coalesces a bell and an MCP notify for the same turn into a
+single OS notification, while still letting a later, separate turn re-notify.
+The `AgentDoneUnseen` insert is unconditional/idempotent.
+
+## Components
+
+### 1. `vmux_core`
+- `src/notify.rs` (new): `AgentAttention`, `OsNotify`, `AgentDoneUnseen` (above);
+  `pub mod notify;` + re-exports in `lib.rs`.
+- `src/event/team.rs`: add `pub is_done_unseen: bool` to `TeamMemberRow`
+  (after `is_running`, line 46). Update the two struct-literal tests in this file.
+
+### 2. `vmux_service`
+- `protocol.rs`: add `AgentCommand::Notify { title: Option<String>, body: Option<String> }`
+  (after `Run`, ~line 131) and `ServiceMessage::Bell { process_id: ProcessId }`
+  (in `ServiceMessage`, ~line 530). rkyv round-trip tests.
+- `process.rs`: in `ServiceEventProxy::send_event` (line 33), add
+  `TermEvent::Bell => { let _ = self.patch_tx.send(ServiceMessage::Bell { process_id: self.process_id }); }`.
+  Test mirrors the existing `Title → ProcessTitle` test (process.rs:2073-2088).
+
+### 3. `vmux_mcp`
+- `tools.rs`: add `McpParamTool::Notify { title: Option<String>, body: Option<String> }`
+  with `#[mcp(description = "Notify the user that you (this agent) need their
+  attention — typically that you have finished. Shows a macOS notification when
+  they're not looking at your page, and a dot on your avatar until they view it.
+  Optional title/body customize the message.")]`, and a `to_agent_command` arm →
+  `AgentCommand::Notify { title, body }`. The macro auto-registers the tool in
+  `tool_definitions()` and routes it through the existing
+  `McpParamTool::from_mcp_call` branch (tools.rs:594); `tool_call_result`'s
+  `DispatchTarget::Command(command) => run_agent_command(command, anchor)` arm
+  (protocol.rs:135) already threads the anchor and returns `ok` on
+  `AgentCommandResult::Ok`. Tests: `vmux_notify` listed; dispatches to
+  `AgentCommand::Notify`.
+
+### 4. `vmux_terminal`
+- `plugin.rs` `poll_service_messages` (match at line 1100): add
+  `ServiceMessage::Bell { process_id } => { writers.bell.write(BellReceived { process_id }); }`.
+  Add a `BellReceived` writer to `PollServiceWriters`. No entity lookup here.
+- (No unit test for this passthrough — the system's many `SystemParam`s,
+  including `NonSend<Browsers>`, make it impractical; the meaningful logic is
+  tested in `vmux_agent` below.)
+
+### 5. `vmux_agent`
+- `plugin.rs` `agent_bell_to_attention` (new system): read `BellReceived`; for
+  each, find the entity whose `ProcessId` component equals `process_id` among
+  `team::Agent` entities (same match as `handle_agent_commands` caller
+  resolution, line 374-381) and write `AgentAttention { entity, title: None,
+  body: None }`. Test: an agent entity with a matching `ProcessId` yields one
+  `AgentAttention`; an unknown `process_id` yields none.
+- `plugin.rs` `handle_agent_commands` (match at line 390): add
+  `ServiceAgentCommand::Notify { title, body }` arm → if `caller` resolved, write
+  `AgentAttention { entity: caller, title, body }` and return
+  `AgentCommandResult::Ok`; else `AgentCommandResult::Error("notify: caller not found")`.
+  Add `attention: MessageWriter<AgentAttention>` to the system.
+- `plugin.rs` (new systems):
+  - `mark_agent_done` (reads `AgentAttention`): compute foreground from
+    `Query<&Window, With<PrimaryWindow>>` (`focused && visible`) and
+    `Res<FocusedStack>` vs the agent's `ChildOf(stack)`. If background: insert
+    `AgentDoneUnseen`; dedup via `Local<HashMap<Entity, f64>>` keyed on
+    `Res<Time>` elapsed; if outside `DEDUP_WINDOW`, send `OsNotify` (title/body
+    from the message, defaulting to `"<agent name> finished"` / space-or-tab
+    context resolved from `Profile`).
+  - `clear_agent_done`: for each `AgentDoneUnseen` entity, remove it when
+    `window.focused && FocusedStack.stack == agent stack`.
+  - Register `add_message::<BellReceived>()`, `add_message::<AgentAttention>()`,
+    `add_message::<OsNotify>()`, and the systems `agent_bell_to_attention`,
+    `mark_agent_done`, `clear_agent_done` (the latter two ordered
+    `.after(vmux_layout::stack::ComputeFocusSet)` so `FocusedStack` is current).
+- Tests: gating matrix {focused/unfocused}×{stack active/inactive} → `OsNotify`
+  + `AgentDoneUnseen` only when background; dedup (two `AgentAttention` within the
+  window → one `OsNotify`); `clear_agent_done` removes the marker when viewed.
+
+### 6. `vmux_team`
+- `plugin.rs`: add `Option<&AgentDoneUnseen>` to `agent_q` in both `emit_team`
+  (line 184) and `build_team_members` (line 130); thread an `is_done_unseen`
+  through `team_member_row` (line 66) and into the row (line 168).
+- Test: an agent entity with `AgentDoneUnseen` yields a row with
+  `is_done_unseen == true`; toggling re-broadcasts `TeamEvent`.
+
+### 7. `vmux_layout` + `vmux_team` pages (the dot)
+- `vmux_layout/src/page.rs` `TeamFacepile` (line 566): after the `is_running`
+  emerald dot, add `else if m.is_done_unseen { span { class: "absolute
+  -bottom-0.5 -right-0.5 size-2 rounded-full bg-amber-400 ring-2 ring-background
+  animate-pulse" } }` (running takes precedence).
+- `vmux_team/src/page.rs`: mirror at the row pill (line 107) and avatar dot
+  (line 146) with amber `is_done_unseen` variants.
+
+### 8. `vmux_desktop`
+- `Cargo.toml`: add (macOS target) `objc2-user-notifications = { version = "0.3",
+  features = ["UNUserNotificationCenter", "UNNotificationRequest",
+  "UNMutableNotificationContent", "UNNotificationContent",
+  "UNNotificationTrigger"] }` (`block2` is already present for the auth block).
+- `src/notify.rs` (new), mirroring `screenshot.rs`'s cfg structure:
+  - `request_notification_auth` (Startup, macOS): get
+    `UNUserNotificationCenter::currentNotificationCenter()` and
+    `requestAuthorizationWithOptions:completionHandler:` for `.Alert | .Sound`.
+  - `post_os_notifications` (Update, reads `OsNotify`, macOS): build a
+    `UNMutableNotificationContent` (title/body, default sound), wrap in a
+    `UNNotificationRequest` with a fresh UUID identifier + nil trigger, and
+    `addNotificationRequest:`. On non-macOS the system just drains the reader.
+  - Guard: if `currentNotificationCenter()` is unavailable (unbundled dev),
+    log once and skip — never panic. (Shipped app has bundle id `ai.vmux.desktop`,
+    so it works there.)
+- `src/lib.rs`: `mod notify;` and register the two systems (Startup + Update)
+  next to the screenshot systems (line 139).
+
+## Constants
+
+- `DEDUP_WINDOW = Duration::from_secs(3)` — coalesces bell + MCP notify per turn.
+
+## Error handling
+
+- Bell for an unknown/non-agent `process_id` → ignored.
+- MCP `Notify` with no resolvable caller → `AgentCommandResult::Error` → MCP error.
+- `UNUserNotificationCenter` unavailable / authorization denied → log once, skip.
+- Non-macOS → notify system no-ops.
+- Agent finishes while foreground → intentionally nothing.
+
+## Testing
+
+Bevy message/system integration (per AGENTS.md — register types, send messages,
+run schedules, assert ECS state/messages; no ad-hoc helper calls). Per-crate
+unit tests as listed in each component above, plus:
+
+- **Service bell mapping** (`vmux_service`): `ServiceEventProxy` given
+  `TermEvent::Bell` enqueues `ServiceMessage::Bell { process_id }`; rkyv
+  round-trips for `AgentCommand::Notify` and `ServiceMessage::Bell`.
+- Run `cargo test -p vmux_layout` after editing `page.rs` (its source-scrape
+  tests are sensitive to that file).
+- Native `UNUserNotificationCenter` delivery is verified manually in the built
+  app (needs bundle id + permission); it sits behind the `OsNotify` message
+  boundary, so all gating/dedup logic is testable headlessly.
+
+## Out of scope (v1)
+
+- "Running" (green) dot for CLI agents — needs start-of-turn detection; this
+  adds only the done/attention dot for CLI agents.
+- Click-the-notification-to-focus-the-specific-page (needs a
+  `UNUserNotificationCenterDelegate`); v1 clicking just activates the app.
+- A deterministic auto-fire on Claude turn-end via a Stop hook → `vmux notify`
+  CLI subcommand (a third channel). Natural follow-up if bell coverage proves
+  insufficient.
+- Aggregate "something is done" badge on the user pill; Linux notifications;
+  notification sound/grouping customization.


### PR DESCRIPTION
## Summary

When a CLI agent (claude/codex/vibe) finishes, vmux now surfaces it two ways, via two triggers that share one downstream:

- **Triggers:** the terminal **bell** (`TermEvent::Bell` → `ServiceMessage::Bell` → `BellReceived`), and a new **`vmux_notify` MCP tool** (rides the anchor-carrying `AgentCommand` path). Both resolve to the agent entity by its `ProcessId` and emit a `vmux_core::AgentAttention`.
- **OS notification:** `mark_agent_done` posts a native macOS `UNUserNotificationCenter` banner — but only when the agent's page is **backgrounded** (window unfocused, or a different stack is active). A 3s dedup window coalesces bell + MCP for the same turn.
- **Avatar dot:** an amber pulsing dot on the agent's top-right facepile avatar (and team page), driven by an `AgentDoneUnseen` marker projected into `TeamMemberRow.is_done_unseen`. It clears when you view the agent's page.

Shared types live in `vmux_core` (cycle-safe, since `vmux_agent` depends on `vmux_terminal`). Non-macOS compiles the notify path to a no-op; unbundled dev builds skip it (no bundle id) and log once.

Spec: `docs/specs/2026-06-23-agent-done-notification-design.md`.

## Test plan

- [x] `cargo fmt --all` clean, `cargo clippy --workspace --all-targets` clean, `cargo test --workspace` green
- [x] Unit tests: bell→attention resolution, background gating matrix, view-to-clear, dedup, `vmux_notify` dispatch, rkyv round-trips, team row projection, wasm page compile
- [ ] **Manual (built app only — native notifications need the bundle id):** background a running agent → expect macOS banner + amber avatar dot; focus its page → dot clears; finish while looking at it → no banner/dot
- [ ] Confirm claude/codex/vibe ring the terminal bell on completion (per-agent config), or call `vmux_notify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- macOS now displays OS notifications when an agent finishes work you aren’t currently viewing (deduplicated to avoid repeats), with notifications based on the agent you’re not focused on.
- Team tabs/avatars show an amber pulsing “done unseen” indicator for completed agents, which clears automatically when you open the agent.
- Added agent attention via `vmux_notify` (optional title/body), including a new CLI `notify` command for targeting a specific agent.

**Bug Fixes**
- Terminal bell events are now correctly captured and translated into completion notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->