### PR TITLE
feat(terminal): clipboard + image paste on agent panes + boot-prompt delivery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10209,6 +10209,8 @@ dependencies = [
  "dioxus",
  "js-sys",
  "libc",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "rfd",
  "rkyv",
  "serde",

--- a/crates/vmux_desktop/Cargo.toml
+++ b/crates/vmux_desktop/Cargo.toml
@@ -68,6 +68,8 @@ objc2-app-kit = { version = "0.3", features = [
     "NSAppearance",
     "NSApplication",
     "NSEvent",
+    "NSMenu",
+    "NSMenuItem",
     "NSView",
     "NSWindow",
     "NSResponder",

--- a/crates/vmux_desktop/src/os_menu.rs
+++ b/crates/vmux_desktop/src/os_menu.rs
@@ -54,10 +54,11 @@ struct OsMenuResource {
     _menu: Menu,
     interactive_mode: Option<InteractiveModeMenuItems>,
     close_window: Option<MenuItem>,
-    /// Native `NSMenuItem`s for Cut/Copy/Paste/Select All, retained so
-    /// [`sync_clipboard_menu_items`] can enable/disable them per focused pane.
+    /// Native `NSMenuItem`s for the Edit menu's standard editing actions
+    /// (Undo/Redo/Cut/Copy/Paste/Select All), retained so [`sync_edit_menu_items`]
+    /// can enable/disable them per focused pane.
     #[cfg(target_os = "macos")]
-    clipboard_items: Vec<Retained<NSMenuItem>>,
+    edit_items: Vec<Retained<NSMenuItem>>,
 }
 
 struct InteractiveModeMenuItems {
@@ -95,7 +96,7 @@ impl Plugin for OsMenuPlugin {
                 ),
             );
         #[cfg(target_os = "macos")]
-        app.add_systems(Update, sync_clipboard_menu_items.after(ReadAppCommands));
+        app.add_systems(Update, sync_edit_menu_items.after(ReadAppCommands));
     }
 }
 
@@ -109,7 +110,7 @@ fn setup(world: &mut World) {
     #[cfg(target_os = "macos")]
     menu.init_for_nsapp();
     #[cfg(target_os = "macos")]
-    let clipboard_items = collect_clipboard_menu_items();
+    let edit_items = collect_edit_menu_items();
 
     // Native CEF views hold keyboard focus, so app shortcuts arrive as menu key-equivalents.
     // `forward_menu_events` only drains on a Bevy tick; with the loop idle that's ~1s late. Wake the
@@ -130,7 +131,7 @@ fn setup(world: &mut World) {
         interactive_mode,
         close_window,
         #[cfg(target_os = "macos")]
-        clipboard_items,
+        edit_items,
     });
 }
 
