### PR TITLE
refactor(mcp): drop vmux_ prefix from tool names

### DIFF
--- a/crates/vmux_cli/tests/mcp_smoke.rs
+++ b/crates/vmux_cli/tests/mcp_smoke.rs
@@ -32,8 +32,8 @@ fn mcp_tools_list_includes_layout_tools() {
         .write_stdin(stdin)
         .assert()
         .success()
-        .stdout(contains("\"vmux_read_layout\""))
-        .stdout(contains("\"vmux_update_layout\""));
+        .stdout(contains("\"read_layout\""))
+        .stdout(contains("\"update_layout\""));
 }
 
 #[test]
@@ -44,8 +44,8 @@ fn mcp_tools_list_includes_self_anchor_tools() {
         .write_stdin(stdin)
         .assert()
         .success()
-        .stdout(contains("\"vmux_open_page\""))
-        .stdout(contains("\"vmux_run\""));
+        .stdout(contains("\"open_page\""))
+        .stdout(contains("\"run\""));
 }
 
 #[test]

--- a/crates/vmux_command/src/command.rs
+++ b/crates/vmux_command/src/command.rs
@@ -508,10 +508,10 @@ mod tests {
 
         for (id, _description, schema) in &entries {
             assert!(
-                id.starts_with("vmux_"),
-                "advertised MCP tool name must be vmux_-prefixed: {id}"
+                !id.starts_with("vmux_"),
+                "advertised MCP tool name must not be vmux_-prefixed (server is already named vmux): {id}"
             );
-            let bare = id.strip_prefix("vmux_").unwrap_or(id);
+            let bare = *id;
             let has_required_params = schema
                 .get("required")
                 .and_then(|v| v.as_array())

--- a/crates/vmux_command/tests/open_command_derives.rs
+++ b/crates/vmux_command/tests/open_command_derives.rs
@@ -118,13 +118,13 @@ fn mcp_tool_entries_has_all_variants() {
     let entries = OpenCommand::mcp_tool_entries();
     assert!(!entries.is_empty());
     let names: Vec<_> = entries.iter().map(|(name, _, _)| *name).collect();
-    assert!(names.contains(&"vmux_in_place"));
-    assert!(names.contains(&"vmux_in_new_stack"));
-    assert!(names.contains(&"vmux_in_new_tab"));
-    assert!(names.contains(&"vmux_in_new_space"));
+    assert!(names.contains(&"in_place"));
+    assert!(names.contains(&"in_new_stack"));
+    assert!(names.contains(&"in_new_tab"));
+    assert!(names.contains(&"in_new_space"));
     assert!(
-        !names.contains(&"vmux_in_pane"),
-        "in_pane is #[mcp(skip)], superseded by the self-relative vmux_open_page tool"
+        !names.contains(&"in_pane"),
+        "in_pane is #[mcp(skip)], superseded by the self-relative open_page tool"
     );
 }
 

--- a/crates/vmux_desktop/src/recording.rs
+++ b/crates/vmux_desktop/src/recording.rs
@@ -21,7 +21,7 @@ pub(crate) type WakeFn = Arc<dyn Fn() + Send + Sync>;
 
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 const PERMISSION_MSG: &str = "Screen Recording permission required - grant it in System Settings > \
-Privacy & Security > Screen Recording, then call vmux_record_start again.";
+Privacy & Security > Screen Recording, then call record_start again.";
 
 /// Carries finalize outcomes from off-thread (stop/auto-stop) back to Bevy.
 /// `request_id == None` means an auto-stop (no pending query to answer).

--- a/crates/vmux_macro/src/lib.rs
+++ b/crates/vmux_macro/src/lib.rs
@@ -1292,7 +1292,7 @@ fn impl_mcp_tool_leaf_fielded(
         }
         let variant_ident = &variant.ident;
         let tool_name = heck_variant_snake_case(&variant_ident.to_string());
-        let advertised_name = format!("vmux_{tool_name}");
+        let advertised_name = tool_name.clone();
         let description = mcp_props.description.clone().ok_or_else(|| {
             syn::Error::new_spanned(
                 variant_ident,
@@ -1550,7 +1550,7 @@ fn impl_mcp_tool_leaf_unit(
             None => continue,
         };
         let id_lit = id.as_str();
-        let advertised_id = format!("vmux_{id}");
+        let advertised_id = id.clone();
         let variant_ident = &variant.ident;
 
         let description = mcp_props

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -847,7 +847,7 @@ mod tests {
 
     #[test]
     fn list_tools_includes_notify() {
-        assert!(tool_names().contains(&"vmux_notify".to_string()));
+        assert!(tool_names().contains(&"notify".to_string()));
     }
 
     #[test]

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -1274,11 +1274,7 @@ mod tests {
             dispatch_from_tool_call("read_terminal", serde_json::json!({"terminal": "bad"}))
                 .is_err()
         );
-        assert!(
-            tool_definitions()
-                .iter()
-                .any(|d| d.name == "read_terminal")
-        );
+        assert!(tool_definitions().iter().any(|d| d.name == "read_terminal"));
     }
 
     #[test]

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -32,7 +32,7 @@ pub enum McpParamTool {
     SelectTab { index: u8 },
     #[mcp(description = "Update a single vmux setting by dot-path. \
             Example: { path: 'layout.pane.gap', value: 12 }. \
-            Use vmux_get_settings to discover the available paths and current values. \
+            Use get_settings to discover the available paths and current values. \
             For nested arrays, use bracket indexing like 'terminal.themes[0].font_size'.")]
     UpdateSettings {
         path: String,
@@ -53,10 +53,10 @@ pub enum McpParamTool {
     )]
     CreateSpace { name: Option<String> },
     #[mcp(
-        description = "Rename a space by id (the id is stable; only the display name changes). Use vmux_list_spaces to discover ids."
+        description = "Rename a space by id (the id is stable; only the display name changes). Use list_spaces to discover ids."
     )]
     RenameSpace { space_id: String, name: String },
-    #[mcp(description = "Delete a space by id. Use vmux_list_spaces to discover ids.")]
+    #[mcp(description = "Delete a space by id. Use list_spaces to discover ids.")]
     DeleteSpace { space_id: String },
     #[mcp(
         description = "Notify the user that you (this agent) need their attention - typically that you have finished your turn. Shows a macOS notification when they are not looking at your page, and a dot on your avatar in the team facepile until they view it. Optional `title` and `body` customize the message; with neither, a default \"<agent> finished\" is shown."
@@ -164,9 +164,9 @@ pub enum DispatchTarget {
 
 fn read_layout_definition() -> ToolDefinition {
     ToolDefinition {
-        name: "vmux_read_layout".into(),
+        name: "read_layout".into(),
         description: "Returns the full vmux layout (tabs, recursive pane tree, focused). \
-Call this FIRST before vmux_update_layout - you need the current tree (with ids) to construct a valid update. \
+Call this FIRST before update_layout - you need the current tree (with ids) to construct a valid update. \
 Useful for: answering questions about what's open; finding the focused tab/pane/stack; \
 reading a stack's url/kind so you can duplicate it elsewhere. \
 Terminal stacks appear as stacks with kind=\"terminal\"; browser stacks use kind=\"browser\"."
@@ -177,11 +177,11 @@ Terminal stacks appear as stacks with kind=\"terminal\"; browser stacks use kind
 
 fn update_layout_definition() -> ToolDefinition {
     ToolDefinition {
-        name: "vmux_update_layout".into(),
+        name: "update_layout".into(),
         description: "Submit the desired layout tree; vmux diffs against current state and reconciles by id (React-style). \
 Use this for compound or structural changes that the per-action tools can't express. \
 \
-Workflow: (1) call vmux_read_layout, (2) mutate the returned tree, (3) submit it back here. \
+Workflow: (1) call read_layout, (2) mutate the returned tree, (3) submit it back here. \
 \
 Recipes: \
 - Add a new pane to a tab: keep the existing root split's id, append a new pane (id: null) to its children. Do NOT wrap the existing pane in a new split - the tab's root split is always present. \
@@ -266,7 +266,7 @@ Identifiers use kind:value format (tab:N, pane:N, split:N, stack:N). Omit id to 
 
 fn get_settings_definition() -> ToolDefinition {
     ToolDefinition {
-        name: "vmux_get_settings".into(),
+        name: "get_settings".into(),
         description: "Return the full vmux settings as a JSON snapshot.".into(),
         input_schema: serde_json::json!({"type": "object", "properties": {}, "additionalProperties": false}),
     }
@@ -274,17 +274,17 @@ fn get_settings_definition() -> ToolDefinition {
 
 fn list_spaces_definition() -> ToolDefinition {
     ToolDefinition {
-        name: "vmux_list_spaces".into(),
-        description: "List all spaces as a JSON array of { id, name, profile, is_active }. Use the `id` with vmux_rename_space / vmux_delete_space.".into(),
+        name: "list_spaces".into(),
+        description: "List all spaces as a JSON array of { id, name, profile, is_active }. Use the `id` with rename_space / delete_space.".into(),
         input_schema: serde_json::json!({"type": "object", "properties": {}, "additionalProperties": false}),
     }
 }
 
 fn open_page_definition() -> ToolDefinition {
     ToolDefinition {
-        name: "vmux_open_page".into(),
+        name: "open_page".into(),
         description: "Open a page in a new pane directly beside YOUR pane (the agent calling this). \
-direction is one of right|left|top|bottom (default right). url uses the same rules as vmux_browser_navigate \
+direction is one of right|left|top|bottom (default right). url uses the same rules as browser_navigate \
 (vmux://terminal/ opens a terminal; anything else loads as a browser). \
 focus (default true): true moves focus to the new pane (use when the human will interact with it); \
 false keeps focus on your own pane."
@@ -304,7 +304,7 @@ false keeps focus on your own pane."
 
 fn open_file_definition() -> ToolDefinition {
     ToolDefinition {
-        name: "vmux_open_file".into(),
+        name: "open_file".into(),
         description: "Open a local file (or directory) in the vmux editor, in a new pane beside \
 YOUR pane (the agent calling this). path is an absolute filesystem path, e.g. \
 /Users/me/project/src/main.rs. Files render with syntax highlighting; directories show a listing. \
@@ -326,12 +326,12 @@ new pane."
 
 fn run_definition() -> ToolDefinition {
     ToolDefinition {
-        name: "vmux_run".into(),
+        name: "run".into(),
         description:
             "Run a shell command in a visible terminal pane the user can watch live and take over. \
 Blocks until the command finishes and returns its full output plus the exit code \
 (`terminal: <id>`, `exit: <code>`, `output: ...`). If it has not finished within ~50s, returns the \
-output so far with a note to call vmux_read_terminal for the rest. \
+output so far with a note to call read_terminal for the rest. \
 \
 PLACEMENT — by DEFAULT you don't need to think about this: a bare `run` reuses ONE persistent terminal \
 beside you — the SAME shell across calls, so its working directory and environment persist. Do NOT `cd` \
@@ -367,10 +367,10 @@ is typed into an interactive shell, so the terminal stays usable afterwards."
 
 fn read_terminal_definition() -> ToolDefinition {
     ToolDefinition {
-        name: "vmux_read_terminal".into(),
+        name: "read_terminal".into(),
         description:
             "Return the current visible scrollback text of a terminal (the same text the user sees). \
-Pass `terminal` = a terminal id returned by vmux_run, or a terminal stack's process_id from vmux_read_layout."
+Pass `terminal` = a terminal id returned by run, or a terminal stack's process_id from read_layout."
                 .into(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -385,7 +385,7 @@ Pass `terminal` = a terminal id returned by vmux_run, or a terminal stack's proc
 
 fn screenshot_definition() -> ToolDefinition {
     ToolDefinition {
-        name: "vmux_screenshot".into(),
+        name: "screenshot".into(),
         description: "Capture the vmux window as a PNG and return it inline so you can SEE the current UI \
 (use it to verify your own UI changes). Captures the whole window exactly as it appears on screen - all \
 visible panes (browser, terminal, editor) and layout chrome. Optionally pass `pane` (a pane:<id> or \
@@ -409,10 +409,10 @@ call again."
 
 fn record_start_definition() -> ToolDefinition {
     ToolDefinition {
-        name: "vmux_record_start".into(),
+        name: "record_start".into(),
         description: "Start recording the vmux window to an mp4 video (optionally also a GIF). \
 Returns immediately so you can drive the UI with other tools to demonstrate a feature, then call \
-vmux_record_stop. Record in ONE live take: start, perform the few actions you want to show, then \
+record_stop. Record in ONE live take: start, perform the few actions you want to show, then \
 stop. Do NOT rehearse, build elaborate layouts, or take screenshots to verify - just capture the \
 live interaction in a single pass. Auto-stops after `max_secs` (default 120) as a safety cap. Only \
 one recording at a time. macOS only; the first call may prompt for Screen Recording permission - \
@@ -432,7 +432,7 @@ grant it in System Settings > Privacy & Security > Screen Recording, then call a
 
 fn record_stop_definition() -> ToolDefinition {
     ToolDefinition {
-        name: "vmux_record_stop".into(),
+        name: "record_stop".into(),
         description: "Stop the active recording and write the file(s). Returns the mp4 path, duration, \
 and size (plus the GIF path if one was requested). By default saves to ~/.vmux/recording/; pass `dir` \
 (absolute) and `name` (basename, no extension) to save elsewhere - e.g. dir=<repo>/docs/recording, \
@@ -736,8 +736,8 @@ mod tests {
     #[test]
     fn record_tools_are_listed() {
         let names = tool_names();
-        assert!(names.contains(&"vmux_record_start".to_string()));
-        assert!(names.contains(&"vmux_record_stop".to_string()));
+        assert!(names.contains(&"record_start".to_string()));
+        assert!(names.contains(&"record_stop".to_string()));
     }
 
     #[test]
@@ -798,32 +798,27 @@ mod tests {
     fn list_tools_includes_auto_generated_and_handwritten() {
         let names = tool_names();
 
-        for hand in [
-            "vmux_open_command_bar",
-            "vmux_open_page",
-            "vmux_run",
-            "vmux_read_terminal",
-        ] {
+        for hand in ["open_command_bar", "open_page", "run", "read_terminal"] {
             assert!(
                 names.contains(&hand.to_string()),
                 "missing hand-written {hand}"
             );
         }
-        for removed_tool in ["vmux_new_terminal_tab", "vmux_run_shell", "vmux_in_pane"] {
+        for removed_tool in ["new_terminal_tab", "run_shell", "in_pane"] {
             assert!(
                 !names.contains(&removed_tool.to_string()),
                 "superseded tool {removed_tool} should no longer appear in MCP tools"
             );
         }
-        for auto in ["vmux_terminal_clear", "vmux_browser_reload"] {
+        for auto in ["terminal_clear", "browser_reload"] {
             assert!(
                 names.contains(&auto.to_string()),
                 "missing auto-generated {auto}"
             );
         }
         assert!(
-            names.iter().all(|n| n.starts_with("vmux_")),
-            "every MCP tool must be vmux_-prefixed: {names:?}"
+            names.iter().all(|n| !n.starts_with("vmux_")),
+            "MCP tool names must not be vmux_-prefixed (server is already named vmux): {names:?}"
         );
         for removed in ["stack_new", "close_tab", "split_v"] {
             assert!(
@@ -886,7 +881,7 @@ mod tests {
     #[test]
     fn list_tools_includes_browser_navigate() {
         let names = tool_names();
-        assert!(names.contains(&"vmux_browser_navigate".to_string()));
+        assert!(names.contains(&"browser_navigate".to_string()));
     }
 
     #[test]
@@ -929,7 +924,7 @@ mod tests {
     #[test]
     fn list_tools_includes_terminal_send() {
         let names = tool_names();
-        assert!(names.contains(&"vmux_terminal_send".to_string()));
+        assert!(names.contains(&"terminal_send".to_string()));
     }
 
     #[test]
@@ -952,7 +947,7 @@ mod tests {
     #[test]
     fn list_tools_includes_select_tab() {
         let names = tool_names();
-        assert!(names.contains(&"vmux_select_tab".to_string()));
+        assert!(names.contains(&"select_tab".to_string()));
     }
 
     #[test]
@@ -976,13 +971,13 @@ mod tests {
     #[test]
     fn tool_list_includes_read_and_update_layout() {
         let names = tool_names();
-        assert!(names.contains(&"vmux_read_layout".to_string()));
-        assert!(names.contains(&"vmux_update_layout".to_string()));
+        assert!(names.contains(&"read_layout".to_string()));
+        assert!(names.contains(&"update_layout".to_string()));
     }
 
     #[test]
     fn list_tools_includes_screenshot() {
-        assert!(tool_names().contains(&"vmux_screenshot".to_string()));
+        assert!(tool_names().contains(&"screenshot".to_string()));
     }
 
     #[test]
@@ -1019,10 +1014,10 @@ mod tests {
             .map(|(name, _, _)| name)
             .collect();
         for expected in [
-            "vmux_open_command_bar",
-            "vmux_browser_navigate",
-            "vmux_terminal_send",
-            "vmux_select_tab",
+            "open_command_bar",
+            "browser_navigate",
+            "terminal_send",
+            "select_tab",
         ] {
             assert!(names.contains(&expected), "missing param tool {expected}");
         }
@@ -1032,8 +1027,8 @@ mod tests {
     fn mcp_param_tool_browser_navigate_schema_marks_url_required() {
         let entry = McpParamTool::mcp_tool_entries()
             .into_iter()
-            .find(|(name, _, _)| *name == "vmux_browser_navigate")
-            .expect("vmux_browser_navigate present");
+            .find(|(name, _, _)| *name == "browser_navigate")
+            .expect("browser_navigate present");
         let schema = entry.2;
         let required = schema.get("required").expect("required key");
         assert_eq!(required, &serde_json::json!(["url"]));
@@ -1145,12 +1140,8 @@ mod tests {
                 .is_err()
         );
         assert!(dispatch_with_anchor("open_page", serde_json::json!({"url": "x"}), None).is_err());
-        assert!(
-            tool_definitions()
-                .iter()
-                .any(|d| d.name == "vmux_open_page")
-        );
-        assert!(tool_definitions().iter().any(|d| d.name == "vmux_run"));
+        assert!(tool_definitions().iter().any(|d| d.name == "open_page"));
+        assert!(tool_definitions().iter().any(|d| d.name == "run"));
     }
 
     #[test]
@@ -1286,7 +1277,7 @@ mod tests {
         assert!(
             tool_definitions()
                 .iter()
-                .any(|d| d.name == "vmux_read_terminal")
+                .any(|d| d.name == "read_terminal")
         );
     }
 
@@ -1336,8 +1327,8 @@ mod tests {
     #[test]
     fn list_tools_includes_update_settings_and_get_settings() {
         let names = tool_names();
-        assert!(names.contains(&"vmux_update_settings".to_string()));
-        assert!(names.contains(&"vmux_get_settings".to_string()));
+        assert!(names.contains(&"update_settings".to_string()));
+        assert!(names.contains(&"get_settings".to_string()));
     }
 
     #[test]
@@ -1427,20 +1418,15 @@ mod tests {
     #[test]
     fn open_command_tools_are_exposed() {
         let names = tool_names();
-        for expected in [
-            "vmux_in_place",
-            "vmux_in_new_stack",
-            "vmux_in_new_tab",
-            "vmux_in_new_space",
-        ] {
+        for expected in ["in_place", "in_new_stack", "in_new_tab", "in_new_space"] {
             assert!(
                 names.contains(&expected.to_string()),
                 "missing OpenCommand tool: {expected}"
             );
         }
         assert!(
-            !names.contains(&"vmux_in_pane".to_string()),
-            "in_pane is hidden, superseded by vmux_open_page"
+            !names.contains(&"in_pane".to_string()),
+            "in_pane is hidden, superseded by open_page"
         );
     }
 

--- a/docs/architecture/agent-first.md
+++ b/docs/architecture/agent-first.md
@@ -26,18 +26,19 @@ and terminals in its own space and can't read or disrupt the one you're looking 
 
 ## MCP methods
 
-Agents discover the full set via `tools/list`; every tool is namespaced with a `vmux_`
-prefix. The core methods:
+Agents discover the full set via `tools/list`. The server is registered under the name
+`vmux`, so tool names are bare (no `vmux_` prefix) to avoid `vmux:vmux_*` duplication. The
+core methods:
 
-- `vmux_browser_navigate` — point the active (or a target) pane at a URL.
-- `vmux_terminal_send` — send raw text to the active terminal.
-- `vmux_select_tab` — focus a tab by index.
-- `vmux_create_space` — create a new space and switch to it.
-- `vmux_update_settings` — set a single setting by dot-path.
-- `vmux_open_page` — open a page in a new pane beside the requesting agent's own.
-- `vmux_run` — run a process in a human-visible terminal: the user watches live and can take
+- `browser_navigate` — point the active (or a target) pane at a URL.
+- `terminal_send` — send raw text to the active terminal.
+- `select_tab` — focus a tab by index.
+- `create_space` — create a new space and switch to it.
+- `update_settings` — set a single setting by dot-path.
+- `open_page` — open a page in a new pane beside the requesting agent's own.
+- `run` — run a process in a human-visible terminal: the user watches live and can take
   over the prompt, while the agent gets stdout/stderr and the exit code.
-- `vmux_read_layout` / `vmux_update_layout` — fetch the pane tree (stable ids), mutate it, and
+- `read_layout` / `update_layout` — fetch the pane tree (stable ids), mutate it, and
   commit it back; Vmux diffs against the live graph and reconciles **React-style** — add
   panes, move stacks, shift focus, in one atomic transaction.
 

--- a/docs/recording/README.md
+++ b/docs/recording/README.md
@@ -1,16 +1,16 @@
 # Feature demos
 
 Short screen recordings showcasing vmux features. Captured with the
-`vmux_record_start` / `vmux_record_stop` MCP tools (see
+`record_start` / `record_stop` MCP tools (see
 `docs/specs/2026-06-23-video-recording-mcp-tool-design.md`).
 
 ## Recording a demo
 
 From an agent with vmux MCP tools:
 
-1. `vmux_record_start { "gif": true, "max_secs": 60 }`
+1. `record_start { "gif": true, "max_secs": 60 }`
 2. Drive the feature (open pages, run commands, switch tabs).
-3. `vmux_record_stop { "dir": "<repo>/docs/recording", "name": "<feature>" }`
+3. `record_stop { "dir": "<repo>/docs/recording", "name": "<feature>" }`
 
 This writes `<feature>.mp4` (+ `<feature>.gif`) here. Drag the `.mp4` into a PR
 description to embed an inline player, or reference the `.gif` from markdown.

--- a/website/src/landing/ide.rs
+++ b/website/src/landing/ide.rs
@@ -3,11 +3,11 @@ use dioxus::prelude::*;
 use crate::landing::parts::{editor_pane, headline, terminal_pane, website_pane};
 
 const TOOLS: &[&str] = &[
-    "vmux_browser_navigate",
-    "vmux_run",
-    "vmux_read_layout",
-    "vmux_update_layout",
-    "vmux_create_space",
+    "browser_navigate",
+    "run",
+    "read_layout",
+    "update_layout",
+    "create_space",
 ];
 
 #[component]

--- a/website/src/landing/visit.rs
+++ b/website/src/landing/visit.rs
@@ -5,10 +5,10 @@ use crate::landing::parts::{
 };
 
 const TOOLS: &[&str] = &[
-    "vmux_browser_navigate",
-    "vmux_run",
-    "vmux_read_layout",
-    "vmux_update_layout",
+    "browser_navigate",
+    "run",
+    "read_layout",
+    "update_layout",
 ];
 
 #[component]


### PR DESCRIPTION
## Context

The MCP server is registered under the name `vmux`. Because every tool was also `vmux_`-prefixed, clients surfaced them as `vmux:vmux_run`, `vmux:vmux_read_layout`, etc. — the namespace was duplicated. This drops the prefix so tools read as `vmux:run`, `vmux:read_layout`, `vmux:record_start`.

## Implementation

- The `McpTool` derive macro now emits bare names (no `vmux_` prefix) for both fielded and unit variants.
- Hand-written tool definitions in `vmux_mcp/tools.rs` and all in-description cross-references (e.g. "call `read_layout` first") updated to match.
- Dispatch still strips a leading `vmux_` (`strip_prefix`), so any existing `vmux_*` caller keeps routing — the `vmux_prefixed_tool_name_dispatches` test guards this backwards-compat path.
- Test invariants flipped from "every tool must be `vmux_`-prefixed" to "no tool may be `vmux_`-prefixed".
- Living docs (`agent-first.md`, `recording/README.md`) and website demo tool lists updated; historical `docs/specs/*` left as dated records.

## Checks / QA

- `tools/list` over the real binary advertises bare names: `cargo test -p vmux_cli --test mcp_smoke`
- An old-style `vmux_*` tools/call still dispatches (no breakage for existing agents).
- MCP server still reports `serverInfo.name == "vmux"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated MCP tool naming to use bare method names (e.g., `open_page`, `run`, `read_layout`, `update_layout`, `record_start`, `record_stop`, `browser_navigate`) under the `vmux` server, while still accepting legacy `vmux_*` identifiers.
* **Documentation**
  * Refreshed MCP “methods” documentation and the recording guide to match the new names.
* **UI Updates**
  * Updated landing tool chips and adjusted the screen-recording permission prompt text.
* **Tests**
  * Updated MCP smoke and coverage assertions for the renamed tool identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->