### PR TITLE
chore(release): v0.0.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9744,7 +9744,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9780,7 +9780,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_browser"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "base64 0.22.1",
  "bevy",
@@ -9804,7 +9804,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -9816,7 +9816,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9831,7 +9831,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9850,7 +9850,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9915,7 +9915,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_editor"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "arboard",
  "bevy",
@@ -9957,7 +9957,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_git"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9974,7 +9974,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9995,7 +9995,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -10029,7 +10029,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "muda",
  "proc-macro2",
@@ -10039,7 +10039,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -10052,7 +10052,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_server"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "dioxus",
  "regex",
@@ -10073,7 +10073,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "alacritty_terminal",
  "bevy",
@@ -10109,7 +10109,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10132,7 +10132,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10157,7 +10157,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_team"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10178,7 +10178,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10209,7 +10209,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "dioxus",
  "dioxus-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.18"
+version = "0.0.19"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "GPL-3.0-or-later"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.18"
-  sha256 "42029205e1b82af3b1cdb166e37a1135885aaf727956b4bef8633bd8baf663e8"
+  version "0.0.19"
+  sha256 "5a7465a7c385575fd42157628d0045eddba561666d61a58a2576e836920cf831"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.18/Vmux_0.0.18_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.19/Vmux_0.0.19_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai/"

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.18",
-  "pub_date": "2026-06-25T12:42:06Z",
+  "version": "v0.0.19",
+  "pub_date": "2026-06-26T22:45:02Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.18/Vmux-v0.0.18-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzZwQ0VXK05FZDVRclp1YzNpa0xhMGIvNkZxQWhXU1A1WnlXbHZBbkZZeUpSM1pGb3BxWmtreHBnTXY2dmtGc1VEWXVvSDhFcHg0QTN1amZxalFuVUFNPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgyMzg5NzUyCWZpbGU6Vm11eC12MC4wLjE4LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKSXd3QWUxN0dvYXNsbzYyRXlDR2lwUFlzNERwaTRIUUhoamx0L1VZYlFTYlExRHR4VnhkWktJdTlGS1FEUXIvTlFOQVpBVVRjNlI5MUpHVTE5L3ZuREE9PQo=",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.19/Vmux-v0.0.19-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzIrQUZWYzdlSFNjNEJSd0hDd1hYWmRYZXBSeG5BQVBXN3FobE9BSDg1SitxOW5JK0hqa3hKNkNabGJJcEhETmh4R1RKU0M3N252Ty91c0hOdG9JMXc4PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgyNTEzMTg4CWZpbGU6Vm11eC12MC4wLjE5LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKVitUUG1xbEFnOU9sRjBUdDRrcXNPNGhHbnlXV2dpaTRCU0VJNlRlSGVUdUsvd05TMXBBL29pTkI2RlVCV2FJK1YwMTVWaEJrcnJDTmhGd3V4cHFOQ3c9PQo=",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.18/Vmux_0.0.18_aarch64.dmg",
-      "filename": "Vmux_0.0.18_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.19/Vmux_0.0.19_aarch64.dmg",
+      "filename": "Vmux_0.0.19_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
Patch release. Bumps workspace version 0.0.18 -> 0.0.19. Releases on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the app version to 0.0.19.
* **Chores**
  * Refreshed the macOS release artifacts for version 0.0.19 (including updated download URLs and checksums).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->