### PR TITLE
chore(release): v0.0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9672,7 +9672,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9707,7 +9707,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_browser"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9728,7 +9728,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -9740,7 +9740,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9755,7 +9755,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9771,7 +9771,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9836,7 +9836,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_editor"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9875,7 +9875,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_git"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9892,7 +9892,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9913,7 +9913,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -9947,7 +9947,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "muda",
  "proc-macro2",
@@ -9957,7 +9957,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -9970,7 +9970,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_server"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "dioxus",
  "regex",
@@ -9991,7 +9991,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "alacritty_terminal",
  "bevy",
@@ -10027,7 +10027,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10050,7 +10050,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10075,7 +10075,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_team"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10096,7 +10096,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10127,7 +10127,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "dioxus",
  "dioxus-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.17"
+version = "0.0.18"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "GPL-3.0-or-later"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.17"
-  sha256 "8d42328254755fbc034bc2d5bd5ffe565ec86d0d68e5552a1b240abeafa9f33a"
+  version "0.0.18"
+  sha256 "42029205e1b82af3b1cdb166e37a1135885aaf727956b4bef8633bd8baf663e8"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.17/Vmux_0.0.17_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.18/Vmux_0.0.18_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai/"

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.17",
-  "pub_date": "2026-06-23T23:37:40Z",
+  "version": "v0.0.18",
+  "pub_date": "2026-06-25T12:42:06Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.17/Vmux-v0.0.17-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTyt3YWV5b1NKYmg1YnZGR2oySFk4VTNTZ1FOdHJEcHhXTlhVd2QzS0VtUGNWWHFsL0E2R1J6VGlEYWl1SXhib0FHZXNVZHAvYTNjbHpCVXVrc0VZc1F3PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgyMjU0ODk3CWZpbGU6Vm11eC12MC4wLjE3LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKUSt2VXV3Y213RG12azloUWdkczVVcW80bnVNRmVzWHdlU0p5cjdHTWRhUlJxVDUxc2hXRG9yeHVmUDNsOE82Qm0wYXhqVGd4UFdleTNKN0NTSzRMQ2c9PQo=",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.18/Vmux-v0.0.18-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzZwQ0VXK05FZDVRclp1YzNpa0xhMGIvNkZxQWhXU1A1WnlXbHZBbkZZeUpSM1pGb3BxWmtreHBnTXY2dmtGc1VEWXVvSDhFcHg0QTN1amZxalFuVUFNPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgyMzg5NzUyCWZpbGU6Vm11eC12MC4wLjE4LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKSXd3QWUxN0dvYXNsbzYyRXlDR2lwUFlzNERwaTRIUUhoamx0L1VZYlFTYlExRHR4VnhkWktJdTlGS1FEUXIvTlFOQVpBVVRjNlI5MUpHVTE5L3ZuREE9PQo=",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.17/Vmux_0.0.17_aarch64.dmg",
-      "filename": "Vmux_0.0.17_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.18/Vmux_0.0.18_aarch64.dmg",
+      "filename": "Vmux_0.0.18_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
Patch release. Bumps workspace version 0.0.17 -> 0.0.18. Releases on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the workspace package version from `0.0.17` to `0.0.18`.
  * Refreshed the Homebrew cask for `vmux` to release `0.0.18` with updated download URL and checksum.
  * Updated website release metadata for `v0.0.18`, including app download links, signatures, and publish date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->