### PR TITLE
fix(vibe): restore keyboard input across vibe tabs

### DIFF
--- a/crates/vmux_desktop/src/focus_native.rs
+++ b/crates/vmux_desktop/src/focus_native.rs
@@ -2,43 +2,33 @@ use bevy::ecs::system::NonSendMarker;
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 use vmux_browser::HostFocusIntent;
-use vmux_layout::stack::FocusedStack;
 
-/// When the active page is a terminal (OSR) or there is none, the winit host window must own
-/// macOS first-responder so Bevy delivers keys (terminal → PTY, layout shortcuts). A previously
-/// focused windowed web page or the command bar leaves its native `NSView` as first-responder,
-/// which blacks out the host keyboard — so while [`HostFocusIntent::WinitHost`] is active we hand
-/// first-responder back to the winit content view.
+/// In [`HostFocusIntent::WinitHost`] (a terminal/OSR page is active) the winit content view must own
+/// macOS first-responder so Bevy delivers keys to the focused terminal. A windowed CEF page in the
+/// stack — e.g. a terminal webview that autofocuses on load, or the command bar modal — can steal it
+/// a frame or more later, so re-assert every frame. [`reclaim_first_responder`] is a no-op once the
+/// winit view already holds first-responder, so this only acts when it was stolen.
 ///
