### PR TITLE
feat: VMUX_PROFILE test isolation + live-vibe MCP driving

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-.PHONY: dev local release build-local build-release build setup-cef install-debug-render-process doctor ensure-mac-deps ensure-package-deps ensure-codesign-deps website build-website-release build-website-css lint lint-fix test setup-hooks cleanup
+.PHONY: dev test-app local release build-local build-release build setup-cef install-debug-render-process doctor ensure-mac-deps ensure-package-deps ensure-codesign-deps website build-website-release build-website-css lint lint-fix test setup-hooks cleanup
 
 .DEFAULT_GOAL := dev
+
+VMUX_PROFILE ?= personal
 
 CARGO_BIN := $(or $(shell command -v cargo 2>/dev/null),$(HOME)/.cargo/bin/cargo)
 RUSTUP_BIN := $(or $(shell command -v rustup 2>/dev/null),$(HOME)/.cargo/bin/rustup)
@@ -25,14 +27,21 @@ dev: ensure-mac-deps ensure-codesign-deps install-debug-render-process
 	APP_BINARY="target/debug/vmux_desktop" \
 	HELPER_BINARY="$(CEF_DEBUG_RENDER)" \
 	./scripts/sign-dev-mac.sh
-	@pkill -f "target/debug/vmux_desktop" 2>/dev/null || true
-	@pkill -f "bevy_cef_debug_render_process" 2>/dev/null || true
+	@for pid in $$(pgrep -f "target/debug/vmux_desktop" 2>/dev/null); do \
+		ps eww -p $$pid 2>/dev/null | grep -q "VMUX_PROFILE=$(VMUX_PROFILE)" && kill $$pid 2>/dev/null || true; \
+	done
+	@for pid in $$(pgrep -f "bevy_cef_debug_render_process" 2>/dev/null); do \
+		ps eww -p $$pid 2>/dev/null | grep -q "VMUX_PROFILE=$(VMUX_PROFILE)" && kill $$pid 2>/dev/null || true; \
+	done
 	@rust_target_libdir="$$(rustc --print target-libdir)" && \
 	dylib_path="$$rust_target_libdir:$(CURDIR)/target/debug/deps" && \
 	if [ -n "$${DYLD_LIBRARY_PATH:-}" ]; then \
 		dylib_path="$$dylib_path:$$DYLD_LIBRARY_PATH"; \
 	fi; \
-	exec env -u CEF_PATH DYLD_LIBRARY_PATH="$$dylib_path" ./target/debug/vmux_desktop
+	exec env -u CEF_PATH DYLD_LIBRARY_PATH="$$dylib_path" VMUX_PROFILE="$(VMUX_PROFILE)" ./target/debug/vmux_desktop
+
+test-app:
+	$(MAKE) dev VMUX_PROFILE=gregor
 
 build: ensure-mac-deps
 	env -u CEF_PATH "$(CARGO_BIN)" build -p vmux_desktop -p vmux_cli -p vmux_service --release

--- a/crates/vmux_agent/src/client/cli/vibe.rs
+++ b/crates/vmux_agent/src/client/cli/vibe.rs
@@ -38,6 +38,9 @@ impl CliAgentStrategy for VibeStrategy {
         // config (falling back to default models). `--trust` trusts the working
         // directory for this invocation (vibe's documented automation flag).
         let mut args = vec!["--trust".to_string()];
+        if let Some(flag) = vibe_auto_approve_flag(&vmux_core::profile::active_profile_name()) {
+            args.push(flag.to_string());
+        }
         if let Some(sid) = session_id {
             args.push("--resume".to_string());
             args.push(sid.to_string());
@@ -82,6 +85,10 @@ impl CliAgentStrategy for VibeStrategy {
         }
         false
     }
+}
+
+fn vibe_auto_approve_flag(profile: &str) -> Option<&'static str> {
+    (profile != "personal").then_some("--auto-approve")
 }
 
 #[derive(Serialize)]
@@ -197,6 +204,12 @@ mod tests {
             VibeStrategy.build_args(&mcp, Some("sid-1")),
             vec!["--trust", "--resume", "sid-1"]
         );
