### PR TITLE
chore(release): v0.0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9630,7 +9630,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9661,7 +9661,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_browser"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9682,7 +9682,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -9694,7 +9694,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9709,7 +9709,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9724,7 +9724,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9790,7 +9790,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_editor"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9822,7 +9822,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_git"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9839,7 +9839,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9860,7 +9860,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -9894,7 +9894,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "muda",
  "proc-macro2",
@@ -9904,7 +9904,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -9917,7 +9917,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_server"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "dioxus",
  "regex",
@@ -9938,7 +9938,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "alacritty_terminal",
  "bevy",
@@ -9974,7 +9974,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9997,7 +9997,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10022,7 +10022,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_team"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10043,7 +10043,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10074,7 +10074,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "dioxus",
  "dioxus-primitives",
@@ -10091,7 +10091,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_vibe_setup"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "bevy",
  "bevy_cef",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.16"
+version = "0.0.17"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "GPL-3.0-or-later"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.16"
-  sha256 "9473cd939a92c274edf5995dc47e59a7a2a9dab82320ee446bac1015a3ba956b"
+  version "0.0.17"
+  sha256 "8d42328254755fbc034bc2d5bd5ffe565ec86d0d68e5552a1b240abeafa9f33a"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.16/Vmux_0.0.16_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.17/Vmux_0.0.17_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai/"

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.16",
-  "pub_date": "2026-06-19T03:42:14Z",
+  "version": "v0.0.17",
+  "pub_date": "2026-06-23T23:37:40Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.16/Vmux-v0.0.16-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HT3l1YzNYUnJIWXZRMVcyZTV4cFVKVE1NSGtXcmR2NDZLNlVyNWwxU2NLbWJXSkhrdXlxVU85SVlmUjF5VmhMdHc4Wk9YZG1oMzZ4TnhjakJqUXQvM2dVPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgxODM5NzYyCWZpbGU6Vm11eC12MC4wLjE2LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKS0NkZUFXRmtOQkplMUVNQVFRZjRzc0xOZnlKZFkyV3BpY01YQ3c5SmZhM0ptZkhkc1ZSZTdaOGpQUEVMZkd4cWgvRWxiTGNlUkFEY3VPY1dLZW94QlE9PQo=",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.17/Vmux-v0.0.17-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTyt3YWV5b1NKYmg1YnZGR2oySFk4VTNTZ1FOdHJEcHhXTlhVd2QzS0VtUGNWWHFsL0E2R1J6VGlEYWl1SXhib0FHZXNVZHAvYTNjbHpCVXVrc0VZc1F3PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgyMjU0ODk3CWZpbGU6Vm11eC12MC4wLjE3LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKUSt2VXV3Y213RG12azloUWdkczVVcW80bnVNRmVzWHdlU0p5cjdHTWRhUlJxVDUxc2hXRG9yeHVmUDNsOE82Qm0wYXhqVGd4UFdleTNKN0NTSzRMQ2c9PQo=",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.16/Vmux_0.0.16_aarch64.dmg",
-      "filename": "Vmux_0.0.16_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.17/Vmux_0.0.17_aarch64.dmg",
+      "filename": "Vmux_0.0.17_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
Patch release. Bumps workspace version 0.0.16 -> 0.0.17. Releases on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the app version to `0.0.17` across the project, Homebrew cask, and website release metadata (including download URLs and signatures).
  
**Note:** This release contains only version updates with no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->