### PR TITLE
ci: require macOS build on rust/deps changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,29 @@ jobs:
           fi
           echo "Test gate ok (code=$CODE rust=$RESULT)"
 
+  build-macos:
+    name: Build macOS
+    runs-on: ubuntu-latest
+    needs: [changes, build-mac]
+    if: always()
+    steps:
+      - name: Gate
+        env:
+          CHANGES: ${{ needs.changes.result }}
+          CODE: ${{ needs.changes.outputs.code }}
+          PACKAGING: ${{ needs.changes.outputs.packaging }}
+          RESULT: ${{ needs.build-mac.result }}
+        run: |
+          if [ "$CHANGES" != "success" ]; then
+            echo "::error::Detect Changes did not succeed ($CHANGES)"
+            exit 1
+          fi
+          if { [ "$CODE" = "true" ] || [ "$PACKAGING" = "true" ]; } && [ "$RESULT" != "success" ]; then
+            echo "::error::Build macOS App result: $RESULT"
+            exit 1
+          fi
+          echo "Build macOS gate ok (code=$CODE packaging=$PACKAGING build=$RESULT)"
+
   website:
     name: Website Build
     needs: changes
@@ -355,7 +378,7 @@ jobs:
   build-mac:
     name: Build macOS App
     needs: [changes, cef-version]
-    if: needs.changes.outputs.packaging == 'true'
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.packaging == 'true'
     runs-on: macos-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

`Build macOS App` (sign + notarize + DMG) could run, fail, and still be merged — it slipped #138 through with a red macOS build. Two structural gaps:

- **Not requireable.** Branch protection only requires `Lint` + `Test`. `build-mac` had no always-run gate job (unlike `lint`/`test`), so it could not safely be made a required check (a docs-only PR skips it).
- **Filter too narrow.** `build-mac` triggered on the `packaging` filter, which omits general `crates/**` — pure Rust changes (e.g. `vmux_browser`) skipped the macOS build entirely.

## Changes

- Add a **`Build macOS`** gate job mirroring the `Lint`/`Test` pattern: always runs; fails when `code || packaging` changed and `build-mac` did not succeed; passes when `build-mac` is legitimately skipped.
- Trigger `build-mac` on `code || packaging` so any rust/deps change runs the macOS build.

## Follow-up (required, manual)

After merge, add **`Build macOS`** to `main` branch protection required status checks:

```
gh api -X PATCH repos/vmux-ai/vmux/branches/main/protection/required_status_checks   -f "contexts[]=Lint" -f "contexts[]=Test" -f "contexts[]=Build macOS"
```

(Must be added only after this job exists on `main`, else it blocks all PRs.)

## Context

Surfaced while debugging the notarization outage (Apple Developer Program License Agreement 403). Separate fix still wanted: `scripts/sign-and-notarize.sh` swallows the notarytool error (`set -e` aborts the `$(...)` before the `echo`) — not in this PR.

## Test plan

- [ ] CI green on this PR (`Build macOS` gate present; this PR touches `.github/workflows/ci.yml` → `code` true → `build-mac` runs)
- [ ] After merge, add `Build macOS` to required checks and confirm a docs-only PR still goes green (build-mac skipped, gate passes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow reliability with improved build verification checks and expanded build triggering conditions for macOS builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->