-/// The reclaim is retried each frame *until it sticks*, then stops: the active page/command bar can
-/// resign a frame after the intent flips (so a one-shot reclaim would miss it), but re-asserting
-/// every frame fights the page for first-responder and breaks input.
+/// On the frame first-responder is reclaimed *from* a CEF subview, release all tracked keys: while a
+/// CEF subview held first-responder it consumed key-up events winit never saw, so modifiers (Cmd in
+/// particular) can be stuck "pressed" in [`ButtonInput`] and would swallow subsequent typing.
 pub(crate) fn apply_winit_host_focus(
     _non_send: NonSendMarker,
     intent: Res<HostFocusIntent>,
-    focus: Res<FocusedStack>,
     primary: Query<Entity, With<PrimaryWindow>>,
-    mut reclaimed: Local<bool>,
-    mut last_stack: Local<Option<Entity>>,
+    mut keys: ResMut<ButtonInput<KeyCode>>,
 ) {
-    if focus.stack != *last_stack {
-        *last_stack = focus.stack;
-        *reclaimed = false;
-    }
     if *intent != HostFocusIntent::WinitHost {
-        *reclaimed = false;
-        return;
-    }
-    if *reclaimed {
         return;
     }
     let Ok(window_entity) = primary.single() else {
         return;
     };
-    match reclaim_first_responder(window_entity) {
-        ReclaimOutcome::AlreadyWinit | ReclaimOutcome::Reclaimed => *reclaimed = true,
-        // Window/view not ready or the current responder refused to resign — retry next frame.
-        ReclaimOutcome::Failed | ReclaimOutcome::NoView => {}
+    if matches!(
+        reclaim_first_responder(window_entity),
+        ReclaimOutcome::Reclaimed
+    ) {
+        keys.release_all();
     }
 }
 

--- a/crates/vmux_desktop/src/focus_native.rs
+++ b/crates/vmux_desktop/src/focus_native.rs
@@ -3,15 +3,6 @@ use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 use vmux_browser::HostFocusIntent;
 
-/// In [`HostFocusIntent::WinitHost`] (a terminal/OSR page is active) the winit content view must own
-/// macOS first-responder so Bevy delivers keys to the focused terminal. A windowed CEF page in the
-/// stack — e.g. a terminal webview that autofocuses on load, or the command bar modal — can steal it
-/// a frame or more later, so re-assert every frame. [`reclaim_first_responder`] is a no-op once the
-/// winit view already holds first-responder, so this only acts when it was stolen.
-///
-/// On the frame first-responder is reclaimed *from* a CEF subview, release all tracked keys: while a
-/// CEF subview held first-responder it consumed key-up events winit never saw, so modifiers (Cmd in
-/// particular) can be stuck "pressed" in [`ButtonInput`] and would swallow subsequent typing.
 pub(crate) fn apply_winit_host_focus(
     _non_send: NonSendMarker,
     intent: Res<HostFocusIntent>,

--- a/crates/vmux_desktop/src/focus_native.rs
+++ b/crates/vmux_desktop/src/focus_native.rs
@@ -71,21 +71,22 @@ fn reclaim_first_responder(window_entity: Entity) -> ReclaimOutcome {
     let Some(window) = view.window() else {
         return ReclaimOutcome::NoView;
     };
-    if !window.isKeyWindow() {
-        return ReclaimOutcome::Failed;
-    }
     let responder: &NSResponder = view;
-    if let Some(current) = window.firstResponder()
-        && core::ptr::eq(
+    let already_winit = window.firstResponder().is_some_and(|current| {
+        core::ptr::eq(
             (&*current) as *const NSResponder,
             responder as *const NSResponder,
         )
-    {
-        return ReclaimOutcome::AlreadyWinit;
+    });
+    if !already_winit && !window.makeFirstResponder(Some(responder)) {
+        return ReclaimOutcome::Failed;
     }
-    if window.makeFirstResponder(Some(responder)) {
-        ReclaimOutcome::Reclaimed
+    if !window.isKeyWindow() {
+        return ReclaimOutcome::Failed;
+    }
+    if already_winit {
+        ReclaimOutcome::AlreadyWinit
     } else {
-        ReclaimOutcome::Failed
+        ReclaimOutcome::Reclaimed
     }
 }

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -341,7 +341,7 @@ fn add_terminal_update_systems(app: &mut App) -> &mut App {
         .add_message::<vmux_core::notify::BellReceived>()
         .add_systems(Update, apply_osc_title.after(poll_service_messages))
         .add_systems(Update, clear_osc_title_on_exit.after(poll_service_messages))
-        .add_systems(Update, blur_focus_aware_agents.after(poll_service_messages))
+        .add_systems(Update, sync_agent_focus.after(poll_service_messages))
         .add_systems(
             Update,
             handle_terminal_page_open.in_set(PageOpenSet::HandleKnownPages),
@@ -1031,25 +1031,34 @@ fn line_has_content(line: &vmux_core::event::TermLine) -> bool {
     line.spans.iter().any(|s| !s.text.trim().is_empty())
 }
 
-fn blur_focus_aware_agents(
-    agents: Query<
-        (Entity, &ProcessId),
-        (
-            With<vmux_core::agent::AgentSession>,
-            Without<AgentFocusBlurred>,
-        ),
-    >,
+#[allow(clippy::type_complexity)]
+fn sync_agent_focus(
+    agents: Query<(Entity, &ProcessId, Has<AgentFocusBlurred>), With<vmux_core::agent::AgentSession>>,
+    terminals: Query<(Entity, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
+    focus: Res<vmux_layout::stack::FocusedStack>,
     mode_map: Res<TerminalModeMap>,
     service: Option<Res<ServiceClient>>,
     mut commands: Commands,
 ) {
     let Some(service) = service else { return };
-    for (entity, process_id) in &agents {
-        if mode_map
+    let active_pid = crate::target::active_terminal_for_tab(focus.stack, &terminals)
+        .and_then(|entity| agents.get(entity).ok().map(|(_, pid, _)| *pid));
+    for (entity, process_id, blurred) in &agents {
+        if !mode_map
             .modes
             .get(process_id)
             .is_some_and(|m| m.focus_reporting)
         {
+            continue;
+        }
+        let active = Some(*process_id) == active_pid;
+        if active && blurred {
+            service.0.send(ClientMessage::ProcessInput {
+                process_id: *process_id,
+                data: b"\x1b[I".to_vec(),
+            });
+            commands.entity(entity).remove::<AgentFocusBlurred>();
+        } else if !active && !blurred {
             service.0.send(ClientMessage::ProcessInput {
                 process_id: *process_id,
                 data: b"\x1b[O".to_vec(),

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -1033,7 +1033,10 @@ fn line_has_content(line: &vmux_core::event::TermLine) -> bool {
 
 #[allow(clippy::type_complexity)]
 fn sync_agent_focus(
-    agents: Query<(Entity, &ProcessId, Has<AgentFocusBlurred>), With<vmux_core::agent::AgentSession>>,
+    agents: Query<
+        (Entity, &ProcessId, Has<AgentFocusBlurred>),
+        With<vmux_core::agent::AgentSession>,
+    >,
     terminals: Query<(Entity, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
     focus: Res<vmux_layout::stack::FocusedStack>,
     mode_map: Res<TerminalModeMap>,

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
@@ -1528,9 +1528,9 @@ impl Browsers {
             size.clone(),
             device_scale.clone(),
         ))
-        .with_wake(texture_wake);
+        .with_wake(texture_wake.clone());
         let client = if cancel_native_focus {
-            client.with_focus_handler(FocusCanceler::build())
+            client.with_focus_handler(FocusCanceler::build(texture_wake))
         } else {
             client
         };
@@ -1997,7 +1997,7 @@ mod tests {
 
         assert!(implementation.contains("allow_native_focus"));
         assert!(implementation.contains("if cancel_native_focus"));
-        assert!(implementation.contains(".with_focus_handler(FocusCanceler::build())"));
+        assert!(implementation.contains(".with_focus_handler(FocusCanceler::build(texture_wake))"));
         assert!(implementation.contains("pub fn set_windowed_focus"));
     }
 

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/client_handler.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/client_handler.rs
@@ -24,14 +24,19 @@ pub use snapshot_result_handler::{SnapshotResultHandler, SnapshotResultRaw};
 // keyboard. Without this, a native (windowed) browser's NSView becomes first responder and steals
 // every key from Bevy — all non-menu shortcuts die. Typing still reaches the page via the
 // `CefKeyboardTarget` forwarding path (keyboard.rs), exactly as in OSR mode.
+//
+// In windowed mode `on_set_focus` cancel is only advisory — the OS view still takes first responder
+// when the page loads — so `on_got_focus` wakes the host loop to reclaim it for the winit view.
 pub struct FocusCanceler {
     object: *mut RcImpl<sys::cef_focus_handler_t, Self>,
+    wake: Option<TextureWake>,
 }
 
 impl FocusCanceler {
-    pub fn build() -> FocusHandler {
+    pub fn build(wake: Option<TextureWake>) -> FocusHandler {
         FocusHandler::new(Self {
             object: core::ptr::null_mut(),
+            wake,
         })
     }
 }
@@ -52,7 +57,10 @@ impl Clone for FocusCanceler {
             rc_impl.interface.add_ref();
             rc_impl
         };
-        Self { object }
+        Self {
+            object,
+            wake: self.wake.clone(),
+        }
     }
 }
 
@@ -65,6 +73,12 @@ impl WrapFocusHandler for FocusCanceler {
 impl ImplFocusHandler for FocusCanceler {
     fn on_set_focus(&self, _browser: Option<&mut Browser>, _source: FocusSource) -> c_int {
         1
+    }
+
+    fn on_got_focus(&self, _browser: Option<&mut Browser>) {
+        if let Some(wake) = &self.wake {
+            wake();
+        }
     }
 
     #[inline]


### PR DESCRIPTION
## Context

Typing stopped working in vibe tabs ("doesn't take keyboard input anymore"), and with multiple vibes only the **first** accepted input. Root causes, all recent regressions:

1. **#139 (vibe focus-bell)** sent a terminal focus-out (`ESC[O`) to every focus-reporting agent and **never a focus-in**, leaving the Vibe TUI in its "unfocused" state where it stops showing typed input. Only the first tab (still in its default-focused startup state) appeared to work. This is exactly why multiple vibes work in tmux — tmux sends focus-in to the active pane.
2. **#144** added an `isKeyWindow` guard to `reclaim_first_responder`, blocking the winit content view from regaining first-responder while the host window wasn't key.
3. Windowed terminal webviews take macOS first-responder on load (bypassing CEF's focus handler), so keys stopped reaching Bevy for later tabs.
4. The command-bar (CEF modal) consumed `Cmd` key-ups, leaving the modifier stuck "pressed" and swallowing input.

## Implementation

- `sync_agent_focus` (replaces `blur_focus_aware_agents`): focus-**in** the active agent, focus-**out** only background ones. The active tab always accepts input; background tabs still get focus-out so the done-bell fires.
- `FocusCanceler::on_got_focus` fires the host wake (`TextureWake`) so the first-responder reclaim runs the instant a terminal webview grabs focus — deterministic, no polling/race.
- `reclaim_first_responder` hands first-responder to the winit view even when the window isn't key; `apply_winit_host_focus` re-asserts it in `WinitHost`, so terminal keys reach Bevy.
- On reclaim from a CEF subview, `release_all` clears modifiers stuck by swallowed key-ups.

## Checks / QA (runtime-verified)

- Open multiple vibe tabs; type in each and switch among them — all accept input (10/10).
- Background vibe still rings the done-bell on completion; the active tab does not.
- Single vibe types immediately, including when opened via the command bar.
- Browse / Le Chat Web pages still type; keyboard-follows-mouse + space restore intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard focus recovery in windowed mode with more accurate first-responder reclaim and proper release of any held modifier/button states after success.
  * Refined focus-cancel handling for embedded browser flows by adding optional wake integration when focus is obtained.
  * Updated terminal focus synchronization so the active terminal process is correctly unblurred and inactive agents are blurred based on the current focused process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->