### PR TITLE
fix(agent): stabilize pane placement

### DIFF
--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -59,6 +59,63 @@ pub struct AgentExecutableOverride(pub std::collections::HashMap<AgentKind, bool
 #[derive(Resource, Default)]
 pub struct AgentTerminalRegions {
     pub run_terminals: std::collections::HashMap<ProcessId, ProcessId>,
+    pub run_panes: std::collections::HashMap<ProcessId, Entity>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct RunTerminalCandidate {
+    pid: ProcessId,
+    pane: Entity,
+    pane_spawn_seq: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct RunTerminalBucketPaneCandidate {
+    pane: Entity,
+    pane_spawn_seq: u64,
+}
+
+fn choose_reusable_run_terminal(
+    anchor: ProcessId,
+    agent_pane: Entity,
+    regions: &AgentTerminalRegions,
+    candidates: &[RunTerminalCandidate],
+) -> Option<RunTerminalCandidate> {
+    if let Some(pid) = regions.run_terminals.get(&anchor)
+        && let Some(candidate) = candidates.iter().find(|c| c.pid == *pid)
+    {
+        return Some(*candidate);
+    }
+    if let Some(pane) = regions.run_panes.get(&anchor)
+        && let Some(candidate) = candidates
+            .iter()
+            .filter(|c| c.pane == *pane)
+            .max_by_key(|c| c.pane_spawn_seq)
+    {
+        return Some(*candidate);
+    }
+    candidates
+        .iter()
+        .filter(|c| c.pane != agent_pane)
+        .max_by_key(|c| c.pane_spawn_seq)
+        .copied()
+}
+
+fn choose_run_terminal_bucket_pane(
+    anchor: ProcessId,
+    agent_pane: Entity,
+    regions: &AgentTerminalRegions,
+    candidates: &[RunTerminalCandidate],
+) -> Option<Entity> {
+    choose_reusable_run_terminal(anchor, agent_pane, regions, candidates)
+        .map(|c| c.pane)
+        .or_else(|| {
+            regions
+                .run_panes
+                .get(&anchor)
+                .copied()
+                .filter(|pane| *pane != agent_pane)
+        })
 }
 
 fn resolve_agent_executable(
@@ -108,6 +165,7 @@ impl Plugin for AgentPlugin {
             .init_resource::<AgentTerminalRegions>()
             .init_resource::<AgentSessionDirty>()
             .init_resource::<NavAwaitingSnapshot>()
+            .init_resource::<vmux_layout::pane::SpawnCounter>()
             .add_message::<AgentCommandRequest>()
             .add_message::<FocusPaneRequest>()
             .add_message::<RenameProfileRequest>()
@@ -310,6 +368,7 @@ struct ProcessStackSpawnRequest {
     args: Vec<String>,
     cwd: PathBuf,
     env: Vec<(String, String)>,
+    activate: bool,
 }
 
 #[derive(Message, Clone)]
@@ -352,6 +411,46 @@ fn handle_rename_profile_requests(
             Err(error) => warn!("rename_profile: failed to persist display name: {error}"),
         }
     }
+}
+
+fn origin_is_agent(origin: &CommandOrigin) -> bool {
+    matches!(origin, CommandOrigin::Agent { .. })
+}
+
+fn requested_focus_for_origin(origin: &CommandOrigin, requested: bool) -> bool {
+    requested && !origin_is_agent(origin)
+}
+
+fn focused_id(kind: vmux_layout::protocol::NodeKind, entity: Option<Entity>) -> Option<String> {
+    entity.map(|entity| vmux_layout::protocol::format_id(kind, entity.to_bits()))
+}
+
+fn preserve_current_focus_in_layout_snapshot(
+    snapshot: &mut vmux_service::protocol::layout::LayoutSnapshot,
+    focus: &FocusedStack,
+) {
+    snapshot.focused = vmux_service::protocol::layout::Focus {
+        tab: focused_id(vmux_layout::protocol::NodeKind::Tab, focus.tab),
+        pane: focused_id(vmux_layout::protocol::NodeKind::Pane, focus.pane),
+        stack: focused_id(vmux_layout::protocol::NodeKind::Stack, focus.stack),
+    };
+    if let Some(tab) = snapshot.focused.tab.as_deref() {
+        for item in &mut snapshot.tabs {
+            item.is_active = item.id.as_deref() == Some(tab);
+        }
+    }
+}
+
+fn agent_may_dispatch_app_command(command: &AppCommand) -> bool {
+    !matches!(
+        command,
+        AppCommand::Layout(_)
+            | AppCommand::Browser(vmux_command::BrowserCommand::Open(_))
+            | AppCommand::Browser(vmux_command::BrowserCommand::Bar(_))
+            | AppCommand::Service(vmux_command::ServiceCommand::Open)
+            | AppCommand::Terminal(vmux_command::TerminalCommand::Next)
+            | AppCommand::Terminal(vmux_command::TerminalCommand::Previous)
+    )
 }
 
 #[derive(bevy::ecs::system::SystemParam)]
@@ -564,6 +663,8 @@ pub(crate) struct AgentBrowserResolve<'w, 's> {
         ),
     >,
     child_of: Query<'w, 's, &'static ChildOf>,
+    pane_children: Query<'w, 's, &'static Children, With<Pane>>,
+    stack_q: Query<'w, 's, Entity, With<vmux_layout::stack::Stack>>,
     browser_stacks: Query<'w, 's, &'static ChildOf, With<vmux_layout::Browser>>,
 }
 
@@ -575,20 +676,31 @@ impl AgentBrowserResolve<'_, '_> {
         use bevy::ecs::relationship::Relationship;
         let agent_parent = self.child_of.get(agent_pane).ok()?.get();
         for stack_co in self.browser_stacks.iter() {
-            let Ok(pane_co) = self.child_of.get(stack_co.get()) else {
-                continue;
-            };
-            let pane = pane_co.get();
+            let pane = stack_co.get();
             if pane == agent_pane {
                 continue;
             }
             if let Ok(parent_co) = self.child_of.get(pane)
                 && parent_co.get() == agent_parent
+                && self.pane_has_only_browser_stacks(pane)
             {
                 return Some(pane);
             }
         }
         None
+    }
+
+    fn pane_has_only_browser_stacks(&self, pane: Entity) -> bool {
+        self.pane_children
+            .get(pane)
+            .ok()
+            .map(|children| {
+                children
+                    .iter()
+                    .filter(|&child| self.stack_q.contains(child))
+                    .all(|child| self.browser_stacks.contains(child))
+            })
+            .unwrap_or(false)
     }
 
     /// The agent's own terminal pane (its stack's parent pane), from its anchor.
@@ -772,7 +884,7 @@ fn handle_agent_file_touch(
             direction: None,
             url: file_touch_url(path, *line, *col, *end_col),
             request_id: request.request_id.0,
-            focus: existing.is_some(),
+            focus: requested_focus_for_origin(&request.origin, existing.is_some()),
         });
         if let Some((_, pane)) = existing {
             let kind = resolve.agent_kind(*anchor);
@@ -842,18 +954,13 @@ fn handle_agent_commands(
                 };
                 match AppCommand::from_mcp_call(id, args) {
                     Some(Ok(command)) => {
-                        if let Some(caller) = caller {
-                            writers.issued.write(vmux_command::CommandIssued {
-                                caller,
-                                command: command.clone(),
-                            });
-                        }
-                        app_commands.write(command);
-                        AgentCommandResult::Ok
-                    }
-                    Some(Err(message)) => AgentCommandResult::Error(message),
-                    None => match AppCommand::from_mcp_id(id) {
-                        Some(command) => {
+                        if origin_is_agent(&request.origin)
+                            && !agent_may_dispatch_app_command(&command)
+                        {
+                            AgentCommandResult::Error(
+                                "focus-changing app command is disabled for agents".to_string(),
+                            )
+                        } else {
                             if let Some(caller) = caller {
                                 writers.issued.write(vmux_command::CommandIssued {
                                     caller,
@@ -862,6 +969,27 @@ fn handle_agent_commands(
                             }
                             app_commands.write(command);
                             AgentCommandResult::Ok
+                        }
+                    }
+                    Some(Err(message)) => AgentCommandResult::Error(message),
+                    None => match AppCommand::from_mcp_id(id) {
+                        Some(command) => {
+                            if origin_is_agent(&request.origin)
+                                && !agent_may_dispatch_app_command(&command)
+                            {
+                                AgentCommandResult::Error(
+                                    "focus-changing app command is disabled for agents".to_string(),
+                                )
+                            } else {
+                                if let Some(caller) = caller {
+                                    writers.issued.write(vmux_command::CommandIssued {
+                                        caller,
+                                        command: command.clone(),
+                                    });
+                                }
+                                app_commands.write(command);
+                                AgentCommandResult::Ok
+                            }
                         }
                         None => AgentCommandResult::Error(format!("unknown app command: {id}")),
                     },
@@ -877,6 +1005,7 @@ fn handle_agent_commands(
                 Some(pane) => match valid_cwd(cwd) {
                     Err(message) => AgentCommandResult::Error(message),
                     Ok(cwd_opt) => {
+                        let activate = !origin_is_agent(&request.origin);
                         let cwd_path = cwd_opt.unwrap_or_else(|| {
                             active_space
                                 .as_ref()
@@ -891,7 +1020,7 @@ fn handle_agent_commands(
                                 cwd: Some(cwd_path),
                                 pending_input: None,
                                 process_id: None,
-                                activate: true,
+                                activate,
                             });
                         } else {
                             process_stack_spawn_writer.write(ProcessStackSpawnRequest {
@@ -900,6 +1029,7 @@ fn handle_agent_commands(
                                 args: args.clone(),
                                 cwd: cwd_path,
                                 env: env.clone(),
+                                activate,
                             });
                         }
                         AgentCommandResult::Ok
@@ -981,10 +1111,14 @@ fn handle_agent_commands(
                 None => AgentCommandResult::Error("notify: caller not found".to_string()),
             },
             ServiceAgentCommand::FocusPane { pane } => {
-                writers
-                    .focus_pane
-                    .write(FocusPaneRequest { pane: pane.clone() });
-                AgentCommandResult::Ok
+                if origin_is_agent(&request.origin) {
+                    AgentCommandResult::Error("focus_pane is disabled for agents".to_string())
+                } else {
+                    writers
+                        .focus_pane
+                        .write(FocusPaneRequest { pane: pane.clone() });
+                    AgentCommandResult::Ok
+                }
             }
             ServiceAgentCommand::RenameProfile { name } => {
                 writers
@@ -1011,11 +1145,15 @@ fn handle_agent_commands(
                 }
             }
             ServiceAgentCommand::UpdateLayout { layout } => {
+                let mut layout = layout.clone();
+                if origin_is_agent(&request.origin) {
+                    preserve_current_focus_in_layout_snapshot(&mut layout, &focus);
+                }
                 writers
                     .layout_apply
                     .write(vmux_layout::reconcile::LayoutApplyRequest {
                         request_id: request.request_id.0,
-                        snapshot: layout.clone(),
+                        snapshot: layout,
                     });
                 continue;
             }
@@ -1090,6 +1228,156 @@ fn resolve_pane_for_pid(
     let stack = child_of_q.get(term).ok()?.get();
     let pane = child_of_q.get(stack).ok()?.get();
     Some(pane)
+}
+
+fn tab_of_run_pane(
+    pane: Entity,
+    child_of_q: &Query<&ChildOf>,
+    tab_q: &Query<Entity, With<vmux_layout::tab::Tab>>,
+) -> Option<Entity> {
+    use bevy::ecs::relationship::Relationship;
+    let mut cur = pane;
+    for _ in 0..32 {
+        if tab_q.contains(cur) {
+            return Some(cur);
+        }
+        cur = child_of_q.get(cur).ok()?.get();
+    }
+    None
+}
+
+fn run_terminal_candidates(
+    agent_pane: Entity,
+    terminals: &Query<
+        (Entity, &ProcessId),
+        (
+            With<Terminal>,
+            Without<AgentSession>,
+            Without<ProcessExited>,
+        ),
+    >,
+    child_of_q: &Query<&ChildOf>,
+    tab_q: &Query<Entity, With<vmux_layout::tab::Tab>>,
+    seq_q: &Query<&vmux_layout::pane::SpawnSeq>,
+) -> Vec<RunTerminalCandidate> {
+    use bevy::ecs::relationship::Relationship;
+    let Some(agent_tab) = tab_of_run_pane(agent_pane, child_of_q, tab_q) else {
+        return Vec::new();
+    };
+    terminals
+        .iter()
+        .filter_map(|(terminal, pid)| {
+            let stack = child_of_q.get(terminal).ok()?.get();
+            let pane = child_of_q.get(stack).ok()?.get();
+            if pane == agent_pane {
+                return None;
+            }
+            if tab_of_run_pane(pane, child_of_q, tab_q) != Some(agent_tab) {
+                return None;
+            }
+            Some(RunTerminalCandidate {
+                pid: *pid,
+                pane,
+                pane_spawn_seq: seq_q.get(pane).map(|s| s.0).unwrap_or(0),
+            })
+        })
+        .collect()
+}
+
+fn run_terminal_bucket_panes(
+    agent_pane: Entity,
+    child_of_q: &Query<&ChildOf>,
+    tab_q: &Query<Entity, With<vmux_layout::tab::Tab>>,
+    leaf_panes: &Query<Entity, (With<Pane>, Without<PaneSplit>)>,
+    pane_children: &Query<&Children, With<Pane>>,
+    stack_q: &Query<Entity, With<vmux_layout::stack::Stack>>,
+    page_q: &Query<&PageMetadata, With<vmux_layout::stack::Stack>>,
+    seq_q: &Query<&vmux_layout::pane::SpawnSeq>,
+) -> Vec<RunTerminalBucketPaneCandidate> {
+    let Some(agent_tab) = tab_of_run_pane(agent_pane, child_of_q, tab_q) else {
+        return Vec::new();
+    };
+    leaf_panes
+        .iter()
+        .filter_map(|pane| {
+            if pane == agent_pane {
+                return None;
+            }
+            if tab_of_run_pane(pane, child_of_q, tab_q) != Some(agent_tab) {
+                return None;
+            }
+            let children = pane_children.get(pane).ok()?;
+            let mut has_stack = false;
+            for stack in children.iter().filter(|&child| stack_q.contains(child)) {
+                has_stack = true;
+                let meta = page_q.get(stack).ok()?;
+                if vmux_layout::placement::page_kind_for_url(&meta.url)
+                    != vmux_layout::placement::PageKind::Terminal
+                {
+                    return None;
+                }
+            }
+            has_stack.then(|| RunTerminalBucketPaneCandidate {
+                pane,
+                pane_spawn_seq: seq_q.get(pane).map(|s| s.0).unwrap_or(0),
+            })
+        })
+        .collect()
+}
+
+fn newest_run_terminal_bucket_pane(
+    agent_pane: Entity,
+    candidates: &[RunTerminalBucketPaneCandidate],
+) -> Option<Entity> {
+    candidates
+        .iter()
+        .filter(|c| c.pane != agent_pane)
+        .max_by_key(|c| c.pane_spawn_seq)
+        .map(|c| c.pane)
+}
+
+fn is_run_terminal_bucket_pane(
+    pane: Entity,
+    candidates: &[RunTerminalBucketPaneCandidate],
+) -> bool {
+    candidates.iter().any(|c| c.pane == pane)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct PendingRunTerminalSpawn {
+    pid: ProcessId,
+    request_index: usize,
+}
+
+fn append_pending_run_terminal_input(
+    anchor: ProcessId,
+    pending_spawns: &std::collections::HashMap<ProcessId, PendingRunTerminalSpawn>,
+    terminal_spawns: &mut [TerminalStackSpawnRequest],
+    data: &[u8],
+) -> Option<ProcessId> {
+    let pending = pending_spawns.get(&anchor)?;
+    let request = terminal_spawns.get_mut(pending.request_index)?;
+    match &mut request.pending_input {
+        Some(input) => input.extend(data),
+        None => request.pending_input = Some(data.to_vec()),
+    }
+    Some(pending.pid)
+}
+
+fn touch_reused_run_pane_spawn_seq(
+    pane: Entity,
+    commands: &mut Commands,
+    spawn_counter: &mut vmux_layout::pane::SpawnCounter,
+    seq_q: &Query<&vmux_layout::pane::SpawnSeq>,
+) {
+    let max_existing = seq_q.iter().map(|s| s.0).max().unwrap_or(0);
+    if spawn_counter.0 <= max_existing {
+        spawn_counter.0 = max_existing;
+    }
+    spawn_counter.0 += 1;
+    commands
+        .entity(pane)
+        .insert(vmux_layout::pane::SpawnSeq(spawn_counter.0));
 }
 
 /// Split `pane` and return the new leaf pane. Batches several splits of the same
@@ -1185,6 +1473,14 @@ fn handle_agent_self_commands(
     mut reader: MessageReader<AgentCommandRequest>,
     agent_terms: Query<(Entity, &ProcessId, &ChildOf), With<AgentSession>>,
     term_pids: Query<(Entity, &ProcessId), With<Terminal>>,
+    run_terms: Query<
+        (Entity, &ProcessId),
+        (
+            With<Terminal>,
+            Without<AgentSession>,
+            Without<ProcessExited>,
+        ),
+    >,
     launch_q: Query<&TerminalLaunch>,
     ctx: vmux_layout::pane::PlacementCtx,
     mut open_beside_writer: MessageWriter<vmux_layout::OpenBesideRequest>,
@@ -1194,6 +1490,7 @@ fn handle_agent_self_commands(
     active_space: Option<Res<ActiveSpace>>,
     settings: Res<AppSettings>,
     mut regions: ResMut<AgentTerminalRegions>,
+    mut spawn_counter: ResMut<vmux_layout::pane::SpawnCounter>,
 ) {
     use vmux_service::protocol::{AgentCommandResult, ClientMessage};
     let Some(service) = service else {
@@ -1204,6 +1501,9 @@ fn handle_agent_self_commands(
     // resolve to the same agent pane; the first splits it, the rest must extend
     // that split rather than re-split the leaf (which would orphan empty panes).
     let mut split_this_batch: std::collections::HashSet<Entity> = std::collections::HashSet::new();
+    let mut terminal_spawns: Vec<TerminalStackSpawnRequest> = Vec::new();
+    let mut pending_run_spawns: std::collections::HashMap<ProcessId, PendingRunTerminalSpawn> =
+        std::collections::HashMap::new();
     for request in reader.read() {
         let result = match &request.command {
             ServiceAgentCommand::OpenBeside {
@@ -1214,12 +1514,13 @@ fn handle_agent_self_commands(
             } => match resolve_self_pane(*anchor, &agent_terms, &ctx.child_of_q) {
                 None => AgentCommandResult::Error("self process not found".to_string()),
                 Some((_, pane)) => {
+                    let focus = requested_focus_for_origin(&request.origin, *focus);
                     open_beside_writer.write(vmux_layout::OpenBesideRequest {
                         pane,
                         direction: direction.as_ref().map(to_pane_direction),
                         url: url.clone(),
                         request_id: request.request_id.0,
-                        focus: *focus,
+                        focus,
                     });
                     AgentCommandResult::Ok
                 }
@@ -1234,6 +1535,7 @@ fn handle_agent_self_commands(
                 terminal,
                 done_marker,
             } => {
+                let focus = requested_focus_for_origin(&request.origin, *focus);
                 let mut data =
                     run_command_line(command, done_marker.as_deref(), &settings).into_bytes();
                 data.push(b'\r');
@@ -1246,17 +1548,6 @@ fn handle_agent_self_commands(
                         AgentCommandResult::Text(pid.to_string())
                     }
                     None => 'spawn: {
-                        if beside.is_none()
-                            && *mode == vmux_service::protocol::PlacementMode::Auto
-                            && let Some(pid) = regions.run_terminals.get(anchor).copied()
-                            && term_pids.iter().any(|(_, p)| *p == pid)
-                        {
-                            service.0.send(ClientMessage::ProcessInput {
-                                process_id: pid,
-                                data,
-                            });
-                            break 'spawn AgentCommandResult::Text(pid.to_string());
-                        }
                         let Some((agent_term, self_pane)) =
                             resolve_self_pane(*anchor, &agent_terms, &ctx.child_of_q)
                         else {
@@ -1264,6 +1555,57 @@ fn handle_agent_self_commands(
                                 "self process not found".to_string(),
                             );
                         };
+                        let candidates = run_terminal_candidates(
+                            self_pane,
+                            &run_terms,
+                            &ctx.child_of_q,
+                            &ctx.tab_q,
+                            &ctx.seq_q,
+                        );
+                        let terminal_bucket_panes = run_terminal_bucket_panes(
+                            self_pane,
+                            &ctx.child_of_q,
+                            &ctx.tab_q,
+                            &ctx.leaf_panes,
+                            &ctx.pane_children,
+                            &ctx.tab_filter,
+                            &ctx.page_q,
+                            &ctx.seq_q,
+                        );
+                        if beside.is_none()
+                            && *mode == vmux_service::protocol::PlacementMode::Auto
+                            && let Some(pid) = append_pending_run_terminal_input(
+                                *anchor,
+                                &pending_run_spawns,
+                                &mut terminal_spawns,
+                                &data,
+                            )
+                        {
+                            break 'spawn AgentCommandResult::Text(pid.to_string());
+                        }
+                        if beside.is_none()
+                            && *mode == vmux_service::protocol::PlacementMode::Auto
+                            && let Some(candidate) = choose_reusable_run_terminal(
+                                *anchor,
+                                self_pane,
+                                &regions,
+                                &candidates,
+                            )
+                        {
+                            regions.run_terminals.insert(*anchor, candidate.pid);
+                            regions.run_panes.insert(*anchor, candidate.pane);
+                            touch_reused_run_pane_spawn_seq(
+                                candidate.pane,
+                                &mut commands,
+                                &mut spawn_counter,
+                                &ctx.seq_q,
+                            );
+                            service.0.send(ClientMessage::ProcessInput {
+                                process_id: candidate.pid,
+                                data,
+                            });
+                            break 'spawn AgentCommandResult::Text(candidate.pid.to_string());
+                        }
                         // Resolve an explicit `beside` anchor up front (errors if stale).
                         let beside_pane = match beside {
                             Some(pid) => {
@@ -1280,23 +1622,58 @@ fn handle_agent_self_commands(
                         };
                         use vmux_service::protocol::PlacementMode;
                         let target_pane = match (beside_pane, *mode) {
-                            // Explicit split: a new pane off the given page's pane (or self).
-                            (anchor, PlacementMode::Split) => split_pane_off(
-                                &mut commands,
-                                anchor.unwrap_or(self_pane),
-                                direction,
-                                *focus,
-                                &ctx.pane_children,
-                                &ctx.tab_filter,
-                                &ctx.split_dir_q,
-                                &mut split_this_batch,
-                            ),
+                            (anchor_pane, PlacementMode::Split) => {
+                                let bucket_pane = if anchor_pane.is_none() {
+                                    choose_run_terminal_bucket_pane(
+                                        *anchor,
+                                        self_pane,
+                                        &regions,
+                                        &candidates,
+                                    )
+                                    .filter(|pane| {
+                                        is_run_terminal_bucket_pane(*pane, &terminal_bucket_panes)
+                                    })
+                                    .or_else(|| {
+                                        newest_run_terminal_bucket_pane(
+                                            self_pane,
+                                            &terminal_bucket_panes,
+                                        )
+                                    })
+                                } else {
+                                    None
+                                };
+                                if let Some(pane) = bucket_pane {
+                                    touch_reused_run_pane_spawn_seq(
+                                        pane,
+                                        &mut commands,
+                                        &mut spawn_counter,
+                                        &ctx.seq_q,
+                                    );
+                                    pane
+                                } else {
+                                    let anchor_pane = anchor_pane.unwrap_or_else(|| {
+                                        vmux_layout::pane::resolve_split_anchor_pane(
+                                            self_pane, &ctx,
+                                        )
+                                    });
+                                    split_pane_off(
+                                        &mut commands,
+                                        anchor_pane,
+                                        direction,
+                                        focus,
+                                        &ctx.pane_children,
+                                        &ctx.tab_filter,
+                                        &ctx.split_dir_q,
+                                        &mut split_this_batch,
+                                    )
+                                }
+                            }
                             (Some(pane), _) => pane,
                             (None, _) => vmux_layout::pane::resolve_spiral_pane(
                                 &mut commands,
                                 self_pane,
                                 TERMINAL_PAGE_URL,
-                                *focus,
+                                focus,
                                 &mut split_this_batch,
                                 &ctx,
                             ),
@@ -1304,16 +1681,25 @@ fn handle_agent_self_commands(
                         let new_pid = ProcessId::new();
                         let agent_cwd = launch_q.get(agent_term).ok().map(|l| l.cwd.clone());
                         let cwd = run_terminal_cwd(agent_cwd.as_deref(), active_space.as_deref());
-                        terminal_stack_spawn_writer.write(TerminalStackSpawnRequest {
+                        let request_index = terminal_spawns.len();
+                        terminal_spawns.push(TerminalStackSpawnRequest {
                             pane: target_pane,
                             cwd: Some(cwd),
                             pending_input: Some(data),
                             process_id: Some(new_pid),
-                            activate: *focus,
+                            activate: focus,
                         });
+                        regions.run_panes.insert(*anchor, target_pane);
                         if beside.is_none() && *mode != vmux_service::protocol::PlacementMode::Split
                         {
                             regions.run_terminals.insert(*anchor, new_pid);
+                            pending_run_spawns.insert(
+                                *anchor,
+                                PendingRunTerminalSpawn {
+                                    pid: new_pid,
+                                    request_index,
+                                },
+                            );
                         }
                         AgentCommandResult::Text(new_pid.to_string())
                     }
@@ -1326,6 +1712,9 @@ fn handle_agent_self_commands(
             result,
         });
     }
+    for spawn in terminal_spawns {
+        terminal_stack_spawn_writer.write(spawn);
+    }
 }
 
 fn respond_process_stack_spawn(
@@ -1336,10 +1725,15 @@ fn respond_process_stack_spawn(
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     for request in reader.read() {
+        let stack_ts = if request.activate {
+            LastActivatedAt::now()
+        } else {
+            LastActivatedAt(0)
+        };
         let stack = commands
             .spawn((
                 vmux_layout::stack::stack_bundle(),
-                LastActivatedAt::now(),
+                stack_ts,
                 ChildOf(request.pane),
             ))
             .id();
@@ -3005,5 +3399,472 @@ mod tests {
         let out = run_command_line("ls -la", Some("tok9"), &settings);
         assert!(out.contains("ls -la"), "got: {out}");
         assert!(out.contains("__VMUX_DONE_tok9_"), "got: {out}");
+    }
+
+    #[test]
+    fn agent_origin_clears_requested_focus() {
+        let origin = CommandOrigin::Agent {
+            sid: Some("s1".into()),
+            anchor: Some(ProcessId::new()),
+        };
+
+        assert!(!requested_focus_for_origin(&origin, true));
+        assert!(!requested_focus_for_origin(&origin, false));
+    }
+
+    #[test]
+    fn user_origin_keeps_requested_focus() {
+        assert!(requested_focus_for_origin(&CommandOrigin::User, true));
+        assert!(!requested_focus_for_origin(&CommandOrigin::User, false));
+    }
+
+    #[test]
+    fn agent_layout_snapshot_keeps_current_focus() {
+        use vmux_service::protocol::layout::{Focus, LayoutNode, LayoutSnapshot, Tab};
+        let mut snapshot = LayoutSnapshot {
+            tabs: vec![
+                Tab {
+                    id: Some("tab:9".into()),
+                    name: "Agent".into(),
+                    is_active: true,
+                    root: LayoutNode::Pane {
+                        id: Some("pane:8".into()),
+                        is_zoomed: false,
+                        stacks: vec![],
+                    },
+                },
+                Tab {
+                    id: Some("tab:1".into()),
+                    name: "User".into(),
+                    is_active: false,
+                    root: LayoutNode::Pane {
+                        id: Some("pane:2".into()),
+                        is_zoomed: false,
+                        stacks: vec![],
+                    },
+                },
+            ],
+            focused: Focus {
+                tab: Some("tab:9".into()),
+                pane: Some("pane:8".into()),
+                stack: None,
+            },
+        };
+        let focus = FocusedStack {
+            tab: Some(Entity::from_bits(1)),
+            pane: Some(Entity::from_bits(2)),
+            stack: Some(Entity::from_bits(3)),
+        };
+
+        preserve_current_focus_in_layout_snapshot(&mut snapshot, &focus);
+
+        assert_eq!(snapshot.focused.tab.as_deref(), Some("tab:1"));
+        assert_eq!(snapshot.focused.pane.as_deref(), Some("pane:2"));
+        assert_eq!(snapshot.focused.stack.as_deref(), Some("stack:3"));
+        assert!(!snapshot.tabs[0].is_active);
+        assert!(snapshot.tabs[1].is_active);
+    }
+
+    #[test]
+    fn agent_app_command_filter_blocks_focus_changers() {
+        assert!(!agent_may_dispatch_app_command(&AppCommand::Browser(
+            vmux_command::BrowserCommand::Open(vmux_command::OpenCommand::InNewStack { url: None }),
+        )));
+        assert!(!agent_may_dispatch_app_command(&AppCommand::Browser(
+            vmux_command::BrowserCommand::Bar(vmux_command::BrowserBarCommand::OpenCommandBar),
+        )));
+        assert!(!agent_may_dispatch_app_command(&AppCommand::Terminal(
+            vmux_command::TerminalCommand::Next,
+        )));
+        assert!(agent_may_dispatch_app_command(&AppCommand::Terminal(
+            vmux_command::TerminalCommand::Clear,
+        )));
+    }
+
+    #[derive(Resource)]
+    struct RunTerminalCandidateInput {
+        agent_pane: Entity,
+    }
+
+    #[derive(Resource, Default)]
+    struct RunTerminalCandidateOutput(Vec<RunTerminalCandidate>);
+
+    fn collect_run_terminal_candidates(
+        input: Res<RunTerminalCandidateInput>,
+        terminals: Query<
+            (Entity, &ProcessId),
+            (
+                With<Terminal>,
+                Without<AgentSession>,
+                Without<ProcessExited>,
+            ),
+        >,
+        child_of_q: Query<&ChildOf>,
+        tab_q: Query<Entity, With<vmux_layout::tab::Tab>>,
+        seq_q: Query<&vmux_layout::pane::SpawnSeq>,
+        mut out: ResMut<RunTerminalCandidateOutput>,
+    ) {
+        out.0 = run_terminal_candidates(input.agent_pane, &terminals, &child_of_q, &tab_q, &seq_q);
+    }
+
+    #[test]
+    fn run_terminal_candidates_fail_closed_when_agent_tab_missing() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<RunTerminalCandidateOutput>()
+            .add_systems(Update, collect_run_terminal_candidates);
+
+        let tab = app.world_mut().spawn(vmux_layout::tab::Tab::default()).id();
+        let terminal_pane = app
+            .world_mut()
+            .spawn((Pane, vmux_layout::pane::SpawnSeq(7), ChildOf(tab)))
+            .id();
+        let stack = app
+            .world_mut()
+            .spawn((vmux_layout::stack::stack_bundle(), ChildOf(terminal_pane)))
+            .id();
+        app.world_mut()
+            .spawn((Terminal, ProcessId::new(), ChildOf(stack)));
+        let agent_pane = app
+            .world_mut()
+            .spawn((Pane, vmux_layout::pane::SpawnSeq(9)))
+            .id();
+
+        app.insert_resource(RunTerminalCandidateInput { agent_pane });
+        app.update();
+
+        assert!(
+            app.world()
+                .resource::<RunTerminalCandidateOutput>()
+                .0
+                .is_empty(),
+            "unresolved agent tab must not match terminals from other tabs"
+        );
+    }
+
+    #[derive(Resource)]
+    struct RunTerminalBucketPaneInput {
+        agent_pane: Entity,
+    }
+
+    #[derive(Resource, Default)]
+    struct RunTerminalBucketPaneOutput(Vec<Entity>);
+
+    fn collect_run_terminal_bucket_panes(
+        input: Res<RunTerminalBucketPaneInput>,
+        child_of_q: Query<&ChildOf>,
+        tab_q: Query<Entity, With<vmux_layout::tab::Tab>>,
+        leaf_panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
+        pane_children: Query<&Children, With<Pane>>,
+        stack_q: Query<Entity, With<vmux_layout::stack::Stack>>,
+        page_q: Query<&PageMetadata, With<vmux_layout::stack::Stack>>,
+        seq_q: Query<&vmux_layout::pane::SpawnSeq>,
+        mut out: ResMut<RunTerminalBucketPaneOutput>,
+    ) {
+        out.0 = run_terminal_bucket_panes(
+            input.agent_pane,
+            &child_of_q,
+            &tab_q,
+            &leaf_panes,
+            &pane_children,
+            &stack_q,
+            &page_q,
+            &seq_q,
+        )
+        .into_iter()
+        .map(|candidate| candidate.pane)
+        .collect();
+    }
+
+    #[test]
+    fn run_terminal_bucket_panes_include_pure_terminal_layout_panes() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<RunTerminalBucketPaneOutput>()
+            .add_systems(Update, collect_run_terminal_bucket_panes);
+
+        let tab = app.world_mut().spawn(vmux_layout::tab::Tab::default()).id();
+        let agent_pane = app
+            .world_mut()
+            .spawn((Pane, vmux_layout::pane::SpawnSeq(1), ChildOf(tab)))
+            .id();
+        let terminal_pane = app
+            .world_mut()
+            .spawn((Pane, vmux_layout::pane::SpawnSeq(3), ChildOf(tab)))
+            .id();
+        spawn_stack_in_pane(&mut app, terminal_pane, "vmux://terminal/68001");
+        let file_pane = app
+            .world_mut()
+            .spawn((Pane, vmux_layout::pane::SpawnSeq(9), ChildOf(tab)))
+            .id();
+        spawn_stack_in_pane(&mut app, file_pane, "file:///repo/src/plugin.rs");
+
+        app.insert_resource(RunTerminalBucketPaneInput { agent_pane });
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<RunTerminalBucketPaneOutput>().0,
+            vec![terminal_pane]
+        );
+    }
+
+    #[test]
+    fn pending_run_terminal_spawn_appends_same_frame_input() {
+        let anchor = ProcessId::new();
+        let terminal = ProcessId::new();
+        let pane = Entity::from_bits(20);
+        let mut pending_spawns = std::collections::HashMap::new();
+        pending_spawns.insert(
+            anchor,
+            PendingRunTerminalSpawn {
+                pid: terminal,
+                request_index: 0,
+            },
+        );
+        let mut terminal_spawns = vec![TerminalStackSpawnRequest {
+            pane,
+            cwd: None,
+            pending_input: Some(b"one\r".to_vec()),
+            process_id: Some(terminal),
+            activate: false,
+        }];
+
+        let picked = append_pending_run_terminal_input(
+            anchor,
+            &pending_spawns,
+            &mut terminal_spawns,
+            b"two\r",
+        );
+
+        assert_eq!(picked, Some(terminal));
+        assert_eq!(
+            terminal_spawns[0].pending_input.as_deref(),
+            Some(&b"one\rtwo\r"[..])
+        );
+        assert_eq!(terminal_spawns.len(), 1);
+    }
+
+    #[derive(Resource)]
+    struct ReusedRunPaneTouchInput {
+        pane: Entity,
+    }
+
+    fn touch_reused_run_pane_spawn_seq_test_system(
+        input: Res<ReusedRunPaneTouchInput>,
+        mut commands: Commands,
+        mut spawn_counter: ResMut<vmux_layout::pane::SpawnCounter>,
+        seq_q: Query<&vmux_layout::pane::SpawnSeq>,
+    ) {
+        touch_reused_run_pane_spawn_seq(input.pane, &mut commands, &mut spawn_counter, &seq_q);
+    }
+
+    #[test]
+    fn reusable_run_pane_touch_refreshes_spawn_seq() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<vmux_layout::pane::SpawnCounter>()
+            .add_systems(Update, touch_reused_run_pane_spawn_seq_test_system);
+
+        let reused = app
+            .world_mut()
+            .spawn((Pane, vmux_layout::pane::SpawnSeq(2)))
+            .id();
+        app.world_mut()
+            .spawn((Pane, vmux_layout::pane::SpawnSeq(10)));
+        app.insert_resource(ReusedRunPaneTouchInput { pane: reused });
+        app.update();
+
+        assert_eq!(
+            app.world()
+                .get::<vmux_layout::pane::SpawnSeq>(reused)
+                .unwrap()
+                .0,
+            11
+        );
+    }
+
+    #[derive(Resource)]
+    struct BrowserPaneClaimInput {
+        anchor: ProcessId,
+    }
+
+    #[derive(Resource, Default)]
+    struct BrowserPaneClaimOutput(Option<Entity>);
+
+    fn claim_browser_pane_test_system(
+        input: Res<BrowserPaneClaimInput>,
+        mut resolve: AgentBrowserResolve,
+        mut out: ResMut<BrowserPaneClaimOutput>,
+    ) {
+        out.0 = resolve.claim_browser_pane(input.anchor);
+    }
+
+    fn spawn_stack_in_pane(app: &mut App, pane: Entity, url: &str) -> Entity {
+        let stack = app
+            .world_mut()
+            .spawn((vmux_layout::stack::stack_bundle(), ChildOf(pane)))
+            .id();
+        app.world_mut().entity_mut(stack).insert(PageMetadata {
+            url: url.to_string(),
+            ..default()
+        });
+        stack
+    }
+
+    fn browser_claim_app() -> (App, ProcessId, Entity) {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<vmux_layout::active_panes::ActivatePane>()
+            .init_resource::<BrowserPaneClaimOutput>()
+            .add_systems(Update, claim_browser_pane_test_system);
+        let split = app
+            .world_mut()
+            .spawn((
+                Pane,
+                PaneSplit {
+                    direction: vmux_layout::pane::PaneSplitDirection::Row,
+                },
+            ))
+            .id();
+        let agent_pane = app.world_mut().spawn((Pane, ChildOf(split))).id();
+        let agent_stack = app
+            .world_mut()
+            .spawn((vmux_layout::stack::stack_bundle(), ChildOf(agent_pane)))
+            .id();
+        let anchor = ProcessId::new();
+        app.world_mut().spawn((
+            Terminal,
+            anchor,
+            AgentSession {
+                kind: AgentKind::Codex,
+            },
+            ChildOf(agent_stack),
+        ));
+        app.insert_resource(BrowserPaneClaimInput { anchor });
+        (app, anchor, split)
+    }
+
+    #[test]
+    fn browser_pane_claim_ignores_mixed_file_browser_pane() {
+        let (mut app, _anchor, split) = browser_claim_app();
+        let mixed_pane = app.world_mut().spawn((Pane, ChildOf(split))).id();
+        spawn_stack_in_pane(&mut app, mixed_pane, "file:///repo/src/main.rs");
+        let browser_stack = spawn_stack_in_pane(&mut app, mixed_pane, "https://example.com");
+        app.world_mut()
+            .entity_mut(browser_stack)
+            .insert(vmux_layout::Browser);
+
+        app.update();
+
+        assert_eq!(app.world().resource::<BrowserPaneClaimOutput>().0, None);
+    }
+
+    #[test]
+    fn browser_pane_claim_prefers_pure_browser_pane_over_mixed_pane() {
+        let (mut app, _anchor, split) = browser_claim_app();
+        let mixed_pane = app.world_mut().spawn((Pane, ChildOf(split))).id();
+        spawn_stack_in_pane(&mut app, mixed_pane, "file:///repo/src/main.rs");
+        let mixed_browser = spawn_stack_in_pane(&mut app, mixed_pane, "https://mixed.example");
+        app.world_mut()
+            .entity_mut(mixed_browser)
+            .insert(vmux_layout::Browser);
+        let pure_pane = app.world_mut().spawn((Pane, ChildOf(split))).id();
+        let pure_browser = spawn_stack_in_pane(&mut app, pure_pane, "https://pure.example");
+        app.world_mut()
+            .entity_mut(pure_browser)
+            .insert(vmux_layout::Browser);
+
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<BrowserPaneClaimOutput>().0,
+            Some(pure_pane)
+        );
+    }
+
+    #[test]
+    fn run_reuses_existing_terminal_when_region_cache_is_empty() {
+        let anchor = ProcessId::new();
+        let terminal = ProcessId::new();
+        let agent_pane = Entity::from_bits(10);
+        let terminal_pane = Entity::from_bits(20);
+        let regions = AgentTerminalRegions::default();
+        let candidates = [RunTerminalCandidate {
+            pid: terminal,
+            pane: terminal_pane,
+            pane_spawn_seq: 7,
+        }];
+
+        let picked =
+            choose_reusable_run_terminal(anchor, agent_pane, &regions, &candidates).unwrap();
+
+        assert_eq!(picked.pid, terminal);
+        assert_eq!(picked.pane, terminal_pane);
+    }
+
+    #[test]
+    fn run_reuses_cached_terminal_before_newer_terminal_candidates() {
+        let anchor = ProcessId::new();
+        let cached = ProcessId::new();
+        let newer = ProcessId::new();
+        let agent_pane = Entity::from_bits(10);
+        let cached_pane = Entity::from_bits(20);
+        let newer_pane = Entity::from_bits(30);
+        let mut regions = AgentTerminalRegions::default();
+        regions.run_terminals.insert(anchor, cached);
+        regions.run_panes.insert(anchor, cached_pane);
+        let candidates = [
+            RunTerminalCandidate {
+                pid: cached,
+                pane: cached_pane,
+                pane_spawn_seq: 3,
+            },
+            RunTerminalCandidate {
+                pid: newer,
+                pane: newer_pane,
+                pane_spawn_seq: 9,
+            },
+        ];
+
+        let picked =
+            choose_reusable_run_terminal(anchor, agent_pane, &regions, &candidates).unwrap();
+
+        assert_eq!(picked.pid, cached);
+        assert_eq!(picked.pane, cached_pane);
+    }
+
+    #[test]
+    fn split_run_stacks_into_cached_terminal_bucket_pane() {
+        let anchor = ProcessId::new();
+        let terminal = ProcessId::new();
+        let agent_pane = Entity::from_bits(10);
+        let terminal_pane = Entity::from_bits(20);
+        let mut regions = AgentTerminalRegions::default();
+        regions.run_panes.insert(anchor, terminal_pane);
+        let candidates = [RunTerminalCandidate {
+            pid: terminal,
+            pane: terminal_pane,
+            pane_spawn_seq: 7,
+        }];
+
+        assert_eq!(
+            choose_run_terminal_bucket_pane(anchor, agent_pane, &regions, &candidates),
+            Some(terminal_pane)
+        );
+    }
+
+    #[test]
+    fn split_run_keeps_cached_terminal_bucket_after_process_exits() {
+        let anchor = ProcessId::new();
+        let agent_pane = Entity::from_bits(10);
+        let terminal_pane = Entity::from_bits(20);
+        let mut regions = AgentTerminalRegions::default();
+        regions.run_panes.insert(anchor, terminal_pane);
+        let candidates = [];
+
+        assert_eq!(
+            choose_run_terminal_bucket_pane(anchor, agent_pane, &regions, &candidates),
+            Some(terminal_pane)
+        );
     }
 }

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -1446,10 +1446,14 @@ fn command_with_marker(shell: &str, command: &str, token: &str) -> String {
         .unwrap_or(shell);
     match base {
         "nu" | "nushell" => format!(
-            "try {{ {command}; print $\"\\n__VMUX_DONE_{token}_($env.LAST_EXIT_CODE)__\" }} catch {{ |e| print $\"\\n__VMUX_DONE_{token}_($e.exit_code? | default 1)__\" }}"
+            "print \"\\n__VMUX_START_{token}__\"; try {{ {command}; print $\"\\n__VMUX_DONE_{token}_($env.LAST_EXIT_CODE)__\" }} catch {{ |e| print $\"\\n__VMUX_DONE_{token}_($e.exit_code? | default 1)__\" }}"
         ),
-        "fish" => format!("{command}; printf '\\n__VMUX_DONE_{token}_%s__\\n' $status"),
-        _ => format!("{command}; printf '\\n__VMUX_DONE_{token}_%s__\\n' \"$?\""),
+        "fish" => format!(
+            "printf '\\n__VMUX_START_{token}__\\n'; {command}; set vmux_status $status; printf '\\n__VMUX_DONE_{token}_%s__\\n' $vmux_status"
+        ),
+        _ => format!(
+            "printf '\\n__VMUX_START_{token}__\\n'; {command}; vmux_status=\"$?\"; printf '\\n__VMUX_DONE_{token}_%s__\\n' \"$vmux_status\""
+        ),
     }
 }
 
@@ -3371,20 +3375,20 @@ mod tests {
         // completion marker.
         assert_eq!(
             command_with_marker("/opt/homebrew/bin/nu", "ls", "abc"),
-            "try { ls; print $\"\\n__VMUX_DONE_abc_($env.LAST_EXIT_CODE)__\" } catch { |e| print $\"\\n__VMUX_DONE_abc_($e.exit_code? | default 1)__\" }"
+            "print \"\\n__VMUX_START_abc__\"; try { ls; print $\"\\n__VMUX_DONE_abc_($env.LAST_EXIT_CODE)__\" } catch { |e| print $\"\\n__VMUX_DONE_abc_($e.exit_code? | default 1)__\" }"
         );
         assert_eq!(
             command_with_marker("/usr/local/bin/fish", "ls", "abc"),
-            "ls; printf '\\n__VMUX_DONE_abc_%s__\\n' $status"
+            "printf '\\n__VMUX_START_abc__\\n'; ls; set vmux_status $status; printf '\\n__VMUX_DONE_abc_%s__\\n' $vmux_status"
         );
         assert_eq!(
             command_with_marker("/bin/zsh", "ls", "abc"),
-            "ls; printf '\\n__VMUX_DONE_abc_%s__\\n' \"$?\""
+            "printf '\\n__VMUX_START_abc__\\n'; ls; vmux_status=\"$?\"; printf '\\n__VMUX_DONE_abc_%s__\\n' \"$vmux_status\""
         );
         // Unknown shells fall back to posix syntax.
         assert_eq!(
             command_with_marker("/bin/bash", "ls", "abc"),
-            "ls; printf '\\n__VMUX_DONE_abc_%s__\\n' \"$?\""
+            "printf '\\n__VMUX_START_abc__\\n'; ls; vmux_status=\"$?\"; printf '\\n__VMUX_DONE_abc_%s__\\n' \"$vmux_status\""
         );
     }
 

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -65,6 +65,7 @@ pub struct AgentTerminalRegions {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct RunTerminalCandidate {
     pid: ProcessId,
+    stack: Entity,
     pane: Entity,
     pane_spawn_seq: u64,
 }
@@ -1278,6 +1279,7 @@ fn run_terminal_candidates(
             }
             Some(RunTerminalCandidate {
                 pid: *pid,
+                stack,
                 pane,
                 pane_spawn_seq: seq_q.get(pane).map(|s| s.0).unwrap_or(0),
             })
@@ -1379,6 +1381,23 @@ fn touch_reused_run_pane_spawn_seq(
     commands
         .entity(pane)
         .insert(vmux_layout::pane::SpawnSeq(spawn_counter.0));
+}
+
+fn focus_reused_run_terminal(
+    candidate: RunTerminalCandidate,
+    commands: &mut Commands,
+    child_of_q: &Query<&ChildOf>,
+    tab_q: &Query<Entity, With<vmux_layout::tab::Tab>>,
+) {
+    commands
+        .entity(candidate.stack)
+        .insert(LastActivatedAt::now());
+    commands
+        .entity(candidate.pane)
+        .insert(LastActivatedAt::now());
+    if let Some(tab) = tab_of_run_pane(candidate.pane, child_of_q, tab_q) {
+        commands.entity(tab).insert(LastActivatedAt::now());
+    }
 }
 
 /// Split `pane` and return the new leaf pane. Batches several splits of the same
@@ -1605,6 +1624,14 @@ fn handle_agent_self_commands(
                                 &mut spawn_counter,
                                 &ctx.seq_q,
                             );
+                            if focus {
+                                focus_reused_run_terminal(
+                                    candidate,
+                                    &mut commands,
+                                    &ctx.child_of_q,
+                                    &ctx.tab_q,
+                                );
+                            }
                             service.0.send(ClientMessage::ProcessInput {
                                 process_id: candidate.pid,
                                 data,
@@ -3813,6 +3840,7 @@ mod tests {
         let regions = AgentTerminalRegions::default();
         let candidates = [RunTerminalCandidate {
             pid: terminal,
+            stack: Entity::from_bits(21),
             pane: terminal_pane,
             pane_spawn_seq: 7,
         }];
@@ -3838,11 +3866,13 @@ mod tests {
         let candidates = [
             RunTerminalCandidate {
                 pid: cached,
+                stack: Entity::from_bits(21),
                 pane: cached_pane,
                 pane_spawn_seq: 3,
             },
             RunTerminalCandidate {
                 pid: newer,
+                stack: Entity::from_bits(31),
                 pane: newer_pane,
                 pane_spawn_seq: 9,
             },
@@ -3855,6 +3885,62 @@ mod tests {
         assert_eq!(picked.pane, cached_pane);
     }
 
+    #[derive(Resource)]
+    struct ReusedRunTerminalFocusInput {
+        candidate: RunTerminalCandidate,
+    }
+
+    fn focus_reused_run_terminal_test_system(
+        input: Res<ReusedRunTerminalFocusInput>,
+        mut commands: Commands,
+        child_of_q: Query<&ChildOf>,
+        tab_q: Query<Entity, With<vmux_layout::tab::Tab>>,
+    ) {
+        focus_reused_run_terminal(input.candidate, &mut commands, &child_of_q, &tab_q);
+    }
+
+    #[test]
+    fn reused_run_terminal_focus_activates_stack_pane_and_tab() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_systems(Update, focus_reused_run_terminal_test_system);
+        let tab = app
+            .world_mut()
+            .spawn((vmux_layout::tab::Tab::default(), LastActivatedAt(1)))
+            .id();
+        let pane = app
+            .world_mut()
+            .spawn((
+                Pane,
+                vmux_layout::pane::SpawnSeq(7),
+                LastActivatedAt(2),
+                ChildOf(tab),
+            ))
+            .id();
+        let stack = app
+            .world_mut()
+            .spawn((
+                vmux_layout::stack::stack_bundle(),
+                LastActivatedAt(3),
+                ChildOf(pane),
+            ))
+            .id();
+        app.insert_resource(ReusedRunTerminalFocusInput {
+            candidate: RunTerminalCandidate {
+                pid: ProcessId::new(),
+                stack,
+                pane,
+                pane_spawn_seq: 7,
+            },
+        });
+
+        app.update();
+
+        assert!(app.world().get::<LastActivatedAt>(tab).unwrap().0 > 1);
+        assert!(app.world().get::<LastActivatedAt>(pane).unwrap().0 > 2);
+        assert!(app.world().get::<LastActivatedAt>(stack).unwrap().0 > 3);
+    }
+
     #[test]
     fn split_run_stacks_into_cached_terminal_bucket_pane() {
         let anchor = ProcessId::new();
@@ -3865,6 +3951,7 @@ mod tests {
         regions.run_panes.insert(anchor, terminal_pane);
         let candidates = [RunTerminalCandidate {
             pid: terminal,
+            stack: Entity::from_bits(21),
             pane: terminal_pane,
             pane_spawn_seq: 7,
         }];

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -238,7 +238,8 @@ impl Plugin for AgentPlugin {
                     forward_history_open_intent,
                     handle_agent_tool_calls,
                     handle_agent_commands,
-                    handle_agent_self_commands,
+                    handle_agent_self_commands
+                        .before(vmux_terminal::plugin::respond_terminal_stack_spawn),
                     handle_agent_file_touch,
                     handle_agent_queries,
                     detect_agent_session_process_exit,
@@ -3479,6 +3480,23 @@ mod tests {
         assert!(agent_may_dispatch_app_command(&AppCommand::Terminal(
             vmux_command::TerminalCommand::Clear,
         )));
+    }
+
+    #[test]
+    fn agent_run_spawns_terminal_before_next_agent_command_frame() {
+        let source = include_str!("plugin.rs");
+        let non_test_source = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("non-test source");
+        let start = non_test_source
+            .find("handle_agent_self_commands")
+            .expect("handle_agent_self_commands registered");
+        assert!(
+            non_test_source[start..]
+                .contains(".before(vmux_terminal::plugin::respond_terminal_stack_spawn)"),
+            "run terminal spawn requests must materialize before the next agent command frame"
+        );
     }
 
     #[derive(Resource)]

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -1054,7 +1054,7 @@ pub fn handle_open_beside_requests(
                     let split_dir = direction_to_split(&direction);
                     let already_split =
                         !split_this_batch.insert(req.pane) || split_dir_q.contains(req.pane);
-                    let (target_pane, target_size) = split_or_extend_for_batch(
+                    let split = split_or_extend_for_batch(
                         &mut commands,
                         req.pane,
                         split_dir,
@@ -1066,9 +1066,20 @@ pub fn handle_open_beside_requests(
                         &mut pending_leaf_stacks,
                         &mut retired_leaf_panes,
                     );
-                    let pending_size =
-                        target_size.unwrap_or_else(|| pane_size(target_pane, &rc.node_q));
-                    (target_pane, pending_size, true)
+                    stamp_split_panes_for_batch(
+                        &mut commands,
+                        &mut spawn_counter,
+                        &rc.seq_q,
+                        &mut spawn_seq_overrides,
+                        &mut pending_leaf_infos,
+                        split.holder,
+                        split.target,
+                        split.target,
+                    );
+                    let pending_size = split
+                        .target_size
+                        .unwrap_or_else(|| pane_size(split.target, &rc.node_q));
+                    (split.target, pending_size, false)
                 }
             };
             let stack = spawn_beside_stack(
@@ -1147,6 +1158,9 @@ pub fn handle_open_beside_requests(
             }
             crate::placement::Placement::Spiral { anchor, axis } => {
                 let old_leaf_info = leaves.iter().find(|leaf| leaf.pane == anchor).cloned();
+                let keep_holder_as_tail = old_leaf_info
+                    .as_ref()
+                    .is_some_and(|info| !info.kinds.contains(&crate::placement::PageKind::Agent));
                 let existing_tabs = stack_children_for_split(
                     anchor,
                     &pane_children,
@@ -1155,7 +1169,7 @@ pub fn handle_open_beside_requests(
                 );
                 let already_split =
                     !split_this_batch.insert(anchor) || split_dir_q.contains(anchor);
-                let (target_pane, target_size) = split_or_extend_for_batch(
+                let split = split_or_extend_for_batch(
                     &mut commands,
                     anchor,
                     axis,
@@ -1167,9 +1181,25 @@ pub fn handle_open_beside_requests(
                     &mut pending_leaf_stacks,
                     &mut retired_leaf_panes,
                 );
-                let pending_size = target_size.unwrap_or_else(|| pane_size(anchor, &rc.node_q));
+                let tail = split
+                    .holder
+                    .filter(|_| keep_holder_as_tail)
+                    .unwrap_or(split.target);
+                stamp_split_panes_for_batch(
+                    &mut commands,
+                    &mut spawn_counter,
+                    &rc.seq_q,
+                    &mut spawn_seq_overrides,
+                    &mut pending_leaf_infos,
+                    split.holder,
+                    split.target,
+                    tail,
+                );
+                let pending_size = split
+                    .target_size
+                    .unwrap_or_else(|| pane_size(anchor, &rc.node_q));
                 let stack = spawn_beside_stack(
-                    target_pane,
+                    split.target,
                     req,
                     &mut commands,
                     &mut new_stack_ctx,
@@ -1180,12 +1210,18 @@ pub fn handle_open_beside_requests(
                     &mut pending_leaf_infos,
                     &mut pending_leaf_stacks,
                     pending_size,
-                    true,
+                    false,
                 );
                 pending_open_stacks.push((req.url.clone(), stack));
             }
         }
     }
+}
+
+struct BatchSplit {
+    target: Entity,
+    holder: Option<Entity>,
+    target_size: Option<Vec2>,
 }
 
 fn split_or_extend_for_batch(
@@ -1199,10 +1235,10 @@ fn split_or_extend_for_batch(
     pending_leaf_infos: &mut std::collections::HashMap<Entity, crate::placement::LeafInfo>,
     pending_leaf_stacks: &mut std::collections::HashMap<Entity, Vec<Entity>>,
     retired_leaf_panes: &mut std::collections::HashSet<Entity>,
-) -> (Entity, Option<Vec2>) {
+) -> BatchSplit {
     if already_split {
-        return (
-            split_or_extend(
+        return BatchSplit {
+            target: split_or_extend(
                 commands,
                 anchor,
                 split_dir,
@@ -1210,8 +1246,9 @@ fn split_or_extend_for_batch(
                 activate_new,
                 true,
             ),
-            None,
-        );
+            holder: None,
+            target_size: None,
+        };
     }
 
     let pending_info = pending_leaf_infos.remove(&anchor);
@@ -1231,7 +1268,42 @@ fn split_or_extend_for_batch(
     if !existing_tabs.is_empty() {
         pending_leaf_stacks.insert(holder, existing_tabs.to_vec());
     }
-    (target, target_size)
+    BatchSplit {
+        target,
+        holder: Some(holder),
+        target_size,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn stamp_split_panes_for_batch(
+    commands: &mut Commands,
+    spawn_counter: &mut SpawnCounter,
+    seq_q: &Query<&SpawnSeq>,
+    spawn_seq_overrides: &mut std::collections::HashMap<Entity, u64>,
+    pending_leaf_infos: &mut std::collections::HashMap<Entity, crate::placement::LeafInfo>,
+    holder: Option<Entity>,
+    target: Entity,
+    tail: Entity,
+) {
+    let mut stamp = |pane| {
+        let seq = touch_pane_spawn_seq(pane, commands, spawn_counter, seq_q);
+        spawn_seq_overrides.insert(pane, seq.0);
+        if let Some(info) = pending_leaf_infos.get_mut(&pane) {
+            info.spawn_seq = seq.0;
+        }
+    };
+    if let Some(holder) = holder {
+        if tail == holder {
+            stamp(target);
+            stamp(holder);
+        } else {
+            stamp(holder);
+            stamp(target);
+        }
+    } else {
+        stamp(target);
+    }
 }
 
 fn focus_reuse_hit(
@@ -3020,7 +3092,7 @@ mod tests {
     }
 
     #[test]
-    fn auto_batched_new_types_dwindle_from_last_spawned_leaf() {
+    fn auto_batched_new_types_dwindle_from_remaining_tail() {
         let mut app = open_beside_app();
         let space = app
             .world_mut()
@@ -3091,11 +3163,11 @@ mod tests {
         let file_split = app.world().get::<ChildOf>(file_parent).unwrap().get();
         assert_eq!(
             app.world().get::<ChildOf>(terminal_parent).unwrap().get(),
-            file_split
+            browser_split
         );
         assert_eq!(
-            app.world().get::<ChildOf>(file_split).unwrap().get(),
-            browser_split
+            app.world().get::<ChildOf>(browser_split).unwrap().get(),
+            file_split
         );
         assert_eq!(
             app.world().get::<PaneSplit>(agent_pane).unwrap().direction,
@@ -3106,16 +3178,16 @@ mod tests {
                 .get::<PaneSplit>(browser_split)
                 .unwrap()
                 .direction,
-            PaneSplitDirection::Column
+            PaneSplitDirection::Row
         );
         assert_eq!(
             app.world().get::<PaneSplit>(file_split).unwrap().direction,
-            PaneSplitDirection::Row
+            PaneSplitDirection::Column
         );
     }
 
     #[test]
-    fn auto_batched_new_browser_splits_latest_leaf_after_other_work() {
+    fn auto_batched_new_browser_stacks_in_existing_browser_bucket_after_other_work() {
         let mut app = open_beside_app();
         let space = app
             .world_mut()
@@ -3177,15 +3249,11 @@ mod tests {
         let ci_parent = parent_for_url("https://github.com/vmux-ai/vmux/actions/runs/28544986467");
         let terminal_parent = parent_for_url("vmux://terminal/");
 
-        assert_ne!(
-            ci_parent, pr_parent,
-            "new CI browser page should not tab into the earlier PR browser pane"
-        );
         assert_eq!(
-            app.world().get::<ChildOf>(ci_parent).unwrap().get(),
-            app.world().get::<ChildOf>(terminal_parent).unwrap().get(),
-            "new CI browser page should split the latest bottom-right terminal leaf"
+            ci_parent, pr_parent,
+            "new CI browser page should tab into the existing browser pane"
         );
+        assert_ne!(ci_parent, terminal_parent);
     }
 
     #[test]
@@ -3320,6 +3388,7 @@ mod tests {
         let plugin_parent = parent_for_url("file:///repo/crates/vmux_agent/src/plugin.rs");
         let pane_parent = parent_for_url("file:///repo/crates/vmux_layout/src/pane.rs");
         let placement_parent = parent_for_url("file:///repo/crates/vmux_layout/src/placement.rs");
+        let pr_parent = parent_for_url("https://github.com/vmux-ai/vmux/pull/221");
         let terminal_parent = parent_for_url("vmux://terminal/");
 
         assert_eq!(pane_parent, plugin_parent);
@@ -3329,8 +3398,92 @@ mod tests {
         );
         assert_eq!(
             app.world().get::<ChildOf>(terminal_parent).unwrap().get(),
-            app.world().get::<ChildOf>(plugin_parent).unwrap().get(),
-            "terminal should split the file pane"
+            app.world().get::<ChildOf>(pr_parent).unwrap().get(),
+            "terminal should split the remaining browser tail"
+        );
+    }
+
+    #[test]
+    fn auto_terminal_splits_remaining_browser_tail_after_file_bucket_reuse() {
+        let mut app = open_beside_app();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                vmux_core::Active,
+                LastActivatedAt::now(),
+                ChildOf(space),
+            ))
+            .id();
+        let agent_pane = place_pane_with_url(
+            &mut app,
+            tab,
+            1,
+            Vec2::new(1600.0, 900.0),
+            "vmux://agent/claude/session",
+        );
+
+        for (i, url) in [
+            "https://github.com/vmux-ai/vmux/pull/221",
+            "file:///repo/crates/vmux_layout/src/pane.rs",
+            "file:///repo/crates/vmux_agent/src/plugin.rs",
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            app.world_mut()
+                .resource_mut::<Messages<OpenBesideRequest>>()
+                .write(OpenBesideRequest {
+                    pane: agent_pane,
+                    direction: None,
+                    url: url.into(),
+                    request_id: [i as u8; 16],
+                    focus: false,
+                });
+            app.update();
+            materialize_page_metadata(&mut app);
+        }
+
+        app.world_mut()
+            .resource_mut::<Messages<OpenBesideRequest>>()
+            .write(OpenBesideRequest {
+                pane: agent_pane,
+                direction: None,
+                url: "vmux://terminal/".into(),
+                request_id: [9; 16],
+                focus: false,
+            });
+        app.update();
+
+        let requests = page_open_requests(&app);
+        let parent_for_url = |url: &str| -> Entity {
+            requests
+                .iter()
+                .find_map(|request| match &request.target {
+                    PageOpenTarget::Stack(stack) if request.url == url => app
+                        .world()
+                        .get::<ChildOf>(*stack)
+                        .map(|parent| parent.get()),
+                    _ => None,
+                })
+                .unwrap()
+        };
+        let pr_parent = parent_for_url("https://github.com/vmux-ai/vmux/pull/221");
+        let plugin_parent = parent_for_url("file:///repo/crates/vmux_agent/src/plugin.rs");
+        let terminal_parent = parent_for_url("vmux://terminal/");
+
+        assert_eq!(
+            app.world().get::<ChildOf>(terminal_parent).unwrap().get(),
+            app.world().get::<ChildOf>(pr_parent).unwrap().get(),
+            "terminal should split the remaining browser tail, not the file bucket"
+        );
+        assert_ne!(
+            app.world().get::<ChildOf>(terminal_parent).unwrap().get(),
+            app.world().get::<ChildOf>(plugin_parent).unwrap().get()
         );
     }
 
@@ -3829,7 +3982,7 @@ mod tests {
     }
 
     #[test]
-    fn auto_terminal_splits_last_spawned_browser_pane() {
+    fn auto_browser_reuses_bucket_before_terminal_splits_existing_tail() {
         let mut app = open_beside_app();
         let space = app
             .world_mut()
@@ -3889,21 +4042,25 @@ mod tests {
 
         assert!(
             app.world().get::<PaneSplit>(browser_pane).is_none(),
-            "older browser pane must not be reused for a new browser URL"
+            "new browser URL should stack in the existing browser pane"
+        );
+        assert_eq!(
+            github_parent, browser_pane,
+            "new browser URL should stack in the existing browser pane"
         );
         assert!(
             app.world().get::<PaneSplit>(file_pane).is_some(),
-            "new browser page should split the latest file pane"
+            "terminal should split the current file tail"
         );
         assert_eq!(
-            app.world().get::<ChildOf>(github_parent).unwrap().get(),
             app.world().get::<ChildOf>(terminal_parent).unwrap().get(),
-            "terminal should split the browser pane that was just spawned"
+            file_pane,
+            "terminal should split the current file tail"
         );
     }
 
     #[test]
-    fn auto_terminal_splits_browser_pane_spawned_earlier_in_same_batch() {
+    fn auto_browser_reuses_bucket_before_same_batch_terminal_splits_existing_tail() {
         let mut app = open_beside_app();
         let space = app
             .world_mut()
@@ -3961,21 +4118,25 @@ mod tests {
 
         assert!(
             app.world().get::<PaneSplit>(browser_pane).is_none(),
-            "older browser pane must not be reused for a new browser URL"
+            "new browser URL should stack in the existing browser pane"
+        );
+        assert_eq!(
+            github_parent, browser_pane,
+            "new browser URL should stack in the existing browser pane"
         );
         assert!(
             app.world().get::<PaneSplit>(file_pane).is_some(),
-            "new browser page should split the latest file pane"
+            "terminal should split the current file tail"
         );
         assert_eq!(
-            app.world().get::<ChildOf>(github_parent).unwrap().get(),
             app.world().get::<ChildOf>(terminal_parent).unwrap().get(),
-            "terminal should split the browser pane spawned earlier in the same batch"
+            file_pane,
+            "terminal should split the current file tail"
         );
     }
 
     #[test]
-    fn forced_split_anchor_follows_last_spawned_browser_pane() {
+    fn forced_split_anchor_keeps_current_tail_when_browser_reuses_bucket() {
         let mut app = open_beside_app();
         let space = app
             .world_mut()
@@ -4020,9 +4181,9 @@ mod tests {
                 _ => None,
             })
             .unwrap();
-        assert_ne!(
+        assert_eq!(
             github_parent, browser_pane,
-            "new browser URL should spawn from the latest leaf, not reuse the older browser pane"
+            "new browser URL should reuse the existing browser pane"
         );
 
         app.insert_resource(SplitAnchorInput { anchor: file_pane })
@@ -4030,10 +4191,7 @@ mod tests {
             .add_systems(Update, split_anchor_test_sys);
         app.update();
 
-        assert_eq!(
-            app.world().resource::<SplitAnchorOut>().0,
-            Some(github_parent)
-        );
+        assert_eq!(app.world().resource::<SplitAnchorOut>().0, Some(file_pane));
     }
 
     #[test]

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -1005,7 +1005,7 @@ pub fn handle_open_beside_requests(
         }
 
         if let Some(direction) = req.direction {
-            let target_pane = match find_sibling_pane(
+            let (target_pane, pending_size) = match find_sibling_pane(
                 req.pane,
                 &direction,
                 &child_of_q,
@@ -1013,7 +1013,7 @@ pub fn handle_open_beside_requests(
                 &pane_children,
                 &leaf_panes,
             ) {
-                Some(sibling) => sibling,
+                Some(sibling) => (sibling, pane_size(sibling, &rc.node_q)),
                 None => {
                     let existing_tabs = stack_children_for_split(
                         req.pane,
@@ -1032,7 +1032,7 @@ pub fn handle_open_beside_requests(
                     let split_dir = direction_to_split(&direction);
                     let already_split =
                         !split_this_batch.insert(req.pane) || split_dir_q.contains(req.pane);
-                    split_or_extend_for_batch(
+                    let (target_pane, target_size) = split_or_extend_for_batch(
                         &mut commands,
                         req.pane,
                         split_dir,
@@ -1043,8 +1043,10 @@ pub fn handle_open_beside_requests(
                         &mut pending_leaf_infos,
                         &mut pending_leaf_stacks,
                         &mut retired_leaf_panes,
-                    )
-                    .0
+                    );
+                    let pending_size =
+                        target_size.unwrap_or_else(|| pane_size(target_pane, &rc.node_q));
+                    (target_pane, pending_size)
                 }
             };
             spawn_beside_stack(
@@ -1058,7 +1060,7 @@ pub fn handle_open_beside_requests(
                 &mut spawn_seq_overrides,
                 &mut pending_leaf_infos,
                 &mut pending_leaf_stacks,
-                pane_size(target_pane, &rc.node_q),
+                pending_size,
             );
             continue;
         }
@@ -2973,6 +2975,78 @@ mod tests {
         assert_eq!(
             app.world().get::<PaneSplit>(file_split).unwrap().direction,
             PaneSplitDirection::Row
+        );
+    }
+
+    #[test]
+    fn direction_batched_new_type_uses_split_target_size() {
+        let mut app = open_beside_app();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                vmux_core::Active,
+                LastActivatedAt::now(),
+                ChildOf(space),
+            ))
+            .id();
+        let agent_pane = place_pane_with_url(
+            &mut app,
+            tab,
+            1,
+            Vec2::new(1600.0, 900.0),
+            "vmux://agent/claude/session",
+        );
+
+        app.world_mut()
+            .resource_mut::<Messages<OpenBesideRequest>>()
+            .write(OpenBesideRequest {
+                pane: agent_pane,
+                direction: Some(PaneDirection::Right),
+                url: "file:///repo/crates/vmux_agent/src/plugin.rs".into(),
+                request_id: [0u8; 16],
+                focus: false,
+            });
+        app.world_mut()
+            .resource_mut::<Messages<OpenBesideRequest>>()
+            .write(OpenBesideRequest {
+                pane: agent_pane,
+                direction: None,
+                url: "vmux://terminal/".into(),
+                request_id: [1u8; 16],
+                focus: false,
+            });
+        app.update();
+
+        let requests = page_open_requests(&app);
+        let parent_for = |prefix: &str| -> Entity {
+            requests
+                .iter()
+                .find_map(|request| match &request.target {
+                    PageOpenTarget::Stack(stack) if request.url.starts_with(prefix) => app
+                        .world()
+                        .get::<ChildOf>(*stack)
+                        .map(|parent| parent.get()),
+                    _ => None,
+                })
+                .unwrap()
+        };
+        let file_parent = parent_for("file:");
+        let terminal_parent = parent_for("vmux://terminal/");
+        let file_split = app.world().get::<ChildOf>(file_parent).unwrap().get();
+
+        assert_eq!(
+            app.world().get::<ChildOf>(terminal_parent).unwrap().get(),
+            file_split
+        );
+        assert_eq!(
+            app.world().get::<PaneSplit>(file_split).unwrap().direction,
+            PaneSplitDirection::Column,
+            "the forced-right target is 800x900, so the next pane should split it vertically"
         );
     }
 

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -1140,6 +1140,10 @@ pub fn handle_open_beside_requests(
                 );
             }
             crate::placement::Placement::AddTab { pane } => {
+                let refresh_spawn_seq = matches!(
+                    crate::placement::page_kind_for_url(&req.url),
+                    crate::placement::PageKind::File | crate::placement::PageKind::Terminal
+                );
                 let stack = spawn_beside_stack(
                     pane,
                     req,
@@ -1152,7 +1156,7 @@ pub fn handle_open_beside_requests(
                     &mut pending_leaf_infos,
                     &mut pending_leaf_stacks,
                     pane_size(pane, &rc.node_q),
-                    false,
+                    refresh_spawn_seq,
                 );
                 pending_open_stacks.push((req.url.clone(), stack));
             }
@@ -3388,7 +3392,6 @@ mod tests {
         let plugin_parent = parent_for_url("file:///repo/crates/vmux_agent/src/plugin.rs");
         let pane_parent = parent_for_url("file:///repo/crates/vmux_layout/src/pane.rs");
         let placement_parent = parent_for_url("file:///repo/crates/vmux_layout/src/placement.rs");
-        let pr_parent = parent_for_url("https://github.com/vmux-ai/vmux/pull/221");
         let terminal_parent = parent_for_url("vmux://terminal/");
 
         assert_eq!(pane_parent, plugin_parent);
@@ -3398,13 +3401,13 @@ mod tests {
         );
         assert_eq!(
             app.world().get::<ChildOf>(terminal_parent).unwrap().get(),
-            app.world().get::<ChildOf>(pr_parent).unwrap().get(),
-            "terminal should split the remaining browser tail"
+            app.world().get::<ChildOf>(plugin_parent).unwrap().get(),
+            "terminal should split the current file tail"
         );
     }
 
     #[test]
-    fn auto_terminal_splits_remaining_browser_tail_after_file_bucket_reuse() {
+    fn auto_terminal_splits_current_file_tail_after_file_bucket_reuse() {
         let mut app = open_beside_app();
         let space = app
             .world_mut()
@@ -3478,12 +3481,12 @@ mod tests {
 
         assert_eq!(
             app.world().get::<ChildOf>(terminal_parent).unwrap().get(),
-            app.world().get::<ChildOf>(pr_parent).unwrap().get(),
-            "terminal should split the remaining browser tail, not the file bucket"
+            app.world().get::<ChildOf>(plugin_parent).unwrap().get(),
+            "terminal should split the current file tail"
         );
         assert_ne!(
             app.world().get::<ChildOf>(terminal_parent).unwrap().get(),
-            app.world().get::<ChildOf>(plugin_parent).unwrap().get()
+            app.world().get::<ChildOf>(pr_parent).unwrap().get()
         );
     }
 

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -984,11 +984,6 @@ pub fn handle_open_beside_requests(
             find_reuse_in_space(&req.url, space, &rc.tab_q, &rc.all_children, &rc.page_q)
         });
         if let Some(hit) = reuse {
-            if let Ok(co) = child_of_q.get(hit.stack) {
-                let seq =
-                    touch_pane_spawn_seq(co.get(), &mut commands, &mut spawn_counter, &rc.seq_q);
-                spawn_seq_overrides.insert(co.get(), seq.0);
-            }
             if let Ok(meta) = rc.page_q.get(hit.stack)
                 && meta.url != req.url
             {
@@ -1005,7 +1000,7 @@ pub fn handle_open_beside_requests(
         }
 
         if let Some(direction) = req.direction {
-            let (target_pane, pending_size) = match find_sibling_pane(
+            let (target_pane, pending_size, refresh_spawn_seq) = match find_sibling_pane(
                 req.pane,
                 &direction,
                 &child_of_q,
@@ -1013,7 +1008,7 @@ pub fn handle_open_beside_requests(
                 &pane_children,
                 &leaf_panes,
             ) {
-                Some(sibling) => (sibling, pane_size(sibling, &rc.node_q)),
+                Some(sibling) => (sibling, pane_size(sibling, &rc.node_q), false),
                 None => {
                     let existing_tabs = stack_children_for_split(
                         req.pane,
@@ -1046,7 +1041,7 @@ pub fn handle_open_beside_requests(
                     );
                     let pending_size =
                         target_size.unwrap_or_else(|| pane_size(target_pane, &rc.node_q));
-                    (target_pane, pending_size)
+                    (target_pane, pending_size, true)
                 }
             };
             spawn_beside_stack(
@@ -1061,6 +1056,7 @@ pub fn handle_open_beside_requests(
                 &mut pending_leaf_infos,
                 &mut pending_leaf_stacks,
                 pending_size,
+                refresh_spawn_seq,
             );
             continue;
         }
@@ -1078,6 +1074,7 @@ pub fn handle_open_beside_requests(
                 &mut pending_leaf_infos,
                 &mut pending_leaf_stacks,
                 pane_size(req.pane, &rc.node_q),
+                false,
             );
             continue;
         };
@@ -1115,6 +1112,7 @@ pub fn handle_open_beside_requests(
                     &mut pending_leaf_infos,
                     &mut pending_leaf_stacks,
                     pane_size(pane, &rc.node_q),
+                    false,
                 );
             }
             crate::placement::Placement::Spiral { anchor, axis } => {
@@ -1152,6 +1150,7 @@ pub fn handle_open_beside_requests(
                     &mut pending_leaf_infos,
                     &mut pending_leaf_stacks,
                     pending_size,
+                    true,
                 );
             }
         }
@@ -1232,6 +1231,20 @@ fn touch_pane_spawn_seq(
     seq
 }
 
+fn current_pane_spawn_seq(
+    pane: Entity,
+    seq_q: &Query<&SpawnSeq>,
+    spawn_seq_overrides: &std::collections::HashMap<Entity, u64>,
+    pending_leaf_infos: &std::collections::HashMap<Entity, crate::placement::LeafInfo>,
+) -> u64 {
+    pending_leaf_infos
+        .get(&pane)
+        .map(|info| info.spawn_seq)
+        .or_else(|| spawn_seq_overrides.get(&pane).copied())
+        .or_else(|| seq_q.get(pane).ok().map(|s| s.0))
+        .unwrap_or(0)
+}
+
 fn spawn_beside_stack(
     target_pane: Entity,
     req: &OpenBesideRequest,
@@ -1244,14 +1257,20 @@ fn spawn_beside_stack(
     pending_leaf_infos: &mut std::collections::HashMap<Entity, crate::placement::LeafInfo>,
     pending_leaf_stacks: &mut std::collections::HashMap<Entity, Vec<Entity>>,
     pending_size: Vec2,
+    refresh_spawn_seq: bool,
 ) {
-    let seq = touch_pane_spawn_seq(target_pane, commands, spawn_counter, seq_q);
-    spawn_seq_overrides.insert(target_pane, seq.0);
+    let spawn_seq = if refresh_spawn_seq {
+        let seq = touch_pane_spawn_seq(target_pane, commands, spawn_counter, seq_q);
+        spawn_seq_overrides.insert(target_pane, seq.0);
+        seq.0
+    } else {
+        current_pane_spawn_seq(target_pane, seq_q, spawn_seq_overrides, pending_leaf_infos)
+    };
     record_pending_leaf_info(
         pending_leaf_infos,
         target_pane,
         crate::placement::page_kind_for_url(&req.url),
-        seq.0,
+        spawn_seq,
         pending_size,
     );
     let stack_ts = if req.focus {
@@ -2979,6 +2998,149 @@ mod tests {
     }
 
     #[test]
+    fn auto_batched_new_browser_splits_latest_leaf_after_other_work() {
+        let mut app = open_beside_app();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                vmux_core::Active,
+                LastActivatedAt::now(),
+                ChildOf(space),
+            ))
+            .id();
+        let agent_pane = place_pane_with_url(
+            &mut app,
+            tab,
+            1,
+            Vec2::new(1600.0, 900.0),
+            "vmux://agent/claude/session",
+        );
+
+        for (i, url) in [
+            "https://github.com/vmux-ai/vmux/pull/221",
+            "file:///repo/crates/vmux_agent/src/plugin.rs",
+            "file:///repo/crates/vmux_layout/src/pane.rs",
+            "vmux://terminal/",
+            "https://github.com/vmux-ai/vmux/actions/runs/28544986467",
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            app.world_mut()
+                .resource_mut::<Messages<OpenBesideRequest>>()
+                .write(OpenBesideRequest {
+                    pane: agent_pane,
+                    direction: None,
+                    url: url.into(),
+                    request_id: [i as u8; 16],
+                    focus: false,
+                });
+        }
+        app.update();
+
+        let requests = page_open_requests(&app);
+        let parent_for_url = |url: &str| -> Entity {
+            requests
+                .iter()
+                .find_map(|request| match &request.target {
+                    PageOpenTarget::Stack(stack) if request.url == url => app
+                        .world()
+                        .get::<ChildOf>(*stack)
+                        .map(|parent| parent.get()),
+                    _ => None,
+                })
+                .unwrap()
+        };
+        let pr_parent = parent_for_url("https://github.com/vmux-ai/vmux/pull/221");
+        let ci_parent = parent_for_url("https://github.com/vmux-ai/vmux/actions/runs/28544986467");
+        let terminal_parent = parent_for_url("vmux://terminal/");
+
+        assert_ne!(
+            ci_parent, pr_parent,
+            "new CI browser page should not tab into the earlier PR browser pane"
+        );
+        assert_eq!(
+            app.world().get::<ChildOf>(ci_parent).unwrap().get(),
+            app.world().get::<ChildOf>(terminal_parent).unwrap().get(),
+            "new CI browser page should split the latest bottom-right terminal leaf"
+        );
+    }
+
+    #[test]
+    fn auto_batched_new_browser_stacks_after_nonbrowser_tab_reuse() {
+        let mut app = open_beside_app();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                vmux_core::Active,
+                LastActivatedAt::now(),
+                ChildOf(space),
+            ))
+            .id();
+        let agent_pane = place_pane_with_url(
+            &mut app,
+            tab,
+            1,
+            Vec2::new(1600.0, 900.0),
+            "vmux://agent/claude/session",
+        );
+
+        for (i, url) in [
+            "https://github.com/vmux-ai/vmux/pull/221",
+            "file:///repo/crates/vmux_agent/src/plugin.rs",
+            "vmux://terminal/",
+            "https://github.com/vmux-ai/vmux/actions/runs/28544986467",
+            "file:///repo/crates/vmux_layout/src/pane.rs",
+            "https://github.com/vmux-ai/vmux/pull/221/files",
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            app.world_mut()
+                .resource_mut::<Messages<OpenBesideRequest>>()
+                .write(OpenBesideRequest {
+                    pane: agent_pane,
+                    direction: None,
+                    url: url.into(),
+                    request_id: [i as u8; 16],
+                    focus: false,
+                });
+        }
+        app.update();
+
+        let requests = page_open_requests(&app);
+        let parent_for_url = |url: &str| -> Entity {
+            requests
+                .iter()
+                .find_map(|request| match &request.target {
+                    PageOpenTarget::Stack(stack) if request.url == url => app
+                        .world()
+                        .get::<ChildOf>(*stack)
+                        .map(|parent| parent.get()),
+                    _ => None,
+                })
+                .unwrap()
+        };
+        let ci_parent = parent_for_url("https://github.com/vmux-ai/vmux/actions/runs/28544986467");
+        let files_parent = parent_for_url("https://github.com/vmux-ai/vmux/pull/221/files");
+
+        assert_eq!(
+            files_parent, ci_parent,
+            "browser pages after file tab reuse should stack in the newest browser pane"
+        );
+    }
+
+    #[test]
     fn direction_batched_new_type_uses_split_target_size() {
         let mut app = open_beside_app();
         let space = app
@@ -3352,7 +3514,7 @@ mod tests {
     }
 
     #[test]
-    fn auto_terminal_splits_last_reused_browser_pane() {
+    fn auto_terminal_splits_last_spawned_browser_pane() {
         let mut app = open_beside_app();
         let space = app
             .world_mut()
@@ -3394,18 +3556,39 @@ mod tests {
             });
         app.update();
 
+        let requests = page_open_requests(&app);
+        let parent_for_url = |url: &str| -> Entity {
+            requests
+                .iter()
+                .find_map(|request| match &request.target {
+                    PageOpenTarget::Stack(stack) if request.url == url => app
+                        .world()
+                        .get::<ChildOf>(*stack)
+                        .map(|parent| parent.get()),
+                    _ => None,
+                })
+                .unwrap()
+        };
+        let github_parent = parent_for_url("https://github.com/vmux-ai/vmux");
+        let terminal_parent = parent_for_url("vmux://terminal/");
+
         assert!(
-            app.world().get::<PaneSplit>(browser_pane).is_some(),
-            "terminal should split the browser pane that was just reused"
+            app.world().get::<PaneSplit>(browser_pane).is_none(),
+            "older browser pane must not be reused for a new browser URL"
         );
         assert!(
-            app.world().get::<PaneSplit>(file_pane).is_none(),
-            "older file pane must not be split"
+            app.world().get::<PaneSplit>(file_pane).is_some(),
+            "new browser page should split the latest file pane"
+        );
+        assert_eq!(
+            app.world().get::<ChildOf>(github_parent).unwrap().get(),
+            app.world().get::<ChildOf>(terminal_parent).unwrap().get(),
+            "terminal should split the browser pane that was just spawned"
         );
     }
 
     #[test]
-    fn auto_terminal_splits_pane_touched_earlier_in_same_batch() {
+    fn auto_terminal_splits_browser_pane_spawned_earlier_in_same_batch() {
         let mut app = open_beside_app();
         let space = app
             .world_mut()
@@ -3445,18 +3628,39 @@ mod tests {
             });
         app.update();
 
+        let requests = page_open_requests(&app);
+        let parent_for_url = |url: &str| -> Entity {
+            requests
+                .iter()
+                .find_map(|request| match &request.target {
+                    PageOpenTarget::Stack(stack) if request.url == url => app
+                        .world()
+                        .get::<ChildOf>(*stack)
+                        .map(|parent| parent.get()),
+                    _ => None,
+                })
+                .unwrap()
+        };
+        let github_parent = parent_for_url("https://github.com/vmux-ai/vmux");
+        let terminal_parent = parent_for_url("vmux://terminal/");
+
         assert!(
-            app.world().get::<PaneSplit>(browser_pane).is_some(),
-            "terminal should split the browser pane touched earlier in the same batch"
+            app.world().get::<PaneSplit>(browser_pane).is_none(),
+            "older browser pane must not be reused for a new browser URL"
         );
         assert!(
-            app.world().get::<PaneSplit>(file_pane).is_none(),
-            "older file pane must not be split"
+            app.world().get::<PaneSplit>(file_pane).is_some(),
+            "new browser page should split the latest file pane"
+        );
+        assert_eq!(
+            app.world().get::<ChildOf>(github_parent).unwrap().get(),
+            app.world().get::<ChildOf>(terminal_parent).unwrap().get(),
+            "terminal should split the browser pane spawned earlier in the same batch"
         );
     }
 
     #[test]
-    fn forced_split_anchor_follows_last_reused_browser_pane() {
+    fn forced_split_anchor_follows_last_spawned_browser_pane() {
         let mut app = open_beside_app();
         let space = app
             .world_mut()
@@ -3486,6 +3690,25 @@ mod tests {
                 focus: false,
             });
         app.update();
+
+        let requests = page_open_requests(&app);
+        let github_parent = requests
+            .iter()
+            .find_map(|request| match &request.target {
+                PageOpenTarget::Stack(stack)
+                    if request.url == "https://github.com/vmux-ai/vmux" =>
+                {
+                    app.world()
+                        .get::<ChildOf>(*stack)
+                        .map(|parent| parent.get())
+                }
+                _ => None,
+            })
+            .unwrap();
+        assert_ne!(
+            github_parent, browser_pane,
+            "new browser URL should spawn from the latest leaf, not reuse the older browser pane"
+        );
 
         app.insert_resource(SplitAnchorInput { anchor: file_pane })
             .init_resource::<SplitAnchorOut>()
@@ -3494,12 +3717,12 @@ mod tests {
 
         assert_eq!(
             app.world().resource::<SplitAnchorOut>().0,
-            Some(browser_pane)
+            Some(github_parent)
         );
     }
 
     #[test]
-    fn forced_split_anchor_follows_exact_reused_browser_page() {
+    fn forced_split_anchor_ignores_exact_reused_browser_page() {
         let mut app = open_beside_app();
         let space = app
             .world_mut()
@@ -3540,10 +3763,11 @@ mod tests {
             .add_systems(Update, split_anchor_test_sys);
         app.update();
 
-        assert_eq!(
-            app.world().resource::<SplitAnchorOut>().0,
-            Some(browser_pane)
+        assert!(
+            app.world().get::<PaneSplit>(browser_pane).is_none(),
+            "exact browser reuse must not split the existing browser pane"
         );
+        assert_eq!(app.world().resource::<SplitAnchorOut>().0, Some(file_pane));
     }
 
     #[derive(Resource)]

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -24,7 +24,7 @@ use vmux_command::{
     AppCommand, BrowserCommand, LayoutCommand, OpenCommand, PaneCommand, ReadAppCommands,
     open::{PaneDirection, PaneOpenMode, PaneTarget},
 };
-use vmux_core::{PageOpenRequest, PageOpenTarget};
+use vmux_core::{PageOpenRequest, PageOpenTarget, PageOpenTask};
 use vmux_history::LastActivatedAt;
 
 /// Marker: pane is waiting for close confirmation dialog.
@@ -953,6 +953,7 @@ pub struct ResolverCtx<'w, 's> {
     seq_q: Query<'w, 's, &'static SpawnSeq>,
     node_q: Query<'w, 's, &'static ComputedNode>,
     page_q: Query<'w, 's, &'static vmux_core::PageMetadata, With<Stack>>,
+    open_task_q: Query<'w, 's, &'static PageOpenTask>,
     spaces: Query<'w, 's, (), With<crate::space::Space>>,
     tab_q: Query<'w, 's, Entity, With<Tab>>,
 }
@@ -977,11 +978,20 @@ pub fn handle_open_beside_requests(
         std::collections::HashMap::new();
     let mut pending_leaf_stacks: std::collections::HashMap<Entity, Vec<Entity>> =
         std::collections::HashMap::new();
+    let mut pending_open_stacks: Vec<(String, Entity)> = Vec::new();
     let mut retired_leaf_panes: std::collections::HashSet<Entity> =
         std::collections::HashSet::new();
     for req in reader.read() {
         let reuse = crate::space::space_of(req.pane, &child_of_q, &rc.spaces).and_then(|space| {
-            find_reuse_in_space(&req.url, space, &rc.tab_q, &rc.all_children, &rc.page_q)
+            find_reuse_in_space(
+                &req.url,
+                space,
+                &rc.tab_q,
+                &rc.all_children,
+                &rc.page_q,
+                &rc.open_task_q,
+                &child_of_q,
+            )
         });
         if let Some(hit) = reuse {
             if let Ok(meta) = rc.page_q.get(hit.stack)
@@ -995,6 +1005,23 @@ pub fn handle_open_beside_requests(
             }
             if req.focus {
                 focus_reuse_hit(&mut commands, &child_of_q, hit);
+            }
+            continue;
+        }
+        if req.direction.is_none()
+            && let Some(index) = pending_open_match_index(&req.url, &pending_open_stacks)
+        {
+            let (pending_url, stack) = &mut pending_open_stacks[index];
+            if *pending_url != req.url {
+                page_open_requests.write(PageOpenRequest {
+                    target: PageOpenTarget::Stack(*stack),
+                    url: req.url.clone(),
+                    request_id: None,
+                });
+                *pending_url = req.url.clone();
+            }
+            if req.focus {
+                focus_stack_in_layout(&mut commands, &child_of_q, &rc.tab_q, *stack);
             }
             continue;
         }
@@ -1044,7 +1071,7 @@ pub fn handle_open_beside_requests(
                     (target_pane, pending_size, true)
                 }
             };
-            spawn_beside_stack(
+            let stack = spawn_beside_stack(
                 target_pane,
                 req,
                 &mut commands,
@@ -1058,11 +1085,12 @@ pub fn handle_open_beside_requests(
                 pending_size,
                 refresh_spawn_seq,
             );
+            pending_open_stacks.push((req.url.clone(), stack));
             continue;
         }
 
         let Some(tab) = tab_of_pane(req.pane, &child_of_q, &rc.tab_q) else {
-            spawn_beside_stack(
+            let stack = spawn_beside_stack(
                 req.pane,
                 req,
                 &mut commands,
@@ -1076,6 +1104,7 @@ pub fn handle_open_beside_requests(
                 pane_size(req.pane, &rc.node_q),
                 false,
             );
+            pending_open_stacks.push((req.url.clone(), stack));
             continue;
         };
         let mut leaves = collect_leaf_infos(
@@ -1100,7 +1129,7 @@ pub fn handle_open_beside_requests(
                 );
             }
             crate::placement::Placement::AddTab { pane } => {
-                spawn_beside_stack(
+                let stack = spawn_beside_stack(
                     pane,
                     req,
                     &mut commands,
@@ -1114,6 +1143,7 @@ pub fn handle_open_beside_requests(
                     pane_size(pane, &rc.node_q),
                     false,
                 );
+                pending_open_stacks.push((req.url.clone(), stack));
             }
             crate::placement::Placement::Spiral { anchor, axis } => {
                 let old_leaf_info = leaves.iter().find(|leaf| leaf.pane == anchor).cloned();
@@ -1138,7 +1168,7 @@ pub fn handle_open_beside_requests(
                     &mut retired_leaf_panes,
                 );
                 let pending_size = target_size.unwrap_or_else(|| pane_size(anchor, &rc.node_q));
-                spawn_beside_stack(
+                let stack = spawn_beside_stack(
                     target_pane,
                     req,
                     &mut commands,
@@ -1152,6 +1182,7 @@ pub fn handle_open_beside_requests(
                     pending_size,
                     true,
                 );
+                pending_open_stacks.push((req.url.clone(), stack));
             }
         }
     }
@@ -1215,6 +1246,22 @@ fn focus_reuse_hit(
     commands.entity(hit.tab).insert(LastActivatedAt::now());
 }
 
+fn focus_stack_in_layout(
+    commands: &mut Commands,
+    child_of_q: &Query<&ChildOf>,
+    tab_q: &Query<Entity, With<Tab>>,
+    stack: Entity,
+) {
+    if let Ok(co) = child_of_q.get(stack) {
+        let pane = co.get();
+        commands.entity(pane).insert(LastActivatedAt::now());
+        if let Some(tab) = tab_of_pane(pane, child_of_q, tab_q) {
+            commands.entity(tab).insert(LastActivatedAt::now());
+        }
+    }
+    commands.entity(stack).insert(LastActivatedAt::now());
+}
+
 fn touch_pane_spawn_seq(
     target_pane: Entity,
     commands: &mut Commands,
@@ -1258,7 +1305,7 @@ fn spawn_beside_stack(
     pending_leaf_stacks: &mut std::collections::HashMap<Entity, Vec<Entity>>,
     pending_size: Vec2,
     refresh_spawn_seq: bool,
-) {
+) -> Entity {
     let spawn_seq = if refresh_spawn_seq {
         let seq = touch_pane_spawn_seq(target_pane, commands, spawn_counter, seq_q);
         spawn_seq_overrides.insert(target_pane, seq.0);
@@ -1281,6 +1328,10 @@ fn spawn_beside_stack(
     let new_stack = commands
         .spawn((stack_bundle(), stack_ts, ChildOf(target_pane)))
         .id();
+    commands.entity(new_stack).insert(vmux_core::PageMetadata {
+        url: req.url.clone(),
+        ..default()
+    });
     pending_leaf_stacks
         .entry(target_pane)
         .or_default()
@@ -1291,6 +1342,13 @@ fn spawn_beside_stack(
         new_stack_ctx,
         page_open_requests,
     );
+    new_stack
+}
+
+fn pending_open_match_index(url: &str, pending_open_stacks: &[(String, Entity)]) -> Option<usize> {
+    pending_open_stacks
+        .iter()
+        .position(|(pending_url, _)| crate::placement::reusable_page_match(url, pending_url))
 }
 
 fn pane_size(pane: Entity, node_q: &Query<&ComputedNode>) -> Vec2 {
@@ -1377,13 +1435,14 @@ fn leaf_info_for_pane(
     page_q: &Query<&vmux_core::PageMetadata, With<Stack>>,
     spawn_seq_overrides: &std::collections::HashMap<Entity, u64>,
 ) -> Option<crate::placement::LeafInfo> {
-    let kinds = pane_children
-        .get(pane)
-        .ok()?
-        .iter()
-        .filter_map(|child| page_q.get(child).ok())
-        .map(|p| crate::placement::page_kind_for_url(&p.url))
-        .collect();
+    let kinds = unique_page_kinds(
+        pane_children
+            .get(pane)
+            .ok()?
+            .iter()
+            .filter_map(|child| page_q.get(child).ok())
+            .map(|p| p.url.as_str()),
+    );
     Some(crate::placement::LeafInfo {
         pane,
         kinds,
@@ -1429,10 +1488,11 @@ fn collect_leaf_infos(
             let kinds = pane_children
                 .get(pane)
                 .map(|c| {
-                    c.iter()
-                        .filter_map(|child| page_q.get(child).ok())
-                        .map(|p| crate::placement::page_kind_for_url(&p.url))
-                        .collect()
+                    unique_page_kinds(
+                        c.iter()
+                            .filter_map(|child| page_q.get(child).ok())
+                            .map(|p| p.url.as_str()),
+                    )
                 })
                 .unwrap_or_default();
             crate::placement::LeafInfo {
@@ -1449,12 +1509,25 @@ fn collect_leaf_infos(
         .collect()
 }
 
+fn unique_page_kinds<'a>(urls: impl Iterator<Item = &'a str>) -> Vec<crate::placement::PageKind> {
+    let mut kinds = Vec::new();
+    for url in urls {
+        let kind = crate::placement::page_kind_for_url(url);
+        if !kinds.contains(&kind) {
+            kinds.push(kind);
+        }
+    }
+    kinds
+}
+
 fn find_reuse_in_space(
     url: &str,
     space: Entity,
     tab_q: &Query<Entity, With<Tab>>,
     all_children: &Query<&Children>,
     page_q: &Query<&vmux_core::PageMetadata, With<Stack>>,
+    open_task_q: &Query<&PageOpenTask>,
+    child_of_q: &Query<&ChildOf>,
 ) -> Option<crate::placement::ReuseHit> {
     let tabs: Vec<Entity> = all_children
         .get(space)
@@ -1472,6 +1545,37 @@ fn find_reuse_in_space(
                 frontier.extend(children.iter());
             }
         }
+    }
+    for task in open_task_q.iter() {
+        if !crate::placement::reusable_page_match(url, &task.url) {
+            continue;
+        }
+        if let Some(tab) = tab_for_stack_in_space(task.stack, space, child_of_q, tab_q) {
+            return Some(crate::placement::ReuseHit {
+                tab,
+                stack: task.stack,
+            });
+        }
+    }
+    None
+}
+
+fn tab_for_stack_in_space(
+    stack: Entity,
+    space: Entity,
+    child_of_q: &Query<&ChildOf>,
+    tab_q: &Query<Entity, With<Tab>>,
+) -> Option<Entity> {
+    let mut cur = stack;
+    let mut tab = None;
+    for _ in 0..32 {
+        if tab_q.contains(cur) {
+            tab = Some(cur);
+        }
+        if cur == space {
+            return tab;
+        }
+        cur = child_of_q.get(cur).ok()?.get();
     }
     None
 }
@@ -2779,6 +2883,19 @@ mod tests {
         cursor.read(messages).cloned().collect()
     }
 
+    fn materialize_page_metadata(app: &mut App) {
+        for request in page_open_requests(app) {
+            if let PageOpenTarget::Stack(stack) = request.target {
+                app.world_mut()
+                    .entity_mut(stack)
+                    .insert(vmux_core::PageMetadata {
+                        url: request.url,
+                        ..default()
+                    });
+            }
+        }
+    }
+
     fn open_beside_app() -> App {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
@@ -3137,6 +3254,204 @@ mod tests {
         assert_eq!(
             files_parent, ci_parent,
             "browser pages after file tab reuse should stack in the newest browser pane"
+        );
+    }
+
+    #[test]
+    fn auto_file_bucket_stays_reusable_after_multiple_file_tabs() {
+        let mut app = open_beside_app();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                vmux_core::Active,
+                LastActivatedAt::now(),
+                ChildOf(space),
+            ))
+            .id();
+        let agent_pane = place_pane_with_url(
+            &mut app,
+            tab,
+            1,
+            Vec2::new(1600.0, 900.0),
+            "vmux://agent/claude/session",
+        );
+
+        for (i, url) in [
+            "https://github.com/vmux-ai/vmux/pull/221",
+            "file:///repo/crates/vmux_agent/src/plugin.rs",
+            "file:///repo/crates/vmux_layout/src/pane.rs",
+            "vmux://terminal/",
+            "file:///repo/crates/vmux_layout/src/placement.rs",
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            app.world_mut()
+                .resource_mut::<Messages<OpenBesideRequest>>()
+                .write(OpenBesideRequest {
+                    pane: agent_pane,
+                    direction: None,
+                    url: url.into(),
+                    request_id: [i as u8; 16],
+                    focus: false,
+                });
+            app.update();
+            materialize_page_metadata(&mut app);
+        }
+
+        let requests = page_open_requests(&app);
+        let parent_for_url = |url: &str| -> Entity {
+            requests
+                .iter()
+                .find_map(|request| match &request.target {
+                    PageOpenTarget::Stack(stack) if request.url == url => app
+                        .world()
+                        .get::<ChildOf>(*stack)
+                        .map(|parent| parent.get()),
+                    _ => None,
+                })
+                .unwrap()
+        };
+        let plugin_parent = parent_for_url("file:///repo/crates/vmux_agent/src/plugin.rs");
+        let pane_parent = parent_for_url("file:///repo/crates/vmux_layout/src/pane.rs");
+        let placement_parent = parent_for_url("file:///repo/crates/vmux_layout/src/placement.rs");
+        let terminal_parent = parent_for_url("vmux://terminal/");
+
+        assert_eq!(pane_parent, plugin_parent);
+        assert_eq!(
+            placement_parent, plugin_parent,
+            "later files should reuse the existing file pane even after it has multiple file tabs"
+        );
+        assert_eq!(
+            app.world().get::<ChildOf>(terminal_parent).unwrap().get(),
+            app.world().get::<ChildOf>(plugin_parent).unwrap().get(),
+            "terminal should split the file pane"
+        );
+    }
+
+    #[test]
+    fn auto_duplicate_url_reuses_pending_open_in_same_batch() {
+        let mut app = open_beside_app();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                vmux_core::Active,
+                LastActivatedAt::now(),
+                ChildOf(space),
+            ))
+            .id();
+        let agent_pane = place_pane_with_url(
+            &mut app,
+            tab,
+            1,
+            Vec2::new(1600.0, 900.0),
+            "vmux://agent/claude/session",
+        );
+
+        for i in 0..2 {
+            app.world_mut()
+                .resource_mut::<Messages<OpenBesideRequest>>()
+                .write(OpenBesideRequest {
+                    pane: agent_pane,
+                    direction: None,
+                    url: "https://github.com/vmux-ai/vmux/pull/221".into(),
+                    request_id: [i; 16],
+                    focus: false,
+                });
+        }
+        app.update();
+
+        let requests = page_open_requests(&app);
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|request| request.url == "https://github.com/vmux-ai/vmux/pull/221")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn auto_duplicate_url_reuses_pending_page_open_task() {
+        let mut app = open_beside_app();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                vmux_core::Active,
+                LastActivatedAt::now(),
+                ChildOf(space),
+            ))
+            .id();
+        let agent_pane = place_pane_with_url(
+            &mut app,
+            tab,
+            1,
+            Vec2::new(1600.0, 900.0),
+            "vmux://agent/claude/session",
+        );
+
+        app.world_mut()
+            .resource_mut::<Messages<OpenBesideRequest>>()
+            .write(OpenBesideRequest {
+                pane: agent_pane,
+                direction: None,
+                url: "https://github.com/vmux-ai/vmux/pull/221".into(),
+                request_id: [0; 16],
+                focus: false,
+            });
+        app.update();
+
+        let first_stack = page_open_requests(&app)
+            .iter()
+            .find_map(|request| match request.target {
+                PageOpenTarget::Stack(stack)
+                    if request.url == "https://github.com/vmux-ai/vmux/pull/221" =>
+                {
+                    Some(stack)
+                }
+                _ => None,
+            })
+            .unwrap();
+        app.world_mut().spawn(vmux_core::PageOpenTask {
+            id: vmux_core::PageOpenId::new(),
+            stack: first_stack,
+            url: "https://github.com/vmux-ai/vmux/pull/221".into(),
+            request_id: None,
+        });
+
+        app.world_mut()
+            .resource_mut::<Messages<OpenBesideRequest>>()
+            .write(OpenBesideRequest {
+                pane: agent_pane,
+                direction: None,
+                url: "https://github.com/vmux-ai/vmux/pull/221".into(),
+                request_id: [1; 16],
+                focus: false,
+            });
+        app.update();
+
+        let requests = page_open_requests(&app);
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|request| request.url == "https://github.com/vmux-ai/vmux/pull/221")
+                .count(),
+            1
         );
     }
 

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -877,6 +877,16 @@ pub fn split_leaf_into_two(
     existing_tabs: &[Entity],
     activate_new: bool,
 ) -> Entity {
+    split_leaf_into_two_parts(commands, active, split_dir, existing_tabs, activate_new).1
+}
+
+fn split_leaf_into_two_parts(
+    commands: &mut Commands,
+    active: Entity,
+    split_dir: PaneSplitDirection,
+    existing_tabs: &[Entity],
+    activate_new: bool,
+) -> (Entity, Entity) {
     let new_ts = if activate_new {
         LastActivatedAt::now()
     } else {
@@ -892,7 +902,7 @@ pub fn split_leaf_into_two(
         commands.entity(*tab).insert(ChildOf(pane1));
     }
     commands.entity(active).insert(split_root_bundle(split_dir));
-    p2
+    (pane1, p2)
 }
 
 /// Return a fresh empty leaf pane beside `anchor`, to host an agent-spawned
@@ -958,9 +968,42 @@ pub fn handle_open_beside_requests(
     mut commands: Commands,
     mut page_open_requests: MessageWriter<PageOpenRequest>,
     mut new_stack_ctx: ResMut<NewStackContext>,
+    mut spawn_counter: ResMut<SpawnCounter>,
 ) {
     let mut split_this_batch: std::collections::HashSet<Entity> = std::collections::HashSet::new();
+    let mut spawn_seq_overrides: std::collections::HashMap<Entity, u64> =
+        std::collections::HashMap::new();
+    let mut pending_leaf_infos: std::collections::HashMap<Entity, crate::placement::LeafInfo> =
+        std::collections::HashMap::new();
+    let mut pending_leaf_stacks: std::collections::HashMap<Entity, Vec<Entity>> =
+        std::collections::HashMap::new();
+    let mut retired_leaf_panes: std::collections::HashSet<Entity> =
+        std::collections::HashSet::new();
     for req in reader.read() {
+        let reuse = crate::space::space_of(req.pane, &child_of_q, &rc.spaces).and_then(|space| {
+            find_reuse_in_space(&req.url, space, &rc.tab_q, &rc.all_children, &rc.page_q)
+        });
+        if let Some(hit) = reuse {
+            if let Ok(co) = child_of_q.get(hit.stack) {
+                let seq =
+                    touch_pane_spawn_seq(co.get(), &mut commands, &mut spawn_counter, &rc.seq_q);
+                spawn_seq_overrides.insert(co.get(), seq.0);
+            }
+            if let Ok(meta) = rc.page_q.get(hit.stack)
+                && meta.url != req.url
+            {
+                page_open_requests.write(PageOpenRequest {
+                    target: PageOpenTarget::Stack(hit.stack),
+                    url: req.url.clone(),
+                    request_id: None,
+                });
+            }
+            if req.focus {
+                focus_reuse_hit(&mut commands, &child_of_q, hit);
+            }
+            continue;
+        }
+
         if let Some(direction) = req.direction {
             let target_pane = match find_sibling_pane(
                 req.pane,
@@ -972,21 +1015,36 @@ pub fn handle_open_beside_requests(
             ) {
                 Some(sibling) => sibling,
                 None => {
-                    let existing_tabs: Vec<Entity> = pane_children
-                        .get(req.pane)
-                        .map(|c| c.iter().filter(|&e| tab_filter.contains(e)).collect())
-                        .unwrap_or_default();
+                    let existing_tabs = stack_children_for_split(
+                        req.pane,
+                        &pane_children,
+                        &tab_filter,
+                        &pending_leaf_stacks,
+                    );
+                    let old_leaf_info = leaf_info_for_pane(
+                        req.pane,
+                        &pane_children,
+                        &rc.seq_q,
+                        &rc.node_q,
+                        &rc.page_q,
+                        &spawn_seq_overrides,
+                    );
                     let split_dir = direction_to_split(&direction);
                     let already_split =
                         !split_this_batch.insert(req.pane) || split_dir_q.contains(req.pane);
-                    split_or_extend(
+                    split_or_extend_for_batch(
                         &mut commands,
                         req.pane,
                         split_dir,
                         &existing_tabs,
                         req.focus,
                         already_split,
+                        old_leaf_info,
+                        &mut pending_leaf_infos,
+                        &mut pending_leaf_stacks,
+                        &mut retired_leaf_panes,
                     )
+                    .0
                 }
             };
             spawn_beside_stack(
@@ -995,6 +1053,12 @@ pub fn handle_open_beside_requests(
                 &mut commands,
                 &mut new_stack_ctx,
                 &mut page_open_requests,
+                &mut spawn_counter,
+                &rc.seq_q,
+                &mut spawn_seq_overrides,
+                &mut pending_leaf_infos,
+                &mut pending_leaf_stacks,
+                pane_size(target_pane, &rc.node_q),
             );
             continue;
         }
@@ -1006,13 +1070,16 @@ pub fn handle_open_beside_requests(
                 &mut commands,
                 &mut new_stack_ctx,
                 &mut page_open_requests,
+                &mut spawn_counter,
+                &rc.seq_q,
+                &mut spawn_seq_overrides,
+                &mut pending_leaf_infos,
+                &mut pending_leaf_stacks,
+                pane_size(req.pane, &rc.node_q),
             );
             continue;
         };
-        let reuse = crate::space::space_of(req.pane, &child_of_q, &rc.spaces).and_then(|space| {
-            find_reuse_in_space(&req.url, space, &rc.tab_q, &rc.all_children, &rc.page_q)
-        });
-        let leaves = collect_leaf_infos(
+        let mut leaves = collect_leaf_infos(
             tab,
             &rc.all_children,
             &leaf_panes,
@@ -1020,15 +1087,18 @@ pub fn handle_open_beside_requests(
             &rc.seq_q,
             &rc.node_q,
             &rc.page_q,
+            &spawn_seq_overrides,
         );
+        leaves.retain(|leaf| !retired_leaf_panes.contains(&leaf.pane));
+        merge_pending_leaf_infos(&mut leaves, &pending_leaf_infos);
 
         match crate::placement::resolve_placement(&req.url, reuse, &leaves, req.pane) {
             crate::placement::Placement::Focus { tab, stack } => {
-                if let Ok(co) = child_of_q.get(stack) {
-                    commands.entity(co.get()).insert(LastActivatedAt::now());
-                }
-                commands.entity(stack).insert(LastActivatedAt::now());
-                commands.entity(tab).insert(LastActivatedAt::now());
+                focus_reuse_hit(
+                    &mut commands,
+                    &child_of_q,
+                    crate::placement::ReuseHit { tab, stack },
+                );
             }
             crate::placement::Placement::AddTab { pane } => {
                 spawn_beside_stack(
@@ -1037,33 +1107,127 @@ pub fn handle_open_beside_requests(
                     &mut commands,
                     &mut new_stack_ctx,
                     &mut page_open_requests,
+                    &mut spawn_counter,
+                    &rc.seq_q,
+                    &mut spawn_seq_overrides,
+                    &mut pending_leaf_infos,
+                    &mut pending_leaf_stacks,
+                    pane_size(pane, &rc.node_q),
                 );
             }
             crate::placement::Placement::Spiral { anchor, axis } => {
-                let existing_tabs: Vec<Entity> = pane_children
-                    .get(anchor)
-                    .map(|c| c.iter().filter(|&e| tab_filter.contains(e)).collect())
-                    .unwrap_or_default();
+                let old_leaf_info = leaves.iter().find(|leaf| leaf.pane == anchor).cloned();
+                let existing_tabs = stack_children_for_split(
+                    anchor,
+                    &pane_children,
+                    &tab_filter,
+                    &pending_leaf_stacks,
+                );
                 let already_split =
                     !split_this_batch.insert(anchor) || split_dir_q.contains(anchor);
-                let target_pane = split_or_extend(
+                let (target_pane, target_size) = split_or_extend_for_batch(
                     &mut commands,
                     anchor,
                     axis,
                     &existing_tabs,
                     req.focus,
                     already_split,
+                    old_leaf_info,
+                    &mut pending_leaf_infos,
+                    &mut pending_leaf_stacks,
+                    &mut retired_leaf_panes,
                 );
+                let pending_size = target_size.unwrap_or_else(|| pane_size(anchor, &rc.node_q));
                 spawn_beside_stack(
                     target_pane,
                     req,
                     &mut commands,
                     &mut new_stack_ctx,
                     &mut page_open_requests,
+                    &mut spawn_counter,
+                    &rc.seq_q,
+                    &mut spawn_seq_overrides,
+                    &mut pending_leaf_infos,
+                    &mut pending_leaf_stacks,
+                    pending_size,
                 );
             }
         }
     }
+}
+
+fn split_or_extend_for_batch(
+    commands: &mut Commands,
+    anchor: Entity,
+    split_dir: PaneSplitDirection,
+    existing_tabs: &[Entity],
+    activate_new: bool,
+    already_split: bool,
+    old_leaf_info: Option<crate::placement::LeafInfo>,
+    pending_leaf_infos: &mut std::collections::HashMap<Entity, crate::placement::LeafInfo>,
+    pending_leaf_stacks: &mut std::collections::HashMap<Entity, Vec<Entity>>,
+    retired_leaf_panes: &mut std::collections::HashSet<Entity>,
+) -> (Entity, Option<Vec2>) {
+    if already_split {
+        return (
+            split_or_extend(
+                commands,
+                anchor,
+                split_dir,
+                existing_tabs,
+                activate_new,
+                true,
+            ),
+            None,
+        );
+    }
+
+    let pending_info = pending_leaf_infos.remove(&anchor);
+    pending_leaf_stacks.remove(&anchor);
+    let (holder, target) =
+        split_leaf_into_two_parts(commands, anchor, split_dir, existing_tabs, activate_new);
+    retired_leaf_panes.insert(anchor);
+    let target_size = pending_info
+        .as_ref()
+        .or(old_leaf_info.as_ref())
+        .map(|info| split_child_size(info.size, split_dir));
+    if let Some(mut info) = pending_info.or(old_leaf_info) {
+        info.pane = holder;
+        info.size = split_child_size(info.size, split_dir);
+        pending_leaf_infos.insert(holder, info);
+    }
+    if !existing_tabs.is_empty() {
+        pending_leaf_stacks.insert(holder, existing_tabs.to_vec());
+    }
+    (target, target_size)
+}
+
+fn focus_reuse_hit(
+    commands: &mut Commands,
+    child_of_q: &Query<&ChildOf>,
+    hit: crate::placement::ReuseHit,
+) {
+    if let Ok(co) = child_of_q.get(hit.stack) {
+        commands.entity(co.get()).insert(LastActivatedAt::now());
+    }
+    commands.entity(hit.stack).insert(LastActivatedAt::now());
+    commands.entity(hit.tab).insert(LastActivatedAt::now());
+}
+
+fn touch_pane_spawn_seq(
+    target_pane: Entity,
+    commands: &mut Commands,
+    spawn_counter: &mut SpawnCounter,
+    seq_q: &Query<&SpawnSeq>,
+) -> SpawnSeq {
+    let max_existing = seq_q.iter().map(|s| s.0).max().unwrap_or(0);
+    if spawn_counter.0 <= max_existing {
+        spawn_counter.0 = max_existing;
+    }
+    spawn_counter.0 += 1;
+    let seq = SpawnSeq(spawn_counter.0);
+    commands.entity(target_pane).insert(seq);
+    seq
 }
 
 fn spawn_beside_stack(
@@ -1072,7 +1236,22 @@ fn spawn_beside_stack(
     commands: &mut Commands,
     new_stack_ctx: &mut NewStackContext,
     page_open_requests: &mut MessageWriter<PageOpenRequest>,
+    spawn_counter: &mut SpawnCounter,
+    seq_q: &Query<&SpawnSeq>,
+    spawn_seq_overrides: &mut std::collections::HashMap<Entity, u64>,
+    pending_leaf_infos: &mut std::collections::HashMap<Entity, crate::placement::LeafInfo>,
+    pending_leaf_stacks: &mut std::collections::HashMap<Entity, Vec<Entity>>,
+    pending_size: Vec2,
 ) {
+    let seq = touch_pane_spawn_seq(target_pane, commands, spawn_counter, seq_q);
+    spawn_seq_overrides.insert(target_pane, seq.0);
+    record_pending_leaf_info(
+        pending_leaf_infos,
+        target_pane,
+        crate::placement::page_kind_for_url(&req.url),
+        seq.0,
+        pending_size,
+    );
     let stack_ts = if req.focus {
         LastActivatedAt::now()
     } else {
@@ -1081,12 +1260,119 @@ fn spawn_beside_stack(
     let new_stack = commands
         .spawn((stack_bundle(), stack_ts, ChildOf(target_pane)))
         .id();
+    pending_leaf_stacks
+        .entry(target_pane)
+        .or_default()
+        .push(new_stack);
     open_or_prompt_stack(
         new_stack,
         Some(req.url.clone()),
         new_stack_ctx,
         page_open_requests,
     );
+}
+
+fn pane_size(pane: Entity, node_q: &Query<&ComputedNode>) -> Vec2 {
+    node_q.get(pane).map(|n| n.size).unwrap_or(Vec2::ZERO)
+}
+
+fn split_child_size(size: Vec2, split_dir: PaneSplitDirection) -> Vec2 {
+    match split_dir {
+        PaneSplitDirection::Row => Vec2::new(size.x * 0.5, size.y),
+        PaneSplitDirection::Column => Vec2::new(size.x, size.y * 0.5),
+    }
+}
+
+fn record_pending_leaf_info(
+    pending_leaf_infos: &mut std::collections::HashMap<Entity, crate::placement::LeafInfo>,
+    pane: Entity,
+    kind: crate::placement::PageKind,
+    spawn_seq: u64,
+    size: Vec2,
+) {
+    let info = pending_leaf_infos
+        .entry(pane)
+        .or_insert_with(|| crate::placement::LeafInfo {
+            pane,
+            kinds: Vec::new(),
+            spawn_seq,
+            size,
+        });
+    if !info.kinds.contains(&kind) {
+        info.kinds.push(kind);
+    }
+    info.spawn_seq = spawn_seq;
+    if info.size == Vec2::ZERO {
+        info.size = size;
+    }
+}
+
+fn merge_pending_leaf_infos(
+    leaves: &mut Vec<crate::placement::LeafInfo>,
+    pending_leaf_infos: &std::collections::HashMap<Entity, crate::placement::LeafInfo>,
+) {
+    for pending in pending_leaf_infos.values() {
+        if let Some(existing) = leaves.iter_mut().find(|leaf| leaf.pane == pending.pane) {
+            for kind in &pending.kinds {
+                if !existing.kinds.contains(kind) {
+                    existing.kinds.push(*kind);
+                }
+            }
+            existing.spawn_seq = pending.spawn_seq;
+            if existing.size == Vec2::ZERO {
+                existing.size = pending.size;
+            }
+        } else {
+            leaves.push(pending.clone());
+        }
+    }
+}
+
+fn stack_children_for_split(
+    pane: Entity,
+    pane_children: &Query<&Children, With<Pane>>,
+    tab_filter: &Query<Entity, With<Stack>>,
+    pending_leaf_stacks: &std::collections::HashMap<Entity, Vec<Entity>>,
+) -> Vec<Entity> {
+    let mut stacks: Vec<Entity> = pane_children
+        .get(pane)
+        .map(|c| c.iter().filter(|&e| tab_filter.contains(e)).collect())
+        .unwrap_or_default();
+    if let Some(pending) = pending_leaf_stacks.get(&pane) {
+        for &stack in pending {
+            if !stacks.contains(&stack) {
+                stacks.push(stack);
+            }
+        }
+    }
+    stacks
+}
+
+fn leaf_info_for_pane(
+    pane: Entity,
+    pane_children: &Query<&Children, With<Pane>>,
+    seq_q: &Query<&SpawnSeq>,
+    node_q: &Query<&ComputedNode>,
+    page_q: &Query<&vmux_core::PageMetadata, With<Stack>>,
+    spawn_seq_overrides: &std::collections::HashMap<Entity, u64>,
+) -> Option<crate::placement::LeafInfo> {
+    let kinds = pane_children
+        .get(pane)
+        .ok()?
+        .iter()
+        .filter_map(|child| page_q.get(child).ok())
+        .map(|p| crate::placement::page_kind_for_url(&p.url))
+        .collect();
+    Some(crate::placement::LeafInfo {
+        pane,
+        kinds,
+        spawn_seq: spawn_seq_overrides
+            .get(&pane)
+            .copied()
+            .or_else(|| seq_q.get(pane).ok().map(|s| s.0))
+            .unwrap_or(0),
+        size: node_q.get(pane).map(|n| n.size).unwrap_or(Vec2::ZERO),
+    })
 }
 
 fn tab_of_pane(
@@ -1112,6 +1398,7 @@ fn collect_leaf_infos(
     seq_q: &Query<&SpawnSeq>,
     node_q: &Query<&ComputedNode>,
     page_q: &Query<&vmux_core::PageMetadata, With<Stack>>,
+    spawn_seq_overrides: &std::collections::HashMap<Entity, u64>,
 ) -> Vec<crate::placement::LeafInfo> {
     let mut panes = Vec::new();
     crate::stack::collect_leaf_panes(tab, all_children, leaf_panes, &mut panes);
@@ -1130,7 +1417,11 @@ fn collect_leaf_infos(
             crate::placement::LeafInfo {
                 pane,
                 kinds,
-                spawn_seq: seq_q.get(pane).map(|s| s.0).unwrap_or(0),
+                spawn_seq: spawn_seq_overrides
+                    .get(&pane)
+                    .copied()
+                    .or_else(|| seq_q.get(pane).ok().map(|s| s.0))
+                    .unwrap_or(0),
                 size: node_q.get(pane).map(|n| n.size).unwrap_or(Vec2::ZERO),
             }
         })
@@ -1152,7 +1443,7 @@ fn find_reuse_in_space(
         let mut frontier = vec![tab];
         while let Some(node) = frontier.pop() {
             if let Ok(meta) = page_q.get(node)
-                && meta.url == url
+                && crate::placement::reusable_page_match(url, &meta.url)
             {
                 return Some(crate::placement::ReuseHit { tab, stack: node });
             }
@@ -1197,6 +1488,7 @@ pub fn resolve_spiral_pane(
         &ctx.seq_q,
         &ctx.node_q,
         &ctx.page_q,
+        &std::collections::HashMap::new(),
     );
     match crate::placement::resolve_placement(url, None, &leaves, anchor_pane) {
         crate::placement::Placement::AddTab { pane } => pane,
@@ -1211,6 +1503,23 @@ pub fn resolve_spiral_pane(
         }
         crate::placement::Placement::Focus { .. } => anchor_pane,
     }
+}
+
+pub fn resolve_split_anchor_pane(anchor_pane: Entity, ctx: &PlacementCtx) -> Entity {
+    let Some(tab) = tab_of_pane(anchor_pane, &ctx.child_of_q, &ctx.tab_q) else {
+        return anchor_pane;
+    };
+    let leaves = collect_leaf_infos(
+        tab,
+        &ctx.all_children,
+        &ctx.leaf_panes,
+        &ctx.pane_children,
+        &ctx.seq_q,
+        &ctx.node_q,
+        &ctx.page_q,
+        &std::collections::HashMap::new(),
+    );
+    crate::placement::resolve_split_anchor(&leaves, anchor_pane)
 }
 
 fn is_after_direction(direction: &PaneDirection) -> bool {
@@ -2309,6 +2618,7 @@ mod tests {
             .add_message::<OpenBesideRequest>()
             .add_message::<PageOpenRequest>()
             .init_resource::<NewStackContext>()
+            .init_resource::<SpawnCounter>()
             .add_systems(Update, handle_open_beside_requests);
 
         let split = app
@@ -2371,6 +2681,7 @@ mod tests {
             .add_message::<OpenBesideRequest>()
             .add_message::<PageOpenRequest>()
             .init_resource::<NewStackContext>()
+            .init_resource::<SpawnCounter>()
             .add_systems(Update, handle_open_beside_requests);
 
         let pane = app.world_mut().spawn((Pane, LastActivatedAt::now())).id();
@@ -2427,12 +2738,33 @@ mod tests {
         pane
     }
 
+    fn stack_in_pane(app: &App, pane: Entity) -> Entity {
+        let stacks: Vec<Entity> = app
+            .world()
+            .get::<Children>(pane)
+            .map(|c| {
+                c.iter()
+                    .filter(|&e| app.world().get::<Stack>(e).is_some())
+                    .collect()
+            })
+            .unwrap_or_default();
+        assert_eq!(stacks.len(), 1, "expected one stack in pane");
+        stacks[0]
+    }
+
+    fn page_open_requests(app: &App) -> Vec<PageOpenRequest> {
+        let messages = app.world().resource::<Messages<PageOpenRequest>>();
+        let mut cursor = messages.get_cursor();
+        cursor.read(messages).cloned().collect()
+    }
+
     fn open_beside_app() -> App {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .add_message::<OpenBesideRequest>()
             .add_message::<PageOpenRequest>()
             .init_resource::<NewStackContext>()
+            .init_resource::<SpawnCounter>()
             .add_systems(Update, handle_open_beside_requests);
         app
     }
@@ -2483,6 +2815,164 @@ mod tests {
         assert_eq!(
             stacks, 2,
             "new browser page tabs into the existing browser pane"
+        );
+    }
+
+    #[test]
+    fn auto_batched_files_stack_in_first_file_pane() {
+        let mut app = open_beside_app();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                vmux_core::Active,
+                LastActivatedAt::now(),
+                ChildOf(space),
+            ))
+            .id();
+        let agent_pane = place_pane_with_url(
+            &mut app,
+            tab,
+            1,
+            Vec2::new(800.0, 900.0),
+            "vmux://agent/claude/session",
+        );
+        place_pane_with_url(
+            &mut app,
+            tab,
+            2,
+            Vec2::new(900.0, 400.0),
+            "vmux://terminal/123",
+        );
+
+        for url in ["file:///repo/a.rs", "file:///repo/b.rs"] {
+            app.world_mut()
+                .resource_mut::<Messages<OpenBesideRequest>>()
+                .write(OpenBesideRequest {
+                    pane: agent_pane,
+                    direction: None,
+                    url: url.into(),
+                    request_id: [0u8; 16],
+                    focus: false,
+                });
+        }
+        app.update();
+
+        let requests = page_open_requests(&app);
+        let file_stack_parents: Vec<Entity> = requests
+            .iter()
+            .filter_map(|request| match &request.target {
+                PageOpenTarget::Stack(stack) if request.url.starts_with("file:") => app
+                    .world()
+                    .get::<ChildOf>(*stack)
+                    .map(|parent| parent.get()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(file_stack_parents.len(), 2);
+        assert_eq!(
+            file_stack_parents[0], file_stack_parents[1],
+            "same-frame file opens should stack in one file pane"
+        );
+    }
+
+    #[test]
+    fn auto_batched_new_types_dwindle_from_last_spawned_leaf() {
+        let mut app = open_beside_app();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                vmux_core::Active,
+                LastActivatedAt::now(),
+                ChildOf(space),
+            ))
+            .id();
+        let agent_pane = place_pane_with_url(
+            &mut app,
+            tab,
+            1,
+            Vec2::new(1600.0, 900.0),
+            "vmux://agent/claude/session",
+        );
+
+        for (i, url) in [
+            "https://github.com/vmux-ai/vmux",
+            "file:///repo/crates/vmux_agent/src/plugin.rs",
+            "vmux://terminal/",
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            app.world_mut()
+                .resource_mut::<Messages<OpenBesideRequest>>()
+                .write(OpenBesideRequest {
+                    pane: agent_pane,
+                    direction: None,
+                    url: url.into(),
+                    request_id: [i as u8; 16],
+                    focus: false,
+                });
+        }
+        app.update();
+
+        let requests = page_open_requests(&app);
+        let parent_for = |prefix: &str| -> Entity {
+            requests
+                .iter()
+                .find_map(|request| match &request.target {
+                    PageOpenTarget::Stack(stack) if request.url.starts_with(prefix) => app
+                        .world()
+                        .get::<ChildOf>(*stack)
+                        .map(|parent| parent.get()),
+                    _ => None,
+                })
+                .unwrap()
+        };
+        let browser_parent = parent_for("https:");
+        let file_parent = parent_for("file:");
+        let terminal_parent = parent_for("vmux://terminal/");
+
+        for parent in [browser_parent, file_parent, terminal_parent] {
+            assert!(
+                app.world().get::<PaneSplit>(parent).is_none(),
+                "new stack must live in a leaf pane, not directly under a split"
+            );
+        }
+
+        let browser_split = app.world().get::<ChildOf>(browser_parent).unwrap().get();
+        let file_split = app.world().get::<ChildOf>(file_parent).unwrap().get();
+        assert_eq!(
+            app.world().get::<ChildOf>(terminal_parent).unwrap().get(),
+            file_split
+        );
+        assert_eq!(
+            app.world().get::<ChildOf>(file_split).unwrap().get(),
+            browser_split
+        );
+        assert_eq!(
+            app.world().get::<PaneSplit>(agent_pane).unwrap().direction,
+            PaneSplitDirection::Row
+        );
+        assert_eq!(
+            app.world()
+                .get::<PaneSplit>(browser_split)
+                .unwrap()
+                .direction,
+            PaneSplitDirection::Column
+        );
+        assert_eq!(
+            app.world().get::<PaneSplit>(file_split).unwrap().direction,
+            PaneSplitDirection::Row
         );
     }
 
@@ -2575,6 +3065,426 @@ mod tests {
             app.world().get::<PaneSplit>(browser_pane).is_none(),
             "reuse must not split"
         );
+    }
+
+    #[test]
+    fn auto_reuse_focuses_existing_file_with_different_fragment() {
+        let mut app = open_beside_app();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                vmux_core::Active,
+                LastActivatedAt::now(),
+                ChildOf(space),
+            ))
+            .id();
+        let file_pane = place_pane_with_url(
+            &mut app,
+            tab,
+            5,
+            Vec2::new(800.0, 600.0),
+            "file:///repo/src/main.rs#L10",
+        );
+        let before = app
+            .world_mut()
+            .query_filtered::<Entity, With<Stack>>()
+            .iter(app.world())
+            .count();
+
+        app.world_mut()
+            .resource_mut::<Messages<OpenBesideRequest>>()
+            .write(OpenBesideRequest {
+                pane: file_pane,
+                direction: None,
+                url: "file:///repo/src/main.rs#L42".into(),
+                request_id: [0u8; 16],
+                focus: true,
+            });
+        app.update();
+
+        let after = app
+            .world_mut()
+            .query_filtered::<Entity, With<Stack>>()
+            .iter(app.world())
+            .count();
+        assert_eq!(
+            after, before,
+            "same file with a new fragment focuses the existing page"
+        );
+    }
+
+    #[test]
+    fn auto_reuse_file_with_different_fragment_navigates_existing_stack() {
+        let mut app = open_beside_app();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                vmux_core::Active,
+                LastActivatedAt::now(),
+                ChildOf(space),
+            ))
+            .id();
+        let file_pane = place_pane_with_url(
+            &mut app,
+            tab,
+            5,
+            Vec2::new(800.0, 600.0),
+            "file:///repo/src/main.rs#L10",
+        );
+        let stack = stack_in_pane(&app, file_pane);
+
+        app.world_mut()
+            .resource_mut::<Messages<OpenBesideRequest>>()
+            .write(OpenBesideRequest {
+                pane: file_pane,
+                direction: None,
+                url: "file:///repo/src/main.rs#L42".into(),
+                request_id: [0u8; 16],
+                focus: false,
+            });
+        app.update();
+
+        let opens = page_open_requests(&app);
+        assert_eq!(opens.len(), 1);
+        match &opens[0] {
+            PageOpenRequest {
+                target: PageOpenTarget::Stack(target),
+                url,
+                ..
+            } => {
+                assert_eq!(*target, stack);
+                assert_eq!(url, "file:///repo/src/main.rs#L42");
+            }
+            other => panic!("expected PageOpenRequest for existing stack, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn explicit_direction_reuse_focuses_existing_file_with_different_fragment() {
+        let mut app = open_beside_app();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                vmux_core::Active,
+                LastActivatedAt::now(),
+                ChildOf(space),
+            ))
+            .id();
+        let file_pane = place_pane_with_url(
+            &mut app,
+            tab,
+            5,
+            Vec2::new(800.0, 600.0),
+            "file:///repo/src/main.rs#L10",
+        );
+        let before = app
+            .world_mut()
+            .query_filtered::<Entity, With<Stack>>()
+            .iter(app.world())
+            .count();
+
+        app.world_mut()
+            .resource_mut::<Messages<OpenBesideRequest>>()
+            .write(OpenBesideRequest {
+                pane: file_pane,
+                direction: Some(PaneDirection::Right),
+                url: "file:///repo/src/main.rs#L42".into(),
+                request_id: [0u8; 16],
+                focus: true,
+            });
+        app.update();
+
+        let after = app
+            .world_mut()
+            .query_filtered::<Entity, With<Stack>>()
+            .iter(app.world())
+            .count();
+        assert_eq!(
+            after, before,
+            "reuse wins before explicit direction can create a duplicate"
+        );
+        assert!(
+            app.world().get::<PaneSplit>(file_pane).is_none(),
+            "reuse must not split the existing pane"
+        );
+    }
+
+    #[test]
+    fn reuse_with_focus_false_does_not_activate_existing_tab() {
+        let mut app = open_beside_app();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active))
+            .id();
+        let old_tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                vmux_core::Active,
+                LastActivatedAt(1),
+                ChildOf(space),
+            ))
+            .id();
+        let active_tab = app
+            .world_mut()
+            .spawn((Tab::default(), LastActivatedAt(10), ChildOf(space)))
+            .id();
+        let file_pane = place_pane_with_url(
+            &mut app,
+            old_tab,
+            5,
+            Vec2::new(800.0, 600.0),
+            "file:///repo/src/main.rs#L10",
+        );
+        place_pane_with_url(
+            &mut app,
+            active_tab,
+            6,
+            Vec2::new(800.0, 600.0),
+            "https://active.example",
+        );
+
+        app.world_mut()
+            .resource_mut::<Messages<OpenBesideRequest>>()
+            .write(OpenBesideRequest {
+                pane: file_pane,
+                direction: None,
+                url: "file:///repo/src/main.rs#L42".into(),
+                request_id: [0u8; 16],
+                focus: false,
+            });
+        app.update();
+
+        assert_eq!(app.world().get::<LastActivatedAt>(old_tab).unwrap().0, 1);
+        assert_eq!(
+            app.world().get::<LastActivatedAt>(active_tab).unwrap().0,
+            10
+        );
+    }
+
+    #[test]
+    fn auto_terminal_splits_last_reused_browser_pane() {
+        let mut app = open_beside_app();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                vmux_core::Active,
+                LastActivatedAt::now(),
+                ChildOf(space),
+            ))
+            .id();
+        let browser_pane =
+            place_pane_with_url(&mut app, tab, 1, Vec2::new(800.0, 600.0), "https://a.com");
+        let file_pane =
+            place_pane_with_url(&mut app, tab, 9, Vec2::new(800.0, 600.0), "file:///x.rs");
+
+        app.world_mut()
+            .resource_mut::<Messages<OpenBesideRequest>>()
+            .write(OpenBesideRequest {
+                pane: file_pane,
+                direction: None,
+                url: "https://github.com/vmux-ai/vmux".into(),
+                request_id: [0u8; 16],
+                focus: false,
+            });
+        app.update();
+
+        app.world_mut()
+            .resource_mut::<Messages<OpenBesideRequest>>()
+            .write(OpenBesideRequest {
+                pane: file_pane,
+                direction: None,
+                url: "vmux://terminal/".into(),
+                request_id: [1u8; 16],
+                focus: false,
+            });
+        app.update();
+
+        assert!(
+            app.world().get::<PaneSplit>(browser_pane).is_some(),
+            "terminal should split the browser pane that was just reused"
+        );
+        assert!(
+            app.world().get::<PaneSplit>(file_pane).is_none(),
+            "older file pane must not be split"
+        );
+    }
+
+    #[test]
+    fn auto_terminal_splits_pane_touched_earlier_in_same_batch() {
+        let mut app = open_beside_app();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                vmux_core::Active,
+                LastActivatedAt::now(),
+                ChildOf(space),
+            ))
+            .id();
+        let browser_pane =
+            place_pane_with_url(&mut app, tab, 1, Vec2::new(800.0, 600.0), "https://a.com");
+        let file_pane =
+            place_pane_with_url(&mut app, tab, 9, Vec2::new(800.0, 600.0), "file:///x.rs");
+
+        app.world_mut()
+            .resource_mut::<Messages<OpenBesideRequest>>()
+            .write(OpenBesideRequest {
+                pane: file_pane,
+                direction: None,
+                url: "https://github.com/vmux-ai/vmux".into(),
+                request_id: [0u8; 16],
+                focus: false,
+            });
+        app.world_mut()
+            .resource_mut::<Messages<OpenBesideRequest>>()
+            .write(OpenBesideRequest {
+                pane: file_pane,
+                direction: None,
+                url: "vmux://terminal/".into(),
+                request_id: [1u8; 16],
+                focus: false,
+            });
+        app.update();
+
+        assert!(
+            app.world().get::<PaneSplit>(browser_pane).is_some(),
+            "terminal should split the browser pane touched earlier in the same batch"
+        );
+        assert!(
+            app.world().get::<PaneSplit>(file_pane).is_none(),
+            "older file pane must not be split"
+        );
+    }
+
+    #[test]
+    fn forced_split_anchor_follows_last_reused_browser_pane() {
+        let mut app = open_beside_app();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                vmux_core::Active,
+                LastActivatedAt::now(),
+                ChildOf(space),
+            ))
+            .id();
+        let browser_pane =
+            place_pane_with_url(&mut app, tab, 1, Vec2::new(800.0, 600.0), "https://a.com");
+        let file_pane =
+            place_pane_with_url(&mut app, tab, 9, Vec2::new(800.0, 600.0), "file:///x.rs");
+
+        app.world_mut()
+            .resource_mut::<Messages<OpenBesideRequest>>()
+            .write(OpenBesideRequest {
+                pane: file_pane,
+                direction: None,
+                url: "https://github.com/vmux-ai/vmux".into(),
+                request_id: [0u8; 16],
+                focus: false,
+            });
+        app.update();
+
+        app.insert_resource(SplitAnchorInput { anchor: file_pane })
+            .init_resource::<SplitAnchorOut>()
+            .add_systems(Update, split_anchor_test_sys);
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<SplitAnchorOut>().0,
+            Some(browser_pane)
+        );
+    }
+
+    #[test]
+    fn forced_split_anchor_follows_exact_reused_browser_page() {
+        let mut app = open_beside_app();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                vmux_core::Active,
+                LastActivatedAt::now(),
+                ChildOf(space),
+            ))
+            .id();
+        let browser_pane = place_pane_with_url(
+            &mut app,
+            tab,
+            1,
+            Vec2::new(800.0, 600.0),
+            "https://github.com/vmux-ai/vmux",
+        );
+        let file_pane =
+            place_pane_with_url(&mut app, tab, 9, Vec2::new(800.0, 600.0), "file:///x.rs");
+
+        app.world_mut()
+            .resource_mut::<Messages<OpenBesideRequest>>()
+            .write(OpenBesideRequest {
+                pane: file_pane,
+                direction: None,
+                url: "https://github.com/vmux-ai/vmux".into(),
+                request_id: [0u8; 16],
+                focus: false,
+            });
+        app.update();
+
+        app.insert_resource(SplitAnchorInput { anchor: file_pane })
+            .init_resource::<SplitAnchorOut>()
+            .add_systems(Update, split_anchor_test_sys);
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<SplitAnchorOut>().0,
+            Some(browser_pane)
+        );
+    }
+
+    #[derive(Resource)]
+    struct SplitAnchorInput {
+        anchor: Entity,
+    }
+    #[derive(Resource, Default)]
+    struct SplitAnchorOut(Option<Entity>);
+
+    fn split_anchor_test_sys(
+        input: Res<SplitAnchorInput>,
+        ctx: PlacementCtx,
+        mut out: ResMut<SplitAnchorOut>,
+    ) {
+        out.0 = Some(resolve_split_anchor_pane(input.anchor, &ctx));
     }
 
     #[derive(Resource)]
@@ -4208,6 +5118,7 @@ mod tests {
             .add_message::<OpenBesideRequest>()
             .add_message::<PageOpenRequest>()
             .init_resource::<NewStackContext>()
+            .init_resource::<SpawnCounter>()
             .add_systems(Update, handle_open_beside_requests);
         let tab = app.world_mut().spawn(crate::tab::tab_bundle()).id();
         let anchor_pane = app
@@ -4241,6 +5152,7 @@ mod tests {
             .add_message::<OpenBesideRequest>()
             .add_message::<PageOpenRequest>()
             .init_resource::<NewStackContext>()
+            .init_resource::<SpawnCounter>()
             .add_systems(Update, handle_open_beside_requests);
         let tab = app.world_mut().spawn(crate::tab::tab_bundle()).id();
         let anchor_pane = app
@@ -4277,6 +5189,7 @@ mod tests {
             .add_message::<OpenBesideRequest>()
             .add_message::<PageOpenRequest>()
             .init_resource::<NewStackContext>()
+            .init_resource::<SpawnCounter>()
             .add_systems(Update, handle_open_beside_requests);
         let tab = app.world_mut().spawn(crate::tab::tab_bundle()).id();
         let anchor_pane = app

--- a/crates/vmux_layout/src/placement.rs
+++ b/crates/vmux_layout/src/placement.rs
@@ -73,6 +73,12 @@ fn newest_leaf_with_kind(leaves: &[LeafInfo], kind: PageKind) -> Option<&LeafInf
         .max_by_key(|l| l.spawn_seq)
 }
 
+fn browser_bucket_is_current(bucket: &LeafInfo, leaves: &[LeafInfo]) -> bool {
+    newest_nonagent_leaf(leaves)
+        .map(|latest| latest.pane == bucket.pane || latest.spawn_seq <= bucket.spawn_seq)
+        .unwrap_or(true)
+}
+
 fn file_reuse_key(url: &str) -> &str {
     url.split('#').next().unwrap_or(url)
 }
@@ -120,7 +126,9 @@ pub fn resolve_placement(
         return Placement::AddTab { pane: self_pane };
     }
 
-    if let Some(same) = newest_leaf_with_kind(leaves, kind) {
+    if let Some(same) = newest_leaf_with_kind(leaves, kind)
+        && (kind != PageKind::Browser || browser_bucket_is_current(same, leaves))
+    {
         return Placement::AddTab { pane: same.pane };
     }
 

--- a/crates/vmux_layout/src/placement.rs
+++ b/crates/vmux_layout/src/placement.rs
@@ -73,12 +73,6 @@ fn newest_leaf_with_kind(leaves: &[LeafInfo], kind: PageKind) -> Option<&LeafInf
         .max_by_key(|l| l.spawn_seq)
 }
 
-fn browser_bucket_is_current(bucket: &LeafInfo, leaves: &[LeafInfo]) -> bool {
-    newest_nonagent_leaf(leaves)
-        .map(|latest| latest.pane == bucket.pane || latest.spawn_seq <= bucket.spawn_seq)
-        .unwrap_or(true)
-}
-
 fn file_reuse_key(url: &str) -> &str {
     url.split('#').next().unwrap_or(url)
 }
@@ -126,9 +120,7 @@ pub fn resolve_placement(
         return Placement::AddTab { pane: self_pane };
     }
 
-    if let Some(same) = newest_leaf_with_kind(leaves, kind)
-        && (kind != PageKind::Browser || browser_bucket_is_current(same, leaves))
-    {
+    if let Some(same) = newest_leaf_with_kind(leaves, kind) {
         return Placement::AddTab { pane: same.pane };
     }
 

--- a/crates/vmux_layout/src/placement.rs
+++ b/crates/vmux_layout/src/placement.rs
@@ -66,6 +66,28 @@ fn newest_nonagent_leaf(leaves: &[LeafInfo]) -> Option<&LeafInfo> {
         .max_by_key(|l| l.spawn_seq)
 }
 
+fn newest_leaf_with_kind(leaves: &[LeafInfo], kind: PageKind) -> Option<&LeafInfo> {
+    leaves
+        .iter()
+        .filter(|l| l.kinds.len() == 1 && l.kinds.contains(&kind))
+        .max_by_key(|l| l.spawn_seq)
+}
+
+fn file_reuse_key(url: &str) -> &str {
+    url.split('#').next().unwrap_or(url)
+}
+
+pub fn reusable_page_match(request_url: &str, existing_url: &str) -> bool {
+    let kind = page_kind_for_url(request_url);
+    if page_kind_for_url(existing_url) != kind {
+        return false;
+    }
+    match kind {
+        PageKind::File => file_reuse_key(request_url) == file_reuse_key(existing_url),
+        _ => request_url == existing_url,
+    }
+}
+
 pub fn resolve_placement(
     url: &str,
     reuse: Option<ReuseHit>,
@@ -86,7 +108,7 @@ pub fn resolve_placement(
     }
 
     if kind == PageKind::Agent {
-        if let Some(agent) = leaves.iter().find(|l| l.kinds.contains(&PageKind::Agent)) {
+        if let Some(agent) = newest_leaf_with_kind(leaves, PageKind::Agent) {
             return Placement::AddTab { pane: agent.pane };
         }
         if let Some(anchor) = newest_nonagent_leaf(leaves) {
@@ -98,7 +120,7 @@ pub fn resolve_placement(
         return Placement::AddTab { pane: self_pane };
     }
 
-    if let Some(same) = leaves.iter().find(|l| l.kinds.contains(&kind)) {
+    if let Some(same) = newest_leaf_with_kind(leaves, kind) {
         return Placement::AddTab { pane: same.pane };
     }
 
@@ -117,6 +139,13 @@ pub fn resolve_placement(
     }
 
     Placement::AddTab { pane: self_pane }
+}
+
+pub fn resolve_split_anchor(leaves: &[LeafInfo], self_pane: Entity) -> Entity {
+    newest_nonagent_leaf(leaves)
+        .or_else(|| leaves.iter().find(|l| l.kinds.contains(&PageKind::Agent)))
+        .map(|l| l.pane)
+        .unwrap_or(self_pane)
 }
 
 #[cfg(test)]
@@ -176,6 +205,71 @@ mod tests {
             e(10),
         );
         assert_eq!(got, Placement::AddTab { pane: e(10) });
+    }
+
+    #[test]
+    fn same_type_uses_newest_matching_bucket() {
+        let got = resolve_placement(
+            "vmux://terminal/",
+            None,
+            &[
+                leaf(10, &[PageKind::Terminal], 1, (800.0, 600.0)),
+                leaf(20, &[PageKind::Terminal], 9, (800.0, 600.0)),
+                leaf(30, &[PageKind::File], 12, (800.0, 600.0)),
+            ],
+            e(1),
+        );
+        assert_eq!(got, Placement::AddTab { pane: e(20) });
+    }
+
+    #[test]
+    fn same_type_prefers_pure_bucket_over_newer_mixed_bucket() {
+        let got = resolve_placement(
+            "file:///b.rs",
+            None,
+            &[
+                leaf(10, &[PageKind::File], 1, (800.0, 600.0)),
+                leaf(20, &[PageKind::File, PageKind::Terminal], 9, (800.0, 600.0)),
+            ],
+            e(1),
+        );
+        assert_eq!(got, Placement::AddTab { pane: e(10) });
+    }
+
+    #[test]
+    fn same_type_does_not_add_to_mixed_bucket_when_no_pure_bucket_exists() {
+        let got = resolve_placement(
+            "https://b.com",
+            None,
+            &[leaf(
+                20,
+                &[PageKind::File, PageKind::Browser],
+                9,
+                (900.0, 400.0),
+            )],
+            e(20),
+        );
+        assert_eq!(
+            got,
+            Placement::Spiral {
+                anchor: e(20),
+                axis: PaneSplitDirection::Row
+            }
+        );
+    }
+
+    #[test]
+    fn forced_split_uses_newest_nonagent_leaf() {
+        let got = resolve_split_anchor(
+            &[
+                leaf(10, &[PageKind::Terminal], 9, (800.0, 600.0)),
+                leaf(20, &[PageKind::Browser], 12, (800.0, 600.0)),
+                leaf(30, &[PageKind::Agent], 50, (800.0, 600.0)),
+            ],
+            e(30),
+        );
+
+        assert_eq!(got, e(20));
     }
 
     #[test]

--- a/crates/vmux_mcp/src/protocol.rs
+++ b/crates/vmux_mcp/src/protocol.rs
@@ -11,9 +11,6 @@ use vmux_service::protocol::{
 const RUN_BLOCK_TIMEOUT: Duration = Duration::from_secs(50);
 /// Interval between terminal reads while waiting for the completion marker.
 const RUN_POLL_INTERVAL: Duration = Duration::from_millis(200);
-/// Grace period for the terminal to be created before a "process not found"
-/// read is treated as a real error.
-const RUN_CREATE_GRACE: Duration = Duration::from_secs(3);
 
 pub fn read_json_line(reader: &mut impl BufRead) -> io::Result<Option<Value>> {
     let mut line = String::new();
@@ -380,6 +377,7 @@ fn byte_to_utf16(line: &str, byte: usize) -> u32 {
     line[..idx].encode_utf16().count() as u32
 }
 
+#[cfg(test)]
 fn output_since(baseline: &str, final_text: &str) -> String {
     final_text
         .strip_prefix(baseline)
@@ -387,6 +385,38 @@ fn output_since(baseline: &str, final_text: &str) -> String {
         .trim_matches('\n')
         .trim_end()
         .to_string()
+}
+
+fn run_done_token(request_id: AgentRequestId) -> String {
+    let mut token = String::with_capacity(32);
+    for byte in request_id.0 {
+        use std::fmt::Write;
+        let _ = write!(&mut token, "{byte:02x}");
+    }
+    token
+}
+
+fn blocking_run_with_marker(mut run: AgentCommand, request_id: AgentRequestId) -> AgentCommand {
+    if let AgentCommand::Run { done_marker, .. } = &mut run {
+        *done_marker = Some(run_done_token(request_id));
+    }
+    run
+}
+
+fn extract_done_marker_output(token: &str, text: &str) -> Option<(i32, String)> {
+    let start_marker = format!("__VMUX_START_{token}__");
+    let done_prefix = format!("__VMUX_DONE_{token}_");
+    let start_index = text.rfind(&start_marker)?;
+    let after_start = &text[start_index + start_marker.len()..];
+    let done_index = after_start.find(&done_prefix)?;
+    let after_prefix = &after_start[done_index + done_prefix.len()..];
+    let code_end = after_prefix.find("__")?;
+    let exit = after_prefix[..code_end].parse().ok()?;
+    let output = after_start[..done_index]
+        .trim_matches(|c| c == '\n' || c == '\r')
+        .trim_end()
+        .to_string();
+    Some((exit, output))
 }
 
 fn run_result(pid: &str, exit: Option<i32>, output: &str, timed_out: bool) -> Value {
@@ -412,6 +442,8 @@ async fn run_blocking(run: AgentCommand) -> Result<Value, String> {
         .map_err(|error| format!("cannot connect to vmux_service: {error}"))?;
 
     let request_id = AgentRequestId::new();
+    let token = run_done_token(request_id);
+    let run = blocking_run_with_marker(run, request_id);
     connection
         .send(&ClientMessage::AgentCommand {
             request_id,
@@ -451,36 +483,14 @@ async fn run_blocking(run: AgentCommand) -> Result<Value, String> {
         .map_err(|_| format!("run: service returned an invalid terminal id: {pid}"))?;
 
     let start = Instant::now();
-    let baseline_seq = loop {
-        match agent_query(&connection, AgentQuery::CommandExit { process_id }).await? {
-            AgentQueryResult::CommandExit { seq, .. } => break seq,
-            AgentQueryResult::Error(message) => {
-                if start.elapsed() > RUN_CREATE_GRACE {
-                    return Err(message);
-                }
-                tokio::time::sleep(RUN_POLL_INTERVAL).await;
-            }
-            other => return Err(format!("run: unexpected command-exit result: {other:?}")),
-        }
-    };
-    let baseline_text = read_full_text(&connection, process_id).await;
-
     let deadline = start + RUN_BLOCK_TIMEOUT;
     loop {
-        match agent_query(&connection, AgentQuery::CommandExit { process_id }).await? {
-            AgentQueryResult::CommandExit { seq, exit } if seq > baseline_seq => {
-                let final_text = read_full_text(&connection, process_id).await;
-                let output = output_since(&baseline_text, &final_text);
-                return Ok(run_result(&pid, exit, &output, false));
-            }
-            AgentQueryResult::CommandExit { .. } => {}
-            AgentQueryResult::Error(message) => return Err(message),
-            other => return Err(format!("run: unexpected command-exit result: {other:?}")),
+        let text = read_full_text(&connection, process_id).await;
+        if let Some((exit, output)) = extract_done_marker_output(&token, &text) {
+            return Ok(run_result(&pid, Some(exit), &output, false));
         }
         if Instant::now() >= deadline {
-            let final_text = read_full_text(&connection, process_id).await;
-            let output = output_since(&baseline_text, &final_text);
-            return Ok(run_result(&pid, None, &output, true));
+            return Ok(run_result(&pid, None, &text, true));
         }
         tokio::time::sleep(RUN_POLL_INTERVAL).await;
     }
@@ -823,5 +833,39 @@ mod tests {
         let text = timeout["content"][0]["text"].as_str().unwrap();
         assert!(text.contains("still running"));
         assert!(text.contains("read_terminal(pid7)"));
+    }
+
+    #[test]
+    fn blocking_run_sets_done_marker_token() {
+        let request_id = AgentRequestId([7; 16]);
+        let anchor = vmux_service::protocol::ProcessId::new();
+        let run = AgentCommand::Run {
+            anchor,
+            command: "git status".into(),
+            direction: vmux_service::protocol::AgentPaneDirection::Right,
+            focus: false,
+            beside: None,
+            mode: vmux_service::protocol::PlacementMode::Auto,
+            terminal: None,
+            done_marker: None,
+        };
+
+        let marked = blocking_run_with_marker(run, request_id);
+
+        match marked {
+            AgentCommand::Run { done_marker, .. } => {
+                assert_eq!(done_marker, Some(run_done_token(request_id)));
+            }
+            _ => panic!("expected run command"),
+        }
+    }
+
+    #[test]
+    fn done_marker_output_extracts_between_start_and_done() {
+        let text = "old output\n__VMUX_START_tok__\nhello\nworld\n__VMUX_DONE_tok_7__\nprompt";
+
+        let parsed = extract_done_marker_output("tok", text);
+
+        assert_eq!(parsed, Some((7, "hello\nworld".to_string())));
     }
 }

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -325,11 +325,11 @@ fn list_spaces_definition() -> ToolDefinition {
 fn open_page_definition() -> ToolDefinition {
     ToolDefinition {
         name: "open_page".into(),
-        description: "Open a page in a new pane directly beside YOUR pane (the agent calling this). \
-direction is one of right|left|top|bottom (default right). url uses the same rules as browser_navigate \
-(vmux://terminal/ opens a terminal; anything else loads as a browser). \
-focus (default true): true moves focus to the new pane (use when the human will interact with it); \
-false keeps focus on your own pane."
+        description: "Open a page using vmux auto placement. Omit `direction` so vmux reuses \
+the existing matching bucket first (terminal pages with terminals, browser pages with browsers) \
+and otherwise spirals off the latest non-agent pane. url uses the same rules as browser_navigate \
+(vmux://terminal/ opens a terminal; anything else loads as a browser). direction is an override \
+for a forced adjacent open: right|left|top|bottom. focus defaults false."
             .into(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -347,11 +347,12 @@ false keeps focus on your own pane."
 fn open_file_definition() -> ToolDefinition {
     ToolDefinition {
         name: "open_file".into(),
-        description: "Open a local file (or directory) in the vmux editor, in a new pane beside \
-YOUR pane (the agent calling this). path is an absolute filesystem path, e.g. \
-/Users/me/project/src/main.rs. Files render with syntax highlighting; directories show a listing. \
-direction is one of right|left|top|bottom (default right). focus (default true) moves focus to the \
-new pane."
+        description: "Open a local file (or directory) in the vmux editor using vmux auto \
+placement. Omit `direction` so vmux focuses an already-open matching file first, then reuses \
+the file pane bucket, and otherwise spirals off the latest non-agent pane. path is an absolute \
+filesystem path, e.g. /Users/me/project/src/main.rs. Files render with syntax highlighting; \
+directories show a listing. direction is an override for a forced adjacent open: \
+right|left|top|bottom. focus defaults false."
             .into(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -369,8 +370,8 @@ new pane."
 fn read_file_definition() -> ToolDefinition {
     ToolDefinition {
         name: "read_file".into(),
-        description: "Read a local file and show it in the vmux editor in a pane beside YOUR pane \
-(the agent calling this). Returns the file's text. USE THIS to read files - do NOT cat/sed/head/tail \
+        description: "Read a local file and show it in the vmux editor through auto placement, \
+preferring an existing file page/bucket. Returns the file's text. USE THIS to read files - do NOT cat/sed/head/tail \
 via run (that dumps into a terminal). path is an absolute filesystem path. offset is the 1-based line \
 to start at; limit is the number of lines (default: the whole file)."
             .into(),
@@ -391,7 +392,7 @@ fn grep_definition() -> ToolDefinition {
     ToolDefinition {
         name: "grep".into(),
         description: "Search files with ripgrep and open each matching file in the vmux editor \
-beside YOUR pane, scrolled to its first match. USE THIS to search code - do NOT run rg/grep/ag via \
+through auto placement, scrolled to its first match. USE THIS to search code - do NOT run rg/grep/ag via \
 run (that dumps into a terminal). Returns matches grouped by file (path:line: text). query is a \
 regex; path is an absolute directory or file to search (default: the current working directory)."
             .into(),
@@ -425,7 +426,8 @@ Override only when you mean to: \
 (force a new stacked terminal in the anchor's pane). \
 - `beside`: anchor to a specific page — a terminal id a previous run returned, or \"self\" for your own \
 pane. With `beside` set, `stack` tabs into that page's pane and `split` splits off it. \
-- `direction`: which side for `split` (right|left|top|bottom, default right). \
+- `direction`: only for `split`; Omit `direction` in auto mode so vmux keeps terminal runs in the \
+terminal bucket and spirals new panes predictably. \
 - `terminal: <id>`: instead of opening anything, run IN that existing terminal (best for dependent / \
 sequential steps that share one shell, in order). \
 \
@@ -646,7 +648,7 @@ pub fn dispatch_with_anchor(
         let focus = arguments
             .get("focus")
             .and_then(Value::as_bool)
-            .unwrap_or(true);
+            .unwrap_or(false);
         return Ok(DispatchTarget::Command(AgentCommand::OpenBeside {
             anchor,
             direction,
@@ -675,7 +677,7 @@ pub fn dispatch_with_anchor(
         let focus = arguments
             .get("focus")
             .and_then(Value::as_bool)
-            .unwrap_or(true);
+            .unwrap_or(false);
         return Ok(DispatchTarget::Command(AgentCommand::OpenBeside {
             anchor,
             direction,
@@ -1152,6 +1154,18 @@ mod tests {
     }
 
     #[test]
+    fn pane_open_tool_descriptions_prefer_auto_placement() {
+        let defs = tool_definitions();
+        let open_page = defs.iter().find(|tool| tool.name == "open_page").unwrap();
+        let open_file = defs.iter().find(|tool| tool.name == "open_file").unwrap();
+        let run = defs.iter().find(|tool| tool.name == "run").unwrap();
+
+        assert!(open_page.description.contains("Omit `direction`"));
+        assert!(open_file.description.contains("Omit `direction`"));
+        assert!(run.description.contains("Omit `direction`"));
+    }
+
+    #[test]
     fn auto_generated_tool_dispatches_as_app_command() {
         let command = dispatch_command("terminal_clear", serde_json::json!({})).unwrap();
         assert_eq!(
@@ -1468,6 +1482,40 @@ mod tests {
         match target {
             DispatchTarget::Command(AgentCommand::OpenBeside { direction, .. }) => {
                 assert_eq!(direction, None, "absent direction => auto placement");
+            }
+            other => panic!("expected OpenBeside, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn open_page_default_does_not_request_focus() {
+        let anchor = vmux_service::protocol::ProcessId::new();
+        let target = dispatch_with_anchor(
+            "open_page",
+            serde_json::json!({"url": "https://x.com"}),
+            Some(anchor),
+        )
+        .unwrap();
+        match target {
+            DispatchTarget::Command(AgentCommand::OpenBeside { focus, .. }) => {
+                assert!(!focus);
+            }
+            other => panic!("expected OpenBeside, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn open_file_default_does_not_request_focus() {
+        let anchor = vmux_service::protocol::ProcessId::new();
+        let target = dispatch_with_anchor(
+            "open_file",
+            serde_json::json!({"path": "/tmp/example.rs"}),
+            Some(anchor),
+        )
+        .unwrap();
+        match target {
+            DispatchTarget::Command(AgentCommand::OpenBeside { focus, .. }) => {
+                assert!(!focus);
             }
             other => panic!("expected OpenBeside, got {other:?}"),
         }

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -753,7 +753,7 @@ pub fn new_terminal_bundle_with_cwd(
     )
 }
 
-fn respond_terminal_stack_spawn(
+pub fn respond_terminal_stack_spawn(
     mut reader: MessageReader<TerminalStackSpawnRequest>,
     settings: Res<AppSettings>,
     mut commands: Commands,


### PR DESCRIPTION
## Context
Agent tools could leave vmux layouts messy: terminal runs opened new panes instead of reusing an existing run terminal, explicit split runs anchored to the agent pane instead of the latest page the agent opened, duplicate file pages could be opened, and agent-initiated focus changes could steal the user away.

## Implementation
Centralized auto placement around reusable page matching and pane recency. Reused and opened panes refresh their spawn sequence so the next forced split anchors to the last used non-agent pane, including a reused GitHub browser page. Agent run commands now reuse persistent terminals, preserve focus for agent-originated requests, and MCP tool defaults/descriptions steer agents toward auto placement.

## Checks / QA
Open GitHub in vmux, open README/Cargo.toml, then ask an agent to run a fresh split terminal; the split should come off the GitHub browser pane. Keep focus in another tab while the agent opens pages/runs commands; focus should not move.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced auto-reuse for page/file opens and terminal **Run**, using smarter reusable candidates, “bucket” split placement, and deterministic sequencing within a batch.
  * Improved split-anchor resolution and browser-only pane detection for more reliable beside/split placement.
* **Bug Fixes**
  * Made agent-initiated focus changes origin-aware so they preserve the user’s focus; disallowed focus-changing agent actions are blocked.
  * Preserved focus during agent layout updates and refined URL/file reuse matching (including fragment handling).
* **Documentation**
  * Updated MCP tool descriptions/defaults: omit `direction` for auto placement; `focus` defaults to `false` for `open_page`/`open_file`.
* **Tests**
  * Expanded coverage for origin gating, reuse/touch ordering, split-anchor selection, terminal reuse, browser-only resolution, and MCP parsing defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->