### PR TITLE
fix(vibe): stabilize keyboard focus across tabs

### DIFF
--- a/crates/vmux_desktop/src/focus_native.rs
+++ b/crates/vmux_desktop/src/focus_native.rs
@@ -2,43 +2,33 @@ use bevy::ecs::system::NonSendMarker;
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 use vmux_browser::HostFocusIntent;
-use vmux_layout::stack::FocusedStack;
 
-/// When the active page is a terminal (OSR) or there is none, the winit host window must own
-/// macOS first-responder so Bevy delivers keys (terminal → PTY, layout shortcuts). A previously
-/// focused windowed web page or the command bar leaves its native `NSView` as first-responder,
-/// which blacks out the host keyboard — so while [`HostFocusIntent::WinitHost`] is active we hand
-/// first-responder back to the winit content view.
+/// In [`HostFocusIntent::WinitHost`] (a terminal/OSR page is active) the winit content view must own
+/// macOS first-responder so Bevy delivers keys to the focused terminal. A windowed CEF page in the
+/// stack — e.g. a terminal webview that autofocuses on load, or the command bar modal — can steal it
+/// a frame or more later, so re-assert every frame. [`reclaim_first_responder`] is a no-op once the
+/// winit view already holds first-responder, so this only acts when it was stolen.
 ///
