### PR TITLE
feat(command-bar): select URL on Cmd+L, keep caret visible on shortcut jumps

### DIFF
--- a/crates/vmux_layout/Cargo.toml
+++ b/crates/vmux_layout/Cargo.toml
@@ -59,12 +59,14 @@ vmux_ui = { path = "../vmux_ui", default-features = false }
 wasm-bindgen = "0.2.115"
 web-sys = { version = "0.3", features = [
     "AddEventListenerOptions",
+    "CanvasRenderingContext2d",
     "CssStyleDeclaration",
     "Document",
     "Element",
     "Event",
     "EventInit",
     "EventTarget",
+    "HtmlCanvasElement",
     "HtmlElement",
     "HtmlInputElement",
     "KeyboardEvent",
@@ -74,6 +76,7 @@ web-sys = { version = "0.3", features = [
     "ResizeObserverEntry",
     "ScrollIntoViewOptions",
     "ScrollLogicalPosition",
+    "TextMetrics",
     "Window",
 ] }
 

--- a/crates/vmux_layout/src/command_bar/keyboard.rs
+++ b/crates/vmux_layout/src/command_bar/keyboard.rs
@@ -67,6 +67,20 @@ pub fn caret_scroll_left(
     ((new_scroll - scroll_left).abs() >= 0.5).then_some(new_scroll)
 }
 
+/// Convert a UTF-16 code-unit offset (the unit DOM `selection_start`/`set_selection_range`
+/// use) to a UTF-8 byte offset into `s`. Offsets past the end clamp to `s.len()`. Byte
+/// offsets are what caret-follow needs to slice the value string for pixel measurement.
+pub fn utf16_offset_to_byte(s: &str, utf16_offset: u32) -> usize {
+    let mut units = 0u32;
+    for (byte, ch) in s.char_indices() {
+        if units >= utf16_offset {
+            return byte;
+        }
+        units += ch.len_utf16() as u32;
+    }
+    s.len()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -151,5 +165,32 @@ mod tests {
     fn degenerate_geometry_is_ignored() {
         assert_eq!(caret_scroll_left(100.0, 0.0, 0.0, 12.0), None);
         assert_eq!(caret_scroll_left(f64::NAN, 200.0, 0.0, 12.0), None);
+    }
+
+    #[test]
+    fn utf16_offset_maps_to_bytes_for_ascii() {
+        assert_eq!(utf16_offset_to_byte("hello", 0), 0);
+        assert_eq!(utf16_offset_to_byte("hello", 3), 3);
+        assert_eq!(utf16_offset_to_byte("hello", 5), 5);
+    }
+
+    #[test]
+    fn utf16_offset_maps_to_bytes_across_multibyte_chars() {
+        // "é" is 1 UTF-16 unit but 2 UTF-8 bytes; "本" is 1 unit, 3 bytes.
+        let s = "aé本b";
+        assert_eq!(utf16_offset_to_byte(s, 0), 0);
+        assert_eq!(utf16_offset_to_byte(s, 1), 1); // after 'a'
+        assert_eq!(utf16_offset_to_byte(s, 2), 3); // after 'é'
+        assert_eq!(utf16_offset_to_byte(s, 3), 6); // after '本'
+        assert_eq!(utf16_offset_to_byte(s, 4), 7); // after 'b'
+    }
+
+    #[test]
+    fn utf16_offset_handles_surrogate_pairs_and_overflow() {
+        // "😀" is a surrogate pair: 2 UTF-16 units, 4 UTF-8 bytes.
+        let s = "x😀y";
+        assert_eq!(utf16_offset_to_byte(s, 1), 1); // after 'x'
+        assert_eq!(utf16_offset_to_byte(s, 3), 5); // after full emoji (1 + 4)
+        assert_eq!(utf16_offset_to_byte(s, 99), s.len()); // past end clamps
     }
 }

--- a/crates/vmux_layout/src/command_bar/keyboard.rs
+++ b/crates/vmux_layout/src/command_bar/keyboard.rs
@@ -41,6 +41,32 @@ pub fn ignore_physical_rerouted_ctrl_keydown(code: &str, is_synthetic: bool) -> 
         )
 }
 
+/// New horizontal `scroll_left` that keeps a caret at pixel offset `caret_px` visible in an
+/// input of width `client_width` currently scrolled to `scroll_left`, preserving `margin` px
+/// at whichever edge the caret approaches. Returns `None` when the caret is already visible
+/// (no scroll change needed). Programmatic `set_selection_range` does not auto-scroll in
+/// CEF/Chromium, so the command-bar input drives its own caret-follow with this.
+pub fn caret_scroll_left(
+    caret_px: f64,
+    client_width: f64,
+    scroll_left: f64,
+    margin: f64,
+) -> Option<f64> {
+    if !caret_px.is_finite() || client_width <= 0.0 {
+        return None;
+    }
+    let margin = margin.clamp(0.0, client_width / 2.0);
+    let new_scroll = if caret_px < scroll_left + margin {
+        caret_px - margin
+    } else if caret_px > scroll_left + client_width - margin {
+        caret_px - client_width + margin
+    } else {
+        return None;
+    }
+    .max(0.0);
+    ((new_scroll - scroll_left).abs() >= 0.5).then_some(new_scroll)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -93,5 +119,37 @@ mod tests {
         assert!(!ignore_physical_rerouted_ctrl_keydown("KeyK", true));
         assert!(!ignore_physical_rerouted_ctrl_keydown("KeyN", false));
         assert!(!ignore_physical_rerouted_ctrl_keydown("KeyP", false));
+    }
+
+    #[test]
+    fn caret_within_view_needs_no_scroll() {
+        assert_eq!(caret_scroll_left(50.0, 200.0, 0.0, 12.0), None);
+    }
+
+    #[test]
+    fn caret_past_right_edge_scrolls_right_to_reveal_it() {
+        // Long URL, caret at end (500px) in a 200px box scrolled to 0.
+        let s = caret_scroll_left(500.0, 200.0, 0.0, 12.0).expect("should scroll");
+        assert!((s - (500.0 - 200.0 + 12.0)).abs() < 0.001, "got {s}");
+        // Caret now sits inside the revealed range.
+        assert!(s < 500.0 && 500.0 <= s + 200.0);
+    }
+
+    #[test]
+    fn caret_before_left_edge_scrolls_left() {
+        // Caret at 40px while scrolled to 300px must pull the view back.
+        let s = caret_scroll_left(40.0, 200.0, 300.0, 12.0).expect("should scroll");
+        assert!((s - (40.0 - 12.0)).abs() < 0.001, "got {s}");
+    }
+
+    #[test]
+    fn caret_at_home_clamps_scroll_to_zero() {
+        assert_eq!(caret_scroll_left(0.0, 200.0, 300.0, 12.0), Some(0.0));
+    }
+
+    #[test]
+    fn degenerate_geometry_is_ignored() {
+        assert_eq!(caret_scroll_left(100.0, 0.0, 0.0, 12.0), None);
+        assert_eq!(caret_scroll_left(f64::NAN, 200.0, 0.0, 12.0), None);
     }
 }

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -2,7 +2,7 @@
 
 use crate::command_bar::keyboard::{
     CtrlEditAction, CtrlKeyCapture, caret_scroll_left, ctrl_key_capture_for_code,
-    ignore_physical_rerouted_ctrl_keydown,
+    ignore_physical_rerouted_ctrl_keydown, utf16_offset_to_byte,
 };
 use crate::command_bar::results::{CommandBarResultItem as ResultItem, filter_results};
 use crate::command_bar::style::{
@@ -803,19 +803,21 @@ fn focus_and_install_ctrl_bindings() {
                 }
             }
             CtrlEditAction::Forward => {
-                let p = (input2.selection_start().unwrap_or(Some(0)).unwrap_or(0) + 1)
-                    .min(input2.value().len() as u32);
+                let value = input2.value();
+                let max = value.encode_utf16().count() as u32;
+                let p = (input2.selection_start().unwrap_or(Some(0)).unwrap_or(0) + 1).min(max);
                 let _ = input2.set_selection_range(p, p);
-                ensure_caret_visible(&input2, p as usize);
+                ensure_caret_visible(&input2, utf16_offset_to_byte(&value, p));
             }
             CtrlEditAction::Back => {
+                let value = input2.value();
                 let p = input2
                     .selection_start()
                     .unwrap_or(Some(0))
                     .unwrap_or(0)
                     .saturating_sub(1);
                 let _ = input2.set_selection_range(p, p);
-                ensure_caret_visible(&input2, p as usize);
+                ensure_caret_visible(&input2, utf16_offset_to_byte(&value, p));
             }
             CtrlEditAction::Delete => {
                 let v = input2.value();

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 use crate::command_bar::keyboard::{
-    CtrlEditAction, CtrlKeyCapture, ctrl_key_capture_for_code,
+    CtrlEditAction, CtrlKeyCapture, caret_scroll_left, ctrl_key_capture_for_code,
     ignore_physical_rerouted_ctrl_keydown,
 };
 use crate::command_bar::results::{CommandBarResultItem as ResultItem, filter_results};
@@ -421,6 +421,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                                         input.set_value(&new_val);
                                         let len = new_val.len() as u32;
                                         let _ = input.set_selection_range(len, len);
+                                        ensure_caret_visible(&input, new_val.len());
                                     }
                                 }
                                 return;
