### PR TITLE
feat(editor): minimap for files:// code editor

### DIFF
--- a/crates/vmux_core/src/event.rs
+++ b/crates/vmux_core/src/event.rs
@@ -14,6 +14,7 @@ pub const TERM_LOADING_EVENT: &str = "term_loading";
 pub const SERVICE_UNAVAILABLE_EVENT: &str = "service_unavailable";
 pub const FILE_META_EVENT: &str = "file_meta";
 pub const FILE_VIEWPORT_EVENT: &str = "file_viewport";
+pub const FILE_OVERVIEW_EVENT: &str = "file_overview";
 pub const FILE_ERROR_EVENT: &str = "file_error";
 pub const FILE_RESIZE_EVENT: &str = "file_resize";
 pub const FILE_SCROLL_EVENT: &str = "file_scroll";
@@ -88,6 +89,55 @@ pub struct FileViewportPatch {
     pub first_line: u32,
     pub total_lines: u32,
     pub lines: Vec<FileLine>,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct MinimapRun {
+    pub fg: [u8; 3],
+    pub start: u16,
+    pub len: u16,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct MinimapLine {
+    pub runs: Vec<MinimapRun>,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct FileOverviewPatch {
+    pub total_lines: u32,
+    pub lines: Vec<MinimapLine>,
 }
 
 #[derive(
@@ -347,6 +397,35 @@ mod file_event_tests {
             parent_entries: vec![],
         };
         assert_eq!(e.parent_path, "/a");
+    }
+
+    #[test]
+    fn file_overview_patch_rkyv_roundtrip() {
+        let patch = FileOverviewPatch {
+            total_lines: 5000,
+            lines: vec![MinimapLine {
+                runs: vec![
+                    MinimapRun {
+                        fg: [220, 220, 170],
+                        start: 0,
+                        len: 2,
+                    },
+                    MinimapRun {
+                        fg: [86, 156, 214],
+                        start: 4,
+                        len: 6,
+                    },
+                ],
+            }],
+        };
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&patch).expect("ser");
+        let decoded =
+            rkyv::from_bytes::<FileOverviewPatch, rkyv::rancor::Error>(&bytes).expect("de");
+        assert_eq!(decoded, patch);
+        assert_eq!(decoded.total_lines, 5000);
+        assert_eq!(decoded.lines[0].runs[1].fg, [86, 156, 214]);
+        assert_eq!(decoded.lines[0].runs[1].start, 4);
+        assert_eq!(decoded.lines[0].runs[1].len, 6);
     }
 }
 

--- a/crates/vmux_editor/Cargo.toml
+++ b/crates/vmux_editor/Cargo.toml
@@ -48,6 +48,7 @@ web-sys = { version = "0.3", features = [
     "Window", "Document", "Element", "HtmlElement", "Node",
     "DomRect", "CssStyleDeclaration",
     "ResizeObserver", "ResizeObserverEntry",
-    "WheelEvent", "KeyboardEvent", "Location",
+    "WheelEvent", "KeyboardEvent", "MouseEvent", "Location",
+    "HtmlCanvasElement", "CanvasRenderingContext2d",
     "Blob", "Url",
 ] }

--- a/crates/vmux_editor/src/lib.rs
+++ b/crates/vmux_editor/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod minimap;
 pub mod viewport;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/vmux_editor/src/minimap.rs
