### PR TITLE
chore(release): v0.0.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9763,7 +9763,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9800,7 +9800,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_browser"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "base64 0.22.1",
  "bevy",
@@ -9825,7 +9825,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -9838,7 +9838,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9853,7 +9853,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9872,7 +9872,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9937,7 +9937,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_editor"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "arboard",
  "bevy",
@@ -9979,7 +9979,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_git"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9996,7 +9996,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10017,7 +10017,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -10051,7 +10051,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "muda",
  "proc-macro2",
@@ -10061,7 +10061,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -10074,7 +10074,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_server"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "dioxus",
  "regex",
@@ -10095,7 +10095,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "alacritty_terminal",
  "bevy",
@@ -10131,7 +10131,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10154,7 +10154,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10179,7 +10179,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_team"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10200,7 +10200,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10233,7 +10233,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "dioxus",
  "dioxus-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.19"
+version = "0.0.20"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "GPL-3.0-or-later"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.19"
-  sha256 "5a7465a7c385575fd42157628d0045eddba561666d61a58a2576e836920cf831"
+  version "0.0.20"
+  sha256 "1aee4b1ffe3da77a0f519da0d3e80b01cd18d835ab09957e1897354d509e7ae2"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.19/Vmux_0.0.19_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.20/Vmux_0.0.20_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai/"

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.19",
-  "pub_date": "2026-06-26T22:45:02Z",
+  "version": "v0.0.20",
+  "pub_date": "2026-06-30T08:15:48Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.19/Vmux-v0.0.19-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzIrQUZWYzdlSFNjNEJSd0hDd1hYWmRYZXBSeG5BQVBXN3FobE9BSDg1SitxOW5JK0hqa3hKNkNabGJJcEhETmh4R1RKU0M3N252Ty91c0hOdG9JMXc4PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgyNTEzMTg4CWZpbGU6Vm11eC12MC4wLjE5LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKVitUUG1xbEFnOU9sRjBUdDRrcXNPNGhHbnlXV2dpaTRCU0VJNlRlSGVUdUsvd05TMXBBL29pTkI2RlVCV2FJK1YwMTVWaEJrcnJDTmhGd3V4cHFOQ3c9PQo=",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.20/Vmux-v0.0.20-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzd5QndPTVFpd0VkU2cvcHRWd0l0WWVFWUx0bENSVjBYdVEwVU9VUUplUmJZSFkxcW9PZGlBU0sxZTVvaktqNEJuUkpFSktPSkk5MXdaUk11S1FFQXdFPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgyODA2MzExCWZpbGU6Vm11eC12MC4wLjIwLWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKVVVTaHFzUEgwOGcyVC9aa3ExNUNkMHVNcEUyTnFBVU1IUnlFVW04TzB5MGduS0FKOXpQVXk3ZnlLblh2TlYra3dsTDZ3NEFGS25tODMzTkUzQlo4QWc9PQo=",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.19/Vmux_0.0.19_aarch64.dmg",
-      "filename": "Vmux_0.0.19_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.20/Vmux_0.0.20_aarch64.dmg",
+      "filename": "Vmux_0.0.20_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
Patch release. Bumps workspace version 0.0.19 -> 0.0.20. Releases on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the workspace version to `0.0.20`.
  * Updated the macOS VMux cask metadata to `0.0.20`, including checksum and download link.
  * Updated the website release feed to publish `v0.0.20` with refreshed artifact URLs and filenames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->