### PR TITLE
feat(agent): force vmux run over native shell for claude + codex

### DIFF
--- a/crates/vmux_agent/src/client/cli/claude.rs
+++ b/crates/vmux_agent/src/client/cli/claude.rs
@@ -8,6 +8,11 @@ use crate::client::cli::strategy::CliAgentStrategy;
 use crate::strategy::AgentStrategy;
 use crate::{AgentKind, AgentVariant, McpServerConfig};
 
+const DISALLOWED_TOOLS: &str = "Bash,Monitor";
+const ALLOWED_TOOLS: &str = "mcp__vmux__run,mcp__vmux__read_terminal";
+const RUN_STEER_PROMPT: &str = "The native Bash tool is disabled. Run ALL shell commands via the \
+mcp__vmux__run tool, which executes in a visible terminal the user can watch and take over.";
+
 pub struct ClaudeStrategy;
 
 impl AgentStrategy for ClaudeStrategy {
@@ -27,7 +32,16 @@ impl CliAgentStrategy for ClaudeStrategy {
     }
 
     fn build_args(&self, mcp: &McpServerConfig, session_id: Option<&str>) -> Vec<String> {
-        let mut args = vec!["--mcp-config".to_string(), build_mcp_config_json(mcp)];
+        let mut args = vec![
+            "--mcp-config".to_string(),
+            build_mcp_config_json(mcp),
+            "--disallowedTools".to_string(),
+            DISALLOWED_TOOLS.to_string(),
+            "--allowedTools".to_string(),
+            ALLOWED_TOOLS.to_string(),
+            "--append-system-prompt".to_string(),
+            RUN_STEER_PROMPT.to_string(),
+        ];
         if let Some(sid) = session_id {
             args.push("--resume".to_string());
             args.push(sid.to_string());
@@ -203,6 +217,34 @@ mod tests {
         let args = ClaudeStrategy.build_args(&mcp, Some("abc-123"));
         let resume_idx = args.iter().position(|a| a == "--resume").unwrap();
         assert_eq!(args[resume_idx + 1], "abc-123");
+        assert_eq!(
+            args.last().map(String::as_str),
+            Some("abc-123"),
+            "--resume must stay last so the tool flags don't swallow it"
+        );
+    }
+
+    #[test]
+    fn build_args_disables_native_bash_and_steers_to_run() {
+        let mcp = McpServerConfig {
+            command: "/bin/vmux".into(),
+            args: vec!["mcp".into()],
+            cwd: None,
+        };
+        let args = ClaudeStrategy.build_args(&mcp, None);
+
+        let disallowed = args.iter().position(|a| a == "--disallowedTools").unwrap();
+        assert_eq!(args[disallowed + 1], "Bash,Monitor");
+
+        let allowed = args.iter().position(|a| a == "--allowedTools").unwrap();
+        assert!(args[allowed + 1].contains("mcp__vmux__run"));
+        assert!(args[allowed + 1].contains("mcp__vmux__read_terminal"));
+
+        let steer = args
+            .iter()
+            .position(|a| a == "--append-system-prompt")
+            .unwrap();
+        assert!(args[steer + 1].contains("mcp__vmux__run"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/client/cli/codex.rs
+++ b/crates/vmux_agent/src/client/cli/codex.rs
@@ -6,6 +6,8 @@ use crate::client::cli::strategy::CliAgentStrategy;
 use crate::strategy::AgentStrategy;
 use crate::{AgentKind, AgentVariant, McpServerConfig};
 
+const DISABLED_FEATURES: &[&str] = &["shell_tool", "unified_exec"];
+
 pub struct CodexStrategy;
 
 impl AgentStrategy for CodexStrategy {
@@ -37,6 +39,10 @@ impl CliAgentStrategy for CodexStrategy {
                 "mcp_servers.vmux.cwd={}",
                 quote_toml(&cwd.to_string_lossy())
             ));
+        }
+        for feature in DISABLED_FEATURES {
+            args.push("--disable".into());
+            args.push((*feature).to_string());
         }
         if let Some(sid) = session_id {
             args.push("resume".into());
@@ -227,6 +233,28 @@ mod tests {
         assert_eq!(args[resume_idx + 1], "abc-123");
         let last_dash_c = args.iter().rposition(|a| a == "-c").unwrap();
         assert!(resume_idx > last_dash_c);
+        let last_disable = args.iter().rposition(|a| a == "--disable").unwrap();
+        assert!(
+            resume_idx > last_disable,
+            "the resume subcommand must follow the global --disable options"
+        );
+    }
+
+    #[test]
+    fn build_args_disables_native_shell_features() {
+        let mcp = McpServerConfig {
+            command: "/bin/vmux".into(),
+            args: vec!["mcp".into()],
+            cwd: None,
+        };
+        let args = CodexStrategy.build_args(&mcp, None);
+        let disabled: Vec<&str> = args
+            .windows(2)
+            .filter(|w| w[0] == "--disable")
+            .map(|w| w[1].as_str())
+            .collect();
+        assert!(disabled.contains(&"shell_tool"));
+        assert!(disabled.contains(&"unified_exec"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/client/cli/codex.rs
+++ b/crates/vmux_agent/src/client/cli/codex.rs
@@ -7,6 +7,7 @@ use crate::strategy::AgentStrategy;
 use crate::{AgentKind, AgentVariant, McpServerConfig};
 
 const DISABLED_FEATURES: &[&str] = &["shell_tool", "unified_exec"];
+const DIRECT_ONLY_NAMESPACE: &str = "mcp__vmux";
 
 pub struct CodexStrategy;
 
@@ -40,6 +41,11 @@ impl CliAgentStrategy for CodexStrategy {
                 quote_toml(&cwd.to_string_lossy())
             ));
         }
+        args.push("-c".into());
+        args.push(format!(
+            "features.code_mode.direct_only_tool_namespaces=[{}]",
+            quote_toml(DIRECT_ONLY_NAMESPACE)
+        ));
         for feature in DISABLED_FEATURES {
             args.push("--disable".into());
             args.push((*feature).to_string());
@@ -255,6 +261,21 @@ mod tests {
             .collect();
         assert!(disabled.contains(&"shell_tool"));
         assert!(disabled.contains(&"unified_exec"));
+    }
+
+    #[test]
+    fn build_args_forces_vmux_tools_direct_to_bypass_deferral() {
+        let mcp = McpServerConfig {
+            command: "/bin/vmux".into(),
+            args: vec!["mcp".into()],
+            cwd: None,
+        };
+        let args = CodexStrategy.build_args(&mcp, None);
+        assert!(
+            args.iter()
+                .any(|a| a == "features.code_mode.direct_only_tool_namespaces=[\"mcp__vmux\"]"),
+            "vmux tools must be pinned direct so codex does not defer run behind tool_search"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Context

claude and codex already receive the vmux MCP server (so `run` and all vmux tools are available) and already launch in the space `startup_dir`. But both defaulted to their own built-in shell tools, so shell commands ran hidden inside the agent process instead of in a visible vmux terminal the user can watch and take over — unlike vibe, which leans on vmux `run`.

## Implementation

Both changes are confined to each strategy's `build_args`:

- **claude**: `--disallowedTools Bash,Monitor` hard-removes the native shell from its context; `--allowedTools mcp__vmux__run,mcp__vmux__read_terminal` auto-approves the replacement (no per-command prompt); `--append-system-prompt` steers it to `mcp__vmux__run`. `--resume` stays last; the variadic tool flags use a single comma-joined value so they don't swallow it.
- **codex**: `--disable shell_tool --disable unified_exec` (both stable+on in codex 0.142.2) removes its built-in exec paths, leaving the vmux `run` MCP tool as the way to run commands. `DISABLED_FEATURES` is a one-line list to tune.
- Unconditional (no new setting), matching vibe's unconditional MCP exposure.

## Checks / QA

- Open a **claude** page, ask it to run `ls` → a visible vmux terminal opens beside it via `mcp__vmux__run` (no native Bash), cwd = space `startup_dir`.
- Open a **codex** page, ask it to run a command → same routing through vmux `run`.
- Resume an existing claude/codex session → still resumes (the new flags don't break `--resume` / `resume`).
- If codex can't exec with both features off, drop `unified_exec` from `DISABLED_FEATURES` in `codex.rs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized command-line configuration for Claude, including explicit allowed/disallowed tool controls and an instruction to route shell commands through the supported execution path.
  * Enhanced Codex CLI argument generation with global feature disabling and additional code-mode configuration to tighten tool behavior.
* **Bug Fixes**
  * Improved command-line argument ordering to ensure session resume remains correctly positioned.
* **Tests**
  * Expanded unit tests to validate allowed/disallowed tool flags, the appended system prompt guidance, and the emitted Codex disable list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->