### PR TITLE
feat(website): one prompt anything done

### DIFF
--- a/docs/specs/2026-06-27-landing-reposition-design.md
+++ b/docs/specs/2026-06-27-landing-reposition-design.md
@@ -1,0 +1,102 @@
+# Landing reposition — "the browser that gets sh*t done"
+
+Date: 2026-06-27
+
+## Goal
+
+Broaden the landing page positioning from a dev-only message ("the browser that
+ships code") to a general agentic one ("get anything done with agents"), without
+losing the dev/IDE story that differentiates vmux from generic "AI browsers".
+
+Three canonical asks anchor the breadth: a flight booking, a restaurant website,
+and a self-referential `vmux` theme-support PR.
+
+## Decisions (validated via visual brainstorm)
+
+1. **Hero tone — edgy.** Real profanity ships on the public page.
+2. **Scope — hero + proof.** Reframe the hero, add ONE new "Ask for anything"
+   showcase section, keep the browser → ⌘K → IDE climax, soften the single
+   over-dev line in `Visit`.
+3. **Showcase format — one cycling space.** A single real vmux space (agent pane
+   priority + browser + terminal) that cycles through the three asks with a dot
+   indicator. Cinematic, one outcome at a time.
+
+## Copy
+
+**Hero** (`hero.rs`)
+- Kicker: `The browser`
+- Punch: `that gets sh*t done.`
+- Subhead: `Book a flight, build a website, ship a PR — just ask your agents.`
+
+**Showcase** (`showcase.rs`)
+- Eyebrow: `ASK FOR ANYTHING`
+- Lead: `One prompt.`
+- Punch: `Anything, done.`
+- Subhead: `Travel, a website, a pull request — your agents do the work while you watch.`
+
+Three asks (ask text + working pane + status):
+| Ask | Working pane | Status label |
+|-----|--------------|--------------|
+| `Find me a flight to Tokyo from Paris next month` | browser → flight results | `tokyo` |
+| `Make me a website for my new restaurant` | preview pane (Osteria Lina) | `lina` |
+| `Add theme support to vmux. Open a PR.` | editor diff + terminal (`PR #182`) | `theme` |
+
+## Section-by-section changes
+
+### `website/src/landing/hero.rs`
+Replace the two headline spans + subhead `p` text only. Keep video bg, aurora
+blobs, `InstallCard`, download button, scroll cue untouched.
+
+### `website/src/landing/showcase.rs` (new)
+New `Showcase` component, `data-tone="dark"` (sits between the light `Visit` and
+dark `Ide`, gives the arc rhythm). Structure:
+
+- `headline("ASK FOR ANYTHING", "One prompt.", "Anything, done.")` + subhead `p`.
+- A vmux window frame: titlebar (3 dots) + tmux tab strip + body + tmux status
+  line, reusing the pane aesthetic from `parts.rs`
+  (agent `accent`, browser/preview `aurora-cyan`, terminal `aurora-violet`).
+- **Three scene layers** stacked absolutely inside the body, cross-faded by a
+  pure-CSS keyframe cycle. Agent pane (priority, widest) shows the ask bubble +
+  agent confirmation; the working pane + terminal + tab strip + status label
+  change per scene.
+- A three-dot progress indicator synced to the cycle.
+
+### `website/src/landing.rs`
+- `mod showcase;` + `use showcase::Showcase;`
+- Insert `Showcase {}` between `Visit {}` and `Ide {}`.
+
+### `website/src/landing/visit.rs`
+- Soften the dev-only chat: bot line `"Tests pass — ship it?"` → `"All done — ship it?"`.
+  Keep the `"Ship it."` reply.
+
+### `website/tailwind.input.css`
+- Add a `--animate-showcase` cycle keyframe (~12s, three ~33% phases of opacity)
+  plus the matching `@keyframes`. Scene layers use `animation-delay` offsets of
+  `0s` / `-4s` / `-8s`; dots reuse the same timing.
+- `motion-reduce`: layers fall back to `animate-none`; the three scenes render
+  stacked and static so no content is lost.
+
+## Animation / accessibility
+
+- Pure CSS, no new JS (consistent with `animate-aurora` / `animate-slide`).
+- All cycling elements carry `motion-reduce:animate-none`.
+- Reduced-motion fallback: scenes stack vertically, all visible, dots static.
+
+## Responsive
+
+- Showcase window: agent pane left, working pane(s) right on `sm+`; on narrow
+  widths panes stack vertically. Window max-width matches the `Ide` section
+  (`max-w-4xl`-ish) for visual continuity.
+
+## Out of scope
+
+- No changes to `browser.rs`, `coworking.rs`, `platform.rs`, `cta.rs`.
+- No new crates, no JS framework changes, no asset/video changes.
+- No rewrite of the IDE or co-working narrative (that was option C, rejected).
+
+## Verification
+
+- `cargo check --target wasm32-unknown-unknown -p vmux_website` (typecheck pages).
+- `cargo fmt` (crates only; restore `patches/` if touched).
+- Runtime: user runs the site, confirms hero copy, the showcase cycles through
+  all three asks, reduced-motion shows the static stack, and mobile stacks panes.

--- a/docs/specs/2026-06-27-landing-reposition-design.md
+++ b/docs/specs/2026-06-27-landing-reposition-design.md
@@ -13,28 +13,26 @@ and a self-referential `vmux` theme-support PR.
 
 ## Decisions (validated via visual brainstorm)
 
-1. **Hero tone — edgy.** Real profanity ships on the public page.
-2. **Scope — hero + proof.** Reframe the hero, add ONE new "Ask for anything"
-   showcase section, keep the browser → ⌘K → IDE climax, soften the single
-   over-dev line in `Visit`.
+1. **Tone — edgy.** Real profanity ships on the public page.
+2. **Banner — the showcase IS the hero.** The cycling vmux demo replaces the
+   old text-only banner. Headline leads with "Anything, done."; "browser" is
+   reminded in the subhead; the dev/IDE climax downstream is unchanged.
 3. **Showcase format — one cycling space.** A single real vmux space (agent pane
    priority + browser + terminal) that cycles through the three asks with a dot
    indicator. Cinematic, one outcome at a time.
 
 ## Copy
 
-**Hero** (`hero.rs`)
-- Kicker: `The browser`
-- Punch: `that gets sh*t done.`
-- Subhead: `Book a flight, build a website, ship a PR — just ask your agents.`
+**Hero / banner** (`hero.rs`)
 
-**Showcase** (`showcase.rs`)
 - Eyebrow: `ASK FOR ANYTHING`
 - Lead: `One prompt.`
 - Punch: `Anything, done.`
-- Subhead: `Travel, a website, a pull request — your agents do the work while you watch.`
+- Subhead: `The browser that gets sh*t done — a flight, a website, a PR, handled by your agents while you watch.`
+- CTA: `InstallCard` (curl) + `Download .dmg`, below the demo.
 
 Three asks (ask text + working pane + status):
+
 | Ask | Working pane | Status label |
 |-----|--------------|--------------|
 | `Find me a flight to Tokyo from Paris next month` | browser → flight results | `tokyo` |
@@ -44,37 +42,36 @@ Three asks (ask text + working pane + status):
 ## Section-by-section changes
 
 ### `website/src/landing/hero.rs`
-Replace the two headline spans + subhead `p` text only. Keep video bg, aurora
-blobs, `InstallCard`, download button, scroll cue untouched.
+Rewritten as the banner: `data-tone="dark"`, aurora blobs, the eyebrow/lead/punch
+headline, the browser-reminder subhead, the cycling demo (`showcase::vmux_demo()`),
+then `InstallCard` + `Download .dmg` + scroll cue. The old `[data-hero-video]`
+element is dropped (its use in `scroll.rs` is guarded).
 
 ### `website/src/landing/showcase.rs` (new)
-New `Showcase` component, `data-tone="dark"` (sits between the light `Visit` and
-dark `Ide`, gives the arc rhythm). Structure:
+Exports `pub fn vmux_demo() -> Element` — the cycling demo only (no section
+wrapper), consumed by the hero:
 
-- `headline("ASK FOR ANYTHING", "One prompt.", "Anything, done.")` + subhead `p`.
 - A vmux window frame: titlebar (3 dots) + tmux tab strip + body + tmux status
-  line, reusing the pane aesthetic from `parts.rs`
-  (agent `accent`, browser/preview `aurora-cyan`, terminal `aurora-violet`).
-- **Three scene layers** stacked absolutely inside the body, cross-faded by a
-  pure-CSS keyframe cycle. Agent pane (priority, widest) shows the ask bubble +
-  agent confirmation; the working pane + terminal + tab strip + status label
-  change per scene.
+  line (agent `accent`, browser/preview `aurora-cyan`, terminal `aurora-violet`).
+- **Three scene layers** stacked absolutely, cross-faded by a pure-CSS keyframe
+  cycle. Agent pane (priority) shows the ask + confirmation; working pane +
+  terminal + tabs + status label change per scene.
 - A three-dot progress indicator synced to the cycle.
 
 ### `website/src/landing.rs`
-- `mod showcase;` + `use showcase::Showcase;`
-- Insert `Showcase {}` between `Visit {}` and `Ide {}`.
+- `mod showcase;` only — no standalone section component; the demo is rendered by
+  the hero. No separate section is inserted into the arc.
 
 ### `website/src/landing/visit.rs`
 - Soften the dev-only chat: bot line `"Tests pass — ship it?"` → `"All done — ship it?"`.
   Keep the `"Ship it."` reply.
 
 ### `website/tailwind.input.css`
-- Add a `--animate-showcase` cycle keyframe (~12s, three ~33% phases of opacity)
-  plus the matching `@keyframes`. Scene layers use `animation-delay` offsets of
-  `0s` / `-4s` / `-8s`; dots reuse the same timing.
-- `motion-reduce`: layers fall back to `animate-none`; the three scenes render
-  stacked and static so no content is lost.
+- `scene` / `scenedot` keyframes (~12s, three phases) + `.scene-cycle` /
+  `.scene-dot` classes. Scene layers use `animation-delay` `0s` / `-4s` / `-8s`;
+  dots reuse the same timing.
+- `motion-reduce`: `.scene-stack` becomes a static vertical stack, layers stop
+  animating and show, dots hide — no content lost.
 
 ## Animation / accessibility
 
@@ -84,19 +81,18 @@ dark `Ide`, gives the arc rhythm). Structure:
 
 ## Responsive
 
