### PR TITLE
fix(layout): stabilize agent-open pane ordering

### DIFF
--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -1736,12 +1736,6 @@ fn handle_agent_self_commands(
                                     None
                                 };
                                 if let Some(pane) = bucket_pane {
-                                    touch_reused_run_pane_spawn_seq(
-                                        pane,
-                                        &mut commands,
-                                        &mut spawn_counter,
-                                        &ctx.seq_q,
-                                    );
                                     pane
                                 } else {
                                     let anchor_pane = anchor_pane.unwrap_or_else(|| {
@@ -1771,6 +1765,12 @@ fn handle_agent_self_commands(
                                 &ctx,
                             ),
                         };
+                        touch_reused_run_pane_spawn_seq(
+                            target_pane,
+                            &mut commands,
+                            &mut spawn_counter,
+                            &ctx.seq_q,
+                        );
                         let new_pid = ProcessId::new();
                         let agent_cwd = launch_q.get(agent_term).ok().map(|l| l.cwd.clone());
                         let cwd = run_terminal_cwd(agent_cwd.as_deref(), active_space.as_deref());
@@ -3838,6 +3838,78 @@ mod tests {
                 .0,
             11
         );
+    }
+
+    #[derive(Resource)]
+    struct SplitRunPaneInput {
+        pane: Entity,
+    }
+
+    #[derive(Resource, Default)]
+    struct SplitRunPaneOutput(Option<Entity>);
+
+    fn split_run_pane_test_system(
+        input: Res<SplitRunPaneInput>,
+        mut out: ResMut<SplitRunPaneOutput>,
+        mut commands: Commands,
+        mut spawn_counter: ResMut<vmux_layout::pane::SpawnCounter>,
+        pane_children: Query<&Children, With<Pane>>,
+        tab_filter: Query<Entity, With<vmux_layout::stack::Stack>>,
+        split_dir_q: Query<&PaneSplit>,
+        seq_q: Query<&vmux_layout::pane::SpawnSeq>,
+    ) {
+        let mut split_batch = std::collections::HashSet::new();
+        let target = split_pane_off(
+            &mut commands,
+            input.pane,
+            &vmux_service::protocol::AgentPaneDirection::Bottom,
+            false,
+            &pane_children,
+            &tab_filter,
+            &split_dir_q,
+            &mut split_batch,
+        );
+        touch_reused_run_pane_spawn_seq(target, &mut commands, &mut spawn_counter, &seq_q);
+        out.0 = Some(target);
+    }
+
+    #[test]
+    fn split_run_pane_becomes_newest_for_followup_placement() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<vmux_layout::pane::SpawnCounter>()
+            .init_resource::<SplitRunPaneOutput>()
+            .add_systems(Update, split_run_pane_test_system);
+
+        let tab = app
+            .world_mut()
+            .spawn((vmux_layout::tab::Tab::default(), LastActivatedAt(1)))
+            .id();
+        let browser_pane = app
+            .world_mut()
+            .spawn((Pane, vmux_layout::pane::SpawnSeq(10), ChildOf(tab)))
+            .id();
+        let browser_stack = app
+            .world_mut()
+            .spawn((vmux_layout::stack::stack_bundle(), ChildOf(browser_pane)))
+            .id();
+        app.world_mut()
+            .entity_mut(browser_stack)
+            .insert(PageMetadata {
+                url: "https://news.ycombinator.com".into(),
+                ..default()
+            });
+        app.insert_resource(SplitRunPaneInput { pane: browser_pane });
+
+        app.update();
+
+        let terminal_pane = app.world().resource::<SplitRunPaneOutput>().0.unwrap();
+        let seq = app
+            .world()
+            .get::<vmux_layout::pane::SpawnSeq>(terminal_pane)
+            .expect("split run target gets fresh spawn seq")
+            .0;
+        assert!(seq > 10, "split run target must become newest");
     }
 
     #[derive(Resource)]

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -1074,7 +1074,6 @@ pub fn handle_open_beside_requests(
                         &mut pending_leaf_infos,
                         split.holder,
                         split.target,
-                        split.target,
                     );
                     let pending_size = split
                         .target_size
