### PR TITLE
feat(editor): dir view selects came-from dir on parent nav

### DIFF
--- a/crates/vmux_editor/src/page.rs
+++ b/crates/vmux_editor/src/page.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use crate::page_model::{clamp_selection, gutter_width, image_mime, span_style};
+use crate::page_model::{clamp_selection, dir_select_index, gutter_width, image_mime, span_style};
 use dioxus::prelude::*;
 use vmux_core::event::*;
 use vmux_git::ui::{DiffView, GitBar, GitFooter};
@@ -139,12 +139,12 @@ fn apply_dir(
     entries: Vec<FileDirEntry>,
     parent: Vec<FileDirEntry>,
     new_path: String,
+    select_path: Option<String>,
 ) {
     for url in thumbs.read().values() {
         revoke(url);
     }
     thumbs.set(HashMap::new());
-    selected.set(0);
     if let Preview::Image(old) = &*preview.read() {
         revoke(old);
     }
@@ -152,8 +152,13 @@ fn apply_dir(
     parent_entries.set(parent);
     path.set(new_path);
     let vis = visible_entries(&entries, show_hidden);
-    if let Some(first) = vis.first() {
-        request_preview(first.path.clone());
+    let sel_idx = select_path
+        .as_deref()
+        .map(|p| dir_select_index(&vis, p))
+        .unwrap_or(0);
+    selected.set(sel_idx);
+    if let Some(sel) = vis.get(sel_idx) {
+        request_preview(sel.path.clone());
     }
     for e in &vis {
         if !e.is_dir && image_mime(&e.path).is_some() {
@@ -336,6 +341,7 @@ pub fn Page() -> Element {
     let parent_entries = use_signal(Vec::<FileDirEntry>::new);
     let mut parent_path = use_signal(String::new);
     let mut selected = use_signal(|| 0usize);
+    let mut came_from = use_signal(String::new);
     let mut back_dir = use_signal(|| Option::<String>::None);
     let mut show_hidden = use_signal(|| true);
     let mut mode = use_signal(|| Mode::Text);
@@ -392,6 +398,8 @@ pub fn Page() -> Element {
         git_path.set(d.abs_path);
         git_nonce.set(git_nonce() + 1);
         mode.set(Mode::Dir);
+        let came = came_from();
+        came_from.set(String::new());
         apply_dir(
             dir_entries,
             parent_entries,
@@ -403,6 +411,7 @@ pub fn Page() -> Element {
             d.entries,
             d.parent_entries,
             d.path,
+            (!came.is_empty()).then_some(came),
         );
     });
 
@@ -572,6 +581,7 @@ pub fn Page() -> Element {
                                             children,
                                             cur_entries,
                                             ent.path.clone(),
+                                            None,
                                         );
                                     }
                                     open_path(ent.path);
@@ -584,6 +594,8 @@ pub fn Page() -> Element {
                                 let pp = parent_path();
                                 if !pp.is_empty() {
                                     e.prevent_default();
+                                    let came = path();
+                                    came_from.set(came.clone());
                                     let pe = parent_entries.read().clone();
                                     if !pe.is_empty() {
                                         parent_path.set(parent_of(&pp));
@@ -598,6 +610,7 @@ pub fn Page() -> Element {
                                             pe,
                                             Vec::new(),
                                             pp.clone(),
+                                            Some(came),
                                         );
                                     }
                                     open_path(pp);

--- a/crates/vmux_editor/src/page_model.rs
+++ b/crates/vmux_editor/src/page_model.rs
@@ -39,8 +39,16 @@ pub fn clamp_selection(idx: usize, len: usize) -> usize {
     if len == 0 { 0 } else { idx.min(len - 1) }
 }
 
-pub fn parent_highlight_index(parent: &[FileDirEntry], current_path: &str) -> Option<usize> {
-    parent.iter().position(|e| e.path == current_path)
+pub fn dir_select_index(entries: &[FileDirEntry], came_from: &str) -> usize {
+    let name = came_from
+        .trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .unwrap_or("");
+    if name.is_empty() {
+        return 0;
+    }
+    entries.iter().position(|e| e.name == name).unwrap_or(0)
 }
 
 pub fn gutter_width(total_lines: u32) -> usize {
@@ -119,13 +127,16 @@ mod dir_browser_tests {
     }
 
     #[test]
-    fn parent_highlight_matches_current_dir() {
+    fn dir_select_index_matches_came_from_by_basename() {
         let parent = vec![
             entry("/a/x", true),
-            entry("/a/b", true),
+            entry("/a/.worktrees", true),
             entry("/a/y", false),
         ];
-        assert_eq!(parent_highlight_index(&parent, "/a/b"), Some(1));
-        assert_eq!(parent_highlight_index(&parent, "/a/zzz"), None);
+        assert_eq!(dir_select_index(&parent, "/a/.worktrees"), 1);
+        assert_eq!(dir_select_index(&parent, "a/.worktrees/"), 1);
+        assert_eq!(dir_select_index(&parent, "~/proj/a/.worktrees"), 1);
+        assert_eq!(dir_select_index(&parent, "/a/zzz"), 0);
+        assert_eq!(dir_select_index(&parent, ""), 0);
     }
 }


### PR DESCRIPTION
## Context

In the `file://` editor's directory view, going to the parent directory always reset the highlight to the first entry. When ascending, the directory you just left should stay highlighted — e.g. coming up out of `.worktrees/` should land on `.worktrees`, not the alphabetically-first `.agents`.

## Implementation

- Record the directory being left (`came_from`) on parent navigation (`h` / `ArrowLeft` / `Escape`).
- `apply_dir` takes an optional `select_path`; when set, it selects the matching entry (and previews it) instead of index 0. Descend and initial open pass `None`, preserving "select first".
- Parent nav round-trips through `open_path` → `FILE_DIR_EVENT`, so `came_from` is consumed in that listener (the authoritative apply) and also used for the optimistic local apply, keeping both in sync.
- Matching is by **basename**, because `FileDirEvent.path` is a `display_path` (absolute, cwd-relative, or `~`) while listing entries are absolute — full-path matching would miss. This repurposes the unused, full-path `parent_highlight_index` into `dir_select_index`, now unit-tested in `page_model`.

## Checks / QA

- Open a directory in the editor, descend (`l` / `Enter`) into a child dir, then go back up (`h` / `ArrowLeft`) → the child you came from is highlighted (not the first entry).
- Repeat with a hidden dir like `.worktrees` (default `show_hidden` is on) → it's the selection on return.
- Confirm initial open and descend still select the first entry.
- `cargo test -p vmux_editor` covers `dir_select_index` (basename match across absolute/relative/`~`/trailing-slash, and fallback to 0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory navigation so returning to a parent folder now restores the previously viewed item instead of always selecting the first entry.
  * Directory selection now works more consistently with paths that include trailing slashes or nested locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->