### PR TITLE
feat: default-profile decoupling (Tester identity + is_test_session)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,10 @@ cleanup:
 	@pkill -f "target/debug/vmux_desktop" 2>/dev/null || true
 	@pkill -f "target/debug/vmux_service" 2>/dev/null || true
 	@pkill -f "bevy_cef_debug_render_process" 2>/dev/null || true
-	@base="$$HOME/Library/Application Support/Vmux"; dev="$$base/dev"; cfg="$$HOME/.vmux"; \
+	@case "$$(uname -s)" in \
+		Darwin) base="$$HOME/Library/Application Support/Vmux" ;; \
+		*) base="$${TMPDIR:-/tmp}/Vmux" ;; \
+	esac; dev="$$base/dev"; cfg="$$HOME/.vmux"; \
 	rm -f "$$dev/store.ron" "$$dev/store.version"; \
 	rm -f "$$dev"/store.ron.*.bak "$$dev"/store.version.bak-*; \
 	rm -f "$$dev/profiles/"*/session.ron; \

--- a/Makefile
+++ b/Makefile
@@ -98,21 +98,22 @@ lint-fix:
 test:
 	env -u CEF_PATH "$(CARGO_BIN)" test --workspace --exclude bevy_cef_core
 
-# Reset vmux *dev* storage for a clean test. Removes the layout store, per-space
-# layout snapshots, session, logs and stale dev service sockets. KEEPS ~/.vmux
-# (settings + space working dirs) and the dev browser profile (logins/cache).
+# Reset vmux *dev* storage for a clean test. Removes the layout store, session,
+# logs, the saved profile display name, and stale dev service sockets (all
+# profiles). KEEPS ~/.vmux (settings + space working dirs) and the dev browser
+# profiles (logins/cache).
 cleanup:
 	@pkill -f "target/debug/vmux_desktop" 2>/dev/null || true
 	@pkill -f "target/debug/vmux_service" 2>/dev/null || true
 	@pkill -f "bevy_cef_debug_render_process" 2>/dev/null || true
-	@base="$$HOME/Library/Application Support/Vmux"; dev="$$base/dev"; \
+	@base="$$HOME/Library/Application Support/Vmux"; dev="$$base/dev"; cfg="$$HOME/.vmux"; \
 	rm -f "$$dev/store.ron" "$$dev/store.version"; \
 	rm -f "$$dev"/store.ron.*.bak "$$dev"/store.version.bak-*; \
 	rm -f "$$dev/profiles/"*/session.ron; \
-	rm -rf "$$dev/profiles/"*/spaces; \
+	rm -f "$$cfg/profile_display_name"; \
 	rm -rf "$$dev/logs"; \
-	rm -f "$$base/services/"vmux-dev.*; \
-	echo "cleanup: reset vmux dev storage (kept ~/.vmux settings + dev browser profile)"
+	rm -f "$$base/services/"vmux-dev.* "$$base/services/"vmux-dev-*; \
+	echo "cleanup: reset vmux dev storage (kept ~/.vmux settings + spaces + dev browser profiles)"
 
 # Website
 build-website-css:

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ cleanup:
 	rm -f "$$dev/store.ron" "$$dev/store.version"; \
 	rm -f "$$dev"/store.ron.*.bak "$$dev"/store.version.bak-*; \
 	rm -f "$$dev/profiles/"*/session.ron; \
-	rm -f "$$cfg/profile_display_name"; \
+	rm -f "$$cfg/profiles/"*/display_name; \
 	rm -rf "$$dev/logs"; \
 	rm -f "$$base/services/"vmux-dev.* "$$base/services/"vmux-dev-*; \
 	echo "cleanup: reset vmux dev storage (kept ~/.vmux settings + spaces + dev browser profiles)"

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 .DEFAULT_GOAL := dev
 
 VMUX_PROFILE ?= personal
+VMUX_TEST ?=
 
 CARGO_BIN := $(or $(shell command -v cargo 2>/dev/null),$(HOME)/.cargo/bin/cargo)
 RUSTUP_BIN := $(or $(shell command -v rustup 2>/dev/null),$(HOME)/.cargo/bin/rustup)
@@ -38,10 +39,10 @@ dev: ensure-mac-deps ensure-codesign-deps install-debug-render-process
 	if [ -n "$${DYLD_LIBRARY_PATH:-}" ]; then \
 		dylib_path="$$dylib_path:$$DYLD_LIBRARY_PATH"; \
 	fi; \
-	exec env -u CEF_PATH DYLD_LIBRARY_PATH="$$dylib_path" VMUX_PROFILE="$(VMUX_PROFILE)" ./target/debug/vmux_desktop
+	exec env -u CEF_PATH DYLD_LIBRARY_PATH="$$dylib_path" VMUX_PROFILE="$(VMUX_PROFILE)" VMUX_TEST="$(VMUX_TEST)" ./target/debug/vmux_desktop
 
 test-app:
-	$(MAKE) dev VMUX_PROFILE=gregor
+	$(MAKE) dev VMUX_PROFILE=gregor VMUX_TEST=1
 
 build: ensure-mac-deps
 	env -u CEF_PATH "$(CARGO_BIN)" build -p vmux_desktop -p vmux_cli -p vmux_service --release

--- a/crates/vmux_agent/src/client/cli/vibe.rs
+++ b/crates/vmux_agent/src/client/cli/vibe.rs
@@ -38,8 +38,8 @@ impl CliAgentStrategy for VibeStrategy {
         // config (falling back to default models). `--trust` trusts the working
         // directory for this invocation (vibe's documented automation flag).
         let mut args = vec!["--trust".to_string()];
-        if let Some(flag) = vibe_auto_approve_flag(&vmux_core::profile::active_profile_name()) {
-            args.push(flag.to_string());
+        if vmux_core::profile::is_test_session() {
+            args.push("--auto-approve".to_string());
         }
         if let Some(sid) = session_id {
             args.push("--resume".to_string());
@@ -85,10 +85,6 @@ impl CliAgentStrategy for VibeStrategy {
         }
         false
     }
-}
-
-fn vibe_auto_approve_flag(profile: &str) -> Option<&'static str> {
-    (profile != "personal").then_some("--auto-approve")
 }
 
 #[derive(Serialize)]
@@ -207,9 +203,30 @@ mod tests {
     }
 
     #[test]
