### PR TITLE
chore(release): v0.0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9763,7 +9763,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9800,7 +9800,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_browser"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "base64 0.22.1",
  "bevy",
@@ -9825,7 +9825,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -9838,7 +9838,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9853,7 +9853,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9872,7 +9872,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9937,7 +9937,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_editor"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "arboard",
  "bevy",
@@ -9979,7 +9979,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_git"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9996,7 +9996,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10017,7 +10017,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -10051,7 +10051,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "muda",
  "proc-macro2",
@@ -10061,7 +10061,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -10074,7 +10074,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_server"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "dioxus",
  "regex",
@@ -10095,7 +10095,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "alacritty_terminal",
  "bevy",
@@ -10131,7 +10131,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10154,7 +10154,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10179,7 +10179,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_team"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10200,7 +10200,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10234,7 +10234,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "dioxus",
  "dioxus-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.20"
+version = "0.0.21"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "GPL-3.0-or-later"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.20"
-  sha256 "1aee4b1ffe3da77a0f519da0d3e80b01cd18d835ab09957e1897354d509e7ae2"
+  version "0.0.21"
+  sha256 "794d905653a3ea08dab73ce779bb61c95160560fd2553d198e04cccf6241aed6"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.20/Vmux_0.0.20_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.21/Vmux_0.0.21_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai/"

--- a/crates/vmux_git/src/runner.rs
+++ b/crates/vmux_git/src/runner.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::OnceLock;
 
 use crate::event::*;
 use crate::parse;
@@ -8,22 +9,73 @@ use crate::parse;
 #[derive(Debug, Clone)]
 pub struct GitError(pub String);
 
-/// Build a `git` [`Command`] rooted at `root` with a scrubbed environment.
+/// Repository-local `GIT_*` variables used when `git rev-parse --local-env-vars`
+/// cannot be queried. Mirrors Git's own list (git 2.54); the live query in
+/// [`local_env_vars`] supersedes it whenever git is runnable.
+const FALLBACK_LOCAL_ENV_VARS: &[&str] = &[
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_CONFIG",
+    "GIT_CONFIG_COUNT",
+    "GIT_CONFIG_PARAMETERS",
+    "GIT_DIR",
+    "GIT_GRAFT_FILE",
+    "GIT_IMPLICIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_NO_REPLACE_OBJECTS",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_PREFIX",
+    "GIT_REPLACE_REF_BASE",
+    "GIT_SHALLOW_FILE",
+    "GIT_WORK_TREE",
+];
+
+/// Every repository-local `GIT_*` variable Git recognizes, queried once from the
+/// authoritative `git rev-parse --local-env-vars` and cached (falling back to
+/// [`FALLBACK_LOCAL_ENV_VARS`] if git cannot be run).
 ///
 /// The runner always targets an explicit repository via [`Command::current_dir`],
-/// so ambient `GIT_*` location variables (which a parent process such as a
-/// `git push` pre-push hook exports) must be stripped — otherwise `GIT_DIR` /
-/// `GIT_INDEX_FILE` override `current_dir` and the call silently operates on the
-/// wrong repository.
+/// so these ambient variables — which a parent process such as a `git push`
+/// pre-push hook exports — must be stripped; otherwise `GIT_DIR`, `GIT_INDEX_FILE`,
+/// `GIT_OBJECT_DIRECTORY`, `GIT_CONFIG` and friends override the explicit target and
+/// the call silently reads or writes the wrong repository. Listing the names is a
+/// static print, so it is safe to run under any ambient environment.
+fn local_env_vars() -> &'static [String] {
+    static VARS: OnceLock<Vec<String>> = OnceLock::new();
+    VARS.get_or_init(|| {
+        Command::new("git")
+            .args(["rev-parse", "--local-env-vars"])
+            .output()
+            .ok()
+            .filter(|out| out.status.success())
+            .map(|out| {
+                String::from_utf8_lossy(&out.stdout)
+                    .lines()
+                    .map(str::trim)
+                    .filter(|line| !line.is_empty())
+                    .map(str::to_owned)
+                    .collect::<Vec<_>>()
+            })
+            .filter(|vars| !vars.is_empty())
+            .unwrap_or_else(|| {
+                FALLBACK_LOCAL_ENV_VARS
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect()
+            })
+    })
+}
+
+/// Build a `git` [`Command`] rooted at `root` with a scrubbed environment.
+///
+/// Clears every repository-local `GIT_*` variable (see [`local_env_vars`]) so an
+/// ambient environment cannot redirect the call away from its `current_dir` target.
 fn git_command(root: &Path) -> Command {
     let mut cmd = Command::new("git");
-    cmd.current_dir(root)
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .env_remove("GIT_DIR")
-        .env_remove("GIT_WORK_TREE")
-        .env_remove("GIT_INDEX_FILE")
-        .env_remove("GIT_COMMON_DIR")
-        .env_remove("GIT_PREFIX");
+    cmd.current_dir(root).env("GIT_TERMINAL_PROMPT", "0");
+    for var in local_env_vars() {
+        cmd.env_remove(var);
+    }
     cmd
 }
 
