### PR TITLE
feat(start): prewarm vmux://start for instant tab/pane opens

### DIFF
--- a/crates/vmux_layout/src/start/plugin.rs
+++ b/crates/vmux_layout/src/start/plugin.rs
@@ -32,6 +32,12 @@ const WARM_START_POOL_SIZE: usize = 1;
 #[derive(Component)]
 struct WarmStartSpare;
 
+/// Set on a warm spare once its page has actually mounted (it emitted [`StartDataRequest`]),
+/// so a claim only reuses a spare that is genuinely warm — never one whose CEF browser or
+/// WASM is still loading (which would defeat the near-instant path and fall to a cold paint).
+#[derive(Component)]
+struct WarmStartReady;
+
 /// The hidden, zero-size holding node the warm spares are parked under so they keep their
 /// CEF browser + WASM warm without compositing (a `Visibility::Hidden` ancestor makes them
 /// non-renderable, so `sync_children_to_ui` collapses them and CEF hides the native view).
@@ -74,7 +80,7 @@ impl Plugin for StartPlugin {
 /// cold launcher webview via [`CefPageAttachRequest`].
 fn handle_start_page_open(
     tasks: Query<(Entity, &PageOpenTask), PendingPageOpen>,
-    spares: Query<Entity, With<WarmStartSpare>>,
+    spares: Query<Entity, (With<WarmStartSpare>, With<WarmStartReady>)>,
     children_q: Query<&Children>,
     mut attach: MessageWriter<CefPageAttachRequest>,
     mut revealed: MessageWriter<StartSpareRevealed>,
@@ -95,7 +101,7 @@ fn handle_start_page_open(
             commands
                 .entity(spare)
                 .insert((ChildOf(task.stack), CefKeyboardTarget))
-                .remove::<WarmStartSpare>();
+                .remove::<(WarmStartSpare, WarmStartReady)>();
             revealed.write(StartSpareRevealed { webview: spare });
         } else {
             attach.write(CefPageAttachRequest {
@@ -182,6 +188,7 @@ fn on_start_spare_revealed(
 /// command-bar launcher payload (opening selections in place).
 fn on_start_data_request(
     trigger: On<BinReceive<StartDataRequest>>,
+    spares: Query<(), With<WarmStartSpare>>,
     tab_gather: TabGatherParams,
     spaces_snapshot: Res<CommandBarSpacesSnapshot>,
     agents_snapshot: Res<CommandBarAgentsSnapshot>,
@@ -189,6 +196,9 @@ fn on_start_data_request(
     mut commands: Commands,
 ) {
     let webview = trigger.event().webview;
+    if spares.contains(webview) {
+        commands.entity(webview).insert(WarmStartReady);
+    }
     let payload = build_start_payload(
         &tab_gather,
         &spaces_snapshot,
@@ -276,7 +286,7 @@ mod tests {
             .add_message::<StartSpareRevealed>()
             .add_systems(Update, handle_start_page_open);
         let stack = app.world_mut().spawn_empty().id();
-        let spare = app.world_mut().spawn(WarmStartSpare).id();
+        let spare = app.world_mut().spawn((WarmStartSpare, WarmStartReady)).id();
         let task = app.world_mut().spawn(start_task(stack)).id();
         app.update();
 
@@ -309,6 +319,35 @@ mod tests {
             .collect();
         assert_eq!(reveals.len(), 1);
         assert_eq!(reveals[0].webview, spare);
+    }
+
+    #[test]
+    fn not_ready_spare_is_not_claimed() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<CefPageAttachRequest>()
+            .add_message::<StartSpareRevealed>()
+            .add_systems(Update, handle_start_page_open);
+        let stack = app.world_mut().spawn_empty().id();
+        let spare = app.world_mut().spawn(WarmStartSpare).id();
+        let task = app.world_mut().spawn(start_task(stack)).id();
+        app.update();
+
+        assert!(
+            app.world().get::<ChildOf>(spare).is_none(),
+            "an unready spare must not be reparented"
+        );
+        assert!(
+            app.world().get::<WarmStartSpare>(spare).is_some(),
+            "an unready spare stays in the pool"
+        );
+        assert!(app.world().get::<PageOpenHandled>(task).is_some());
+        let attaches = app
+            .world_mut()
+            .resource_mut::<Messages<CefPageAttachRequest>>()
+            .drain()
+            .count();
+        assert_eq!(attaches, 1, "unready spare falls back to the cold path");
     }
 
     #[test]

--- a/crates/vmux_layout/src/start/plugin.rs
+++ b/crates/vmux_layout/src/start/plugin.rs
@@ -1,22 +1,53 @@
 use bevy::prelude::*;
-use bevy_cef::prelude::{BinEventEmitterPlugin, BinHostEmitEvent, BinReceive};
-use vmux_command::event::COMMAND_BAR_OPEN_EVENT;
+use bevy_cef::prelude::{
+    BinEventEmitterPlugin, BinHostEmitEvent, BinReceive, CefKeyboardTarget,
+    WebviewExtendStandardMaterial,
+};
+use vmux_command::event::{COMMAND_BAR_OPEN_EVENT, CommandBarOpenEvent};
 use vmux_command::open_target::OpenTarget;
 use vmux_command::snapshot::{
     CommandBarAgentsSnapshot, CommandBarPagesSnapshot, CommandBarSpacesSnapshot,
 };
-use vmux_core::{CefPageAttachRequest, PageOpenError, PageOpenHandled, PageOpenSet, PageOpenTask};
+use vmux_core::{
+    CefPageAttachRequest, PageMetadata, PageOpenError, PageOpenHandled, PageOpenSet, PageOpenTask,
+};
 
+use crate::cef::Browser;
 use crate::command_bar::handler::{
     TabGatherParams, build_command_bar_open_payload, gather_command_bar_tabs,
 };
 use crate::start::START_PAGE_URL;
-use crate::start::event::StartDataRequest;
+use crate::start::event::{START_FOCUS_INPUT_EVENT, StartDataRequest, StartFocusInput};
+use crate::window::VmuxWindow;
 
 type PendingPageOpen = (Without<PageOpenHandled>, Without<PageOpenError>);
 
-/// Bevy plugin for `vmux://start/`: spawns the page manifest, claims start page-open
-/// tasks, and answers [`StartDataRequest`] with the shared command-bar launcher payload.
+/// How many prewarmed `vmux://start/` webviews to keep ready. Each new tab / stack /
+/// pane / space is an independent persistent start page, so a singleton (like the
+/// command-bar modal) cannot serve them — a small pool is refilled after each claim.
+const WARM_START_POOL_SIZE: usize = 1;
+
+/// Marks a prewarmed, parked `vmux://start/` webview waiting to be claimed by the next
+/// start open. Removed when the spare is reparented into a real stack.
+#[derive(Component)]
+struct WarmStartSpare;
+
+/// The hidden, zero-size holding node the warm spares are parked under so they keep their
+/// CEF browser + WASM warm without compositing (a `Visibility::Hidden` ancestor makes them
+/// non-renderable, so `sync_children_to_ui` collapses them and CEF hides the native view).
+#[derive(Component)]
+struct WarmStartPoolNode;
+
+/// Host-internal signal that a warm spare was just revealed into a stack, so its launcher
+/// data must be refreshed (it captured boot-time tabs/spaces) and its input refocused.
+#[derive(Message)]
+struct StartSpareRevealed {
+    webview: Entity,
+}
+
+/// Bevy plugin for `vmux://start/`: spawns the page manifest, keeps a warm pool of
+/// prewarmed launcher webviews, claims start page-open tasks (reusing a warm spare when
+/// available), and answers [`StartDataRequest`] with the shared command-bar payload.
 pub struct StartPlugin;
 
 impl Plugin for StartPlugin {
@@ -25,37 +56,130 @@ impl Plugin for StartPlugin {
         app.add_plugins(BinEventEmitterPlugin::<(StartDataRequest,)>::for_hosts(&[
             "start",
         ]))
+        .add_message::<StartSpareRevealed>()
         .add_observer(on_start_data_request)
         .add_systems(
             Update,
-            handle_start_page_open.in_set(PageOpenSet::HandleKnownPages),
+            (
+                handle_start_page_open.in_set(PageOpenSet::HandleKnownPages),
+                maintain_warm_start_pool,
+                on_start_spare_revealed.after(PageOpenSet::HandleKnownPages),
+            ),
         );
     }
 }
 
-/// Claim `vmux://start/` page-open tasks and attach the launcher webview (titled "Start"),
-/// so the start page is a first-class known page rather than falling to the unknown-URL page.
+/// Claim `vmux://start/` page-open tasks. When a warm spare is available it is reparented
+/// into the target stack for a near-instant paint; otherwise it falls back to spawning a
+/// cold launcher webview via [`CefPageAttachRequest`].
 fn handle_start_page_open(
     tasks: Query<(Entity, &PageOpenTask), PendingPageOpen>,
+    spares: Query<Entity, With<WarmStartSpare>>,
+    children_q: Query<&Children>,
     mut attach: MessageWriter<CefPageAttachRequest>,
+    mut revealed: MessageWriter<StartSpareRevealed>,
     mut commands: Commands,
 ) {
+    let mut available: Vec<Entity> = spares.iter().collect();
     for (entity, task) in &tasks {
         if task.url != START_PAGE_URL {
             continue;
         }
-        attach.write(CefPageAttachRequest {
-            stack: task.stack,
-            url: START_PAGE_URL.to_string(),
-            title: "Start".to_string(),
-            bg_color: None,
-        });
+        if let Some(spare) = available.pop() {
+            clear_stack_children(task.stack, &children_q, &mut commands);
+            commands.entity(task.stack).insert(PageMetadata {
+                url: START_PAGE_URL.to_string(),
+                title: "Start".to_string(),
+                ..default()
+            });
+            commands
+                .entity(spare)
+                .insert((ChildOf(task.stack), CefKeyboardTarget))
+                .remove::<WarmStartSpare>();
+            revealed.write(StartSpareRevealed { webview: spare });
+        } else {
+            attach.write(CefPageAttachRequest {
+                stack: task.stack,
+                url: START_PAGE_URL.to_string(),
+                title: "Start".to_string(),
+                bg_color: None,
+            });
+        }
         commands.entity(entity).insert(PageOpenHandled);
     }
 }
 
-/// Builds the command-bar launcher payload and emits it back to the requesting
-/// `vmux://start/` webview as a `CommandBarOpenEvent` (opening in place).
+/// Keep the warm-start pool topped up to [`WARM_START_POOL_SIZE`]. Spares are parked under a
+/// hidden holding node (created lazily once the window exists) so their CEF browser + WASM
+/// load ahead of time without compositing.
+fn maintain_warm_start_pool(
+    pool_node: Query<Entity, With<WarmStartPoolNode>>,
+    vmux_window: Query<Entity, With<VmuxWindow>>,
+    spares: Query<(), With<WarmStartSpare>>,
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
+) {
+    let Ok(window) = vmux_window.single() else {
+        return;
+    };
+    let node = match pool_node.single() {
+        Ok(node) => node,
+        Err(_) => commands
+            .spawn((
+                WarmStartPoolNode,
+                Node {
+                    width: Val::Px(0.0),
+                    height: Val::Px(0.0),
+                    position_type: PositionType::Absolute,
+                    ..default()
+                },
+                Visibility::Hidden,
+                ChildOf(window),
+            ))
+            .id(),
+    };
+    for _ in spares.iter().count()..WARM_START_POOL_SIZE {
+        commands.spawn((
+            Browser::new_with_title(&mut meshes, &mut webview_mt, START_PAGE_URL, "Start"),
+            WarmStartSpare,
+            ChildOf(node),
+        ));
+    }
+}
+
+/// Refresh a freshly-revealed warm spare: push current launcher data (the spare captured
+/// boot-time state) and refocus its input, matching a cold open.
+fn on_start_spare_revealed(
+    mut revealed: MessageReader<StartSpareRevealed>,
+    tab_gather: TabGatherParams,
+    spaces_snapshot: Res<CommandBarSpacesSnapshot>,
+    agents_snapshot: Res<CommandBarAgentsSnapshot>,
+    pages_snapshot: Res<CommandBarPagesSnapshot>,
+    mut commands: Commands,
+) {
+    for ev in revealed.read() {
+        let payload = build_start_payload(
+            &tab_gather,
+            &spaces_snapshot,
+            &agents_snapshot,
+            &pages_snapshot,
+        );
+        commands.trigger(BinHostEmitEvent::from_rkyv(
+            ev.webview,
+            COMMAND_BAR_OPEN_EVENT,
+            &payload,
+        ));
+        commands.trigger(BinHostEmitEvent::from_rkyv(
+            ev.webview,
+            START_FOCUS_INPUT_EVENT,
+            &StartFocusInput,
+        ));
+    }
+}
+
+/// Answer the `vmux://start/` page's on-mount [`StartDataRequest`] with the shared
+/// command-bar launcher payload (opening selections in place).
 fn on_start_data_request(
     trigger: On<BinReceive<StartDataRequest>>,
     tab_gather: TabGatherParams,
@@ -65,6 +189,26 @@ fn on_start_data_request(
     mut commands: Commands,
 ) {
     let webview = trigger.event().webview;
+    let payload = build_start_payload(
+        &tab_gather,
+        &spaces_snapshot,
+        &agents_snapshot,
+        &pages_snapshot,
+    );
+    commands.trigger(BinHostEmitEvent::from_rkyv(
+        webview,
+        COMMAND_BAR_OPEN_EVENT,
+        &payload,
+    ));
+}
+
+/// Build the launcher payload shared by the on-mount data feed and warm-spare refresh.
+fn build_start_payload(
+    tab_gather: &TabGatherParams,
+    spaces_snapshot: &CommandBarSpacesSnapshot,
+    agents_snapshot: &CommandBarAgentsSnapshot,
+    pages_snapshot: &CommandBarPagesSnapshot,
+) -> CommandBarOpenEvent {
     let active_stack_count = tab_gather.stack_q.iter().count();
     let space_name = spaces_snapshot.active_space_name.clone();
     let tabs = gather_command_bar_tabs(
@@ -78,28 +222,33 @@ fn on_start_data_request(
         &tab_gather.browser_meta,
         &tab_gather.child_of_q,
     );
-    let payload = build_command_bar_open_payload(
+    build_command_bar_open_payload(
         0,
         false,
         space_name,
         String::new(),
-        &spaces_snapshot,
-        &agents_snapshot,
-        &pages_snapshot,
+        spaces_snapshot,
+        agents_snapshot,
+        pages_snapshot,
         active_stack_count,
         tabs,
         Some(OpenTarget::InPlace),
-    );
-    commands.trigger(BinHostEmitEvent::from_rkyv(
-        webview,
-        COMMAND_BAR_OPEN_EVENT,
-        &payload,
-    ));
+    )
+}
+
+/// Despawn a stack's existing webview children before attaching new content.
+fn clear_stack_children(stack: Entity, children_q: &Query<&Children>, commands: &mut Commands) {
+    if let Ok(children) = children_q.get(stack) {
+        for child in children.iter() {
+            commands.entity(child).try_despawn();
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use vmux_core::PageOpenId;
     use vmux_core::page::PageManifest;
 
     #[test]
@@ -108,5 +257,103 @@ mod tests {
         app.add_plugins(StartPlugin);
         let mut q = app.world_mut().query::<&PageManifest>();
         assert!(q.iter(app.world()).any(|m| m.host == "start"));
+    }
+
+    fn start_task(stack: Entity) -> PageOpenTask {
+        PageOpenTask {
+            id: PageOpenId::new(),
+            stack,
+            url: START_PAGE_URL.to_string(),
+            request_id: None,
+        }
+    }
+
+    #[test]
+    fn warm_claim_reuses_spare() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<CefPageAttachRequest>()
+            .add_message::<StartSpareRevealed>()
+            .add_systems(Update, handle_start_page_open);
+        let stack = app.world_mut().spawn_empty().id();
+        let spare = app.world_mut().spawn(WarmStartSpare).id();
+        let task = app.world_mut().spawn(start_task(stack)).id();
+        app.update();
+
+        assert_eq!(
+            app.world().get::<ChildOf>(spare).map(|c| c.parent()),
+            Some(stack),
+            "spare reparented into the target stack"
+        );
+        assert!(
+            app.world().get::<WarmStartSpare>(spare).is_none(),
+            "spare marker removed on claim"
+        );
+        let meta = app
+            .world()
+            .get::<PageMetadata>(stack)
+            .expect("stack received start metadata");
+        assert_eq!(meta.url, START_PAGE_URL);
+        assert!(app.world().get::<PageOpenHandled>(task).is_some());
+
+        let attaches = app
+            .world_mut()
+            .resource_mut::<Messages<CefPageAttachRequest>>()
+            .drain()
+            .count();
+        assert_eq!(attaches, 0, "warm claim must not spawn a cold webview");
+        let reveals: Vec<StartSpareRevealed> = app
+            .world_mut()
+            .resource_mut::<Messages<StartSpareRevealed>>()
+            .drain()
+            .collect();
+        assert_eq!(reveals.len(), 1);
+        assert_eq!(reveals[0].webview, spare);
+    }
+
+    #[test]
+    fn cold_fallback_when_pool_empty() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<CefPageAttachRequest>()
+            .add_message::<StartSpareRevealed>()
+            .add_systems(Update, handle_start_page_open);
+        let stack = app.world_mut().spawn_empty().id();
+        let task = app.world_mut().spawn(start_task(stack)).id();
+        app.update();
+
+        assert!(app.world().get::<PageOpenHandled>(task).is_some());
+        let attaches: Vec<CefPageAttachRequest> = app
+            .world_mut()
+            .resource_mut::<Messages<CefPageAttachRequest>>()
+            .drain()
+            .collect();
+        assert_eq!(attaches.len(), 1);
+        assert_eq!(attaches[0].url, START_PAGE_URL);
+        let reveals = app
+            .world_mut()
+            .resource_mut::<Messages<StartSpareRevealed>>()
+            .drain()
+            .count();
+        assert_eq!(reveals, 0, "cold fallback emits no reveal");
+    }
+
+    #[test]
+    fn pool_fills_to_target() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+            .add_systems(Update, maintain_warm_start_pool);
+        app.world_mut().spawn(VmuxWindow);
+        app.update();
+        app.update();
+
+        let count = app
+            .world_mut()
+            .query_filtered::<(), With<WarmStartSpare>>()
+            .iter(app.world())
+            .count();
+        assert_eq!(count, WARM_START_POOL_SIZE);
     }
 }

--- a/docs/specs/2026-06-30-warm-start-prewarm-design.md
+++ b/docs/specs/2026-06-30-warm-start-prewarm-design.md
@@ -1,0 +1,172 @@
+# Warm-start prewarm — Design
+
+## Problem
+
+Opening `vmux://start/` (the default content of every new tab / stack / pane / space, and
+the startup tab) shows a visible cold-load delay. The page only paints after a fresh CEF
+browser is created and navigated. The goal: make `vmux://start/` appear **near-instant**
+whenever it is opened, with no UI or keybinding changes — pure backend perf.
+
+## Diagnosis
+
+The dominant per-open cost is **CEF browser creation**
+(`browser_host_create_browser_sync` — new renderer, V8 context, GPU IOSurface, child
+`NSView`), not WASM. The start WASM is one embedded bundle shared by every page, served
+from in-memory embedded assets, compiled once at build time and cached by V8/disk. So the
+lever is warming the **browser instance** (and letting its page + WASM load ahead of time),
+exactly as the command bar already does for its modal.
+
+Reference: cold path today is `handle_start_page_open` (`crates/vmux_layout/src/start/plugin.rs:38`)
+→ `CefPageAttachRequest` → `attach_cef_page_to_stack` (`crates/vmux_browser/src/lib.rs:3578`),
+which spawns a cold `Browser` for every start open.
+
+## Why not copy the command bar verbatim
+
+The command bar is **one** reused instance — it is a modal, only ever one visible, hidden
+and revealed in place (`prewarm_command_bar_modal`, `crates/vmux_layout/src/command_bar/handler.rs:233`).
+
+`vmux://start/` is different: every new tab / stack / pane / space is an **independent,
+persistent** start page that stays alive in its own stack. Two open start tabs are two live
+browsers. A single hidden instance cannot serve them. Start therefore needs a small **warm
+pool**, not a singleton.
+
+## Goal / non-goals
+
+**Goal:** every post-startup start open (new tab / stack / pane / space, and in-place nav to
+start) reuses a pre-created start browser whose page + WASM are already loaded, so it appears
+with no browser-creation latency.
+
+**Non-goals:** no UI surface, no overlay, no keybinding, no placement/target changes. Start
+behavior is identical to today — only faster. The very first startup tab may remain cold
+(one-time, already tolerated); the pool benefits every open after boot.
+
+## Architecture
+
+### Warm pool of pre-created start browsers
+
+A small pool (target size `WARM_START_POOL_SIZE`, default `1`, may bump to `2` to absorb
+back-to-back opens) of pre-created `vmux://start/` `Browser` entities. Each spare's CEF
+browser is created at boot and navigated to start, so the **expensive work — browser
+creation, page load, WASM instantiation — is already done** before the user opens anything.
+
+**Parking mode (decided): non-compositing.** A spare is parked `Visibility::Hidden` under a
+dedicated holding node (NOT a `Pane` / `Stack`). The renderer still loads and runs the page
+while hidden (JS/WASM execute regardless of view visibility) — so it is fully warm — but the
+hidden view does **not** composite, giving near-zero idle GPU/CPU cost. This matches the
+repo's strict idle-CPU stance. (Alternative, rejected as default: keep it compositing via the
+command-bar `Display::Flex` + `Visibility::Hidden` trick for pixel-instant reveal — adopt
+only if the non-compositing reveal shows a visible flash in end-to-end testing.)
+
+**Marker + sync exclusion.** Pool entities carry a new `WarmStartSpare` marker that excludes
+them from the content visibility / focus / windowed-frame sync systems while parked (the same
+way `Modal` / `Header` / `SideSheet` are excluded), so stack-active logic can't unhide,
+hide, or mis-position them. Add `Without<WarmStartSpare>` to those content queries in
+`crates/vmux_browser/src/lib.rs` (`sync_children_to_ui`, windowed/OSR focus + frame sync).
+Spares spawn `Visibility::Hidden` and, being excluded, stay hidden until claimed.
+
+**Backend mode.** Spares are created as `WebviewWindowed` in User-mode backend (what
+`Browser::new` produces). This keeps `needs_recreate` false on reveal
+(`sync_cef_backend_for_interaction_mode`, `crates/vmux_browser/src/lib.rs:935`) — a backend
+flip would close+recreate and negate the win.
+
+**Claim eligibility.** A spare is claimable once its CEF browser exists
+(`Browsers::has_browser`) and its page has loaded. Use the most reliable available
+load/ready signal; do not depend on `RenderTextureMessage` (that is the OSR texture path and
+may not fire for windowed spares).
+
+### Claim flow (hook point: `handle_start_page_open`)
+
+All start opens funnel through `handle_start_page_open`
+(`crates/vmux_layout/src/start/plugin.rs:38`), which already has the resolved `task.stack`
+and knows the URL is exactly `START_PAGE_URL`. Hook here:
+
+1. If no claimable spare → **fall back to the existing cold path** (emit
+   `CefPageAttachRequest`). Graceful degradation; no regression.
+2. If a claimable spare exists:
+   a. `clear_stack_children(task.stack)` — remove any existing content (no-op for the
+      freshly-created empty stacks of new tab/stack/pane; required for in-place/ActiveStack
+      targets that replace current content).
+   b. Reparent the spare: `ChildOf(task.stack)`, remove `WarmStartSpare`, add
+      `CefKeyboardTarget`. Normal content sync now positions it from the stack's live rect
+      and unhides it (active stack). Reveal rides the existing `webview_reveal.rs` 2-frame
+      anti-flash path, or immediately if no flash is observed.
+   c. Set the stack's `PageMetadata` to start (url / title / icon / bg) — this is what tab
+      strips and `apply_cef_state_from_webview` read.
+   d. **Push fresh launcher data** to the revealed spare (see Correctness) so it reflects
+      current tabs/spaces/history, not boot-time state.
+   e. **Focus** the launcher input via `StartFocusInput`
+      (`crates/vmux_layout/src/start/event.rs:19`).
+   f. Mark the task handled (`PageOpenHandled`) so `attach_cef_page_requests` skips the cold
+      spawn.
+3. Enqueue a **refill** — spawn one replacement spare (cold create, off the critical path;
+   the user already sees their instant start page).
+
+### Refill
+
+A system maintains `WARM_START_POOL_SIZE` claimable spares: whenever the count drops below
+target, spawn a new `WarmStartSpare` start browser under the holding node. Initial fill
+happens at boot (after the window/CEF are up).
+
+## Correctness requirements
+
+- **Fresh data on reveal (load-bearing).** The start page emits `StartDataRequest` on mount
+  and the host answers with the command-bar payload (`on_start_data_request`,
+  `crates/vmux_layout/src/start/plugin.rs:59`). A spare loaded at boot captured *boot-time*
+  tabs/spaces/history. On claim, the host must re-build and push the current payload to the
+  spare entity (reuse the `on_start_data_request` builder) so the launcher is not stale.
+- **Input focus on reveal.** Send `StartFocusInput` to the spare on claim so the launcher
+  input is focused, matching today's cold-open behavior.
+- **Clear before reparent, never after.** `clear_stack_children` must run on the target
+  stack *before* the spare becomes its child; it must never run against a stack that already
+  holds a live spare (it would despawn the spare → close the browser via the
+  `WebviewSource` `on_despawn` hook, `patches/bevy_cef-0.5.2/src/webview.rs:155`).
+- **Single-window assumption.** Spares have no `HostWindow` and bind to `primary_window`;
+  this serves every space (spaces are sibling UI nodes under `Main`, not OS windows). If
+  multi-window is ever introduced, the pool must become per-window.
+
+## Idle cost
+
+Near-zero: a parked spare does not composite (hidden view), so it costs no steady-state
+GPU/CPU beyond the one-time load. The start hero has no infinite CSS animations anyway (only
+a one-shot 700ms mount transition, `crates/vmux_layout/src/start/page.rs:37`). This is the
+key reason for the non-compositing parking mode over the command-bar keep-painting trick.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Reparent mis-positions or recreates the browser | Spike-confirmed sound: position recomputed every frame from live parent rect (`sync_windowed_frames`, `crates/vmux_browser/src/lib.rs:1168`); no teardown on `ChildOf` change. Keep spare in User/windowed backend. |
+| Visible flash on reveal (page wasn't compositing while parked) | Reveal via existing 2-frame `webview_reveal.rs` path; if still flashing, switch the parking mode to keep-compositing. |
+| Empty pool on back-to-back opens | Default pool size 1; bump constant to 2. Cold fallback covers the miss with no regression. |
+| Stale launcher data | Push fresh `StartData` payload on claim (required, above). |
+| Spare swept by stack/focus/layout systems | `WarmStartSpare` excluded from content sync queries; parked under non-stack holding node. |
+| First startup tab still cold | Accepted (one-time); pool warms immediately after for all subsequent opens. |
+
+## Testing
+
+ECS message+system integration tests (no real CEF needed):
+
+- **Boot fill:** after running the refill schedule, `WARM_START_POOL_SIZE` entities carry
+  `WarmStartSpare`.
+- **Claim reuses spare:** with a claimable spare present, sending a start `PageOpenTask`
+  reparents the spare to `task.stack` (assert `ChildOf` == stack), sets the stack's
+  `PageMetadata` to start, inserts `PageOpenHandled`, and does **not** emit a
+  `CefPageAttachRequest`.
+- **Empty pool falls back:** with no claimable spare, the same task emits a
+  `CefPageAttachRequest` (existing cold path) — no panic, no regression.
+- **Refill:** after a claim, the spare count is restored to target on the next refill run.
+- **Fresh data on claim:** a claim triggers a fresh start-data push to the revealed entity.
+
+Register any new message types in the owning plugin's `build()` (idempotent) so
+`cargo test --workspace` passes. Runtime/visual verification (actual instant paint) is a
+single manual pass at the end by the user.
+
+## Files to touch
+
+- `crates/vmux_layout/src/start/plugin.rs` — pool resource, boot fill, refill system, claim
+  hook in `handle_start_page_open`, `WarmStartSpare` marker, fresh-data push + focus on claim.
+- `crates/vmux_layout/src/start.rs` / `start/event.rs` — any new marker/message exports.
+- `crates/vmux_browser/src/lib.rs` — add `Without<WarmStartSpare>` to content
+  visibility/focus/frame sync queries; expose/share `clear_stack_children`.
+- `crates/vmux_layout/src/cef.rs` — spare `Browser` bundle helper (reuse `Browser::new`),
+  parked node styling.


### PR DESCRIPTION
## Context

Opening `vmux://start/` — the default content of every new tab, pane, stack, and space — showed a visible cold-load delay while a fresh CEF browser was created and the page + WASM loaded. That made the most common "new surface" action feel sluggish.

## Implementation

Keep a small warm pool (default 1) of prewarmed `vmux://start/` webviews parked under a hidden, zero-size node: their CEF browser and WASM load at boot but never composite (a `Visibility::Hidden` ancestor makes them non-renderable, so `sync_children_to_ui` collapses them and CEF hides the native view — near-zero idle cost).

On a start open, `handle_start_page_open` reparents a warm spare into the target stack — instant, since the browser already exists — then refills the pool. It falls back to the existing cold path when the pool is empty, so there is no regression. A parked spare captured boot-time launcher data, so on reveal the host pushes current tabs/spaces/history and refocuses the input, matching a cold open.

Notably required **no changes to `vmux_core` or `vmux_browser`**: reparenting a windowed CEF browser between stacks repositions cleanly via the existing per-frame windowed-sync (teardown only fires on despawn or a windowed↔OSR flip, never on a parent change), and the single-window model means one pool serves every space. Pool size is the `WARM_START_POOL_SIZE` constant.

Design notes in `docs/specs/2026-06-30-warm-start-prewarm-design.md`.

## Checks / QA

- Open new tabs / panes / stacks / spaces — start page should paint near-instantly vs the prior cold delay.
- First open right after launch may still be cold (pool fills at boot) — expected.
- Rapid back-to-back opens (pool = 1) can outrun refill → cold; bump `WARM_START_POOL_SIZE` to 2 if noticeable.
- Pick an entry from a freshly-opened start page → it opens in place and the launcher list reflects current tabs/spaces (not stale boot-time state).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added warm-start prewarming to reuse preloaded `vmux://start/` views when available.
  * Maintains a background pool of parked spares and reveals them on demand with refreshed launcher data and keyboard focus.

* **Bug Fixes**
  * Ensures only “ready” warm views are claimed; otherwise falls back to the existing cold-start path.
  * Improves correctness for start-page refresh and focus handling during reuse.

* **Documentation**
  * Added a warm-start prewarm design specification covering behavior and edge cases.

* **Tests**
  * Extended coverage for warm spare reuse, empty-pool fallback, and pool sizing to the configured target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->