-/// The reclaim is retried each frame *until it sticks*, then stops: the active page/command bar can
-/// resign a frame after the intent flips (so a one-shot reclaim would miss it), but re-asserting
-/// every frame fights the page for first-responder and breaks input.
+/// On the frame first-responder is reclaimed *from* a CEF subview, release all tracked keys: while a
+/// CEF subview held first-responder it consumed key-up events winit never saw, so modifiers (Cmd in
+/// particular) can be stuck "pressed" in [`ButtonInput`] and would swallow subsequent typing.
 pub(crate) fn apply_winit_host_focus(
     _non_send: NonSendMarker,
     intent: Res<HostFocusIntent>,
-    focus: Res<FocusedStack>,
     primary: Query<Entity, With<PrimaryWindow>>,
-    mut reclaimed: Local<bool>,
-    mut last_stack: Local<Option<Entity>>,
+    mut keys: ResMut<ButtonInput<KeyCode>>,
 ) {
-    if focus.stack != *last_stack {
-        *last_stack = focus.stack;
-        *reclaimed = false;
-    }
     if *intent != HostFocusIntent::WinitHost {
-        *reclaimed = false;
-        return;
-    }
-    if *reclaimed {
         return;
     }
     let Ok(window_entity) = primary.single() else {
         return;
     };
-    match reclaim_first_responder(window_entity) {
-        ReclaimOutcome::AlreadyWinit | ReclaimOutcome::Reclaimed => *reclaimed = true,
-        // Window/view not ready or the current responder refused to resign — retry next frame.
-        ReclaimOutcome::Failed | ReclaimOutcome::NoView => {}
+    if matches!(
+        reclaim_first_responder(window_entity),
+        ReclaimOutcome::Reclaimed
+    ) {
+        keys.release_all();
     }
 }
 

--- a/crates/vmux_desktop/src/focus_native.rs
+++ b/crates/vmux_desktop/src/focus_native.rs
@@ -3,15 +3,6 @@ use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 use vmux_browser::HostFocusIntent;
 
-/// In [`HostFocusIntent::WinitHost`] (a terminal/OSR page is active) the winit content view must own
-/// macOS first-responder so Bevy delivers keys to the focused terminal. A windowed CEF page in the
-/// stack — e.g. a terminal webview that autofocuses on load, or the command bar modal — can steal it
-/// a frame or more later, so re-assert every frame. [`reclaim_first_responder`] is a no-op once the
-/// winit view already holds first-responder, so this only acts when it was stolen.
-///
-/// On the frame first-responder is reclaimed *from* a CEF subview, release all tracked keys: while a
-/// CEF subview held first-responder it consumed key-up events winit never saw, so modifiers (Cmd in
-/// particular) can be stuck "pressed" in [`ButtonInput`] and would swallow subsequent typing.
 pub(crate) fn apply_winit_host_focus(
     _non_send: NonSendMarker,
     intent: Res<HostFocusIntent>,

--- a/crates/vmux_desktop/src/focus_native.rs
+++ b/crates/vmux_desktop/src/focus_native.rs
@@ -8,16 +8,18 @@ pub(crate) fn apply_winit_host_focus(
     intent: Res<HostFocusIntent>,
     primary: Query<Entity, With<PrimaryWindow>>,
     mut keys: ResMut<ButtonInput<KeyCode>>,
+    mut pending_key_window: Local<bool>,
 ) {
     if *intent != HostFocusIntent::WinitHost {
+        *pending_key_window = false;
         return;
     }
     let Ok(window_entity) = primary.single() else {
         return;
     };
-    if matches!(
+    if should_release_keys(
         reclaim_first_responder(window_entity),
-        ReclaimOutcome::Reclaimed
+        &mut pending_key_window,
     ) {
         keys.release_all();
     }
@@ -26,8 +28,27 @@ pub(crate) fn apply_winit_host_focus(
 enum ReclaimOutcome {
     AlreadyWinit,
     Reclaimed,
+    PendingKeyWindow,
     Failed,
     NoView,
+}
+
+fn should_release_keys(outcome: ReclaimOutcome, pending_key_window: &mut bool) -> bool {
+    match outcome {
+        ReclaimOutcome::Reclaimed => {
+            *pending_key_window = false;
+            true
+        }
+        ReclaimOutcome::PendingKeyWindow => {
+            *pending_key_window = true;
+            false
+        }
+        ReclaimOutcome::AlreadyWinit if *pending_key_window => {
+            *pending_key_window = false;
+            true
+        }
+        ReclaimOutcome::AlreadyWinit | ReclaimOutcome::Failed | ReclaimOutcome::NoView => false,
+    }
 }
 
 /// Make the winit content view the window's first responder.
@@ -59,15 +80,40 @@ fn reclaim_first_responder(window_entity: Entity) -> ReclaimOutcome {
             responder as *const NSResponder,
         )
     });
-    if !already_winit && !window.makeFirstResponder(Some(responder)) {
+    let changed_responder = !already_winit;
+    if changed_responder && !window.makeFirstResponder(Some(responder)) {
         return ReclaimOutcome::Failed;
     }
     if !window.isKeyWindow() {
+        if changed_responder {
+            return ReclaimOutcome::PendingKeyWindow;
+        }
         return ReclaimOutcome::Failed;
     }
     if already_winit {
         ReclaimOutcome::AlreadyWinit
     } else {
         ReclaimOutcome::Reclaimed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pending_key_window_releases_keys_when_winit_becomes_responder() {
+        let mut pending = false;
+
+        assert!(!should_release_keys(
+            ReclaimOutcome::PendingKeyWindow,
+            &mut pending
+        ));
+        assert!(pending);
+        assert!(should_release_keys(
+            ReclaimOutcome::AlreadyWinit,
+            &mut pending
+        ));
+        assert!(!pending);
     }
 }

--- a/crates/vmux_desktop/src/focus_native.rs
+++ b/crates/vmux_desktop/src/focus_native.rs
@@ -71,21 +71,22 @@ fn reclaim_first_responder(window_entity: Entity) -> ReclaimOutcome {
     let Some(window) = view.window() else {
         return ReclaimOutcome::NoView;
     };
-    if !window.isKeyWindow() {
-        return ReclaimOutcome::Failed;
-    }
     let responder: &NSResponder = view;
-    if let Some(current) = window.firstResponder()
-        && core::ptr::eq(
+    let already_winit = window.firstResponder().is_some_and(|current| {
+        core::ptr::eq(
             (&*current) as *const NSResponder,
             responder as *const NSResponder,
         )
-    {
-        return ReclaimOutcome::AlreadyWinit;
+    });
+    if !already_winit && !window.makeFirstResponder(Some(responder)) {
+        return ReclaimOutcome::Failed;
     }
-    if window.makeFirstResponder(Some(responder)) {
-        ReclaimOutcome::Reclaimed
+    if !window.isKeyWindow() {
+        return ReclaimOutcome::Failed;
+    }
+    if already_winit {
+        ReclaimOutcome::AlreadyWinit
     } else {
-        ReclaimOutcome::Failed
+        ReclaimOutcome::Reclaimed
     }
 }

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -1545,7 +1545,14 @@ fn is_non_character_key(key: KeyCode) -> bool {
 
 fn handle_terminal_keyboard(
     mut er: MessageReader<KeyboardInput>,
-    targeted_terminals: Query<(&ProcessId, &ChildOf), (With<Terminal>, With<CefKeyboardTarget>)>,
+    targeted_terminals: Query<
+        (&ProcessId, &ChildOf),
+        (
+            With<Terminal>,
+            With<CefKeyboardTarget>,
+            Without<ProcessExited>,
+        ),
+    >,
     keyboard_targets: Query<(), With<CefKeyboardTarget>>,
     terminals: Query<(&ProcessId, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
     focus: Res<vmux_layout::stack::FocusedStack>,
@@ -2977,7 +2984,14 @@ fn on_restart_pty(
 /// visual/copy mode for the currently focused terminal process.
 fn handle_terminal_copy_mode_command(
     mut er: MessageReader<AppCommand>,
-    targeted_terminals: Query<(&ProcessId, &ChildOf), (With<Terminal>, With<CefKeyboardTarget>)>,
+    targeted_terminals: Query<
+        (&ProcessId, &ChildOf),
+        (
+            With<Terminal>,
+            With<CefKeyboardTarget>,
+            Without<ProcessExited>,
+        ),
+    >,
     keyboard_targets: Query<(), With<CefKeyboardTarget>>,
     terminals: Query<(&ProcessId, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
     focus: Res<vmux_layout::stack::FocusedStack>,

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -341,7 +341,7 @@ fn add_terminal_update_systems(app: &mut App) -> &mut App {
         .add_message::<vmux_core::notify::BellReceived>()
         .add_systems(Update, apply_osc_title.after(poll_service_messages))
         .add_systems(Update, clear_osc_title_on_exit.after(poll_service_messages))
-        .add_systems(Update, blur_focus_aware_agents.after(poll_service_messages))
+        .add_systems(Update, sync_agent_focus.after(poll_service_messages))
         .add_systems(
             Update,
             handle_terminal_page_open.in_set(PageOpenSet::HandleKnownPages),
@@ -1031,30 +1031,65 @@ fn line_has_content(line: &vmux_core::event::TermLine) -> bool {
     line.spans.iter().any(|s| !s.text.trim().is_empty())
 }
 
-fn blur_focus_aware_agents(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AgentFocusTransition {
+    FocusIn,
+    FocusOut,
+}
+
+fn agent_focus_transition(
+    focus_reporting: bool,
+    active: bool,
+    blurred: bool,
+) -> Option<AgentFocusTransition> {
+    if !focus_reporting {
+        None
+    } else if active && blurred {
+        Some(AgentFocusTransition::FocusIn)
+    } else if !active && !blurred {
+        Some(AgentFocusTransition::FocusOut)
+    } else {
+        None
+    }
+}
+
+#[allow(clippy::type_complexity)]
+fn sync_agent_focus(
     agents: Query<
-        (Entity, &ProcessId),
-        (
-            With<vmux_core::agent::AgentSession>,
-            Without<AgentFocusBlurred>,
-        ),
+        (Entity, &ProcessId, Has<AgentFocusBlurred>),
+        With<vmux_core::agent::AgentSession>,
     >,
+    terminals: Query<(Entity, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
+    focus: Res<vmux_layout::stack::FocusedStack>,
     mode_map: Res<TerminalModeMap>,
     service: Option<Res<ServiceClient>>,
     mut commands: Commands,
 ) {
     let Some(service) = service else { return };
-    for (entity, process_id) in &agents {
-        if mode_map
+    let active_pid = crate::target::active_terminal_for_tab(focus.stack, &terminals)
+        .and_then(|entity| agents.get(entity).ok().map(|(_, pid, _)| *pid));
+    for (entity, process_id, blurred) in &agents {
+        let focus_reporting = mode_map
             .modes
             .get(process_id)
-            .is_some_and(|m| m.focus_reporting)
-        {
-            service.0.send(ClientMessage::ProcessInput {
-                process_id: *process_id,
-                data: b"\x1b[O".to_vec(),
-            });
-            commands.entity(entity).insert(AgentFocusBlurred);
+            .is_some_and(|m| m.focus_reporting);
+        let active = Some(*process_id) == active_pid;
+        match agent_focus_transition(focus_reporting, active, blurred) {
+            Some(AgentFocusTransition::FocusIn) => {
+                service.0.send(ClientMessage::ProcessInput {
+                    process_id: *process_id,
+                    data: b"\x1b[I".to_vec(),
+                });
+                commands.entity(entity).remove::<AgentFocusBlurred>();
+            }
+            Some(AgentFocusTransition::FocusOut) => {
+                service.0.send(ClientMessage::ProcessInput {
+                    process_id: *process_id,
+                    data: b"\x1b[O".to_vec(),
+                });
+                commands.entity(entity).insert(AgentFocusBlurred);
+            }
+            None => {}
         }
     }
 }
@@ -1508,16 +1543,9 @@ fn is_non_character_key(key: KeyCode) -> bool {
     )
 }
 
-/// Handle keyboard input directly from Bevy, bypassing CEF round-trip.
-///
-/// Only routes input to the single focused terminal (CefKeyboardTarget is
-/// expected to mark exactly one entity). If multiple terminals are
-/// keyboard-targeted simultaneously, only the first is used and the rest
-/// are ignored — copy-mode and Cmd+C decisions are per-terminal so we
-/// must not broadcast them.
 fn handle_terminal_keyboard(
     mut er: MessageReader<KeyboardInput>,
-    targeted_terminals: Query<&ProcessId, (With<Terminal>, With<CefKeyboardTarget>)>,
+    targeted_terminals: Query<(&ProcessId, &ChildOf), (With<Terminal>, With<CefKeyboardTarget>)>,
     keyboard_targets: Query<(), With<CefKeyboardTarget>>,
     terminals: Query<(&ProcessId, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
     focus: Res<vmux_layout::stack::FocusedStack>,
@@ -1529,7 +1557,9 @@ fn handle_terminal_keyboard(
     mut local_copy_mode: ResMut<LocalCopyModeState>,
 ) {
     let target_processes = resolve_terminal_input_targets(
-        targeted_terminals.iter().copied(),
+        targeted_terminals
+            .iter()
+            .map(|(pid, child_of)| (child_of.get(), *pid)),
         !keyboard_targets.is_empty(),
         focus.stack,
         terminals
@@ -1880,26 +1910,47 @@ fn key_char_eq(input: CopyModeKeyInput<'_>, expected: char) -> bool {
 }
 
 fn resolve_terminal_input_targets(
-    targeted_terminal_ids: impl IntoIterator<Item = ProcessId>,
+    targeted_terminal_ids_by_stack: impl IntoIterator<Item = (Entity, ProcessId)>,
     any_keyboard_target_active: bool,
-    focused_tab: Option<Entity>,
-    terminal_ids_by_tab: impl IntoIterator<Item = (Entity, ProcessId)>,
+    focused_stack: Option<Entity>,
+    terminal_ids_by_stack: impl IntoIterator<Item = (Entity, ProcessId)>,
     mode: vmux_layout::scene::InteractionMode,
 ) -> Vec<ProcessId> {
-    let targeted: Vec<ProcessId> = targeted_terminal_ids.into_iter().collect();
+    let targeted: Vec<(Entity, ProcessId)> = targeted_terminal_ids_by_stack.into_iter().collect();
+    let focused = focused_stack.and_then(|focused_stack| {
+        let focused: Vec<ProcessId> = terminal_ids_by_stack
+            .into_iter()
+            .filter_map(|(stack, process_id)| (stack == focused_stack).then_some(process_id))
+            .collect();
+        (!focused.is_empty()).then_some(focused)
+    });
     if !targeted.is_empty() {
-        return targeted;
+        if let Some(focused_stack) = focused_stack {
+            let focused: Vec<ProcessId> = targeted
+                .iter()
+                .filter_map(|(stack, process_id)| (*stack == focused_stack).then_some(*process_id))
+                .collect();
+            if !focused.is_empty() {
+                return focused;
+            }
+        }
+        if mode == vmux_layout::scene::InteractionMode::User
+            && let Some(focused) = focused
+        {
+            return focused;
+        }
+        if mode == vmux_layout::scene::InteractionMode::User && focused_stack.is_some() {
+            return Vec::new();
+        }
+        return targeted
+            .into_iter()
+            .map(|(_, process_id)| process_id)
+            .collect();
     }
     if any_keyboard_target_active || mode != vmux_layout::scene::InteractionMode::User {
         return Vec::new();
     }
-    let Some(focused_tab) = focused_tab else {
-        return Vec::new();
-    };
-    terminal_ids_by_tab
-        .into_iter()
-        .filter_map(|(tab, process_id)| (tab == focused_tab).then_some(process_id))
-        .collect()
+    focused.unwrap_or_default()
 }
 
 fn logical_key_to_bytes(key: &Key, ctrl: bool, alt: bool) -> Vec<u8> {
@@ -2926,7 +2977,7 @@ fn on_restart_pty(
 /// visual/copy mode for the currently focused terminal process.
 fn handle_terminal_copy_mode_command(
     mut er: MessageReader<AppCommand>,
-    targeted_terminals: Query<&ProcessId, (With<Terminal>, With<CefKeyboardTarget>)>,
+    targeted_terminals: Query<(&ProcessId, &ChildOf), (With<Terminal>, With<CefKeyboardTarget>)>,
     keyboard_targets: Query<(), With<CefKeyboardTarget>>,
     terminals: Query<(&ProcessId, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
     focus: Res<vmux_layout::stack::FocusedStack>,
@@ -2939,7 +2990,9 @@ fn handle_terminal_copy_mode_command(
         return;
     };
     let target_processes = resolve_terminal_input_targets(
-        targeted_terminals.iter().copied(),
+        targeted_terminals
+            .iter()
+            .map(|(pid, child_of)| (child_of.get(), *pid)),
         !keyboard_targets.is_empty(),
         focus.stack,
         terminals
@@ -3324,14 +3377,14 @@ mod tests {
 
     #[test]
     fn terminal_input_targets_fallback_to_focused_terminal_in_user_mode() {
-        let tab = Entity::from_bits(1);
+        let stack = Entity::from_bits(1);
         let process_id = process_id(7);
 
         let targets = resolve_terminal_input_targets(
             [],
             false,
-            Some(tab),
-            [(tab, process_id)],
+            Some(stack),
+            [(stack, process_id)],
             vmux_layout::scene::InteractionMode::User,
         );
 
@@ -3340,17 +3393,78 @@ mod tests {
 
     #[test]
     fn terminal_input_targets_do_not_steal_input_from_non_terminal_target() {
-        let tab = Entity::from_bits(1);
+        let stack = Entity::from_bits(1);
 
         let targets = resolve_terminal_input_targets(
             [],
             true,
-            Some(tab),
-            [(tab, process_id(7))],
+            Some(stack),
+            [(stack, process_id(7))],
             vmux_layout::scene::InteractionMode::User,
         );
 
         assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn terminal_input_targets_choose_focused_terminal_when_multiple_targets_exist() {
+        let stale_stack = Entity::from_bits(1);
+        let focused_stack = Entity::from_bits(2);
+        let stale_pid = process_id(7);
+        let focused_pid = process_id(8);
+
+        let targets = resolve_terminal_input_targets(
+            [(stale_stack, stale_pid), (focused_stack, focused_pid)],
+            true,
+            Some(focused_stack),
+            [(stale_stack, stale_pid), (focused_stack, focused_pid)],
+            vmux_layout::scene::InteractionMode::User,
+        );
+
+        assert_eq!(targets, vec![focused_pid]);
+    }
+
+    #[test]
+    fn terminal_input_targets_choose_focused_terminal_when_targets_are_stale() {
+        let stale_stack = Entity::from_bits(1);
+        let focused_stack = Entity::from_bits(2);
+        let stale_pid = process_id(7);
+        let focused_pid = process_id(8);
+
+        let targets = resolve_terminal_input_targets(
+            [(stale_stack, stale_pid)],
+            true,
+            Some(focused_stack),
+            [(stale_stack, stale_pid), (focused_stack, focused_pid)],
+            vmux_layout::scene::InteractionMode::User,
+        );
+
+        assert_eq!(targets, vec![focused_pid]);
+    }
+
+    #[test]
+    fn terminal_input_targets_ignore_stale_targets_when_focus_is_not_terminal() {
+        let stale_stack = Entity::from_bits(1);
+        let focused_stack = Entity::from_bits(2);
+        let stale_pid = process_id(7);
+
+        let targets = resolve_terminal_input_targets(
+            [(stale_stack, stale_pid)],
+            true,
+            Some(focused_stack),
+            [(stale_stack, stale_pid)],
+            vmux_layout::scene::InteractionMode::User,
+        );
+
+        assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn agent_focus_transition_restores_focus_to_active_blurred_agent() {
+        assert_eq!(
+            agent_focus_transition(true, true, true),
+            Some(AgentFocusTransition::FocusIn)
+        );
     }
 
     #[test]

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
@@ -1528,9 +1528,9 @@ impl Browsers {
             size.clone(),
             device_scale.clone(),
         ))
-        .with_wake(texture_wake);
+        .with_wake(texture_wake.clone());
         let client = if cancel_native_focus {
-            client.with_focus_handler(FocusCanceler::build())
+            client.with_focus_handler(FocusCanceler::build(texture_wake))
         } else {
             client
         };
@@ -1997,7 +1997,7 @@ mod tests {
 
         assert!(implementation.contains("allow_native_focus"));
         assert!(implementation.contains("if cancel_native_focus"));
-        assert!(implementation.contains(".with_focus_handler(FocusCanceler::build())"));
+        assert!(implementation.contains(".with_focus_handler(FocusCanceler::build(texture_wake))"));
         assert!(implementation.contains("pub fn set_windowed_focus"));
     }
 

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/client_handler.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/client_handler.rs
@@ -26,12 +26,14 @@ pub use snapshot_result_handler::{SnapshotResultHandler, SnapshotResultRaw};
 // `CefKeyboardTarget` forwarding path (keyboard.rs), exactly as in OSR mode.
 pub struct FocusCanceler {
     object: *mut RcImpl<sys::cef_focus_handler_t, Self>,
+    wake: Option<TextureWake>,
 }
 
 impl FocusCanceler {
-    pub fn build() -> FocusHandler {
+    pub fn build(wake: Option<TextureWake>) -> FocusHandler {
         FocusHandler::new(Self {
             object: core::ptr::null_mut(),
+            wake,
         })
     }
 }
@@ -52,7 +54,10 @@ impl Clone for FocusCanceler {
             rc_impl.interface.add_ref();
             rc_impl
         };
-        Self { object }
+        Self {
+            object,
+            wake: self.wake.clone(),
+        }
     }
 }
 
@@ -65,6 +70,12 @@ impl WrapFocusHandler for FocusCanceler {
 impl ImplFocusHandler for FocusCanceler {
     fn on_set_focus(&self, _browser: Option<&mut Browser>, _source: FocusSource) -> c_int {
         1
+    }
+
+    fn on_got_focus(&self, _browser: Option<&mut Browser>) {
+        if let Some(wake) = &self.wake {
+            wake();
+        }
     }
 
     #[inline]


### PR DESCRIPTION
## Context

Supersedes Claude PR #152. Multiple Vibe tabs could race focus state so a tab sometimes stopped accepting keyboard input even while visually focused.

## Implementation

Keeps the Claude PR's focus-reporting fix so the active agent terminal receives focus-in and inactive agents receive focus-out. Adds stale `CefKeyboardTarget` resolution so keyboard input follows the focused terminal when old targets linger, and wakes the host loop when CEF gets native focus so winit can reclaim input.

## Checks / QA

Spawn four or more Vibe tabs, switch between them, and verify each tab accepts typing after activation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved agent focus synchronization for terminals, with clearer focus-in/out transitions and updated focus reporting behavior.
  * Refined stack-aware terminal keyboard and copy-mode routing for more reliable target selection.
* **Bug Fixes**
  * Fixed stuck-key scenarios by ensuring pressed keys are released appropriately after focus is restored.
  * Improved focus recovery so embedded browser views and native focus-cancel behavior respond more reliably.
  * Reduced stale terminal routing when focus is on non-terminal stacks or targets become invalid.
* **Tests**
  * Added/updated coverage for the new focus and key-release behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->