@@ -742,8 +743,7 @@ fn focus_and_install_ctrl_bindings() {
     };
     let input: web_sys::HtmlInputElement = el.unchecked_into();
     input.focus().ok();
-    let len = input.value().len() as u32;
-    let _ = input.set_selection_range(0, len);
+    select_all_on_open(&input);
 
     if js_sys::Reflect::get(&input, &JsValue::from_str("_ctrlBound"))
         .map(|v| v.is_truthy())
@@ -785,6 +785,7 @@ fn focus_and_install_ctrl_bindings() {
         match action {
             CtrlEditAction::Home => {
                 let _ = input2.set_selection_range(0, 0);
+                ensure_caret_visible(&input2, 0);
             }
             CtrlEditAction::End => {
                 let ghost = input2.get_attribute("data-ghost").unwrap_or_default();
@@ -794,15 +795,18 @@ fn focus_and_install_ctrl_bindings() {
                     let len = new_val.len() as u32;
                     let _ = input2.set_selection_range(len, len);
                     dispatch_input_event(&input2);
+                    ensure_caret_visible(&input2, new_val.len());
                 } else {
-                    let len = input2.value().len() as u32;
-                    let _ = input2.set_selection_range(len, len);
+                    let len = input2.value().len();
+                    let _ = input2.set_selection_range(len as u32, len as u32);
+                    ensure_caret_visible(&input2, len);
                 }
             }
             CtrlEditAction::Forward => {
                 let p = (input2.selection_start().unwrap_or(Some(0)).unwrap_or(0) + 1)
                     .min(input2.value().len() as u32);
                 let _ = input2.set_selection_range(p, p);
+                ensure_caret_visible(&input2, p as usize);
             }
             CtrlEditAction::Back => {
                 let p = input2
@@ -811,6 +815,7 @@ fn focus_and_install_ctrl_bindings() {
                     .unwrap_or(0)
                     .saturating_sub(1);
                 let _ = input2.set_selection_range(p, p);
+                ensure_caret_visible(&input2, p as usize);
             }
             CtrlEditAction::Delete => {
                 let v = input2.value();
@@ -820,6 +825,7 @@ fn focus_and_install_ctrl_bindings() {
                 input2.set_value(&new_val);
                 let _ = input2.set_selection_range(s as u32, s as u32);
                 dispatch_input_event(&input2);
+                ensure_caret_visible(&input2, s);
             }
             CtrlEditAction::Backspace => {
                 let v = input2.value();
@@ -834,6 +840,7 @@ fn focus_and_install_ctrl_bindings() {
                     input2.set_value(&new_val);
                     let _ = input2.set_selection_range(prev as u32, prev as u32);
                     dispatch_input_event(&input2);
+                    ensure_caret_visible(&input2, prev);
                 }
             }
             CtrlEditAction::DeleteWord => {
@@ -852,6 +859,7 @@ fn focus_and_install_ctrl_bindings() {
                 input2.set_value(&new_val);
                 let _ = input2.set_selection_range(i as u32, i as u32);
                 dispatch_input_event(&input2);
+                ensure_caret_visible(&input2, i);
             }
             CtrlEditAction::DeleteToBeginning => {
                 let v = input2.value();
@@ -859,6 +867,7 @@ fn focus_and_install_ctrl_bindings() {
                 input2.set_value(&v[s..]);
                 let _ = input2.set_selection_range(0, 0);
                 dispatch_input_event(&input2);
+                ensure_caret_visible(&input2, 0);
             }
         }
     }) as Box<dyn FnMut(web_sys::KeyboardEvent)>);
@@ -872,6 +881,79 @@ fn focus_and_install_ctrl_bindings() {
         &opts,
     );
     closure.forget();
+}
+
+/// Select the whole query one animation frame after open so Cmd+L reveals the current URL
+/// ready to overtype. The query signal is populated by a sibling effect that re-renders the
+/// input `value`; selecting synchronously here would catch the still-empty value and leave
+/// nothing highlighted.
+fn select_all_on_open(input: &web_sys::HtmlInputElement) {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let input = input.clone();
+    let cb = Closure::once_into_js(move || {
+        input.focus().ok();
+        let len = input.value().len() as u32;
+        let _ = input.set_selection_range(0, len);
+        input.set_scroll_left(0);
+    });
+    let _ = window.request_animation_frame(cb.unchecked_ref());
+}
+
+/// Scroll the command-bar input so the caret at byte offset `caret` is visible. Programmatic
+/// caret moves (Ctrl+E/A/F/B, deletes, Tab-complete) bypass Chromium's native caret-follow,
+/// so on a long URL the caret would otherwise sit off-screen.
+fn ensure_caret_visible(input: &web_sys::HtmlInputElement, caret: usize) {
+    let value = input.value();
+    let caret = floor_char_boundary(&value, caret);
+    let Some((viewport, caret_px)) = caret_metrics(input, &value[..caret]) else {
+        return;
+    };
+    if let Some(scroll_left) =
+        caret_scroll_left(caret_px, viewport, input.scroll_left() as f64, 8.0)
+    {
+        input.set_scroll_left(scroll_left as i32);
+    }
+}
+
+/// The input's usable text viewport width and the pixel offset of `prefix` in the input's
+/// current font (measured on an offscreen canvas). `None` if the canvas/context or computed
+/// font is unavailable.
+fn caret_metrics(input: &web_sys::HtmlInputElement, prefix: &str) -> Option<(f64, f64)> {
+    let window = web_sys::window()?;
+    let document = window.document()?;
+    let style = window.get_computed_style(input).ok()??;
+    let font_size = style.get_property_value("font-size").unwrap_or_default();
+    let font_family = style.get_property_value("font-family").unwrap_or_default();
+    if font_size.is_empty() || font_family.is_empty() {
+        return None;
+    }
+    let font_weight = style.get_property_value("font-weight").unwrap_or_default();
+    let font_style = style.get_property_value("font-style").unwrap_or_default();
+    let canvas: web_sys::HtmlCanvasElement =
+        document.create_element("canvas").ok()?.unchecked_into();
+    let ctx: web_sys::CanvasRenderingContext2d = canvas.get_context("2d").ok()??.unchecked_into();
+    ctx.set_font(format!("{font_style} {font_weight} {font_size} {font_family}").trim());
+    let caret_px = ctx.measure_text(prefix).ok()?.width();
+    let pad_left = css_px(&style.get_property_value("padding-left").unwrap_or_default());
+    let pad_right = css_px(
+        &style
+            .get_property_value("padding-right")
+            .unwrap_or_default(),
+    );
+    let viewport = (input.client_width() as f64 - pad_left - pad_right).max(1.0);
+    caret_px.is_finite().then_some((viewport, caret_px))
+}
+
+/// Parse a computed `<n>px` length to `f64`, defaulting to `0.0`.
+fn css_px(value: &str) -> f64 {
+    value
+        .trim()
+        .strip_suffix("px")
+        .and_then(|v| v.parse::<f64>().ok())
+        .filter(|v| v.is_finite())
+        .unwrap_or(0.0)
 }
 
 fn handle_plain_meta_a(e: &web_sys::KeyboardEvent, input: &web_sys::HtmlInputElement) -> bool {


### PR DESCRIPTION
## Context

Cmd+L opened the command bar with the current URL prefilled but *not* selected, so you could not overtype it immediately. Separately, caret-moving shortcuts (Ctrl+E, etc.) on a long URL parked the caret off-screen: programmatic `set_selection_range` does not trigger Chromium/CEF native caret-follow.

## Implementation

- **Select-all on open**: select-all is deferred one animation frame. The query signal (URL) is populated by a sibling effect that re-renders the input `value` *after* the focus effect ran, so the old synchronous select hit an empty value. Deferring catches the committed URL, then scrolls to offset 0 to reveal the start.
- **Caret-follow**: new pure `caret_scroll_left()` (unit-tested) computes the `scrollLeft` needed to keep a caret pixel-offset within the input viewport. `ensure_caret_visible()` measures the caret x-offset on an offscreen canvas in the input font and applies it after every programmatic caret move — Ctrl+A/E/F/B, Ctrl+D/H/W/U deletes, and Tab-complete. Plain arrow keys keep native scrolling.

## Checks / QA

- Cmd+L on a page with a long URL → whole URL highlighted and scrolled to start; typing replaces it.
- With a long URL in the bar: Ctrl+E → caret visible at end; Ctrl+A → visible at start; Ctrl+F/B step and stay visible; Ctrl+W/U/D/H and Tab-complete keep the caret on-screen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved command-bar editing behavior so the text caret stays visible while using keyboard shortcuts and tab completion.
  * Updated the input experience when opening the command bar so selection happens more reliably.

* **Bug Fixes**
  * Fixed caret scrolling in edge cases, including left/right overflow and scrolled positions.
  * Prevented odd behavior for invalid or empty input states, making keyboard navigation more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->