### PR TITLE
fix(browser): re-apply windowed frame when the live NSView drifts

### DIFF
--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -16,6 +16,7 @@ use bevy::{
     prelude::*,
     ui::{UiGlobalTransform, UiSystems},
     window::{CursorMoved, PrimaryWindow, WindowResized},
+    winit::{EventLoopProxyWrapper, WinitUserEvent},
 };
 use bevy_cef::prelude::*;
 use bevy_cef_core::prelude::{CefEmbeddedHosts, RenderTextureMessage, webview_debug_log};
@@ -1625,8 +1626,10 @@ fn sync_cef_webview_resize_after_ui(
     host_window: Query<&HostWindow>,
     windows: Query<&Window>,
     primary_window: Query<Entity, With<PrimaryWindow>>,
+    proxy: Option<Res<EventLoopProxyWrapper>>,
     mut last_entries: Local<Vec<(u64, Vec2, f32)>>,
     mut window_resized: MessageReader<WindowResized>,
+    mut first_run: Local<Option<std::time::Instant>>,
 ) {
     // Force-resize all CEF browsers (tabs, terminals, side sheets, modals) on
     // window resize so backgrounded surfaces also repaint at the new size
@@ -1635,8 +1638,11 @@ fn sync_cef_webview_resize_after_ui(
     if force {
         last_entries.clear();
     }
+    let mut pushed_any = false;
+    let mut awaiting_create = false;
     for (entity, size) in webviews.iter() {
         if !browsers.has_browser(entity) {
+            awaiting_create = true;
             continue;
         }
         let key = entity.to_bits();
@@ -1661,6 +1667,7 @@ fn sync_cef_webview_resize_after_ui(
             "resize entity={entity:?} size={:?} scale={device_scale_factor} force={force}",
             size.0
         ));
+        pushed_any = true;
         if let Some(entry) = last_entries.iter_mut().find(|(k, _, _)| *k == key) {
             entry.1 = size.0;
             entry.2 = device_scale_factor;
@@ -1668,6 +1675,30 @@ fn sync_cef_webview_resize_after_ui(
             last_entries.push((key, size.0, device_scale_factor));
         }
     }
+    // Native (windowed) pages never paint into the OSR texture, so a freshly created CEF
+    // browser does not wake the reactive winit loop. At startup the loop can park after a
+    // page spawns at its placeholder size but before this system observes `has_browser` and
+    // pushes the real pane size, freezing the page at the stale size until the next input.
+    // Route the missing wake (see AGENTS.md): keep ticking while a push just landed or a
+    // spawned page still awaits its browser, bounded so a page that never creates cannot
+    // spin the loop.
+    let within_startup_grace = first_run
+        .get_or_insert_with(std::time::Instant::now)
+        .elapsed()
+        < std::time::Duration::from_secs(10);
+    if windowed_reconcile_should_wake(pushed_any, awaiting_create, within_startup_grace)
+        && let Some(proxy) = proxy.as_ref()
+    {
+        let _ = proxy.send_event(WinitUserEvent::WakeUp);
+    }
+}
+
+fn windowed_reconcile_should_wake(
+    pushed_any: bool,
+    awaiting_create: bool,
+    within_startup_grace: bool,
+) -> bool {
+    pushed_any || (awaiting_create && within_startup_grace)
 }
 
 /// Walks up from a browser entity to find its enclosing Tab, then counts
@@ -4675,6 +4706,14 @@ mod tests {
             .unwrap_or_default();
 
         assert!(resize_fn.contains("Without<Modal>"));
+    }
+
+    #[test]
+    fn windowed_reconcile_wakes_until_native_pages_are_sized() {
+        assert!(windowed_reconcile_should_wake(true, false, false));
+        assert!(windowed_reconcile_should_wake(false, true, true));
+        assert!(!windowed_reconcile_should_wake(false, true, false));
+        assert!(!windowed_reconcile_should_wake(false, false, true));
     }
 
     #[test]

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -1675,13 +1675,6 @@ fn sync_cef_webview_resize_after_ui(
             last_entries.push((key, size.0, device_scale_factor));
         }
     }
