### PR TITLE
fix(browser): route in-place opens of marker pages through host-spawn

### DIFF
--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -97,6 +97,7 @@ pub struct AgentPlugin;
 
 impl Plugin for AgentPlugin {
     fn build(&self, app: &mut App) {
+        vmux_core::register_host_spawn(app, "agent");
         let mut strategies = AgentStrategies::default();
         strategies.register_cli(Box::new(VibeStrategy));
         strategies.register_cli(Box::new(ClaudeStrategy));

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -29,8 +29,8 @@ use vmux_command::{
     LayoutCommand, ReadAppCommands, StackCommand, event::CommandBarActionEvent, open::OpenCommand,
 };
 use vmux_core::{
-    CefPageAttachRequest, OscTitle, PageMetadata, PageOpenError, PageOpenHandled, PageOpenId,
-    PageOpenRequest, PageOpenSet, PageOpenTarget, PageOpenTask,
+    CefPageAttachRequest, HostSpawnRegistry, OscTitle, PageMetadata, PageOpenError,
+    PageOpenHandled, PageOpenId, PageOpenRequest, PageOpenSet, PageOpenTarget, PageOpenTask,
     page::{PageManifest, PageReady},
 };
 use vmux_history::{CreatedAt, LastActivatedAt, Visit};
@@ -208,6 +208,7 @@ impl Plugin for BrowserPlugin {
             .add_systems(Last, refresh_active_windowed_hover)
             .init_resource::<HostFocusIntent>()
             .init_resource::<PendingNavSnapshots>()
+            .init_resource::<HostSpawnRegistry>()
             .add_systems(
                 PostUpdate,
                 (
@@ -2859,6 +2860,7 @@ fn handle_browser_commands(
     mut meta_q: Query<&mut PageMetadata, With<Browser>>,
     terminal_q: Query<(), With<Terminal>>,
     effective_startup_url: Option<Res<vmux_layout::settings::EffectiveStartupUrl>>,
+    host_spawn: Res<HostSpawnRegistry>,
     mut page_open_requests: MessageWriter<PageOpenRequest>,
     mut font_size_writer: MessageWriter<vmux_terminal::TerminalFontSizeCommand>,
     mut commands: Commands,
@@ -2930,8 +2932,8 @@ fn handle_browser_commands(
                         .map(|m| m.url.clone())
                         .unwrap_or_default();
                     if is_terminal
-                        || page_needs_host_spawn(&current_url)
-                        || page_needs_host_spawn(&resolved)
+                        || host_spawn.needs_host_spawn(&current_url)
+                        || host_spawn.needs_host_spawn(&resolved)
                     {
                         page_open_requests.write(PageOpenRequest {
                             target: PageOpenTarget::Stack(active),
@@ -3369,19 +3371,6 @@ fn normalize_vmux_url(url: &str) -> String {
         return format!("vmux://{rest}/");
     }
     url.to_string()
-}
-
-fn page_needs_host_spawn(url: &str) -> bool {
-    fn has_vmux_host(url: &str, host: &str) -> bool {
-        let Some(rest) = url.strip_prefix("vmux://") else {
-            return false;
-        };
-        let Some(tail) = rest.strip_prefix(host) else {
-            return false;
-        };
-        tail.is_empty() || matches!(tail.as_bytes().first(), Some(b'/' | b'?' | b'#'))
-    }
-    url.starts_with("file:") || has_vmux_host(url, "terminal") || has_vmux_host(url, "agent")
 }
 
 fn resolve_page_open_target(
@@ -3840,21 +3829,6 @@ mod tests {
             normalize_vmux_url("file:///tmp/main.rs"),
             "file:///tmp/main.rs"
         );
-    }
-
-    #[test]
-    fn page_needs_host_spawn_matches_host_on_boundaries() {
-        assert!(page_needs_host_spawn("file:///tmp/x"));
-        assert!(page_needs_host_spawn("vmux://terminal"));
-        assert!(page_needs_host_spawn("vmux://terminal/"));
-        assert!(page_needs_host_spawn("vmux://terminal/?pid=1"));
-        assert!(page_needs_host_spawn("vmux://agent"));
-        assert!(page_needs_host_spawn("vmux://agent/vibe/setup"));
-
-        assert!(!page_needs_host_spawn("vmux://agentic/"));
-        assert!(!page_needs_host_spawn("vmux://terminals/"));
-        assert!(!page_needs_host_spawn("vmux://settings/"));
-        assert!(!page_needs_host_spawn("https://example.com"));
     }
 
     #[test]
@@ -5772,6 +5746,11 @@ mod tests {
                         captured.0.push(trigger.url.clone());
                     },
                 );
+            for host in [
+                "terminal", "agent", "services", "settings", "team", "spaces",
+            ] {
+                vmux_core::register_host_spawn(&mut app, host);
+            }
             app
         }
 
@@ -5890,7 +5869,7 @@ mod tests {
         #[test]
         fn in_place_from_plain_vmux_to_web_navigates_in_place() {
             let mut app = build_app();
-            build_focused_native_stack(&mut app, "vmux://spaces/");
+            build_focused_native_stack(&mut app, "vmux://history/");
 
             app.world_mut()
                 .resource_mut::<Messages<AppCommand>>()
@@ -5917,7 +5896,7 @@ mod tests {
                 .resource_mut::<Messages<AppCommand>>()
                 .write(AppCommand::Browser(BrowserCommand::Open(
                     OpenCommand::InPlace {
-                        url: Some("vmux://settings/".into()),
+                        url: Some("vmux://history/".into()),
                     },
                 )));
 
@@ -5926,7 +5905,30 @@ mod tests {
             let page_opens = app.world().resource::<CapturedPageOpenRequests>();
             assert!(page_opens.0.is_empty());
             let navigates = app.world().resource::<CapturedNavigateUrls>();
-            assert_eq!(navigates.0, vec!["vmux://settings/".to_string()]);
+            assert_eq!(navigates.0, vec!["vmux://history/".to_string()]);
+        }
+
+        #[test]
+        fn in_place_to_settings_routes_through_page_open() {
+            let mut app = build_app();
+            build_focused_native_stack(&mut app, "https://example.com/");
+
+            app.world_mut()
+                .resource_mut::<Messages<AppCommand>>()
+                .write(AppCommand::Browser(BrowserCommand::Open(
+                    OpenCommand::InPlace {
+                        url: Some("vmux://settings/".into()),
+                    },
+                )));
+
+            app.update();
+
+            let navigates = app.world().resource::<CapturedNavigateUrls>();
+            assert!(navigates.0.is_empty());
+            let page_opens = app.world().resource::<CapturedPageOpenRequests>();
+            assert_eq!(page_opens.0.len(), 1);
+            assert_eq!(page_opens.0[0].url, "vmux://settings/");
+            assert!(matches!(page_opens.0[0].target, PageOpenTarget::Stack(_)));
         }
 
         #[test]

--- a/crates/vmux_core/src/host_spawn.rs
+++ b/crates/vmux_core/src/host_spawn.rs
@@ -1,0 +1,107 @@
+use bevy::prelude::*;
+use std::collections::HashSet;
+
+/// Set of `vmux://` hosts whose pages must be created through the
+/// [`PageOpenSet::HandleKnownPages`](crate::page_open::PageOpenSet) spawn pipeline
+/// rather than navigated in place.
+///
+/// Pages that render backend-pushed data gate their host emits on a per-page marker
+/// component (e.g. `ProcessesMonitor`, `Settings`, `Team`, `Spaces`). That marker is
+/// only attached when the page is spawned by its known-page handler; navigating an
+/// existing generic webview in place leaves it markerless, so the backend never
+/// targets it and the page stays empty. Each owning crate registers its host via
+/// [`register_host_spawn`] next to its `HandleKnownPages` handler.
+#[derive(Resource, Default, Debug, Clone)]
+pub struct HostSpawnRegistry(pub HashSet<String>);
+
+impl HostSpawnRegistry {
+    /// Register a `vmux://` host (e.g. `"services"`) as requiring host-spawn.
+    pub fn register(&mut self, host: &str) {
+        self.0.insert(host.to_string());
+    }
+
+    /// Whether opening `url` must route through the host-spawn pipeline: either the
+    /// `file:` scheme (editor file viewer) or a registered `vmux://<host>`.
+    pub fn needs_host_spawn(&self, url: &str) -> bool {
+        if url.starts_with("file:") {
+            return true;
+        }
+        vmux_host(url).is_some_and(|host| self.0.contains(host))
+    }
+}
+
+/// Extract the host of a `vmux://<host>[/…]` URL, matching only on a host boundary so
+/// `vmux://terminals/` is not treated as host `terminal`.
+fn vmux_host(url: &str) -> Option<&str> {
+    let rest = url.strip_prefix("vmux://")?;
+    let host = rest.split(['/', '?', '#']).next().unwrap_or("");
+    (!host.is_empty()).then_some(host)
+}
+
+/// Register `host` as host-spawned. Call from a plugin `build()` alongside the crate's
+/// [`PageOpenSet::HandleKnownPages`](crate::page_open::PageOpenSet) handler.
+pub fn register_host_spawn(app: &mut App, host: &'static str) {
+    app.init_resource::<HostSpawnRegistry>();
+    app.world_mut()
+        .resource_mut::<HostSpawnRegistry>()
+        .register(host);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn registry(hosts: &[&str]) -> HostSpawnRegistry {
+        let mut r = HostSpawnRegistry::default();
+        for h in hosts {
+            r.register(h);
+        }
+        r
+    }
+
+    #[test]
+    fn file_scheme_always_needs_host_spawn() {
+        assert!(HostSpawnRegistry::default().needs_host_spawn("file:///tmp/x.rs"));
+    }
+
+    #[test]
+    fn registered_host_matches_on_boundary() {
+        let r = registry(&["services", "terminal"]);
+        assert!(r.needs_host_spawn("vmux://services/"));
+        assert!(r.needs_host_spawn("vmux://services"));
+        assert!(r.needs_host_spawn("vmux://terminal/?pid=1"));
+    }
+
+    #[test]
+    fn unregistered_or_partial_host_does_not_match() {
+        let r = registry(&["services", "terminal"]);
+        assert!(!r.needs_host_spawn("vmux://settings/"));
+        assert!(!r.needs_host_spawn("vmux://terminals/"));
+        assert!(!r.needs_host_spawn("vmux://services-x/"));
+        assert!(!r.needs_host_spawn("https://example.com"));
+    }
+
+    #[test]
+    fn registering_settings_makes_it_match() {
+        let r = registry(&["settings"]);
+        assert!(r.needs_host_spawn("vmux://settings/"));
+    }
+
+    #[test]
+    fn register_is_idempotent() {
+        let mut r = HostSpawnRegistry::default();
+        r.register("team");
+        r.register("team");
+        assert_eq!(r.0.len(), 1);
+    }
+
+    #[test]
+    fn register_host_spawn_inserts_resource() {
+        let mut app = App::new();
+        register_host_spawn(&mut app, "spaces");
+        register_host_spawn(&mut app, "team");
+        let reg = app.world().resource::<HostSpawnRegistry>();
+        assert!(reg.needs_host_spawn("vmux://spaces/"));
+        assert!(reg.needs_host_spawn("vmux://team/"));
+    }
+}

--- a/crates/vmux_core/src/lib.rs
+++ b/crates/vmux_core/src/lib.rs
@@ -12,6 +12,8 @@ pub use icon::{BuiltinIcon, PageIcon};
 pub use process_id::ProcessId;
 
 #[cfg(not(target_arch = "wasm32"))]
+pub mod host_spawn;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod page;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod page_open;
@@ -32,6 +34,8 @@ pub mod notify;
 pub mod team;
 #[cfg(not(target_arch = "wasm32"))]
 pub use archive::{ArchivedPage, ArchivedPagePosition, PageArchiveRequest, PaneStep, SplitAxis};
+#[cfg(not(target_arch = "wasm32"))]
+pub use host_spawn::{HostSpawnRegistry, register_host_spawn};
 #[cfg(not(target_arch = "wasm32"))]
 pub use notify::{AgentAttention, AgentDoneUnseen, BellReceived, OsNotify};
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/vmux_setting/src/plugin.rs
+++ b/crates/vmux_setting/src/plugin.rs
@@ -13,7 +13,7 @@ use runtime::{
 };
 use view::{
     broadcast_schema_to_views, broadcast_settings_to_views, handle_open_settings_command,
-    on_settings_command, reset_sent_markers_on_page_ready,
+    handle_settings_page_open, on_settings_command, reset_sent_markers_on_page_ready,
 };
 
 /// Wires settings: RON load/save with debounce, schema and settings broadcasts, and the
@@ -23,6 +23,7 @@ pub struct SettingsPlugin;
 impl Plugin for SettingsPlugin {
     fn build(&self, app: &mut App) {
         app.world_mut().spawn(crate::PAGE_MANIFEST);
+        vmux_core::register_host_spawn(app, "settings");
         app.init_resource::<LastSelfWriteHash>()
             .init_resource::<SettingsSaveDebounce>()
             .add_message::<SettingsWriteRequest>()
@@ -45,6 +46,10 @@ impl Plugin for SettingsPlugin {
             )
             .add_message::<vmux_core::page::SettingsPageSpawnRequest>()
             .add_systems(Update, respond_settings_spawn.in_set(ReadAppCommands))
+            .add_systems(
+                Update,
+                handle_settings_page_open.in_set(vmux_core::PageOpenSet::HandleKnownPages),
+            )
             .add_plugins(BinEventEmitterPlugin::<(SettingsCommandEvent,)>::for_hosts(
                 &["settings"],
             ))

--- a/crates/vmux_setting/src/plugin/view.rs
+++ b/crates/vmux_setting/src/plugin/view.rs
@@ -72,8 +72,13 @@ pub(crate) fn handle_settings_page_open(
     mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
+    let mut handled_stacks = std::collections::HashSet::new();
     for (entity, task) in &tasks {
         if task.url != SETTINGS_PAGE_URL {
+            continue;
+        }
+        if !handled_stacks.insert(task.stack) {
+            commands.entity(entity).insert(PageOpenHandled);
             continue;
         }
         if let Ok(children) = children_q.get(task.stack) {
@@ -494,6 +499,27 @@ mod page_open_tests {
         app.update();
         assert!(app.world().get::<PageOpenHandled>(claimed).is_some());
         assert!(app.world().get::<PageOpenHandled>(decoy).is_none());
+        let mut q = app.world_mut().query_filtered::<(), With<Settings>>();
+        assert_eq!(q.iter(app.world()).count(), 1);
+    }
+
+    #[test]
+    fn settings_page_open_dedupes_per_stack() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+            .add_systems(Update, handle_settings_page_open);
+        let stack = app.world_mut().spawn_empty().id();
+        for _ in 0..2 {
+            app.world_mut().spawn(PageOpenTask {
+                id: PageOpenId::new(),
+                stack,
+                url: SETTINGS_PAGE_URL.to_string(),
+                request_id: None,
+            });
+        }
+        app.update();
         let mut q = app.world_mut().query_filtered::<(), With<Settings>>();
         assert_eq!(q.iter(app.world()).count(), 1);
     }

--- a/crates/vmux_setting/src/plugin/view.rs
+++ b/crates/vmux_setting/src/plugin/view.rs
@@ -1,8 +1,8 @@
 use bevy::{picking::Pickable, prelude::*};
 use bevy_cef::prelude::*;
 use vmux_command::command::{AppCommand, LayoutCommand, WindowCommand};
-use vmux_core::PageMetadata;
 use vmux_core::page::PageReady;
+use vmux_core::{PageMetadata, PageOpenError, PageOpenHandled, PageOpenTask};
 use vmux_history::{CreatedAt, LastActivatedAt};
 use vmux_layout::{
     Browser,
@@ -59,6 +59,38 @@ impl Settings {
                 Pickable::default(),
             ),
         )
+    }
+}
+
+/// Spawn the settings webview (with its [`Settings`] marker) when a `vmux://settings/`
+/// page is opened by URL, so the backend settings broadcasts target it. Without this,
+/// in-place navigation would reuse a markerless webview that never receives settings.
+pub(crate) fn handle_settings_page_open(
+    tasks: Query<(Entity, &PageOpenTask), (Without<PageOpenHandled>, Without<PageOpenError>)>,
+    children_q: Query<&Children>,
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
+) {
+    for (entity, task) in &tasks {
+        if task.url != SETTINGS_PAGE_URL {
+            continue;
+        }
+        if let Ok(children) = children_q.get(task.stack) {
+            for child in children.iter() {
+                commands.entity(child).try_despawn();
+            }
+        }
+        commands.entity(task.stack).insert(PageMetadata {
+            title: "Settings".to_string(),
+            url: SETTINGS_PAGE_URL.to_string(),
+            ..default()
+        });
+        commands.spawn((
+            Settings::new(&mut meshes, &mut webview_mt),
+            ChildOf(task.stack),
+        ));
+        commands.entity(entity).insert(PageOpenHandled);
     }
 }
 
@@ -425,5 +457,44 @@ mod appearance_schema_tests {
         assert_eq!(mode.widget, Some(WidgetKind::Select));
         let vals: Vec<_> = mode.options.iter().map(|o| o.value.as_str()).collect();
         assert_eq!(vals, vec!["device", "light", "dark"]);
+    }
+}
+
+#[cfg(test)]
+mod page_open_tests {
+    use super::*;
+    use vmux_core::PageOpenId;
+
+    #[test]
+    fn settings_page_open_spawns_marker_and_handles() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+            .add_systems(Update, handle_settings_page_open);
+        let stack = app.world_mut().spawn_empty().id();
+        let claimed = app
+            .world_mut()
+            .spawn(PageOpenTask {
+                id: PageOpenId::new(),
+                stack,
+                url: SETTINGS_PAGE_URL.to_string(),
+                request_id: None,
+            })
+            .id();
+        let decoy = app
+            .world_mut()
+            .spawn(PageOpenTask {
+                id: PageOpenId::new(),
+                stack,
+                url: "vmux://history/".to_string(),
+                request_id: None,
+            })
+            .id();
+        app.update();
+        assert!(app.world().get::<PageOpenHandled>(claimed).is_some());
+        assert!(app.world().get::<PageOpenHandled>(decoy).is_none());
+        let mut q = app.world_mut().query_filtered::<(), With<Settings>>();
+        assert_eq!(q.iter(app.world()).count(), 1);
     }
 }

--- a/crates/vmux_space/src/plugin.rs
+++ b/crates/vmux_space/src/plugin.rs
@@ -37,6 +37,7 @@ pub struct SpacePlugin;
 impl Plugin for SpacePlugin {
     fn build(&self, app: &mut App) {
         app.world_mut().spawn(crate::PAGE_MANIFEST);
+        vmux_core::register_host_spawn(app, "spaces");
         app.init_resource::<ActiveSpace>()
             .add_message::<SaveSpaceRequest>()
             .add_message::<SpaceCommandRequest>()

--- a/crates/vmux_team/src/plugin.rs
+++ b/crates/vmux_team/src/plugin.rs
@@ -29,6 +29,7 @@ pub struct TeamPlugin;
 impl Plugin for TeamPlugin {
     fn build(&self, app: &mut App) {
         app.world_mut().spawn(crate::PAGE_MANIFEST);
+        vmux_core::register_host_spawn(app, "team");
         app.add_systems(Startup, spawn_user_profile)
             .add_systems(Update, (sync_user_profile_name, emit_team).chain())
             .add_systems(

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -318,6 +318,8 @@ pub fn format_terminal_url(
 impl Plugin for TerminalPlugin {
     fn build(&self, app: &mut App) {
         app.world_mut().spawn(crate::PAGE_MANIFEST);
+        vmux_core::register_host_spawn(app, "terminal");
+        vmux_core::register_host_spawn(app, "services");
         app.register_type::<crate::launch::TerminalLaunch>()
             .register_type::<crate::launch::TerminalKind>()
             .add_message::<TerminalSendRequest>()


### PR DESCRIPTION
## Problem

`vmux://services`, `settings`, `team`, and `spaces` render but stay on their empty/default state ("Service is not running", "Loading settings…", "No one here yet", "No spaces") when opened via the command bar, address bar, or `vmux://start` launcher.

## Root cause

Those entry points emit `Browser(Open(InPlace))`. The handler only routed to the host-spawn pipeline when `page_needs_host_spawn(url)` matched its hardcoded allowlist (`file:`/`terminal`/`agent`); everything else navigated the existing generic webview in place. The backend pushes page data (`BinHostEmitEvent`) only to entities carrying a per-page marker (`ProcessesMonitor`/`Settings`/`Team`/`Spaces`), which is attached only by the page's `HandleKnownPages` spawn handler — so an in-place-navigated, markerless webview never received data. LSP looked fine only because it fetches client-side.

## Fix

- Replace the hardcoded `page_needs_host_spawn` allowlist with a `HostSpawnRegistry` (vmux_core) each owning crate populates next to its `HandleKnownPages` handler.
- Register `terminal`, `services`, `agent`, `team`, `spaces`, `settings`; `file:` stays scheme-matched.
- Add the missing `handle_settings_page_open` handler (settings was the only marker page without one).

## Tests

- Unit tests for `HostSpawnRegistry::needs_host_spawn` and `handle_settings_page_open`.
- New `in_place_to_settings_routes_through_page_open` regression test; updated two tests that assumed spaces/settings were "plain".
- `cargo test --workspace` green, clippy clean, runtime-verified (all four pages load data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added improved handling for built-in app pages, including dedicated support for opening the settings page via the correct flow.
  * Expanded local host-based page support across browser, settings, space, team, agent, terminal, and services.

* **Bug Fixes**
  * Fixed in-place navigation so known local `vmux://` and `file:` links are routed through the appropriate host-spawn behavior instead of being treated as generic external navigations.
  * Improved routing decisions to account for both the original and resolved target URLs, preventing incorrect direct navigation for settings-related links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->