+++ b/crates/vmux_editor/src/minimap.rs
@@ -1,0 +1,212 @@
+use vmux_core::event::{FileLine, MinimapLine, MinimapRun};
+
+use crate::viewport::clamp_top_line;
+
+pub const MINIMAP_MAX_LINES: u32 = 100_000;
+pub const MINIMAP_MAX_RUNS_PER_LINE: usize = 256;
+
+pub fn build_overview(lines: &[FileLine]) -> Vec<MinimapLine> {
+    lines.iter().map(build_line).collect()
+}
+
+fn build_line(line: &FileLine) -> MinimapLine {
+    let mut runs: Vec<MinimapRun> = Vec::new();
+    let mut cur: Option<MinimapRun> = None;
+    let mut col: u32 = 0;
+    'outer: for span in &line.spans {
+        for ch in span.text.chars() {
+            let c = col.min(u16::MAX as u32) as u16;
+            if ch.is_whitespace() {
+                if let Some(run) = cur.take() {
+                    runs.push(run);
+                    if runs.len() >= MINIMAP_MAX_RUNS_PER_LINE {
+                        break 'outer;
+                    }
+                }
+            } else {
+                match cur.as_mut() {
+                    Some(run) if run.fg == span.fg => {
+                        run.len = run.len.saturating_add(1);
+                    }
+                    _ => {
+                        if let Some(run) = cur.take() {
+                            runs.push(run);
+                            if runs.len() >= MINIMAP_MAX_RUNS_PER_LINE {
+                                break 'outer;
+                            }
+                        }
+                        cur = Some(MinimapRun {
+                            fg: span.fg,
+                            start: c,
+                            len: 1,
+                        });
+                    }
+                }
+            }
+            col += 1;
+        }
+    }
+    if runs.len() < MINIMAP_MAX_RUNS_PER_LINE
+        && let Some(run) = cur.take()
+    {
+        runs.push(run);
+    }
+    MinimapLine { runs }
+}
+
+pub fn line_to_y(line: u32, total_lines: u32, height_px: f32) -> f32 {
+    if total_lines == 0 {
+        return 0.0;
+    }
+    let line = line.min(total_lines);
+    height_px * line as f32 / total_lines as f32
+}
+
+pub fn viewport_box(first_line: u32, rows: u16, total_lines: u32, height_px: f32) -> (f32, f32) {
+    if total_lines == 0 {
+        return (0.0, height_px);
+    }
+    let end = first_line.saturating_add(rows as u32).min(total_lines);
+    let y = line_to_y(first_line, total_lines, height_px);
+    let y_end = line_to_y(end, total_lines, height_px);
+    (y, y_end - y)
+}
+
+pub fn y_to_top_line(y_px: f32, height_px: f32, total_lines: u32, rows: u16) -> u32 {
+    if height_px <= 0.0 || total_lines == 0 {
+        return 0;
+    }
+    let frac = (y_px / height_px).clamp(0.0, 1.0);
+    let top = (frac * total_lines as f32).round().max(0.0) as u32;
+    clamp_top_line(top, total_lines, rows)
+}
+
+pub fn sample_step(total_lines: u32, height_px: f32) -> usize {
+    if height_px <= 0.0 || total_lines == 0 {
+        return 1;
+    }
+    ((total_lines as f32 / height_px).ceil() as usize).max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vmux_core::event::{FileLine, StyledSpan};
+
+    const A: [u8; 3] = [1, 2, 3];
+    const B: [u8; 3] = [9, 8, 7];
+
+    fn line(spans: &[(&str, [u8; 3])]) -> FileLine {
+        FileLine {
+            line_no: 0,
+            spans: spans
+                .iter()
+                .map(|(t, fg)| StyledSpan {
+                    text: (*t).into(),
+                    fg: *fg,
+                    bold: false,
+                    italic: false,
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn build_overview_whitespace_makes_gaps() {
+        let out = build_overview(&[line(&[("ab cd", A)])]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].runs.len(), 2);
+        assert_eq!((out[0].runs[0].start, out[0].runs[0].len), (0, 2));
+        assert_eq!((out[0].runs[1].start, out[0].runs[1].len), (3, 2));
+        assert_eq!(out[0].runs[0].fg, A);
+    }
+
+    #[test]
+    fn build_overview_merges_same_color_across_spans() {
+        let out = build_overview(&[line(&[("fn", A), ("x", A)])]);
+        assert_eq!(out[0].runs.len(), 1);
+        assert_eq!((out[0].runs[0].start, out[0].runs[0].len), (0, 3));
+    }
+
+    #[test]
+    fn build_overview_splits_on_color_change() {
+        let out = build_overview(&[line(&[("fn", A), ("x", B)])]);
+        assert_eq!(out[0].runs.len(), 2);
+        assert_eq!(out[0].runs[0].fg, A);
+        assert_eq!((out[0].runs[0].start, out[0].runs[0].len), (0, 2));
+        assert_eq!(out[0].runs[1].fg, B);
+        assert_eq!((out[0].runs[1].start, out[0].runs[1].len), (2, 1));
+    }
+
+    #[test]
+    fn build_overview_preserves_leading_indent() {
+        let out = build_overview(&[line(&[("    x", A)])]);
+        assert_eq!(out[0].runs.len(), 1);
+        assert_eq!((out[0].runs[0].start, out[0].runs[0].len), (4, 1));
+    }
+
+    #[test]
+    fn build_overview_empty_line_has_no_runs() {
+        let out = build_overview(&[line(&[]), line(&[("   ", A)])]);
+        assert_eq!(out.len(), 2);
+        assert!(out[0].runs.is_empty());
+        assert!(out[1].runs.is_empty());
+    }
+
+    #[test]
+    fn build_overview_caps_runs_per_line() {
+        let mut spans = Vec::new();
+        for i in 0..(MINIMAP_MAX_RUNS_PER_LINE + 50) {
+            let fg = if i % 2 == 0 { A } else { B };
+            spans.push(("x", fg));
+        }
+        let owned: Vec<(&str, [u8; 3])> = spans;
+        let out = build_overview(&[line(&owned)]);
+        assert_eq!(out[0].runs.len(), MINIMAP_MAX_RUNS_PER_LINE);
+    }
+
+    #[test]
+    fn line_to_y_fits_height() {
+        assert_eq!(line_to_y(0, 100, 200.0), 0.0);
+        assert_eq!(line_to_y(50, 100, 200.0), 100.0);
+        assert_eq!(line_to_y(100, 100, 200.0), 200.0);
+        assert_eq!(line_to_y(50, 0, 200.0), 0.0);
+    }
+
+    #[test]
+    fn viewport_box_top_middle_end() {
+        assert_eq!(viewport_box(0, 10, 100, 200.0), (0.0, 20.0));
+        assert_eq!(viewport_box(50, 10, 100, 200.0), (100.0, 20.0));
+        assert_eq!(viewport_box(95, 10, 100, 200.0), (190.0, 10.0));
+    }
+
+    #[test]
+    fn viewport_box_file_shorter_than_viewport_fills() {
+        assert_eq!(viewport_box(0, 10, 5, 200.0), (0.0, 200.0));
+    }
+
+    #[test]
+    fn viewport_box_empty_file_fills() {
+        assert_eq!(viewport_box(0, 10, 0, 200.0), (0.0, 200.0));
+    }
+
+    #[test]
+    fn y_to_top_line_round_trips_with_box() {
+        let (y, _) = viewport_box(50, 10, 100, 200.0);
+        assert_eq!(y_to_top_line(y, 200.0, 100, 10), 50);
+    }
+
+    #[test]
+    fn y_to_top_line_clamps_both_ends() {
+        assert_eq!(y_to_top_line(-5.0, 200.0, 100, 10), 0);
+        assert_eq!(y_to_top_line(500.0, 200.0, 100, 10), 90);
+    }
+
+    #[test]
+    fn sample_step_at_least_one_and_collapses() {
+        assert_eq!(sample_step(10, 500.0), 1);
+        assert_eq!(sample_step(100_000, 500.0), 200);
+        assert_eq!(sample_step(0, 500.0), 1);
+        assert_eq!(sample_step(100, 0.0), 1);
+    }
+}

--- a/crates/vmux_editor/src/page.rs
+++ b/crates/vmux_editor/src/page.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 
+use crate::minimap::{line_to_y, sample_step, viewport_box, y_to_top_line};
 use crate::page_model::{clamp_selection, gutter_width, image_mime, span_style};
 use dioxus::prelude::*;
 use vmux_core::event::*;
@@ -13,6 +14,7 @@ use wasm_bindgen::prelude::*;
 
 const CONTAINER_ID: &str = "file-container";
 const MEASURE_ID: &str = "file-measure";
+const MINIMAP_CANVAS_ID: &str = "file-minimap-canvas";
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Mode {
@@ -331,6 +333,8 @@ pub fn Page() -> Element {
     let mut total_lines = use_signal(|| 0u32);
     let mut first_line = use_signal(|| 0u32);
     let mut lines = use_signal(Vec::<FileLine>::new);
+    let mut overview = use_signal(|| Option::<FileOverviewPatch>::None);
+    let mut dragging = use_signal(|| false);
     let mut error = use_signal(String::new);
     let dir_entries = use_signal(Vec::<FileDirEntry>::new);
     let parent_entries = use_signal(Vec::<FileDirEntry>::new);
@@ -363,6 +367,7 @@ pub fn Page() -> Element {
         path.set(m.path);
         git_path.set(m.abs_path);
         total_lines.set(m.total_lines);
+        overview.set(None);
         mode.set(Mode::Text);
         git_nonce.set(git_nonce() + 1);
     });
@@ -371,6 +376,10 @@ pub fn Page() -> Element {
         first_line.set(p.first_line);
         total_lines.set(p.total_lines);
         lines.set(p.lines);
+    });
+
+    let _ov = use_bin_event_listener::<FileOverviewPatch, _>(FILE_OVERVIEW_EVENT, move |p| {
+        overview.set(Some(p));
     });
 
     let _err = use_bin_event_listener::<FileErrorEvent, _>(FILE_ERROR_EVENT, move |e| {
@@ -473,6 +482,11 @@ pub fn Page() -> Element {
     use_effect(move || {
         setup_measurement(cell_dims);
         focus_container();
+    });
+
+    use_effect(move || {
+        let _ = cell_dims();
+        paint_minimap(&overview.read());
     });
 
     let gw = gutter_width(total_lines());
@@ -740,18 +754,51 @@ pub fn Page() -> Element {
                     if show_diff() {
                         DiffView { path: git_path, nonce: git_nonce }
                     } else {
-                        div { class: "min-h-0 flex-1 overflow-auto",
-                            div { class: "min-w-max py-2",
-                                for line in lines().iter() {
-                                    div { key: "{line.line_no}", class: "group flex hover:bg-white/[0.035]",
-                                        span {
-                                            class: "sticky left-0 z-[1] shrink-0 select-none bg-background pl-4 pr-5 text-right tabular-nums opacity-40 group-hover:opacity-90",
-                                            style: "min-width:calc(var(--cw, 1ch) * {gw} + 2.25rem);",
-                                            "{line.line_no + 1}"
+                        div { class: "relative flex min-h-0 flex-1",
+                            div { class: "min-h-0 flex-1 overflow-auto",
+                                div { class: "min-w-max py-2",
+                                    for line in lines().iter() {
+                                        div { key: "{line.line_no}", class: "group flex hover:bg-white/[0.035]",
+                                            span {
+                                                class: "sticky left-0 z-[1] shrink-0 select-none bg-background pl-4 pr-5 text-right tabular-nums opacity-40 group-hover:opacity-90",
+                                                style: "min-width:calc(var(--cw, 1ch) * {gw} + 2.25rem);",
+                                                "{line.line_no + 1}"
+                                            }
+                                            span { class: "whitespace-pre pr-8",
+                                                for (i, s) in line.spans.iter().enumerate() {
+                                                    span { key: "{i}", style: "{span_style(s)}", "{s.text}" }
+                                                }
+                                            }
                                         }
-                                        span { class: "whitespace-pre pr-8",
-                                            for (i, s) in line.spans.iter().enumerate() {
-                                                span { key: "{i}", style: "{span_style(s)}", "{s.text}" }
+                                    }
+                                }
+                            }
+                            if overview().is_some() {
+                                {
+                                    let (box_top, box_h) = viewport_box(
+                                        first_line(),
+                                        lines().len() as u16,
+                                        total_lines(),
+                                        100.0,
+                                    );
+                                    rsx! {
+                                        div {
+                                            class: "relative w-[120px] shrink-0 cursor-pointer border-l border-white/[0.06] bg-black/20",
+                                            onmousedown: move |e: Event<MouseData>| {
+                                                dragging.set(true);
+                                                minimap_scroll_to(&e, total_lines(), lines().len() as u16);
+                                            },
+                                            onmousemove: move |e: Event<MouseData>| {
+                                                if dragging() {
+                                                    minimap_scroll_to(&e, total_lines(), lines().len() as u16);
+                                                }
+                                            },
+                                            onmouseup: move |_| dragging.set(false),
+                                            onmouseleave: move |_| dragging.set(false),
+                                            canvas { id: MINIMAP_CANVAS_ID, class: "block h-full w-full" }
+                                            div {
+                                                class: "pointer-events-none absolute inset-x-0 rounded-sm bg-cyan-400/15 ring-1 ring-inset ring-cyan-400/40",
+                                                style: "top:{box_top}%;height:{box_h}%;",
                                             }
                                         }
                                     }
@@ -771,6 +818,80 @@ pub fn Page() -> Element {
                 message: git_message,
             }
         }
+    }
+}
+
+fn minimap_scroll_to(e: &Event<MouseData>, total: u32, rows: u16) {
+    let data = e.data();
+    let Some(raw) = data.downcast::<web_sys::MouseEvent>() else {
+        return;
+    };
+    let Some(el) = web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.get_element_by_id(MINIMAP_CANVAS_ID))
+    else {
+        return;
+    };
+    let rect = el.get_bounding_client_rect();
+    if rect.height() <= 0.0 {
+        return;
+    }
+    let y = raw.client_y() as f64 - rect.top();
+    let top = y_to_top_line(y as f32, rect.height() as f32, total, rows);
+    let _ = try_cef_bin_emit_rkyv(&FileScrollEvent { top_line: top });
+}
+
+fn paint_minimap(ov: &Option<FileOverviewPatch>) {
+    let Some(ov) = ov.as_ref() else {
+        return;
+    };
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let Some(canvas) = window
+        .document()
+        .and_then(|d| d.get_element_by_id(MINIMAP_CANVAS_ID))
+        .and_then(|el| el.dyn_into::<web_sys::HtmlCanvasElement>().ok())
+    else {
+        return;
+    };
+    let dpr = window.device_pixel_ratio().max(1.0);
+    let css_w = canvas.client_width() as f64;
+    let css_h = canvas.client_height() as f64;
+    if css_w <= 0.0 || css_h <= 0.0 {
+        return;
+    }
+    let bw = (css_w * dpr).round();
+    let bh = (css_h * dpr).round();
+    canvas.set_width(bw as u32);
+    canvas.set_height(bh as u32);
+    let Ok(Some(obj)) = canvas.get_context("2d") else {
+        return;
+    };
+    let Ok(ctx) = obj.dyn_into::<web_sys::CanvasRenderingContext2d>() else {
+        return;
+    };
+    ctx.clear_rect(0.0, 0.0, bw, bh);
+    let total = ov.total_lines;
+    if total == 0 {
+        return;
+    }
+    let height = bh as f32;
+    let step = sample_step(total, height);
+    let scale_x = dpr as f32;
+    let row_h = ((height / total as f32) * step as f32).max(1.0) as f64;
+    let n = ov.lines.len();
+    let mut li = 0usize;
+    while li < n {
+        let y = line_to_y(li as u32, total, height) as f64;
+        for run in &ov.lines[li].runs {
+            let [r, g, b] = run.fg;
+            ctx.set_fill_style_str(&format!("rgba({r},{g},{b},0.55)"));
+            let x = (run.start as f32 * scale_x) as f64;
+            let w = (run.len as f32 * scale_x) as f64;
+            ctx.fill_rect(x, y, w, row_h);
+        }
+        li += step;
     }
 }
 

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -13,6 +13,7 @@ use vmux_layout::Browser;
 
 use crate::dir::{list_dir, parent_listing};
 use crate::highlight::Highlighter;
+use crate::minimap::{MINIMAP_MAX_LINES, build_overview};
 use crate::preview;
 use crate::viewport::{clamp_top_line, rows_from_viewport, visible_slice};
 
@@ -276,6 +277,7 @@ fn send_initial_meta(
             if vp.rows > 0 {
                 emit_window(entity, buf, vp, &browsers, &mut commands);
             }
+            emit_overview(entity, buf, &browsers, &mut commands);
         }
         commands.entity(entity).insert(FileInitialMetaSent);
     }
@@ -358,6 +360,24 @@ fn emit_window(
             first_line: first,
             total_lines: total,
             lines,
+        },
+    ));
+}
+
+fn emit_overview(entity: Entity, buf: &FileBuffer, browsers: &Browsers, commands: &mut Commands) {
+    if !browsers.has_browser(entity) || !browsers.host_emit_ready(&entity) {
+        return;
+    }
+    let total = buf.lines.len() as u32;
+    if total > MINIMAP_MAX_LINES {
+        return;
+    }
+    commands.trigger(BinHostEmitEvent::from_rkyv(
+        entity,
+        FILE_OVERVIEW_EVENT,
+        &FileOverviewPatch {
+            total_lines: total,
+            lines: build_overview(&buf.lines),
         },
     ));
 }
@@ -684,6 +704,7 @@ fn reload_changed_files(
             ));
             let vpc = *vp;
             emit_window(entity, &buf, &vpc, &browsers, &mut commands);
+            emit_overview(entity, &buf, &browsers, &mut commands);
         }
         commands.entity(entity).insert(buf);
     }

--- a/docs/specs/2026-06-24-editor-minimap-design.md
+++ b/docs/specs/2026-06-24-editor-minimap-design.md
@@ -1,0 +1,146 @@
+# Editor Minimap Design
+
+Date: 2026-06-24
+Status: Draft — awaiting spec review
+
+## Goal
+
+Add a VS Code-style minimap to the `files://` code editor: a narrow, syntax-colored,
+scaled-down overview of the whole file pinned to the right edge of the text view, with a
+translucent viewport box showing the visible region. Click to jump, drag the box to scroll.
+
+## Constraints / context
+
+The editor is **server-driven and line-windowed**, not a real scrolling DOM:
+
+- Host (`vmux_editor`, Bevy/CEF, native) owns the full file in `FileBuffer { language, lines: Vec<FileLine> }`
+  with syntect-highlighted `StyledSpan`s. It streams only the visible window to the page via
+  `FileViewportPatch { first_line, total_lines, lines }` (`emit_window`, `plugin.rs:340`).
+- Frontend (`page.rs`, Dioxus/WASM) holds only the windowed slice in the `lines` signal — never the whole file.
+- Scroll is **line-index based**: wheel/keyboard compute a `top_line` and emit `FileScrollEvent { top_line }`;
+  the host re-windows and pushes a new patch. Signals `first_line` / `total_lines` / `rows` already track position.
+- The editor is **view-only** (modes Text/Dir/Image; keydown only navigates — no editing). So the file's
+  content is static for the lifetime of a view (until reload), which means the minimap overview can be a
+  **one-shot payload per file open**, refreshed only on file-watch reload.
+
+A minimap needs a representation of the *entire* file. That data does not exist on the frontend today, so the
+core of this work is a new host→page overview payload plus a canvas painter. The viewport box and all scrolling
+reuse existing state and the existing `FileScrollEvent` loop.
+
+Note: unlike `vmux_layout`'s `command_bar/page.rs`, `vmux_editor/page.rs` has **no `include_str!` source-scrape
+tests**, so it can be edited freely.
+
+## Approach (chosen: full code-preview)
+
+Canvas-based, matching how VS Code renders its minimap. Per-line colored run-rectangles painted to a `<canvas>`
+(not DOM-per-line, which would choke on large files). Fit-to-height layout (whole file always visible; no
+secondary minimap scrolling in v1). Always-on (no toggle in v1).
+
+### 1. Wire types — `crates/vmux_core/src/event.rs`
+
+New event constant and rkyv/serde types, alongside the existing `File*` family:
+
+```rust
+pub const FILE_OVERVIEW_EVENT: &str = "file_overview";
+
+pub struct MinimapRun { pub fg: [u8; 3], pub start: u16, pub len: u16 }
+pub struct MinimapLine { pub runs: Vec<MinimapRun> }
+pub struct FileOverviewPatch { pub total_lines: u32, pub lines: Vec<MinimapLine> }
+```
+
+All derive the same set as `FileViewportPatch` (`Debug, Clone, PartialEq, Serialize, Deserialize, rkyv::*`).
+A run is a maximal span of consecutive **non-whitespace** characters of one color; whitespace becomes gaps,
+so indentation structure (code shape) is preserved like VS Code. Columns are character offsets (`start`, `len`).
+
+### 2. Overview builder — shared pure fn in `crates/vmux_editor/src/minimap.rs` (new, not cfg-gated)
+
+`viewport.rs` is the precedent: a dependency-light module compiled for native + wasm + test. The new `minimap.rs`
+holds the pure, unit-tested logic used by both host (builder) and frontend (paint math):
+
+- `build_overview(lines: &[FileLine]) -> Vec<MinimapLine>` — collapse each line's `StyledSpan`s into
+  non-whitespace runs, tracking the char column. Caps runs/line at `MINIMAP_MAX_RUNS_PER_LINE` to bound
+  pathological minified lines.
+- `line_to_y(line, total_lines, height_px) -> f32` — fit-to-height position of a file line on the canvas.
+- `viewport_box(first_line, rows, total_lines, height_px) -> (y_px, h_px)` — the translucent box rect.
+- `y_to_top_line(y_px, height_px, total_lines, rows) -> u32` — map a click/drag y back to a `top_line`
+  (clamped via existing `clamp_top_line`).
+- `sample_step(total_lines, height_px) -> usize` — for fit-to-height, how many file-lines map to one canvas
+  row; the painter steps by this so a 50k-line file doesn't paint 50k sub-pixel rows.
+
+Constants: `MINIMAP_MAX_LINES` (skip overview entirely above this, e.g. 100_000) and `MINIMAP_MAX_RUNS_PER_LINE`.
+
+### 3. Host emit — `crates/vmux_editor/src/plugin.rs`
+
+- In `send_initial_meta` (non-error branch, after `FILE_META_EVENT`): if `buf.lines.len() <= MINIMAP_MAX_LINES`,
+  build the overview from `buf.lines` and `commands.trigger(BinHostEmitEvent::from_rkyv(entity, FILE_OVERVIEW_EVENT, &patch))`.
+  Re-sends automatically on page-ready because `FileInitialMetaSent` is cleared by `reset_file_sent_markers_on_page_ready`.
+- In `reload_changed_files` (non-error branch, after `FILE_META_EVENT` + `emit_window`): rebuild and re-emit the
+  overview, since the file content changed.
+- **No new inbound event.** The minimap scrolls by emitting the existing `FileScrollEvent`, already registered in
+  `BinEventEmitterPlugin` and handled by `on_file_scroll`.
+
+### 4. Frontend — `crates/vmux_editor/src/page.rs`
+
+- New signal `overview: Signal<Option<FileOverviewPatch>>`, fed by
+  `use_bin_event_listener::<FileOverviewPatch>(FILE_OVERVIEW_EVENT, ...)`. Cleared to `None` on `FILE_META_EVENT`
+  (new file) until its overview arrives, so the minimap hides during load and for over-cap files.
+- **Layout:** wrap the `Mode::Text` body (when `!show_diff()`) in a relative flex row: existing scrolling text
+  region (`flex-1`) + a fixed-width minimap column (`~120px`, `shrink-0`). Hidden when `overview()` is `None`.
+- **Canvas painter:** a `<canvas>` filled via `web_sys` `CanvasRenderingContext2d`. A `use_effect` reacting to
+  `overview()` and the canvas pixel size paints once per overview change: for each sampled line, draw its runs as
+  filled rects (`x = start * scale_x`, `w = len * scale_x`, `y = line_to_y(...)`), colored from `fg` with low alpha
+  for the soft look. Canvas backing-store sized to `clientWidth/Height * devicePixelRatio` for crisp rendering;
+  resize handled by a `ResizeObserver` (same pattern as `setup_measurement`).
+- **Viewport box:** a translucent absolutely-positioned `div` over the canvas, positioned from
+  `viewport_box(first_line(), rows, total_lines(), height)`. It repositions reactively on scroll **without
+  repainting the canvas** (cheap). `rows` derived from `cell_dims` + container height (same math as host's
+  `rows_from_viewport`).
+- **Interaction:** `onmousedown` on the minimap → `y_to_top_line` → emit `FileScrollEvent`; set a `dragging`
+  signal; `onmousemove` while dragging repeats; `onmouseup`/leave clears it. Click = jump (single mousedown).
+  Reuses the existing scroll loop end-to-end; the host echoes back a patch that moves `first_line`, confirming.
+
+## Data flow
+
+```
+file open ─▶ host build_overview(buf.lines) ─▶ FileOverviewPatch ─▶ page `overview` signal ─▶ canvas paint
+scroll/drag ─▶ FileScrollEvent { top_line } ─▶ host on_file_scroll ─▶ FileViewportPatch ─▶ first_line ─▶ box moves
+file reload ─▶ host rebuild overview ─▶ FileOverviewPatch ─▶ repaint
+```
+
+## Error / edge handling
+
+- Over-cap files (`> MINIMAP_MAX_LINES`): host skips the overview event; frontend leaves `overview = None`;
+  minimap simply doesn't render. No error surfaced.
+- Empty file / zero rows: `viewport_box` and `y_to_top_line` clamp via existing `clamp_top_line`; box collapses
+  or fills; no panic.
+- `__error__:` buffers and Dir/Image modes: no overview emitted (guarded by the existing non-error / Text path).
+- Very tall files within cap: `sample_step` keeps paint cost ~O(canvas height), not O(total_lines).
+
+## Testing
+
+Pure unit tests in `minimap.rs` (native, fast — no CEF, no WASM):
+
+- `build_overview`: whitespace becomes gaps; adjacent same-color non-whitespace merges into one run; per-line run cap.
+- `viewport_box`: top of file, middle, clamped at end, file shorter than viewport.
+- `y_to_top_line`: round-trips with `viewport_box`; clamps at 0 and max scroll.
+- `sample_step`: ≥1; collapses many lines/pixel for tall files.
+- rkyv round-trip for `FileOverviewPatch` in `vmux_core` (mirrors the existing `FileViewportPatch` test).
+
+Frontend behavior is verified by the observable output — dragging the minimap emits `FileScrollEvent { top_line }`
+— consistent with how scroll is already tested (assert on the emitted event, not internal DOM state). Final visual
+confirmation is a manual runtime test by the user.
+
+## Out of scope (v1)
+
+- VS Code-style minimap that *scrolls* when the file is taller than the minimap (fit-to-height instead).
+- A show/hide toggle or width/side configuration.
+- Live updates while editing (editor is view-only).
+- Search-match / diff / error decorations on the minimap.
+
+## Files touched
+
+- `crates/vmux_core/src/event.rs` — new const + 3 types + rkyv test.
+- `crates/vmux_editor/src/minimap.rs` — new shared module (builder + paint math + tests).
+- `crates/vmux_editor/src/lib.rs` — `pub mod minimap;`.
+- `crates/vmux_editor/src/plugin.rs` — emit overview in `send_initial_meta` + `reload_changed_files`.
+- `crates/vmux_editor/src/page.rs` — signal, listener, minimap column, canvas painter, box, drag handlers.


### PR DESCRIPTION
## Context

The `files://` code editor had no overview of the whole file — you could only see the windowed slice around the scroll position. This adds a VS Code-style minimap: a narrow, syntax-colored, scaled-down view of the entire file pinned to the right edge, with a translucent box marking the visible region. Click or drag the box to jump/scroll.

## Implementation

The editor is server-driven and line-windowed: the host owns the full file and streams only the visible window to the page, so the whole-file data a minimap needs did not exist on the frontend. Core of the change is a new host→page overview payload plus a canvas painter; the viewport box and all scrolling reuse existing state and the existing `FileScrollEvent` loop (no new inbound event).

- **Wire types** (`vmux_core`): `FileOverviewPatch { total_lines, lines: Vec<MinimapLine> }` where each line is non-whitespace color runs (`MinimapRun { fg, start, len }`). Whitespace becomes gaps so indentation/code-shape is preserved; adjacent same-color runs merge.
- **Pure module** (`vmux_editor/minimap.rs`, native+wasm+test): `build_overview` plus paint/scroll math (`line_to_y`, `viewport_box`, `y_to_top_line`, `sample_step`). Fully unit-tested. Caps: skip overview above 100k lines; bound runs/line at 256.
- **Host** (`plugin.rs`): builds the overview once per file open and on file-watch reload, emitted alongside the existing meta/window patches.
- **Frontend** (`page.rs`): canvas painter via `CanvasRenderingContext2d` (dpr-scaled backing store, sampled per `sample_step` so large files stay O(canvas height), soft low-alpha runs). Viewport box positioned in percentages from `viewport_box`; click/drag maps y→`top_line` and emits `FileScrollEvent`. Fit-to-height, always-on (no toggle in v1).

## Checks / QA

- Open a code file in the editor (`files://`) — minimap renders on the right, colored to match the syntax.
- Scroll with wheel/keys — the translucent box tracks the visible region.
- Click in the minimap — jumps there; drag the box — scrolls continuously.
- Open a very large file (>100k lines) — no minimap, no error, editor still works.
- Open a short file (fewer lines than the viewport) — box fills the column.
- Switch to a directory / image / diff view — no minimap shown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a file minimap/overview to the editor, showing a compact preview of file contents alongside the text view.
  * Enabled clicking and dragging on the minimap to quickly jump through large files.
  * The minimap automatically adjusts to the visible viewport and file length.

* **Bug Fixes**
  * Improved scrolling behavior and clamping for empty, short, or very large files.
  * Added internal validation to ensure overview data stays consistent during rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->