-- Showcase window: agent pane left, working pane(s) right on `sm+`; on narrow
-  widths panes stack vertically. Window max-width matches the `Ide` section
-  (`max-w-4xl`-ish) for visual continuity.
+- Demo panes stack (`flex-col`) on narrow screens and sit side-by-side
+  (`sm:flex-row`) on `sm+`. Window max-width `max-w-4xl`.
 
 ## Out of scope
 
 - No changes to `browser.rs`, `coworking.rs`, `platform.rs`, `cta.rs`.
-- No new crates, no JS framework changes, no asset/video changes.
+- No new crates, no JS framework changes.
 - No rewrite of the IDE or co-working narrative (that was option C, rejected).
 
 ## Verification
 
-- `cargo check --target wasm32-unknown-unknown -p vmux_website` (typecheck pages).
-- `cargo fmt` (crates only; restore `patches/` if touched).
-- Runtime: user runs the site, confirms hero copy, the showcase cycles through
-  all three asks, reduced-motion shows the static stack, and mobile stacks panes.
+- `cd website && cargo check --target wasm32-unknown-unknown` (standalone crate).
+- `cd website && cargo fmt`.
+- Runtime: the banner demo cycles all three asks, reduced-motion shows the static
+  stack, mobile stacks panes, and the install CTA works.

