### PR TITLE
docs(agents): default-on, strip-after debug diagnostics rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,10 @@ If a change affects an excluded patched CEF crate, run the appropriate package c
 
 If any check fails, fix the issue before committing. Do not push broken code.
 
+## Debugging
+
+When adding temporary diagnostics to investigate a bug, make logging unconditional (default-on) — never gate it behind an env var or flag the user must set. The user runs the normal build; logs must appear without extra setup. Strip every temporary diagnostic before committing the fix.
+
 ## Platform-Specific Code
 
 This project targets macOS (primary) and Linux (CI). When adding imports or code that uses platform-specific APIs (CEF, winit, AppKit), always add appropriate `#[cfg(...)]` gates. Let rustfmt reorder cfg-gated imports.


### PR DESCRIPTION
Adds a Debugging rule to AGENTS.md: temporary diagnostics must be unconditional (no env var/flag the user has to set) so logs appear on a normal build, and must be stripped before the fix commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AGENTS.md with new Debugging section containing guidelines for managing temporary diagnostics during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->