### PR TITLE
fix(terminal): zoom font size when default theme is unmaterialized

### DIFF
--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -3199,12 +3199,16 @@ pub fn handle_terminal_font_size(
             continue;
         };
         let name = terminal.default_theme.clone();
-        let Some(idx) = terminal.themes.iter().position(|t| t.name == name) else {
-            tracing::warn!(
-                "terminal font size: default theme '{name}' not in themes; cannot persist"
-            );
-            continue;
+        let idx = match terminal.themes.iter().position(|t| t.name == name) {
+            Some(idx) => idx,
+            None => {
+                let resolved = terminal.resolve_theme(&name);
+                let terminal = settings.terminal.as_mut().unwrap();
+                terminal.themes.push(resolved);
+                terminal.themes.len() - 1
+            }
         };
+        let terminal = settings.terminal.as_mut().unwrap();
         let cur = terminal.themes[idx].font_size;
         let new = match cmd {
             TerminalFontSizeCommand::Increase => (cur + 1.0).min(40.0),
@@ -3214,7 +3218,7 @@ pub fn handle_terminal_font_size(
         if new == cur {
             continue;
         }
-        settings.terminal.as_mut().unwrap().themes[idx].font_size = new;
+        terminal.themes[idx].font_size = new;
         saves.write(SettingsSaveRequest);
     }
 }
@@ -4876,6 +4880,46 @@ mod tests {
             .drain()
             .count();
         (size, saves)
+    }
+
+    #[test]
+    fn font_size_materializes_missing_default_theme() {
+        use bevy::ecs::message::Messages;
+        let mut settings = test_settings();
+        settings.terminal = Some(vmux_setting::TerminalSettings {
+            default_theme: "default".to_string(),
+            themes: Vec::new(),
+            ..Default::default()
+        });
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .insert_resource(settings)
+            .add_message::<TerminalFontSizeCommand>()
+            .add_message::<SettingsSaveRequest>()
+            .add_systems(Update, handle_terminal_font_size);
+        app.world_mut()
+            .resource_mut::<Messages<TerminalFontSizeCommand>>()
+            .write(TerminalFontSizeCommand::Increase);
+        app.update();
+
+        let terminal = app
+            .world()
+            .resource::<AppSettings>()
+            .terminal
+            .clone()
+            .unwrap();
+        let theme = terminal
+            .themes
+            .iter()
+            .find(|t| t.name == "default")
+            .expect("missing default theme must be materialized so zoom persists");
+        assert_eq!(theme.font_size, 15.0);
+        let saves = app
+            .world_mut()
+            .resource_mut::<Messages<SettingsSaveRequest>>()
+            .drain()
+            .count();
+        assert_eq!(saves, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`Cmd+-` / `Cmd+=` (zoom out/in) silently did nothing on terminal & agent panes.

## Root cause

The command path is fine — the log shows `Browser(View(ZoomOut))` issued and `TerminalFontSizeCommand` reaching `handle_terminal_font_size`. The failure is downstream:

A minimal `terminal: (...)` override in `settings.ron` (e.g. just `startup_dir`) replaces the **whole** embedded terminal section during merge (`merge_over_embedded` is section-level, not field-level), so `themes` deserializes to its `#[serde(default)]` **empty Vec**. In-memory: `default_theme = "default"`, `themes = []`.

Rendering survived because `resolve_theme` synthesizes a fallback theme. But `handle_terminal_font_size` looked the theme up directly:

```rust
let Some(idx) = terminal.themes.iter().position(|t| t.name == name) else {
    warn!("terminal font size: default theme '{name}' not in themes; cannot persist");
    continue;
};
```

→ `None` → warn → bail. Zoom no-op. The log was full of:

```
WARN vmux_terminal::plugin: terminal font size: default theme 'default' not in themes; cannot persist
```

## Fix

Materialize the active theme via `resolve_theme` (the same fallback the renderer already uses) when it's absent, then adjust + persist. It's the only theme reader that wasn't going through `resolve_theme`.

## Test

`font_size_materializes_missing_default_theme` reproduces a minimal config (empty `themes`) and asserts the theme is materialized, font size steps, and a save fires. All 7 `font_size` tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Font size changes are now saved even when the default terminal theme is missing, ensuring the setting persists correctly.
  * Missing default themes are now created automatically when applying a font size update, preventing the change from being ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->