### PR TITLE
fix(persistence): reset layout store when incompatible with build

### DIFF
--- a/crates/vmux_desktop/src/persistence.rs
+++ b/crates/vmux_desktop/src/persistence.rs
@@ -153,38 +153,22 @@ fn auto_save_system(
     spaces: Query<(), With<Space>>,
     mut commands: Commands,
 ) {
-    auto_save_tick(
-        &mut auto_save,
-        time.delta(),
-        !spaces.is_empty(),
-        &mut commands,
-        store_path(),
-    );
-}
+    auto_save.periodic.tick(time.delta());
 
-fn auto_save_tick(
-    auto_save: &mut AutoSave,
-    delta: std::time::Duration,
-    has_space: bool,
-    commands: &mut Commands,
-    path: PathBuf,
-) {
-    auto_save.periodic.tick(delta);
-
-    if !has_space {
+    if spaces.is_empty() {
         return;
     }
 
     if auto_save.dirty {
-        auto_save.debounce.tick(delta);
+        auto_save.debounce.tick(time.delta());
         if auto_save.debounce.is_finished() {
-            save_space_to_path(commands, path.clone());
+            save_space_to_path(&mut commands, store_path());
             auto_save.dirty = false;
         }
     }
 
     if auto_save.periodic.just_finished() {
-        save_space_to_path(commands, path);
+        save_space_to_path(&mut commands, store_path());
     }
 }
 
@@ -1226,63 +1210,110 @@ mod tests {
         assert!(path.exists());
     }
 
-    fn savable_geometry_app() -> (tempfile::TempDir, App) {
-        let dir = tempfile::tempdir().expect("tempdir");
+    #[test]
+    fn incompatible_store_resets_layout_on_startup() {
+        let _home = HomeEnvGuard::use_temp_home("incompatible-store-resets-layout-on-startup");
+        let path = store_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("store dir");
+        }
+        std::fs::write(
+            &path,
+            store_body_with_key("vmux_desktop::ghost::DoesNotExist"),
+        )
+        .expect("write store");
+        std::fs::write(store_version_path(), STORE_SCHEMA_VERSION.to_string())
+            .expect("write version");
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .insert_resource(test_settings())
+            .insert_resource(ActiveSpace {
+                record: vmux_space::model::bootstrap_space_record(),
+            })
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+            .init_resource::<vmux_agent::strategy::AgentStrategies>()
+            .add_plugins(PersistencePlugin);
+        app.world_mut().spawn(Main);
+        app.world_mut().spawn(PrimaryWindow);
+        app.update();
+
+        assert!(
+            !path.exists(),
+            "incompatible store should be removed on startup"
+        );
+        assert!(
+            !store_version_path().exists(),
+            "store.version should be removed with the incompatible store"
+        );
+        let spaces = app.world_mut().query::<&Space>().iter(app.world()).count();
+        assert_eq!(spaces, 1, "a fresh space should be spawned after reset");
+    }
+
+    #[test]
+    fn auto_save_system_skips_save_without_space() {
+        let _home = HomeEnvGuard::use_temp_home("auto-save-system-skips-without-space");
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .add_plugins(vmux_core::CorePlugin)
             .register_type::<WindowGeometry>()
             .register_type::<Option<IVec2>>()
             .register_type::<Option<Vec2>>()
-            .add_observer(save_on_default_event);
+            .insert_resource(AutoSave {
+                debounce: Timer::from_seconds(0.0, TimerMode::Once),
+                periodic: Timer::from_seconds(0.0, TimerMode::Repeating),
+                dirty: true,
+            })
+            .add_observer(save_on_default_event)
+            .add_systems(Update, auto_save_system);
         app.world_mut().spawn((
             Save,
             WindowGeometry {
-                fullscreen: true,
-                position: Some(IVec2::new(1, 2)),
-                size: Some(Vec2::new(3.0, 4.0)),
+                fullscreen: false,
+                position: None,
+                size: None,
             },
         ));
-        (dir, app)
-    }
-
-    fn dirty_auto_save() -> AutoSave {
-        AutoSave {
-            debounce: Timer::from_seconds(0.0, TimerMode::Once),
-            periodic: Timer::from_seconds(60.0, TimerMode::Repeating),
-            dirty: true,
-        }
+        app.update();
+        app.update();
+        assert!(
+            !store_path().exists(),
+            "auto_save must skip when no Space exists"
+        );
     }
 
     #[test]
-    fn auto_save_writes_when_space_present() {
-        let (dir, mut app) = savable_geometry_app();
-        let path = dir.path().join("store.ron");
-        let mut auto_save = dirty_auto_save();
-        auto_save_tick(
-            &mut auto_save,
-            std::time::Duration::from_millis(1),
-            true,
-            &mut app.world_mut().commands(),
-            path.clone(),
-        );
+    fn auto_save_system_saves_with_space() {
+        let _home = HomeEnvGuard::use_temp_home("auto-save-system-saves-with-space");
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(vmux_core::CorePlugin)
+            .register_type::<WindowGeometry>()
+            .register_type::<Option<IVec2>>()
+            .register_type::<Option<Vec2>>()
+            .insert_resource(AutoSave {
+                debounce: Timer::from_seconds(0.0, TimerMode::Once),
+                periodic: Timer::from_seconds(0.0, TimerMode::Repeating),
+                dirty: true,
+            })
+            .add_observer(save_on_default_event)
+            .add_systems(Update, auto_save_system);
+        app.world_mut().spawn((
+            Save,
+            Space,
+            SpaceId("space-1".to_string()),
+            WindowGeometry {
+                fullscreen: false,
+                position: None,
+                size: None,
+            },
+        ));
         app.update();
-        assert!(path.exists());
-    }
-
-    #[test]
-    fn auto_save_skips_when_no_space() {
-        let (dir, mut app) = savable_geometry_app();
-        let path = dir.path().join("store.ron");
-        let mut auto_save = dirty_auto_save();
-        auto_save_tick(
-            &mut auto_save,
-            std::time::Duration::from_millis(1),
-            false,
-            &mut app.world_mut().commands(),
-            path.clone(),
-        );
         app.update();
-        assert!(!path.exists());
+        assert!(
+            store_path().exists(),
+            "auto_save must save when a Space exists"
+        );
     }
 }

--- a/crates/vmux_desktop/src/persistence.rs
+++ b/crates/vmux_desktop/src/persistence.rs
@@ -147,19 +147,44 @@ fn mark_dirty_on_change(
     }
 }
 
