### PR TITLE
feat(agent): styled CLI setup flow with split install + auto-redirect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9775,6 +9775,7 @@ dependencies = [
  "vmux_space",
  "vmux_terminal",
  "vmux_ui",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/vmux_agent/Cargo.toml
+++ b/crates/vmux_agent/Cargo.toml
@@ -40,6 +40,8 @@ vmux_terminal = { path = "../vmux_terminal" }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 dioxus = { workspace = true }
 vmux_ui = { path = "../vmux_ui", default-features = false }
+vmux_core = { path = "../vmux_core" }
+web-sys = { version = "0.3", features = ["Window", "Location"] }
 
 [dev-dependencies]
 mockito = "1"

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -1437,8 +1437,6 @@ fn handle_agent_page_open_task(
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
     default_cwd: &std::path::Path,
 ) -> Result<(), String> {
-    // Served setup pages (vmux://agent/<kind>/setup) attach directly, before
-    // AgentUrl::parse mis-reads "<kind>/setup" as a provider/model pair.
     if let Some(kind) = AgentKind::all()
         .into_iter()
         .find(|k| task.url == k.setup_url())
@@ -1610,6 +1608,9 @@ fn attach_cli_setup_to_stack(
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     clear_stack_children(stack, children_q, commands);
+    commands
+        .entity(stack)
+        .remove::<crate::vibe::setup::AgentSetupNavigated>();
     let title = format!("Set up {} CLI", kind.display_name());
     let url = kind.setup_url();
     commands.entity(stack).insert(PageMetadata {
@@ -2469,6 +2470,36 @@ mod tests {
                 format!("Set up {} CLI", kind.display_name())
             );
         }
+    }
+
+    #[test]
+    fn explicit_setup_url_attaches_setup_page() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<SpawnAgentInStackRequest>()
+            .insert_resource(AgentStrategies::default())
+            .insert_resource(test_settings())
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+            .add_systems(Update, handle_agent_page_open);
+
+        let stack = app
+            .world_mut()
+            .spawn(vmux_layout::stack::stack_bundle())
+            .id();
+        app.world_mut().spawn(PageOpenTask {
+            id: vmux_core::PageOpenId::new(),
+            stack,
+            url: "vmux://agent/codex/setup".to_string(),
+            request_id: None,
+        });
+
+        app.update();
+        app.update();
+
+        let stack_meta = app.world().get::<PageMetadata>(stack).unwrap();
+        assert_eq!(stack_meta.url, "vmux://agent/codex/setup");
+        assert_eq!(stack_meta.title, "Set up Codex CLI");
     }
 
     #[test]

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -1437,10 +1437,13 @@ fn handle_agent_page_open_task(
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
     default_cwd: &std::path::Path,
 ) -> Result<(), String> {
-    // The Vibe-CLI setup page lives in the agent namespace but is a *served* page, not an agent
-    // session — attach it directly rather than mis-parsing "vibe/setup" as a Page-agent provider/model.
-    if task.url == "vmux://agent/vibe/setup" {
-        attach_vibe_cli_setup_to_stack(task.stack, children_q, commands, meshes, webview_mt);
+    // Served setup pages (vmux://agent/<kind>/setup) attach directly, before
+    // AgentUrl::parse mis-reads "<kind>/setup" as a provider/model pair.
+    if let Some(kind) = AgentKind::all()
+        .into_iter()
+        .find(|k| task.url == k.setup_url())
+    {
+        attach_cli_setup_to_stack(kind, task.stack, children_q, commands, meshes, webview_mt);
         return Ok(());
     }
     let parsed =
@@ -1573,11 +1576,6 @@ fn attach_agent_spawn_error_to_stack(
     meshes: &mut ResMut<Assets<Mesh>>,
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
-    if kind == AgentKind::Vibe && message == "vibe executable not found" {
-        attach_vibe_cli_setup_to_stack(stack, children_q, commands, meshes, webview_mt);
-        return;
-    }
-
     clear_stack_children(stack, children_q, commands);
     let title = "Agent failed to start";
     let url = format!("vmux://error/agent/{}/", kind.as_url_segment());
@@ -1603,7 +1601,8 @@ fn attach_agent_spawn_error_to_stack(
     commands.entity(browser).insert(CefKeyboardTarget);
 }
 
-fn attach_vibe_cli_setup_to_stack(
+fn attach_cli_setup_to_stack(
+    kind: AgentKind,
     stack: Entity,
     children_q: &Query<&Children>,
     commands: &mut Commands,
@@ -1611,17 +1610,17 @@ fn attach_vibe_cli_setup_to_stack(
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     clear_stack_children(stack, children_q, commands);
-    let title = "Set up Vibe CLI";
-    let url = "vmux://agent/vibe/setup";
+    let title = format!("Set up {} CLI", kind.display_name());
+    let url = kind.setup_url();
     commands.entity(stack).insert(PageMetadata {
-        url: url.to_string(),
-        title: title.to_string(),
+        url: url.clone(),
+        title: title.clone(),
         bg_color: Some("#101114".to_string()),
         ..default()
     });
     let browser = commands
         .spawn((
-            vmux_layout::Browser::new_with_title(meshes, webview_mt, url, title),
+            vmux_layout::Browser::new_with_title(meshes, webview_mt, &url, &title),
             ChildOf(stack),
         ))
         .id();
@@ -1678,12 +1677,9 @@ fn handle_spawn_agent_requests(
             continue;
         };
         let Some(exe_path) = resolve_agent_executable(req.kind, exec_override.as_deref()) else {
-            let message = format!("{} executable not found", req.kind.executable());
-            bevy::log::warn!("agent spawn ({:?}) failed: {message}", req.kind);
-            attach_agent_spawn_error_to_stack(
-                req.stack,
+            attach_cli_setup_to_stack(
                 req.kind,
-                &message,
+                req.stack,
                 &children_q,
                 &mut commands,
                 &mut meshes,
@@ -2432,6 +2428,47 @@ mod tests {
         assert_eq!(metas.len(), 1);
         assert_eq!(metas[0].title, "Set up Vibe CLI");
         assert_eq!(metas[0].url, "vmux://agent/vibe/setup");
+    }
+
+    #[test]
+    fn missing_claude_or_codex_cli_shows_setup_page() {
+        for (kind, segment) in [(AgentKind::Claude, "claude"), (AgentKind::Codex, "codex")] {
+            let mut app = App::new();
+            app.add_plugins(MinimalPlugins)
+                .add_message::<SpawnAgentInStackRequest>()
+                .insert_resource(AgentStrategies::default())
+                .insert_resource(AgentExecutableOverride(std::collections::HashMap::from([
+                    (kind, false),
+                ])))
+                .insert_resource(test_settings())
+                .init_resource::<Assets<Mesh>>()
+                .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+                .add_systems(
+                    Update,
+                    (handle_agent_page_open, handle_spawn_agent_requests).chain(),
+                );
+
+            let stack = app
+                .world_mut()
+                .spawn(vmux_layout::stack::stack_bundle())
+                .id();
+            app.world_mut().spawn(PageOpenTask {
+                id: vmux_core::PageOpenId::new(),
+                stack,
+                url: format!("vmux://agent/{segment}/"),
+                request_id: None,
+            });
+
+            app.update();
+            app.update();
+
+            let stack_meta = app.world().get::<PageMetadata>(stack).unwrap();
+            assert_eq!(stack_meta.url, format!("vmux://agent/{segment}/setup"));
+            assert_eq!(
+                stack_meta.title,
+                format!("Set up {} CLI", kind.display_name())
+            );
+        }
     }
 
     #[test]

--- a/crates/vmux_agent/src/vibe/setup.rs
+++ b/crates/vmux_agent/src/vibe/setup.rs
@@ -9,7 +9,9 @@ use bevy::prelude::*;
 use bevy_cef::prelude::{BinEventEmitterPlugin, BinReceive};
 
 #[cfg(not(target_arch = "wasm32"))]
-use crate::vibe::setup::event::VibeInstallRunRequest;
+use crate::vibe::setup::event::AgentInstallRunRequest;
+#[cfg(not(target_arch = "wasm32"))]
+use vmux_core::agent::AgentKind;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
@@ -21,31 +23,129 @@ pub const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageMa
 };
 
 #[cfg(not(target_arch = "wasm32"))]
-pub const VIBE_SETUP_URL: &str = "vmux://agent/vibe/setup";
+#[derive(Component)]
+struct AgentInstallPane {
+    setup_stack: Entity,
+}
 
 #[cfg(not(target_arch = "wasm32"))]
-pub const VIBE_INSTALL_COMMAND: &str = "curl -LsSf https://mistral.ai/vibe/install.sh | bash";
+#[derive(Component)]
+struct AgentSetupNavigated;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub struct VibeSetupPlugin;
+pub struct AgentSetupPlugin;
 
 #[cfg(not(target_arch = "wasm32"))]
-impl Plugin for VibeSetupPlugin {
+impl Plugin for AgentSetupPlugin {
     fn build(&self, app: &mut App) {
         app.world_mut().spawn(PAGE_MANIFEST);
-        app.add_plugins(BinEventEmitterPlugin::<(VibeInstallRunRequest,)>::for_hosts(&["agent"]))
-            .add_observer(on_vibe_install_run);
+        app.add_plugins(BinEventEmitterPlugin::<(AgentInstallRunRequest,)>::for_hosts(&["agent"]))
+            .add_observer(on_agent_install_run)
+            .add_systems(Update, auto_redirect_agent_setup_when_installed);
     }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn on_vibe_install_run(
-    _trigger: On<BinReceive<VibeInstallRunRequest>>,
-    mut run: MessageWriter<vmux_terminal::RunShellRequest>,
-) {
+fn run_install_in_new_tab(run: &mut MessageWriter<vmux_terminal::RunShellRequest>, command: &str) {
     run.write(vmux_terminal::RunShellRequest {
-        command: VIBE_INSTALL_COMMAND.to_string(),
+        command: command.to_string(),
         cwd: String::new(),
         mode: vmux_terminal::ShellMode::NewTab,
     });
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn on_agent_install_run(
+    trigger: On<BinReceive<AgentInstallRunRequest>>,
+    focus: Res<vmux_layout::stack::FocusedStack>,
+    ctx: vmux_layout::pane::PlacementCtx,
+    mut commands: Commands,
+    mut spawn: MessageWriter<vmux_terminal::TerminalStackSpawnRequest>,
+    mut run: MessageWriter<vmux_terminal::RunShellRequest>,
+) {
+    let segment = &trigger.event().payload.agent;
+    let Some(command) = vmux_core::agent_setup::install_command(segment) else {
+        warn!("agent install run: unknown agent segment '{segment}'");
+        return;
+    };
+    let input = vmux_terminal::shell_input::shell_command_input(command);
+    let (Some(pane), Some(setup_stack)) = (focus.pane, focus.stack) else {
+        run_install_in_new_tab(&mut run, command);
+        return;
+    };
+    if !ctx.leaf_panes.contains(pane) {
+        run_install_in_new_tab(&mut run, command);
+        return;
+    }
+    let existing_tabs: Vec<Entity> = ctx
+        .pane_children
+        .get(pane)
+        .map(|c| c.iter().filter(|&e| ctx.tab_filter.contains(e)).collect())
+        .unwrap_or_default();
+    let already_split = ctx.split_dir_q.contains(pane);
+    let install_pane = vmux_layout::pane::split_or_extend(
+        &mut commands,
+        pane,
+        vmux_layout::pane::PaneSplitDirection::Row,
+        &existing_tabs,
+        true,
+        already_split,
+    );
+    commands
+        .entity(install_pane)
+        .insert(AgentInstallPane { setup_stack });
+    spawn.write(vmux_terminal::TerminalStackSpawnRequest {
+        pane: install_pane,
+        cwd: None,
+        pending_input: Some(input),
+        process_id: Some(vmux_service::protocol::ProcessId::new()),
+        activate: true,
+    });
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn auto_redirect_agent_setup_when_installed(
+    time: Res<Time>,
+    mut throttle: Local<f32>,
+    setup_stacks: Query<
+        (Entity, &vmux_core::PageMetadata),
+        (
+            With<vmux_layout::stack::Stack>,
+            Without<AgentSetupNavigated>,
+        ),
+    >,
+    install_panes: Query<(Entity, &AgentInstallPane)>,
+    mut commands: Commands,
+) {
+    *throttle += time.delta_secs();
+    if *throttle < 0.5 {
+        return;
+    }
+    *throttle = 0.0;
+
+    for (setup_stack, meta) in &setup_stacks {
+        let Some(kind) = AgentKind::all()
+            .into_iter()
+            .find(|k| meta.url == k.setup_url())
+        else {
+            continue;
+        };
+        if crate::exec::find_executable(kind.executable()).is_none() {
+            continue;
+        }
+        commands.spawn(vmux_core::PageOpenTask {
+            id: vmux_core::PageOpenId::new(),
+            stack: setup_stack,
+            url: kind.cli_url_prefix(),
+            request_id: None,
+        });
+        commands.entity(setup_stack).insert(AgentSetupNavigated);
+        for (install_pane, marker) in &install_panes {
+            if marker.setup_stack == setup_stack {
+                commands
+                    .entity(install_pane)
+                    .insert(vmux_layout::pane::ForcePaneClose);
+            }
+        }
+    }
 }

--- a/crates/vmux_agent/src/vibe/setup.rs
+++ b/crates/vmux_agent/src/vibe/setup.rs
@@ -30,7 +30,7 @@ struct AgentInstallPane {
 
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Component)]
-struct AgentSetupNavigated;
+pub(crate) struct AgentSetupNavigated;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub struct AgentSetupPlugin;

--- a/crates/vmux_agent/src/vibe/setup/event.rs
+++ b/crates/vmux_agent/src/vibe/setup/event.rs
@@ -8,4 +8,6 @@
     rkyv::Serialize,
     rkyv::Deserialize,
 )]
-pub struct VibeInstallRunRequest;
+pub struct AgentInstallRunRequest {
+    pub agent: String,
+}

--- a/crates/vmux_agent/src/vibe/setup/page.rs
+++ b/crates/vmux_agent/src/vibe/setup/page.rs
@@ -1,31 +1,116 @@
 #![allow(non_snake_case)]
 
-use crate::vibe::setup::event::VibeInstallRunRequest;
+use crate::vibe::setup::event::AgentInstallRunRequest;
 use dioxus::prelude::*;
+use vmux_ui::components::icon::Icon;
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_theme};
+
+struct Accent {
+    glow_top: &'static str,
+    glow_bottom: &'static str,
+    badge: &'static str,
+    prompt: &'static str,
+    cta: &'static str,
+}
+
+fn current_agent_segment() -> String {
+    web_sys::window()
+        .and_then(|w| w.location().pathname().ok())
+        .and_then(|path| path.split('/').find(|s| !s.is_empty()).map(str::to_string))
+        .filter(|seg| vmux_core::agent_setup::display_name(seg).is_some())
+        .unwrap_or_else(|| "vibe".to_string())
+}
+
+fn tagline(segment: &str) -> &'static str {
+    match segment {
+        "claude" => "Anthropic's coding agent, in vmux",
+        "codex" => "OpenAI's coding agent, in vmux",
+        _ => "Mistral's coding agent, in vmux",
+    }
+}
+
+fn accent(segment: &str) -> Accent {
+    match segment {
+        "claude" => Accent {
+            glow_top: "pointer-events-none absolute -top-1/3 left-1/2 h-[60vh] w-[60vh] -translate-x-1/2 rounded-full bg-rose-500/20 blur-[120px]",
+            glow_bottom: "pointer-events-none absolute -bottom-1/4 right-1/4 h-[44vh] w-[44vh] rounded-full bg-orange-400/10 blur-[120px]",
+            badge: "flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-orange-400 to-rose-500 text-white shadow-lg shadow-rose-500/30",
+            prompt: "select-none font-mono text-sm text-rose-400/80",
+            cta: "group inline-flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-br from-orange-400 to-rose-500 px-4 py-2.5 text-sm font-medium text-white shadow-lg shadow-rose-500/25 transition-all hover:shadow-rose-500/40 hover:brightness-110 active:scale-[0.99]",
+        },
+        "codex" => Accent {
+            glow_top: "pointer-events-none absolute -top-1/3 left-1/2 h-[60vh] w-[60vh] -translate-x-1/2 rounded-full bg-emerald-500/20 blur-[120px]",
+            glow_bottom: "pointer-events-none absolute -bottom-1/4 right-1/4 h-[44vh] w-[44vh] rounded-full bg-teal-400/10 blur-[120px]",
+            badge: "flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-emerald-500 to-teal-600 text-white shadow-lg shadow-emerald-500/30",
+            prompt: "select-none font-mono text-sm text-emerald-400/80",
+            cta: "group inline-flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-br from-emerald-500 to-teal-600 px-4 py-2.5 text-sm font-medium text-white shadow-lg shadow-emerald-500/25 transition-all hover:shadow-emerald-500/40 hover:brightness-110 active:scale-[0.99]",
+        },
+        _ => Accent {
+            glow_top: "pointer-events-none absolute -top-1/3 left-1/2 h-[60vh] w-[60vh] -translate-x-1/2 rounded-full bg-orange-500/20 blur-[120px]",
+            glow_bottom: "pointer-events-none absolute -bottom-1/4 right-1/4 h-[44vh] w-[44vh] rounded-full bg-amber-400/10 blur-[120px]",
+            badge: "flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-orange-500 to-amber-600 text-white shadow-lg shadow-orange-500/30",
+            prompt: "select-none font-mono text-sm text-orange-400/80",
+            cta: "group inline-flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-br from-orange-500 to-amber-600 px-4 py-2.5 text-sm font-medium text-white shadow-lg shadow-orange-500/25 transition-all hover:shadow-orange-500/40 hover:brightness-110 active:scale-[0.99]",
+        },
+    }
+}
 
 #[component]
 pub fn Page() -> Element {
     use_theme();
+    let segment = current_agent_segment();
+    let name = vmux_core::agent_setup::display_name(&segment).unwrap_or("Vibe");
+    let command = vmux_core::agent_setup::install_command(&segment).unwrap_or_default();
+    let tagline = tagline(&segment);
+    let accent = accent(&segment);
+    let emit_segment = segment.clone();
     rsx! {
-        main { class: "flex min-h-screen items-center justify-center bg-background p-10 text-foreground",
-            section { class: "max-w-2xl",
-                h1 { class: "mb-3 text-2xl font-semibold leading-tight", "Install Vibe CLI" }
-                p { class: "mb-4 text-sm leading-relaxed text-muted-foreground",
-                    "Vmux opens this page through the local "
-                    code { class: "rounded bg-muted px-1.5 py-0.5 text-foreground", "vibe" }
-                    " command. Install Vibe, then run it below."
+        main { class: "relative flex min-h-screen items-center justify-center overflow-hidden bg-background p-10 text-foreground",
+            div { class: "{accent.glow_top}" }
+            div { class: "{accent.glow_bottom}" }
+
+            section { class: "relative w-full max-w-lg rounded-3xl bg-white/[0.04] p-8 ring-1 ring-inset ring-white/10 backdrop-blur-2xl shadow-[0_24px_80px_-24px_rgba(0,0,0,0.7)]",
+                div { class: "mb-6 flex items-center gap-4",
+                    div { class: "{accent.badge}",
+                        Icon { class: "h-6 w-6",
+                            path { d: "M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" }
+                            path { d: "M7 10l5 5 5-5" }
+                            path { d: "M12 15V3" }
+                        }
+                    }
+                    div { class: "min-w-0",
+                        h1 { class: "text-xl font-semibold leading-tight tracking-tight", "Install {name} CLI" }
+                        p { class: "text-sm text-muted-foreground", "{tagline}" }
+                    }
                 }
-                code {
-                    class: "mb-5 block whitespace-pre-wrap break-words rounded-md bg-muted p-3 text-sm text-foreground",
-                    "curl -LsSf https://mistral.ai/vibe/install.sh | bash"
+
+                p { class: "mb-5 text-sm leading-relaxed text-muted-foreground",
+                    "vmux opened this page because the local "
+                    code { class: "rounded bg-white/10 px-1.5 py-0.5 font-mono text-[0.8em] text-foreground", "{segment}" }
+                    " command isn't installed yet. Run the command below to get it."
                 }
+
+                div { class: "mb-5 flex items-center gap-3 rounded-xl bg-black/40 p-4 ring-1 ring-inset ring-white/10",
+                    span { class: "{accent.prompt}", "$" }
+                    code { class: "min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-sm text-foreground", "{command}" }
+                }
+
                 button {
-                    class: "rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90",
+                    class: "{accent.cta}",
                     onclick: move |_| {
-                        let _ = try_cef_bin_emit_rkyv(&VibeInstallRunRequest);
+                        let _ = try_cef_bin_emit_rkyv(&AgentInstallRunRequest { agent: emit_segment.clone() });
                     },
-                    "Want me to run?"
+                    Icon { class: "h-4 w-4",
+                        path { d: "M5 12h14" }
+                        path { d: "m12 5 7 7-7 7" }
+                    }
+                    "Run install command"
+                }
+
+                p { class: "mt-3 text-center text-xs text-muted-foreground/70",
+                    "vmux runs it in a terminal and reloads when "
+                    code { class: "font-mono", "{segment}" }
+                    " is ready."
                 }
             }
         }

--- a/crates/vmux_core/src/agent.rs
+++ b/crates/vmux_core/src/agent.rs
@@ -60,6 +60,10 @@ impl AgentKind {
         format!("vmux://agent/{}/", self.as_url_segment())
     }
 
+    pub fn setup_url(self) -> String {
+        format!("vmux://agent/{}/setup", self.as_url_segment())
+    }
+
     pub fn all() -> [AgentKind; 3] {
         [AgentKind::Vibe, AgentKind::Claude, AgentKind::Codex]
     }

--- a/crates/vmux_core/src/agent_setup.rs
+++ b/crates/vmux_core/src/agent_setup.rs
@@ -1,0 +1,48 @@
+pub fn display_name(segment: &str) -> Option<&'static str> {
+    match segment {
+        "vibe" => Some("Vibe"),
+        "claude" => Some("Claude"),
+        "codex" => Some("Codex"),
+        _ => None,
+    }
+}
+
+pub fn install_command(segment: &str) -> Option<&'static str> {
+    match segment {
+        "vibe" => Some("curl -LsSf https://mistral.ai/vibe/install.sh | bash"),
+        "claude" => Some("brew install --cask claude-code"),
+        "codex" => Some("brew install --cask codex"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_segments_resolve() {
+        for segment in ["vibe", "claude", "codex"] {
+            assert!(display_name(segment).is_some(), "display_name {segment}");
+            assert!(
+                install_command(segment).is_some(),
+                "install_command {segment}"
+            );
+        }
+        assert_eq!(
+            install_command("vibe"),
+            Some("curl -LsSf https://mistral.ai/vibe/install.sh | bash")
+        );
+        assert_eq!(
+            install_command("claude"),
+            Some("brew install --cask claude-code")
+        );
+        assert_eq!(install_command("codex"), Some("brew install --cask codex"));
+    }
+
+    #[test]
+    fn unknown_segment_is_none() {
+        assert_eq!(display_name("nope"), None);
+        assert_eq!(install_command("nope"), None);
+    }
+}

--- a/crates/vmux_core/src/lib.rs
+++ b/crates/vmux_core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod agent_setup;
 pub mod dom_snapshot;
 pub mod editor;
 pub mod event;

--- a/crates/vmux_desktop/src/lib.rs
+++ b/crates/vmux_desktop/src/lib.rs
@@ -123,7 +123,7 @@ impl Plugin for VmuxPlugin {
             .add_plugins((
                 vmux_team::TeamPlugin,
                 vmux_history::HistoryPlugin,
-                vmux_agent::vibe::setup::VibeSetupPlugin,
+                vmux_agent::vibe::setup::AgentSetupPlugin,
                 LayoutCefPlugin,
                 BrowserPlugin,
                 lechat_bridge::LeChatBridgePlugin,

--- a/crates/vmux_server/assets/index.css
+++ b/crates/vmux_server/assets/index.css
@@ -1,6 +1,7 @@
 @import "../../vmux_ui/assets/theme.css";
 @import "tailwindcss";
 @source "../src";
+@source "../../vmux_agent/src";
 @source "../../vmux_editor/src";
 @source "../../vmux_history/src";
 @source "../../vmux_layout/src";


### PR DESCRIPTION
## Summary
- When a coding-agent CLI is missing, vmux now shows a styled glass setup page for **all three** agents (vibe, claude, codex) — previously only vibe had this; claude/codex hit a generic "Agent failed to start" error page.
- **Run install command** runs in a right-split pane next to the setup page. Once the binary is detected, the page auto-redirects to the agent (`vmux://agent/<kind>/`) and the install pane collapses so the agent fills the pane.
- Single source of truth for per-agent display name + install command lives in a new wasm-safe `vmux_core::agent_setup`, shared by the WASM page and the native backend (no drift). The page reads its agent from the URL and themes a per-agent accent.
- Install commands: vibe `curl -LsSf https://mistral.ai/vibe/install.sh | bash`, claude `brew install --cask claude-code`, codex `brew install --cask codex`.
- Fix: `vmux_agent/src` was missing from the Tailwind `@source` list in `crates/vmux_server/assets/index.css`, so the setup page's utility classes were never generated (page rendered unstyled). Added it.

## Notes
- Code stays under `vmux_agent::vibe::setup` (symbols renamed `Agent*`) to avoid churning the `vmux_server/build.rs` rebuild tracking and the `web_pages!` host mapping. A follow-up could move it to `vmux_agent::setup`.

## Test plan
- [x] `cargo fmt`, `cargo clippy -p vmux_core -p vmux_agent` (native + `--target wasm32-unknown-unknown`)
- [x] `cargo test -p vmux_core -p vmux_agent` (incl. new `agent_setup` unit tests + `missing_claude_or_codex_cli_shows_setup_page`)
- [ ] Runtime: uninstall a CLI (`brew uninstall --cask codex` / `claude-code`), open `vmux://agent/codex/` → setup page renders → **Run install command** installs in a right split → on completion auto-redirects to the agent and the install pane collapses. Repeat for claude. Confirm vibe unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified setup flow for multiple agent types, including dynamic “Install <Agent> CLI” pages with agent-specific commands and setup URLs.
  * Setup UI now supports direct deep links to the correct agent setup screen.

* **Bug Fixes**
  * Improved missing-CLI handling by taking users to the matching agent setup page.
  * After install readiness, setup auto-redirects and closes related install panes.

* **Tests**
  * Expanded coverage for missing CLI setup behavior and deep-link routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->