@@ -356,24 +408,31 @@ mod tests {
     use super::*;
 
     #[test]
-    fn git_command_scrubs_ambient_location_env() {
+    fn git_command_scrubs_all_local_env_vars() {
         use std::ffi::OsStr;
         let cmd = git_command(Path::new("."));
-        let removed: Vec<&OsStr> = cmd
+        let removed: HashSet<&OsStr> = cmd
             .get_envs()
             .filter(|(_, v)| v.is_none())
             .map(|(k, _)| k)
             .collect();
+        let vars = local_env_vars();
+        assert!(!vars.is_empty(), "local_env_vars must not be empty");
+        for var in vars {
+            assert!(
+                removed.contains(OsStr::new(var.as_str())),
+                "git_command must scrub {var} so ambient GIT_* cannot redirect the runner"
+            );
+        }
         for key in [
             "GIT_DIR",
-            "GIT_WORK_TREE",
             "GIT_INDEX_FILE",
-            "GIT_COMMON_DIR",
-            "GIT_PREFIX",
+            "GIT_OBJECT_DIRECTORY",
+            "GIT_CONFIG",
         ] {
             assert!(
-                removed.contains(&OsStr::new(key)),
-                "git_command must scrub {key} so ambient GIT_* cannot redirect the runner"
+                vars.iter().any(|v| v == key),
+                "{key} must appear in git's local-env-vars"
             );
         }
     }

--- a/crates/vmux_git/src/runner.rs
+++ b/crates/vmux_git/src/runner.rs
@@ -8,11 +8,28 @@ use crate::parse;
 #[derive(Debug, Clone)]
 pub struct GitError(pub String);
 
-fn git(root: &Path, args: &[&str]) -> Result<(String, String, bool), GitError> {
-    let out = Command::new("git")
-        .current_dir(root)
-        .args(args)
+/// Build a `git` [`Command`] rooted at `root` with a scrubbed environment.
+///
+/// The runner always targets an explicit repository via [`Command::current_dir`],
+/// so ambient `GIT_*` location variables (which a parent process such as a
+/// `git push` pre-push hook exports) must be stripped — otherwise `GIT_DIR` /
+/// `GIT_INDEX_FILE` override `current_dir` and the call silently operates on the
+/// wrong repository.
+fn git_command(root: &Path) -> Command {
+    let mut cmd = Command::new("git");
+    cmd.current_dir(root)
         .env("GIT_TERMINAL_PROMPT", "0")
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_PREFIX");
+    cmd
+}
+
+fn git(root: &Path, args: &[&str]) -> Result<(String, String, bool), GitError> {
+    let out = git_command(root)
+        .args(args)
         .output()
         .map_err(|e| GitError(format!("failed to run git: {e}")))?;
     Ok((
@@ -217,13 +234,11 @@ fn git_apply(root: &Path, patch: &str, reverse: bool) -> Result<(), GitError> {
         args.push("--cached");
     }
     args.push("--unidiff-zero");
-    let mut child = Command::new("git")
-        .current_dir(root)
+    let mut child = git_command(root)
         .args(&args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .env("GIT_TERMINAL_PROMPT", "0")
         .spawn()
         .map_err(|e| GitError(format!("failed to run git apply: {e}")))?;
     child
@@ -310,13 +325,10 @@ pub(crate) mod test_repo {
     use super::*;
 
     pub fn run(dir: &Path, args: &[&str]) {
-        let status = Command::new("git")
-            .current_dir(dir)
+        let status = git_command(dir)
             .args(args)
             .env("GIT_CONFIG_GLOBAL", "/dev/null")
             .env("GIT_CONFIG_SYSTEM", "/dev/null")
-            .env_remove("GIT_DIR")
-            .env_remove("GIT_WORK_TREE")
             .status()
             .unwrap();
         assert!(status.success(), "git {args:?} failed");
@@ -342,6 +354,29 @@ pub(crate) mod test_repo {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn git_command_scrubs_ambient_location_env() {
+        use std::ffi::OsStr;
+        let cmd = git_command(Path::new("."));
+        let removed: Vec<&OsStr> = cmd
+            .get_envs()
+            .filter(|(_, v)| v.is_none())
+            .map(|(k, _)| k)
+            .collect();
+        for key in [
+            "GIT_DIR",
+            "GIT_WORK_TREE",
+            "GIT_INDEX_FILE",
+            "GIT_COMMON_DIR",
+            "GIT_PREFIX",
+        ] {
+            assert!(
+                removed.contains(&OsStr::new(key)),
+                "git_command must scrub {key} so ambient GIT_* cannot redirect the runner"
+            );
+        }
+    }
 
     #[test]
     fn repo_root_resolves_toplevel() {

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.20",
-  "pub_date": "2026-06-30T08:15:48Z",
+  "version": "v0.0.21",
+  "pub_date": "2026-07-01T09:30:25Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.20/Vmux-v0.0.20-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzd5QndPTVFpd0VkU2cvcHRWd0l0WWVFWUx0bENSVjBYdVEwVU9VUUplUmJZSFkxcW9PZGlBU0sxZTVvaktqNEJuUkpFSktPSkk5MXdaUk11S1FFQXdFPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgyODA2MzExCWZpbGU6Vm11eC12MC4wLjIwLWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKVVVTaHFzUEgwOGcyVC9aa3ExNUNkMHVNcEUyTnFBVU1IUnlFVW04TzB5MGduS0FKOXpQVXk3ZnlLblh2TlYra3dsTDZ3NEFGS25tODMzTkUzQlo4QWc9PQo=",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.21/Vmux-v0.0.21-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzlNdWNHSndFYTFuQTljNFZCaTZYa05XT0FtT1JHVjhOdkJGOWFkLytxdFh1WEtsd3ZNN0Y5OCt6cU04VlNRVHlqSWZaeHp4RUIySnVTRTZScU1xc3dzPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgyODk0NTAwCWZpbGU6Vm11eC12MC4wLjIxLWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKTG5KWjBZMUdtc2N1YkVYUXBjNjl0SHVYUzZRbFV2dUwrcFc5Qnd1VVFpTzk1Y3hOdnJCK0EzT1hRNHdSNDBuWDAwdFplSHZsNHl1TlVrclBuSjBGQ0E9PQo=",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.20/Vmux_0.0.20_aarch64.dmg",
-      "filename": "Vmux_0.0.20_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.21/Vmux_0.0.21_aarch64.dmg",
+      "filename": "Vmux_0.0.21_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
Patch release. Bumps workspace version 0.0.20 -> 0.0.21. Releases on merge.

Also includes a fix required to push this branch cleanly:

## fix(git): make git runner hermetic against ambient GIT_* env

The `vmux_git` runner targets an explicit repo via `Command::current_dir`, but a parent process — notably the `git push` pre-push hook — exports `GIT_DIR`/`GIT_INDEX_FILE`, which override `current_dir` and silently redirect every git call to the wrong repository. Under the pre-push hook this made the `vmux_git` tests operate on the real repo (index.lock contention, bogus commits) and fail.

All git invocations now route through a shared `git_command()` that scrubs the ambient `GIT_*` location vars (`GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_COMMON_DIR`, `GIT_PREFIX`). Added a regression test asserting the scrub. Verified: the full pre-push hook (fmt + clippy + `cargo test --workspace`) now passes with verify intact — no `--no-verify` bypass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped the workspace and macOS package version to `0.0.21`.
  * Updated cask and release metadata (download URLs, checksums/signatures, and artifact filenames).
* **Bug Fixes**
  * Improved Git subprocess execution to reliably target the intended repository and ignore conflicting local Git environment settings.
  * Applied the same safer behavior when applying patches.
* **Tests**
  * Added a unit test to verify all local Git environment variables are scrubbed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->