### PR TITLE
feat(layout): bind tab next/prev to cmd+opt+arrow

### DIFF
--- a/crates/vmux_command/src/command.rs
+++ b/crates/vmux_command/src/command.rs
@@ -311,12 +311,12 @@ pub enum TabCommand {
     Close,
     #[menu(id = "next_tab", label = "Next Tab", accel = "super+shift+]")]
     #[shortcut(direct = "Super+Shift+L")]
-    #[shortcut(direct = "Super+Shift+ArrowRight")]
+    #[shortcut(direct = "Super+Alt+ArrowRight")]
     #[shortcut(direct = "Super+Shift+BracketRight")]
     Next,
     #[menu(id = "prev_tab", label = "Previous Tab", accel = "super+shift+[")]
     #[shortcut(direct = "Super+Shift+H")]
-    #[shortcut(direct = "Super+Shift+ArrowLeft")]
+    #[shortcut(direct = "Super+Alt+ArrowLeft")]
     #[shortcut(direct = "Super+Shift+BracketLeft")]
     Previous,
     #[menu(id = "rename_tab", label = "Rename Tab")]


### PR DESCRIPTION
## Summary
- Bind tab next/prev to `Cmd+Opt+Right` / `Cmd+Opt+Left` to match Chrome on macOS.
- Replaces the old `Cmd+Shift+Arrow` direct bindings. `Cmd+Shift+]`/`[` (brackets), `Cmd+Shift+L`/`H`, and the menu accelerator are unchanged, so existing muscle memory still works.

## Test plan
- [x] `cargo test -p vmux_command` (55 passed) — shortcut strings parse, bracket bindings still global.
- [ ] Manual: `Cmd+Opt+Left/Right` cycles tabs under terminal/layout/browser focus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the direct keyboard shortcuts for switching tabs: `Next Tab` now uses `Super+Alt+Right Arrow`, and `Previous Tab` now uses `Super+Alt+Left Arrow`.
  * Existing bracket-based shortcuts for moving between tabs remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->