### PR TITLE
docs: architecture pages refresh (ECS, Pages, Background Service)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,8 +28,8 @@ both humans and agents tile, persist, and reconcile in real time.
   why a web sandbox is the wrong ceiling for an OS-level workspace.
 - **[Rust for React JS developers](architecture/rust-without-the-headaches.md)** — Bevy ECS as an
   in-memory database, lock-free concurrency, and Rust as the universal FFI glue.
-- **[ECS: Design to scale](architecture/built-to-scale.md)** — composition over inheritance,
-  and what compounds as features, surfaces, and agents grow.
+- **[ECS, explained](architecture/built-to-scale.md)** — entities, components, and systems
+  from the ground up, mapped onto the React model you already know.
 - **[Plugins](architecture/plugins.md)** — the `build()` contract, one capability per crate,
   and how the whole app is assembled from the plugin stack.
 - **[Co-working with agents](architecture/agent-first.md)** — the MCP surface,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,8 +43,8 @@ both humans and agents tile, persist, and reconcile in real time.
 
 ## The pages
 
-The surfaces you actually work in — each a [webview app](architecture/pages.md) on the `vmux://`
-scheme:
+The surfaces you actually work in — what each [page](architecture/pages.md) is depends on its URL
+scheme (`https://`, `file://`, or `vmux://`):
 
 - **[Pages](architecture/pages.md)** — the page abstraction, the `vmux://` scheme, and the
   scheme-gated security bridge.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,9 +32,12 @@ both humans and agents tile, persist, and reconcile in real time.
   from the ground up, mapped onto the React model you already know.
 - **[Plugins](architecture/plugins.md)** — the `build()` contract, one capability per crate,
   and how the whole app is assembled from the plugin stack.
-- **[Co-working with agents](architecture/agent-first.md)** — the MCP surface,
-  the persistence daemon, and the scheme-gated security bridge.
+- **[Co-working with agents](architecture/agent-first.md)** — the MCP surface, anchored
+  agent spaces, and the workspace-as-an-API tool set.
+- **[Background Service](architecture/background-service.md)** — the launchd-supervised daemon
+  that owns PTYs and agent sessions so work outlives the window.
 - **[The layout model](architecture/layout-model.md)** — Space → Tab → Pane → Stack, the
   selection invariant, and structural persistence.
 - **[The render stack](architecture/render-stack.md)** — many CEF surfaces in one window,
-  zero-copy interop, Rust-all-the-way-down UI, and the 3D mode.
+  zero-copy interop, Rust-all-the-way-down UI, the `vmux://` scheme and its security gate,
+  and the 3D mode.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,5 +39,17 @@ both humans and agents tile, persist, and reconcile in real time.
 - **[The layout model](architecture/layout-model.md)** — Space → Tab → Pane → Stack, the
   selection invariant, and structural persistence.
 - **[The render stack](architecture/render-stack.md)** — many CEF surfaces in one window,
-  zero-copy interop, Rust-all-the-way-down UI, the `vmux://` scheme and its security gate,
-  and the 3D mode.
+  zero-copy interop, Rust-all-the-way-down UI, and the 3D mode.
+
+## The pages
+
+The surfaces you actually work in — each a [webview app](architecture/pages.md) on the `vmux://`
+scheme:
+
+- **[Pages](architecture/pages.md)** — the page abstraction, the `vmux://` scheme, and the
+  scheme-gated security bridge.
+- **[Browser](architecture/browser.md)** — Chromium embedded via CEF; windowed-native vs
+  GPU-texture rendering.
+- **[Terminal](architecture/terminal.md)** — a real PTY parsed in the daemon, streamed to a
+  Dioxus grid as incremental patches.
+- **[Editor](architecture/editor.md)** — a syntect + two-face highlighted files surface.

--- a/docs/architecture/agent-first.md
+++ b/docs/architecture/agent-first.md
@@ -18,7 +18,8 @@ it gets the full tool surface; that's all the vibe CLI is wired to under the hoo
 The server is a thin front end: it connects to the `vmux_service` daemon over its
 Unix socket and forwards each call as a typed protocol message. The daemon — not
 the agent — owns the PTYs, terminals, and sessions, so work keeps running even if
-the agent process exits.
+the agent process exits. See **[Background Service](background-service.md)** for how that
+daemon is supervised and how the work it owns persists.
 
 Every agent is launched **anchored to its own Space** (`vmux mcp --anchor <id>`).
 Tool calls resolve relative to that anchor, so a background agent spawns its pages
@@ -41,29 +42,3 @@ core methods:
 - `read_layout` / `update_layout` — fetch the pane tree (stable ids), mutate it, and
   commit it back; Vmux diffs against the live graph and reconciles **React-style** — add
   panes, move stacks, shift focus, in one atomic transaction.
-
-## Persistence via a daemon
-
-Commands route through a `launchd`-supervised background daemon (`crates/vmux_service`)
-that owns the PTYs and agent sessions. Because it outlives the window, shells, long
-builds, and agent routines persist across app restarts — an agent can kick off a build,
-the app can close, and the output is still waiting when it reopens.
-
-## A privileged bridge behind a scheme gate
-
-Agents reach Vmux over MCP. Web pages reach it over a second, tightly gated path — and
-"the workspace is an API" invites the obvious question: can a random website drive it? No.
-
-The host bridge (`window.cef` — the messaging that lets a page read or command the
-workspace) only works for **trusted frames**: a page is trusted *iff* its URL is
-`vmux://<known-host>/`. `vmux://` is a registered scheme served only from bundled assets, so
-no web page can ever *be* at a `vmux://` URL — an unforgeable boundary, checked **per frame**
-(an `evil.com` iframe inside a trusted page is still rejected). Anything you browse over
-`https://` gets zero bridge access; calls are dropped before they reach the ECS, enforced in
-the browser process with a defense-in-depth check in the renderer.
-
-A second layer adds **least privilege** among trusted pages: each message type is bound to
-the page that may emit it (`for_hosts(&["history"])`, …), so a compromised Vmux page can't
-pivot to another's handlers — and the full Bevy Remote Protocol is locked to the `debug`
-page alone. The predicate lives in the patched `bevy_cef_core` (`url_is_trusted_embedded_page`),
-unit-tested against `https://evil.com`, `about:blank`, and bare `vmux://`.

