### PR TITLE
fix(browser): keep back/forward history across vmux:// and web pages

### DIFF
--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -2579,14 +2579,13 @@ fn handle_browser_commands(
                     if resolved.is_empty() {
                         continue;
                     }
-                    let on_native_view = meta_q
+                    let current_url = meta_q
                         .get(webview)
-                        .map(|m| m.url.starts_with("vmux://"))
-                        .unwrap_or(false);
+                        .map(|m| m.url.clone())
+                        .unwrap_or_default();
                     if is_terminal
-                        || on_native_view
-                        || resolved.starts_with("vmux://")
-                        || resolved.starts_with("file:")
+                        || page_needs_host_spawn(&current_url)
+                        || page_needs_host_spawn(&resolved)
                     {
                         page_open_requests.write(PageOpenRequest {
                             target: PageOpenTarget::Stack(active),
@@ -2595,12 +2594,7 @@ fn handle_browser_commands(
                         });
                         continue;
                     }
-                    if is_terminal {
-                        commands
-                            .entity(webview)
-                            .remove::<Terminal>()
-                            .remove::<vmux_service::protocol::ProcessId>();
-                    }
+                    let resolved = normalize_vmux_url(&resolved);
                     if let Ok(mut meta) = meta_q.get_mut(webview) {
                         meta.url = resolved.clone();
                         meta.title = resolved.clone();
@@ -3004,6 +2998,12 @@ fn normalize_vmux_url(url: &str) -> String {
         return format!("vmux://{rest}/");
     }
     url.to_string()
+}
+
+fn page_needs_host_spawn(url: &str) -> bool {
+    url.starts_with("file:")
+        || url.starts_with("vmux://terminal")
+        || url.starts_with("vmux://agent")
 }
 
 fn resolve_page_open_target(
@@ -5380,7 +5380,7 @@ mod tests {
         }
 
         #[test]
-        fn in_place_from_native_view_to_web_routes_through_page_open() {
+        fn in_place_from_plain_vmux_to_web_navigates_in_place() {
             let mut app = build_app();
             build_focused_native_stack(&mut app, "vmux://spaces/");
 
@@ -5394,11 +5394,76 @@ mod tests {
 
             app.update();
 
+            let page_opens = app.world().resource::<CapturedPageOpenRequests>();
+            assert!(page_opens.0.is_empty());
+            let navigates = app.world().resource::<CapturedNavigateUrls>();
+            assert_eq!(navigates.0, vec!["https://mistral.ai".to_string()]);
+        }
+
+        #[test]
+        fn in_place_from_web_to_plain_vmux_navigates_in_place() {
+            let mut app = build_app();
+            build_focused_native_stack(&mut app, "https://example.com/");
+
+            app.world_mut()
+                .resource_mut::<Messages<AppCommand>>()
+                .write(AppCommand::Browser(BrowserCommand::Open(
+                    OpenCommand::InPlace {
+                        url: Some("vmux://settings/".into()),
+                    },
+                )));
+
+            app.update();
+
+            let page_opens = app.world().resource::<CapturedPageOpenRequests>();
+            assert!(page_opens.0.is_empty());
+            let navigates = app.world().resource::<CapturedNavigateUrls>();
+            assert_eq!(navigates.0, vec!["vmux://settings/".to_string()]);
+        }
+
+        #[test]
+        fn in_place_to_terminal_routes_through_page_open() {
+            let mut app = build_app();
+            build_focused_native_stack(&mut app, "vmux://settings/");
+
+            app.world_mut()
+                .resource_mut::<Messages<AppCommand>>()
+                .write(AppCommand::Browser(BrowserCommand::Open(
+                    OpenCommand::InPlace {
+                        url: Some("vmux://terminal/".into()),
+                    },
+                )));
+
+            app.update();
+
             let navigates = app.world().resource::<CapturedNavigateUrls>();
             assert!(navigates.0.is_empty());
             let page_opens = app.world().resource::<CapturedPageOpenRequests>();
             assert_eq!(page_opens.0.len(), 1);
-            assert_eq!(page_opens.0[0].url, "https://mistral.ai");
+            assert_eq!(page_opens.0[0].url, "vmux://terminal/");
+            assert!(matches!(page_opens.0[0].target, PageOpenTarget::Stack(_)));
+        }
+
+        #[test]
+        fn in_place_to_file_routes_through_page_open() {
+            let mut app = build_app();
+            build_focused_native_stack(&mut app, "https://example.com/");
+
+            app.world_mut()
+                .resource_mut::<Messages<AppCommand>>()
+                .write(AppCommand::Browser(BrowserCommand::Open(
+                    OpenCommand::InPlace {
+                        url: Some("file:///tmp/x".into()),
+                    },
+                )));
+
+            app.update();
+
+            let navigates = app.world().resource::<CapturedNavigateUrls>();
+            assert!(navigates.0.is_empty());
+            let page_opens = app.world().resource::<CapturedPageOpenRequests>();
+            assert_eq!(page_opens.0.len(), 1);
+            assert_eq!(page_opens.0[0].url, "file:///tmp/x");
             assert!(matches!(page_opens.0[0].target, PageOpenTarget::Stack(_)));
         }
 

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -2579,6 +2579,7 @@ fn handle_browser_commands(
                     if resolved.is_empty() {
                         continue;
                     }
+                    let resolved = normalize_vmux_url(&resolved);
                     let current_url = meta_q
                         .get(webview)
                         .map(|m| m.url.clone())
@@ -2594,7 +2595,6 @@ fn handle_browser_commands(
                         });
                         continue;
                     }
-                    let resolved = normalize_vmux_url(&resolved);
                     if let Ok(mut meta) = meta_q.get_mut(webview) {
                         meta.url = resolved.clone();
                         meta.title = resolved.clone();
@@ -3001,9 +3001,16 @@ fn normalize_vmux_url(url: &str) -> String {
 }
 
 fn page_needs_host_spawn(url: &str) -> bool {
-    url.starts_with("file:")
-        || url.starts_with("vmux://terminal")
-        || url.starts_with("vmux://agent")
+    fn has_vmux_host(url: &str, host: &str) -> bool {
+        let Some(rest) = url.strip_prefix("vmux://") else {
+            return false;
+        };
+        let Some(tail) = rest.strip_prefix(host) else {
+            return false;
+        };
+        tail.is_empty() || matches!(tail.as_bytes().first(), Some(b'/' | b'?' | b'#'))
+    }
+    url.starts_with("file:") || has_vmux_host(url, "terminal") || has_vmux_host(url, "agent")
 }
 
 fn resolve_page_open_target(
@@ -3393,6 +3400,21 @@ mod tests {
             normalize_vmux_url("file:///tmp/main.rs"),
             "file:///tmp/main.rs"
         );
+    }
+
+    #[test]
+    fn page_needs_host_spawn_matches_host_on_boundaries() {
+        assert!(page_needs_host_spawn("file:///tmp/x"));
+        assert!(page_needs_host_spawn("vmux://terminal"));
+        assert!(page_needs_host_spawn("vmux://terminal/"));
+        assert!(page_needs_host_spawn("vmux://terminal/?pid=1"));
+        assert!(page_needs_host_spawn("vmux://agent"));
+        assert!(page_needs_host_spawn("vmux://agent/vibe/setup"));
+
+        assert!(!page_needs_host_spawn("vmux://agentic/"));
+        assert!(!page_needs_host_spawn("vmux://terminals/"));
+        assert!(!page_needs_host_spawn("vmux://settings/"));
+        assert!(!page_needs_host_spawn("https://example.com"));
     }
 
     #[test]


### PR DESCRIPTION
## Context

Navigating from a `vmux://` page (e.g. `vmux://settings`) to a web URL lost the back/forward history — you couldn't go back to the vmux page. The address-bar `InPlace` open handler short-circuited to a stack respawn whenever the current page was `vmux://`, despawning the CEF webview and spawning a fresh one with empty history.

`vmux://` is registered as a STANDARD CEF scheme, so it can participate in a single webview's unified back/forward list alongside web pages.

## Implementation

`OpenCommand::InPlace` now navigates the existing CEF browser in place (`RequestNavigate`) whenever both the current and destination pages are plain navigable — web plus scheme-served vmux pages (settings, history, lsp, spaces, team, error). CEF then maintains unified back/forward across them for free.

A new `page_needs_host_spawn()` classifier keeps the respawn path only for destinations/current views that require host-side state: `file:` (editor FileView), `vmux://terminal` (PTY), and `vmux://agent` (session). The previous unreachable terminal-strip block was removed.

Known boundary by design: entering/leaving terminal, agent, or file-editor pages still resets history, since those aren't plain navigable pages.

## Checks / QA

- Open `vmux://settings`, navigate to `google.com`, press Back → returns to `vmux://settings`; Forward → returns to google.
- Web → `vmux://history` → Back returns to the web page.
- Navigating to `vmux://terminal` still spawns a terminal; `vmux://agent` still attaches an agent; a `file://` path still opens the editor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how browser links are handled between hosted pages and web navigation.
  * Reduced unnecessary “open in place” rerouting for some `vmux://` pages, allowing them to navigate normally.
  * Better handles URL normalization for browser navigation, including bare host-style addresses.
  * Updated related checks so only specific page types switch to host-managed opening behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->