-fn auto_save_system(time: Res<Time>, mut auto_save: ResMut<AutoSave>, mut commands: Commands) {
-    auto_save.periodic.tick(time.delta());
+fn auto_save_system(
+    time: Res<Time>,
+    mut auto_save: ResMut<AutoSave>,
+    spaces: Query<(), With<Space>>,
+    mut commands: Commands,
+) {
+    auto_save_tick(
+        &mut auto_save,
+        time.delta(),
+        !spaces.is_empty(),
+        &mut commands,
+        store_path(),
+    );
+}
+
+fn auto_save_tick(
+    auto_save: &mut AutoSave,
+    delta: std::time::Duration,
+    has_space: bool,
+    commands: &mut Commands,
+    path: PathBuf,
+) {
+    auto_save.periodic.tick(delta);
+
+    if !has_space {
+        return;
+    }
 
     if auto_save.dirty {
-        auto_save.debounce.tick(time.delta());
+        auto_save.debounce.tick(delta);
         if auto_save.debounce.is_finished() {
-            save_space_to_path(&mut commands, store_path());
+            save_space_to_path(commands, path.clone());
             auto_save.dirty = false;
         }
     }
 
     if auto_save.periodic.just_finished() {
-        save_space_to_path(&mut commands, store_path());
+        save_space_to_path(commands, path);
     }
 }
 
@@ -210,6 +235,7 @@ pub(crate) fn save_space_to_path(commands: &mut Commands, path: PathBuf) {
 /// Check if a space file exists and trigger load on startup.
 pub(crate) fn load_space_on_startup(
     active: Res<ActiveSpace>,
+    registry: Res<AppTypeRegistry>,
     mut restore: ResMut<crate::boot_status::RestoreComplete>,
     mut commands: Commands,
 ) {
@@ -221,6 +247,10 @@ pub(crate) fn load_space_on_startup(
     }
     let path = store_path();
     let removed_stale = remove_stale_space_if_needed(&path);
+    let removed_incompatible = {
+        let registry = registry.read();
+        remove_incompatible_store_if_needed(&path, &registry)
+    };
     let schema_outdated = path.exists() && !store_schema_is_current();
     if schema_outdated {
         warn!("Store schema outdated; resetting {:?}", path);
@@ -231,7 +261,7 @@ pub(crate) fn load_space_on_startup(
     }
     // Never load a schema-incompatible store, even if deletion failed above —
     // loading it would hit deserialization errors / unknown component types.
-    let exists = path.exists() && !removed_stale && !schema_outdated;
+    let exists = path.exists() && !removed_stale && !removed_incompatible && !schema_outdated;
     commands.insert_resource(SpaceFilePresent(exists));
     if exists {
         info!("Loading space from {:?}", path);
@@ -252,6 +282,43 @@ fn remove_stale_space_if_needed(path: &Path) -> bool {
     warn!("Removing stale store from {:?}", path);
     let _ = std::fs::remove_file(path);
     true
+}
+
+fn remove_incompatible_store_if_needed(
+    path: &Path,
+    registry: &bevy::reflect::TypeRegistry,
+) -> bool {
+    let Ok(body) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    if !space_has_unregistered_types(&body, registry) {
+        return false;
+    }
+    warn!(
+        "Removing incompatible store (unregistered component types) from {:?}",
+        path
+    );
+    let _ = std::fs::remove_file(path);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::remove_file(parent.join("store.version"));
+    }
+    true
+}
+
+fn space_has_unregistered_types(body: &str, registry: &bevy::reflect::TypeRegistry) -> bool {
+    component_type_path_keys(body).any(|path| registry.get_with_type_path(path).is_none())
+}
+
+fn component_type_path_keys(body: &str) -> impl Iterator<Item = &str> {
+    body.lines().filter_map(|line| {
+        let rest = line.trim_start().strip_prefix('"')?;
+        let (key, after) = rest.split_once('"')?;
+        if key.contains("::") && after.trim_start().starts_with(':') {
+            Some(key)
+        } else {
+            None
+        }
+    })
 }
 
 fn space_is_stale(body: &str) -> bool {
@@ -1096,5 +1163,126 @@ mod tests {
         assert!(remove_stale_space_if_needed(&path));
         assert!(!path.exists());
         assert!(space_dir.exists());
+    }
+
+    fn registry_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(vmux_core::CorePlugin);
+        app
+    }
+
+    fn store_body_with_key(key: &str) -> String {
+        format!(
+            "(\n  resources: {{}},\n  entities: {{\n    1: (\n      components: {{\n        \"{key}\": (),\n      }},\n    ),\n  }},\n)\n"
+        )
+    }
+
+    #[test]
+    fn store_with_unregistered_component_type_is_incompatible() {
+        let app = registry_app();
+        let registry = app.world().resource::<AppTypeRegistry>().read();
+        let body = store_body_with_key("vmux_desktop::ghost::DoesNotExist");
+        assert!(space_has_unregistered_types(&body, &registry));
+    }
+
+    #[test]
+    fn store_with_registered_component_types_is_compatible() {
+        let app = registry_app();
+        let registry = app.world().resource::<AppTypeRegistry>().read();
+        let key = <vmux_core::PageMetadata as bevy::reflect::TypePath>::type_path();
+        let body = store_body_with_key(key);
+        assert!(!space_has_unregistered_types(&body, &registry));
+    }
+
+    #[test]
+    fn incompatible_store_is_removed_before_load() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("store.ron");
+        std::fs::write(dir.path().join("store.version"), "2").expect("write version");
+        std::fs::write(
+            &path,
+            store_body_with_key("vmux_desktop::ghost::DoesNotExist"),
+        )
+        .expect("write store");
+
+        let app = registry_app();
+        let registry = app.world().resource::<AppTypeRegistry>().read();
+        assert!(remove_incompatible_store_if_needed(&path, &registry));
+        assert!(!path.exists());
+        assert!(!dir.path().join("store.version").exists());
+    }
+
+    #[test]
+    fn compatible_store_is_kept_before_load() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("store.ron");
+        let app = registry_app();
+        let registry = app.world().resource::<AppTypeRegistry>().read();
+        let key = <vmux_core::PageMetadata as bevy::reflect::TypePath>::type_path();
+        std::fs::write(&path, store_body_with_key(key)).expect("write store");
+
+        assert!(!remove_incompatible_store_if_needed(&path, &registry));
+        assert!(path.exists());
+    }
+
+    fn savable_geometry_app() -> (tempfile::TempDir, App) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(vmux_core::CorePlugin)
+            .register_type::<WindowGeometry>()
+            .register_type::<Option<IVec2>>()
+            .register_type::<Option<Vec2>>()
+            .add_observer(save_on_default_event);
+        app.world_mut().spawn((
+            Save,
+            WindowGeometry {
+                fullscreen: true,
+                position: Some(IVec2::new(1, 2)),
+                size: Some(Vec2::new(3.0, 4.0)),
+            },
+        ));
+        (dir, app)
+    }
+
+    fn dirty_auto_save() -> AutoSave {
+        AutoSave {
+            debounce: Timer::from_seconds(0.0, TimerMode::Once),
+            periodic: Timer::from_seconds(60.0, TimerMode::Repeating),
+            dirty: true,
+        }
+    }
+
+    #[test]
+    fn auto_save_writes_when_space_present() {
+        let (dir, mut app) = savable_geometry_app();
+        let path = dir.path().join("store.ron");
+        let mut auto_save = dirty_auto_save();
+        auto_save_tick(
+            &mut auto_save,
+            std::time::Duration::from_millis(1),
+            true,
+            &mut app.world_mut().commands(),
+            path.clone(),
+        );
+        app.update();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn auto_save_skips_when_no_space() {
+        let (dir, mut app) = savable_geometry_app();
+        let path = dir.path().join("store.ron");
+        let mut auto_save = dirty_auto_save();
+        auto_save_tick(
+            &mut auto_save,
+            std::time::Duration::from_millis(1),
+            false,
+            &mut app.world_mut().commands(),
+            path.clone(),
+        );
+        app.update();
+        assert!(!path.exists());
     }
 }

--- a/crates/vmux_desktop/src/persistence.rs
+++ b/crates/vmux_desktop/src/persistence.rs
@@ -705,22 +705,26 @@ mod tests {
     struct HomeEnvGuard {
         _guard: std::sync::MutexGuard<'static, ()>,
         old_home: Option<std::ffi::OsString>,
+        old_tmpdir: Option<std::ffi::OsString>,
     }
 
     impl HomeEnvGuard {
         fn use_temp_home(name: &str) -> Self {
-            let guard = ENV_LOCK.lock().expect("env lock");
+            let guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
             let old_home = std::env::var_os("HOME");
+            let old_tmpdir = std::env::var_os("TMPDIR");
             let home =
                 std::env::temp_dir().join(format!("vmux-test-{name}-{}", std::process::id()));
             let _ = std::fs::remove_dir_all(&home);
             std::fs::create_dir_all(&home).expect("create temp home");
             unsafe {
                 std::env::set_var("HOME", &home);
+                std::env::set_var("TMPDIR", &home);
             }
             Self {
                 _guard: guard,
                 old_home,
+                old_tmpdir,
             }
         }
     }
@@ -728,10 +732,13 @@ mod tests {
     impl Drop for HomeEnvGuard {
         fn drop(&mut self) {
             unsafe {
-                if let Some(home) = &self.old_home {
-                    std::env::set_var("HOME", home);
-                } else {
-                    std::env::remove_var("HOME");
+                match &self.old_home {
+                    Some(home) => std::env::set_var("HOME", home),
+                    None => std::env::remove_var("HOME"),
+                }
+                match &self.old_tmpdir {
+                    Some(tmpdir) => std::env::set_var("TMPDIR", tmpdir),
+                    None => std::env::remove_var("TMPDIR"),
                 }
             }
         }

--- a/docs/specs/2026-06-27-store-reset-on-incompat-design.md
+++ b/docs/specs/2026-06-27-store-reset-on-incompat-design.md
@@ -1,0 +1,111 @@
+# Store reset on incompatible layout — design
+
+Date: 2026-06-27
+Status: approved
+Crate: `vmux_desktop` (`src/persistence.rs`)
+
+## Problem
+
+After an in-place auto-update (e.g. 0.0.18 → 0.0.19), the app launches to a
+blank layout: native menu bar present, page area empty. Settings and the
+Chromium profile are intact; only the layout is gone, and it does not recover on
+relaunch.
+
+## Root cause
+
+The layout scene is persisted to `store.ron` in `store_dir()` (the
+profile-agnostic shared data dir) via `moonshine-save`. On startup
+`load_space_on_startup` decides whether to load it.
+
+When a release renames, removes, or moves a component type that appears in a
+previously-saved `store.ron`, the stored scene references a type path the new
+binary no longer registers. `moonshine-save`'s `load_on` (load.rs:329) hits
+`LoadError::Scene(SceneSpawnError)`, logs `error!("load failed: …")`, and
+**swallows the error** — the world is left empty.
+
+Two existing facts then make the blank state permanent:
+
+1. `load_space_on_startup` set `SpaceFilePresent(true)` because the file
+   existed, so the fresh-default branch (`space_profile_bundle`) never runs — no
+   default space is spawned.
+2. The periodic/debounced `auto_save_system` then writes the empty world back to
+   `store.ron`, clobbering the original. Relaunch now loads an empty (but valid)
+   scene → still blank, forever.
+
+`load_space_on_startup` already drops `store.ron` for two narrower cases
+(`remove_stale_space_if_needed` for stale agent URLs / prompt-only empty URLs,
+and a manual `STORE_SCHEMA_VERSION` bump). Neither covers a renamed/removed
+component type, which is the actual break and is easy to forget to bump.
+
+## Goals
+
+- Recover automatically when the stored layout is incompatible with the running
+  binary: drop it and start fresh, instead of showing a permanent blank.
+- Preserve `settings.ron` and the Chromium profile.
+- Never let an empty/failed world overwrite a good `store.ron`.
+
+## Non-goals (explicit user choices)
+
+- **Not** an unconditional wipe on every version change. Reset only when the
+  stored scene is genuinely incompatible, so compatible updates keep the layout.
+- **No** partial scene surgery to preserve in-layout vmux history. When a reset
+  happens, the whole `store.ron` is dropped (vmux's own history layer resets with
+  it; the Chromium profile's history is unaffected).
+- No broad per-component migration framework.
+
+## Design
+
+Two focused changes in `vmux_desktop/src/persistence.rs`.
+
+### 1. Pre-load registry validation (primary)
+
+Detect incompatibility *before* loading, by checking the stored type paths
+against the live `AppTypeRegistry`. This is deterministic and never attempts the
+doomed load, so the clobber path is never entered.
+
+- Add `registry: Res<AppTypeRegistry>` to `load_space_on_startup`.
+- Add `space_has_unregistered_types(body: &str, registry: &TypeRegistry) -> bool`:
+  extract every component/resource type path from the scene (the quoted
+  `"crate::path::Type"` map keys under `resources:` and `components:`) and return
+  `true` if any path is absent from the registry.
+- Fold it into the existing pre-load drop logic alongside
+  `remove_stale_space_if_needed`: if the body has unregistered types, delete
+  `store.ron` and `store.version`, which routes startup into the existing
+  fresh-default branch (`space_profile_bundle`). `warn!` what was dropped.
+
+Type extraction reuses the line-oriented parsing style already present
+(`page_metadata_urls`): match quoted keys containing `::`. It does not need a
+full RON parse.
+
+### 2. Empty-save guard (defense-in-depth)
+
+Make a failed/empty world incapable of clobbering a good store, so any
+incompatibility that ever slips past validation is recoverable on relaunch
+rather than permanent.
+
+- In `save_space_to_path` (or its caller), skip the save when the world contains
+  no `Space` entity. A healthy layout always has at least one `Space`; zero means
+  the world is degenerate (failed load or pre-spawn window) and must not be
+  persisted.
+
+## Testing
+
+- `space_has_unregistered_types`:
+  - returns `true` for a body containing a bogus key like
+    `"vmux_desktop::does_not_exist::Ghost"`.
+  - returns `false` for a body whose keys are all registered types.
+- Empty-save guard: saving with no `Space` in the world leaves `store.ron`
+  untouched (no write).
+- Integration (App + observers, mirroring existing persistence tests): trigger a
+  load against a `store.ron` containing an unregistered component path; assert the
+  file is removed and exactly one fresh `Space` is spawned.
+
+## Risks
+
+- **False positive drop:** a valid type momentarily unregistered (e.g. a plugin
+  not yet added at check time) would wipe layout. Mitigated by running the check
+  in `load_space_on_startup`, which is ordered after plugin/registration setup,
+  and by validating only against the same registry the loader will use.
+- **Type-path extraction misses a key:** a missed key means a missed reset (fall
+  back to old behavior), not a wrongful wipe. The empty-save guard still prevents
+  a permanent blank.


### PR DESCRIPTION
## Problem

After an in-place auto-update (e.g. 0.0.18 → 0.0.19) the app could launch to a **blank layout**: native menu bar present, page area empty, settings and the Chromium profile intact. It did not recover on relaunch.

## Root cause

The layout scene is persisted to `store.ron` via `moonshine-save`. When a release renames/removes/moves a component type that appears in a previously-saved scene, the stored scene references a type path the new binary no longer registers. `moonshine-save`'s `load_on` hits `LoadError::Scene(SceneSpawnError)`, **logs and swallows it**, leaving the world empty. Because `SpaceFilePresent(true)` was set (the file existed), the fresh-default branch never ran, and the periodic auto-save then wrote the empty world back over `store.ron` — making the blank state **permanent**.

The existing pre-load drops (`remove_stale_space_if_needed`, manual `STORE_SCHEMA_VERSION`) did not cover a renamed/removed component type, and the schema constant is easy to forget to bump.

## Changes (`crates/vmux_desktop/src/persistence.rs`)

1. **Pre-load registry validation** — `space_has_unregistered_types` + `remove_incompatible_store_if_needed`. `load_space_on_startup` now drops `store.ron` + `store.version` when the saved scene references any component/resource type path absent from the live `AppTypeRegistry`, routing into the existing fresh-default branch. Deterministic, runs before the doomed load. Settings and the browser profile are untouched.
2. **Empty-save guard** — `auto_save_tick` skips persisting when the world has no `Space`, so a failed/empty world can never clobber a good store into a permanent blank.

Behavior is **reset-only-on-incompatibility** (compatible updates keep the layout); when a reset happens the whole `store.ron` is dropped.

## Testing

`cargo test -p vmux_desktop` — 166 passed. New tests (each watched fail first, TDD):
- unregistered component type detected / registered types pass
- incompatible store removed (+ version file) / compatible store kept
- auto-save skips when no `Space` / writes when present

fmt + workspace clippy (`-D warnings`) + `cargo test --workspace` green via pre-push hook.

Design: `docs/specs/2026-06-27-store-reset-on-incompat-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup recovery by validating the saved layout against the current component set; when incompatible, the saved store is removed so the app can reset to a working state instead of loading a blank scene.
  * Updated autosave so it does not debounce/save when there is no existing Space, preventing empty data from overwriting a valid workspace.
* **Documentation**
  * Added a design note detailing the recovery approach and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->