@@ -143,7 +144,7 @@ fn setup(world: &mut World) {
 /// auto-validation keeps the items enabled and `[NSApp.mainMenu performKeyEquivalent:]` consumes
 /// ⌘C/⌘V before the view's `keyDown:`. That is correct for browser pages, but it steals the
 /// keystrokes from terminal panes, whose own handlers (`vmux_terminal::on_term_key` /
-/// `handle_terminal_keyboard`) implement clipboard against the PTY. [`sync_clipboard_menu_items`]
+/// `handle_terminal_keyboard`) implement clipboard against the PTY. [`sync_edit_menu_items`]
 /// disables these items while a terminal is focused so the keys fall through to the page.
 fn append_standard_edit_menu(menu: &Menu) {
     use muda::{PredefinedMenuItem, Submenu};
@@ -165,21 +166,30 @@ fn append_standard_edit_menu(menu: &Menu) {
     let _ = menu.append(&edit);
 }
 
-/// Find the live Cut/Copy/Paste/Select All `NSMenuItem`s in the app's main menu and turn OFF the
-/// containing submenu's `autoenablesItems`, so [`sync_clipboard_menu_items`] can drive their enabled
-/// state directly. Without disabling auto-validation, AppKit would re-enable `copy:`/`paste:`
-/// whenever a CEF view (which answers those selectors) is first responder, defeating the gate.
+/// Find the live Undo/Redo/Cut/Copy/Paste/Select All `NSMenuItem`s in the app's main menu and turn
+/// OFF the containing submenu's `autoenablesItems`, so [`sync_edit_menu_items`] can drive their
+/// enabled state directly. Without disabling auto-validation, AppKit would re-enable these standard
+/// editing selectors whenever a CEF view (which answers them) is first responder, defeating the gate.
+/// Undo/Redo are gated alongside the clipboard items so ⌘Z/⌘⇧Z also fall through to a focused
+/// terminal rather than being swallowed by the now-manually-managed submenu.
 ///
 /// Must run on the main thread, after the menu is installed via `Menu::init_for_nsapp`.
 #[cfg(target_os = "macos")]
-fn collect_clipboard_menu_items() -> Vec<Retained<NSMenuItem>> {
+fn collect_edit_menu_items() -> Vec<Retained<NSMenuItem>> {
     let Some(mtm) = MainThreadMarker::new() else {
         return Vec::new();
     };
     let Some(main_menu) = NSApplication::sharedApplication(mtm).mainMenu() else {
         return Vec::new();
     };
-    let actions: [Sel; 4] = [sel!(cut:), sel!(copy:), sel!(paste:), sel!(selectAll:)];
+    let actions: [Sel; 6] = [
+        sel!(undo:),
+        sel!(redo:),
+        sel!(cut:),
+        sel!(copy:),
+        sel!(paste:),
+        sel!(selectAll:),
+    ];
     let mut items = Vec::new();
     for top in 0..main_menu.numberOfItems() {
         let Some(submenu) = main_menu.itemAtIndex(top).and_then(|item| item.submenu()) else {
@@ -205,20 +215,21 @@ fn collect_clipboard_menu_items() -> Vec<Retained<NSMenuItem>> {
     items
 }
 
-/// Whether the standard Edit-menu clipboard items should be enabled for the current focus.
+/// Whether the standard Edit-menu items (Undo/Redo/Cut/Copy/Paste/Select All) should be enabled for
+/// the current focus.
 ///
 /// They are disabled only when a terminal owns focus ([`HostFocusIntent::WinitHost`]) so ⌘C/⌘V/⌘X/⌘A
-/// fall through to the terminal's own key handling. Web pages, the command bar, and the idle state
-/// keep the native items enabled.
+/// (and ⌘Z) fall through to the terminal's own key handling. Web pages, the command bar, and the idle
+/// state keep the native items enabled.
 #[cfg(target_os = "macos")]
-fn clipboard_menu_items_enabled(intent: HostFocusIntent) -> bool {
+fn edit_menu_items_enabled(intent: HostFocusIntent) -> bool {
     !matches!(intent, HostFocusIntent::WinitHost)
 }
 
-/// Drive the Cut/Copy/Paste/Select All items' enabled state from [`HostFocusIntent`] so terminal
-/// panes receive their own ⌘C/⌘V while browser/web inputs keep native clipboard behavior.
+/// Drive the Edit-menu items' enabled state from [`HostFocusIntent`] so terminal panes receive their
+/// own ⌘C/⌘V/⌘Z while browser/web inputs keep native edit behavior.
 #[cfg(target_os = "macos")]
-fn sync_clipboard_menu_items(
+fn sync_edit_menu_items(
     menu: Option<NonSend<OsMenuResource>>,
     intent: Option<Res<HostFocusIntent>>,
 ) {
@@ -231,8 +242,8 @@ fn sync_clipboard_menu_items(
     let Some(menu) = menu else {
         return;
     };
-    let enabled = clipboard_menu_items_enabled(*intent);
-    for item in &menu.clipboard_items {
+    let enabled = edit_menu_items_enabled(*intent);
+    for item in &menu.edit_items {
         item.setEnabled(enabled);
     }
 }
@@ -418,15 +429,15 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn clipboard_items_disabled_only_for_terminal_focus() {
+    fn edit_items_disabled_only_for_terminal_focus() {
         assert!(
-            !clipboard_menu_items_enabled(HostFocusIntent::WinitHost),
+            !edit_menu_items_enabled(HostFocusIntent::WinitHost),
             "terminal focus must release ⌘C/⌘V to the terminal's own handler"
         );
-        assert!(clipboard_menu_items_enabled(HostFocusIntent::Windowed(
+        assert!(edit_menu_items_enabled(HostFocusIntent::Windowed(
             Entity::PLACEHOLDER
         )));
-        assert!(clipboard_menu_items_enabled(HostFocusIntent::Unmanaged));
+        assert!(edit_menu_items_enabled(HostFocusIntent::Unmanaged));
     }
 
     fn test_settings() -> AppSettings {

--- a/crates/vmux_desktop/src/os_menu.rs
+++ b/crates/vmux_desktop/src/os_menu.rs
@@ -2,8 +2,18 @@ use bevy::ecs::message::Messages;
 use bevy::prelude::*;
 use bevy::window::WindowCloseRequested;
 use muda::{Menu, MenuEvent, MenuItem, MenuItemKind};
+#[cfg(target_os = "macos")]
+use objc2::rc::Retained;
+#[cfg(target_os = "macos")]
+use objc2::{runtime::Sel, sel};
+#[cfg(target_os = "macos")]
+use objc2_app_kit::{NSApplication, NSMenuItem};
+#[cfg(target_os = "macos")]
+use objc2_foundation::MainThreadMarker;
 use parking_lot::Mutex;
 use std::sync::LazyLock;
+#[cfg(target_os = "macos")]
+use vmux_browser::HostFocusIntent;
 use vmux_command::{
     AppCommand, BrowserCommand, LayoutCommand, ReadAppCommands, StackCommand, WriteAppCommands,
     build_native_root_menu, open::OpenCommand,
@@ -44,6 +54,10 @@ struct OsMenuResource {
     _menu: Menu,
     interactive_mode: Option<InteractiveModeMenuItems>,
     close_window: Option<MenuItem>,
+    /// Native `NSMenuItem`s for Cut/Copy/Paste/Select All, retained so
+    /// [`sync_clipboard_menu_items`] can enable/disable them per focused pane.
+    #[cfg(target_os = "macos")]
+    clipboard_items: Vec<Retained<NSMenuItem>>,
 }
 
 struct InteractiveModeMenuItems {
@@ -80,6 +94,8 @@ impl Plugin for OsMenuPlugin {
                     sync_close_menu_item.after(hide_window_on_close_request),
                 ),
             );
+        #[cfg(target_os = "macos")]
+        app.add_systems(Update, sync_clipboard_menu_items.after(ReadAppCommands));
     }
 }
 
@@ -92,6 +108,8 @@ fn setup(world: &mut World) {
 
     #[cfg(target_os = "macos")]
     menu.init_for_nsapp();
+    #[cfg(target_os = "macos")]
+    let clipboard_items = collect_clipboard_menu_items();
 
     // Native CEF views hold keyboard focus, so app shortcuts arrive as menu key-equivalents.
     // `forward_menu_events` only drains on a Bevy tick; with the loop idle that's ~1s late. Wake the
@@ -111,14 +129,22 @@ fn setup(world: &mut World) {
         _menu: menu,
         interactive_mode,
         close_window,
+        #[cfg(target_os = "macos")]
+        clipboard_items,
     });
 }
 
 /// CEF/Chromium on macOS routes web-content editing shortcuts (Select All, Cut, Copy, Paste, Undo,
 /// Redo) through the application's standard Edit menu — without it, cmd+A / cmd+C / cmd+V etc. do
-/// nothing in web text inputs. The predefined items use the standard responder-chain selectors and
-/// auto-disable when a non-text view (winit content view for terminals) holds first responder, so
-/// terminal clipboard handling is unaffected.
+/// nothing in web text inputs (browser pages, command bar, editor inputs).
+///
+/// The predefined items use the standard responder-chain selectors (`copy:`/`paste:`/…). A focused
+/// page is always a CEF `NSView`, which *answers* those selectors, so `NSMenu`'s default
+/// auto-validation keeps the items enabled and `[NSApp.mainMenu performKeyEquivalent:]` consumes
+/// ⌘C/⌘V before the view's `keyDown:`. That is correct for browser pages, but it steals the
+/// keystrokes from terminal panes, whose own handlers (`vmux_terminal::on_term_key` /
+/// `handle_terminal_keyboard`) implement clipboard against the PTY. [`sync_clipboard_menu_items`]
+/// disables these items while a terminal is focused so the keys fall through to the page.
 fn append_standard_edit_menu(menu: &Menu) {
     use muda::{PredefinedMenuItem, Submenu};
 
@@ -137,6 +163,78 @@ fn append_standard_edit_menu(menu: &Menu) {
         return;
     };
     let _ = menu.append(&edit);
+}
+
+/// Find the live Cut/Copy/Paste/Select All `NSMenuItem`s in the app's main menu and turn OFF the
+/// containing submenu's `autoenablesItems`, so [`sync_clipboard_menu_items`] can drive their enabled
+/// state directly. Without disabling auto-validation, AppKit would re-enable `copy:`/`paste:`
+/// whenever a CEF view (which answers those selectors) is first responder, defeating the gate.
+///
+/// Must run on the main thread, after the menu is installed via `Menu::init_for_nsapp`.
+#[cfg(target_os = "macos")]
+fn collect_clipboard_menu_items() -> Vec<Retained<NSMenuItem>> {
+    let Some(mtm) = MainThreadMarker::new() else {
+        return Vec::new();
+    };
+    let Some(main_menu) = NSApplication::sharedApplication(mtm).mainMenu() else {
+        return Vec::new();
+    };
+    let actions: [Sel; 4] = [sel!(cut:), sel!(copy:), sel!(paste:), sel!(selectAll:)];
+    let mut items = Vec::new();
+    for top in 0..main_menu.numberOfItems() {
+        let Some(submenu) = main_menu.itemAtIndex(top).and_then(|item| item.submenu()) else {
+            continue;
+        };
+        let mut found = false;
+        for idx in 0..submenu.numberOfItems() {
+            let Some(item) = submenu.itemAtIndex(idx) else {
+                continue;
+            };
+            if item
+                .action()
+                .is_some_and(|action| actions.contains(&action))
+            {
+                items.push(item);
+                found = true;
+            }
+        }
+        if found {
+            submenu.setAutoenablesItems(false);
+        }
+    }
+    items
+}
+
+/// Whether the standard Edit-menu clipboard items should be enabled for the current focus.
+///
+/// They are disabled only when a terminal owns focus ([`HostFocusIntent::WinitHost`]) so ⌘C/⌘V/⌘X/⌘A
+/// fall through to the terminal's own key handling. Web pages, the command bar, and the idle state
+/// keep the native items enabled.
+#[cfg(target_os = "macos")]
+fn clipboard_menu_items_enabled(intent: HostFocusIntent) -> bool {
+    !matches!(intent, HostFocusIntent::WinitHost)
+}
+
+/// Drive the Cut/Copy/Paste/Select All items' enabled state from [`HostFocusIntent`] so terminal
+/// panes receive their own ⌘C/⌘V while browser/web inputs keep native clipboard behavior.
+#[cfg(target_os = "macos")]
+fn sync_clipboard_menu_items(
+    menu: Option<NonSend<OsMenuResource>>,
+    intent: Option<Res<HostFocusIntent>>,
+) {
+    let Some(intent) = intent else {
+        return;
+    };
+    if !intent.is_changed() {
+        return;
+    }
+    let Some(menu) = menu else {
+        return;
+    };
+    let enabled = clipboard_menu_items_enabled(*intent);
+    for item in &menu.clipboard_items {
+        item.setEnabled(enabled);
+    }
 }
 
 fn interactive_mode_menu_items(menu: &Menu) -> Option<InteractiveModeMenuItems> {
@@ -317,6 +415,19 @@ mod tests {
         FocusRingSettings, LayoutSettings, PaneSettings, SideSheetSettings, WindowSettings,
     };
     use vmux_setting::{AgentSettings, AppSettings, BrowserSettings, ShortcutSettings};
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn clipboard_items_disabled_only_for_terminal_focus() {
+        assert!(
+            !clipboard_menu_items_enabled(HostFocusIntent::WinitHost),
+            "terminal focus must release ⌘C/⌘V to the terminal's own handler"
+        );
+        assert!(clipboard_menu_items_enabled(HostFocusIntent::Windowed(
+            Entity::PLACEHOLDER
+        )));
+        assert!(clipboard_menu_items_enabled(HostFocusIntent::Unmanaged));
+    }
 
     fn test_settings() -> AppSettings {
         AppSettings {

--- a/crates/vmux_terminal/Cargo.toml
+++ b/crates/vmux_terminal/Cargo.toml
@@ -39,6 +39,10 @@ tempfile = "3"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-app-kit = { version = "0.3", features = ["NSPasteboard"] }
+objc2-foundation = { version = "0.3", features = ["NSArray", "NSData", "NSString"] }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 dioxus = { workspace = true }
 js-sys = "0.3"

--- a/crates/vmux_terminal/src/clipboard.rs
+++ b/crates/vmux_terminal/src/clipboard.rs
@@ -20,22 +20,23 @@ pub fn read_blocking() -> Option<String> {
     read_inner()
 }
 
-/// Whether the system clipboard currently holds image data (PNG/TIFF).
+/// Whether the system clipboard currently holds PNG image data.
 ///
 /// On ⌘V in a terminal this decides whether to forward `Ctrl+V` (`0x16`) so the
 /// focused agent CLI grabs the image from the pasteboard itself, instead of a
-/// text paste. Returns `false` where no pasteboard image query is available.
+/// text paste. Scoped to PNG so it stays consistent with [`read_image_png`] (the
+/// Vibe/boot-draft paths extract PNG); returns `false` otherwise.
 pub fn has_image() -> bool {
     has_image_inner()
 }
 
 #[cfg(target_os = "macos")]
 fn has_image_inner() -> bool {
-    use objc2_app_kit::{NSPasteboard, NSPasteboardTypePNG, NSPasteboardTypeTIFF};
+    use objc2_app_kit::{NSPasteboard, NSPasteboardTypePNG};
     use objc2_foundation::NSArray;
-    let image_types = unsafe { NSArray::from_slice(&[NSPasteboardTypePNG, NSPasteboardTypeTIFF]) };
+    let png_type = unsafe { NSArray::from_slice(&[NSPasteboardTypePNG]) };
     NSPasteboard::generalPasteboard()
-        .availableTypeFromArray(&image_types)
+        .availableTypeFromArray(&png_type)
         .is_some()
 }
 

--- a/crates/vmux_terminal/src/clipboard.rs
+++ b/crates/vmux_terminal/src/clipboard.rs
@@ -20,6 +20,104 @@ pub fn read_blocking() -> Option<String> {
     read_inner()
 }
 
+/// Whether the system clipboard currently holds image data (PNG/TIFF).
+///
+/// On ⌘V in a terminal this decides whether to forward `Ctrl+V` (`0x16`) so the
+/// focused agent CLI grabs the image from the pasteboard itself, instead of a
+/// text paste. Returns `false` where no pasteboard image query is available.
+pub fn has_image() -> bool {
+    has_image_inner()
+}
+
+#[cfg(target_os = "macos")]
+fn has_image_inner() -> bool {
+    use objc2_app_kit::{NSPasteboard, NSPasteboardTypePNG, NSPasteboardTypeTIFF};
+    use objc2_foundation::NSArray;
+    let image_types = unsafe { NSArray::from_slice(&[NSPasteboardTypePNG, NSPasteboardTypeTIFF]) };
+    NSPasteboard::generalPasteboard()
+        .availableTypeFromArray(&image_types)
+        .is_some()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn has_image_inner() -> bool {
+    false
+}
+
+/// Read PNG image bytes from the system clipboard, if present.
+///
+/// Used for the Vibe fallback, which cannot read the pasteboard itself: vmux
+/// writes these bytes to a temp file and pastes its path instead of `Ctrl+V`.
+pub fn read_image_png() -> Option<Vec<u8>> {
+    read_image_png_inner()
+}
+
+#[cfg(target_os = "macos")]
+fn read_image_png_inner() -> Option<Vec<u8>> {
+    use objc2_app_kit::{NSPasteboard, NSPasteboardTypePNG};
+    let png_type = unsafe { NSPasteboardTypePNG };
+    let data = NSPasteboard::generalPasteboard().dataForType(png_type)?;
+    Some(data.to_vec())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn read_image_png_inner() -> Option<Vec<u8>> {
+    None
+}
+
+/// Absolute path of an image *file* on the clipboard (a copied file, e.g. a
+/// saved screenshot), if any.
+///
+/// Distinct from [`has_image`], which reports raw image *data*. Agent CLIs
+/// auto-detect an image path pasted as text, so this lets ⌘V attach a copied
+/// image file without raw clipboard image data.
+pub fn image_file_path() -> Option<String> {
+    image_file_path_inner()
+}
+
+#[cfg(target_os = "macos")]
+fn image_file_path_inner() -> Option<String> {
+    use objc2_app_kit::{NSPasteboard, NSPasteboardTypeFileURL};
+    let url_type = unsafe { NSPasteboardTypeFileURL };
+    let url_str = NSPasteboard::generalPasteboard()
+        .stringForType(url_type)?
+        .to_string();
+    let path = url::Url::parse(&url_str).ok()?.to_file_path().ok()?;
+    path_looks_like_image(&path).then(|| path.to_string_lossy().into_owned())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn image_file_path_inner() -> Option<String> {
+    None
+}
+
+/// Whether `path` has a known raster-image extension.
+#[cfg(target_os = "macos")]
+fn path_looks_like_image(path: &std::path::Path) -> bool {
+    matches!(
+        path.extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| ext.to_ascii_lowercase())
+            .as_deref(),
+        Some("png" | "jpg" | "jpeg" | "gif" | "webp" | "tiff" | "tif" | "bmp" | "heic")
+    )
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn image_extensions_detected_case_insensitively() {
+        assert!(path_looks_like_image(Path::new("/tmp/Screenshot.png")));
+        assert!(path_looks_like_image(Path::new("/tmp/a.JPG")));
+        assert!(path_looks_like_image(Path::new("/tmp/a.jpeg")));
+        assert!(!path_looks_like_image(Path::new("/tmp/notes.txt")));
+        assert!(!path_looks_like_image(Path::new("/tmp/noext")));
+    }
+}
+
 #[cfg(target_os = "macos")]
 fn write_blocking(text: &str) {
     use std::io::Write;

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -38,6 +38,10 @@ use crate::{ProcessExited, Terminal};
 
 const MULTI_CLICK_WINDOW: std::time::Duration = std::time::Duration::from_millis(300);
 const MULTI_CLICK_CELL_TOLERANCE: i32 = 1;
+/// `Ctrl+V` control byte. Sent on ⌘V when the clipboard holds an image, so the
+/// focused agent CLI (Claude Code / Codex) reads the image from the pasteboard
+/// itself — image data never transits the PTY.
+const CTRL_V: u8 = 0x16;
 
 /// Check if confirmation is needed based on settings.
 pub fn should_confirm_close(settings: &AppSettings) -> bool {
@@ -194,20 +198,15 @@ fn agent_prompt_flush_bytes(alt_screen: bool, buf: &BufferedAgentPrompt) -> Opti
 
 fn flush_buffered_agent_prompt(
     q: Query<(Entity, &ProcessId, &BufferedAgentPrompt), With<vmux_core::agent::AgentSession>>,
-    mode_map: Res<TerminalModeMap>,
     service: Option<Res<ServiceClient>>,
     mut commands: Commands,
 ) {
     let Some(service) = service else { return };
     for (entity, pid, buf) in &q {
-        let alt_screen = mode_map
-            .modes
-            .get(pid)
-            .map(|m| m.alt_screen)
-            .unwrap_or(false);
-        if !alt_screen {
-            continue;
-        }
+        // Readiness is already decided by `clear_agent_loading` (which only
+        // creates a `BufferedAgentPrompt` once the TUI is up); deliver as soon as
+        // one exists. Re-gating on `alt_screen` here strands the prompt forever
+        // for inline TUIs (Claude Code, Codex, Vibe) that never use alt-screen.
         if let Some(data) = agent_prompt_flush_bytes(true, buf) {
             service.0.send(ClientMessage::ProcessInput {
                 process_id: *pid,
@@ -1685,6 +1684,14 @@ fn handle_terminal_keyboard(
     >,
     keyboard_targets: Query<(), With<CefKeyboardTarget>>,
     terminals: Query<(&ProcessId, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
+    terminal_kinds: Query<
+        (
+            &ProcessId,
+            Option<&vmux_core::agent::AgentSession>,
+            Option<&crate::launch::TerminalLaunch>,
+        ),
+        With<Terminal>,
+    >,
     mut capture_q: Query<(Entity, &ProcessId, &mut PromptCapture), With<Terminal>>,
     focus: Res<vmux_layout::stack::FocusedStack>,
     mode: Res<vmux_layout::scene::InteractionMode>,
@@ -1735,6 +1742,13 @@ fn handle_terminal_keyboard(
             .get(cap_e)
             .map(|(_, _, c)| (c.draft.clone(), c.skipped))
             .unwrap_or_default();
+        let is_vibe = active_process_id
+            .and_then(|pid| terminal_kinds.iter().find(|(p, ..)| **p == pid))
+            .map(|(_, agent, launch)| {
+                agent.map(|s| s.kind) == Some(vmux_core::agent::AgentKind::Vibe)
+                    || launch.map(|l| l.kind.clone()) == Some(crate::launch::TerminalKind::Vibe)
+            })
+            .unwrap_or(false);
         let mut changed = false;
         let mut seen_keys: Vec<KeyCode> = Vec::new();
         for event in er.read() {
@@ -1754,6 +1768,19 @@ fn handle_terminal_keyboard(
                 draft.clear();
                 skipped = false;
                 changed = true;
+                continue;
+            }
+            if super_key && event.key_code == KeyCode::KeyV {
+                if let Some(pasted) =
+                    active_process_id.and_then(|pid| resolve_paste_text(is_vibe, pid))
+                {
+                    if !draft.is_empty() && !draft.ends_with(char::is_whitespace) {
+                        draft.push(' ');
+                    }
+                    draft.push_str(&pasted);
+                    skipped = false;
+                    changed = true;
+                }
                 continue;
             }
             match &event.logical_key {
@@ -1842,15 +1869,16 @@ fn handle_terminal_keyboard(
         if super_key {
             match event.key_code {
                 KeyCode::KeyV => {
-                    // Paste via OS clipboard.
-                    if let Some(text) = crate::clipboard::read_blocking()
-                        && !text.is_empty()
+                    let active = active_process_id
+                        .and_then(|pid| terminal_kinds.iter().find(|(p, ..)| **p == pid));
+                    let agent_kind = active.and_then(|(_, agent, _)| agent.map(|s| s.kind));
+                    let launch_kind =
+                        active.and_then(|(_, _, launch)| launch.map(|l| l.kind.clone()));
+                    let is_vibe = agent_kind == Some(vmux_core::agent::AgentKind::Vibe)
+                        || launch_kind == Some(crate::launch::TerminalKind::Vibe);
+                    if let Some(data) =
+                        active_process_id.and_then(|pid| resolve_paste(is_vibe, pid))
                     {
-                        // Wrap in bracketed paste sequences
-                        let mut data = Vec::new();
-                        data.extend_from_slice(b"\x1b[200~");
-                        data.extend_from_slice(text.as_bytes());
-                        data.extend_from_slice(b"\x1b[201~");
                         for process_id in &target_processes {
                             service.0.send(ClientMessage::ProcessInput {
                                 process_id: *process_id,
@@ -2240,6 +2268,75 @@ fn term_key_event_to_key(event: &TermKeyEvent) -> Key {
             Key::Character(text.into())
         }
     }
+}
+
+/// Wrap `payload` in terminal bracketed-paste markers.
+fn bracketed_paste(payload: &[u8]) -> Vec<u8> {
+    let mut data = Vec::with_capacity(payload.len() + 12);
+    data.extend_from_slice(b"\x1b[200~");
+    data.extend_from_slice(payload);
+    data.extend_from_slice(b"\x1b[201~");
+    data
+}
+
+/// Paste payload for an image file path. Vibe attaches a single-quoted path
+/// (it prepends its own `@` on paste; the quotes keep paths with spaces as one
+/// token); Claude Code and Codex auto-detect a bare path.
+fn image_path_payload(is_vibe: bool, path: &str) -> String {
+    if is_vibe {
+        format!("'{path}'")
+    } else {
+        path.to_string()
+    }
+}
+
+/// Write clipboard PNG bytes to a per-process temp file and return its path.
+fn write_clipboard_image_temp(process_id: ProcessId, png: &[u8]) -> Option<std::path::PathBuf> {
+    let path = std::env::temp_dir().join(format!("vmux-clip-{process_id}.png"));
+    std::fs::write(&path, png).ok()?;
+    Some(path)
+}
+
+/// Resolve the bytes to forward to the PTY for a ⌘V paste. A copied image *file*
+/// is pasted as its path; raw image *data* goes to the CLI via `Ctrl+V` (Claude
+/// Code, Codex read the pasteboard), except Vibe (`is_vibe`) — which cannot read
+/// the pasteboard, so its data is written to a temp file and pasted as a path.
+/// Otherwise the clipboard text is bracketed-pasted. `None` when nothing to paste.
+fn resolve_paste(is_vibe: bool, process_id: ProcessId) -> Option<Vec<u8>> {
+    if let Some(path) = crate::clipboard::image_file_path() {
+        return Some(bracketed_paste(
+            image_path_payload(is_vibe, &path).as_bytes(),
+        ));
+    }
+    if crate::clipboard::has_image() {
+        if is_vibe {
+            let png = crate::clipboard::read_image_png()?;
+            let path = write_clipboard_image_temp(process_id, &png)?;
+            let payload = image_path_payload(true, &path.to_string_lossy());
+            return Some(bracketed_paste(payload.as_bytes()));
+        }
+        return Some(vec![CTRL_V]);
+    }
+    let text = crate::clipboard::read_blocking()?;
+    (!text.is_empty()).then(|| bracketed_paste(text.as_bytes()))
+}
+
+/// Text to append to an agent's boot-time draft prompt for a ⌘V paste. Unlike
+/// [`resolve_paste`], an image always resolves to a *path* (raw clipboard data is
+/// written to a temp file) — the booting CLI isn't running yet to read the
+/// pasteboard via `Ctrl+V`, and the draft is delivered later as text. Returns
+/// `None` when there is nothing to paste.
+fn resolve_paste_text(is_vibe: bool, process_id: ProcessId) -> Option<String> {
+    if let Some(path) = crate::clipboard::image_file_path() {
+        return Some(image_path_payload(is_vibe, &path));
+    }
+    if crate::clipboard::has_image() {
+        let png = crate::clipboard::read_image_png()?;
+        let path = write_clipboard_image_temp(process_id, &png)?;
+        return Some(image_path_payload(is_vibe, &path.to_string_lossy()));
+    }
+    let text = crate::clipboard::read_blocking()?;
+    (!text.is_empty()).then_some(text)
 }
 
 fn term_key_event_to_bytes(event: &TermKeyEvent) -> Vec<u8> {
@@ -2784,6 +2881,8 @@ fn on_term_mouse(
 fn on_term_key(
     trigger: On<BinReceive<TermKeyEvent>>,
     q: Query<&ProcessId, With<Terminal>>,
+    agents: Query<&vmux_core::agent::AgentSession>,
+    launches: Query<&crate::launch::TerminalLaunch>,
     service: Option<Res<ServiceClient>>,
     mode_map: Res<TerminalModeMap>,
     mut local_copy_mode: ResMut<LocalCopyModeState>,
@@ -2822,13 +2921,11 @@ fn on_term_key(
     if super_key {
         match event.code.as_str() {
             "KeyV" => {
-                if let Some(text) = crate::clipboard::read_blocking()
-                    && !text.is_empty()
-                {
-                    let mut data = Vec::new();
-                    data.extend_from_slice(b"\x1b[200~");
-                    data.extend_from_slice(text.as_bytes());
-                    data.extend_from_slice(b"\x1b[201~");
+                let agent_kind = agents.get(entity).ok().map(|session| session.kind);
+                let launch_kind = launches.get(entity).ok().map(|launch| launch.kind.clone());
+                let is_vibe = agent_kind == Some(vmux_core::agent::AgentKind::Vibe)
+                    || launch_kind == Some(crate::launch::TerminalKind::Vibe);
+                if let Some(data) = resolve_paste(is_vibe, process_id) {
                     service
                         .0
                         .send(ClientMessage::ProcessInput { process_id, data });
@@ -2962,13 +3059,15 @@ fn clear_agent_loading(
     mut commands: Commands,
 ) {
     for (entity, pid, session, loading, capture) in &loading_q {
-        // Agents clear when the TUI takes over (alt-screen); plain terminals,
-        // whose shell prints instantly, show a brief minimum splash instead.
+        // Agents clear when the TUI takes over its terminal. Inline TUIs (Claude
+        // Code, Codex, Vibe) never enter alt-screen, so also treat mouse or focus
+        // reporting — enabled when their input is ready — as readiness. Plain
+        // terminals, whose shell prints instantly, show a brief minimum splash.
         let ready = match session {
             Some(_) => mode_map
                 .modes
                 .get(pid)
-                .map(|m| m.alt_screen)
+                .map(|m| m.alt_screen || m.mouse_capture || m.focus_reporting)
                 .unwrap_or(false),
             None => loading.since.elapsed() >= TERMINAL_LOADING_MIN_DISPLAY,
         };
@@ -3510,6 +3609,25 @@ mod tests {
         FocusRingSettings, LayoutSettings, PaneSettings, SideSheetSettings, WindowSettings,
     };
     use vmux_setting::{BrowserSettings, ShortcutSettings};
+
+    #[test]
+    fn bracketed_paste_wraps_payload() {
+        assert_eq!(bracketed_paste(b"hi"), b"\x1b[200~hi\x1b[201~".to_vec());
+    }
+
+    #[test]
+    fn image_path_payload_uses_vibe_attach_syntax() {
+        assert_eq!(image_path_payload(true, "/tmp/a b.png"), "'/tmp/a b.png'");
+        assert_eq!(image_path_payload(false, "/tmp/a b.png"), "/tmp/a b.png");
+    }
+
+    #[test]
+    fn write_clipboard_image_temp_writes_png_bytes() {
+        let png = [137u8, 80, 78, 71, 1, 2, 3];
+        let path = write_clipboard_image_temp(process_id(7), &png).expect("temp write");
+        assert_eq!(std::fs::read(&path).unwrap(), png);
+        let _ = std::fs::remove_file(&path);
+    }
 
     fn process_id(byte: u8) -> ProcessId {
         ProcessId([byte; 16])

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -2281,18 +2281,23 @@ fn bracketed_paste(payload: &[u8]) -> Vec<u8> {
 
 /// Paste payload for an image file path. Vibe attaches a single-quoted path
 /// (it prepends its own `@` on paste; the quotes keep paths with spaces as one
-/// token); Claude Code and Codex auto-detect a bare path.
+/// token, with embedded `'` shell-escaped); Claude Code and Codex auto-detect a
+/// bare path.
 fn image_path_payload(is_vibe: bool, path: &str) -> String {
     if is_vibe {
-        format!("'{path}'")
+        format!("'{}'", path.replace('\'', "'\\''"))
     } else {
         path.to_string()
     }
 }
 
-/// Write clipboard PNG bytes to a per-process temp file and return its path.
+/// Write clipboard PNG bytes to a unique temp file and return its path. The
+/// per-paste sequence number prevents a later paste from overwriting an earlier
+/// one still pending delivery (e.g. several images in a boot-screen draft).
 fn write_clipboard_image_temp(process_id: ProcessId, png: &[u8]) -> Option<std::path::PathBuf> {
-    let path = std::env::temp_dir().join(format!("vmux-clip-{process_id}.png"));
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!("vmux-clip-{process_id}-{seq}.png"));
     std::fs::write(&path, png).ok()?;
     Some(path)
 }
@@ -3619,6 +3624,10 @@ mod tests {
     fn image_path_payload_uses_vibe_attach_syntax() {
         assert_eq!(image_path_payload(true, "/tmp/a b.png"), "'/tmp/a b.png'");
         assert_eq!(image_path_payload(false, "/tmp/a b.png"), "/tmp/a b.png");
+        assert_eq!(
+            image_path_payload(true, "/tmp/bob's.png"),
+            "'/tmp/bob'\\''s.png'"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Copy/paste was dead on terminal/agent CLI panes, images couldn't be pasted into agents, and a prompt typed on the agent loading screen never reached the CLI. Three fixes:

### 1. Edit-menu focus-gate (text ⌘C/⌘V/⌘X/⌘A)
The macOS Edit menu's `copy:`/`cut:`/`paste:`/`selectAll:` key-equivalents were auto-enabled against the focused CEF terminal view, so AppKit consumed ⌘C/⌘V before the page/PTY ever saw them. We now turn off `autoenablesItems` on the Edit submenu and disable those items while a terminal owns focus (`HostFocusIntent::WinitHost`); browser/web inputs keep native clipboard behavior.

### 2. Image paste (⌘V)
- A copied image **file** pastes as its absolute path.
- Raw clipboard image **data** → **Claude Code / Codex** get `Ctrl+V` (they read the pasteboard themselves); **Vibe** gets a temp-file path in its `@'path'` attach syntax (it can't read the pasteboard).
- Clipboard reads via `NSPasteboard` (objc2).

### 3. Boot-prompt delivery
A prompt typed/pasted on the agent loading screen now delivers on ready:
- `flush` no longer re-gates on alt-screen — inline TUIs (Claude/Codex/Vibe) never enter it, so the prompt was stranded forever.
- loading clears on alt-screen **or** mouse/focus reporting, so inline CLIs stop waiting out the 10s timeout.
- ⌘V in the boot draft appends the image path too.

## Test
- `cargo test -p vmux_terminal -p vmux_desktop` green (incl. new unit tests for the menu gate, image-path payload, temp-file write, extension detection).
- Manual: ⌘C/⌘V text in terminal + agent panes; ⌘V image into Claude/Codex/Vibe; type/paste on the loading screen → delivered on boot; browser pane clipboard still native.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS clipboard image support: detect PNG availability, read PNG bytes, and extract image file paths from pasteboard URLs.
* **Bug Fixes**
  * Improved macOS Edit-menu shortcut behavior (Undo/Redo/Cut/Copy/Paste/Select All) by syncing native menu items with terminal focus so shortcuts route correctly.
  * Refined clipboard pasting behavior for bracketed paste and image handling, including Vibe-specific quoting/temp-file behavior; improved agent loading/buffered prompt flushing readiness to avoid inline lockups.
* **Tests**
  * Added macOS-only unit coverage for image parsing and edit-menu enabled/disabled behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->