### PR TITLE
fix(terminal): capture login-shell env under a pty for agent spawns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10211,6 +10211,7 @@ dependencies = [
  "libc",
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
+ "portable-pty",
  "rfd",
  "rkyv",
  "serde",

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ build-local: ensure-mac-deps ensure-package-deps
 	./scripts/build-mac-release.sh local
 
 local: build-local
-	@sha="$$(git rev-parse --short HEAD)" && \
+	@sha="$$(git rev-parse --short=7 HEAD)" && \
 	open "target/release/Vmux ($$sha).app"
 
 build-release: ensure-mac-deps ensure-package-deps

--- a/crates/vmux_terminal/Cargo.toml
+++ b/crates/vmux_terminal/Cargo.toml
@@ -22,6 +22,7 @@ bevy = { workspace = true }
 bevy_cef = { workspace = true }
 bevy_ecs = { workspace = true }
 bevy_reflect = { workspace = true }
+portable-pty = { workspace = true }
 rfd = { workspace = true }
 sysinfo = "0.38"
 tracing = "0.1"

--- a/crates/vmux_terminal/src/shell_env.rs
+++ b/crates/vmux_terminal/src/shell_env.rs
@@ -6,11 +6,35 @@
 //! inherits the daemon's environment — which is missing those vars when the
 //! daemon was started by launchd rather than from a shell. We capture the login
 //! shell's exported environment once and merge it into agent spawns.
+//!
+//! The capture runs the shell **under a pty**, in login + interactive mode, and
+//! reads the environment back between two sentinels. The pty matters: real shell
+//! configs routinely call commands that need a controlling terminal (e.g.
+//! `$env.GPG_TTY = (tty)` in `env.nu`, `tput`/`[[ -t 0 ]]` guards in `.zshrc`).
+//! Without a pty those abort or skip, dropping every export that follows. Each
+//! shell sources its own config files, so this works for zsh, bash, fish, and
+//! nushell alike.
 
 use std::collections::HashSet;
+use std::io::Read;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::sync::OnceLock;
+use std::sync::mpsc;
+use std::time::Duration;
+
+use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
+
+/// Markers the capture command prints around `/usr/bin/env` output so we can
+/// recover the environment from a pty stream that also carries shell banners,
+/// prompts, and control sequences. The random suffix avoids colliding with a
+/// real environment value.
+const ENV_BEGIN: &str = "__VMUX_LOGIN_ENV_BEGIN_7Qz9__";
+const ENV_END: &str = "__VMUX_LOGIN_ENV_END_7Qz9__";
+
+/// How long to wait for the login shell to source its config and dump the
+/// environment before giving up (a misbehaving config could block forever).
+const CAPTURE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// The environment the user's login shell exports, captured once per process.
 pub fn login_shell_env(shell: &str) -> &'static [(String, String)] {
@@ -28,32 +52,147 @@ pub fn merge_login_shell_env(env: &mut Vec<(String, String)>, shell: &str) {
     dedup_env_keep_last(env);
 }
 
-/// Run the login shell so it sources its config (where exports live), then dump
-/// the environment it hands to child processes. Shell-specific flags: nushell
-/// auto-loads `env.nu` with a plain `-c` (and `-l -i` can suppress it), while
-/// POSIX-style shells (bash/zsh) and fish need `-l -i` to source their login +
-/// interactive config. Returns empty on any failure (callers keep their env).
+/// Run the login shell under a pty so it sources its config (where exports
+/// live), then dump the environment it hands to child processes. Returns empty
+/// on any failure (callers keep their env).
 fn capture_login_shell_env(shell: &str) -> Vec<(String, String)> {
+    capture_via_pty(shell).unwrap_or_default()
+}
+
+/// Spawn `shell` on a pty with the per-shell capture arguments, read its output
+/// until EOF (or the timeout elapses), and parse the environment dumped between
+/// the sentinels. `None` on any spawn/read failure or timeout.
+fn capture_via_pty(shell: &str) -> Option<Vec<(String, String)>> {
+    let args = shell_capture_args(shell);
+
+    let pty_system = NativePtySystem::default();
+    let pair = pty_system
+        .openpty(PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .ok()?;
+
+    let mut cmd = CommandBuilder::new(shell);
+    cmd.args(&args);
+    for (key, value) in std::env::vars() {
+        cmd.env(key, value);
+    }
+    cmd.env("TERM", "xterm-256color");
+    if let Some(home) = std::env::var_os("HOME") {
+        cmd.cwd(home);
+    }
+
+    let mut child = pair.slave.spawn_command(cmd).ok()?;
+    let reader = pair.master.try_clone_reader().ok()?;
+    drop(pair.slave);
+
+    let (tx, rx) = mpsc::channel();
+    std::thread::Builder::new()
+        .name("login-shell-env-capture".to_string())
+        .spawn(move || {
+            let mut reader = reader;
+            let mut buf = Vec::new();
+            let _ = reader.read_to_end(&mut buf);
+            let _ = tx.send(buf);
+        })
+        .ok()?;
+
+    let bytes = match rx.recv_timeout(CAPTURE_TIMEOUT) {
+        Ok(buf) => buf,
+        Err(_) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+    };
+    let _ = child.wait();
+
+    Some(extract_env_between_sentinels(&bytes))
+}
+
+/// Per-shell arguments that source the shell's config and print the environment
+/// fenced by [`ENV_BEGIN`]/[`ENV_END`]. nushell does not load `env.nu`/`config.nu`
+/// with a bare `-c`, so it is pointed at them explicitly (`-l` if the paths can't
+/// be resolved); POSIX-style shells and fish need `-l -i` to source their login +
+/// interactive config.
+fn shell_capture_args(shell: &str) -> Vec<String> {
     let base = Path::new(shell)
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or(shell);
-    let args: &[&str] = match base {
-        "nu" | "nushell" => &["-c", "/usr/bin/env"],
-        _ => &["-l", "-i", "-c", "/usr/bin/env"],
-    };
-    let Ok(output) = Command::new(shell)
-        .args(args)
+    match base {
+        "nu" | "nushell" => {
+            let command = format!("print '{ENV_BEGIN}'; /usr/bin/env; print '{ENV_END}'");
+            match resolve_nu_config_paths(shell) {
+                Some((env_path, config_path)) => vec![
+                    "--env-config".to_string(),
+                    env_path,
+                    "--config".to_string(),
+                    config_path,
+                    "-c".to_string(),
+                    command,
+                ],
+                None => vec!["-l".to_string(), "-c".to_string(), command],
+            }
+        }
+        _ => {
+            let command =
+                format!("printf '%s\\n' '{ENV_BEGIN}'; /usr/bin/env; printf '%s\\n' '{ENV_END}'");
+            vec![
+                "-l".to_string(),
+                "-i".to_string(),
+                "-c".to_string(),
+                command,
+            ]
+        }
+    }
+}
+
+/// Resolve nushell's active `env.nu` and `config.nu` paths via `$nu.env-path` /
+/// `$nu.config-path` (parse-time constants, so a bare `-c` suffices and sources
+/// nothing). `None` if either path can't be read.
+fn resolve_nu_config_paths(shell: &str) -> Option<(String, String)> {
+    let output = Command::new(shell)
+        .args(["-c", "[$nu.env-path $nu.config-path] | to text"])
         .stdin(Stdio::null())
         .stderr(Stdio::null())
         .output()
-    else {
-        return Vec::new();
-    };
+        .ok()?;
     if !output.status.success() {
-        return Vec::new();
+        return None;
     }
-    parse_env(&output.stdout)
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut lines = text.lines().map(str::trim).filter(|line| !line.is_empty());
+    let env_path = lines.next()?.to_string();
+    let config_path = lines.next()?.to_string();
+    Some((env_path, config_path))
+}
+
+/// Collect the `KEY=VALUE` lines that appear between [`ENV_BEGIN`] and
+/// [`ENV_END`] in pty output, ignoring banners/prompts/control sequences outside
+/// the fence. Marker detection is substring-based so a prompt printed on the
+/// same line as the marker doesn't hide it.
+fn extract_env_between_sentinels(bytes: &[u8]) -> Vec<(String, String)> {
+    let text = String::from_utf8_lossy(bytes);
+    let mut started = false;
+    let mut body = String::new();
+    for line in text.lines() {
+        if !started {
+            if line.contains(ENV_BEGIN) {
+                started = true;
+            }
+            continue;
+        }
+        if line.contains(ENV_END) {
+            break;
+        }
+        body.push_str(line);
+        body.push('\n');
+    }
+    parse_env(body.as_bytes())
 }
 
 /// Parse `KEY=VALUE` lines from `env` output. Splits on the first `=` and skips
@@ -115,6 +254,51 @@ mod tests {
                 ("ANTHROPIC_FOUNDRY_API_KEY".to_string(), "fresh".to_string()),
                 ("PATH".to_string(), "/login/bin".to_string()),
             ]
+        );
+    }
+
+    #[test]
+    fn extract_env_ignores_noise_outside_sentinels() {
+        let raw = format!(
+            "Welcome banner\r\nuser@host prompt $\r\n{ENV_BEGIN}\r\nPATH=/usr/bin:/bin\r\nFOO=bar\r\n{ENV_END}\r\nexit noise\r\n"
+        );
+        assert_eq!(
+            extract_env_between_sentinels(raw.as_bytes()),
+            vec![
+                ("PATH".to_string(), "/usr/bin:/bin".to_string()),
+                ("FOO".to_string(), "bar".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_env_finds_marker_with_prompt_prefix() {
+        // An interactive shell may print a prompt on the same line as the marker.
+        let raw = format!("host% {ENV_BEGIN}\nKEY=val\n{ENV_END}\n");
+        assert_eq!(
+            extract_env_between_sentinels(raw.as_bytes()),
+            vec![("KEY".to_string(), "val".to_string())]
+        );
+    }
+
+    #[test]
+    fn extract_env_without_markers_is_empty() {
+        let raw = b"PATH=/usr/bin\nFOO=bar\n";
+        assert!(extract_env_between_sentinels(raw).is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pty_capture_reads_env_from_login_shell() {
+        let shell = ["/bin/zsh", "/bin/bash", "/bin/sh"]
+            .into_iter()
+            .find(|path| Path::new(path).exists())
+            .expect("a POSIX login shell should exist on unix");
+        let env = capture_login_shell_env(shell);
+        assert!(
+            env.iter().any(|(key, _)| key == "PATH"),
+            "expected PATH in env captured from {shell}, got {} vars",
+            env.len()
         );
     }
 }

--- a/crates/vmux_terminal/src/shell_env.rs
+++ b/crates/vmux_terminal/src/shell_env.rs
@@ -75,6 +75,8 @@ fn capture_via_pty(shell: &str) -> Option<Vec<(String, String)>> {
         })
         .ok()?;
 
+    let reader = pair.master.try_clone_reader().ok()?;
+
     let mut cmd = CommandBuilder::new(shell);
     cmd.args(&args);
     for (key, value) in std::env::vars() {
@@ -86,11 +88,10 @@ fn capture_via_pty(shell: &str) -> Option<Vec<(String, String)>> {
     }
 
     let mut child = pair.slave.spawn_command(cmd).ok()?;
-    let reader = pair.master.try_clone_reader().ok()?;
     drop(pair.slave);
 
     let (tx, rx) = mpsc::channel();
-    std::thread::Builder::new()
+    if std::thread::Builder::new()
         .name("login-shell-env-capture".to_string())
         .spawn(move || {
             let mut reader = reader;
@@ -98,7 +99,12 @@ fn capture_via_pty(shell: &str) -> Option<Vec<(String, String)>> {
             let _ = reader.read_to_end(&mut buf);
             let _ = tx.send(buf);
         })
-        .ok()?;
+        .is_err()
+    {
+        let _ = child.kill();
+        let _ = child.wait();
+        return None;
+    }
 
     let bytes = match rx.recv_timeout(CAPTURE_TIMEOUT) {
         Ok(buf) => buf,
@@ -273,7 +279,6 @@ mod tests {
 
     #[test]
     fn extract_env_finds_marker_with_prompt_prefix() {
-        // An interactive shell may print a prompt on the same line as the marker.
         let raw = format!("host% {ENV_BEGIN}\nKEY=val\n{ENV_END}\n");
         assert_eq!(
             extract_env_between_sentinels(raw.as_bytes()),


### PR DESCRIPTION
## Context

Agents (claude/codex/vibe) launch as bare executables, so they inherit the daemon environment rather than a shell that sourced the user's config. When vmux is started from Finder/launchd (production) that environment is minimal — the user's exported vars (API keys, model config, `PATH` additions) are absent — so e.g. Claude Code in an agent pane shows **"Not logged in"**. Launching via `make` from a terminal masked the bug because the app inherited the already-sourced shell env.

`shell_env.rs` was meant to recover this, but had two compounding bugs:

1. **`nu -c` never sources `env.nu`.** For nushell the capture ran `nu -c "/usr/bin/env"`, which loads no config — so zero of the user's `env.nu` exports were captured. (The correct mechanism is `--env-config`/`--config`.)
2. **No controlling tty aborts the capture.** Common config lines need a terminal — e.g. `$env.GPG_TTY = (tty)` in `env.nu`, or `tput`/`[[ -t 0 ]]` guards in `.zshrc`. Run without a pty, `(tty)` errors and aborts the whole file, dropping every export after it.

## Implementation

Capture now runs the login shell **under a pty**, in login + interactive mode, and reads the environment back fenced between two sentinels (so banners/prompts/control sequences outside the fence are ignored). The pty makes tty-dependent config succeed instead of aborting.

Per-shell, each sources its own config files:

- **zsh / bash / fish / sh** → `-l -i -c` (login + interactive rc: `~/.zshrc`, `~/.bash_profile`, `config.fish`, …)
- **nushell** → `--env-config <env.nu> --config <config.nu>` resolved from `$nu.env-path`/`$nu.config-path` (so both `env.nu` and `config.nu` load); `-l` fallback if paths can't be resolved.

Result is captured once (`OnceLock`) and merged into agent spawns (shell values win). A 10s timeout + child-kill guards against a config that blocks. Failure returns empty, so callers keep their existing env (no regression vs. today).

## Checks / QA

- `cargo test -p vmux_terminal shell_env` — 6 pass, incl. an end-to-end pty smoke test that captures a real login shell and asserts `PATH` is present.
- Runtime (production build, nushell default): open an agent pane → Claude Code is logged in; `env.nu` exports (e.g. `ANTHROPIC_*`, `CLAUDE_CODE_*`) are present.
- Cross-shell: set the terminal shell to zsh / bash / fish and confirm an agent pane sees vars exported from that shell's rc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved login-shell environment capture by running shells in a pseudo-terminal for more consistent cross-shell behavior.

* **Bug Fixes**
  * More accurately extracts `KEY=VALUE` pairs from the intended output section, ignoring unrelated prompts/banners.
  * Returns the existing environment when capture fails or times out.

* **Tests**
  * Added unit and Unix-style integration coverage for fence-based parsing and `PATH` extraction.

* **Chores**
  * Updated the local build version stamp to use a 7-character Git SHA.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->