-    // Native (windowed) pages never paint into the OSR texture, so a freshly created CEF
-    // browser does not wake the reactive winit loop. At startup the loop can park after a
-    // page spawns at its placeholder size but before this system observes `has_browser` and
-    // pushes the real pane size, freezing the page at the stale size until the next input.
-    // Route the missing wake (see AGENTS.md): keep ticking while a push just landed or a
-    // spawned page still awaits its browser, bounded so a page that never creates cannot
-    // spin the loop.
     let within_startup_grace = first_run
         .get_or_insert_with(std::time::Instant::now)
         .elapsed()

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
@@ -889,6 +889,27 @@ impl Browsers {
     #[cfg(not(target_os = "macos"))]
     pub fn set_windowed_corner_cover(&self, _: &Entity, _: f32, _: f32, _: bool, _: [f32; 3]) {}
 
+    /// A windowed view's frame must be re-applied not only when our target changes, but also when
+    /// the live `NSView` frame has drifted from that target. AppKit can resize the view behind us
+    /// (a window manager resizing the host window, a stale frame from creation time), and a
+    /// `last_frame` cache keyed only on our own target would skip the corrective `setFrame`,
+    /// leaving the page over- or under-sized until the next distinct target.
+    #[cfg(target_os = "macos")]
+    fn windowed_frame_should_apply(
+        last_frame: Option<(f64, f64, f64, f64)>,
+        target: (f64, f64, f64, f64),
+        actual: (f64, f64, f64, f64),
+    ) -> bool {
+        if last_frame != Some(target) {
+            return true;
+        }
+        const EPS: f64 = 1.0;
+        (actual.0 - target.0).abs() > EPS
+            || (actual.1 - target.1).abs() > EPS
+            || (actual.2 - target.2).abs() > EPS
+            || (actual.3 - target.3).abs() > EPS
+    }
+
     #[cfg(target_os = "macos")]
     pub fn set_windowed_frame(
         &self,
@@ -934,8 +955,15 @@ impl Browsers {
             (parent_h - top_px as f64 / s - h).max(0.0)
         };
         let frame = (x, y, w, h);
+        let actual = view.frame();
+        let actual_frame = (
+            actual.origin.x,
+            actual.origin.y,
+            actual.size.width,
+            actual.size.height,
+        );
         Self::refresh_windowed_transparency(browser, view);
-        if browser.last_frame.get() == Some(frame) {
+        if !Self::windowed_frame_should_apply(browser.last_frame.get(), frame, actual_frame) {
             return;
         }
         browser.last_frame.set(Some(frame));
@@ -1746,6 +1774,24 @@ mod tests {
         assert_eq!(effective_windowless_frame_rate(60, true, true), 60);
     }
 
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn windowed_frame_reapplies_when_live_view_drifts() {
+        use super::Browsers;
+        let target = (0.0, 0.0, 1492.0, 992.0);
+        assert!(Browsers::windowed_frame_should_apply(None, target, target));
+        assert!(!Browsers::windowed_frame_should_apply(
+            Some(target),
+            target,
+            target
+        ));
+        assert!(Browsers::windowed_frame_should_apply(
+            Some(target),
+            target,
+            (0.0, 0.0, 1940.0, 1275.0)
+        ));
+    }
+
     #[test]
     fn visible_unfocused_window_is_throttled_but_never_above_monitor() {
         assert_eq!(
@@ -1959,7 +2005,7 @@ mod tests {
             .find("Self::refresh_windowed_transparency")
             .expect("windowed transparency refresh");
         let cache_idx = set_frame_fn
-            .find("browser.last_frame.get() == Some(frame)")
+            .find("Self::windowed_frame_should_apply")
             .expect("same frame cache check");
 
         assert!(refresh_idx < cache_idx);

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
@@ -889,11 +889,6 @@ impl Browsers {
     #[cfg(not(target_os = "macos"))]
     pub fn set_windowed_corner_cover(&self, _: &Entity, _: f32, _: f32, _: bool, _: [f32; 3]) {}
 
-    /// A windowed view's frame must be re-applied not only when our target changes, but also when
-    /// the live `NSView` frame has drifted from that target. AppKit can resize the view behind us
-    /// (a window manager resizing the host window, a stale frame from creation time), and a
-    /// `last_frame` cache keyed only on our own target would skip the corrective `setFrame`,
-    /// leaving the page over- or under-sized until the next distinct target.
     #[cfg(target_os = "macos")]
     fn windowed_frame_should_apply(
         last_frame: Option<(f64, f64, f64, f64)>,
@@ -955,7 +950,11 @@ impl Browsers {
             (parent_h - top_px as f64 / s - h).max(0.0)
         };
         let frame = (x, y, w, h);
-        let actual = view.frame();
+        let actual = if let Some(glass_view) = glass_view {
+            glass_view.frame()
+        } else {
+            view.frame()
+        };
         let actual_frame = (
             actual.origin.x,
             actual.origin.y,


### PR DESCRIPTION
## Summary
- Browse-mode pages are native (windowed) CEF views positioned by `set_windowed_frame`, whose `last_frame` cache compared only against our own target. When AppKit resized the view behind us (a window-manager resize, or a stale frame from creation time) the corrective `setFrame` was skipped, so the page rendered over- or under-sized until the next input.
- Now compare against the **actual** live `NSView` frame and re-apply on divergence (`windowed_frame_should_apply`).
- Also keep the reactive winit loop awake until freshly-created native pages get their real pane size — native pages don't paint into the OSR texture and so never wake the loop on their own, so the startup reconcile could race the loop parking.

## Root cause
Default-on diagnostics showed, every frame in the broken state:

```
set_windowed_frame req=(1492x992) actual=(1940x1275) cache_hit=true diverged=true
```

vmux computed the correct frame; the cache refused to apply it. Only reproduces when a window manager auto-resizes the window on launch (a race against the reactive loop parking), which is why it was intermittent.

## Test plan
- [x] `cargo clippy -p vmux_browser -p bevy_cef_core --all-targets -- -D warnings`
- [x] `cargo test -p vmux_browser -p bevy_cef_core` — new `windowed_frame_reapplies_when_live_view_drifts` + `windowed_reconcile_wakes_until_native_pages_are_sized`
- [x] Manual: relaunched ~10x under a tiling WM that auto-resizes on launch; page correctly sized every time (previously intermittently too-small / overflow)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved native webview behavior during window resizing, including smarter wakeups to ensure newly created or resized native pages reach the correct size.

* **Bug Fixes**
  * Prevented native pages from getting stuck while waiting for resize updates.
  * Improved macOS windowed browser frame handling to keep visible content aligned with the window, even when system view frames drift slightly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->