### PR TITLE
perf(terminal): fix caret flicker + intermittent input lag

### DIFF
--- a/crates/vmux_service/src/client.rs
+++ b/crates/vmux_service/src/client.rs
@@ -240,6 +240,16 @@ impl ServiceHandle {
 
     /// Drain a bounded batch of service messages (non-blocking).
     pub fn drain(&self) -> Vec<ServiceMessage> {
+        self.drain_with_status().0
+    }
+
+    /// Drain a bounded batch, also reporting whether the per-frame cap was hit.
+    ///
+    /// When the returned flag is `true` the channel filled the whole batch and
+    /// more messages likely remain; the caller must wake the event loop again so
+    /// the tail is processed on the next frame instead of stalling until the
+    /// reactive timeout.
+    pub fn drain_with_status(&self) -> (Vec<ServiceMessage>, bool) {
         let rx = self.msg_rx.lock().unwrap();
         drain_service_messages_bounded(&rx)
     }
@@ -247,15 +257,15 @@ impl ServiceHandle {
 
 fn drain_service_messages_bounded(
     rx: &std::sync::mpsc::Receiver<ServiceMessage>,
-) -> Vec<ServiceMessage> {
+) -> (Vec<ServiceMessage>, bool) {
     let mut msgs = Vec::with_capacity(MAX_SERVICE_MESSAGES_PER_DRAIN);
     for _ in 0..MAX_SERVICE_MESSAGES_PER_DRAIN {
         let Ok(msg) = rx.try_recv() else {
-            break;
+            return (msgs, false);
         };
         msgs.push(msg);
     }
-    msgs
+    (msgs, true)
 }
 
 #[cfg(test)]
@@ -298,9 +308,30 @@ mod tests {
             .expect("service message should queue");
         }
 
-        let drained = drain_service_messages_bounded(&rx);
+        let (drained, capped) = drain_service_messages_bounded(&rx);
 
         assert_eq!(drained.len(), MAX_SERVICE_MESSAGES_PER_DRAIN);
+        assert!(
+            capped,
+            "hitting the cap must report capped so the caller re-wakes"
+        );
         assert!(rx.try_recv().is_ok());
+    }
+
+    #[test]
+    fn service_message_drain_reports_not_capped_when_drained_dry() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        for _ in 0..3 {
+            tx.send(ServiceMessage::ProcessList {
+                processes: Vec::new(),
+            })
+            .expect("service message should queue");
+        }
+
+        let (drained, capped) = drain_service_messages_bounded(&rx);
+
+        assert_eq!(drained.len(), 3);
+        assert!(!capped);
+        assert!(rx.try_recv().is_err());
     }
 }

--- a/crates/vmux_terminal/src/page.rs
+++ b/crates/vmux_terminal/src/page.rs
@@ -427,10 +427,13 @@ pub fn Page() -> Element {
                     style: "height:{spacer_h}px;",
                     {
                         let base_rows = rows();
+                        let cur = cursor();
                         rsx! {
                             for (doc_row, line) in base_rows.iter() {
                                 {
                                     let top = *doc_row as f64 * ch;
+                                    let row_cursor =
+                                        cur.as_ref().filter(|c| c.row == *doc_row).cloned();
                                     rsx! {
                                         div {
                                             key: "{doc_row}",
@@ -440,12 +443,12 @@ pub fn Page() -> Element {
                                                 line: *line,
                                                 selection,
                                                 cols,
+                                                cursor: row_cursor,
                                             }
                                         }
                                     }
                                 }
                             }
-                            TerminalCursor { cursor, theme, cell_dims }
                         }
                     }
                 }
@@ -470,54 +473,13 @@ const _TW_SAFELIST: &[&str] = &[
     "border-ansi-1",
 ];
 