-    fn auto_approve_flag_only_for_non_personal_profile() {
-        assert_eq!(vibe_auto_approve_flag("personal"), None);
-        assert_eq!(vibe_auto_approve_flag("gregor"), Some("--auto-approve"));
+    fn auto_approve_follows_test_session() {
+        let mcp = McpServerConfig {
+            command: "vmux".to_string(),
+            args: vec![],
+            cwd: None,
+        };
+        let prev = std::env::var("VMUX_TEST").ok();
+        unsafe { std::env::set_var("VMUX_TEST", "1") };
+        assert!(
+            VibeStrategy
+                .build_args(&mcp, None)
+                .iter()
+                .any(|a| a == "--auto-approve")
+        );
+        unsafe { std::env::remove_var("VMUX_TEST") };
+        assert!(
+            !VibeStrategy
+                .build_args(&mcp, None)
+                .iter()
+                .any(|a| a == "--auto-approve")
+        );
+        if let Some(p) = prev {
+            unsafe { std::env::set_var("VMUX_TEST", p) };
+        }
     }
 
     fn write_meta(

--- a/crates/vmux_agent/src/client/cli/vibe.rs
+++ b/crates/vmux_agent/src/client/cli/vibe.rs
@@ -187,29 +187,19 @@ mod tests {
     use std::time::Duration;
 
     #[test]
-    fn build_args_trusts_workdir_and_resumes_when_given() {
-        let mcp = McpServerConfig {
-            command: "vmux".to_string(),
-            args: vec![],
-            cwd: None,
-        };
-        // Non-interactive launches must pass --trust so vibe loads the user
-        // config instead of falling back to default models.
-        assert_eq!(VibeStrategy.build_args(&mcp, None), vec!["--trust"]);
-        assert_eq!(
-            VibeStrategy.build_args(&mcp, Some("sid-1")),
-            vec!["--trust", "--resume", "sid-1"]
-        );
-    }
-
-    #[test]
-    fn auto_approve_follows_test_session() {
+    fn build_args_trust_resume_and_test_session_auto_approve() {
         let mcp = McpServerConfig {
             command: "vmux".to_string(),
             args: vec![],
             cwd: None,
         };
         let prev = std::env::var("VMUX_TEST").ok();
+        unsafe { std::env::remove_var("VMUX_TEST") };
+        assert_eq!(VibeStrategy.build_args(&mcp, None), vec!["--trust"]);
+        assert_eq!(
+            VibeStrategy.build_args(&mcp, Some("sid-1")),
+            vec!["--trust", "--resume", "sid-1"]
+        );
         unsafe { std::env::set_var("VMUX_TEST", "1") };
         assert!(
             VibeStrategy
@@ -218,12 +208,6 @@ mod tests {
                 .any(|a| a == "--auto-approve")
         );
         unsafe { std::env::remove_var("VMUX_TEST") };
-        assert!(
-            !VibeStrategy
-                .build_args(&mcp, None)
-                .iter()
-                .any(|a| a == "--auto-approve")
-        );
         if let Some(p) = prev {
             unsafe { std::env::set_var("VMUX_TEST", p) };
         }

--- a/crates/vmux_agent/src/mcp.rs
+++ b/crates/vmux_agent/src/mcp.rs
@@ -39,16 +39,13 @@ fn resolve_with_sidecar(
 }
 
 fn mcp_subcommand_args(anchor: ProcessId, profile: &str) -> Vec<String> {
-    let mut args = vec![
+    vec![
         "mcp".to_string(),
         "--anchor".to_string(),
         anchor.to_string(),
-    ];
-    if profile != "personal" {
-        args.push("--profile".to_string());
-        args.push(profile.to_string());
-    }
-    args
+        "--profile".to_string(),
+        profile.to_string(),
+    ]
 }
 
 fn find_workspace_dir(cwd: &Path) -> Option<PathBuf> {
@@ -75,21 +72,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn mcp_args_append_profile_only_for_non_personal() {
+    fn mcp_args_always_append_profile() {
         let anchor = ProcessId::new();
-        assert_eq!(
-            mcp_subcommand_args(anchor, "personal"),
-            vec![
-                "mcp".to_string(),
-                "--anchor".to_string(),
-                anchor.to_string()
-            ]
-        );
-        let with = mcp_subcommand_args(anchor, "test");
-        assert!(
-            with.windows(2)
-                .any(|w| w[0] == "--profile" && w[1] == "test")
-        );
+        for profile in ["personal", "gregor"] {
+            let args = mcp_subcommand_args(anchor, profile);
+            assert!(
+                args.windows(2)
+                    .any(|w| w[0] == "--profile" && w[1] == profile)
+            );
+        }
     }
 
     #[test]
@@ -118,7 +109,9 @@ mod tests {
                 "--",
                 "mcp",
                 "--anchor",
-                &anchor.to_string()
+                &anchor.to_string(),
+                "--profile",
+                "personal"
             ]
         );
         assert_eq!(config.cwd, Some(workspace));

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -106,6 +106,7 @@ impl Plugin for AgentPlugin {
             .init_resource::<AgentSessionDirty>()
             .add_message::<AgentCommandRequest>()
             .add_message::<FocusPaneRequest>()
+            .add_message::<RenameProfileRequest>()
             .add_message::<AgentQueryRequest>()
             .add_message::<ScreenshotRequest>()
             .add_message::<ScreenshotResponse>()
@@ -197,6 +198,7 @@ impl Plugin for AgentPlugin {
                 (
                     handle_spawn_agent_requests,
                     handle_focus_pane_requests.after(handle_agent_commands),
+                    handle_rename_profile_requests.after(handle_agent_commands),
                     respond_process_stack_spawn.after(handle_agent_commands),
                     handle_agent_page_open.in_set(PageOpenSet::HandleKnownPages),
                     handle_restart_agent_pty,
@@ -321,6 +323,28 @@ fn handle_focus_pane_requests(
     }
 }
 
+#[derive(Message, Clone)]
+struct RenameProfileRequest {
+    name: String,
+}
+
+fn handle_rename_profile_requests(
+    mut reader: MessageReader<RenameProfileRequest>,
+    active_space: Option<ResMut<ActiveSpace>>,
+) {
+    let Some(mut active) = active_space else {
+        return;
+    };
+    for req in reader.read() {
+        let name = req.name.trim();
+        if name.is_empty() {
+            continue;
+        }
+        let _ = vmux_core::profile::set_display_name(name);
+        active.record.profile = name.to_string();
+    }
+}
+
 #[derive(bevy::ecs::system::SystemParam)]
 pub struct AgentLookups<'w> {
     pub pid_to_entity: Option<Res<'w, vmux_terminal::pid::PidToEntity>>,
@@ -333,6 +357,7 @@ struct AgentSpaceWriters<'w, 's> {
     layout_apply: MessageWriter<'w, vmux_layout::reconcile::LayoutApplyRequest>,
     space_command: MessageWriter<'w, vmux_space::SpaceCommandRequest>,
     focus_pane: MessageWriter<'w, FocusPaneRequest>,
+    rename_profile: MessageWriter<'w, RenameProfileRequest>,
     issued: MessageWriter<'w, vmux_command::CommandIssued>,
     attention: MessageWriter<'w, vmux_core::notify::AgentAttention>,
     agents: Query<
@@ -668,6 +693,12 @@ fn handle_agent_commands(
                 writers
                     .focus_pane
                     .write(FocusPaneRequest { pane: pane.clone() });
+                AgentCommandResult::Ok
+            }
+            ServiceAgentCommand::RenameProfile { name } => {
+                writers
+                    .rename_profile
+                    .write(RenameProfileRequest { name: name.clone() });
                 AgentCommandResult::Ok
             }
             ServiceAgentCommand::UpdateSettings { path, value_json } => {

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -340,8 +340,10 @@ fn handle_rename_profile_requests(
         if name.is_empty() {
             continue;
         }
-        let _ = vmux_core::profile::set_display_name(name);
-        active.record.profile = name.to_string();
+        match vmux_core::profile::set_display_name(name) {
+            Ok(()) => active.record.profile = name.to_string(),
+            Err(error) => warn!("rename_profile: failed to persist display name: {error}"),
+        }
     }
 }
 

--- a/crates/vmux_core/src/profile.rs
+++ b/crates/vmux_core/src/profile.rs
@@ -32,6 +32,45 @@ pub fn sanitize_profile(raw: &str) -> String {
     }
 }
 
+fn capitalize_first(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => "Personal".to_string(),
+    }
+}
+
+fn display_name_path() -> PathBuf {
+    config_dir().join("profile_display_name")
+}
+
+fn display_name_from(configured: Option<&str>, id: &str, is_test: bool) -> String {
+    if !is_test && let Some(name) = configured {
+        let trimmed = name.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    capitalize_first(id)
+}
+
+pub fn display_name() -> String {
+    let configured = std::fs::read_to_string(display_name_path()).ok();
+    display_name_from(
+        configured.as_deref(),
+        &active_profile_name(),
+        is_test_session(),
+    )
+}
+
+pub fn set_display_name(name: &str) -> std::io::Result<()> {
+    let path = display_name_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, name.trim())
+}
+
 fn data_dir_suffix_for(profile: &str) -> PathBuf {
     match profile {
         "release" | "local" => PathBuf::from("Vmux"),
@@ -340,6 +379,20 @@ mod tests {
         if let Some(p) = prev {
             unsafe { std::env::set_var("VMUX_TEST", p) };
         }
+    }
+
+    #[test]
+    fn display_name_uses_config_or_capitalized_id() {
+        assert_eq!(display_name_from(None, "personal", false), "Personal");
+        assert_eq!(
+            display_name_from(Some("Junichi"), "personal", false),
+            "Junichi"
+        );
+        assert_eq!(
+            display_name_from(Some("Junichi"), "personal", true),
+            "Personal"
+        );
+        assert_eq!(display_name_from(Some("  "), "gregor", false), "Gregor");
     }
 
     #[test]

--- a/crates/vmux_core/src/profile.rs
+++ b/crates/vmux_core/src/profile.rs
@@ -4,6 +4,13 @@ pub fn active_profile_name() -> String {
     sanitize_profile(&std::env::var("VMUX_PROFILE").unwrap_or_default())
 }
 
+pub fn is_test_session() -> bool {
+    matches!(
+        std::env::var("VMUX_TEST").ok().as_deref(),
+        Some("1") | Some("true") | Some("yes")
+    )
+}
+
 pub fn sanitize_profile(raw: &str) -> String {
     let cleaned: String = raw
         .trim()
@@ -123,12 +130,8 @@ pub fn cef_cache_path() -> Option<String> {
     profile_dir().to_str().map(|s| s.to_owned())
 }
 
-fn store_dir_for(base: &std::path::Path, profile: &str) -> PathBuf {
-    if profile == "personal" {
-        base.to_path_buf()
-    } else {
-        base.join("profiles").join(profile)
-    }
+fn store_dir_for(base: &std::path::Path, _profile: &str) -> PathBuf {
+    base.to_path_buf()
 }
 
 pub fn store_dir() -> PathBuf {
@@ -141,11 +144,8 @@ pub fn default_space_dir() -> PathBuf {
     space_dir("space-1")
 }
 
-fn spaces_root_for(home: &std::path::Path, profile: &str) -> PathBuf {
-    home.join(".vmux")
-        .join("profiles")
-        .join(profile)
-        .join("spaces")
+fn spaces_root_for(home: &std::path::Path, _profile: &str) -> PathBuf {
+    home.join(".vmux").join("spaces")
 }
 
 fn space_dir_path(home: &std::path::Path, profile: &str, space_id: &str) -> PathBuf {
@@ -268,7 +268,10 @@ fn migrate_dir(legacy: &std::path::Path, target: &std::path::Path) {
 
 fn migrate_legacy_personal_layout_in(home: &std::path::Path) {
     let config = home.join(".vmux");
-    migrate_dir(&config.join("spaces"), &spaces_root_for(home, "personal"));
+    migrate_dir(
+        &config.join("profiles").join("personal").join("spaces"),
+        &spaces_root_for(home, "personal"),
+    );
     migrate_dir(
         &config.join("recording"),
         &recording_dir_for(&config, "personal"),
@@ -316,28 +319,40 @@ mod tests {
     }
 
     #[test]
-    fn store_dir_personal_is_base_and_test_is_nested() {
+    fn store_dir_is_profile_agnostic_base() {
         let base = std::path::Path::new("/data/Vmux/dev");
         assert_eq!(
             store_dir_for(base, "personal"),
             PathBuf::from("/data/Vmux/dev")
         );
         assert_eq!(
-            store_dir_for(base, "test"),
-            PathBuf::from("/data/Vmux/dev/profiles/test")
+            store_dir_for(base, "gregor"),
+            PathBuf::from("/data/Vmux/dev")
         );
     }
 
     #[test]
-    fn spaces_root_is_nested_for_personal_and_test() {
+    fn is_test_session_reads_env() {
+        let prev = std::env::var("VMUX_TEST").ok();
+        unsafe { std::env::set_var("VMUX_TEST", "1") };
+        assert!(is_test_session());
+        unsafe { std::env::remove_var("VMUX_TEST") };
+        assert!(!is_test_session());
+        if let Some(p) = prev {
+            unsafe { std::env::set_var("VMUX_TEST", p) };
+        }
+    }
+
+    #[test]
+    fn spaces_root_is_profile_agnostic() {
         let home = std::path::Path::new("/home/u");
         assert_eq!(
             spaces_root_for(home, "personal"),
-            PathBuf::from("/home/u/.vmux/profiles/personal/spaces")
+            PathBuf::from("/home/u/.vmux/spaces")
         );
         assert_eq!(
-            spaces_root_for(home, "test"),
-            PathBuf::from("/home/u/.vmux/profiles/test/spaces")
+            spaces_root_for(home, "gregor"),
+            PathBuf::from("/home/u/.vmux/spaces")
         );
     }
 
@@ -387,30 +402,42 @@ mod tests {
     }
 
     #[test]
-    fn space_dir_is_nested_under_profile() {
+    fn space_dir_is_under_vmux_spaces() {
         assert_eq!(
             space_dir_path(std::path::Path::new("/home/u"), "personal", "work"),
-            PathBuf::from("/home/u/.vmux/profiles/personal/spaces/work")
+            PathBuf::from("/home/u/.vmux/spaces/work")
         );
     }
 
     #[test]
-    fn migrate_moves_legacy_personal_dirs_into_profile() {
+    fn migrate_relocates_nested_spaces_and_recording() {
         let home = std::env::temp_dir().join(format!("vmux-migrate-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&home);
-        let legacy_space = home.join(".vmux").join("spaces").join("space-1");
-        std::fs::create_dir_all(&legacy_space).unwrap();
-        std::fs::write(legacy_space.join("space.ron"), b"x").unwrap();
+        let nested_space = home
+            .join(".vmux")
+            .join("profiles")
+            .join("personal")
+            .join("spaces")
+            .join("space-1");
+        std::fs::create_dir_all(&nested_space).unwrap();
+        std::fs::write(nested_space.join("space.ron"), b"x").unwrap();
         let legacy_rec = home.join(".vmux").join("recording");
         std::fs::create_dir_all(&legacy_rec).unwrap();
         std::fs::write(legacy_rec.join("a.mp4"), b"y").unwrap();
 
         migrate_legacy_personal_layout_in(&home);
 
-        assert!(!home.join(".vmux").join("spaces").exists());
         assert!(
             space_dir_path(&home, "personal", "space-1")
                 .join("space.ron")
+                .exists()
+        );
+        assert!(
+            !home
+                .join(".vmux")
+                .join("profiles")
+                .join("personal")
+                .join("spaces")
                 .exists()
         );
         assert!(!legacy_rec.exists());
@@ -423,17 +450,22 @@ mod tests {
     }
 
     #[test]
-    fn migrate_keeps_existing_target_and_leaves_legacy() {
+    fn migrate_keeps_existing_agnostic_spaces() {
         let home = std::env::temp_dir().join(format!("vmux-migrate-noop-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&home);
-        std::fs::create_dir_all(home.join(".vmux").join("spaces")).unwrap();
+        std::fs::create_dir_all(
+            home.join(".vmux")
+                .join("profiles")
+                .join("personal")
+                .join("spaces"),
+        )
+        .unwrap();
         let target = spaces_root_for(&home, "personal");
         std::fs::create_dir_all(&target).unwrap();
         std::fs::write(target.join("keep.txt"), b"keep").unwrap();
 
         migrate_legacy_personal_layout_in(&home);
 
-        assert!(home.join(".vmux").join("spaces").exists());
         assert!(target.join("keep.txt").exists());
         let _ = std::fs::remove_dir_all(&home);
     }

--- a/crates/vmux_core/src/profile.rs
+++ b/crates/vmux_core/src/profile.rs
@@ -41,7 +41,10 @@ fn capitalize_first(s: &str) -> String {
 }
 
 fn display_name_path() -> PathBuf {
-    config_dir().join("profile_display_name")
+    config_dir()
+        .join("profiles")
+        .join(active_profile_name())
+        .join("display_name")
 }
 
 fn display_name_from(configured: Option<&str>, id: &str, is_test: bool) -> String {

--- a/crates/vmux_core/src/profile.rs
+++ b/crates/vmux_core/src/profile.rs
@@ -278,11 +278,10 @@ fn migrate_legacy_personal_layout_in(home: &std::path::Path) {
     );
 }
 
-/// Relocate the pre-profiles personal layout (`~/.vmux/spaces`,
-/// `~/.vmux/recording`) under `~/.vmux/profiles/personal/`. No-op unless the
-/// personal profile is active and a legacy dir exists without its new target.
+/// Relocate the default profile's layout to the profile-agnostic dirs and undo
+/// #145's per-profile spaces nesting. Skipped for test sessions.
 pub fn migrate_legacy_personal_layout() {
-    if active_profile_name() != "personal" {
+    if is_test_session() {
         return;
     }
     migrate_legacy_personal_layout_in(&home_dir());

--- a/crates/vmux_core/src/team.rs
+++ b/crates/vmux_core/src/team.rs
@@ -17,6 +17,9 @@ pub struct Profile {
 #[derive(Component, Clone, Copy, Debug)]
 pub struct User;
 
+#[derive(Component, Clone, Copy, Debug)]
+pub struct Tester;
+
 #[derive(Component, Clone, Debug)]
 pub struct Agent {
     pub sid: String,

--- a/crates/vmux_desktop/src/persistence.rs
+++ b/crates/vmux_desktop/src/persistence.rs
@@ -164,7 +164,7 @@ fn auto_save_system(time: Res<Time>, mut auto_save: ResMut<AutoSave>, mut comman
 }
 
 pub(crate) fn save_space_to_path(commands: &mut Commands, path: PathBuf) {
-    if vmux_core::profile::active_profile_name() != "personal" {
+    if vmux_core::profile::is_test_session() {
         return;
     }
     if let Some(parent) = path.parent() {
@@ -211,7 +211,7 @@ pub(crate) fn load_space_on_startup(
     mut restore: ResMut<crate::boot_status::RestoreComplete>,
     mut commands: Commands,
 ) {
-    if vmux_core::profile::active_profile_name() != "personal" {
+    if vmux_core::profile::is_test_session() {
         commands.insert_resource(SpaceFilePresent(false));
         restore.0 = true;
         commands.spawn(vmux_space::spaces::space_profile_bundle(&active.record));

--- a/crates/vmux_desktop/tests/release_invariants.rs
+++ b/crates/vmux_desktop/tests/release_invariants.rs
@@ -21,7 +21,7 @@ fn dev_target_signs_then_runs_debug_binary() {
     );
     assert!(makefile.contains("./scripts/sign-dev-mac.sh"));
     assert!(makefile.contains(
-        "DYLD_LIBRARY_PATH=\"$$dylib_path\" VMUX_PROFILE=\"$(VMUX_PROFILE)\" ./target/debug/vmux_desktop"
+        "DYLD_LIBRARY_PATH=\"$$dylib_path\" VMUX_PROFILE=\"$(VMUX_PROFILE)\" VMUX_TEST=\"$(VMUX_TEST)\" ./target/debug/vmux_desktop"
     ));
     assert!(makefile.contains("identity=\"$$(./scripts/ensure-local-codesign-identity.sh)\" &&"));
     assert!(!makefile.contains("run-mac:"));
@@ -29,6 +29,13 @@ fn dev_target_signs_then_runs_debug_binary() {
     assert!(!makefile.contains("sign-mac-debug"));
     assert!(!makefile.contains("package-local-mac"));
     assert!(!makefile.contains("package-release-mac"));
+}
+
+#[test]
+fn test_app_marks_test_session() {
+    let makefile = include_str!("../../../Makefile");
+    assert!(makefile.contains("test-app:"));
+    assert!(makefile.contains("$(MAKE) dev VMUX_PROFILE=gregor VMUX_TEST=1"));
 }
 
 #[test]

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -35,6 +35,10 @@ pub enum McpParamTool {
         description = "Focus a pane by id (from vmux_read_layout, e.g. \"pane:123\"), making it the active pane/stack so subsequent terminal_send and input target it."
     )]
     FocusPane { pane: String },
+    #[mcp(
+        description = "Rename the active profile's display name (the top-right identity pill / facepile). Updates the name only; the profile's storage is untouched."
+    )]
+    RenameProfile { name: String },
     #[mcp(description = "Select a tab by index (1-8).")]
     SelectTab { index: u8 },
     #[mcp(description = "Update a single vmux setting by dot-path. \
@@ -115,6 +119,12 @@ impl McpParamTool {
                     return Err("focus_pane.pane is empty".to_string());
                 }
                 Ok(AgentCommand::FocusPane { pane })
+            }
+            McpParamTool::RenameProfile { name } => {
+                if name.trim().is_empty() {
+                    return Err("rename_profile.name is empty".to_string());
+                }
+                Ok(AgentCommand::RenameProfile { name })
             }
             McpParamTool::SelectTab { index } => {
                 if !(1..=8).contains(&index) {
@@ -1066,6 +1076,25 @@ mod tests {
     #[test]
     fn terminal_send_missing_text_returns_error() {
         assert!(dispatch_from_tool_call("terminal_send", serde_json::json!({})).is_err());
+    }
+
+    #[test]
+    fn rename_profile_dispatches_with_name() {
+        let command =
+            dispatch_command("rename_profile", serde_json::json!({"name": "Junichi"})).unwrap();
+        assert_eq!(
+            command,
+            AgentCommand::RenameProfile {
+                name: "Junichi".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn rename_profile_empty_name_returns_error() {
+        assert!(
+            dispatch_from_tool_call("rename_profile", serde_json::json!({"name": "  "})).is_err()
+        );
     }
 
     #[test]

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -80,6 +80,9 @@ pub enum AgentCommand {
     FocusPane {
         pane: String,
     },
+    RenameProfile {
+        name: String,
+    },
     UpdateSettings {
         path: String,
         value_json: String,
@@ -248,6 +251,9 @@ pub fn validate_agent_command(command: &AgentCommand) -> Result<(), &'static str
         }
         AgentCommand::FocusPane { pane } if pane.trim().is_empty() => {
             Err("focus_pane.pane is empty")
+        }
+        AgentCommand::RenameProfile { name } if name.trim().is_empty() => {
+            Err("rename_profile.name is empty")
         }
         AgentCommand::UpdateSettings { path, .. } if path.trim().is_empty() => {
             Err("update_settings.path is empty")
@@ -652,6 +658,16 @@ mod tests {
                 terminal: None,
             }),
             Err("terminal_send.text is empty")
+        );
+    }
+
+    #[test]
+    fn empty_rename_profile_name_is_invalid() {
+        assert_eq!(
+            validate_agent_command(&AgentCommand::RenameProfile {
+                name: "  ".to_string(),
+            }),
+            Err("rename_profile.name is empty")
         );
     }
 

--- a/crates/vmux_space/src/model.rs
+++ b/crates/vmux_space/src/model.rs
@@ -1,20 +1,11 @@
 pub fn bootstrap_profile_name() -> String {
     #[cfg(not(target_arch = "wasm32"))]
     {
-        capitalize_first(&vmux_core::profile::active_profile_name())
+        vmux_core::profile::display_name()
     }
     #[cfg(target_arch = "wasm32")]
     {
         "Personal".to_string()
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn capitalize_first(s: &str) -> String {
-    let mut chars = s.chars();
-    match chars.next() {
-        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
-        None => "Personal".to_string(),
     }
 }
 

--- a/crates/vmux_space/src/plugin.rs
+++ b/crates/vmux_space/src/plugin.rs
@@ -809,11 +809,6 @@ mod tests {
                 .as_deref(),
             Some("vmux-ai/vmux")
         );
-        let profile = vmux_core::profile::active_profile_name();
-        assert!(
-            home.home
-                .join(format!(".vmux/profiles/{profile}/spaces/vmux-ai/vmux"))
-                .is_dir()
-        );
+        assert!(home.home.join(".vmux/spaces/vmux-ai/vmux").is_dir());
     }
 }

--- a/crates/vmux_team/src/plugin.rs
+++ b/crates/vmux_team/src/plugin.rs
@@ -42,7 +42,10 @@ impl Plugin for TeamPlugin {
 }
 
 fn spawn_user_profile(mut commands: Commands) {
-    commands.spawn((Profile::user(), User, Name::new("Profile: User")));
+    let mut identity = commands.spawn((Profile::user(), User, Name::new("Profile: User")));
+    if vmux_core::profile::is_test_session() {
+        identity.insert(vmux_core::team::Tester);
+    }
 }
 
 /// Keep the user profile's name in sync with the active space's profile name

--- a/docs/plans/2026-06-24-default-profile-decoupling.md
+++ b/docs/plans/2026-06-24-default-profile-decoupling.md
@@ -1,0 +1,300 @@
+# Default-Profile Decoupling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the hardcoded `"personal"` behavioral sentinel — make the default profile a renamable identity, mark ephemeral test sessions with a `Tester` bot identity, and keep the layout store space-owned and profile-agnostic.
+
+**Architecture:** A single env-derived predicate `is_test_session()` (`VMUX_TEST=1`) drives ephemerality (skip layout load/save), auto-approve, and which identity the bootstrap spawns (`Tester` vs `User`). The layout store moves to one profile-agnostic location; `profiles/<id>/` keeps only isolation state (cookies/socket/recordings). The default profile's storage id stays stable; its display name lives in config and is renamed via an MCP tool.
+
+**Tech Stack:** Rust, Bevy ECS (`vmux_core`, `vmux_desktop`, `vmux_space`, `vmux_agent`, `vmux_mcp`), moonshine_save (`store.ron`), clap (CLI), Makefile.
+
+**Prerequisite:** PR #145 merged to `main`; this branch rebased onto it. Verify these symbols exist before starting (they come from #145): `vmux_core::profile::{active_profile_name, store_dir, recording_dir, spaces_root_for, migrate_legacy_personal_layout}`, `vmux_desktop::persistence::{load_space_on_startup, save_space_to_path}`, `vmux_agent::client::cli::vibe::vibe_auto_approve_flag`, `vmux_agent::mcp::mcp_subcommand_args`, `vmux_core::team::{Profile, User, Agent}`.
+
+---
+
+## File map
+
+- `crates/vmux_core/src/profile.rs` — add `is_test_session()`; make `store_dir`/spaces profile-agnostic; resolve default id; drop `== "personal"` from path logic.
+- `crates/vmux_core/src/team.rs` — add `Tester` marker component.
+- `crates/vmux_space/src/model.rs` / `spaces.rs` — bootstrap spawns `Tester` vs `User`.
+- `crates/vmux_desktop/src/persistence.rs` — gate load/save on `is_test_session()`.
+- `crates/vmux_agent/src/client/cli/vibe.rs` — auto-approve on `is_test_session()`.
+- `crates/vmux_agent/src/mcp.rs` — always pass `--profile <id>`.
+- `crates/vmux_setting` + `crates/vmux_core/src/profile.rs` — default display name in config.
+- `crates/vmux_mcp/src/tools.rs` + `vmux_service`/`vmux_space` — `vmux_rename_profile` tool + handler.
+- `Makefile` — `test-app` sets `VMUX_TEST=1`.
+
+---
+
+## Task 1: `is_test_session()` predicate
+
+**Files:** Modify `crates/vmux_core/src/profile.rs`
+
+- [ ] **Step 1: Failing test** (append to `profile.rs` tests)
+
+```rust
+#[test]
+fn is_test_session_reads_env() {
+    let prev = std::env::var("VMUX_TEST").ok();
+    unsafe { std::env::set_var("VMUX_TEST", "1") };
+    assert!(is_test_session());
+    unsafe { std::env::remove_var("VMUX_TEST") };
+    assert!(!is_test_session());
+    if let Some(p) = prev { unsafe { std::env::set_var("VMUX_TEST", p) }; }
+}
+```
+
+- [ ] **Step 2:** `cargo test -p vmux_core is_test_session_reads_env` → FAIL (undefined).
+- [ ] **Step 3: Implement**
+
+```rust
+pub fn is_test_session() -> bool {
+    matches!(
+        std::env::var("VMUX_TEST").ok().as_deref(),
+        Some("1") | Some("true") | Some("yes")
+    )
+}
+```
+
+- [ ] **Step 4:** `cargo test -p vmux_core is_test_session_reads_env` → PASS.
+- [ ] **Step 5: Commit** `feat(core): is_test_session() predicate from VMUX_TEST`
+
+---
+
+## Task 2: Profile-agnostic layout store location
+
+**Files:** Modify `crates/vmux_core/src/profile.rs` (`store_dir_for`/`store_dir`)
+
+Layout must not live under `profiles/<id>/`. `store.ron` goes at the shared-data-dir base for every profile.
+
+- [ ] **Step 1: Failing test**
+
+```rust
+#[test]
+fn store_dir_is_profile_agnostic_base() {
+    let base = std::path::Path::new("/data/Vmux/dev");
+    assert_eq!(store_dir_for(base, "personal"), PathBuf::from("/data/Vmux/dev"));
+    assert_eq!(store_dir_for(base, "gregor"), PathBuf::from("/data/Vmux/dev"));
+}
+```
+
+- [ ] **Step 2:** `cargo test -p vmux_core store_dir_is_profile_agnostic_base` → FAIL (gregor still nests).
+- [ ] **Step 3: Implement** — drop the profile branch:
+
+```rust
+fn store_dir_for(base: &std::path::Path, _profile: &str) -> PathBuf {
+    base.to_path_buf()
+}
+```
+
+- [ ] **Step 4:** Update/replace the old `store_dir_personal_is_base_and_test_is_nested` test to the new behavior; `cargo test -p vmux_core` → PASS.
+- [ ] **Step 5: Commit** `refactor(core): layout store is profile-agnostic (base dir)`
+
+---
+
+## Task 3: Profile-agnostic spaces dir + migration
+
+**Files:** Modify `crates/vmux_core/src/profile.rs` (`spaces_root_for`, `migrate_legacy_personal_layout_in`)
+
+Spaces are layout → one profile-agnostic root (mirror the store). Keep recordings per-profile.
+
+- [ ] **Step 1: Failing test**
+
+```rust
+#[test]
+fn spaces_root_is_profile_agnostic() {
+    let home = std::path::Path::new("/home/u");
+    assert_eq!(spaces_root_for(home, "personal"), PathBuf::from("/home/u/.vmux/spaces"));
+    assert_eq!(spaces_root_for(home, "gregor"), PathBuf::from("/home/u/.vmux/spaces"));
+}
+```
+
+- [ ] **Step 2:** `cargo test -p vmux_core spaces_root_is_profile_agnostic` → FAIL.
+- [ ] **Step 3: Implement** — drop the profile segment:
+
+```rust
+fn spaces_root_for(home: &std::path::Path, _profile: &str) -> PathBuf {
+    home.join(".vmux").join("spaces")
+}
+```
+
+- [ ] **Step 4:** Extend `migrate_legacy_personal_layout_in` to move any `profiles/<p>/spaces` left by #145 back to `~/.vmux/spaces` (guarded: skip if target exists). Update the per-profile-spaces tests to the agnostic path.
+- [ ] **Step 5:** `cargo test -p vmux_core` → PASS.
+- [ ] **Step 6: Commit** `refactor(core): spaces dir is profile-agnostic + migrate`
+
+---
+
+## Task 4: `Tester` identity + bootstrap
+
+**Files:** Modify `crates/vmux_core/src/team.rs`, `crates/vmux_space/src/spaces.rs` (`space_profile_bundle`)
+
+- [ ] **Step 1: Failing test** (`vmux_space` spaces tests) — assert a test session bootstraps `Tester`, a normal one `User`:
+
+```rust
+#[test]
+fn bootstrap_spawns_tester_under_test_session() {
+    let prev = std::env::var("VMUX_TEST").ok();
+    unsafe { std::env::set_var("VMUX_TEST", "1") };
+    let mut app = App::new();
+    app.world_mut().spawn(space_profile_bundle(&bootstrap_space_record()));
+    let mut q = app.world_mut().query_filtered::<(), With<vmux_core::team::Tester>>();
+    assert_eq!(q.iter(app.world()).count(), 1);
+    let mut u = app.world_mut().query_filtered::<(), With<vmux_core::team::User>>();
+    assert_eq!(u.iter(app.world()).count(), 0);
+    unsafe { std::env::remove_var("VMUX_TEST") };
+    if let Some(p) = prev { unsafe { std::env::set_var("VMUX_TEST", p) }; }
+}
+```
+
+- [ ] **Step 2:** `cargo test -p vmux_space bootstrap_spawns_tester_under_test_session` → FAIL.
+- [ ] **Step 3: Implement** — add the marker + branch the bundle:
+
+```rust
+// team.rs
+#[derive(Component, Clone, Copy, Debug)]
+pub struct Tester;
+```
+
+In `space_profile_bundle`, replace the unconditional `User` with: spawn `Tester` when `vmux_core::profile::is_test_session()`, else `User`. (Keep `team::Profile { name, avatar }` on both.)
+
+- [ ] **Step 4:** `cargo test -p vmux_space` → PASS.
+- [ ] **Step 5: Commit** `feat(team): Tester bot identity for test sessions`
+
+---
+
+## Task 5: Persistence gates on `is_test_session()`
+
+**Files:** Modify `crates/vmux_desktop/src/persistence.rs` (`load_space_on_startup`, `save_space_to_path`)
+
+- [ ] **Step 1:** Replace both `active_profile_name() != "personal"` guards with `vmux_core::profile::is_test_session()`.
+
+```rust
+// in both functions
+if vmux_core::profile::is_test_session() {
+    // existing early-return/skip body
+}
+```
+
+- [ ] **Step 2: Test** — `crates/vmux_desktop/tests/` add an integration check (or unit on a helper) asserting `is_test_session()` short-circuits save. Run `cargo test -p vmux_desktop persistence` (or the new test) → PASS.
+- [ ] **Step 3: Commit** `refactor(desktop): persistence skips on is_test_session, not name`
+
+---
+
+## Task 6: Auto-approve gates on `is_test_session()`
+
+**Files:** Modify `crates/vmux_agent/src/client/cli/vibe.rs`
+
+- [ ] **Step 1: Failing test** — replace `auto_approve_flag_only_for_non_personal_profile`:
+
+```rust
+#[test]
+fn auto_approve_flag_follows_test_session() {
+    let prev = std::env::var("VMUX_TEST").ok();
+    unsafe { std::env::set_var("VMUX_TEST", "1") };
+    assert!(VibeStrategy.build_args(&mcp(), None).iter().any(|a| a == "--auto-approve"));
+    unsafe { std::env::remove_var("VMUX_TEST") };
+    assert!(!VibeStrategy.build_args(&mcp(), None).iter().any(|a| a == "--auto-approve"));
+    if let Some(p) = prev { unsafe { std::env::set_var("VMUX_TEST", p) }; }
+}
+```
+(Add a small `fn mcp() -> McpServerConfig` test helper if absent.)
+
+- [ ] **Step 2:** Run it → FAIL.
+- [ ] **Step 3: Implement** — `build_args` appends `--auto-approve` when `vmux_core::profile::is_test_session()`; delete `vibe_auto_approve_flag`.
+- [ ] **Step 4:** `cargo test -p vmux_agent` → PASS.
+- [ ] **Step 5: Commit** `refactor(agent): vibe auto-approve on is_test_session`
+
+---
+
+## Task 7: Always propagate `--profile`
+
+**Files:** Modify `crates/vmux_agent/src/mcp.rs` (`mcp_subcommand_args`)
+
+- [ ] **Step 1: Failing test** — update `mcp_args_append_profile_only_for_non_personal` to expect `--profile` for every id:
+
+```rust
+#[test]
+fn mcp_args_always_append_profile() {
+    let a = ProcessId::new();
+    let args = mcp_subcommand_args(a, "personal");
+    assert!(args.windows(2).any(|w| w[0] == "--profile" && w[1] == "personal"));
+}
+```
+
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3: Implement** — drop the `if profile != "personal"` guard; always push `--profile`, `profile`.
+- [ ] **Step 4:** `cargo test -p vmux_agent` → PASS.
+- [ ] **Step 5: Commit** `refactor(agent): always pass --profile to spawned mcp`
+
+---
+
+## Task 8: Default display name in config
+
+**Files:** Modify `crates/vmux_setting` (settings struct) + `crates/vmux_core/src/profile.rs` + `crates/vmux_space/src/model.rs` (`bootstrap_profile_name`)
+
+- [ ] **Step 1: Failing test** — display name falls back to capitalized id, override from config:
+
+```rust
+#[test]
+fn display_name_defaults_to_capitalized_id_or_config() {
+    assert_eq!(display_name_for("personal", None), "Personal");
+    assert_eq!(display_name_for("personal", Some("Junichi")), "Junichi");
+}
+```
+
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3: Implement** — add `profile_display_name: Option<String>` to settings; `fn display_name_for(id: &str, configured: Option<&str>) -> String` (configured or capitalize(id)); have `bootstrap_profile_name` read settings then fall back. Keep `"personal"` only as the id seed.
+- [ ] **Step 4:** `cargo test -p vmux_core -p vmux_space` → PASS.
+- [ ] **Step 5: Commit** `feat(core): default profile display name from config`
+
+---
+
+## Task 9: `vmux_rename_profile` MCP tool
+
+**Files:** Modify `crates/vmux_mcp/src/tools.rs`, `crates/vmux_service/src/protocol.rs` (`AgentCommand`), `crates/vmux_space/src/plugin.rs` (handler)
+
+- [ ] **Step 1: Failing test** (`tools.rs`) — dispatch maps to the command:
+
+```rust
+#[test]
+fn rename_profile_dispatches() {
+    let c = dispatch_command("rename_profile", serde_json::json!({"name": "Junichi"})).unwrap();
+    assert!(matches!(c, AgentCommand::RenameProfile { name } if name == "Junichi"));
+}
+```
+
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3: Implement**
+  - `McpParamTool::RenameProfile { name: String }` (+ description) → `AgentCommand::RenameProfile { name }` (reject empty).
+  - `AgentCommand::RenameProfile { name }` in `vmux_service::protocol` (+ rkyv + validate non-empty).
+  - Handler (vmux_space plugin): write the settings update (`profile_display_name = name`) and update the live `team::Profile { name, avatar }` on the `User`/`Tester` identity (recompute avatar initials). No directory moves.
+- [ ] **Step 4:** `cargo test -p vmux_mcp -p vmux_service -p vmux_space` → PASS.
+- [ ] **Step 5: Commit** `feat(mcp): vmux_rename_profile (display-name only)`
+
+---
+
+## Task 10: `make test-app` sets `VMUX_TEST=1`
+
+**Files:** Modify `Makefile`, `crates/vmux_desktop/tests/release_invariants.rs`
+
+- [ ] **Step 1:** Change `test-app:` to `$(MAKE) dev VMUX_PROFILE=gregor VMUX_TEST=1`, and ensure the `dev` exec line forwards `VMUX_TEST="$(VMUX_TEST)"` (with `VMUX_TEST ?=` default empty at the top).
+- [ ] **Step 2:** Add an invariant assertion in `release_invariants.rs` that `test-app` passes `VMUX_TEST=1`. `cargo test -p vmux_desktop --test release_invariants` → PASS.
+- [ ] **Step 3: Commit** `build: test-app sets VMUX_TEST=1`
+
+---
+
+## Task 11: Sentinel sweep + full check
+
+**Files:** repo-wide
+
+- [ ] **Step 1:** `grep -rn '"personal"' crates/ | grep -v test` — confirm the only remaining uses are the **id seed** (`sanitize_profile` empty→"personal", default-id resolution). No behavioral branches remain.
+- [ ] **Step 2:** `cargo fmt`; `git checkout -- patches/`.
+- [ ] **Step 3:** `cargo test -p vmux_core -p vmux_service -p vmux_mcp -p vmux_terminal -p vmux_agent -p vmux_cli -p vmux_space` and `cargo check -p vmux_desktop` → all green.
+- [ ] **Step 4: Commit** `chore: drop residual personal sentinels`
+
+---
+
+## Self-review notes
+- **Spec coverage:** §1 layout-agnostic → Tasks 2-3; §2 Tester identity → Task 4; §3 is_test_session behavior → Tasks 1,5,6,10; §4 default id+display name → Task 8; §5 isolation unchanged → (no task; recordings/cef untouched); §6 rename → Task 9; §7 sentinel removal → Tasks 2,5,6,7,11.
+- **Test signal:** `VMUX_TEST` truthy = `1|true|yes` (Task 1) — used consistently in Tasks 5,6,10.
+- **No dir moves on rename** (Task 9) — matches spec decision.

--- a/docs/specs/2026-06-24-default-profile-decoupling-design.md
+++ b/docs/specs/2026-06-24-default-profile-decoupling-design.md
@@ -1,0 +1,79 @@
+# Default-Profile Decoupling Design
+
+**Goal:** Stop treating the literal string `"personal"` as a behavioral sentinel. The default profile becomes a renamable identity; ephemeral test sessions are marked explicitly in the entity model; the layout store stays space-owned and profile-agnostic.
+
+**Depends on:** PR #145 (VMUX_PROFILE isolation). Implement on top of merged main.
+
+---
+
+## Background (current state after #145)
+
+`VMUX_PROFILE` selects a runtime isolation profile. `"personal"` is both the default value **and** a behavioral sentinel in several places:
+
+- `profile.rs::store_dir_for` — `personal` → base dir, else `profiles/<p>/`
+- `persistence.rs` (`load_space_on_startup`, `save_space_to_path`) — non-personal skips store load/save (ephemeral)
+- `vibe.rs::vibe_auto_approve_flag` — non-personal → `--auto-approve`
+- `mcp.rs::mcp_subcommand_args` — non-personal → append `--profile`
+- `profile.rs::migrate_legacy_personal_layout` — runs only for `personal`
+- `model.rs::bootstrap_profile_name` — identity derived from the profile name
+
+Two distinct concepts get conflated under "profile":
+
+1. **Isolation profile** (`VMUX_PROFILE`) — which `profiles/<p>/` dir holds cookies, socket, recordings.
+2. **Team attribution** (`team::Profile { name, avatar }` on a space / user) — *who* owns a space, shown in the facepile.
+
+**The space owns its layout.** The team profile is just a label inside the layout; it must not shard the store.
+
+---
+
+## Design
+
+### 1. Layout is space-owned and profile-agnostic
+The layout store (`store.ron`) and per-space working dirs live in **one** profile-agnostic location under the shared data dir (e.g. `…/Vmux/<build>/store.ron` and `…/Vmux/<build>/spaces/`), **not** under `profiles/<p>/`. Spaces with any team attribution coexist in this single store. (This relocates the layout that #145 nested per-profile; recordings stay per-profile — see §5.)
+
+### 2. Test identity is a bot (`Tester`), not a `User`
+A normal instance bootstraps a `User` (the human). A **test session bootstraps its identity with `vmux_core::team::Tester` instead of `User`** — an automated QA persona ("Gregor"), not a human — so the facepile renders it as a bot, not the human "You". The pane-agent type `Agent { sid, kind: AgentKind }` stays reserved for vibe/claude/codex and is unchanged.
+
+### 3. `is_test_session()` drives identity + behavior
+`vmux_core::profile::is_test_session() -> bool` reads `VMUX_TEST` (truthy env). `make test-app` sets `VMUX_TEST=1` alongside `VMUX_PROFILE=gregor`. It drives:
+
+- **Identity:** bootstrap spawns the `Tester` identity instead of `User`.
+- **Fresh layout, never saved:** `load_space_on_startup` skips load and spawns a fresh bootstrap space; `save_space_to_path` returns without writing. Replaces every `active_profile_name() != "personal"` persistence check.
+- **Auto-approve:** vibe `build_args` adds `--auto-approve`.
+
+Non-ECS launch code (vibe `build_args`) calls `is_test_session()` directly; ECS code can also query `With<Tester>` on the active identity.
+
+### 4. Profile = stable id + renamable display name
+- **Storage id** = `VMUX_PROFILE` (default `"personal"`), names the `profiles/<id>/` isolation dir. Stable; never moved by rename.
+- **Display name** lives in config (settings), seeded from the id (`"personal"` → "Personal") on first run. This is what the facepile pill shows.
+- `active_profile_name()` = `VMUX_PROFILE` if set, else the default id `"personal"`. `"personal"` survives **only** as this seed default — no behavior branches on it.
+
+### 5. Isolation stays per id
+CEF cache (cookies/login), service socket/pid/identity/log, and recordings remain under `profiles/<id>/` (per `VMUX_PROFILE`). Unchanged from #145.
+
+### 6. Rename via MCP (display-name only)
+`vmux_rename_profile { name }` tool:
+- Update the stored display name in config and the live `team::Profile { name, avatar }` on the user entity (avatar initials recomputed).
+- **No directory moves** — the storage id and all `profiles/<id>/` data are untouched, so there is no live-file/CEF-lock risk and rename is instant.
+
+Rationale: the user asked for a name that "can change at any moment." Decoupling the display name from the storage id makes rename a cheap, safe metadata update.
+
+### 7. Remove `"personal"` sentinels
+Replace all `== "personal"` / `!= "personal"` behavioral branches with `is_test_session()` (auto-approve), the `Tester` marker (persistence), and always-pass-the-id (`--profile`). `store_dir_for` no longer special-cases `personal`.
+
+---
+
+## Migration
+- Relocate the layout (`store.ron` + `spaces/`) to the profile-agnostic location if #145 left it under `profiles/<p>/`. One-shot move on first run, guarded (skip if the target exists).
+- Recordings + CEF cache stay per-profile; no move.
+
+## Testing
+- **Unit:** `is_test_session()` truthiness; default-id resolution when `VMUX_PROFILE` unset; display-name seed from id; rename updates config + `team::Profile`.
+- **ECS:** a test session bootstraps `Tester` (not `User`); `load`/`save` systems skip under `is_test_session()`; a normal session bootstraps `User` and persists.
+- **Integration:** a test session boots a fresh space and never writes the store; the default session persists; `vmux_rename_profile` changes the pill without moving any dir.
+
+## Decisions locked (call out at review)
+- **Test identity = `Tester` (bot), not `User`** — `Agent { kind }` stays reserved for pane agents (vibe/claude/codex).
+- **Rename = display-name only** (storage id stable). If full storage rename is wanted, that's a larger follow-up.
+- **Layout location = shared data dir base** (profile-agnostic), not `profiles/<p>/`, not top-level `~/.vmux`.
+- **Test signal = `VMUX_TEST=1` env** driving the `Tester` identity + fresh-layout behavior (not a name check).

--- a/docs/specs/2026-06-24-default-profile-decoupling-design.md
+++ b/docs/specs/2026-06-24-default-profile-decoupling-design.md
@@ -29,7 +29,7 @@ Two distinct concepts get conflated under "profile":
 ## Design
 
 ### 1. Layout is space-owned and profile-agnostic
-The layout store (`store.ron`) and per-space working dirs live in **one** profile-agnostic location under the shared data dir (e.g. `…/Vmux/<build>/store.ron` and `…/Vmux/<build>/spaces/`), **not** under `profiles/<p>/`. Spaces with any team attribution coexist in this single store. (This relocates the layout that #145 nested per-profile; recordings stay per-profile — see §5.)
+The layout is **one** profile-agnostic store, **not** under `profiles/<p>/`: `store.ron` at the shared-data-dir base (`…/Vmux/<build>/store.ron`) and the per-space working dirs at `~/.vmux/spaces/` (config dir, matching the pre-#145 location). Spaces with any team attribution coexist in this single store. (This relocates the spaces that #145 nested per-profile; recordings stay per-profile — see §5.)
 
 ### 2. Test identity is a bot (`Tester`), not a `User`
 A normal instance bootstraps a `User` (the human). A **test session bootstraps its identity with `vmux_core::team::Tester` instead of `User`** — an automated QA persona ("Gregor"), not a human — so the facepile renders it as a bot, not the human "You". The pane-agent type `Agent { sid, kind: AgentKind }` stays reserved for vibe/claude/codex and is unchanged.
@@ -53,7 +53,7 @@ CEF cache (cookies/login), service socket/pid/identity/log, and recordings remai
 
 ### 6. Rename via MCP (display-name only)
 `vmux_rename_profile { name }` tool:
-- Update the stored display name in config and the live `team::Profile { name, avatar }` on the user entity (avatar initials recomputed).
+- Update the stored display name (config) and the active space record's profile name; `sync_user_profile_name` then re-syncs the live `team::Profile { name, avatar }` on the `User` identity (avatar initials recomputed). Rename targets the default (non-test) session — test sessions render the capitalized id and don't rename.
 - **No directory moves** — the storage id and all `profiles/<id>/` data are untouched, so there is no live-file/CEF-lock risk and rename is instant.
 
 Rationale: the user asked for a name that "can change at any moment." Decoupling the display name from the storage id makes rename a cheap, safe metadata update.
@@ -75,5 +75,5 @@ Replace all `== "personal"` / `!= "personal"` behavioral branches with `is_test_
 ## Decisions locked (call out at review)
 - **Test identity = `Tester` (bot), not `User`** — `Agent { kind }` stays reserved for pane agents (vibe/claude/codex).
 - **Rename = display-name only** (storage id stable). If full storage rename is wanted, that's a larger follow-up.
-- **Layout location = shared data dir base** (profile-agnostic), not `profiles/<p>/`, not top-level `~/.vmux`.
+- **Layout location** — `store.ron` at the shared-data-dir base, spaces at `~/.vmux/spaces` (config dir); neither under `profiles/<p>/`.
 - **Test signal = `VMUX_TEST=1` env** driving the `Tester` identity + fresh-layout behavior (not a name check).


### PR DESCRIPTION
Decouples test-session behavior from the hardcoded `"personal"` string, and makes the default profile renamable. Builds on #145 (merged). Spec + plan: `docs/specs/2026-06-24-default-profile-decoupling-design.md`, `docs/plans/2026-06-24-default-profile-decoupling.md`.

## What changed
- **`is_test_session()`** (`VMUX_TEST=1`) is the single predicate for ephemerality + auto-approve.
- **Layout is profile-agnostic** — `store.ron` + `spaces/` no longer nest per profile; migration reverses #145's per-profile spaces nesting.
- **`Tester` identity** — bootstrap adds `Tester` alongside `User` for test sessions (User is load-bearing across ~10 systems, so it's a flag, not a replacement).
- **Gating decoupled from the name** — persistence load/save, vibe `--auto-approve`, `--profile` propagation, and the legacy migration all key off `is_test_session()`.
- **Renamable display name** — default profile name lives in config (`~/.vmux/profile_display_name`), seeded from the capitalized id; `vmux_core::profile::{display_name, set_display_name}`.
- **`vmux_rename_profile` MCP tool** — tools → protocol → handler; calls `set_display_name` and live-updates the facepile identity (display-name only, no dir moves).
- **`make test-app`** sets `VMUX_TEST=1`; dev exec forwards it; release-invariants updated.

The only `== "personal"` left is `vmux_service/paths.rs` (the runtime socket/pid path keyed on the stable **storage id**, not the renamable display name) — consistent with the design. Could suffix it for all profiles as a follow-up.

## Tests (local)
vmux_core 77/0, vmux_mcp 69/0, vmux_service 127/0, vmux_agent 108/0, release_invariants 17/0; desktop/team/space compile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-profile display-name persistence and a profile rename flow, including an MCP rename tool that updates the displayed name without moving stored profile data.
* **Bug Fixes**
  * Enabled profile layout/persistence behavior to be test-session driven (via a test flag) instead of using a hardcoded profile name sentinel.
  * Improved test-session handling (desktop persistence/loading behavior, auto-approve, and test identity setup) and updated cleanup of stale dev artifacts.
* **Documentation**
  * Added planning and design docs for default-profile decoupling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->