+    }
+
+    #[test]
+    fn auto_approve_flag_only_for_non_personal_profile() {
+        assert_eq!(vibe_auto_approve_flag("personal"), None);
+        assert_eq!(vibe_auto_approve_flag("gregor"), Some("--auto-approve"));
     }
 
     fn write_meta(

--- a/crates/vmux_agent/src/mcp.rs
+++ b/crates/vmux_agent/src/mcp.rs
@@ -7,38 +7,48 @@ use crate::exec;
 
 pub fn resolve(cwd: &Path, anchor: ProcessId) -> Result<McpServerConfig, String> {
     let sidecar = vmux_sidecar_path()?;
-    resolve_with_sidecar(&sidecar, cwd, anchor)
+    let profile = vmux_core::profile::active_profile_name();
+    resolve_with_sidecar(&sidecar, cwd, anchor, &profile)
 }
 
 fn resolve_with_sidecar(
     sidecar: &Path,
     cwd: &Path,
     anchor: ProcessId,
+    profile: &str,
 ) -> Result<McpServerConfig, String> {
     if exec::is_executable_path(sidecar) {
         return Ok(McpServerConfig {
             command: sidecar.to_string_lossy().to_string(),
-            args: vec![
-                "mcp".to_string(),
-                "--anchor".to_string(),
-                anchor.to_string(),
-            ],
+            args: mcp_subcommand_args(anchor, profile),
             cwd: None,
         });
     }
     let workspace = find_workspace_dir(cwd)
         .ok_or_else(|| format!("vmux executable not found: {}", sidecar.display()))?;
-    Ok(McpServerConfig {
-        command: "cargo".to_string(),
-        args: [
-            "run", "--quiet", "-p", "vmux_cli", "--bin", "vmux", "--", "mcp", "--anchor",
-        ]
+    let mut args: Vec<String> = ["run", "--quiet", "-p", "vmux_cli", "--bin", "vmux", "--"]
         .into_iter()
         .map(str::to_string)
-        .chain(std::iter::once(anchor.to_string()))
-        .collect(),
+        .collect();
+    args.extend(mcp_subcommand_args(anchor, profile));
+    Ok(McpServerConfig {
+        command: "cargo".to_string(),
+        args,
         cwd: Some(workspace),
     })
+}
+
+fn mcp_subcommand_args(anchor: ProcessId, profile: &str) -> Vec<String> {
+    let mut args = vec![
+        "mcp".to_string(),
+        "--anchor".to_string(),
+        anchor.to_string(),
+    ];
+    if profile != "personal" {
+        args.push("--profile".to_string());
+        args.push(profile.to_string());
+    }
+    args
 }
 
 fn find_workspace_dir(cwd: &Path) -> Option<PathBuf> {
@@ -65,6 +75,24 @@ mod tests {
     use super::*;
 
     #[test]
+    fn mcp_args_append_profile_only_for_non_personal() {
+        let anchor = ProcessId::new();
+        assert_eq!(
+            mcp_subcommand_args(anchor, "personal"),
+            vec![
+                "mcp".to_string(),
+                "--anchor".to_string(),
+                anchor.to_string()
+            ]
+        );
+        let with = mcp_subcommand_args(anchor, "test");
+        assert!(
+            with.windows(2)
+                .any(|w| w[0] == "--profile" && w[1] == "test")
+        );
+    }
+
+    #[test]
     fn falls_back_to_cargo_run_when_sidecar_is_missing() {
         let temp = std::env::temp_dir().join(format!("vmux-agent-mcp-{}", std::process::id()));
         let workspace = temp.join("workspace");
@@ -72,7 +100,9 @@ mod tests {
         std::fs::write(workspace.join("Cargo.toml"), b"[workspace]\n").unwrap();
 
         let anchor = ProcessId::new();
-        let config = resolve_with_sidecar(&temp.join("missing-vmux"), &workspace, anchor).unwrap();
+        let config =
+            resolve_with_sidecar(&temp.join("missing-vmux"), &workspace, anchor, "personal")
+                .unwrap();
         let _ = std::fs::remove_dir_all(&temp);
 
         assert_eq!(config.command, "cargo");
@@ -102,7 +132,9 @@ mod tests {
         std::fs::write(workspace.join("Cargo.toml"), b"[workspace]\n").unwrap();
 
         let anchor = ProcessId::new();
-        let config = resolve_with_sidecar(&temp.join("missing-vmux"), &workspace, anchor).unwrap();
+        let config =
+            resolve_with_sidecar(&temp.join("missing-vmux"), &workspace, anchor, "personal")
+                .unwrap();
         let _ = std::fs::remove_dir_all(&temp);
 
         assert!(config.args.windows(2).any(|w| w[0] == "--anchor"));

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -105,6 +105,7 @@ impl Plugin for AgentPlugin {
             .init_resource::<AgentTerminalRegions>()
             .init_resource::<AgentSessionDirty>()
             .add_message::<AgentCommandRequest>()
+            .add_message::<FocusPaneRequest>()
             .add_message::<AgentQueryRequest>()
             .add_message::<ScreenshotRequest>()
             .add_message::<ScreenshotResponse>()
@@ -195,6 +196,7 @@ impl Plugin for AgentPlugin {
                 Update,
                 (
                     handle_spawn_agent_requests,
+                    handle_focus_pane_requests.after(handle_agent_commands),
                     respond_process_stack_spawn.after(handle_agent_commands),
                     handle_agent_page_open.in_set(PageOpenSet::HandleKnownPages),
                     handle_restart_agent_pty,
@@ -301,6 +303,24 @@ struct ProcessStackSpawnRequest {
     env: Vec<(String, String)>,
 }
 
+#[derive(Message, Clone)]
+struct FocusPaneRequest {
+    pane: String,
+}
+
+fn handle_focus_pane_requests(
+    mut reader: MessageReader<FocusPaneRequest>,
+    child_of_q: Query<&ChildOf>,
+    mut commands: Commands,
+) {
+    for req in reader.read() {
+        let Ok((_, bits)) = vmux_layout::protocol::parse_id(&req.pane) else {
+            continue;
+        };
+        vmux_core::focus_pane_entity(Entity::from_bits(bits), &mut commands, &child_of_q);
+    }
+}
+
 #[derive(bevy::ecs::system::SystemParam)]
 pub struct AgentLookups<'w> {
     pub pid_to_entity: Option<Res<'w, vmux_terminal::pid::PidToEntity>>,
@@ -312,6 +332,7 @@ pub struct AgentLookups<'w> {
 struct AgentSpaceWriters<'w, 's> {
     layout_apply: MessageWriter<'w, vmux_layout::reconcile::LayoutApplyRequest>,
     space_command: MessageWriter<'w, vmux_space::SpaceCommandRequest>,
+    focus_pane: MessageWriter<'w, FocusPaneRequest>,
     issued: MessageWriter<'w, vmux_command::CommandIssued>,
     attention: MessageWriter<'w, vmux_core::notify::AgentAttention>,
     agents: Query<
@@ -643,6 +664,12 @@ fn handle_agent_commands(
                 }
                 None => AgentCommandResult::Error("notify: caller not found".to_string()),
             },
+            ServiceAgentCommand::FocusPane { pane } => {
+                writers
+                    .focus_pane
+                    .write(FocusPaneRequest { pane: pane.clone() });
+                AgentCommandResult::Ok
+            }
             ServiceAgentCommand::UpdateSettings { path, value_json } => {
                 match serde_json::from_str::<serde_json::Value>(value_json) {
                     Ok(value) => {
@@ -1144,7 +1171,7 @@ fn handle_agent_queries(
                             serde_json::json!({
                                 "id": id.0,
                                 "name": name.to_string(),
-                                "profile": vmux_space::model::BOOTSTRAP_PROFILE_NAME,
+                                "profile": vmux_space::model::bootstrap_profile_name(),
                                 "is_active": is_active,
                             }),
                         )
@@ -2292,7 +2319,11 @@ mod tests {
             .spawn(vmux_layout::stack::stack_bundle())
             .insert(ChildOf(pane))
             .id();
-        let terminal = app.world_mut().spawn(Terminal).insert(ChildOf(stack)).id();
+        let terminal = app
+            .world_mut()
+            .spawn((Terminal, ProcessId::new()))
+            .insert(ChildOf(stack))
+            .id();
 
         app.world_mut().resource_mut::<FocusedStack>().pane = Some(pane);
         app.world_mut().resource_mut::<FocusedStack>().stack = Some(stack);

--- a/crates/vmux_cli/src/commands.rs
+++ b/crates/vmux_cli/src/commands.rs
@@ -17,6 +17,8 @@ pub enum Command {
     Mcp {
         #[arg(long)]
         anchor: Option<String>,
+        #[arg(long)]
+        profile: Option<String>,
     },
     Notify {
         #[arg(long)]

--- a/crates/vmux_cli/src/commands/mcp.rs
+++ b/crates/vmux_cli/src/commands/mcp.rs
@@ -1,6 +1,12 @@
 use std::io;
 
-pub async fn run(anchor: Option<String>) -> io::Result<()> {
+pub async fn run(anchor: Option<String>, profile: Option<String>) -> io::Result<()> {
+    if let Some(p) = profile
+        .map(|p| p.trim().to_string())
+        .filter(|p| !p.is_empty())
+    {
+        unsafe { std::env::set_var("VMUX_PROFILE", p) };
+    }
     let anchor = anchor.and_then(|s| s.parse::<vmux_service::protocol::ProcessId>().ok());
     vmux_mcp::protocol::run_stdio(anchor).await
 }

--- a/crates/vmux_cli/src/main.rs
+++ b/crates/vmux_cli/src/main.rs
@@ -8,7 +8,7 @@ use commands::{Cli, Command, open::OpenAppLauncher};
 async fn main() -> std::io::Result<()> {
     let cli = Cli::parse();
     match cli.command {
-        Some(Command::Mcp { anchor }) => commands::mcp::run(anchor).await,
+        Some(Command::Mcp { anchor, profile }) => commands::mcp::run(anchor, profile).await,
         Some(Command::Notify {
             title,
             body,

--- a/crates/vmux_core/src/profile.rs
+++ b/crates/vmux_core/src/profile.rs
@@ -1,7 +1,28 @@
 use std::path::PathBuf;
 
-pub fn active_profile_name() -> &'static str {
-    "personal"
+pub fn active_profile_name() -> String {
+    sanitize_profile(&std::env::var("VMUX_PROFILE").unwrap_or_default())
+}
+
+pub fn sanitize_profile(raw: &str) -> String {
+    let cleaned: String = raw
+        .trim()
+        .to_ascii_lowercase()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let trimmed = cleaned.trim_matches('-');
+    if trimmed.is_empty() {
+        "personal".to_string()
+    } else {
+        trimmed.to_string()
+    }
 }
 
 fn data_dir_suffix_for(profile: &str) -> PathBuf {
@@ -39,9 +60,14 @@ pub fn config_dir() -> PathBuf {
 }
 
 /// Default output directory for screenshots and screen recordings:
-/// `~/.vmux/recording`. Overridable via the `recording.output_dir` setting.
+/// `~/.vmux/profiles/<profile>/recording`. Overridable via the
+/// `recording.output_dir` setting.
+fn recording_dir_for(config: &std::path::Path, profile: &str) -> PathBuf {
+    config.join("profiles").join(profile).join("recording")
+}
+
 pub fn recording_dir() -> PathBuf {
-    config_dir().join("recording")
+    recording_dir_for(&config_dir(), &active_profile_name())
 }
 
 /// Per-build config subdir, or `None` for the shared (release) settings.
@@ -97,16 +123,33 @@ pub fn cef_cache_path() -> Option<String> {
     profile_dir().to_str().map(|s| s.to_owned())
 }
 
+fn store_dir_for(base: &std::path::Path, profile: &str) -> PathBuf {
+    if profile == "personal" {
+        base.to_path_buf()
+    } else {
+        base.join("profiles").join(profile)
+    }
+}
+
+pub fn store_dir() -> PathBuf {
+    let dir = store_dir_for(&shared_data_dir(), &active_profile_name());
+    let _ = std::fs::create_dir_all(&dir);
+    dir
+}
+
 pub fn default_space_dir() -> PathBuf {
     space_dir("space-1")
 }
 
-fn spaces_root(home: &std::path::Path) -> PathBuf {
-    home.join(".vmux").join("spaces")
+fn spaces_root_for(home: &std::path::Path, profile: &str) -> PathBuf {
+    home.join(".vmux")
+        .join("profiles")
+        .join(profile)
+        .join("spaces")
 }
 
-fn space_dir_path(home: &std::path::Path, space_id: &str) -> PathBuf {
-    spaces_root(home).join(space_id)
+fn space_dir_path(home: &std::path::Path, profile: &str, space_id: &str) -> PathBuf {
+    spaces_root_for(home, profile).join(space_id)
 }
 
 fn home_dir() -> PathBuf {
@@ -136,17 +179,17 @@ fn prune_empty_dirs_up(mut dir: PathBuf, root: &std::path::Path) {
 }
 
 pub fn space_dir(space_id: &str) -> PathBuf {
-    let dir = space_dir_path(&home_dir(), space_id);
+    let dir = space_dir_path(&home_dir(), &active_profile_name(), space_id);
     let _ = std::fs::create_dir_all(&dir);
     dir
 }
 
-fn rename_space_dir_in(home: &std::path::Path, old_id: &str, new_id: &str) {
+fn rename_space_dir_in(home: &std::path::Path, profile: &str, old_id: &str, new_id: &str) {
     if old_id == new_id {
         return;
     }
-    let old = space_dir_path(home, old_id);
-    let new = space_dir_path(home, new_id);
+    let old = space_dir_path(home, profile, old_id);
+    let new = space_dir_path(home, profile, new_id);
     if old == new {
         return;
     }
@@ -160,7 +203,7 @@ fn rename_space_dir_in(home: &std::path::Path, old_id: &str, new_id: &str) {
         if std::fs::rename(&old, &new).is_ok()
             && let Some(parent) = old.parent()
         {
-            prune_empty_dirs_up(parent.to_path_buf(), &spaces_root(home));
+            prune_empty_dirs_up(parent.to_path_buf(), &spaces_root_for(home, profile));
         }
     } else if !new.exists() {
         let _ = std::fs::create_dir_all(&new);
@@ -168,7 +211,7 @@ fn rename_space_dir_in(home: &std::path::Path, old_id: &str, new_id: &str) {
 }
 
 pub fn rename_space_dir(old_id: &str, new_id: &str) {
-    rename_space_dir_in(&home_dir(), old_id, new_id);
+    rename_space_dir_in(&home_dir(), &active_profile_name(), old_id, new_id);
 }
 
 fn collect_subdirs(dir: &std::path::Path, out: &mut Vec<PathBuf>) {
@@ -186,8 +229,12 @@ fn collect_subdirs(dir: &std::path::Path, out: &mut Vec<PathBuf>) {
 
 /// Remove directories under `~/.vmux/spaces/` that no longer match a live space
 /// id and are empty. Folders that contain files (or back a live space) are kept.
-fn prune_orphan_space_dirs_in(home: &std::path::Path, live: &std::collections::HashSet<String>) {
-    let root = spaces_root(home);
+fn prune_orphan_space_dirs_in(
+    home: &std::path::Path,
+    profile: &str,
+    live: &std::collections::HashSet<String>,
+) {
+    let root = spaces_root_for(home, profile);
     let mut dirs = Vec::new();
     collect_subdirs(&root, &mut dirs);
     dirs.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
@@ -206,7 +253,36 @@ fn prune_orphan_space_dirs_in(home: &std::path::Path, live: &std::collections::H
 }
 
 pub fn prune_orphan_space_dirs(live: &std::collections::HashSet<String>) {
-    prune_orphan_space_dirs_in(&home_dir(), live);
+    prune_orphan_space_dirs_in(&home_dir(), &active_profile_name(), live);
+}
+
+fn migrate_dir(legacy: &std::path::Path, target: &std::path::Path) {
+    if !legacy.exists() || target.exists() {
+        return;
+    }
+    if let Some(parent) = target.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::rename(legacy, target);
+}
+
+fn migrate_legacy_personal_layout_in(home: &std::path::Path) {
+    let config = home.join(".vmux");
+    migrate_dir(&config.join("spaces"), &spaces_root_for(home, "personal"));
+    migrate_dir(
+        &config.join("recording"),
+        &recording_dir_for(&config, "personal"),
+    );
+}
+
+/// Relocate the pre-profiles personal layout (`~/.vmux/spaces`,
+/// `~/.vmux/recording`) under `~/.vmux/profiles/personal/`. No-op unless the
+/// personal profile is active and a legacy dir exists without its new target.
+pub fn migrate_legacy_personal_layout() {
+    if active_profile_name() != "personal" {
+        return;
+    }
+    migrate_legacy_personal_layout_in(&home_dir());
 }
 
 #[cfg(test)]
@@ -214,9 +290,67 @@ mod tests {
     use super::*;
 
     #[test]
-    fn recording_dir_is_under_config_dir() {
-        assert_eq!(recording_dir(), config_dir().join("recording"));
-        assert!(recording_dir().ends_with(".vmux/recording"));
+    fn recording_dir_is_nested_under_profile() {
+        assert_eq!(
+            recording_dir_for(std::path::Path::new("/home/u/.vmux"), "personal"),
+            PathBuf::from("/home/u/.vmux/profiles/personal/recording")
+        );
+    }
+
+    #[test]
+    fn recording_dir_test_profile_is_nested() {
+        assert_eq!(
+            recording_dir_for(std::path::Path::new("/home/u/.vmux"), "test"),
+            PathBuf::from("/home/u/.vmux/profiles/test/recording")
+        );
+    }
+
+    #[test]
+    fn sanitize_profile_keeps_safe_and_defaults_empty() {
+        assert_eq!(sanitize_profile("test"), "test");
+        assert_eq!(sanitize_profile("Test"), "test");
+        assert_eq!(sanitize_profile(""), "personal");
+        assert_eq!(sanitize_profile("  "), "personal");
+        assert_eq!(sanitize_profile("a/b"), "a-b");
+        assert_eq!(sanitize_profile("../evil"), "evil");
+    }
+
+    #[test]
+    fn store_dir_personal_is_base_and_test_is_nested() {
+        let base = std::path::Path::new("/data/Vmux/dev");
+        assert_eq!(
+            store_dir_for(base, "personal"),
+            PathBuf::from("/data/Vmux/dev")
+        );
+        assert_eq!(
+            store_dir_for(base, "test"),
+            PathBuf::from("/data/Vmux/dev/profiles/test")
+        );
+    }
+
+    #[test]
+    fn spaces_root_is_nested_for_personal_and_test() {
+        let home = std::path::Path::new("/home/u");
+        assert_eq!(
+            spaces_root_for(home, "personal"),
+            PathBuf::from("/home/u/.vmux/profiles/personal/spaces")
+        );
+        assert_eq!(
+            spaces_root_for(home, "test"),
+            PathBuf::from("/home/u/.vmux/profiles/test/spaces")
+        );
+    }
+
+    #[test]
+    fn active_profile_name_reads_and_sanitizes_env() {
+        let prev = std::env::var("VMUX_PROFILE").ok();
+        unsafe { std::env::set_var("VMUX_PROFILE", "Test/X") };
+        assert_eq!(active_profile_name(), "test-x");
+        unsafe { std::env::remove_var("VMUX_PROFILE") };
+        assert_eq!(active_profile_name(), "personal");
+        if let Some(p) = prev {
+            unsafe { std::env::set_var("VMUX_PROFILE", p) };
+        }
     }
 
     #[test]
@@ -253,21 +387,65 @@ mod tests {
     }
 
     #[test]
-    fn space_dir_is_under_vmux_spaces() {
+    fn space_dir_is_nested_under_profile() {
         assert_eq!(
-            space_dir_path(std::path::Path::new("/home/u"), "work"),
-            PathBuf::from("/home/u/.vmux/spaces/work")
+            space_dir_path(std::path::Path::new("/home/u"), "personal", "work"),
+            PathBuf::from("/home/u/.vmux/profiles/personal/spaces/work")
         );
+    }
+
+    #[test]
+    fn migrate_moves_legacy_personal_dirs_into_profile() {
+        let home = std::env::temp_dir().join(format!("vmux-migrate-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        let legacy_space = home.join(".vmux").join("spaces").join("space-1");
+        std::fs::create_dir_all(&legacy_space).unwrap();
+        std::fs::write(legacy_space.join("space.ron"), b"x").unwrap();
+        let legacy_rec = home.join(".vmux").join("recording");
+        std::fs::create_dir_all(&legacy_rec).unwrap();
+        std::fs::write(legacy_rec.join("a.mp4"), b"y").unwrap();
+
+        migrate_legacy_personal_layout_in(&home);
+
+        assert!(!home.join(".vmux").join("spaces").exists());
+        assert!(
+            space_dir_path(&home, "personal", "space-1")
+                .join("space.ron")
+                .exists()
+        );
+        assert!(!legacy_rec.exists());
+        assert!(
+            recording_dir_for(&home.join(".vmux"), "personal")
+                .join("a.mp4")
+                .exists()
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn migrate_keeps_existing_target_and_leaves_legacy() {
+        let home = std::env::temp_dir().join(format!("vmux-migrate-noop-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(home.join(".vmux").join("spaces")).unwrap();
+        let target = spaces_root_for(&home, "personal");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("keep.txt"), b"keep").unwrap();
+
+        migrate_legacy_personal_layout_in(&home);
+
+        assert!(home.join(".vmux").join("spaces").exists());
+        assert!(target.join("keep.txt").exists());
+        let _ = std::fs::remove_dir_all(&home);
     }
 
     #[test]
     fn rename_space_dir_moves_existing_folder() {
         let home = std::env::temp_dir().join(format!("vmux-rndir-mv-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&home);
-        std::fs::create_dir_all(space_dir_path(&home, "old")).unwrap();
-        rename_space_dir_in(&home, "old", "new");
-        assert!(!space_dir_path(&home, "old").exists());
-        assert!(space_dir_path(&home, "new").exists());
+        std::fs::create_dir_all(space_dir_path(&home, "personal", "old")).unwrap();
+        rename_space_dir_in(&home, "personal", "old", "new");
+        assert!(!space_dir_path(&home, "personal", "old").exists());
+        assert!(space_dir_path(&home, "personal", "new").exists());
         let _ = std::fs::remove_dir_all(&home);
     }
 
@@ -275,8 +453,8 @@ mod tests {
     fn rename_space_dir_creates_folder_when_absent() {
         let home = std::env::temp_dir().join(format!("vmux-rndir-new-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&home);
-        rename_space_dir_in(&home, "old", "new");
-        assert!(space_dir_path(&home, "new").exists());
+        rename_space_dir_in(&home, "personal", "old", "new");
+        assert!(space_dir_path(&home, "personal", "new").exists());
         let _ = std::fs::remove_dir_all(&home);
     }
 
@@ -284,10 +462,10 @@ mod tests {
     fn rename_space_dir_creates_nested_path() {
         let home = std::env::temp_dir().join(format!("vmux-rndir-nest-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&home);
-        std::fs::create_dir_all(space_dir_path(&home, "old")).unwrap();
-        rename_space_dir_in(&home, "old", "org/new");
-        assert!(!space_dir_path(&home, "old").exists());
-        assert!(space_dir_path(&home, "org/new").exists());
+        std::fs::create_dir_all(space_dir_path(&home, "personal", "old")).unwrap();
+        rename_space_dir_in(&home, "personal", "old", "org/new");
+        assert!(!space_dir_path(&home, "personal", "old").exists());
+        assert!(space_dir_path(&home, "personal", "org/new").exists());
         let _ = std::fs::remove_dir_all(&home);
     }
 
@@ -295,12 +473,11 @@ mod tests {
     fn rename_prunes_empty_old_parent() {
         let home = std::env::temp_dir().join(format!("vmux-rndir-prune-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&home);
-        std::fs::create_dir_all(space_dir_path(&home, "org/old")).unwrap();
-        rename_space_dir_in(&home, "org/old", "elsewhere");
-        assert!(space_dir_path(&home, "elsewhere").is_dir());
-        assert!(!space_dir_path(&home, "org/old").exists());
-        // the now-empty `org` parent is pruned too
-        assert!(!space_dir_path(&home, "org").exists());
+        std::fs::create_dir_all(space_dir_path(&home, "personal", "org/old")).unwrap();
+        rename_space_dir_in(&home, "personal", "org/old", "elsewhere");
+        assert!(space_dir_path(&home, "personal", "elsewhere").is_dir());
+        assert!(!space_dir_path(&home, "personal", "org/old").exists());
+        assert!(!space_dir_path(&home, "personal", "org").exists());
         let _ = std::fs::remove_dir_all(&home);
     }
 
@@ -308,26 +485,29 @@ mod tests {
     fn prune_removes_empty_orphans_keeps_live_and_files() {
         let home = std::env::temp_dir().join(format!("vmux-prune-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&home);
-        std::fs::create_dir_all(space_dir_path(&home, "org/live")).unwrap();
-        std::fs::create_dir_all(space_dir_path(&home, "org/orphan")).unwrap();
-        std::fs::create_dir_all(space_dir_path(&home, "solo")).unwrap();
-        std::fs::create_dir_all(space_dir_path(&home, "keep")).unwrap();
-        std::fs::write(space_dir_path(&home, "keep").join("f.txt"), b"x").unwrap();
+        std::fs::create_dir_all(space_dir_path(&home, "personal", "org/live")).unwrap();
+        std::fs::create_dir_all(space_dir_path(&home, "personal", "org/orphan")).unwrap();
+        std::fs::create_dir_all(space_dir_path(&home, "personal", "solo")).unwrap();
+        std::fs::create_dir_all(space_dir_path(&home, "personal", "keep")).unwrap();
+        std::fs::write(
+            space_dir_path(&home, "personal", "keep").join("f.txt"),
+            b"x",
+        )
+        .unwrap();
 
         let live: std::collections::HashSet<String> =
             ["org/live".to_string()].into_iter().collect();
-        prune_orphan_space_dirs_in(&home, &live);
+        prune_orphan_space_dirs_in(&home, "personal", &live);
 
-        assert!(space_dir_path(&home, "org/live").is_dir());
-        assert!(space_dir_path(&home, "org").is_dir());
-        assert!(!space_dir_path(&home, "org/orphan").exists());
-        assert!(!space_dir_path(&home, "solo").exists());
-        assert!(space_dir_path(&home, "keep").is_dir());
+        assert!(space_dir_path(&home, "personal", "org/live").is_dir());
+        assert!(space_dir_path(&home, "personal", "org").is_dir());
+        assert!(!space_dir_path(&home, "personal", "org/orphan").exists());
+        assert!(!space_dir_path(&home, "personal", "solo").exists());
+        assert!(space_dir_path(&home, "personal", "keep").is_dir());
         let _ = std::fs::remove_dir_all(&home);
     }
     #[test]
     fn settings_live_in_dot_vmux_not_data_dir() {
-        // Settings live under ~/.vmux, separate from the profile-isolated data dir.
         for candidate in settings_path_candidates() {
             assert!(candidate.starts_with(config_dir()));
             assert!(!candidate.starts_with(shared_data_dir()));
@@ -337,12 +517,10 @@ mod tests {
     #[test]
     fn settings_candidates_prefer_per_build_override_then_shared() {
         let base = PathBuf::from("/base");
-        // Release/local: shared file only.
         assert_eq!(
             settings_candidates_in(&base, None),
             vec![base.join("settings.ron")]
         );
-        // Dev: per-build override first, then the shared file.
         assert_eq!(
             settings_candidates_in(&base, Some("dev")),
             vec![

--- a/crates/vmux_desktop/src/main.rs
+++ b/crates/vmux_desktop/src/main.rs
@@ -36,6 +36,8 @@ fn main() {
         }
     );
 
+    vmux_core::profile::migrate_legacy_personal_layout();
+
     let mut app = App::new();
     app.add_plugins(VmuxPlugin);
 

--- a/crates/vmux_desktop/src/persistence.rs
+++ b/crates/vmux_desktop/src/persistence.rs
@@ -97,11 +97,11 @@ struct AutoSave {
 const STORE_SCHEMA_VERSION: u32 = 2;
 
 pub(crate) fn store_path() -> PathBuf {
-    vmux_core::profile::shared_data_dir().join("store.ron")
+    vmux_core::profile::store_dir().join("store.ron")
 }
 
 fn store_version_path() -> PathBuf {
-    vmux_core::profile::shared_data_dir().join("store.version")
+    vmux_core::profile::store_dir().join("store.version")
 }
 
 fn store_schema_is_current() -> bool {
@@ -164,6 +164,9 @@ fn auto_save_system(time: Res<Time>, mut auto_save: ResMut<AutoSave>, mut comman
 }
 
 pub(crate) fn save_space_to_path(commands: &mut Commands, path: PathBuf) {
+    if vmux_core::profile::active_profile_name() != "personal" {
+        return;
+    }
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
@@ -208,6 +211,12 @@ pub(crate) fn load_space_on_startup(
     mut restore: ResMut<crate::boot_status::RestoreComplete>,
     mut commands: Commands,
 ) {
+    if vmux_core::profile::active_profile_name() != "personal" {
+        commands.insert_resource(SpaceFilePresent(false));
+        restore.0 = true;
+        commands.spawn(vmux_space::spaces::space_profile_bundle(&active.record));
+        return;
+    }
     let path = store_path();
     let removed_stale = remove_stale_space_if_needed(&path);
     let schema_outdated = path.exists() && !store_schema_is_current();

--- a/crates/vmux_desktop/src/recording.rs
+++ b/crates/vmux_desktop/src/recording.rs
@@ -157,6 +157,17 @@ pub(crate) fn bgra_to_rgba(bgra: &[u8]) -> Vec<u8> {
     out
 }
 
+/// Long-edge cap for encoded recordings. Keeps text legible while spreading the
+/// bitrate over far fewer pixels than a raw retina capture.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub(crate) const RECORDING_MAX_EDGE: u32 = 1280;
+
+/// Fixed average H.264 bitrate (bits/s) for recordings. Tuned for legible screen
+/// content at the downscaled resolution; file size scales with duration
+/// (~1-2 MB/min for typical low-motion screen capture).
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub(crate) const RECORDING_BITRATE_BPS: i32 = 800_000;
+
 /// Cap the long edge at `max_edge`, never upscaling.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub(crate) fn downscale_to(w: u32, h: u32, max_edge: u32) -> (u32, u32) {

--- a/crates/vmux_desktop/src/recording_capture_macos.rs
+++ b/crates/vmux_desktop/src/recording_capture_macos.rs
@@ -11,7 +11,8 @@ use objc2::runtime::{AnyObject, NSObject, NSObjectProtocol, ProtocolObject};
 use objc2::{AllocAnyThread, DefinedClass, define_class, msg_send};
 use objc2_av_foundation::{
     AVAssetWriter, AVAssetWriterInput, AVAssetWriterInputPixelBufferAdaptor, AVFileTypeMPEG4,
-    AVMediaTypeVideo, AVVideoCodecKey, AVVideoCodecTypeH264, AVVideoHeightKey, AVVideoWidthKey,
+    AVMediaTypeVideo, AVVideoAverageBitRateKey, AVVideoCodecKey, AVVideoCodecTypeH264,
+    AVVideoCompressionPropertiesKey, AVVideoHeightKey, AVVideoWidthKey,
 };
 use objc2_core_foundation::{CGPoint, CGRect, CGSize};
 use objc2_core_media::{CMSampleBuffer, CMTime};
@@ -279,6 +280,7 @@ fn build_writer(
     temp_mp4: &Path,
     out_w: u32,
     out_h: u32,
+    bitrate: i32,
 ) -> Result<
     (
         Retained<AVAssetWriter>,
@@ -298,14 +300,25 @@ fn build_writer(
     let codec_h264 = unsafe { AVVideoCodecTypeH264 }.ok_or("AVVideoCodecTypeH264 unavailable")?;
     let width_key = unsafe { AVVideoWidthKey }.ok_or("AVVideoWidthKey unavailable")?;
     let height_key = unsafe { AVVideoHeightKey }.ok_or("AVVideoHeightKey unavailable")?;
+    let compression_key = unsafe { AVVideoCompressionPropertiesKey }
+        .ok_or("AVVideoCompressionPropertiesKey unavailable")?;
+    let bitrate_key =
+        unsafe { AVVideoAverageBitRateKey }.ok_or("AVVideoAverageBitRateKey unavailable")?;
+
+    let bitrate_num = NSNumber::new_i32(bitrate);
+    let compression = NSDictionary::<NSString, AnyObject>::from_slices(
+        &[bitrate_key],
+        &[AsRef::<AnyObject>::as_ref(&bitrate_num)],
+    );
 
     let w_num = NSNumber::new_i32(out_w as i32);
     let h_num = NSNumber::new_i32(out_h as i32);
-    let keys: [&NSString; 3] = [codec_key, width_key, height_key];
-    let objects: [&AnyObject; 3] = [
+    let keys: [&NSString; 4] = [codec_key, width_key, height_key, compression_key];
+    let objects: [&AnyObject; 4] = [
         AsRef::<AnyObject>::as_ref(codec_h264),
         AsRef::<AnyObject>::as_ref(&w_num),
         AsRef::<AnyObject>::as_ref(&h_num),
+        AsRef::<AnyObject>::as_ref(&compression),
     ];
     let settings = NSDictionary::<NSString, AnyObject>::from_slices(&keys, &objects);
 
@@ -446,10 +459,11 @@ fn setup_stream(
     let filter = unsafe {
         SCContentFilter::initWithDesktopIndependentWindow(SCContentFilter::alloc(), &window)
     };
+    let (enc_w, enc_h) = super::downscale_to(out_w, out_h, super::RECORDING_MAX_EDGE);
     let config = unsafe { SCStreamConfiguration::new() };
     unsafe {
-        config.setWidth(out_w as usize);
-        config.setHeight(out_h as usize);
+        config.setWidth(enc_w as usize);
+        config.setHeight(enc_h as usize);
         config.setPixelFormat(PIXEL_FORMAT_BGRA);
         config.setMinimumFrameInterval(CMTime::new(1, 60));
         config.setShowsCursor(true);
@@ -464,13 +478,14 @@ fn setup_stream(
         }
     }
 
-    let (writer, input, adaptor) = match build_writer(temp_mp4, out_w, out_h) {
-        Ok(t) => t,
-        Err(e) => {
-            let _ = done_tx.send(Err(e));
-            return;
-        }
-    };
+    let (writer, input, adaptor) =
+        match build_writer(temp_mp4, enc_w, enc_h, super::RECORDING_BITRATE_BPS) {
+            Ok(t) => t,
+            Err(e) => {
+                let _ = done_tx.send(Err(e));
+                return;
+            }
+        };
 
     let (gif_tx, gif_join) = if let Some(path) = temp_gif.clone() {
         let (s, r) = crossbeam_channel::bounded::<GifMsg>(8);

--- a/crates/vmux_desktop/tests/release_invariants.rs
+++ b/crates/vmux_desktop/tests/release_invariants.rs
@@ -20,7 +20,9 @@ fn dev_target_signs_then_runs_debug_binary() {
         makefile.contains("dev: ensure-mac-deps ensure-codesign-deps install-debug-render-process")
     );
     assert!(makefile.contains("./scripts/sign-dev-mac.sh"));
-    assert!(makefile.contains("DYLD_LIBRARY_PATH=\"$$dylib_path\" ./target/debug/vmux_desktop"));
+    assert!(makefile.contains(
+        "DYLD_LIBRARY_PATH=\"$$dylib_path\" VMUX_PROFILE=\"$(VMUX_PROFILE)\" ./target/debug/vmux_desktop"
+    ));
     assert!(makefile.contains("identity=\"$$(./scripts/ensure-local-codesign-identity.sh)\" &&"));
     assert!(!makefile.contains("run-mac:"));
     assert!(!makefile.contains("build-mac-debug"));

--- a/crates/vmux_desktop/tests/release_invariants.rs
+++ b/crates/vmux_desktop/tests/release_invariants.rs
@@ -54,8 +54,8 @@ fn dev_target_stops_existing_debug_desktop_before_cef_initialize() {
         .find("exec env -u CEF_PATH")
         .expect("debug desktop run");
 
-    assert!(makefile.contains("pkill -f \"target/debug/vmux_desktop\""));
-    assert!(makefile.contains("pkill -f \"bevy_cef_debug_render_process\""));
+    assert!(makefile.contains("pgrep -f \"target/debug/vmux_desktop\""));
+    assert!(makefile.contains("pgrep -f \"bevy_cef_debug_render_process\""));
     assert!(stop_idx < run_idx);
 }
 

--- a/crates/vmux_layout/src/tab.rs
+++ b/crates/vmux_layout/src/tab.rs
@@ -528,6 +528,7 @@ mod tests {
             .add_message::<crate::LayoutSpawnRequest>()
             .add_message::<crate::TabLayoutSpawnRequest>()
             .add_message::<PageOpenRequest>()
+            .add_message::<vmux_core::agent::SpawnAgentInStackRequest>()
             .init_resource::<crate::NewStackContext>()
             .insert_resource(test_settings())
             .init_resource::<CollectedSpawns>()

--- a/crates/vmux_layout/src/window.rs
+++ b/crates/vmux_layout/src/window.rs
@@ -1170,6 +1170,7 @@ mod tests {
             .init_resource::<crate::NewStackContext>()
             .add_message::<crate::TabLayoutSpawnRequest>()
             .add_message::<PageOpenRequest>()
+            .add_message::<vmux_core::agent::SpawnAgentInStackRequest>()
             .insert_resource(LayoutSettings {
                 radius: 0.0,
                 window: crate::settings::WindowSettings { padding: 0.0 },
@@ -1200,6 +1201,7 @@ mod tests {
             .init_resource::<crate::NewStackContext>()
             .add_message::<crate::TabLayoutSpawnRequest>()
             .add_message::<PageOpenRequest>()
+            .add_message::<vmux_core::agent::SpawnAgentInStackRequest>()
             .insert_resource(LayoutSettings {
                 radius: 0.0,
                 window: crate::settings::WindowSettings { padding: 0.0 },
@@ -1243,6 +1245,7 @@ mod tests {
             .init_resource::<crate::NewStackContext>()
             .add_message::<crate::TabLayoutSpawnRequest>()
             .add_message::<PageOpenRequest>()
+            .add_message::<vmux_core::agent::SpawnAgentInStackRequest>()
             .insert_resource(LayoutSettings {
                 radius: 0.0,
                 window: crate::settings::WindowSettings { padding: 0.0 },

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -23,11 +23,18 @@ pub enum McpParamTool {
         description = "Navigate the active webview to a URL, or open a URL in a target pane. URLs starting with 'vmux://terminal/' open a terminal (use '?cwd=/path' to set working dir), 'vmux://spaces/' opens the spaces view, 'vmux://services/' opens the processes monitor; other 'vmux://' URLs are rejected; everything else opens as a browser. With 'vmux://' URLs, a new tab is always created in the target pane (defaulting to the focused pane)."
     )]
     BrowserNavigate { url: String, pane: Option<String> },
-    #[mcp(description = "Send raw text to the active terminal (no carriage return appended).")]
+    #[mcp(
+        description = "Send text to a terminal. Target by `terminal` (a process_id from vmux_read_layout) or omit to use the active terminal. Set `enter: true` to append a carriage return and submit the line (required for TUIs like the vibe agent, whose Enter is CR)."
+    )]
     TerminalSend {
         text: String,
         terminal: Option<String>,
+        enter: Option<bool>,
     },
+    #[mcp(
+        description = "Focus a pane by id (from vmux_read_layout, e.g. \"pane:123\"), making it the active pane/stack so subsequent terminal_send and input target it."
+    )]
+    FocusPane { pane: String },
     #[mcp(description = "Select a tab by index (1-8).")]
     SelectTab { index: u8 },
     #[mcp(description = "Update a single vmux setting by dot-path. \
@@ -88,11 +95,26 @@ impl McpParamTool {
                 }
                 Ok(AgentCommand::BrowserNavigate { url, pane })
             }
-            McpParamTool::TerminalSend { text, terminal } => {
+            McpParamTool::TerminalSend {
+                text,
+                terminal,
+                enter,
+            } => {
+                let text = if enter.unwrap_or(false) {
+                    format!("{text}\r")
+                } else {
+                    text
+                };
                 if text.is_empty() {
                     return Err("terminal_send.text is empty".to_string());
                 }
                 Ok(AgentCommand::TerminalSend { text, terminal })
+            }
+            McpParamTool::FocusPane { pane } => {
+                if pane.trim().is_empty() {
+                    return Err("focus_pane.pane is empty".to_string());
+                }
+                Ok(AgentCommand::FocusPane { pane })
             }
             McpParamTool::SelectTab { index } => {
                 if !(1..=8).contains(&index) {
@@ -437,7 +459,7 @@ fn record_start_definition() -> ToolDefinition {
 Returns immediately so you can drive the UI with other tools to demonstrate a feature, then call \
 record_stop. Record in ONE live take: start, perform the few actions you want to show, then \
 stop. Do NOT rehearse, build elaborate layouts, or take screenshots to verify - just capture the \
-live interaction in a single pass. Auto-stops after `max_secs` (default 120) as a safety cap. Only \
+live interaction in a single pass. Auto-stops after `max_secs` (default 600) as a safety cap. Only \
 one recording at a time. macOS only; the first call may prompt for Screen Recording permission - \
 grant it in System Settings > Privacy & Security > Screen Recording, then call again."
             .into(),
@@ -446,7 +468,7 @@ grant it in System Settings > Privacy & Security > Screen Recording, then call a
             "additionalProperties": false,
             "properties": {
                 "gif": {"type": "boolean", "description": "Also emit a GIF next to the mp4 (default false)."},
-                "max_secs": {"type": "integer", "description": "Auto-stop cap in seconds (default 120)."},
+                "max_secs": {"type": "integer", "description": "Auto-stop cap in seconds (default 600)."},
                 "pane": {"type": "string", "description": "Optional pane:<id> or stack:<id> to crop to; whole window if omitted."}
             }
         }),
@@ -457,7 +479,7 @@ fn record_stop_definition() -> ToolDefinition {
     ToolDefinition {
         name: "record_stop".into(),
         description: "Stop the active recording and write the file(s). Returns the mp4 path, duration, \
-and size (plus the GIF path if one was requested). By default saves to ~/.vmux/recording/; pass `dir` \
+and size (plus the GIF path if one was requested). By default saves to ~/.vmux/profiles/<profile>/recording/; pass `dir` \
 (absolute) and `name` (basename, no extension) to save elsewhere - e.g. dir=<repo>/docs/recording, \
 name=<feature> to drop a demo straight into the repo."
             .into(),
@@ -465,7 +487,7 @@ name=<feature> to drop a demo straight into the repo."
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "dir": {"type": "string", "description": "Absolute output directory (default ~/.vmux/recording)."},
+                "dir": {"type": "string", "description": "Absolute output directory (default ~/.vmux/profiles/<profile>/recording)."},
                 "name": {"type": "string", "description": "Output basename without extension (default vmux-<timestamp>)."}
             }
         }),
@@ -665,7 +687,7 @@ pub fn dispatch_with_anchor(
         let max_secs = arguments
             .get("max_secs")
             .and_then(Value::as_u64)
-            .unwrap_or(120) as u32;
+            .unwrap_or(600) as u32;
         let pane = match arguments.get("pane") {
             None | Some(Value::Null) => None,
             Some(Value::String(s)) => {
@@ -817,7 +839,7 @@ mod tests {
             q,
             AgentQuery::RecordStart {
                 gif: false,
-                max_secs: 120,
+                max_secs: 600,
                 pane: None
             }
         );
@@ -1004,6 +1026,38 @@ mod tests {
             command,
             AgentCommand::TerminalSend {
                 text: "ls".to_string(),
+                terminal: None,
+            }
+        );
+    }
+
+    #[test]
+    fn terminal_send_enter_appends_carriage_return() {
+        let command = dispatch_command(
+            "terminal_send",
+            serde_json::json!({"text": "ls", "enter": true}),
+        )
+        .unwrap();
+        assert_eq!(
+            command,
+            AgentCommand::TerminalSend {
+                text: "ls\r".to_string(),
+                terminal: None,
+            }
+        );
+    }
+
+    #[test]
+    fn terminal_send_enter_with_empty_text_submits_carriage_return() {
+        let command = dispatch_command(
+            "terminal_send",
+            serde_json::json!({"text": "", "enter": true}),
+        )
+        .unwrap();
+        assert_eq!(
+            command,
+            AgentCommand::TerminalSend {
+                text: "\r".to_string(),
                 terminal: None,
             }
         );

--- a/crates/vmux_service/src/paths.rs
+++ b/crates/vmux_service/src/paths.rs
@@ -13,8 +13,21 @@ pub fn service_dir() -> PathBuf {
     shared_data_dir().join("services")
 }
 
+fn profile_file_stem(build: &str, profile: &str) -> String {
+    if profile == "personal" {
+        format!("vmux-{build}")
+    } else {
+        format!("vmux-{build}-{profile}")
+    }
+}
+
+fn profile_file_name(build: &str, profile: &str, ext: &str) -> String {
+    format!("{}.{ext}", profile_file_stem(build, profile))
+}
+
 fn profile_file(ext: &str) -> PathBuf {
-    service_dir().join(format!("vmux-{}.{ext}", current_profile()))
+    let profile = vmux_core::profile::active_profile_name();
+    service_dir().join(profile_file_name(current_profile(), &profile, ext))
 }
 
 /// Path to the per-profile Unix domain socket.
@@ -35,7 +48,8 @@ pub fn identity_path() -> PathBuf {
 /// Path to the per-profile service stdout/stderr capture log. Lives alongside
 /// the rotated application logs in `log_dir`, not in `service_dir`.
 pub fn log_path() -> PathBuf {
-    log_dir().join(format!("vmux-{}.log", current_profile()))
+    let profile = vmux_core::profile::active_profile_name();
+    log_dir().join(profile_file_name(current_profile(), &profile, "log"))
 }
 
 /// Directory for application log files (separate from runtime files in
@@ -54,7 +68,11 @@ pub fn shell_integration_dir() -> PathBuf {
 /// daemon, the desktop file layer, and the panic hook all target the same file.
 pub fn current_log_file() -> PathBuf {
     let date = chrono::Utc::now().format("%Y-%m-%d");
-    log_dir().join(format!("vmux-{}.{date}.log", current_profile()))
+    let profile = vmux_core::profile::active_profile_name();
+    log_dir().join(format!(
+        "{}.{date}.log",
+        profile_file_stem(current_profile(), &profile)
+    ))
 }
 
 /// LaunchAgent label for the given profile.
@@ -233,6 +251,22 @@ mod tests {
         assert!(name.starts_with("vmux-"));
         assert!(name.ends_with(".sock"));
         assert!(name.contains(current_profile()));
+    }
+
+    #[test]
+    fn profile_file_name_suffixes_only_non_personal() {
+        assert_eq!(
+            profile_file_name("dev", "personal", "sock"),
+            "vmux-dev.sock"
+        );
+        assert_eq!(
+            profile_file_name("dev", "test", "sock"),
+            "vmux-dev-test.sock"
+        );
+        assert_eq!(
+            profile_file_name("release", "test", "log"),
+            "vmux-release-test.log"
+        );
     }
 
     #[test]

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -77,6 +77,9 @@ pub enum AgentCommand {
         text: String,
         terminal: Option<String>,
     },
+    FocusPane {
+        pane: String,
+    },
     UpdateSettings {
         path: String,
         value_json: String,
@@ -242,6 +245,9 @@ pub fn validate_agent_command(command: &AgentCommand) -> Result<(), &'static str
         }
         AgentCommand::TerminalSend { text, .. } if text.is_empty() => {
             Err("terminal_send.text is empty")
+        }
+        AgentCommand::FocusPane { pane } if pane.trim().is_empty() => {
+            Err("focus_pane.pane is empty")
         }
         AgentCommand::UpdateSettings { path, .. } if path.trim().is_empty() => {
             Err("update_settings.path is empty")

--- a/crates/vmux_space/src/model.rs
+++ b/crates/vmux_space/src/model.rs
@@ -1,8 +1,3 @@
-/// Display name of the bootstrap space's identity profile (the top-right pill /
-/// command attribution), derived from the active `VMUX_PROFILE` the same way the
-/// profile store/spaces/recording dirs are: the profile name, capitalized
-/// (`personal` -> "Personal", `gregor` -> "Gregor"). Keeps a test instance's
-/// identity tied to its storage profile instead of impersonating "Personal".
 pub fn bootstrap_profile_name() -> String {
     #[cfg(not(target_arch = "wasm32"))]
     {

--- a/crates/vmux_space/src/model.rs
+++ b/crates/vmux_space/src/model.rs
@@ -1,4 +1,28 @@
-pub const BOOTSTRAP_PROFILE_NAME: &str = "Personal";
+/// Display name of the bootstrap space's identity profile (the top-right pill /
+/// command attribution), derived from the active `VMUX_PROFILE` the same way the
+/// profile store/spaces/recording dirs are: the profile name, capitalized
+/// (`personal` -> "Personal", `gregor` -> "Gregor"). Keeps a test instance's
+/// identity tied to its storage profile instead of impersonating "Personal".
+pub fn bootstrap_profile_name() -> String {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        capitalize_first(&vmux_core::profile::active_profile_name())
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        "Personal".to_string()
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn capitalize_first(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => "Personal".to_string(),
+    }
+}
+
 pub const BOOTSTRAP_SPACE_ID: &str = "space-1";
 pub const BOOTSTRAP_SPACE_NAME: &str = "space-1";
 
@@ -19,7 +43,7 @@ pub fn bootstrap_space_record() -> SpaceRecord {
     SpaceRecord {
         id: BOOTSTRAP_SPACE_ID.to_string(),
         name: BOOTSTRAP_SPACE_NAME.to_string(),
-        profile: BOOTSTRAP_PROFILE_NAME.to_string(),
+        profile: bootstrap_profile_name(),
     }
 }
 

--- a/crates/vmux_space/src/plugin.rs
+++ b/crates/vmux_space/src/plugin.rs
@@ -809,6 +809,11 @@ mod tests {
                 .as_deref(),
             Some("vmux-ai/vmux")
         );
-        assert!(home.home.join(".vmux/spaces/vmux-ai/vmux").is_dir());
+        let profile = vmux_core::profile::active_profile_name();
+        assert!(
+            home.home
+                .join(format!(".vmux/profiles/{profile}/spaces/vmux-ai/vmux"))
+                .is_dir()
+        );
     }
 }

--- a/crates/vmux_space/src/plugin.rs
+++ b/crates/vmux_space/src/plugin.rs
@@ -197,7 +197,7 @@ fn space_rows_from_world(
                 SpaceRow {
                     id: sid.0.clone(),
                     name: name.to_string(),
-                    profile: crate::model::BOOTSTRAP_PROFILE_NAME.to_string(),
+                    profile: crate::model::bootstrap_profile_name(),
                     is_active,
                     tab_count,
                     startup_dir,
@@ -627,7 +627,7 @@ fn respond_spaces_spawn(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{BOOTSTRAP_PROFILE_NAME, SpaceRecord};
+    use crate::model::{SpaceRecord, bootstrap_profile_name};
     use vmux_layout::settings::{
         FocusRingSettings, LayoutSettings, PaneSettings, SideSheetSettings, WindowSettings,
     };
@@ -698,7 +698,7 @@ mod tests {
         SpaceRecord {
             id: "work".to_string(),
             name: "Work".to_string(),
-            profile: BOOTSTRAP_PROFILE_NAME.to_string(),
+            profile: bootstrap_profile_name(),
         }
     }
 

--- a/crates/vmux_space/src/snapshot_updater.rs
+++ b/crates/vmux_space/src/snapshot_updater.rs
@@ -19,7 +19,7 @@ pub fn update_spaces_snapshot(
                 SpaceSummary {
                     id: id.0.clone(),
                     name: name.to_string(),
-                    profile: crate::model::BOOTSTRAP_PROFILE_NAME.to_string(),
+                    profile: crate::model::bootstrap_profile_name(),
                 },
             )
         })

--- a/crates/vmux_space/src/spaces.rs
+++ b/crates/vmux_space/src/spaces.rs
@@ -71,7 +71,7 @@ impl Spaces {
 mod tests {
     use super::*;
     use crate::model::{
-        BOOTSTRAP_PROFILE_NAME, BOOTSTRAP_SPACE_ID, BOOTSTRAP_SPACE_NAME, bootstrap_space_record,
+        BOOTSTRAP_SPACE_ID, BOOTSTRAP_SPACE_NAME, bootstrap_profile_name, bootstrap_space_record,
     };
 
     #[test]
@@ -88,7 +88,7 @@ mod tests {
         let (name, profile, space_id) = query.single(app.world()).unwrap();
 
         assert_eq!(name.as_str(), BOOTSTRAP_SPACE_NAME);
-        assert_eq!(profile.name, BOOTSTRAP_PROFILE_NAME);
+        assert_eq!(profile.name, bootstrap_profile_name());
         assert_eq!(space_id.0, BOOTSTRAP_SPACE_ID);
     }
 }

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -1059,7 +1059,7 @@ fn sync_agent_focus(
         (Entity, &ProcessId, Has<AgentFocusBlurred>),
         With<vmux_core::agent::AgentSession>,
     >,
-    terminals: Query<(Entity, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
+    terminals: Query<(Entity, &ProcessId, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
     focus: Res<vmux_layout::stack::FocusedStack>,
     mode_map: Res<TerminalModeMap>,
     service: Option<Res<ServiceClient>>,
@@ -3121,7 +3121,7 @@ fn update_local_copy_mode_for_mouse_action(
 pub fn handle_terminal_send_requests(
     mut reader: MessageReader<crate::TerminalSendRequest>,
     focus: Res<vmux_layout::stack::FocusedStack>,
-    terminals: Query<(Entity, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
+    terminals: Query<(Entity, &ProcessId, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
     mut commands: Commands,
 ) {
     for request in reader.read() {
@@ -3163,7 +3163,7 @@ pub fn handle_run_shell_requests(
             Without<vmux_layout::pane::PaneSplit>,
         ),
     >,
-    terminals: Query<(Entity, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
+    terminals: Query<(Entity, &ProcessId, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
     mut commands: Commands,
     mut terminal_stack_spawns: Option<MessageWriter<TerminalStackSpawnRequest>>,
 ) {
@@ -3226,6 +3226,37 @@ mod tests {
             spaces: Default::default(),
             recording: Default::default(),
         }
+    }
+
+    #[test]
+    fn terminal_send_resolves_target_by_process_id_uuid() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<crate::TerminalSendRequest>()
+            .insert_resource(vmux_layout::stack::FocusedStack::default())
+            .add_systems(Update, handle_terminal_send_requests);
+
+        let parent = app.world_mut().spawn_empty().id();
+        let pid = process_id(7);
+        let terminal = app
+            .world_mut()
+            .spawn((Terminal, pid))
+            .insert(ChildOf(parent))
+            .id();
+
+        app.world_mut()
+            .resource_mut::<Messages<crate::TerminalSendRequest>>()
+            .write(crate::TerminalSendRequest {
+                text: "hi".to_string(),
+                terminal: Some(pid.to_string()),
+            });
+        app.update();
+
+        let pending = app
+            .world()
+            .get::<PendingTerminalInput>(terminal)
+            .expect("input routed to terminal by process id uuid");
+        assert_eq!(pending.data, b"hi".to_vec());
     }
 
     #[test]

--- a/crates/vmux_terminal/src/target.rs
+++ b/crates/vmux_terminal/src/target.rs
@@ -1,24 +1,33 @@
 use bevy::ecs::relationship::Relationship;
 use bevy::prelude::*;
+use vmux_core::ProcessId;
 use vmux_core::terminal::{ProcessExited, Terminal};
 
 #[allow(clippy::type_complexity)]
 pub fn active_terminal_for_tab(
     tab: Option<Entity>,
-    terminals: &Query<(Entity, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
+    terminals: &Query<(Entity, &ProcessId, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
 ) -> Option<Entity> {
     let tab = tab?;
     terminals
         .iter()
-        .find_map(|(entity, child_of)| (child_of.get() == tab).then_some(entity))
+        .find_map(|(entity, _, child_of)| (child_of.get() == tab).then_some(entity))
 }
 
 #[allow(clippy::type_complexity)]
 pub fn parse_terminal_target(
     s: &str,
-    terminals: &Query<(Entity, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
+    terminals: &Query<(Entity, &ProcessId, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
 ) -> Option<Entity> {
+    if let Ok(pid) = s.parse::<ProcessId>()
+        && let Some((entity, _, _)) = terminals.iter().find(|(_, p, _)| **p == pid)
+    {
+        return Some(entity);
+    }
     let bits = s.parse::<u64>().ok()?;
     let entity = Entity::try_from_bits(bits)?;
-    terminals.iter().any(|(e, _)| e == entity).then_some(entity)
+    terminals
+        .iter()
+        .any(|(e, _, _)| e == entity)
+        .then_some(entity)
 }

--- a/docs/specs/2026-06-23-test-profile-isolation-design.md
+++ b/docs/specs/2026-06-23-test-profile-isolation-design.md
@@ -1,0 +1,67 @@
+# Test profile isolation (`VMUX_PROFILE`) — design
+
+- **Date:** 2026-06-23
+- **Status:** Approved (pending spec review)
+- **Branch:** `feat/agent-test-space` (extends the `vmux agent` seeded-test feature)
+
+## Summary
+
+Introduce a **runtime** profile selector, the `VMUX_PROFILE` env var (default `personal`), so test runs of the `vmux agent` harness are fully isolated from the user's real state. The `personal` profile resolves to today's exact paths (no migration); any other profile (e.g. `test`) redirects its spaces, session/spaces-list, recordings, CEF cache, and service socket under a per-profile location, and gets its own socket so a test instance can run **alongside** a normal vmux.
+
+`VMUX_PROFILE` is orthogonal to the compile-time `VMUX_BUILD_PROFILE` (dev/release/local). The same binaries serve any runtime profile — no rebuild.
+
+## Motivation
+
+The seeded-agent test command (`vmux agent vibe -p "..."`) currently opens its throwaway space in the user's real `personal` profile: it pollutes the spaces list (`session.ron`), creates a `~/.vmux/spaces/space-N` dir, and writes screenshots to the shared `~/.vmux/recording`. A dedicated, disposable test profile keeps deterministic test runs from touching real state, and a separate socket lets the user keep their normal vmux open while testing.
+
+## Path resolution (`vmux_core/src/profile.rs`)
+
+`personal` keeps current paths exactly; other profiles redirect. `<build>` = `VMUX_BUILD_PROFILE`, `<p>` = sanitized `VMUX_PROFILE`.
+
+| Resource | `personal` (unchanged) | other (`test`) |
+|---|---|---|
+| session / spaces-list | `…/Vmux/<build>/profiles/personal/session.ron` | `…/profiles/test/session.ron` (already via `active_profile_name`) |
+| CEF cache | `…/profiles/personal` | `…/profiles/test` (already) |
+| space dirs | `~/.vmux/spaces/<id>` | `~/.vmux/profiles/test/spaces/<id>` |
+| recording | `~/.vmux/recording` | `~/.vmux/profiles/test/recording` |
+| socket / pid / identity / log | `…/services/vmux-<build>.{sock,pid,identity}`, `…/logs/vmux-<build>.log` | `…/vmux-<build>-test.{…}`, `vmux-<build>-test.log` |
+
+### Components changed
+
+1. **`active_profile_name()`** — change return type `&'static str` → `String`; read `VMUX_PROFILE` (default `personal`) and pass through `sanitize_profile`. (`profile_dir().join(active_profile_name())` already accepts `String`.) Verify the re-export consumer `vmux_layout/src/profile.rs` still compiles with `String`.
+2. **`sanitize_profile(raw: &str) -> String`** — lowercase; keep `[a-z0-9_-]`; collapse everything else; if empty, fall back to `personal`. Prevents path traversal / nested segments. Used by every profile-derived path.
+3. **`spaces_root(home)`** — `personal` → `home/.vmux/spaces`; else `home/.vmux/profiles/<p>/spaces`. (`space_dir`, `default_space_dir`, rename/prune helpers all flow through `spaces_root`, so they isolate automatically.)
+4. **`recording_dir()`** — `personal` → `config_dir()/recording`; else `config_dir()/profiles/<p>/recording`.
+5. **`paths.rs::profile_file(ext)`** (vmux_service) — filename `vmux-<build>` → `vmux-<build>-<p>` when `<p> != personal`. Affects `socket_path`/`pid_path`/`identity_path`. Apply the same suffix in `log_path` (uses `log_dir`, not `service_dir`).
+   - `paths.rs` reads the runtime profile via `vmux_core::profile::active_profile_name()` (sanitized) to build the suffix.
+
+`personal` branches MUST produce byte-identical paths to today so existing installs are untouched.
+
+## Activation
+
+- **App (`make`)**: add `VMUX_PROFILE ?= personal` to the Makefile; the `dev` target's final `exec env …` passes `VMUX_PROFILE="$(VMUX_PROFILE)"` to `vmux_desktop`. So `make dev VMUX_PROFILE=test` launches a test instance. Add a `test:` target = `$(MAKE) dev VMUX_PROFILE=test`.
+- **CLI (`vmux agent`)**: add `--profile <name>` as `Option<String>` (no clap `env` feature needed). In `commands/agent::run`, resolve `profile = flag.or_else(|| std::env::var("VMUX_PROFILE").ok()).filter(non-empty).unwrap_or("personal")`, then `std::env::set_var("VMUX_PROFILE", &profile)` **before** `ServiceConnection::connect()` so socket resolution targets the right instance. So `vmux agent --profile test vibe -p "…"` or `VMUX_PROFILE=test vmux agent vibe -p "…"` both hit the test instance; bare `vmux agent …` stays `personal`.
+
+## Data flow
+
+`make test` → app launched with `VMUX_PROFILE=test` → resolves `…-test` socket + `profiles/test/...` paths. `vmux agent --profile test vibe -p "…"` → CLI sets `VMUX_PROFILE=test` → connects to the `…-test` socket → opens the seeded space, which persists under `~/.vmux/profiles/test/spaces`; the inner vibe's screenshots land in `~/.vmux/profiles/test/recording`. Your `personal` vmux (if running) is untouched on its own socket.
+
+## Testing strategy
+
+Unit (`cargo test -p vmux_core`, `-p vmux_service`), env-guarded:
+- `active_profile_name` defaults to `personal` when `VMUX_PROFILE` unset; returns sanitized value when set.
+- `sanitize_profile`: `"test"`→`test`; `"../evil"`/`"a/b"`→ collapsed single segment; `""`→`personal`.
+- `personal` resolves to the exact legacy paths for `spaces_root`, `recording_dir`, `profile_file`/`socket_path` (regression guard).
+- `test` redirects `spaces_root`→`~/.vmux/profiles/test/spaces`, `recording_dir`→`~/.vmux/profiles/test/recording`, `socket_path` filename ends `-test.sock`.
+
+CLI (`cargo test -p vmux_cli`): `agent --profile test` parses; default is `personal` when env unset.
+
+Manual: `make test` + `vmux agent --profile test vibe -p "screenshot the space"` → space appears in a test instance; artifacts under `~/.vmux/profiles/test/`; personal `~/.vmux/spaces` and `~/.vmux/recording` unchanged.
+
+## Out of scope
+- Settings stay build-profile-based (shared across runtime profiles); tests don't pollute settings.
+- No auto-cleanup of the test profile dir (it's a self-contained `~/.vmux/profiles/test/` you can delete).
+- `vmux mcp` keeps reading `VMUX_PROFILE` from the environment only (no new flag).
+
+## Concurrency note
+Tests that set `VMUX_PROFILE` via `std::env::set_var` must serialize (shared process env) — reuse the existing `HomeEnvGuard`-style serialization pattern or a dedicated env mutex, mirroring how `HomeEnvGuard` tests already guard `HOME`.


### PR DESCRIPTION
## What

A disposable, isolated **test profile** for driving the live vibe CLI via MCP with screen-recording capture — plus the MCP and recording fixes that make it usable.

## Changes

**Profile isolation (`VMUX_PROFILE`)** — `vmux_core/profile.rs`, `vmux_service/paths.rs`, `vmux_desktop/{main,persistence}.rs`, `vmux_space/model.rs`
- Every profile (incl. `personal`) nests storage under `profiles/<p>/`: spaces, recordings, session, `store.ron`, and the service socket/pid/identity/log. Legacy top-level `~/.vmux/{spaces,recording}` migrate on first run.
- Non-personal profiles are ephemeral (no store restore/save); identity derives from the profile (`gregor → "Gregor"`).

**MCP agent driving** — `vmux_mcp/tools.rs`, `vmux_terminal/{target,plugin}.rs`, `vmux_agent/{plugin,mcp,client/cli/vibe}.rs`, `vmux_cli/commands`
- `vmux_focus_pane` tool.
- `terminal_send` targets by `process_id` (was raw entity bits, so input never reached agent panes) and gains an `enter` flag to submit TUIs like vibe.
- `vmux mcp --profile` propagates the profile to the agent's injected MCP server; vibe launches with `--auto-approve` under test profiles.

**Recording** — `vmux_desktop/recording*.rs`
- Downscaled (≤1280px long edge) + H.264 average-bitrate cap (~800 kbps) → ~1-2 MB/min (was ~7); 600s default auto-stop; saved under `profiles/<p>/recording`.

**Tooling** — `Makefile`: `make test-app` (= `make dev VMUX_PROFILE=gregor`); `dev`'s pre-launch kill is scoped to the active profile so it never stops a personal instance.

## Review (CodeRabbit) — addressed/triaged, threads resolved
- Makefile `test-app` killing the user's app → fixed (profile-scoped kill)
- `mcp.rs` / `profile.rs` env-dependent tests + added comment → fixed (profile via DI; comments removed)
- `paths.rs` log-path coverage → follow-up (no failing test; CI has no `VMUX_PROFILE`)
- `agent.rs` finding → obsolete (file removed when the seeded-agent path was reverted)

## Test plan
- [x] `cargo test` (core/service/mcp/terminal/agent/cli) green; `cargo fmt` clean; `cargo check -p vmux_desktop` clean
- [x] Live: drive vibe via MCP end-to-end (open → `terminal_send` by process_id → `enter` → auto-approve → record) → ~2 MB recording under `profiles/gregor/recording`
- [ ] CI: clippy + full workspace + build-mac