### PR TITLE
fix(browser): re-apply OSR webview size on page ready

### DIFF
--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -176,6 +176,7 @@ impl Plugin for BrowserPlugin {
                     sync_windowed_frames,
                     sync_windowed_command_bar,
                     apply_repaint_nudge,
+                    bump_osr_size_on_ready,
                     sync_cef_webview_resize_after_ui,
                     sync_webview_pane_corner_clip,
                     sync_osr_webview_focus,
@@ -1572,6 +1573,14 @@ fn sync_windowed_command_bar(
 fn apply_repaint_nudge(browsers: NonSend<Browsers>, ready: Query<Entity, Added<PageReady>>) {
     for entity in &ready {
         browsers.nudge_windowed_repaint(&entity);
+    }
+}
+
+fn bump_osr_size_on_ready(
+    mut ready: Query<&mut WebviewSize, (Added<PageReady>, With<Browser>, Without<WebviewWindowed>)>,
+) {
+    for mut size in &mut ready {
+        size.set_changed();
     }
 }
 
@@ -3368,6 +3377,51 @@ mod tests {
         assert!(should_show_osr_webview(true, false, true, false, false));
         assert!(should_show_osr_webview(true, true, false, false, false));
         assert!(should_show_osr_webview(true, true, true, false, true));
+    }
+
+    #[test]
+    fn osr_page_ready_rebumps_webview_size_so_resize_refires() {
+        #[derive(Resource, Default)]
+        struct ChangedProbe(Vec<Entity>);
+
+        fn record_changed(mut probe: ResMut<ChangedProbe>, q: Query<Entity, Changed<WebviewSize>>) {
+            probe.0 = q.iter().collect();
+        }
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<ChangedProbe>()
+            .add_systems(Update, (bump_osr_size_on_ready, record_changed).chain());
+
+        let osr = app
+            .world_mut()
+            .spawn((Browser, WebviewSize(Vec2::new(100.0, 100.0))))
+            .id();
+        let windowed = app
+            .world_mut()
+            .spawn((
+                Browser,
+                WebviewWindowed,
+                WebviewSize(Vec2::new(100.0, 100.0)),
+            ))
+            .id();
+
+        app.update();
+
+        app.world_mut().entity_mut(osr).insert(PageReady {});
+        app.world_mut().entity_mut(windowed).insert(PageReady {});
+
+        app.update();
+
+        let changed = &app.world().resource::<ChangedProbe>().0;
+        assert!(
+            changed.contains(&osr),
+            "OSR page should re-bump WebviewSize on ready so the edge-gated resize re-fires after CEF's first paint"
+        );
+        assert!(
+            !changed.contains(&windowed),
+            "windowed pages refresh via the native repaint nudge, not a size re-bump"
+        );
     }
 
     fn layout_material_after_mode(


### PR DESCRIPTION
## Context

OSR CEF surfaces — the always-OSR layout chrome (sidebar/header/command bar) and any page in 3D/Player mode — render at the wrong size on startup and only correct themselves when you drag the window. The size *value* is right; it just never gets applied to CEF after the browser is live.

## Implementation

Root cause: an OSR browser's size is applied once, shortly after creation, **before CEF's first paint** — and then never again. The patch `resize` system is edge-gated on `Changed<WebviewSize>`, and the `sync_cef_webview_resize_after_ui` safety net dedups by value. CEF drops a `was_resized()` issued before its first OnPaint, so the surface stays at its creation size. The only thing that re-applies it is `WindowResized` (a drag), which clears the safety-net dedup.

New system `bump_osr_size_on_ready`: on `Added<PageReady>` for non-windowed `Browser` entities, call `WebviewSize::set_changed()`. `PageReady` fires when the page's JS emits `vmux-page-ready` — i.e. after document load + first paint — so re-firing the edge-gated `resize` at that point lands a `was_resized()` CEF will honor. This mirrors the existing windowed-only `apply_repaint_nudge`; windowed pages are excluded since they already refresh via the native repaint nudge.

## Checks / QA

- `make dev`: on a cold start, confirm the layout chrome + any open page render at the correct size **without** dragging the window.
- Open a new page (windowed browse mode) and confirm no size regression.
- Switch to 3D/Player mode and confirm OSR pages are correctly sized on first show.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resize handling for non-windowed browsers to ensure resize logic properly re-triggers after initial page load and rendering completion.

* **Tests**
  * Added unit test verifying that resize behavior correctly re-triggers for non-windowed browsers on page load, while windowed browsers remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->