### PR TITLE
fix(terminal): render backgrounds via overlay only

### DIFF
--- a/crates/vmux_terminal/src/render_model.rs
+++ b/crates/vmux_terminal/src/render_model.rs
@@ -18,7 +18,7 @@ fn effective_colors(span: &TermSpan) -> (&TermColor, &TermColor) {
 pub fn span_classes(span: &TermSpan) -> String {
     let mut classes = Vec::new();
 
-    let (fg, bg) = effective_colors(span);
+    let (fg, _) = effective_colors(span);
 
     match fg {
         TermColor::Default => {
@@ -27,16 +27,6 @@ pub fn span_classes(span: &TermSpan) -> String {
             }
         }
         TermColor::Indexed(i) => classes.push(format!("text-ansi-{i}")),
-        TermColor::Rgb(..) => {}
-    }
-
-    match bg {
-        TermColor::Default => {
-            if span.flags & FLAG_INVERSE != 0 {
-                classes.push("bg-term-fg".into());
-            }
-        }
-        TermColor::Indexed(i) => classes.push(format!("bg-ansi-{i}")),
         TermColor::Rgb(..) => {}
     }
 
@@ -62,13 +52,10 @@ pub fn span_classes(span: &TermSpan) -> String {
 pub fn span_inline_style(span: &TermSpan) -> String {
     let mut parts = Vec::new();
 
-    let (fg, bg) = effective_colors(span);
+    let (fg, _) = effective_colors(span);
 
     if let TermColor::Rgb(r, g, b) = fg {
         parts.push(format!("color:rgb({r},{g},{b})"));
-    }
-    if let TermColor::Rgb(r, g, b) = bg {
-        parts.push(format!("background:rgb({r},{g},{b})"));
     }
 
     parts.join(";")
@@ -221,5 +208,29 @@ mod tests {
 
         assert!(overlay.class.contains("bg-ansi-4"));
         assert!(overlay.style.contains("width:calc(var(--cw, 1ch) * 80)"));
+    }
+
+    #[test]
+    fn rgb_background_renders_only_in_overlay() {
+        let span = TermSpan {
+            text: "selected".into(),
+            bg: TermColor::Rgb(32, 80, 160),
+            ..TermSpan::default()
+        };
+
+        assert!(!span_inline_style(&span).contains("background:"));
+        assert!(span_background_overlay(&span).is_some());
+    }
+
+    #[test]
+    fn indexed_background_renders_only_in_overlay() {
+        let span = TermSpan {
+            text: "selected".into(),
+            bg: TermColor::Indexed(4),
+            ..TermSpan::default()
+        };
+
+        assert!(!span_classes(&span).contains("bg-ansi-4"));
+        assert!(span_background_overlay(&span).is_some());
     }
 }

--- a/crates/vmux_terminal/src/render_model.rs
+++ b/crates/vmux_terminal/src/render_model.rs
@@ -233,4 +233,16 @@ mod tests {
         assert!(!span_classes(&span).contains("bg-ansi-4"));
         assert!(span_background_overlay(&span).is_some());
     }
+
+    #[test]
+    fn inverse_default_background_renders_only_in_overlay() {
+        let span = TermSpan {
+            text: "selected".into(),
+            flags: FLAG_INVERSE,
+            ..TermSpan::default()
+        };
+
+        assert!(!span_classes(&span).contains("bg-term-fg"));
+        assert!(span_background_overlay(&span).is_some());
+    }
 }


### PR DESCRIPTION
## Context
Terminal spans were painting cell backgrounds twice: once on the inline text span and once through the absolute row overlay. In agent scrollback, that left the prompt background band visually detached from the scrolling text.

## Implementation
Inline span classes/styles now only describe foreground/text attributes. Background color stays in the positioned overlay path, keeping one DOM owner for cell background geometry. Regression coverage asserts RGB and indexed backgrounds render only through the overlay.

## Checks / QA
- Open a Claude agent pane.
- Print enough output to create scrollback.
- Scroll upward and confirm prompt block backgrounds move with their text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal text rendering so background coloring is handled exclusively via the background overlay layer.
  * Prevented RGB and indexed background color details from appearing in text styling; foreground styling remains unchanged.
* **Tests**
  * Extended end-to-end coverage to confirm RGB and indexed background colors (and inverse default background) render correctly via the overlay and do not leak into inline/text CSS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->