--- a/docs/architecture/background-service.md
+++ b/docs/architecture/background-service.md
@@ -1,0 +1,60 @@
+# Background Service: work that outlives the window
+
+> Part of the [Vmux Architecture](../architecture.md) overview.
+
+Vmux runs as two processes. The one you see is the app window — the Bevy host compositing CEF
+surfaces. Behind it sits a long-lived background daemon (`crates/vmux_service`) that owns the
+actual work: the PTYs behind every terminal, and the agent sessions. The window is just a client
+of that daemon, so closing it doesn't stop anything that's running.
+
+## launchd keeps it alive
+
+A per-profile **LaunchAgent** (`ai.vmux.service.<profile>`) supervises the daemon:
+
+- **`KeepAlive` on crash, not on exit** — launchd relaunches the daemon if it crashes, but lets a
+  clean shutdown stay down.
+- **`RunAtLoad` is false** — the daemon is *not* a login item; it never starts on boot. The app
+  starts it on demand the first time it's needed (`ensure_running`, which is idempotent and even
+  rewrites the plist when the binary path drifts between builds or worktrees).
+- **Two backends** — a packaged `.app` registers an embedded agent through `SMAppService`; a dev
+  binary is wired up with `launchctl bootstrap`/`kickstart`.
+
+On start the daemon boots a Tokio runtime, binds a **Unix-domain socket**, and runs an IPC
+server. The app — and the standalone [MCP server](agent-first.md) — connect to that socket as
+clients and exchange typed protocol messages.
+
+## Terminals and agents register by id
+
+The daemon holds two in-memory registries; "registering" is just inserting into one of them.
+
+- **Terminals.** `ProcessManager` keeps a `HashMap<ProcessId, Process>`. Creating a terminal
+  (`create_process`) opens a real PTY (`portable_pty`), spawns the child shell or command, and
+  starts a dedicated reader thread that pumps PTY bytes through an `alacritty` VTE parser into an
+  in-memory grid. The daemon owns the master PTY, the child process, and that grid.
+- **Agent sessions.** `AgentSessionManager` keeps a `HashMap<String, SessionHandle>` keyed by a
+  session id (`sid`). Spawning one (idempotent per `sid`) starts a Tokio task that drives the
+  provider stream and retains the running message history.
+
+Each registered thing exposes the same two surfaces: a **broadcast channel** of updates, and a
+point-in-time **snapshot**.
+
+## Attach, detach, re-attach
+
+Clients don't hold state — they subscribe to it.
+
+- To show a terminal, the window `subscribe()`s and receives live **viewport patches** (only the
+  changed lines), after painting an initial `snapshot()` of the current screen. Agents work the
+  same way: `subscribe(sid)` streams deltas; `snapshot(sid)` replays the full transcript.
+- Because the PTY, child, and tasks live in the daemon, a client can leave at any moment — close
+  the window, quit the app — without disturbing them. The shell keeps reading, the build keeps
+  building, the agent keeps streaming.
+- On reopen, the app reconnects to the socket, re-subscribes, and replays snapshots. Whatever ran
+  while it was gone is already in the daemon's grid and history, so it's right there when you
+  return.
+
+## What it buys you
+
+An agent can kick off a long build, you can quit Vmux, and the output is waiting when it reopens.
+Terminals and agent runs survive app restarts; a daemon crash is healed by launchd; and many
+agents can work in their own [spaces](layout-model.md) at once — all because the work lives in a
+process that outlives the window.