@@ -1190,7 +1189,6 @@ pub fn handle_open_beside_requests(
                     &mut pending_leaf_infos,
                     split.holder,
                     split.target,
-                    split.target,
                 );
                 let pending_size = split
                     .target_size
@@ -1281,7 +1279,6 @@ fn stamp_split_panes_for_batch(
     pending_leaf_infos: &mut std::collections::HashMap<Entity, crate::placement::LeafInfo>,
     holder: Option<Entity>,
     target: Entity,
-    tail: Entity,
 ) {
     let mut stamp = |pane| {
         let seq = touch_pane_spawn_seq(pane, commands, spawn_counter, seq_q);
@@ -1291,13 +1288,8 @@ fn stamp_split_panes_for_batch(
         }
     };
     if let Some(holder) = holder {
-        if tail == holder {
-            stamp(target);
-            stamp(holder);
-        } else {
-            stamp(holder);
-            stamp(target);
-        }
+        stamp(holder);
+        stamp(target);
     } else {
         stamp(target);
     }

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -1046,6 +1046,7 @@ pub fn handle_open_beside_requests(
                     let old_leaf_info = leaf_info_for_pane(
                         req.pane,
                         &pane_children,
+                        &child_of_q,
                         &rc.seq_q,
                         &rc.node_q,
                         &rc.page_q,
@@ -1123,6 +1124,7 @@ pub fn handle_open_beside_requests(
             &rc.all_children,
             &leaf_panes,
             &pane_children,
+            &child_of_q,
             &rc.seq_q,
             &rc.node_q,
             &rc.page_q,
@@ -1185,6 +1187,9 @@ pub fn handle_open_beside_requests(
                     &mut pending_leaf_stacks,
                     &mut retired_leaf_panes,
                 );
+                let keep_holder_as_tail = keep_holder_as_tail
+                    && crate::placement::page_kind_for_url(&req.url)
+                        != crate::placement::PageKind::Browser;
                 let tail = split
                     .holder
                     .filter(|_| keep_holder_as_tail)
@@ -1449,6 +1454,7 @@ fn record_pending_leaf_info(
         .entry(pane)
         .or_insert_with(|| crate::placement::LeafInfo {
             pane,
+            parent: None,
             kinds: Vec::new(),
             spawn_seq,
             size,
@@ -1506,6 +1512,7 @@ fn stack_children_for_split(
 fn leaf_info_for_pane(
     pane: Entity,
     pane_children: &Query<&Children, With<Pane>>,
+    child_of_q: &Query<&ChildOf>,
     seq_q: &Query<&SpawnSeq>,
     node_q: &Query<&ComputedNode>,
     page_q: &Query<&vmux_core::PageMetadata, With<Stack>>,
@@ -1521,6 +1528,7 @@ fn leaf_info_for_pane(
     );
     Some(crate::placement::LeafInfo {
         pane,
+        parent: child_of_q.get(pane).ok().map(|parent| parent.get()),
         kinds,
         spawn_seq: spawn_seq_overrides
             .get(&pane)
@@ -1551,6 +1559,7 @@ fn collect_leaf_infos(
     all_children: &Query<&Children>,
     leaf_panes: &Query<Entity, (With<Pane>, Without<PaneSplit>)>,
     pane_children: &Query<&Children, With<Pane>>,
+    child_of_q: &Query<&ChildOf>,
     seq_q: &Query<&SpawnSeq>,
     node_q: &Query<&ComputedNode>,
     page_q: &Query<&vmux_core::PageMetadata, With<Stack>>,
@@ -1573,6 +1582,7 @@ fn collect_leaf_infos(
                 .unwrap_or_default();
             crate::placement::LeafInfo {
                 pane,
+                parent: child_of_q.get(pane).ok().map(|parent| parent.get()),
                 kinds,
                 spawn_seq: spawn_seq_overrides
                     .get(&pane)
@@ -1686,6 +1696,7 @@ pub fn resolve_spiral_pane(
         &ctx.all_children,
         &ctx.leaf_panes,
         &ctx.pane_children,
+        &ctx.child_of_q,
         &ctx.seq_q,
         &ctx.node_q,
         &ctx.page_q,
@@ -1715,6 +1726,7 @@ pub fn resolve_split_anchor_pane(anchor_pane: Entity, ctx: &PlacementCtx) -> Ent
         &ctx.all_children,
         &ctx.leaf_panes,
         &ctx.pane_children,
+        &ctx.child_of_q,
         &ctx.seq_q,
         &ctx.node_q,
         &ctx.page_q,
@@ -3559,6 +3571,164 @@ mod tests {
         assert!(
             app.world().get::<PaneSplit>(terminal_pane).is_none(),
             "terminal pane must not split for first file"
+        );
+    }
+
+    #[test]
+    fn auto_browser_open_after_files_becomes_anchor_for_terminal() {
+        let mut app = open_beside_app();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                vmux_core::Active,
+                LastActivatedAt::now(),
+                ChildOf(space),
+            ))
+            .id();
+        let agent_pane = place_pane_with_url(
+            &mut app,
+            tab,
+            1,
+            Vec2::new(1600.0, 900.0),
+            "vmux://agent/claude/session",
+        );
+
+        for (i, url) in [
+            "file:///repo/.git/HEAD",
+            "file:///repo/.git/refs/heads/main",
+            "https://news.ycombinator.com/news",
+            "vmux://terminal/",
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            app.world_mut()
+                .resource_mut::<Messages<OpenBesideRequest>>()
+                .write(OpenBesideRequest {
+                    pane: agent_pane,
+                    direction: None,
+                    url: url.into(),
+                    request_id: [i as u8; 16],
+                    focus: false,
+                });
+            app.update();
+            materialize_page_metadata(&mut app);
+        }
+
+        let requests = page_open_requests(&app);
+        let parent_for_url = |url: &str| -> Entity {
+            requests
+                .iter()
+                .find_map(|request| match &request.target {
+                    PageOpenTarget::Stack(stack) if request.url == url => app
+                        .world()
+                        .get::<ChildOf>(*stack)
+                        .map(|parent| parent.get()),
+                    _ => None,
+                })
+                .unwrap()
+        };
+        let file_parent = parent_for_url("file:///repo/.git/refs/heads/main");
+        let browser_parent = parent_for_url("https://news.ycombinator.com/news");
+        let terminal_parent = parent_for_url("vmux://terminal/");
+        let terminal_split = app.world().get::<ChildOf>(terminal_parent).unwrap().get();
+
+        assert_eq!(
+            terminal_split,
+            app.world().get::<ChildOf>(browser_parent).unwrap().get(),
+            "terminal should split the browser pane when the browser opened after files"
+        );
+        assert_ne!(
+            terminal_split,
+            app.world().get::<ChildOf>(file_parent).unwrap().get(),
+            "terminal must not split the older file pane"
+        );
+    }
+
+    #[test]
+    fn auto_file_after_terminal_ignores_stale_file_bucket_when_browser_is_tail() {
+        let mut app = open_beside_app();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                vmux_core::Active,
+                LastActivatedAt::now(),
+                ChildOf(space),
+            ))
+            .id();
+        let agent_pane = place_pane_with_url(
+            &mut app,
+            tab,
+            1,
+            Vec2::new(1600.0, 900.0),
+            "vmux://agent/claude/session",
+        );
+
+        for (i, url) in [
+            "file:///repo/.git/HEAD",
+            "file:///repo/.git/refs/heads/main",
+            "https://news.ycombinator.com/news",
+            "vmux://terminal/",
+            "file:///repo/README.md",
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            app.world_mut()
+                .resource_mut::<Messages<OpenBesideRequest>>()
+                .write(OpenBesideRequest {
+                    pane: agent_pane,
+                    direction: None,
+                    url: url.into(),
+                    request_id: [i as u8; 16],
+                    focus: false,
+                });
+            app.update();
+            materialize_page_metadata(&mut app);
+        }
+
+        let requests = page_open_requests(&app);
+        let parent_for_url = |url: &str| -> Entity {
+            requests
+                .iter()
+                .find_map(|request| match &request.target {
+                    PageOpenTarget::Stack(stack) if request.url == url => app
+                        .world()
+                        .get::<ChildOf>(*stack)
+                        .map(|parent| parent.get()),
+                    _ => None,
+                })
+                .unwrap()
+        };
+        let stale_file_parent = parent_for_url("file:///repo/.git/refs/heads/main");
+        let browser_parent = parent_for_url("https://news.ycombinator.com/news");
+        let terminal_parent = parent_for_url("vmux://terminal/");
+        let readme_parent = parent_for_url("file:///repo/README.md");
+        let readme_split = app.world().get::<ChildOf>(readme_parent).unwrap().get();
+
+        assert_eq!(
+            readme_split,
+            app.world().get::<ChildOf>(browser_parent).unwrap().get(),
+            "README should split the browser pane"
+        );
+        assert_ne!(
+            readme_split,
+            app.world().get::<ChildOf>(terminal_parent).unwrap().get(),
+            "README must not split the terminal pane"
+        );
+        assert_ne!(
+            readme_parent, stale_file_parent,
+            "README must not tab into stale setup files"
         );
     }
 

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -3491,6 +3491,78 @@ mod tests {
     }
 
     #[test]
+    fn auto_first_file_splits_browser_when_terminal_is_newer() {
+        let mut app = open_beside_app();
+        let space = app
+            .world_mut()
+            .spawn((crate::space::Space, vmux_core::Active))
+            .id();
+        let tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                vmux_core::Active,
+                LastActivatedAt::now(),
+                ChildOf(space),
+            ))
+            .id();
+        let agent_pane = place_pane_with_url(
+            &mut app,
+            tab,
+            1,
+            Vec2::new(1600.0, 900.0),
+            "vmux://agent/claude/session",
+        );
+        let browser_pane = place_pane_with_url(
+            &mut app,
+            tab,
+            10,
+            Vec2::new(900.0, 400.0),
+            "https://news.ycombinator.com/news",
+        );
+        let terminal_pane = place_pane_with_url(
+            &mut app,
+            tab,
+            20,
+            Vec2::new(900.0, 400.0),
+            "vmux://terminal/",
+        );
+
+        app.world_mut()
+            .resource_mut::<Messages<OpenBesideRequest>>()
+            .write(OpenBesideRequest {
+                pane: agent_pane,
+                direction: None,
+                url: "file:///repo/README.md".into(),
+                request_id: [9; 16],
+                focus: false,
+            });
+        app.update();
+
+        let requests = page_open_requests(&app);
+        let file_parent = requests
+            .iter()
+            .find_map(|request| match &request.target {
+                PageOpenTarget::Stack(stack) if request.url == "file:///repo/README.md" => app
+                    .world()
+                    .get::<ChildOf>(*stack)
+                    .map(|parent| parent.get()),
+                _ => None,
+            })
+            .unwrap();
+
+        assert_eq!(
+            app.world().get::<ChildOf>(file_parent).unwrap().get(),
+            browser_pane,
+            "first file should split the browser pane, not the newer terminal pane"
+        );
+        assert!(
+            app.world().get::<PaneSplit>(terminal_pane).is_none(),
+            "terminal pane must not split for first file"
+        );
+    }
+
+    #[test]
     fn auto_duplicate_url_reuses_pending_open_in_same_batch() {
         let mut app = open_beside_app();
         let space = app

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -1046,7 +1046,6 @@ pub fn handle_open_beside_requests(
                     let old_leaf_info = leaf_info_for_pane(
                         req.pane,
                         &pane_children,
-                        &child_of_q,
                         &rc.seq_q,
                         &rc.node_q,
                         &rc.page_q,
@@ -1124,7 +1123,6 @@ pub fn handle_open_beside_requests(
             &rc.all_children,
             &leaf_panes,
             &pane_children,
-            &child_of_q,
             &rc.seq_q,
             &rc.node_q,
             &rc.page_q,
@@ -1164,9 +1162,6 @@ pub fn handle_open_beside_requests(
             }
             crate::placement::Placement::Spiral { anchor, axis } => {
                 let old_leaf_info = leaves.iter().find(|leaf| leaf.pane == anchor).cloned();
-                let keep_holder_as_tail = old_leaf_info
-                    .as_ref()
-                    .is_some_and(|info| !info.kinds.contains(&crate::placement::PageKind::Agent));
                 let existing_tabs = stack_children_for_split(
                     anchor,
                     &pane_children,
@@ -1187,13 +1182,6 @@ pub fn handle_open_beside_requests(
                     &mut pending_leaf_stacks,
                     &mut retired_leaf_panes,
                 );
-                let keep_holder_as_tail = keep_holder_as_tail
-                    && crate::placement::page_kind_for_url(&req.url)
-                        != crate::placement::PageKind::Browser;
-                let tail = split
-                    .holder
-                    .filter(|_| keep_holder_as_tail)
-                    .unwrap_or(split.target);
                 stamp_split_panes_for_batch(
                     &mut commands,
                     &mut spawn_counter,
@@ -1202,7 +1190,7 @@ pub fn handle_open_beside_requests(
                     &mut pending_leaf_infos,
                     split.holder,
                     split.target,
-                    tail,
+                    split.target,
                 );
                 let pending_size = split
                     .target_size
@@ -1454,7 +1442,6 @@ fn record_pending_leaf_info(
         .entry(pane)
         .or_insert_with(|| crate::placement::LeafInfo {
             pane,
-            parent: None,
             kinds: Vec::new(),
             spawn_seq,
             size,
@@ -1512,7 +1499,6 @@ fn stack_children_for_split(
 fn leaf_info_for_pane(
     pane: Entity,
     pane_children: &Query<&Children, With<Pane>>,
-    child_of_q: &Query<&ChildOf>,
     seq_q: &Query<&SpawnSeq>,
     node_q: &Query<&ComputedNode>,
     page_q: &Query<&vmux_core::PageMetadata, With<Stack>>,
@@ -1528,7 +1514,6 @@ fn leaf_info_for_pane(
     );
     Some(crate::placement::LeafInfo {
         pane,
-        parent: child_of_q.get(pane).ok().map(|parent| parent.get()),
         kinds,
         spawn_seq: spawn_seq_overrides
             .get(&pane)
@@ -1559,7 +1544,6 @@ fn collect_leaf_infos(
     all_children: &Query<&Children>,
     leaf_panes: &Query<Entity, (With<Pane>, Without<PaneSplit>)>,
     pane_children: &Query<&Children, With<Pane>>,
-    child_of_q: &Query<&ChildOf>,
     seq_q: &Query<&SpawnSeq>,
     node_q: &Query<&ComputedNode>,
     page_q: &Query<&vmux_core::PageMetadata, With<Stack>>,
@@ -1582,7 +1566,6 @@ fn collect_leaf_infos(
                 .unwrap_or_default();
             crate::placement::LeafInfo {
                 pane,
-                parent: child_of_q.get(pane).ok().map(|parent| parent.get()),
                 kinds,
                 spawn_seq: spawn_seq_overrides
                     .get(&pane)
@@ -1696,7 +1679,6 @@ pub fn resolve_spiral_pane(
         &ctx.all_children,
         &ctx.leaf_panes,
         &ctx.pane_children,
-        &ctx.child_of_q,
         &ctx.seq_q,
         &ctx.node_q,
         &ctx.page_q,
@@ -1726,7 +1708,6 @@ pub fn resolve_split_anchor_pane(anchor_pane: Entity, ctx: &PlacementCtx) -> Ent
         &ctx.all_children,
         &ctx.leaf_panes,
         &ctx.pane_children,
-        &ctx.child_of_q,
         &ctx.seq_q,
         &ctx.node_q,
         &ctx.page_q,
@@ -3108,7 +3089,7 @@ mod tests {
     }
 
     #[test]
-    fn auto_batched_new_types_dwindle_from_remaining_tail() {
+    fn auto_batched_new_types_split_from_newest_target() {
         let mut app = open_beside_app();
         let space = app
             .world_mut()
@@ -3179,11 +3160,11 @@ mod tests {
         let file_split = app.world().get::<ChildOf>(file_parent).unwrap().get();
         assert_eq!(
             app.world().get::<ChildOf>(terminal_parent).unwrap().get(),
-            browser_split
+            file_split
         );
         assert_eq!(
-            app.world().get::<ChildOf>(browser_split).unwrap().get(),
-            file_split
+            app.world().get::<ChildOf>(file_split).unwrap().get(),
+            browser_split
         );
         assert_eq!(
             app.world().get::<PaneSplit>(agent_pane).unwrap().direction,
@@ -3194,11 +3175,11 @@ mod tests {
                 .get::<PaneSplit>(browser_split)
                 .unwrap()
                 .direction,
-            PaneSplitDirection::Row
+            PaneSplitDirection::Column
         );
         assert_eq!(
             app.world().get::<PaneSplit>(file_split).unwrap().direction,
-            PaneSplitDirection::Column
+            PaneSplitDirection::Row
         );
     }
 
@@ -3503,7 +3484,7 @@ mod tests {
     }
 
     #[test]
-    fn auto_first_file_splits_browser_when_terminal_is_newer() {
+    fn auto_first_file_splits_terminal_when_terminal_is_newer() {
         let mut app = open_beside_app();
         let space = app
             .world_mut()
@@ -3565,12 +3546,12 @@ mod tests {
 
         assert_eq!(
             app.world().get::<ChildOf>(file_parent).unwrap().get(),
-            browser_pane,
-            "first file should split the browser pane, not the newer terminal pane"
+            terminal_pane,
+            "first file should split the newest terminal pane"
         );
         assert!(
-            app.world().get::<PaneSplit>(terminal_pane).is_none(),
-            "terminal pane must not split for first file"
+            app.world().get::<PaneSplit>(browser_pane).is_none(),
+            "browser pane must not split for first file"
         );
     }
 
@@ -3651,7 +3632,7 @@ mod tests {
     }
 
     #[test]
-    fn auto_file_after_terminal_ignores_stale_file_bucket_when_browser_is_tail() {
+    fn auto_file_after_terminal_stacks_in_existing_file_bucket() {
         let mut app = open_beside_app();
         let space = app
             .world_mut()
@@ -3711,24 +3692,16 @@ mod tests {
                 .unwrap()
         };
         let stale_file_parent = parent_for_url("file:///repo/.git/refs/heads/main");
-        let browser_parent = parent_for_url("https://news.ycombinator.com/news");
         let terminal_parent = parent_for_url("vmux://terminal/");
         let readme_parent = parent_for_url("file:///repo/README.md");
-        let readme_split = app.world().get::<ChildOf>(readme_parent).unwrap().get();
 
         assert_eq!(
-            readme_split,
-            app.world().get::<ChildOf>(browser_parent).unwrap().get(),
-            "README should split the browser pane"
-        );
-        assert_ne!(
-            readme_split,
-            app.world().get::<ChildOf>(terminal_parent).unwrap().get(),
-            "README must not split the terminal pane"
-        );
-        assert_ne!(
             readme_parent, stale_file_parent,
-            "README must not tab into stale setup files"
+            "README should tab into the existing file pane"
+        );
+        assert_ne!(
+            readme_parent, terminal_parent,
+            "README must not tab into the terminal pane"
         );
     }
 

--- a/crates/vmux_layout/src/placement.rs
+++ b/crates/vmux_layout/src/placement.rs
@@ -124,6 +124,15 @@ pub fn resolve_placement(
         return Placement::AddTab { pane: same.pane };
     }
 
+    if kind == PageKind::File
+        && let Some(browser) = newest_leaf_with_kind(leaves, PageKind::Browser)
+    {
+        return Placement::Spiral {
+            anchor: browser.pane,
+            axis: longer_axis(browser.size),
+        };
+    }
+
     if let Some(anchor) = newest_nonagent_leaf(leaves) {
         return Placement::Spiral {
             anchor: anchor.pane,
@@ -290,6 +299,23 @@ mod tests {
             leaf(2, &[PageKind::File], 9, (900.0, 400.0)),
         ];
         let got = resolve_placement("https://b.com", None, &leaves, e(1));
+        assert_eq!(
+            got,
+            Placement::Spiral {
+                anchor: e(2),
+                axis: PaneSplitDirection::Row
+            }
+        );
+    }
+
+    #[test]
+    fn first_file_prefers_browser_leaf_over_newer_terminal_leaf() {
+        let leaves = [
+            leaf(1, &[PageKind::Agent], 1, (800.0, 900.0)),
+            leaf(2, &[PageKind::Browser], 10, (900.0, 400.0)),
+            leaf(3, &[PageKind::Terminal], 20, (900.0, 400.0)),
+        ];
+        let got = resolve_placement("file:///repo/README.md", None, &leaves, e(1));
         assert_eq!(
             got,
             Placement::Spiral {

--- a/crates/vmux_layout/src/placement.rs
+++ b/crates/vmux_layout/src/placement.rs
@@ -40,6 +40,7 @@ pub enum Placement {
 #[derive(Debug, Clone)]
 pub struct LeafInfo {
     pub pane: Entity,
+    pub parent: Option<Entity>,
     pub kinds: Vec<PageKind>,
     pub spawn_seq: u64,
     pub size: Vec2,
@@ -71,6 +72,10 @@ fn newest_leaf_with_kind(leaves: &[LeafInfo], kind: PageKind) -> Option<&LeafInf
         .iter()
         .filter(|l| l.kinds.len() == 1 && l.kinds.contains(&kind))
         .max_by_key(|l| l.spawn_seq)
+}
+
+fn same_parent(a: &LeafInfo, b: &LeafInfo) -> bool {
+    a.parent.is_some() && a.parent == b.parent
 }
 
 fn file_reuse_key(url: &str) -> &str {
@@ -120,17 +125,29 @@ pub fn resolve_placement(
         return Placement::AddTab { pane: self_pane };
     }
 
-    if let Some(same) = newest_leaf_with_kind(leaves, kind) {
+    if kind == PageKind::File {
+        let same_file = newest_leaf_with_kind(leaves, PageKind::File);
+        let browser = newest_leaf_with_kind(leaves, PageKind::Browser);
+        if let Some(file) = same_file {
+            if let Some(browser) = browser
+                && browser.spawn_seq > file.spawn_seq
+                && !same_parent(file, browser)
+            {
+                return Placement::Spiral {
+                    anchor: browser.pane,
+                    axis: longer_axis(browser.size),
+                };
+            }
+            return Placement::AddTab { pane: file.pane };
+        }
+        if let Some(browser) = browser {
+            return Placement::Spiral {
+                anchor: browser.pane,
+                axis: longer_axis(browser.size),
+            };
+        }
+    } else if let Some(same) = newest_leaf_with_kind(leaves, kind) {
         return Placement::AddTab { pane: same.pane };
-    }
-
-    if kind == PageKind::File
-        && let Some(browser) = newest_leaf_with_kind(leaves, PageKind::Browser)
-    {
-        return Placement::Spiral {
-            anchor: browser.pane,
-            axis: longer_axis(browser.size),
-        };
     }
 
     if let Some(anchor) = newest_nonagent_leaf(leaves) {
@@ -178,6 +195,7 @@ mod tests {
     fn leaf(pane: u64, kinds: &[PageKind], seq: u64, size: (f32, f32)) -> LeafInfo {
         LeafInfo {
             pane: e(pane),
+            parent: None,
             kinds: kinds.to_vec(),
             spawn_seq: seq,
             size: Vec2::new(size.0, size.1),

--- a/crates/vmux_layout/src/placement.rs
+++ b/crates/vmux_layout/src/placement.rs
@@ -40,7 +40,6 @@ pub enum Placement {
 #[derive(Debug, Clone)]
 pub struct LeafInfo {
     pub pane: Entity,
-    pub parent: Option<Entity>,
     pub kinds: Vec<PageKind>,
     pub spawn_seq: u64,
     pub size: Vec2,
@@ -72,10 +71,6 @@ fn newest_leaf_with_kind(leaves: &[LeafInfo], kind: PageKind) -> Option<&LeafInf
         .iter()
         .filter(|l| l.kinds.len() == 1 && l.kinds.contains(&kind))
         .max_by_key(|l| l.spawn_seq)
-}
-
-fn same_parent(a: &LeafInfo, b: &LeafInfo) -> bool {
-    a.parent.is_some() && a.parent == b.parent
 }
 
 fn file_reuse_key(url: &str) -> &str {
@@ -125,28 +120,7 @@ pub fn resolve_placement(
         return Placement::AddTab { pane: self_pane };
     }
 
-    if kind == PageKind::File {
-        let same_file = newest_leaf_with_kind(leaves, PageKind::File);
-        let browser = newest_leaf_with_kind(leaves, PageKind::Browser);
-        if let Some(file) = same_file {
-            if let Some(browser) = browser
-                && browser.spawn_seq > file.spawn_seq
-                && !same_parent(file, browser)
-            {
-                return Placement::Spiral {
-                    anchor: browser.pane,
-                    axis: longer_axis(browser.size),
-                };
-            }
-            return Placement::AddTab { pane: file.pane };
-        }
-        if let Some(browser) = browser {
-            return Placement::Spiral {
-                anchor: browser.pane,
-                axis: longer_axis(browser.size),
-            };
-        }
-    } else if let Some(same) = newest_leaf_with_kind(leaves, kind) {
+    if let Some(same) = newest_leaf_with_kind(leaves, kind) {
         return Placement::AddTab { pane: same.pane };
     }
 
@@ -195,7 +169,6 @@ mod tests {
     fn leaf(pane: u64, kinds: &[PageKind], seq: u64, size: (f32, f32)) -> LeafInfo {
         LeafInfo {
             pane: e(pane),
-            parent: None,
             kinds: kinds.to_vec(),
             spawn_seq: seq,
             size: Vec2::new(size.0, size.1),
@@ -327,7 +300,7 @@ mod tests {
     }
 
     #[test]
-    fn first_file_prefers_browser_leaf_over_newer_terminal_leaf() {
+    fn first_file_splits_newest_terminal_when_no_file_bucket_exists() {
         let leaves = [
             leaf(1, &[PageKind::Agent], 1, (800.0, 900.0)),
             leaf(2, &[PageKind::Browser], 10, (900.0, 400.0)),
@@ -337,7 +310,7 @@ mod tests {
         assert_eq!(
             got,
             Placement::Spiral {
-                anchor: e(2),
+                anchor: e(3),
                 axis: PaneSplitDirection::Row
             }
         );


### PR DESCRIPTION
## Context
Agent-opened files, browsers, and run terminals were landing in inconsistent panes after the earlier PR. Files could split away from the existing file pane, and later page types could anchor to stale content instead of the newest visible target.

## Implementation
This keeps same-kind file buckets reusable, makes the newly split pane become the newest placement tail, and refreshes run terminal pane recency when agent runs create or reuse a terminal. Regression coverage locks the file bucket, terminal split, and follow-up placement behavior.

## Checks / QA
- From an agent session, open .git/HEAD, .git/refs/heads/main, Hacker News, run a shell command, then open README.md. README.md should stack with the two file tabs.
- After opening a terminal, open a different new page type and confirm it splits from the terminal area, not Hacker News.
- Confirm one run does not create duplicate terminal panes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved run-pane and split behavior so the reused run pane receives the correct updated spawn sequence, making it the newest target for subsequent follow-up placement.
  * Refined spiral split stamping logic to use consistent holder/target ordering during batch-spiral openings, keeping browser, terminal, and file pane ordering aligned.

* **Tests**
  * Added unit tests covering run-pane reuse after splitting, plus several file/terminal/browser opening-order scenarios.
  * Updated an existing auto-batched expectations test to match the corrected pane relationships and directions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->