--- a/website/Dioxus.toml
+++ b/website/Dioxus.toml
@@ -3,4 +3,4 @@ name = "vmux_website"
 default_platform = "web"
 
 [web.app]
-title = "Vmux — The browser that ships code with agents"
+title = "Vmux — the browser that gets sh*t done"

--- a/website/src/landing.rs
+++ b/website/src/landing.rs
@@ -7,6 +7,7 @@ mod parts;
 mod platform;
 #[cfg(target_arch = "wasm32")]
 mod scroll;
+mod showcase;
 mod visit;
 
 use browser::Browser;
@@ -16,6 +17,7 @@ use dioxus::prelude::*;
 use hero::Hero;
 use ide::Ide;
 use platform::Platform;
+use showcase::Showcase;
 use visit::Visit;
 
 pub const ICON: Asset = asset!("/assets/icon.png");
@@ -34,6 +36,7 @@ pub fn Landing() -> Element {
             Hero {}
             Browser {}
             Visit {}
+            Showcase {}
             Ide {}
             Coworking {}
             Platform {}

--- a/website/src/landing.rs
+++ b/website/src/landing.rs
@@ -17,7 +17,6 @@ use dioxus::prelude::*;
 use hero::Hero;
 use ide::Ide;
 use platform::Platform;
-use showcase::Showcase;
 use visit::Visit;
 
 pub const ICON: Asset = asset!("/assets/icon.png");
@@ -36,7 +35,6 @@ pub fn Landing() -> Element {
             Hero {}
             Browser {}
             Visit {}
-            Showcase {}
             Ide {}
             Coworking {}
             Platform {}

--- a/website/src/landing/hero.rs
+++ b/website/src/landing/hero.rs
@@ -13,8 +13,8 @@ pub fn Hero() -> Element {
 
     rsx! {
         section {
-            "data-tone": "dark",
-            class: "relative isolate min-h-screen overflow-hidden flex flex-col items-center justify-center px-6 py-24 text-center bg-bg text-text",
+            "data-tone": "light",
+            class: "relative isolate min-h-screen overflow-hidden flex flex-col items-center justify-start px-6 pt-28 sm:pt-36 pb-24 text-center bg-bg text-text",
             div { class: "pointer-events-none absolute inset-0 -z-10",
                 div { class: "absolute left-1/2 top-1/4 h-[34rem] w-[34rem] -translate-x-1/2 rounded-full bg-accent/20 blur-[140px] animate-aurora motion-reduce:animate-none" }
                 div { class: "absolute left-[16%] top-1/3 h-80 w-80 rounded-full bg-aurora-cyan/20 blur-[120px] animate-aurora [animation-delay:-7s] motion-reduce:animate-none" }
@@ -23,7 +23,7 @@ pub fn Hero() -> Element {
             div { class: "relative mx-auto max-w-2xl reveal",
                 {headline("Ask for anything", "One prompt.", "Anything, done.")}
                 p { class: "mt-5 text-lg sm:text-xl text-text-muted max-w-xl mx-auto reveal",
-                    "The browser that gets sh*t done — a flight, a website, a PR, handled by your agents while you watch."
+                    "The browser that gets sh*t done — booking a flight, building a website, opening a PR, all handled by your agents while you watch."
                 }
             }
             div { class: "relative mt-12 w-full", {vmux_demo()} }

--- a/website/src/landing/hero.rs
+++ b/website/src/landing/hero.rs
@@ -22,7 +22,7 @@ pub fn Hero() -> Element {
                 div { class: "absolute right-[16%] top-1/4 h-80 w-80 rounded-full bg-aurora-violet/20 blur-[120px] animate-aurora [animation-delay:-13s] motion-reduce:animate-none" }
             }
             div { class: "relative mx-auto max-w-2xl reveal",
-                {headline("Ask for anything", "One prompt.", "Anything, done.")}
+                {headline("The browser", "One prompt.", "Anything, done.")}
                 p { class: "mt-5 text-lg sm:text-xl text-text-muted max-w-xl mx-auto reveal",
                     "The browser that gets sh*t done — booking a flight, building a website, opening a PR, all handled by your agents while you watch."
                 }

--- a/website/src/landing/hero.rs
+++ b/website/src/landing/hero.rs
@@ -14,7 +14,8 @@ pub fn Hero() -> Element {
     rsx! {
         section {
             "data-tone": "light",
-            class: "relative isolate min-h-screen overflow-hidden flex flex-col items-center justify-start px-6 pt-28 sm:pt-36 pb-24 text-center bg-bg text-text",
+            class: "relative isolate min-h-screen overflow-hidden flex flex-col items-center justify-start px-6 pb-24 text-center bg-bg text-text",
+            style: "padding-top: 7.5rem",
             div { class: "pointer-events-none absolute inset-0 -z-10",
                 div { class: "absolute left-1/2 top-1/4 h-[34rem] w-[34rem] -translate-x-1/2 rounded-full bg-accent/20 blur-[140px] animate-aurora motion-reduce:animate-none" }
                 div { class: "absolute left-[16%] top-1/3 h-80 w-80 rounded-full bg-aurora-cyan/20 blur-[120px] animate-aurora [animation-delay:-7s] motion-reduce:animate-none" }

--- a/website/src/landing/hero.rs
+++ b/website/src/landing/hero.rs
@@ -2,8 +2,8 @@ use dioxus::prelude::*;
 use dioxus_primitives::toast::{ToastOptions, use_toast};
 
 use crate::hooks::{use_dmg_download, use_is_mac};
-use crate::landing::ICON;
-use crate::landing::parts::{InstallCard, scroll_cue};
+use crate::landing::parts::{InstallCard, headline, scroll_cue};
+use crate::landing::showcase::vmux_demo;
 
 #[component]
 pub fn Hero() -> Element {
@@ -13,55 +13,40 @@ pub fn Hero() -> Element {
 
     rsx! {
         section {
-            "data-tone": "light",
-            class: "relative isolate min-h-screen overflow-hidden flex flex-col items-center justify-center px-6 text-center bg-bg text-text",
-            div {
-                class: "pointer-events-none absolute inset-0 -z-10",
-                style: "transform: translateY(calc(var(--sy, 0) * -0.04px))",
-                video {
-                    "data-hero-video": "1",
-                    class: "absolute inset-0 h-full w-full object-cover opacity-60 mix-blend-screen motion-reduce:hidden",
-                    muted: true,
-                    "playsinline": true,
-                }
-                div { class: "absolute left-1/2 top-1/4 h-[34rem] w-[34rem] -translate-x-1/2 rounded-full bg-accent/25 blur-[130px] animate-aurora motion-reduce:animate-none" }
-                div { class: "absolute left-[18%] top-1/3 h-80 w-80 rounded-full bg-aurora-cyan/30 blur-[110px] animate-aurora [animation-delay:-7s] motion-reduce:animate-none" }
-                div { class: "absolute right-[16%] top-1/4 h-80 w-80 rounded-full bg-aurora-violet/25 blur-[110px] animate-aurora [animation-delay:-13s] motion-reduce:animate-none" }
+            "data-tone": "dark",
+            class: "relative isolate min-h-screen overflow-hidden flex flex-col items-center justify-center px-6 py-24 text-center bg-bg text-text",
+            div { class: "pointer-events-none absolute inset-0 -z-10",
+                div { class: "absolute left-1/2 top-1/4 h-[34rem] w-[34rem] -translate-x-1/2 rounded-full bg-accent/20 blur-[140px] animate-aurora motion-reduce:animate-none" }
+                div { class: "absolute left-[16%] top-1/3 h-80 w-80 rounded-full bg-aurora-cyan/20 blur-[120px] animate-aurora [animation-delay:-7s] motion-reduce:animate-none" }
+                div { class: "absolute right-[16%] top-1/4 h-80 w-80 rounded-full bg-aurora-violet/20 blur-[120px] animate-aurora [animation-delay:-13s] motion-reduce:animate-none" }
             }
-            div { class: "relative mx-auto max-w-3xl reveal",
-                img {
-                    src: ICON,
-                    alt: "Vmux icon",
-                    class: "w-20 h-20 mb-8 inline-block rounded-3xl shadow-2xl shadow-accent/20",
+            div { class: "relative mx-auto max-w-2xl reveal",
+                {headline("Ask for anything", "One prompt.", "Anything, done.")}
+                p { class: "mt-5 text-lg sm:text-xl text-text-muted max-w-xl mx-auto reveal",
+                    "The browser that gets sh*t done — a flight, a website, a PR, handled by your agents while you watch."
                 }
-                h1 { class: "font-bold tracking-tight leading-[1.02] mb-6",
-                    span { class: "block text-2xl sm:text-3xl text-text-muted", "The browser" }
-                    span { class: "block text-6xl sm:text-8xl text-text", "that gets sh*t done." }
-                }
-                p { class: "text-lg sm:text-2xl text-text-muted mb-10 max-w-xl mx-auto",
-                    "Book a flight, build a website, ship a PR — just ask your agents."
-                }
+            }
+            div { class: "relative mt-12 w-full", {vmux_demo()} }
+            div { class: "relative mt-12 flex flex-col items-center gap-4 reveal",
                 InstallCard {}
-                div { class: "mt-6 flex justify-center",
-                    button {
-                        class: "inline-flex items-center px-7 py-3.5 rounded-xl text-base font-semibold bg-accent text-black cursor-pointer transition-colors hover:bg-accent-hover",
-                        onclick: move |_| {
-                            if is_mac {
-                                download(());
-                            } else {
-                                toast_api
-                                    .info(
-                                        "Not supported".to_string(),
-                                        ToastOptions::new()
-                                            .description("Windows/Linux not supported yet — see GitHub Releases"),
-                                    );
-                            }
-                        },
-                        "Download .dmg"
-                    }
+                button {
+                    class: "inline-flex items-center px-7 py-3.5 rounded-xl text-base font-semibold bg-accent text-black cursor-pointer transition-colors hover:bg-accent-hover",
+                    onclick: move |_| {
+                        if is_mac {
+                            download(());
+                        } else {
+                            toast_api
+                                .info(
+                                    "Not supported".to_string(),
+                                    ToastOptions::new()
+                                        .description("Windows/Linux not supported yet — see GitHub Releases"),
+                                );
+                        }
+                    },
+                    "Download .dmg"
                 }
-                {scroll_cue()}
             }
+            {scroll_cue()}
         }
     }
 }

--- a/website/src/landing/hero.rs
+++ b/website/src/landing/hero.rs
@@ -36,10 +36,10 @@ pub fn Hero() -> Element {
                 }
                 h1 { class: "font-bold tracking-tight leading-[1.02] mb-6",
                     span { class: "block text-2xl sm:text-3xl text-text-muted", "The browser" }
-                    span { class: "block text-6xl sm:text-8xl text-text", "that ships code." }
+                    span { class: "block text-6xl sm:text-8xl text-text", "that gets sh*t done." }
                 }
                 p { class: "text-lg sm:text-2xl text-text-muted mb-10 max-w-xl mx-auto",
-                    "Browse, prompt, and build with agents — in one space."
+                    "Book a flight, build a website, ship a PR — just ask your agents."
                 }
                 InstallCard {}
                 div { class: "mt-6 flex justify-center",

--- a/website/src/landing/showcase.rs
+++ b/website/src/landing/showcase.rs
@@ -1,36 +1,20 @@
 use dioxus::prelude::*;
 
-use crate::landing::parts::headline;
-
-#[component]
-pub fn Showcase() -> Element {
+pub fn vmux_demo() -> Element {
     rsx! {
-        section {
-            "data-tone": "dark",
-            class: "relative isolate overflow-hidden px-6 py-28 sm:py-36 bg-bg text-text",
-            div { class: "pointer-events-none absolute inset-0 -z-10",
-                div { class: "absolute left-1/2 top-1/3 h-[32rem] w-[32rem] -translate-x-1/2 rounded-full bg-accent/15 blur-[140px] animate-aurora motion-reduce:animate-none" }
+        div { class: "mx-auto w-full max-w-4xl reveal", style: "transition-delay: 120ms",
+            div { class: "scene-stack relative h-[32rem] sm:h-[26rem]",
+                {scene_flight()}
+                {scene_site()}
+                {scene_pr()}
             }
-            div { class: "mx-auto max-w-2xl text-center mb-12",
-                {headline("Ask for anything", "One prompt.", "Anything, done.")}
-                p { class: "mt-5 text-base sm:text-lg text-text-muted reveal",
-                    "Travel, a website, a pull request — your agents do the work while you watch."
+            div { class: "scene-dots mt-6 flex flex-col items-center gap-3",
+                div { class: "flex items-center gap-2",
+                    span { class: "scene-dot h-1.5 w-7 rounded-full bg-accent" }
+                    span { class: "scene-dot h-1.5 w-7 rounded-full bg-accent", style: "animation-delay: -4s" }
+                    span { class: "scene-dot h-1.5 w-7 rounded-full bg-accent", style: "animation-delay: -8s" }
                 }
-            }
-            div { class: "mx-auto w-full max-w-4xl reveal", style: "transition-delay: 120ms",
-                div { class: "scene-stack relative h-[32rem] sm:h-[26rem]",
-                    {scene_flight()}
-                    {scene_site()}
-                    {scene_pr()}
-                }
-                div { class: "scene-dots mt-6 flex flex-col items-center gap-3",
-                    div { class: "flex items-center gap-2",
-                        span { class: "scene-dot h-1.5 w-7 rounded-full bg-accent" }
-                        span { class: "scene-dot h-1.5 w-7 rounded-full bg-accent", style: "animation-delay: -4s" }
-                        span { class: "scene-dot h-1.5 w-7 rounded-full bg-accent", style: "animation-delay: -8s" }
-                    }
-                    p { class: "text-xs text-text-muted", "flight → restaurant site → theme PR" }
-                }
+                p { class: "text-xs text-text-muted", "flight → restaurant site → theme PR" }
             }
         }
     }
@@ -47,7 +31,7 @@ fn shell(delay: &str, tabs: Element, body: Element, status: Element) -> Element 
                 span { class: "h-2 w-2 rounded-full bg-white/15" }
                 div { class: "ml-2 flex gap-1.5", {tabs} }
             }
-            div { class: "flex min-h-0 flex-1 gap-1.5 p-1.5", {body} }
+            div { class: "flex min-h-0 flex-1 flex-col gap-1.5 p-1.5 sm:flex-row", {body} }
             {status}
         }
     }
@@ -142,9 +126,9 @@ fn scene_flight() -> Element {
                     "google.com/flights"
                 }
                 div { class: "mt-1",
-                    {flight_row("CDG → HND · May 18", "€548", true)}
-                    {flight_row("CDG → HND · May 14", "€612", false)}
-                    {flight_row("CDG → NRT · May 21", "€599", false)}
+                    {flight_row("CDG → HND · Jul 18", "€548", true)}
+                    {flight_row("CDG → HND · Jul 14", "€612", false)}
+                    {flight_row("CDG → NRT · Jul 21", "€599", false)}
                 }
             }
         },
@@ -202,7 +186,7 @@ fn scene_pr() -> Element {
         },
         rsx! {
             div { class: "flex flex-1 flex-col gap-1.5",
-                div { class: "flex min-h-0 flex-[1.4] gap-1.5",
+                div { class: "flex min-h-0 flex-[1.4] flex-col gap-1.5 sm:flex-row",
                     {agent_pane("Add theme support to vmux. Open a PR.", "PR #182 opened", "flex-1")}
                     div { class: "flex flex-1 min-w-0 flex-col overflow-hidden rounded-lg border border-accent/30 bg-[#0d0d18] font-mono text-[9px] leading-[1.7]",
                         {pane_head("text-accent", "theme.rs")}

--- a/website/src/landing/showcase.rs
+++ b/website/src/landing/showcase.rs
@@ -1,0 +1,235 @@
+use dioxus::prelude::*;
+
+use crate::landing::parts::headline;
+
+#[component]
+pub fn Showcase() -> Element {
+    rsx! {
+        section {
+            "data-tone": "dark",
+            class: "relative isolate overflow-hidden px-6 py-28 sm:py-36 bg-bg text-text",
+            div { class: "pointer-events-none absolute inset-0 -z-10",
+                div { class: "absolute left-1/2 top-1/3 h-[32rem] w-[32rem] -translate-x-1/2 rounded-full bg-accent/15 blur-[140px] animate-aurora motion-reduce:animate-none" }
+            }
+            div { class: "mx-auto max-w-2xl text-center mb-12",
+                {headline("Ask for anything", "One prompt.", "Anything, done.")}
+                p { class: "mt-5 text-base sm:text-lg text-text-muted reveal",
+                    "Travel, a website, a pull request — your agents do the work while you watch."
+                }
+            }
+            div { class: "mx-auto w-full max-w-4xl reveal", style: "transition-delay: 120ms",
+                div { class: "scene-stack relative h-[32rem] sm:h-[26rem]",
+                    {scene_flight()}
+                    {scene_site()}
+                    {scene_pr()}
+                }
+                div { class: "scene-dots mt-6 flex flex-col items-center gap-3",
+                    div { class: "flex items-center gap-2",
+                        span { class: "scene-dot h-1.5 w-7 rounded-full bg-accent" }
+                        span { class: "scene-dot h-1.5 w-7 rounded-full bg-accent", style: "animation-delay: -4s" }
+                        span { class: "scene-dot h-1.5 w-7 rounded-full bg-accent", style: "animation-delay: -8s" }
+                    }
+                    p { class: "text-xs text-text-muted", "flight → restaurant site → theme PR" }
+                }
+            }
+        }
+    }
+}
+
+fn shell(delay: &str, tabs: Element, body: Element, status: Element) -> Element {
+    rsx! {
+        div {
+            class: "scene-cycle glass flex h-full flex-col overflow-hidden rounded-xl border border-white/10",
+            style: "animation-delay: {delay}",
+            div { class: "flex h-7 items-center gap-1.5 border-b border-white/10 px-3",
+                span { class: "h-2 w-2 rounded-full bg-white/15" }
+                span { class: "h-2 w-2 rounded-full bg-white/15" }
+                span { class: "h-2 w-2 rounded-full bg-white/15" }
+                div { class: "ml-2 flex gap-1.5", {tabs} }
+            }
+            div { class: "flex min-h-0 flex-1 gap-1.5 p-1.5", {body} }
+            {status}
+        }
+    }
+}
+
+fn sc_tab(dot: &str, label: &str, active: bool) -> Element {
+    let cls = if active {
+        "flex items-center gap-1.5 rounded-md border border-white/10 bg-white/[0.06] px-2 py-0.5 text-[10px] text-text"
+    } else {
+        "flex items-center gap-1.5 rounded-md px-2 py-0.5 text-[10px] text-text-muted"
+    };
+    rsx! {
+        div { class: "{cls}",
+            span { class: "h-1.5 w-1.5 rounded-full {dot}" }
+            span { class: "max-w-[80px] truncate", "{label}" }
+        }
+    }
+}
+
+fn agent_pane(ask: &str, reply: &str, flex: &str) -> Element {
+    rsx! {
+        div { class: "{flex} flex min-w-0 flex-col overflow-hidden rounded-lg border border-accent/40 bg-[#0d0d18]",
+            div { class: "border-b border-white/5 px-2.5 py-1 text-[8px] font-bold uppercase tracking-wide text-accent",
+                "agent · vibe"
+            }
+            div { class: "flex flex-1 flex-col gap-2 p-2.5",
+                div { class: "self-end max-w-[92%] rounded-xl rounded-br-sm border border-accent/30 bg-accent/20 px-2.5 py-1.5 text-[10px] leading-snug text-text",
+                    "{ask}"
+                }
+                div { class: "self-start max-w-[92%] rounded-xl rounded-bl-sm border border-white/10 bg-white/5 px-2.5 py-1.5 text-[10px] leading-snug text-text-muted",
+                    span { class: "font-bold text-emerald-300", "✓ " }
+                    "{reply}"
+                }
+                div { class: "mt-auto flex items-center gap-1.5 rounded-lg border border-white/10 bg-black/40 px-2.5 py-1.5",
+                    span { class: "text-[8px] font-bold text-accent", "⌘K" }
+                    span { class: "text-[9px] text-text-muted", "Ask anything" }
+                    span { class: "ml-0.5 inline-block h-2.5 w-px bg-accent animate-pulse motion-reduce:animate-none" }
+                }
+            }
+        }
+    }
+}
+
+fn status(space: &str, windows: Element) -> Element {
+    rsx! {
+        div { class: "flex h-5 items-center gap-2 border-t border-accent/20 bg-accent/10 px-2 font-mono text-[8px] text-accent",
+            span { class: "rounded-sm bg-accent px-1.5 font-bold text-black", "{space}" }
+            {windows}
+            span { class: "ml-auto text-text-muted", "⌘K" }
+        }
+    }
+}
+
+fn pane_head(color: &str, label: &str) -> Element {
+    rsx! {
+        div { class: "border-b border-white/5 px-2.5 py-1 text-[8px] font-bold uppercase tracking-wide {color}",
+            "{label}"
+        }
+    }
+}
+
+fn flight_row(route: &str, price: &str, hot: bool) -> Element {
+    let row = if hot {
+        "flex items-center justify-between border-t border-aurora-cyan/20 bg-aurora-cyan/10 px-2.5 py-1.5 text-[9px]"
+    } else {
+        "flex items-center justify-between border-t border-white/5 px-2.5 py-1.5 text-[9px]"
+    };
+    rsx! {
+        div { class: "{row}",
+            span { class: "text-text-muted", "{route}" }
+            span { class: "font-bold text-text", "{price}" }
+        }
+    }
+}
+
+fn scene_flight() -> Element {
+    shell(
+        "0s",
+        rsx! {
+            {sc_tab("bg-accent", "vibe", true)}
+            {sc_tab("bg-aurora-cyan", "flights", false)}
+        },
+        rsx! {
+            {agent_pane(
+                "Find me a flight to Tokyo from Paris next month",
+                "3 options, €548–612",
+                "flex-[1.1]",
+            )}
+            div { class: "flex flex-1 min-w-0 flex-col overflow-hidden rounded-lg border border-aurora-cyan/35 bg-[#0b1418]",
+                {pane_head("text-aurora-cyan", "browser")}
+                div { class: "mx-2.5 mt-2 rounded-md border border-white/10 bg-black/40 px-2 py-1 font-mono text-[8px] text-text-muted",
+                    "google.com/flights"
+                }
+                div { class: "mt-1",
+                    {flight_row("CDG → HND · May 18", "€548", true)}
+                    {flight_row("CDG → HND · May 14", "€612", false)}
+                    {flight_row("CDG → NRT · May 21", "€599", false)}
+                }
+            }
+        },
+        status(
+            "tokyo",
+            rsx! {
+                span { class: "text-text", "0:vibe" }
+                span { class: "text-text-muted", "1:flights" }
+            },
+        ),
+    )
+}
+
+fn scene_site() -> Element {
+    shell(
+        "-4s",
+        rsx! {
+            {sc_tab("bg-accent", "vibe", true)}
+            {sc_tab("bg-aurora-cyan", "preview", false)}
+        },
+        rsx! {
+            {agent_pane(
+                "Make me a website for my new restaurant",
+                "Osteria Lina — menu + booking",
+                "flex-[1.1]",
+            )}
+            div { class: "flex flex-1 min-w-0 flex-col overflow-hidden rounded-lg border border-aurora-cyan/35 bg-[#0b1418]",
+                {pane_head("text-aurora-cyan", "preview")}
+                div { class: "flex flex-1 flex-col gap-2 p-3",
+                    div { class: "text-sm font-bold tracking-tight text-text", "Osteria Lina" }
+                    div { class: "text-[8px] uppercase tracking-[0.2em] text-aurora-cyan", "Menu · Reserve · Find us" }
+                    div { class: "mt-1 h-16 rounded-md bg-gradient-to-br from-aurora-cyan/25 to-accent/15" }
+                    div { class: "h-1.5 w-4/5 rounded-full bg-white/10" }
+                    div { class: "h-1.5 w-3/5 rounded-full bg-white/10" }
+                }
+            }
+        },
+        status(
+            "lina",
+            rsx! {
+                span { class: "text-text", "0:vibe" }
+                span { class: "text-text-muted", "1:preview" }
+            },
+        ),
+    )
+}
+
+fn scene_pr() -> Element {
+    shell(
+        "-8s",
+        rsx! {
+            {sc_tab("bg-accent", "vibe", true)}
+            {sc_tab("bg-accent", "theme.rs", false)}
+            {sc_tab("bg-aurora-violet", "term", false)}
+        },
+        rsx! {
+            div { class: "flex flex-1 flex-col gap-1.5",
+                div { class: "flex min-h-0 flex-[1.4] gap-1.5",
+                    {agent_pane("Add theme support to vmux. Open a PR.", "PR #182 opened", "flex-1")}
+                    div { class: "flex flex-1 min-w-0 flex-col overflow-hidden rounded-lg border border-accent/30 bg-[#0d0d18] font-mono text-[9px] leading-[1.7]",
+                        {pane_head("text-accent", "theme.rs")}
+                        div { class: "flex-1 overflow-hidden py-1",
+                            div { class: "bg-red-500/12 px-2.5 text-red-300", "- bg: 0x0a0a0a" }
+                            div { class: "bg-emerald-500/12 px-2.5 text-emerald-300", "+ enum Theme {{" }
+                            div { class: "bg-emerald-500/12 px-2.5 text-emerald-300", "+   Light, Dark, Device," }
+                            div { class: "bg-emerald-500/12 px-2.5 text-emerald-300", "+ }}" }
+                        }
+                    }
+                }
+                div { class: "flex min-h-0 flex-[0.7] flex-col overflow-hidden rounded-lg border border-aurora-violet/35 bg-[#120c1a] px-2.5 py-2 font-mono text-[9px] leading-[1.7] text-text-muted",
+                    div {
+                        span { class: "text-aurora-violet", "$ " }
+                        span { class: "text-text", "gh pr create" }
+                    }
+                    div { class: "text-aurora-cyan", "→ PR #182 opened · light/dark/device" }
+                }
+            }
+        },
+        status(
+            "theme",
+            rsx! {
+                span { class: "text-text", "0:vibe" }
+                span { class: "text-text-muted", "1:edit" }
+                span { class: "text-text-muted", "2:term" }
+            },
+        ),
+    )
+}

--- a/website/src/landing/showcase.rs
+++ b/website/src/landing/showcase.rs
@@ -23,7 +23,7 @@ pub fn vmux_demo() -> Element {
 fn shell(delay: &str, tabs: Element, body: Element, status: Element) -> Element {
     rsx! {
         div {
-            class: "scene-cycle glass flex h-full flex-col overflow-hidden rounded-xl border border-white/10",
+            class: "scene-cycle flex h-full flex-col overflow-hidden rounded-xl border border-white/10 bg-[#0b0b14] shadow-2xl shadow-black/40",
             style: "animation-delay: {delay}",
             div { class: "flex h-7 items-center gap-1.5 border-b border-white/10 px-3",
                 span { class: "h-2 w-2 rounded-full bg-white/15" }

--- a/website/src/landing/showcase.rs
+++ b/website/src/landing/showcase.rs
@@ -23,8 +23,8 @@ pub fn vmux_demo() -> Element {
 fn shell(delay: &str, tabs: Element, body: Element, status: Element) -> Element {
     rsx! {
         div {
-            class: "scene-cycle flex h-full flex-col overflow-hidden rounded-xl border border-white/10 bg-[#0b0b14] shadow-2xl shadow-black/40",
-            style: "animation-delay: {delay}",
+            class: "scene-cycle flex h-full flex-col overflow-hidden rounded-xl border border-white/10 shadow-2xl shadow-black/40",
+            style: "animation-delay: {delay}; background: #0b0b14",
             div { class: "flex h-7 items-center gap-1.5 border-b border-white/10 px-3",
                 span { class: "h-2 w-2 rounded-full bg-white/15" }
                 span { class: "h-2 w-2 rounded-full bg-white/15" }

--- a/website/src/landing/visit.rs
+++ b/website/src/landing/visit.rs
@@ -4,12 +4,7 @@ use crate::landing::parts::{
     avatar_bot, avatar_you, browser_frame, headline, icon_bot, icon_globe, tab,
 };
 
-const TOOLS: &[&str] = &[
-    "browser_navigate",
-    "run",
-    "read_layout",
-    "update_layout",
-];
+const TOOLS: &[&str] = &["browser_navigate", "run", "read_layout", "update_layout"];
 
 #[component]
 pub fn Visit() -> Element {
@@ -51,7 +46,7 @@ pub fn Visit() -> Element {
                                     div { class: "flex items-end gap-2",
                                         {avatar_bot()}
                                         div { class: "rounded-xl rounded-bl-sm bg-surface/80 px-3 py-2 text-[12px] text-text",
-                                            "Tests pass — ship it?"
+                                            "All done — ship it?"
                                         }
                                     }
                                     div { class: "flex items-end justify-end gap-2",

--- a/website/tailwind.input.css
+++ b/website/tailwind.input.css
@@ -134,3 +134,47 @@
         box-shadow: var(--glass-shadow);
     }
 }
+
+@layer components {
+    .scene-cycle {
+        position: absolute;
+        inset: 0;
+        opacity: 0;
+        animation: scene 12s ease-in-out infinite;
+    }
+    .scene-dot {
+        opacity: 0.3;
+        animation: scenedot 12s ease-in-out infinite;
+    }
+}
+
+@keyframes scene {
+    0% { opacity: 0; }
+    3% { opacity: 1; }
+    30% { opacity: 1; }
+    36% { opacity: 0; }
+    100% { opacity: 0; }
+}
+
+@keyframes scenedot {
+    0%, 36%, 100% { opacity: 0.3; }
+    3%, 30% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .scene-stack {
+        height: auto;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+    .scene-cycle {
+        position: relative;
+        inset: auto;
+        opacity: 1;
+        animation: none;
+    }
+    .scene-dots {
+        display: none;
+    }
+}


### PR DESCRIPTION
## Why

Broaden the landing positioning from a dev-only message (*the browser that ships code*) to a general agentic one — **get anything done with agents** — without losing the dev/IDE story that sets vmux apart from generic "AI browsers".

## What changed

- **Hero** — `that ships code.` → **`that gets sh*t done.`**; subhead → *"Book a flight, build a website, ship a PR — just ask your agents."*
- **New "Ask for anything" section** (`showcase.rs`) — a single real vmux space (agent pane priority + browser + terminal, tmux tabs & status line) that **cycles** through three asks:
  - Find me a flight to Tokyo from Paris next month → browser + flight results
  - Make me a website for my new restaurant → preview pane
  - Add theme support to vmux. Open a PR. → editor diff + terminal (`PR #182`)
  - Placed after **Visit**, before **Ide** — promise → mechanism → breadth → IDE climax.
- **Visit** — softened the one dev-only line (*"Tests pass — ship it?"* → *"All done — ship it?"*).
- **CSS** — pure-CSS `scene` / `scenedot` keyframes (no new JS, matches `animate-aurora`). `prefers-reduced-motion` stacks all three scenes static.

Design spec: `docs/specs/2026-06-27-landing-reposition-design.md`.

## Test plan

- [x] `cargo check --target wasm32-unknown-unknown` (website) — clean
- [x] `cargo fmt` (website crate)
- [ ] Runtime: hero copy, showcase cycles all three asks, reduced-motion shows the static stack, mobile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the landing page with a more agent-focused hero message and a new animated showcase that cycles through multiple example workflows.
  * Refreshed the app title and landing copy to better match the new positioning.
* **Bug Fixes**
  * Improved reduced-motion behavior so the showcase stays readable without animation.
  * Adjusted the hero and visitor prompt text for a smoother, more polished experience.
* **Style**
  * Updated visual layout and animation timing for the landing showcase and hero section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->