--- a/docs/architecture/browser.md
+++ b/docs/architecture/browser.md
@@ -1,0 +1,42 @@
+# Browser: Chromium as a guest surface
+
+> Part of the [Vmux Architecture](../architecture.md) overview. One of the
+> [pages](pages.md) Vmux renders in a pane.
+
+The pages you browse are full **Chromium**, embedded with the **Chromium Embedded Framework
+(CEF)** — the same engine Chrome ships, not a system WebView wrapper. Vmux drives it from Rust
+through **[`bevy_cef`](https://crates.io/crates/bevy_cef)** (and `bevy_cef_core`), a Bevy plugin
+layer vendored and patched in-tree (`crates/vmux_browser` + `patches/bevy_cef*`). CEF runs
+multi-process exactly like Chrome: the Vmux app is the **browser process**, and a separate
+**render process** runs each page's V8/JavaScript, talking back over CEF's process messages.
+
+## Two ways to paint a page
+
+Vmux renders each web view one of two ways and swaps between them at runtime:
+
+- **Native windowed CEF** *(macOS, browse mode)* — a real native `NSView` is positioned over the
+  pane. The page gets its own first responder, native scrolling, and **Chrome-parity CPU** —
+  scrolling costs exactly what Chrome costs. The 3D mesh that normally carries the page drops its
+  alpha to reveal the native view underneath.
+- **Offscreen rendering (OSR) into a GPU texture** *(everywhere else — Linux, the layout overlay,
+  3D mode)* — CEF paints the page offscreen and hands Vmux an accelerated frame. On macOS the
+  shared GPU texture (an `IOSurface`) is imported **straight into Bevy's `wgpu` device** and
+  composited onto a quad — no CPU copy. Running on Bevy `0.19` is what unlocks this zero-copy path.
+
+Switching backends tears the CEF browser down and recreates it in the other mode, so a page can
+move between a native overlay and a GPU texture as you change modes. How these surfaces composite
+into one window is **[the render stack](render-stack.md)**.
+
+## Talking to a page
+
+Vmux's own pages get a typed, zero-copy bridge; arbitrary websites get none.
+
+- **rkyv messages** — host→page state (tabs, layout, theme) travels as zero-copy **rkyv** binary
+  buffers, not JSON-on-IPC; pages send commands back the same way.
+- **`window.cef`** — the render process injects a small JS API (`emit` / `listen` / `brp`) that
+  Vmux's WASM pages use to read and command the workspace.
+- **Trust is gated on the scheme** — the bridge only answers **trusted frames** served from bundled
+  assets; anything over `https://` gets zero access. See **[Pages](pages.md)** for the full model.
+
+Keyboard focus across windowed pages, OSR terminals, and the host window is reconciled in
+`crates/vmux_browser/src/host_focus.rs`, so typing always lands in the surface you're looking at.

--- a/docs/architecture/built-to-scale.md
+++ b/docs/architecture/built-to-scale.md
@@ -1,42 +1,101 @@
-# ECS: Design to scale
+# ECS, explained
 
 > Part of the [Vmux Architecture](../architecture.md) overview.
 
-The same property that makes Vmux pleasant to write makes it compound as it grows:
-**composition over inheritance**. An entity is just an id, defined entirely by the
-components attached to it — no base classes, no inheritance trees:
+Vmux's host runs on **Bevy**, an **Entity-Component-System (ECS)**. If you've never touched
+one, the name sounds exotic — but the whole model is three nouns, and each maps cleanly onto
+something you already use in React. Here it is from the ground up.
 
-- A web view *becomes* a shell by adding a `Terminal` component.
-- A web view switches to a native surface via `WebviewWindowed`.
-- Systems query for component sets (e.g. the `Active` tag), so behavior is opt-in — you
-  add a capability, you don't inherit one.
+The one move that feels new: ECS **splits the atom of a React component** into *data* and
+*behavior*. State lives in one place, the functions that act on it live in another, and an id
+ties them together.
 
-## State in components, behavior in systems
+## Entity — just an id
 
-Vmux holds no object graph. Every pane, stack, space, and surface is an **entity**; its
-state lives in **components** (plain data), and every behavior is a **system** — a function
-that queries for a set of components and runs over each matching entity. The `World` ties
-them together as the one source of truth: an in-memory database the systems read and write.
+An entity is **not** an object. No methods, no fields, no class to extend — it's a bare id,
+like a primary key in a table or the `key` prop on a list item. A pane, a tab, a space, a
+browser surface: each *is* one entity, and on its own that entity is nothing but a number.
 
-Because table-backed components are stored contiguously by type, a system touches only the
-data it asks for — cache-friendly by construction. Bevy then schedules systems with non-overlapping
-queries across cores in **parallel** on its own: you declare *what* data you need, the
-engine decides *when* it runs.
+What an entity actually *is* comes entirely from the components you attach to it. Spawn one
+and you get back its id:
 
-## What compounds as you grow
+```rust
+let pane = commands.spawn(Pane).id();
+```
 
-- **More behavior → more systems.** A capability is a system over a query; independent
-  systems run in parallel, so adding one rarely costs the others.
-- **More surfaces → more entities.** Panes, stacks, and spaces are just entities; their
-  components are stored contiguously and iterated at speed.
-- **More agents → more spaces.** Each agent is anchored to its own Space subtree, so many
-  can work concurrently without touching the space you're in.
-- **Heavier pages → the GPU.** Web surfaces composite on the GPU while the host loop stays
-  reactive — load goes up, idle cost doesn't.
+## Component — your state
 
-## Built to sit idle
+A component is **plain data** attached to an entity: a struct with no behavior. Think of the
+typed columns of a database row, or a single `useState` slice lifted out of the component and
+stored on its own.
 
-Most game engines pump the render loop continuously, pinning a core even on a static
-scene. Vmux forces `winit` into a strictly **reactive** update mode and uses a CEF wake
-throttler to tick the loop at the monitor's refresh rate *only* when there's work — render
-changes, scroll, cursor animation, terminal output. Static workspace, quiet machine.
+```rust
+#[derive(Component)]
+pub struct Terminal;
+
+#[derive(Component)]
+pub struct Active;
+```
+
+Both are *tag* components — empty structs whose mere presence on an entity is the data
+("this entity is a terminal", "this one is focused"). Components carry fields when there's
+something to store, but they never carry logic.
+
+Because state is just components you bolt on, **capabilities compose** instead of being
+inherited. A plain web-view entity *becomes* a shell the moment you add a `Terminal`
+component — no subclass, no base class, no `extends`. You add a capability; you don't inherit
+one.
+
+## System — your behavior
+
+A system is an ordinary function that runs over **every entity matching a query**. It's your
+`useEffect` or your reducer — except instead of being bound to one component instance, it runs
+across the whole world at once.
+
+```rust
+fn focus_active(panes: Query<&Terminal, With<Active>>) {
+    for terminal in &panes {
+        // …
+    }
+}
+```
+
+Read the query out loud and it's obvious: *"for each entity that has a `Terminal` and is
+`Active`, do this."* It's an `array.filter(…).forEach(…)` — and the engine calls it for you on
+a schedule, tick after tick, so you never wire up the *when*.
+
+## The world — your single store
+
+Every entity and component lives in one **`World`**: a single Redux store, an in-memory
+database. It is the one source of truth. Systems read from it and write to it; nothing else
+holds state on the side. A query is your `array.filter(…)`; the world is the array.
+
+## Messages — your actions
+
+Systems don't call each other directly. To make something happen elsewhere, a system **sends
+a message**, and another system reads it on a later tick:
+
+```rust
+#[derive(Message)]
+pub struct TerminalSpawnRequest {
+    pub target_stack: Option<Entity>,
+}
+```
+
+That's `dispatch(action)` and the reducer that handles it — sender and receiver stay
+decoupled, exactly like a Redux action and the slice that reacts to it.
+
+## Why split data from behavior
+
+Pulling state (components) apart from behavior (systems) buys two things for free:
+
+- **Composition over inheritance** — every capability is a component you add, never a class
+  you extend, so features stack instead of tangling.
+- **Real parallelism, scheduled for you** — because each system declares the data it touches,
+  Bevy runs every non-conflicting system across CPU cores at once. You describe *what* you
+  need; the engine decides *when* it runs.
+
+That's the whole model. For the side-by-side React / Redux → Rust mapping in real code, see
+**[Rust for React JS developers](rust-without-the-headaches.md)**. To go deeper, the official
+[Bevy guides](https://bevyengine.org/learn/) and the
+[Bevy Cheat Book](https://bevy-cheatbook.github.io) cover it in an afternoon.

--- a/docs/architecture/editor.md
+++ b/docs/architecture/editor.md
@@ -1,0 +1,38 @@
+# Editor: a syntax-highlighted files surface
+
+> Part of the [Vmux Architecture](../architecture.md) overview. One of the
+> [pages](pages.md) Vmux renders in a pane.
+
+The `vmux://files` page (`crates/vmux_editor`) is a fast, syntax-highlighted file browser and
+viewer. Today it is **read-first**: open, navigate, and read code with full highlighting — in-place
+editing and language servers aren't wired up yet.
+
+## Highlighting: syntect + two-face
+
+Highlighting is pure Rust, no native toolchain and no separate process:
+
+- **[`syntect`](https://crates.io/crates/syntect)** highlights line by line (`HighlightLines`)
+  against a theme (`base16-ocean.dark`).
+- **[`two-face`](https://crates.io/crates/two-face)** swaps syntect's tiny default grammar set for
+  the **~200 syntaxes** from the `bat` project, chosen by file extension.
+
+Each line becomes a list of **`StyledSpan`** (text + RGB + bold/italic) — a small, render-ready
+model. That same model is the shared thread across surfaces: the file viewer, the file **preview**,
+and **git diffs** (`crates/vmux_git`) all run the same syntect + two-face engine and emit the same
+spans, so code looks identical wherever it appears. There's no tree-sitter and no LSP — highlighting
+is grammar-based.
+
+## The files:// page
+
+- **Miller-column browser** — parent · current · preview, navigated with vim keys (`j`/`k`/`h`/`l`;
+  `.` toggles hidden files).
+- **Typed previews** — directories, **images** (downscaled to thumbnails), and **text**
+  (highlighted, capped for snappiness); binary files are sniffed and shown as info rather than
+  garbage.
+- **SVG language icons** — file types render as monochrome [simple-icons](https://simpleicons.org)
+  path data (`currentColor`), not a glyph font.
+- **Line virtualization** — the host ships only the **visible slice** of a file to the page and
+  re-slices as you scroll, so a huge file opens instantly.
+
+Like the other pages, it's a Dioxus app inside CEF, fed host→page over zero-copy **rkyv** events,
+and it reloads automatically when a file changes on disk.

--- a/docs/architecture/editor.md
+++ b/docs/architecture/editor.md
@@ -3,9 +3,10 @@
 > Part of the [Vmux Architecture](../architecture.md) overview. One of the
 > [pages](pages.md) Vmux renders in a pane.
 
-The `vmux://files` page (`crates/vmux_editor`) is a fast, syntax-highlighted file browser and
-viewer. Today it is **read-first**: open, navigate, and read code with full highlighting — in-place
-editing and language servers aren't wired up yet.
+The files Editor (`crates/vmux_editor`) is a fast, syntax-highlighted file browser and viewer. It
+opens local files on the **`file://`** scheme — `file:///path/to/main.rs` — not on `vmux://`. Today
+it is **read-first**: open, navigate, and read code with full highlighting — in-place editing and
+language servers aren't wired up yet.
 
 ## Highlighting: syntect + two-face
 
@@ -22,7 +23,7 @@ and **git diffs** (`crates/vmux_git`) all run the same syntect + two-face engine
 spans, so code looks identical wherever it appears. There's no tree-sitter and no LSP — highlighting
 is grammar-based.
 
-## The files:// page
+## The file browser
 
 - **Miller-column browser** — parent · current · preview, navigated with vim keys (`j`/`k`/`h`/`l`;
   `.` toggles hidden files).

--- a/docs/architecture/pages.md
+++ b/docs/architecture/pages.md
@@ -1,0 +1,42 @@
+# Pages: webview apps on the `vmux://` scheme
+
+> Part of the [Vmux Architecture](../architecture.md) overview.
+
+In Vmux, a **page** is whatever fills a pane. Some pages are the open web — full Chromium. The
+rest are Vmux's *own* surfaces — the [Browser](browser.md) frame, the [Terminal](terminal.md), the
+files [Editor](editor.md), history, settings, spaces, the command bar, even the layout overlay
+itself — and those are **webview apps**: Dioxus/WASM apps Vmux ships and renders inside CEF.
+
+Vmux's pages aren't fetched from a server. They're bundled into the app and served from a
+registered custom scheme, **`vmux://`**, addressed by host — `vmux://terminal`, `vmux://files`,
+`vmux://history`, `vmux://settings`, `vmux://debug`, one per page. The scheme is registered as
+**standard** and **secure** in both the browser and renderer processes, and a handler answers each
+request straight from embedded assets, so a page loads **instantly, offline, with no server in the
+loop**. (The name is `vmux` by default, overridable via `BEVY_CEF_EMBEDDED_SCHEME`.)
+
+## A privileged bridge, gated on the scheme
+
+The scheme is also the app's security boundary. "The workspace is an API" — every action is
+reachable over [MCP](agent-first.md) — invites the obvious question: can a random website drive
+it? No.
+
+The host bridge (`window.cef` — the messaging that lets a page read or command the workspace) only
+works for **trusted frames**: a page is trusted *iff* its URL is `vmux://<known-host>/`. Because
+`vmux://` is served only from bundled assets, no web page can ever *be* at a `vmux://` URL — an
+unforgeable boundary, checked **per frame** (an `evil.com` iframe inside a trusted page is still
+rejected). Anything you browse over `https://` gets zero bridge access; calls are dropped before
+they reach the ECS, enforced in the browser process with a defense-in-depth check in the renderer.
+
+A second layer adds **least privilege** among trusted pages: each message type is bound to the page
+that may emit it (`for_hosts(&["history"])`, …), so a compromised Vmux page can't pivot to
+another's handlers — and the full Bevy Remote Protocol is locked to the `debug` page alone. The
+predicate lives in the patched `bevy_cef_core` (`url_is_trusted_embedded_page`), unit-tested against
+`https://evil.com`, `about:blank`, and bare `vmux://`.
+
+## The pages, one by one
+
+- **[Browser](browser.md)** — the open web: full Chromium, embedded via CEF.
+- **[Terminal](terminal.md)** — a real PTY parsed in the daemon, streamed to a Dioxus grid.
+- **[Editor](editor.md)** — a syntect-highlighted files surface with typed previews.
+
+…plus the smaller built-ins — history, settings, spaces, services, debug — cut from the same cloth.

--- a/docs/architecture/pages.md
+++ b/docs/architecture/pages.md
@@ -2,17 +2,20 @@
 
 > Part of the [Vmux Architecture](../architecture.md) overview.
 
-In Vmux, a **page** is whatever fills a pane. Some pages are the open web — full Chromium. The
-rest are Vmux's *own* surfaces — the [Browser](browser.md) frame, the [Terminal](terminal.md), the
-files [Editor](editor.md), history, settings, spaces, the command bar, even the layout overlay
-itself — and those are **webview apps**: Dioxus/WASM apps Vmux ships and renders inside CEF.
+In Vmux, a **page** is whatever fills a pane, and the URL scheme decides what a page *is*:
 
-Vmux's pages aren't fetched from a server. They're bundled into the app and served from a
-registered custom scheme, **`vmux://`**, addressed by host — `vmux://terminal`, `vmux://files`,
-`vmux://history`, `vmux://settings`, `vmux://debug`, one per page. The scheme is registered as
-**standard** and **secure** in both the browser and renderer processes, and a handler answers each
-request straight from embedded assets, so a page loads **instantly, offline, with no server in the
-loop**. (The name is `vmux` by default, overridable via `BEVY_CEF_EMBEDDED_SCHEME`.)
+- **`https://`** (and the open web) — full Chromium. That's the [Browser](browser.md).
+- **`file://`** — a local file or directory, opened in the files [Editor](editor.md).
+- **`vmux://`** — Vmux's own built-in apps: the [Terminal](terminal.md), history, settings, spaces,
+  the command bar, even the layout overlay. These are **webview apps** — Dioxus/WASM apps Vmux ships
+  and renders inside CEF.
+
+The `vmux://` pages aren't fetched from a server. They're bundled into the app and served from a
+registered custom scheme, addressed by host — `vmux://terminal`, `vmux://history`, `vmux://settings`,
+`vmux://debug`, one per page. The scheme is registered as **standard** and **secure** in both the
+browser and renderer processes, and a handler answers each request straight from embedded assets, so
+a page loads **instantly, offline, with no server in the loop**. (The name is `vmux` by default,
+overridable via `BEVY_CEF_EMBEDDED_SCHEME`.)
 
 ## A privileged bridge, gated on the scheme
 
@@ -21,11 +24,13 @@ reachable over [MCP](agent-first.md) — invites the obvious question: can a ran
 it? No.
 
 The host bridge (`window.cef` — the messaging that lets a page read or command the workspace) only
-works for **trusted frames**: a page is trusted *iff* its URL is `vmux://<known-host>/`. Because
-`vmux://` is served only from bundled assets, no web page can ever *be* at a `vmux://` URL — an
-unforgeable boundary, checked **per frame** (an `evil.com` iframe inside a trusted page is still
-rejected). Anything you browse over `https://` gets zero bridge access; calls are dropped before
-they reach the ECS, enforced in the browser process with a defense-in-depth check in the renderer.
+works for **trusted frames**: a frame is trusted only when Vmux itself serves it — a
+`vmux://<known-host>/` app or a local `file://` document — never a page fetched from the network.
+Because `vmux://` and `file://` are served straight from disk, no website can ever *be* at one of
+those URLs — an unforgeable boundary, checked **per frame** (an `evil.com` iframe inside a trusted
+page is still rejected). Anything you browse over `https://` gets zero bridge access; calls are
+dropped before they reach the ECS, enforced in the browser process with a defense-in-depth check in
+the renderer.
 
 A second layer adds **least privilege** among trusted pages: each message type is bound to the page
 that may emit it (`for_hosts(&["history"])`, …), so a compromised Vmux page can't pivot to

--- a/docs/architecture/render-stack.md
+++ b/docs/architecture/render-stack.md
@@ -73,6 +73,37 @@ at the end of the day, on the inside it's just Chromium — and Vmux talks to an
 way the web already does: JS message passing. (Vmux's own WASM surfaces get the typed
 rkyv bridge; arbitrary pages use plain JS messaging.)
 
+## The `vmux://` URL scheme
+
+Vmux's own pages — history, settings, the layout overlay, the `debug` console, the services
+monitor — aren't fetched over the network. They're bundled into the app and served from a
+registered custom scheme, `vmux://`, addressed by host: `vmux://history`, `vmux://settings`,
+`vmux://debug`, one per page crate. The scheme is registered as **standard** and **secure**
+(`CEF_SCHEME_OPTION_STANDARD | …_SECURE`) in both the browser and renderer processes, and a
+scheme handler answers each request straight from embedded assets — so a Vmux page loads
+instantly, offline, with no server in the loop. (The name is `vmux` by default, overridable via
+`BEVY_CEF_EMBEDDED_SCHEME`.)
+
+### A privileged bridge, gated on the scheme
+
+The scheme is also the app's security boundary. "The workspace is an API" — every action is
+reachable over [MCP](agent-first.md) — invites the obvious question: can a random website drive
+it? No.
+
+The host bridge (`window.cef` — the messaging that lets a page read or command the workspace)
+only works for **trusted frames**: a page is trusted *iff* its URL is `vmux://<known-host>/`.
+Because `vmux://` is served only from bundled assets, no web page can ever *be* at a `vmux://`
+URL — an unforgeable boundary, checked **per frame** (an `evil.com` iframe inside a trusted page
+is still rejected). Anything you browse over `https://` gets zero bridge access; calls are
+dropped before they reach the ECS, enforced in the browser process with a defense-in-depth check
+in the renderer.
+
+A second layer adds **least privilege** among trusted pages: each message type is bound to the
+page that may emit it (`for_hosts(&["history"])`, …), so a compromised Vmux page can't pivot to
+another's handlers — and the full Bevy Remote Protocol is locked to the `debug` page alone. The
+predicate lives in the patched `bevy_cef_core` (`url_is_trusted_embedded_page`), unit-tested
+against `https://evil.com`, `about:blank`, and bare `vmux://`.
+
 ## One more thing — your workspace in 3D
 
 The whole workspace already lives in a Bevy 3D scene, so flipping to **Player mode** tilts

--- a/docs/architecture/render-stack.md
+++ b/docs/architecture/render-stack.md
@@ -73,37 +73,6 @@ at the end of the day, on the inside it's just Chromium — and Vmux talks to an
 way the web already does: JS message passing. (Vmux's own WASM surfaces get the typed
 rkyv bridge; arbitrary pages use plain JS messaging.)
 
-## The `vmux://` URL scheme
-
-Vmux's own pages — history, settings, the layout overlay, the `debug` console, the services
-monitor — aren't fetched over the network. They're bundled into the app and served from a
-registered custom scheme, `vmux://`, addressed by host: `vmux://history`, `vmux://settings`,
-`vmux://debug`, one per page crate. The scheme is registered as **standard** and **secure**
-(`CEF_SCHEME_OPTION_STANDARD | …_SECURE`) in both the browser and renderer processes, and a
-scheme handler answers each request straight from embedded assets — so a Vmux page loads
-instantly, offline, with no server in the loop. (The name is `vmux` by default, overridable via
-`BEVY_CEF_EMBEDDED_SCHEME`.)
-
-### A privileged bridge, gated on the scheme
-
-The scheme is also the app's security boundary. "The workspace is an API" — every action is
-reachable over [MCP](agent-first.md) — invites the obvious question: can a random website drive
-it? No.
-
-The host bridge (`window.cef` — the messaging that lets a page read or command the workspace)
-only works for **trusted frames**: a page is trusted *iff* its URL is `vmux://<known-host>/`.
-Because `vmux://` is served only from bundled assets, no web page can ever *be* at a `vmux://`
-URL — an unforgeable boundary, checked **per frame** (an `evil.com` iframe inside a trusted page
-is still rejected). Anything you browse over `https://` gets zero bridge access; calls are
-dropped before they reach the ECS, enforced in the browser process with a defense-in-depth check
-in the renderer.
-
-A second layer adds **least privilege** among trusted pages: each message type is bound to the
-page that may emit it (`for_hosts(&["history"])`, …), so a compromised Vmux page can't pivot to
-another's handlers — and the full Bevy Remote Protocol is locked to the `debug` page alone. The
-predicate lives in the patched `bevy_cef_core` (`url_is_trusted_embedded_page`), unit-tested
-against `https://evil.com`, `about:blank`, and bare `vmux://`.
-
 ## One more thing — your workspace in 3D
 
 The whole workspace already lives in a Bevy 3D scene, so flipping to **Player mode** tilts

--- a/docs/architecture/rust-without-the-headaches.md
+++ b/docs/architecture/rust-without-the-headaches.md
@@ -7,11 +7,13 @@ fights, lifetimes, and FFI boilerplate. The surprise: in day-to-day feature work
 none of that shows up. The scary Rust lives deep in the engine — the code you write looks a
 lot like the front-end you already write.
 
-## The UI is React — in Rust
+## Coming from React? You already know this
 
-Vmux's own surfaces — header, command bar, settings, error pages — are built with
-**[Dioxus](https://dioxuslabs.com)**, which ports React's model to Rust almost one-to-one:
-function components, a JSX-like `rsx!` macro, and hooks.
+Vmux is React-shaped at both layers — the surfaces you *write*, and the host they run *on*.
+
+**The UI is React, in Rust.** Vmux's own surfaces — header, command bar, settings, error
+pages — are built with **[Dioxus](https://dioxuslabs.com)**, which ports React's model to Rust
+almost one-to-one: function components, a JSX-like `rsx!` macro, and hooks.
 
 ```rust
 #[component]
@@ -27,8 +29,8 @@ fn Counter(start: i32) -> Element {
 }
 ```
 
-If you've written a React function component, that reads exactly how you'd expect: state in
-a hook, markup returned declaratively, a click handler that updates state — and the view
+If you've written a React function component, that reads exactly how you'd expect: state in a
+hook, markup returned declaratively, a click handler that updates state — and the view
 re-renders on its own. The names barely change:
 
 | React | Dioxus (Rust) |
@@ -42,19 +44,12 @@ re-renders on its own. The names barely change:
 | props object | typed `#[component]` arguments |
 | `className` + Tailwind | `class:` + the same Tailwind utilities |
 
-Same component-and-hook mental model, now type-checked end to end — no `undefined is not a
-function`, no prop-shape drift. The toolkit (`crates/vmux_ui`) even mirrors **shadcn/ui** on
-Dioxus primitives, so the dialogs, dropdowns, and popovers are the ones you already reach for.
+The toolkit (`crates/vmux_ui`) even mirrors **shadcn/ui** on Dioxus primitives, so the dialogs,
+dropdowns, and popovers are the ones you already reach for — now type-checked end to end: no
+`undefined is not a function`, no prop-shape drift.
 
-## Coming from React? You already know this
-
-Below the UI, the host is built on **Bevy**, a data-oriented **Entity-Component-System
-(ECS)**. Squint and it's a shape you've seen:
-
-- The **world** is one big store — a single Redux store, or an in-memory database.
-- **Entities** are rows; **components** are typed columns (your state).
-- **Systems** are functions that run over the rows matching a query (your effects/reducers).
-- **Messages** are dispatched events (your actions).
+**Below the UI, it's Redux-shaped.** The host runs on **Bevy**, a data-oriented
+**Entity-Component-System (ECS)**. Squint and it's a shape you've seen:
 
 | React / Redux / JS | Vmux (Bevy ECS, Rust) |
 | :--- | :--- |
@@ -66,10 +61,8 @@ Below the UI, the host is built on **Bevy**, a data-oriented **Entity-Component-
 | `package.json` / npm | `Cargo.toml` / cargo |
 | TS: caught at compile, not runtime | Rust: same — extended to memory + data races |
 
-A system is just *"for each entity with `A` and `B`, do X"* — an `array.filter` that runs
-every frame. Components are your state, systems your effects, messages your events; a web
-dev ramps fast. New to ECS? The official [Bevy guides](https://bevyengine.org/learn/) and
-the [Bevy Cheat Book](https://bevy-cheatbook.github.io) cover it in an afternoon.
+A system is just *"for each entity with `A` and `B`, do X"* — an `array.filter` that runs every
+frame. New to ECS? **[ECS, explained](built-to-scale.md)** walks the whole model from the ground up.
 
 ## The borrow checker, where you'll actually meet it
 

--- a/docs/architecture/terminal.md
+++ b/docs/architecture/terminal.md
@@ -1,0 +1,38 @@
+# Terminal: a PTY in the daemon, a grid in the page
+
+> Part of the [Vmux Architecture](../architecture.md) overview. One of the
+> [pages](pages.md) Vmux renders in a pane.
+
+A Vmux terminal is split in two: the **shell runs in the background daemon**, and the **screen
+renders in a web page**. The halves talk over the daemon's Unix socket — which is why a shell
+survives the window closing (see **[Background Service](background-service.md)**).
+
+## The backend: PTY + VTE, in the daemon
+
+In `crates/vmux_service`, each terminal is a real OS pseudo-terminal:
+
+- **[`portable_pty`](https://crates.io/crates/portable-pty)** opens the PTY and spawns the child
+  shell; a dedicated reader thread pumps its output.
+- **[`alacritty_terminal`](https://crates.io/crates/alacritty_terminal)** — the VTE engine behind
+  Alacritty — advances that byte stream into an in-memory **cell grid**.
+- On each poll the daemon **diffs the grid by row hash** and broadcasts only the **changed lines**
+  as a `ViewportPatch` (or a full `Snapshot` for a freshly attached viewer) over a Tokio broadcast
+  channel.
+
+The daemon also owns the parts that should outlive any single frame: **OSC 133** command-lifecycle
+tracking (so Vmux knows when a command starts and how it exits), per-shell **shell-integration**
+injection (bash/zsh/fish/nu), tmux-style **copy-mode** motions, and title/bell events.
+
+## The frontend: patches to a Dioxus grid
+
+`crates/vmux_terminal` is the other half:
+
+- A native Bevy plugin subscribes to the daemon and relays each `ViewportPatch` to the page as a
+  zero-copy **rkyv** event.
+- The `vmux://terminal` Dioxus app applies the patch to **per-row signals**, so only the lines that
+  changed repaint — the same incremental model the daemon used to send them.
+- Keystrokes flow back the other way: page → rkyv key event → plugin → `ProcessInput` → the daemon
+  writes the PTY. Selection and `Cmd-C/V` round-trip through the system clipboard.
+
+The result: the heavy, stateful work — a real shell, scrollback, command tracking — lives in a
+durable process, while the UI is a thin, reactive view that can detach and re-attach at any time.

--- a/website/Cargo.toml
+++ b/website/Cargo.toml
@@ -37,6 +37,7 @@ web-sys = { version = "0.3", features = [
     "HtmlElement",
     "HtmlMediaElement",
     "HtmlVideoElement",
+    "Location",
     "MediaQueryList",
     "MouseEvent",
     "Navigator",

--- a/website/src/docs.rs
+++ b/website/src/docs.rs
@@ -32,7 +32,7 @@ pub const DOCS: &[Doc] = &[
     },
     Doc {
         slug: "built-to-scale",
-        title: "ECS: Design to scale",
+        title: "ECS, explained",
         group: "Architecture",
         content: include_str!("../../docs/architecture/built-to-scale.md"),
     },

--- a/website/src/docs.rs
+++ b/website/src/docs.rs
@@ -66,6 +66,30 @@ pub const DOCS: &[Doc] = &[
         group: "Architecture",
         content: include_str!("../../docs/architecture/render-stack.md"),
     },
+    Doc {
+        slug: "pages",
+        title: "Pages",
+        group: "Pages",
+        content: include_str!("../../docs/architecture/pages.md"),
+    },
+    Doc {
+        slug: "browser",
+        title: "Browser",
+        group: "Pages",
+        content: include_str!("../../docs/architecture/browser.md"),
+    },
+    Doc {
+        slug: "terminal",
+        title: "Terminal",
+        group: "Pages",
+        content: include_str!("../../docs/architecture/terminal.md"),
+    },
+    Doc {
+        slug: "editor",
+        title: "Editor",
+        group: "Pages",
+        content: include_str!("../../docs/architecture/editor.md"),
+    },
 ];
 
 pub fn find(slug: &str) -> Option<&'static Doc> {

--- a/website/src/docs.rs
+++ b/website/src/docs.rs
@@ -49,6 +49,12 @@ pub const DOCS: &[Doc] = &[
         content: include_str!("../../docs/architecture/agent-first.md"),
     },
     Doc {
+        slug: "background-service",
+        title: "Background Service",
+        group: "Architecture",
+        content: include_str!("../../docs/architecture/background-service.md"),
+    },
+    Doc {
         slug: "layout-model",
         title: "Layout",
         group: "Architecture",

--- a/website/src/hooks.rs
+++ b/website/src/hooks.rs
@@ -11,6 +11,13 @@ pub fn use_clipboard_copy() -> Callback<String> {
     })
 }
 
+pub fn use_copy_link() -> Callback<String> {
+    use_callback(|_id: String| {
+        #[cfg(target_arch = "wasm32")]
+        wasm::copy_link(_id);
+    })
+}
+
 pub fn use_dmg_download() -> Callback<()> {
     use_callback(|()| {
         #[cfg(target_arch = "wasm32")]
@@ -71,6 +78,18 @@ mod wasm {
         spawn(async move {
             if let Some(window) = web_sys::window() {
                 let _ = JsFuture::from(window.navigator().clipboard().write_text(&text)).await;
+            }
+        });
+    }
+
+    pub fn copy_link(id: String) {
+        spawn(async move {
+            if let Some(window) = web_sys::window() {
+                let loc = window.location();
+                let origin = loc.origin().unwrap_or_default();
+                let path = loc.pathname().unwrap_or_default();
+                let url = format!("{origin}{path}#{id}");
+                let _ = JsFuture::from(window.navigator().clipboard().write_text(&url)).await;
             }
         });
     }

--- a/website/src/markdown.rs
+++ b/website/src/markdown.rs
@@ -240,10 +240,10 @@ fn render_node(n: &Node) -> Element {
                     rsx! { h1 { id: "{id}", class: "scroll-mt-6 text-3xl sm:text-4xl font-bold tracking-tight mt-10 mb-4", {render_nodes(ch)} } }
                 }
                 2 => {
-                    rsx! { h2 { id: "{id}", class: "scroll-mt-6 text-2xl font-semibold tracking-tight mt-10 mb-3 pb-2 border-b border-border", {render_nodes(ch)} } }
+                    rsx! { h2 { id: "{id}", class: "group scroll-mt-6 text-2xl font-semibold tracking-tight mt-10 mb-3 pb-2 border-b border-border", {render_nodes(ch)} CopyLink { id: id.clone() } } }
                 }
                 3 => {
-                    rsx! { h3 { id: "{id}", class: "scroll-mt-6 text-lg font-semibold mt-6 mb-2 text-accent", {render_nodes(ch)} } }
+                    rsx! { h3 { id: "{id}", class: "group scroll-mt-6 text-lg font-semibold mt-6 mb-2 text-accent", {render_nodes(ch)} CopyLink { id: id.clone() } } }
                 }
                 4 => {
                     rsx! { h4 { id: "{id}", class: "scroll-mt-6 text-base font-semibold mt-5 mb-2", {render_nodes(ch)} } }
@@ -342,6 +342,31 @@ fn render_node(n: &Node) -> Element {
         }
         Node::SoftBreak => rsx! { " " },
         Node::HardBreak => rsx! { br {} },
+    }
+}
+
+#[component]
+fn CopyLink(id: String) -> Element {
+    let copy = crate::hooks::use_copy_link();
+    rsx! {
+        button {
+            r#type: "button",
+            aria_label: "Copy link to this section",
+            class: "ml-2 inline-flex items-center align-middle text-text-muted opacity-0 transition-opacity hover:text-accent group-hover:opacity-100 focus-visible:opacity-100",
+            onclick: move |_| copy.call(id.clone()),
+            svg {
+                width: "15",
+                height: "15",
+                view_box: "0 0 24 24",
+                fill: "none",
+                stroke: "currentColor",
+                stroke_width: "2",
+                stroke_linecap: "round",
+                stroke_linejoin: "round",
+                path { d: "M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" }
+                path { d: "M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Replaces the `ECS: Design to scale` architecture page with a ground-up **ECS, explained** primer aimed at React/JS developers.

- Rewrites `docs/architecture/built-to-scale.md`: entity → id, component → state, system → behavior, world → store, message → action — each mapped to React/Redux, with real vmux names (`Pane`, `Terminal`, `Active`, `TerminalSpawnRequest`). Old composition/scale/idle content dropped.
- Retitles the page to **ECS, explained** in `website/src/docs.rs` (slug `built-to-scale` unchanged).
- Updates the deep-dives link + description in `docs/architecture.md`.

## Test plan

- [ ] Render the docs site, open the **ECS, explained** page, confirm formatting + links (sibling Rust page, Bevy guides) resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Copy link” buttons on documentation headings for quick deep-linking.
  * Expanded architecture documentation with new and updated pages: Background Service, Pages (including `vmux://`), Browser, Terminal, and Editor.
  * Refreshed the ECS guide with a clearer “ECS, explained” overview.
* **Bug Fixes**
  * Improved deep-link copying to generate fragments from the current page URL (origin + pathname) for more reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->