-/// Terminal caret rendered as a persistent, always-present DOM node.
-///
-/// Subscribes to `cursor` internally so a caret move re-renders only this node
-/// (not the parent `Page` and its whole row list). Visibility is toggled via
-/// `display` rather than by adding/removing the element, so the caret never
-/// disappears for a frame while typing.
-#[component]
-fn TerminalCursor(
-    cursor: Signal<Option<TermCursor>>,
-    theme: Signal<Option<TermThemeEvent>>,
-    cell_dims: Signal<(f64, f64)>,
-) -> Element {
-    let (cw, ch) = cell_dims();
-    let cstyle = theme()
-        .map(|t| t.cursor_style.clone())
-        .unwrap_or_else(|| "block".to_string());
-    let c = cursor();
-    let visible = c.as_ref().is_some_and(|c| c.visible) && cw > 0.0 && ch > 0.0;
-    let (col, row, glyph) = c
-        .as_ref()
-        .map(|c| (c.col as f64, c.row as f64, c.ch.clone()))
-        .unwrap_or((0.0, 0.0, String::new()));
-    let (w, h, oy, show_ch) = match cstyle.as_str() {
-        "beam" | "bar" => (2.0, ch, 0.0, false),
-        "underline" => (cw, 2.0, ch - 2.0, false),
-        _ => (cw, ch, 0.0, true),
-    };
-    let left = col * cw;
-    let ctop = row * ch + oy;
-    let display = if visible { "block" } else { "none" };
-
-    rsx! {
-        div {
-            class: "pointer-events-none absolute whitespace-pre",
-            style: "display:{display};left:{left}px;top:{ctop}px;width:{w}px;height:{h}px;background:var(--term-cursor);color:var(--term-bg);overflow:hidden;",
-            if show_ch {
-                "{glyph}"
-            }
-        }
-    }
-}
-
 #[component]
 fn TerminalRow(
     row_idx: usize,
     line: Signal<TermLine>,
     selection: Signal<Option<TermSelectionRange>>,
     cols: Signal<u16>,
+    cursor: Option<TermCursor>,
 ) -> Element {
     let line = line();
     let selected_cols = row_selection_cols(&selection(), row_idx, cols());
@@ -536,7 +498,7 @@ fn TerminalRow(
                 }
             }
             for (span_idx, span) in line.spans.iter().enumerate() {
-                {render_span(span, span_idx, None, "block")}
+                {render_span(span, span_idx, cursor.as_ref(), "block")}
             }
             if let Some((sel_start, sel_end)) = selected_cols {
                 div {

--- a/crates/vmux_terminal/src/page.rs
+++ b/crates/vmux_terminal/src/page.rs
@@ -473,7 +473,7 @@ const _TW_SAFELIST: &[&str] = &[
 /// Terminal caret rendered as a persistent, always-present DOM node.
 ///
 /// Subscribes to `cursor` internally so a caret move re-renders only this node
-/// (not the parent `Terminal` and its whole row list). Visibility is toggled via
+/// (not the parent `Page` and its whole row list). Visibility is toggled via
 /// `display` rather than by adding/removing the element, so the caret never
 /// disappears for a frame while typing.
 #[component]

--- a/crates/vmux_terminal/src/page.rs
+++ b/crates/vmux_terminal/src/page.rs
@@ -445,30 +445,7 @@ pub fn Page() -> Element {
                                     }
                                 }
                             }
-                            {
-                                cursor().filter(|c| c.visible).map(|c| {
-                                    let cstyle = theme()
-                                        .map(|t| t.cursor_style.clone())
-                                        .unwrap_or_else(|| "block".to_string());
-                                    let top = c.row as f64 * ch;
-                                    let left = c.col as f64 * cw;
-                                    let (w, h, oy, show_ch) = match cstyle.as_str() {
-                                        "beam" | "bar" => (2.0, ch, 0.0, false),
-                                        "underline" => (cw, 2.0, ch - 2.0, false),
-                                        _ => (cw, ch, 0.0, true),
-                                    };
-                                    let ctop = top + oy;
-                                    rsx! {
-                                        div {
-                                            class: "pointer-events-none absolute whitespace-pre",
-                                            style: "left:{left}px;top:{ctop}px;width:{w}px;height:{h}px;background:var(--term-cursor);color:var(--term-bg);overflow:hidden;",
-                                            if show_ch {
-                                                "{c.ch}"
-                                            }
-                                        }
-                                    }
-                                })
-                            }
+                            TerminalCursor { cursor, theme, cell_dims }
                         }
                     }
                 }
@@ -492,6 +469,48 @@ const _TW_SAFELIST: &[&str] = &[
     "text-term-bg", "bg-term-fg",
     "border-ansi-1",
 ];
