### PR TITLE
fix(desktop): keyboard focus follows the mouse into vmux

### DIFF
--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -50,6 +50,7 @@ impl Plugin for BackgroundLifecyclePlugin {
                 Update,
                 keep_awake_while_command_bar_opening.after(vmux_command::ReadAppCommands),
             )
+            .add_systems(Update, grab_key_window_on_pane_hover)
             .add_systems(
                 Startup,
                 (
@@ -70,6 +71,8 @@ static LAST_NATIVE_MOUSE_WAKE: LazyLock<Mutex<Option<Instant>>> =
 static IN_LIVE_RESIZE: AtomicBool = AtomicBool::new(false);
 #[cfg(target_os = "macos")]
 static LIVE_RESIZE_MONITOR_INSTALLED: AtomicBool = AtomicBool::new(false);
+#[cfg(target_os = "macos")]
+static HOVER_OVER_PANE: AtomicBool = AtomicBool::new(false);
 
 #[cfg(target_os = "macos")]
 fn activate_primary_window_on_startup(
@@ -86,6 +89,26 @@ fn activate_primary_window_on_startup(
 
 #[cfg(not(target_os = "macos"))]
 fn activate_primary_window_on_startup() {}
+
+#[cfg(target_os = "macos")]
+fn grab_key_window_on_pane_hover(
+    intent: Res<vmux_browser::HostFocusIntent>,
+    primary_window: Query<Entity, With<bevy::window::PrimaryWindow>>,
+) {
+    if !HOVER_OVER_PANE.swap(false, Ordering::Relaxed) {
+        return;
+    }
+    if *intent == vmux_browser::HostFocusIntent::Unmanaged {
+        return;
+    }
+    let Ok(window_entity) = primary_window.single() else {
+        return;
+    };
+    ensure_native_window_active(window_entity);
+}
+
+#[cfg(not(target_os = "macos"))]
+fn grab_key_window_on_pane_hover() {}
 
 #[cfg(target_os = "macos")]
 pub(crate) fn activate_native_window(window_entity: Entity) {
@@ -239,8 +262,17 @@ fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) 
         {
             vmux_browser::request_native_command_bar_dismiss_for_mouse_down(x_px, y_px);
         }
-        if event_type == NSEventType::MouseMoved {
-            let should_wake = event_location_in_window_physical_px(ev)
+        if matches!(
+            event_type,
+            NSEventType::MouseMoved | NSEventType::LeftMouseDown
+        ) {
+            let location = event_location_in_window_physical_px(ev);
+            if let Some((x, y)) = location
+                && vmux_layout::pane::cursor_over_pane(x, y)
+            {
+                HOVER_OVER_PANE.store(true, Ordering::Relaxed);
+            }
+            let should_wake = location
                 .map(|(x, y)| vmux_layout::pane::wake_on_move(x, y))
                 .unwrap_or(false);
             if should_wake {

--- a/crates/vmux_desktop/src/focus_native.rs
+++ b/crates/vmux_desktop/src/focus_native.rs
@@ -71,12 +71,6 @@ fn reclaim_first_responder(window_entity: Entity) -> ReclaimOutcome {
     let Some(window) = view.window() else {
         return ReclaimOutcome::NoView;
     };
-    // The window boots hidden and is revealed + activated asynchronously. `makeFirstResponder`
-    // on a not-yet-key window can report success without durably sticking, so a one-shot reclaim
-    // marks itself done while the view never actually holds first-responder once the window
-    // becomes key — keystrokes then go nowhere until a click. Wait for the window to be key so the
-    // reclaim that sticks happens on a live window. This matters most on space restore, where the
-    // active stack resolves while the window is still hidden.
     if !window.isKeyWindow() {
         return ReclaimOutcome::Failed;
     }

--- a/crates/vmux_desktop/src/focus_native.rs
+++ b/crates/vmux_desktop/src/focus_native.rs
@@ -71,6 +71,15 @@ fn reclaim_first_responder(window_entity: Entity) -> ReclaimOutcome {
     let Some(window) = view.window() else {
         return ReclaimOutcome::NoView;
     };
+    // The window boots hidden and is revealed + activated asynchronously. `makeFirstResponder`
+    // on a not-yet-key window can report success without durably sticking, so a one-shot reclaim
+    // marks itself done while the view never actually holds first-responder once the window
+    // becomes key — keystrokes then go nowhere until a click. Wait for the window to be key so the
+    // reclaim that sticks happens on a live window. This matters most on space restore, where the
+    // active stack resolves while the window is still hidden.
+    if !window.isKeyWindow() {
+        return ReclaimOutcome::Failed;
+    }
     let responder: &NSResponder = view;
     if let Some(current) = window.firstResponder()
         && core::ptr::eq(

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -1633,6 +1633,11 @@ mod hover_wake {
         }
     }
 
+    fn region_contains(region: &(u64, f32, f32, f32, f32), x: f32, y: f32) -> bool {
+        let (_, min_x, min_y, max_x, max_y) = *region;
+        x >= min_x && x <= max_x && y >= min_y && y <= max_y
+    }
+
     pub fn wake_on_move(x: f32, y: f32) -> bool {
         let Ok(regions) = REGIONS.lock() else {
             return false;
@@ -1640,9 +1645,7 @@ mod hover_wake {
         let hit = regions
             .panes
             .iter()
-            .find(|(_, min_x, min_y, max_x, max_y)| {
-                x >= *min_x && x <= *max_x && y >= *min_y && y <= *max_y
-            })
+            .find(|region| region_contains(region, x, y))
             .map(|(entity, ..)| *entity);
         match hit {
             Some(entity) if Some(entity) == regions.active => false,
@@ -1658,9 +1661,10 @@ mod hover_wake {
         let Ok(regions) = REGIONS.lock() else {
             return false;
         };
-        regions.panes.iter().any(|(_, min_x, min_y, max_x, max_y)| {
-            x >= *min_x && x <= *max_x && y >= *min_y && y <= *max_y
-        })
+        regions
+            .panes
+            .iter()
+            .any(|region| region_contains(region, x, y))
     }
 
     pub fn take_pending_target() -> Option<u64> {

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -1654,6 +1654,15 @@ mod hover_wake {
         }
     }
 
+    pub fn cursor_over_pane(x: f32, y: f32) -> bool {
+        let Ok(regions) = REGIONS.lock() else {
+            return false;
+        };
+        regions.panes.iter().any(|(_, min_x, min_y, max_x, max_y)| {
+            x >= *min_x && x <= *max_x && y >= *min_y && y <= *max_y
+        })
+    }
+
     pub fn take_pending_target() -> Option<u64> {
         match PENDING.swap(0, Ordering::Relaxed) {
             0 => None,
@@ -1663,7 +1672,7 @@ mod hover_wake {
 }
 
 #[cfg(target_os = "macos")]
-pub use hover_wake::wake_on_move;
+pub use hover_wake::{cursor_over_pane, wake_on_move};
 
 #[cfg(target_os = "macos")]
 fn publish_pane_hover_regions(


### PR DESCRIPTION
## Summary
- When the mouse activates a layout pane, make vmux the **key window** so OS text input follows the mouse in. Previously, activating a pane updated vmux's internal focus but not OS key-window status, so keystrokes kept going to the previously-active app (e.g. the terminal vmux was launched from) until you clicked. Gated off while `HostFocusIntent::Unmanaged` (Player mode / command bar open).
- Defer the winit first-responder reclaim until the host window is actually key, so it sticks on space restore instead of no-op'ing on a still-hidden window.

## Test plan
- [ ] Type in another app, then move the mouse over a vmux pane (no click) → typing lands in vmux
- [ ] In-vmux pane→pane hover still moves keyboard focus
- [ ] Command bar still receives input (not stolen mid-use)
- [ ] Player/3D mode unaffected
- [ ] Space restore: keys work without an initial click

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS native window focus so it reliably activates when hovering over panes.
  * Improved first-responder reclaiming by avoiding first-responder transfer until the window is already key.

* **Improvements**
  * Enhanced pane hover detection using published pane regions for more accurate cursor-over-pane checks and wake-on-move behavior.
  * Added an internal macOS-only cursor-over-pane capability to support the improved hover interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->