### PR TITLE
fix(layout): activate adjacent tab on close instead of first

### DIFF
--- a/crates/vmux_layout/src/command_bar/handler.rs
+++ b/crates/vmux_layout/src/command_bar/handler.rs
@@ -1458,7 +1458,7 @@ fn close_tab_if_only_pending_stack(
     if siblings.len() <= 1 {
         return false;
     }
-    if let Some(next) = pick_tab_after_close(tab, &siblings) {
+    if let Some(next) = crate::tab::pick_after_close(tab, &siblings) {
         commands.entity(next).insert(LastActivatedAt::now());
     }
     commands.entity(tab).despawn();
@@ -1507,16 +1507,6 @@ fn sibling_tabs(
         return vec![tab];
     };
     children.iter().filter(|e| tab_q.get(*e).is_ok()).collect()
-}
-
-fn pick_tab_after_close(active: Entity, siblings: &[Entity]) -> Option<Entity> {
-    if siblings.len() <= 1 {
-        return None;
-    }
-    let idx = siblings.iter().position(|e| *e == active)?;
-    let next_idx = if idx + 1 < siblings.len() { idx + 1 } else { 0 };
-    let target = siblings[next_idx];
-    if target == active { None } else { Some(target) }
 }
 
 fn deferred_dismiss_modal(

--- a/crates/vmux_layout/src/stack.rs
+++ b/crates/vmux_layout/src/stack.rs
@@ -558,7 +558,7 @@ fn close_tab_if_only_closing_stack(
     if siblings.len() <= 1 {
         return false;
     }
-    if let Some(next) = pick_tab_after_close(tab, &siblings) {
+    if let Some(next) = crate::tab::pick_after_close(tab, &siblings) {
         commands.entity(next).insert(LastActivatedAt::now());
     }
     commands.entity(tab).despawn();
@@ -592,16 +592,6 @@ fn sibling_tabs(
         return vec![tab];
     };
     children.iter().filter(|e| tabs.get(*e).is_ok()).collect()
-}
-
-fn pick_tab_after_close(active: Entity, siblings: &[Entity]) -> Option<Entity> {
-    if siblings.len() <= 1 {
-        return None;
-    }
-    let idx = siblings.iter().position(|e| *e == active)?;
-    let next_idx = if idx + 1 < siblings.len() { idx + 1 } else { 0 };
-    let target = siblings[next_idx];
-    if target == active { None } else { Some(target) }
 }
 
 fn sync_stack_picking(
@@ -820,6 +810,54 @@ mod tests {
         let ctx = app.world().resource::<NewStackContext>();
         assert_eq!(ctx.stack, None);
         assert!(!ctx.needs_open);
+    }
+
+    #[test]
+    fn closing_last_stack_in_active_rightmost_tab_activates_left_neighbor_not_first() {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, CommandPlugin))
+            .add_message::<PageOpenRequest>()
+            .init_resource::<NewStackContext>()
+            .init_resource::<PendingCursorWarp>()
+            .insert_resource(test_settings())
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+            .add_systems(Update, handle_stack_commands.in_set(WriteAppCommands));
+
+        let root = app.world_mut().spawn_empty().id();
+        let make_tab = |app: &mut App, ts: i64| -> Entity {
+            let tab = app
+                .world_mut()
+                .spawn((Tab::default(), LastActivatedAt(ts), ChildOf(root)))
+                .id();
+            let pane = app
+                .world_mut()
+                .spawn((Pane, LastActivatedAt(ts), ChildOf(tab)))
+                .id();
+            app.world_mut()
+                .spawn((Stack::default(), LastActivatedAt(ts), ChildOf(pane)));
+            tab
+        };
+        let first = make_tab(&mut app, 1);
+        let middle = make_tab(&mut app, 2);
+        let active_rightmost = make_tab(&mut app, 3);
+
+        app.world_mut()
+            .resource_mut::<Messages<AppCommand>>()
+            .write(AppCommand::Layout(LayoutCommand::Stack(
+                StackCommand::Close,
+            )));
+
+        app.update();
+
+        assert!(app.world().get_entity(active_rightmost).is_err());
+        let first_ts = app.world().get::<LastActivatedAt>(first).unwrap().0;
+        let middle_ts = app.world().get::<LastActivatedAt>(middle).unwrap().0;
+        assert_eq!(first_ts, 1, "first tab must not be re-activated");
+        assert!(
+            middle_ts > first_ts,
+            "left neighbor (middle) must become most-recently-activated, not the first tab"
+        );
     }
 
     #[test]

--- a/crates/vmux_layout/src/tab.rs
+++ b/crates/vmux_layout/src/tab.rs
@@ -241,12 +241,16 @@ pub fn active_tab_siblings(
         .collect::<Vec<_>>()
 }
 
-fn pick_after_close(active: Entity, siblings: &[Entity]) -> Option<Entity> {
+pub(crate) fn pick_after_close(active: Entity, siblings: &[Entity]) -> Option<Entity> {
     if siblings.len() <= 1 {
         return None;
     }
     let idx = siblings.iter().position(|e| *e == active)?;
-    let next_idx = if idx + 1 < siblings.len() { idx + 1 } else { 0 };
+    let next_idx = if idx + 1 < siblings.len() {
+        idx + 1
+    } else {
+        idx - 1
+    };
     let target = siblings[next_idx];
     if target == active { None } else { Some(target) }
 }
@@ -387,6 +391,21 @@ mod tests {
         let id = target.to_bits().to_string();
 
         assert_eq!(tab_target(Some(&id), [other, target]), Some(target));
+    }
+
+    #[test]
+    fn pick_after_close_prefers_right_then_left_neighbor() {
+        let a = Entity::from_bits(1);
+        let b = Entity::from_bits(2);
+        let c = Entity::from_bits(3);
+        let d = Entity::from_bits(4);
+        let tabs = [a, b, c, d];
+
+        assert_eq!(pick_after_close(d, &tabs), Some(c));
+        assert_eq!(pick_after_close(b, &tabs), Some(c));
+        assert_eq!(pick_after_close(a, &tabs), Some(b));
+        assert_eq!(pick_after_close(b, &[a, b]), Some(a));
+        assert_eq!(pick_after_close(a, &[a]), None);
     }
 
     #[test]
@@ -700,6 +719,115 @@ mod tests {
         assert!(app.world().get_entity(tab).is_err());
         assert!(app.world().get_entity(other_tab).is_ok());
         assert!(app.world().resource::<LastTabCloseAt>().0.is_some());
+    }
+
+    #[test]
+    fn closing_active_rightmost_tab_activates_left_neighbor_not_first() {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, CommandPlugin, crate::space::SpacePlugin))
+            .add_message::<crate::TabLayoutSpawnRequest>()
+            .add_systems(Update, handle_tab_commands.in_set(ReadAppCommands));
+
+        app.world_mut().spawn(PrimaryWindow);
+        let main = app.world_mut().spawn(MainNode).id();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active, ChildOf(main)))
+            .id();
+        let a = app
+            .world_mut()
+            .spawn((tab_bundle(), LastActivatedAt(1), ChildOf(space)))
+            .id();
+        let c = app
+            .world_mut()
+            .spawn((tab_bundle(), LastActivatedAt(3), ChildOf(space)))
+            .id();
+        let d = app
+            .world_mut()
+            .spawn((
+                tab_bundle(),
+                LastActivatedAt(4),
+                vmux_core::Active,
+                ChildOf(space),
+            ))
+            .id();
+
+        app.world_mut()
+            .resource_mut::<Messages<AppCommand>>()
+            .write(AppCommand::Layout(LayoutCommand::Tab(TabCommand::Close)));
+
+        app.update();
+        app.update();
+
+        assert!(
+            app.world().get_entity(d).is_err(),
+            "the active rightmost tab must be closed"
+        );
+        assert!(
+            app.world().entity(c).contains::<vmux_core::Active>(),
+            "left neighbor must become active after closing the rightmost active tab"
+        );
+        assert!(
+            !app.world().entity(a).contains::<vmux_core::Active>(),
+            "closing the rightmost tab must not jump to the first tab"
+        );
+    }
+
+    #[test]
+    fn page_close_command_on_active_rightmost_activates_left_neighbor() {
+        use bevy::ecs::system::RunSystemOnce;
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, CommandPlugin))
+            .add_message::<crate::TabLayoutSpawnRequest>()
+            .init_resource::<LastTabCloseAt>()
+            .add_observer(on_tabs_command_emit);
+
+        let webview = app.world_mut().spawn_empty().id();
+        app.world_mut().spawn(PrimaryWindow);
+        let main = app.world_mut().spawn(MainNode).id();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active, ChildOf(main)))
+            .id();
+        let a = app
+            .world_mut()
+            .spawn((tab_bundle(), LastActivatedAt(1), ChildOf(space)))
+            .id();
+        let c = app
+            .world_mut()
+            .spawn((tab_bundle(), LastActivatedAt(3), ChildOf(space)))
+            .id();
+        let d = app
+            .world_mut()
+            .spawn((
+                tab_bundle(),
+                LastActivatedAt(4),
+                vmux_core::Active,
+                ChildOf(space),
+            ))
+            .id();
+
+        app.world_mut().trigger(BinReceive::<TabsCommandEvent> {
+            webview,
+            payload: TabsCommandEvent {
+                command: "close".to_string(),
+                tab_id: Some(d.to_bits().to_string()),
+            },
+        });
+        app.world_mut().flush();
+        app.world_mut()
+            .run_system_once(crate::active::ensure_active_tab)
+            .ok();
+
+        assert!(app.world().get_entity(d).is_err(), "active tab closed");
+        assert!(
+            app.world().entity(c).contains::<vmux_core::Active>(),
+            "left neighbor must be active via the page close observer"
+        );
+        assert!(
+            !app.world().entity(a).contains::<vmux_core::Active>(),
+            "must not jump to first tab"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Context

Closing the active tab moved selection to the **first** tab instead of an adjacent one. Expected Chrome behavior: activate the right neighbor, or the left neighbor when the rightmost tab is closed.

## Implementation

The next-tab picker wrapped to index 0 when closing the rightmost tab; it now falls back to the left neighbor (Chrome-positional).

This logic was duplicated in three places — tab close (X button), stack close that collapses its last stack (Cmd+W on a single-stack tab), and command-bar close — and only the tab-close copy was correct. Closing via Cmd+W routed through the stack-close copy, which still wrapped to first, so the earlier tab-only fix appeared to do nothing. All three are now consolidated into a single `tab::pick_after_close`.

Added tests covering each close path with 3+ tabs, where wrap-to-first and left-neighbor diverge; the pre-existing 2-tab stack-close test could not distinguish them.

## Checks / QA

- Open 3+ tabs, activate the rightmost, close it via both the X button and Cmd+W → the left neighbor activates, never the first tab.
- Close a middle tab → the right neighbor activates.
- Close down to the last tab → a fresh startup tab opens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Closing the active rightmost tab now selects the immediate left tab instead of jumping to the first tab.
  * Tab activation after closing now follows a more consistent neighbor-selection rule across close actions.
  * The newly activated tab is now correctly brought to the front when a close occurs.
  * Added coverage for closing the rightmost active tab to ensure the expected tab remains active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->