### PR TITLE
test(vmux_git): isolate GIT_DIR/GIT_WORK_TREE in test git runner

### DIFF
--- a/crates/vmux_git/src/runner.rs
+++ b/crates/vmux_git/src/runner.rs
@@ -315,6 +315,8 @@ pub(crate) mod test_repo {
             .args(args)
             .env("GIT_CONFIG_GLOBAL", "/dev/null")
             .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
             .status()
             .unwrap();
         assert!(status.success(), "git {args:?} failed");


### PR DESCRIPTION
Fixes the source of bogus `Test <t@example.com>` author/`Co-authored-by` trailers on commits.

## Root cause
`test_repo::run` (crates/vmux_git/src/runner.rs) cleared `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` but **not** `GIT_DIR`/`GIT_WORK_TREE`. The pre-push hook runs `cargo test --workspace`, during which git exports `GIT_DIR` pointing at the real repo. The helper then ran unscoped `git config user.email/name`, writing `Test <t@example.com>` into the **real** `.git/config`. Subsequent commits picked up that identity; squash-merge aggregated it as a `Co-authored-by` trailer.

## Fix
`.env_remove("GIT_DIR")` + `.env_remove("GIT_WORK_TREE")` so the helper always discovers the temp repo from `current_dir`, never the ambient repo.

## Test
`cargo test -p vmux_git` → 37 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved git command isolation during repository-related operations by clearing additional inherited git environment settings.
  * This helps prevent unexpected behavior when local shell or system git settings are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->