### PR TITLE
chore(release): v0.0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10032,7 +10032,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10074,7 +10074,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_browser"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "base64 0.22.1",
  "bevy",
@@ -10100,7 +10100,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -10113,7 +10113,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -10128,7 +10128,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10147,7 +10147,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10212,7 +10212,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_editor"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "arboard",
  "bevy",
@@ -10255,7 +10255,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_git"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10272,7 +10272,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10293,7 +10293,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -10329,7 +10329,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "muda",
  "proc-macro2",
@@ -10339,7 +10339,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -10352,7 +10352,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_server"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "dioxus",
  "regex",
@@ -10373,7 +10373,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "agent-client-protocol",
  "alacritty_terminal",
@@ -10411,7 +10411,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10434,7 +10434,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10459,7 +10459,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_team"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10480,7 +10480,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10514,7 +10514,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "dioxus",
  "dioxus-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.21"
+version = "0.0.22"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "GPL-3.0-or-later"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.21"
-  sha256 "794d905653a3ea08dab73ce779bb61c95160560fd2553d198e04cccf6241aed6"
+  version "0.0.22"
+  sha256 "056127700925bf6bc22d5ac891a8a27affb46581e279bd2db7f08b6bd83d8237"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.21/Vmux_0.0.21_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.22/Vmux_0.0.22_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai/"

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.21",
-  "pub_date": "2026-07-01T09:30:25Z",
+  "version": "v0.0.22",
+  "pub_date": "2026-07-07T12:24:26Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.21/Vmux-v0.0.21-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzlNdWNHSndFYTFuQTljNFZCaTZYa05XT0FtT1JHVjhOdkJGOWFkLytxdFh1WEtsd3ZNN0Y5OCt6cU04VlNRVHlqSWZaeHp4RUIySnVTRTZScU1xc3dzPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgyODk0NTAwCWZpbGU6Vm11eC12MC4wLjIxLWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKTG5KWjBZMUdtc2N1YkVYUXBjNjl0SHVYUzZRbFV2dUwrcFc5Qnd1VVFpTzk1Y3hOdnJCK0EzT1hRNHdSNDBuWDAwdFplSHZsNHl1TlVrclBuSjBGQ0E9PQo=",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.22/Vmux-v0.0.22-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HT3prdytzQUhwUFJ6N0NDbWsvNm1DNFZJck1IVE9mM2U0NlBhOGNSenAxUDJTanBNa1dlcXBUSmVndmg4VlRvSGtDR3FUY2NHK1kvUjlWVXcwTHNWNXcwPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgzNDI1MTQxCWZpbGU6Vm11eC12MC4wLjIyLWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKdlBqSEdNVVBhS1B1cTFGWUV6YVdRMjRoYkN1WUtaZlg5U2Z6WGZYbElLd0dyQVd5YnFGRktyUTVLK0xSV2pna3FKU09CU2hYN2ZRcER1WFNyNWVYREE9PQo=",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.21/Vmux_0.0.21_aarch64.dmg",
-      "filename": "Vmux_0.0.21_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.22/Vmux_0.0.22_aarch64.dmg",
+      "filename": "Vmux_0.0.22_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
Patch release. Bumps workspace version 0.0.21 -> 0.0.22. Releases on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the workspace/package version to `0.0.22`.
  * Updated the vmux cask to `0.0.22`, including matching checksums and download URL/artifact details.
  * Updated published release metadata (website updates) for `v0.0.22`, including macOS aarch64 download, signature, and filename.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->