### PR TITLE
fix(browser): preserve native CEF text selection

### DIFF
--- a/crates/vmux_browser/src/host_focus.rs
+++ b/crates/vmux_browser/src/host_focus.rs
@@ -72,12 +72,37 @@ fn set_intent(intent: &mut ResMut<HostFocusIntent>, next: HostFocusIntent) {
     }
 }
 
-pub(crate) fn apply_windowed_host_focus(intent: Res<HostFocusIntent>, browsers: NonSend<Browsers>) {
-    // Runs every frame so a page that becomes active before its browser exists still gets focused
-    // once the browser is created. `set_windowed_focus` is a no-op until then.
-    if let HostFocusIntent::Windowed(webview) = *intent
-        && browsers.has_browser(webview)
-    {
+fn windowed_focus_action(
+    intent: HostFocusIntent,
+    has_browser: bool,
+    focused: &mut Option<Entity>,
+) -> Option<Entity> {
+    match intent {
+        HostFocusIntent::Windowed(webview) if has_browser => {
+            if *focused != Some(webview) {
+                *focused = Some(webview);
+                Some(webview)
+            } else {
+                None
+            }
+        }
+        _ => {
+            *focused = None;
+            None
+        }
+    }
+}
+
+pub(crate) fn apply_windowed_host_focus(
+    intent: Res<HostFocusIntent>,
+    browsers: NonSend<Browsers>,
+    mut focused: Local<Option<Entity>>,
+) {
+    let has_browser = match *intent {
+        HostFocusIntent::Windowed(webview) => browsers.has_browser(webview),
+        _ => false,
+    };
+    if let Some(webview) = windowed_focus_action(*intent, has_browser, &mut focused) {
         browsers.set_windowed_focus(&webview, true);
     }
 }
@@ -131,6 +156,43 @@ mod tests {
         let mut app = app();
         app.update();
         assert_eq!(intent(&app), HostFocusIntent::WinitHost);
+    }
+
+    #[test]
+    fn windowed_focus_action_focuses_available_target_once() {
+        let webview = Entity::from_bits(1);
+        let mut focused = None;
+
+        assert_eq!(
+            windowed_focus_action(HostFocusIntent::Windowed(webview), true, &mut focused),
+            Some(webview)
+        );
+        assert_eq!(focused, Some(webview));
+        assert_eq!(
+            windowed_focus_action(HostFocusIntent::Windowed(webview), true, &mut focused),
+            None
+        );
+        assert_eq!(focused, Some(webview));
+    }
+
+    #[test]
+    fn windowed_focus_action_refocuses_after_browser_reappears() {
+        let webview = Entity::from_bits(1);
+        let mut focused = None;
+
+        assert_eq!(
+            windowed_focus_action(HostFocusIntent::Windowed(webview), true, &mut focused),
+            Some(webview)
+        );
+        assert_eq!(
+            windowed_focus_action(HostFocusIntent::Windowed(webview), false, &mut focused),
+            None
+        );
+        assert_eq!(focused, None);
+        assert_eq!(
+            windowed_focus_action(HostFocusIntent::Windowed(webview), true, &mut focused),
+            Some(webview)
+        );
     }
 
     #[test]

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -1470,6 +1470,9 @@ fn refresh_active_windowed_hover(
     if vmux_layout::command_bar::handler::is_command_bar_open(&modal_q) {
         return;
     }
+    if native_left_mouse_down() {
+        return;
+    }
     let Some((entity, transform, computed, ui_gt, host_window)) = active_q.iter().next() else {
         return;
     };
@@ -1513,6 +1516,15 @@ const COMMAND_BAR_NATIVE_Z: f64 = 200.0;
 static NATIVE_COMMAND_BAR_CLICK_FRAME: LazyLock<Mutex<Option<CommandBarWindowedFrame>>> =
     LazyLock::new(|| Mutex::new(None));
 static NATIVE_COMMAND_BAR_DISMISS_REQUESTED: AtomicBool = AtomicBool::new(false);
+static NATIVE_LEFT_MOUSE_DOWN: AtomicBool = AtomicBool::new(false);
+
+pub fn set_native_left_mouse_down(down: bool) {
+    NATIVE_LEFT_MOUSE_DOWN.store(down, Ordering::Relaxed);
+}
+
+pub fn native_left_mouse_down() -> bool {
+    NATIVE_LEFT_MOUSE_DOWN.load(Ordering::Relaxed)
+}
 
 fn command_bar_windowed_frame(
     window_width_px: f32,
@@ -4972,6 +4984,19 @@ mod tests {
         assert!(refresh_fn.contains("With<WebviewWindowed>"));
         assert!(refresh_fn.contains("vmux_layout::pane::pane_hover_cursor_position"));
         assert!(refresh_fn.contains("browsers.send_mouse_move"));
+    }
+
+    #[test]
+    fn active_windowed_hover_refresh_skips_native_left_drag() {
+        let source = include_str!("lib.rs");
+        let refresh_fn = source
+            .split("fn refresh_active_windowed_hover")
+            .nth(1)
+            .and_then(|tail| tail.split("fn sync_windowed_layout").next())
+            .unwrap_or_default();
+
+        assert!(refresh_fn.contains("native_left_mouse_down()"));
+        assert!(refresh_fn.contains("return;"));
     }
 
     #[test]

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -257,6 +257,11 @@ fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) 
     let local_block = block2::RcBlock::new(move |event: NonNull<NSEvent>| -> *mut NSEvent {
         let ev = unsafe { event.as_ref() };
         let event_type = ev.r#type();
+        if event_type == NSEventType::LeftMouseDown {
+            vmux_browser::set_native_left_mouse_down(true);
+        } else if event_type == NSEventType::LeftMouseUp {
+            vmux_browser::set_native_left_mouse_down(false);
+        }
         if event_type == NSEventType::LeftMouseDown
             && let Some((x_px, y_px)) = event_location_in_window_physical_px(ev)
         {
@@ -284,7 +289,13 @@ fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) 
         event.as_ptr()
     });
     let global_wake = wake.clone();
-    let global_block = block2::RcBlock::new(move |_event: NonNull<NSEvent>| {
+    let global_block = block2::RcBlock::new(move |event: NonNull<NSEvent>| {
+        let event_type = unsafe { event.as_ref() }.r#type();
+        if event_type == NSEventType::LeftMouseDown {
+            vmux_browser::set_native_left_mouse_down(true);
+        } else if event_type == NSEventType::LeftMouseUp {
+            vmux_browser::set_native_left_mouse_down(false);
+        }
         global_wake(NATIVE_MOUSE_MOVE_WAKE_INTERVAL);
     });
     let mask = NSEventMask::MouseMoved
@@ -722,6 +733,19 @@ mod tests {
 
         assert!(monitor.contains("addLocalMonitorForEventsMatchingMask_handler"));
         assert!(monitor.contains("addGlobalMonitorForEventsMatchingMask_handler"));
+    }
+
+    #[test]
+    fn native_mouse_monitor_tracks_left_button_state() {
+        let source = include_str!("background_lifecycle.rs");
+        let monitor = source
+            .split("fn install_native_mouse_wake_monitor")
+            .nth(1)
+            .and_then(|tail| tail.split("fn foreground_winit_settings").next())
+            .unwrap_or_default();
+
+        assert!(monitor.contains("vmux_browser::set_native_left_mouse_down(true)"));
+        assert!(monitor.contains("vmux_browser::set_native_left_mouse_down(false)"));
     }
 
     #[test]


### PR DESCRIPTION
## Context

Native windowed CEF browser panes lost their text selection during a left-mouse drag. The active-pane hover-refresh system re-sends synthetic mouse-move events every frame; firing mid-drag cleared the in-page selection, so click-drag selecting text in a browser pane was effectively broken.

## Implementation

- Track native left-mouse button state globally in `vmux_browser` via an `AtomicBool` (`set_native_left_mouse_down` / `native_left_mouse_down`), driven by the AppKit local + global mouse monitors in `background_lifecycle.rs` (LeftMouseDown/Up).
- `refresh_active_windowed_hover` bails while the left button is held, so no synthetic mouse-move interrupts an active selection drag.
- Extracted the windowed-focus decision into a pure `windowed_focus_action` helper (focus target once; refocus after the browser reappears) with unit tests.

## Checks / QA

- Open a browser pane, click-drag to select text -> selection persists through the drag and after release.
- Switch focus away and back to the pane -> focus restored once, no repeated focus churn.
- Command bar over a browser pane still dismisses on outside click.