### PR TITLE
fix(settings): default terminal shell defers to $SHELL

### DIFF
--- a/crates/vmux_setting/src/plugin/runtime.rs
+++ b/crates/vmux_setting/src/plugin/runtime.rs
@@ -1263,6 +1263,14 @@ mod tests {
     }
 
     #[test]
+    fn embedded_default_theme_shell_is_portable() {
+        let s = load_embedded_settings();
+        let terminal = s.terminal.expect("embedded settings define terminal");
+        let shell = terminal.resolve_theme(&terminal.default_theme).shell;
+        assert_eq!(shell, default_shell());
+    }
+
+    #[test]
     fn resolve_startup_dir_prefers_per_space_then_global_then_builtin() {
         let per = tempfile::tempdir().unwrap();
         let glob = tempfile::tempdir().unwrap();

--- a/crates/vmux_setting/src/settings.ron
+++ b/crates/vmux_setting/src/settings.ron
@@ -48,7 +48,6 @@
                 padding: 4.0,
                 cursor_style: "block",
                 cursor_blink: true,
-                shell: "/opt/homebrew/bin/nu",
             ),
         ],
     )),


### PR DESCRIPTION
## Context

A first-time install from the latest release shows a **blank terminal** (no CEF page) when opening a terminal via the command bar. Browse mode works; only terminals break.

Root cause: the embedded `crates/vmux_setting/src/settings.ron` hardcoded the default terminal theme's `shell` to `/opt/homebrew/bin/nu` — a dev's Homebrew Nushell. Fresh installs never write `~/.vmux/settings.ron` (defaults load in-memory), so every launch used that absolute path. On any machine without `nu` it doesn't exist, so the service's `CreateProcess` fails, `apply_process_create_failed` despawns the terminal entity, and the pane is left blank with no OSR page. Browse mode spawns no shell, so it was unaffected.

## Implementation

Removed the hardcoded `shell` line so the default theme resolves it via the existing `#[serde(default = "default_shell")]` — `$SHELL`, falling back to `/bin/zsh`. Machines keep their own login shell (the dev still gets `nu` via `$SHELL`); fresh installs get a shell that actually exists.

Added `embedded_default_theme_shell_is_portable` asserting the embedded default theme shell equals `default_shell()`, so a machine-specific path can't be reintroduced.

Note (out of scope): `apply_process_create_failed` despawns silently, which is why a bad shell surfaces as a confusing blank rather than an error. Surfacing the failure in-pane is worth a follow-up.

## Checks / QA

- On a machine without `nu` (or with `$SHELL=/bin/zsh`), fresh profile (no `~/.vmux/settings.ron`): open a terminal via the command bar → it renders and a shell prompt appears.
- With a user-set `terminal.themes[].shell`, that override is still honored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the app’s default terminal shell behavior so embedded theme settings now match the expected portable default shell.
  * Removed a hardcoded shell value from the default terminal theme, helping the app respect the user’s environment more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->