+
+/// Terminal caret rendered as a persistent, always-present DOM node.
+///
+/// Subscribes to `cursor` internally so a caret move re-renders only this node
+/// (not the parent `Terminal` and its whole row list). Visibility is toggled via
+/// `display` rather than by adding/removing the element, so the caret never
+/// disappears for a frame while typing.
+#[component]
+fn TerminalCursor(
+    cursor: Signal<Option<TermCursor>>,
+    theme: Signal<Option<TermThemeEvent>>,
+    cell_dims: Signal<(f64, f64)>,
+) -> Element {
+    let (cw, ch) = cell_dims();
+    let cstyle = theme()
+        .map(|t| t.cursor_style.clone())
+        .unwrap_or_else(|| "block".to_string());
+    let c = cursor();
+    let visible = c.as_ref().is_some_and(|c| c.visible) && cw > 0.0 && ch > 0.0;
+    let (col, row, glyph) = c
+        .as_ref()
+        .map(|c| (c.col as f64, c.row as f64, c.ch.clone()))
+        .unwrap_or((0.0, 0.0, String::new()));
+    let (w, h, oy, show_ch) = match cstyle.as_str() {
+        "beam" | "bar" => (2.0, ch, 0.0, false),
+        "underline" => (cw, 2.0, ch - 2.0, false),
+        _ => (cw, ch, 0.0, true),
+    };
+    let left = col * cw;
+    let ctop = row * ch + oy;
+    let display = if visible { "block" } else { "none" };
+
+    rsx! {
+        div {
+            class: "pointer-events-none absolute whitespace-pre",
+            style: "display:{display};left:{left}px;top:{ctop}px;width:{w}px;height:{h}px;background:var(--term-cursor);color:var(--term-bg);overflow:hidden;",
+            if show_ch {
+                "{glyph}"
+            }
+        }
+    }
+}
 
 #[component]
 fn TerminalRow(

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -1264,6 +1264,7 @@ fn poll_service_messages(
     launches: Query<&crate::launch::TerminalLaunch>,
     agent_sessions: Query<&vmux_core::agent::AgentSession>,
     output_seen: Query<(), With<ShellOutputSeen>>,
+    proxy: Option<Res<bevy::winit::EventLoopProxyWrapper>>,
 ) {
     let Some(service) = service else { return };
 
@@ -1311,7 +1312,11 @@ fn poll_service_messages(
 
     // Drain service messages and dispatch
     let mut restarted_missing_processes = Vec::new();
-    for msg in service.0.drain() {
+    let (messages, capped) = service.0.drain_with_status();
+    if capped && let Some(proxy) = proxy.as_deref() {
+        let _ = proxy.send_event(bevy::winit::WinitUserEvent::WakeUp);
+    }
+    for msg in messages {
         match msg {
             ServiceMessage::ProcessCreated { process_id, pid } => {
                 let entity = (&awaiting_create)


### PR DESCRIPTION
## Context
In terminal / agent panes the caret visibly toggled show/hide on nearly every keystroke, and input felt intermittently laggy. Two independent root causes.

## Implementation
**Caret flicker (`page.rs`).** The caret was an absolutely-positioned overlay div floating over the row text. In the windowed-CEF terminal surface that overlapping element flickered against the row repainting beneath it every keystroke. Instrumentation proved the caret DOM was correct and stable each keystroke (one render per key, correct position, `cw/ch` nonzero, promoted to its own compositor layer with `z-index`), yet Chromium would not paint the moving overlay consistently — compositor-layer promotion (`transform`/`will-change`) and reconciliation isolation did not help. Fix: render the caret as an inverted cell **inside the row's own span text** (`render_span` + `cursor_cell_style`, which already supported it), so it is drawn in the same paint path as the characters — which never flickered. No overlapping element remains.

**Intermittent lag (`client.rs`, `plugin.rs`).** `poll_service_messages` drained ≤128 msgs/frame and never re-woke; the reactive loop idles at a 1s wait, so a burst >128 (fast typing + echo + output) left the tail stalled up to ~1s. `drain_with_status()` reports the cap-hit and the system sends `WinitUserEvent::WakeUp`, so the remainder drains on the next frame.

## Checks / QA
- Type quickly in a terminal pane — caret stays steady, no per-keystroke flicker (verified).
- Heavy output while typing — no ~1s freezes.
- Caret inverts the correct cell; scrollback hides it.

Note: the inline caret renders as a block; beam/underline theme caret styles would need `cursor_style` threaded through `TerminalRow` (follow-up).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved terminal cursor rendering for smoother, more consistent caret updates.

* **Bug Fixes**
  * Enhanced service message draining to better handle large bursts of pending events without stalling.
  * Added UI wake-up behavior when the per-batch draining limit is reached, helping ensure updates aren’t missed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->