### PR TITLE
fix(extensions): isolate the file:// editor from browser extensions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,13 @@ If any check fails, fix the issue before committing. Do not push broken code.
 
 When adding temporary diagnostics to investigate a bug, make logging unconditional (default-on) — never gate it behind an env var or flag the user must set. The user runs the normal build; logs must appear without extra setup. Strip every temporary diagnostic before committing the fix.
 
+**Always read the app's own logs in Application Support first** — do not ask the user to capture stderr. vmux writes them to:
+
+- `~/Library/Application Support/Vmux/<build-profile>/logs/vmux-<build-profile>.<date>.log` — the Bevy/tracing output (`info!`/`warn!`/`error!`). For the `dev` build that's `…/Vmux/dev/logs/vmux-dev.<date>.log`.
+- `~/Library/Application Support/Vmux/<build-profile>/profiles/<profile>/chrome_debug.log` — CEF/Chromium plus the page JS console (surfaced via `display_handler`).
+
+Diagnostics must use the tracing macros (`bevy::log::info!`/`warn!`) to land in the tracing log — **raw `eprintln!`/stderr is NOT captured there**.
+
 ## Platform-Specific Code
 
 This project targets macOS (primary) and Linux (CI). When adding imports or code that uses platform-specific APIs (CEF, winit, AppKit), always add appropriate `#[cfg(...)]` gates. Let rustfmt reorder cfg-gated imports.

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
@@ -65,6 +65,19 @@ pub const HIDDEN_WINDOWLESS_FRAME_RATE: i32 = 1;
 
 static REGISTER_GLOBAL_SCHEME_HANDLER_FACTORIES: Once = Once::new();
 
+/// Whether a webview at `uri` must use an extension-free request context.
+///
+/// User browser extensions are loaded globally via Chromium's `--load-extension` switch
+/// into the default profile. Their content scripts can match `file://` — the only internal
+/// scheme a content script can match (`<all_urls>` covers `http`/`https`/`file`/`ftp`,
+/// never the custom embedded schemes `vmux://`/`cef://`). Routing `file://` webviews (the
+/// editor) to a request context that does not carry those extensions stops the content
+/// scripts from hijacking the editor's keyboard handling, while extensions keep working on
+/// real web pages, which stay on the shared (extension-enabled) context.
+fn requires_extension_free_context(uri: &str) -> bool {
+    uri.starts_with("file://")
+}
+
 /// Disk profile root for [`RequestContextSettings::cache_path`], aligned with `CefPlugin::root_cache_path` in the `bevy_cef` crate.
 /// Inserted by that plugin; when `bevy_cef_core` is used without it, initialize via `init_resource` (default `None`).
 #[derive(Resource, Clone, Debug, Default)]
@@ -278,7 +291,10 @@ impl Browsers {
         #[allow(unused_assignments)]
         let mut ephemeral_local: Option<RequestContext> = None;
         let color_scheme = self.color_scheme;
-        let context_for_browser = match disk_profile_root.filter(|s| !s.trim().is_empty()) {
+        let context_for_browser = match disk_profile_root
+            .filter(|s| !s.trim().is_empty())
+            .filter(|_| !requires_extension_free_context(_uri))
+        {
             Some(root) => {
                 if self.shared_disk_context.is_none() {
                     self.ensure_shared_disk_context(requester, root);
@@ -1930,9 +1946,23 @@ mod tests {
         windowless_frame_interval_from_refresh_millihertz,
         windowless_frame_rate_from_refresh_millihertz,
     };
+    use super::requires_extension_free_context;
     use crate::prelude::modifiers_from_mouse_buttons;
     use bevy::prelude::*;
     use std::time::Duration;
+
+    #[test]
+    fn only_file_scheme_uses_extension_free_context() {
+        assert!(requires_extension_free_context(
+            "file:///Users/x/Projects/readme.md"
+        ));
+        assert!(requires_extension_free_context("file://"));
+        assert!(!requires_extension_free_context("vmux://layout/"));
+        assert!(!requires_extension_free_context("cef://localhost/"));
+        assert!(!requires_extension_free_context("https://example.com/"));
+        assert!(!requires_extension_free_context("http://example.com/"));
+        assert!(!requires_extension_free_context("about:blank"));
+    }
 
     #[test]
     fn focused_window_keeps_monitor_frame_rate() {


### PR DESCRIPTION
## Problem

vmux loads user Chrome extensions (e.g. Vimium) globally via Chromium's `--load-extension`. Their content scripts injected into vmux's own `file://` editor page and hijacked its keyboard navigation — Vimium captured `h/j/k/l`/space and held the page in "Insert mode", so the editor's own nav didn't work.

## Root cause (verified against Chromium source)

- `--load-extension` → `ManifestLocation::kCommandLine` (an unpacked location) → `UnpackedInstaller::GetFlags()` defaults `allow_file_access = ShouldAlwaysAllowFileAccess(kUnpacked) = true`, so the extension gets `Extension::ALLOW_FILE_ACCESS` and its `<all_urls>` content scripts match `file://`.
- Content scripts can only ever match `chrome-ui | http | https | file | ftp | uuid-in-package` (`UserScript::kValidUserScriptSchemes`). **`file://` is the only internal scheme they can reach** — the custom embedded schemes `vmux://` / `cef://` can never match, so those pages are already safe.

## Why not the pref route

Pre-seeding the profile pref `extensions.settings.<id>.newAllowFileAccess=false` does **not** work, confirmed at runtime: the write lands on disk before CEF starts, but Chromium's pref-hash (MAC) validation distrusts an externally written value and `extension_registrar.cc` re-grants `true` on load. Making it stick would require forging Chromium's HMAC — brittle and version-fragile.

## Fix

Route `file://` webviews (the editor) to an **extension-free request context** instead of the shared, extension-enabled one. `--load-extension` extensions live only in the default profile, and unpacked extensions aren't active in a secondary/incognito context, so their content scripts don't run there. Real web pages (`http`/`https`) stay on the shared context, so extensions keep working (Vimium `f` link hints still work).

`patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs`:
- `requires_extension_free_context(uri)` → true only for `file://`.
- `create_browser` routes such URIs to the ephemeral (extension-free) request context regardless of the disk profile root.

## Verified at runtime

- `file://` editor → isolated context: `h/j/k/l` move the selection, Vimium no longer injects.
- `vmux://` (layout/terminal/command-bar/start) → shared context, unaffected (safe by scheme).
- `http`/`https` browse → shared context, extensions still work.

(Confirmed via the `cef_context` routing log and the editor's behavior.)

## Notes

- A `requires_extension_free_context` unit test covers the scheme routing (`file://` → isolated; `vmux://`/`cef://`/`http`/`https` → shared).
- AGENTS.md: documented that vmux runtime logs live in Application Support (`logs/vmux-<profile>.<date>.log` and `chrome_debug.log`) and that diagnostics must use the tracing macros, not `eprintln` — so future debugging reads those instead of capturing stderr.
- Independent of PR #201 (`file-media-viewer`); based on `origin/main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser startup behavior so local `file://` pages use a safer isolated context when needed, even if a shared profile is configured.
  * Fixed debugging guidance to point to the right log locations and ensure diagnostics use the app’s standard logging system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->