### PR TITLE
fix(hooks): mirror CI in pre-push, stop installing worktree-pinned hook

### DIFF
--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cargo fmt --all -- --check
-env -u CEF_PATH cargo clippy --workspace --exclude bevy_cef --exclude bevy_cef_core --exclude bevy_cef_debug_render_process --all-targets -- -D warnings
-env -u CEF_PATH cargo test --workspace --exclude bevy_cef --exclude bevy_cef_core --exclude bevy_cef_debug_render_process
+PKG_ARGS=$(cargo metadata --no-deps --format-version 1 \
+  | jq -r '.packages[] | select(.manifest_path | test("patches") | not) | "-p " + .name' \
+  | tr '\n' ' ')
+
+cargo fmt $PKG_ARGS -- --check
+env -u CEF_PATH cargo clippy $PKG_ARGS --all-targets -- -D warnings
+env -u CEF_PATH cargo test --workspace --exclude bevy_cef_core --exclude bevy_cef

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
-ROOT="$(git rev-parse --show-toplevel)"
-GIT_DIR="$(git rev-parse --git-common-dir)"
+GIT_DIR="$(cd "$(git rev-parse --git-common-dir)" && pwd)"
+ROOT="$(dirname "$GIT_DIR")"
 mkdir -p "$GIT_DIR/hooks"
 ln -sf "$ROOT/scripts/hooks/pre-push" "$GIT_DIR/hooks/pre-push"
-echo "Installed pre-push hook -> scripts/hooks/pre-push"
+echo "Installed pre-push hook -> $ROOT/scripts/hooks/pre-push"


### PR DESCRIPTION
## Problems

### 1. Dangling pre-push hook
`scripts/setup-hooks.sh` linked `$(git rev-parse --show-toplevel)/scripts/hooks/pre-push` (the **current worktree** root) into the **shared** `--git-common-dir/hooks/`. Run from a worktree, the shared hook pointed into that worktree and became a **dangling symlink** once the worktree was removed (an old `release-v0.0.12` worktree did exactly this). Git skips an unresolvable hook, so the pre-push checks were silently disabled for **every** checkout — main and all worktrees.

**Fix:** target the main worktree root (`dirname` of the git-common-dir), a stable path that survives worktree churn.

### 2. Hook stricter than CI
The hook ran `cargo fmt --all`, which includes vendored `patches/*`. CI deliberately **excludes** `patches/*` from fmt and clippy (keeping the vendored CEF/bevy patches diffable against upstream). So once the hook actually ran, it would **block every push** whenever the patches had formatting drift CI ignores.

**Fix:** compute the same patch-excluding package list CI uses (`cargo metadata | jq 'test("patches") | not'`) and feed it to `cargo fmt` and `cargo clippy`; use CI's test exclusions (`--exclude bevy_cef_core --exclude bevy_cef`).

## Verification
- `bash -n` clean on both scripts.
- New fmt step passes on current main (38 pkgs, patches excluded) where `--all` failed.
- `setup-hooks.sh` run from a worktree now resolves the target to the main repo root.
- Exec bits preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the pre-push checks to automatically run formatting, linting, and tests against the relevant Rust packages instead of relying on a fixed package list.
  * Updated hook setup to better detect the repository location and install the pre-push hook using the correct path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->