### PR TITLE
feat(command-bar): tmux-style space switcher on <leader> s

### DIFF
--- a/crates/vmux_command/src/event.rs
+++ b/crates/vmux_command/src/event.rs
@@ -34,6 +34,8 @@ pub struct CommandBarOpenEvent {
     #[serde(default)]
     pub recent_files: Vec<CommandBarRecentFile>,
     pub target: Option<crate::open_target::OpenTarget>,
+    #[serde(default)]
+    pub space_switch: bool,
 }
 
 #[derive(

--- a/crates/vmux_layout/src/command_bar/handler.rs
+++ b/crates/vmux_layout/src/command_bar/handler.rs
@@ -455,11 +455,11 @@ struct CommandBarOpenRequest {
     should_dismiss_nav: bool,
     replace_active_stack: bool,
     url_override: Option<String>,
+    space_switch: bool,
 }
 
 fn command_bar_open_request(
     commands: impl IntoIterator<Item = AppCommand>,
-    spaces_page_url: &str,
 ) -> CommandBarOpenRequest {
     let mut request = CommandBarOpenRequest::default();
     for cmd in commands {
@@ -482,7 +482,8 @@ fn command_bar_open_request(
             }
             AppCommand::Layout(LayoutCommand::Space(SpaceCommand::Open)) => {
                 request.should_toggle = true;
-                request.url_override = Some(spaces_page_url.to_string());
+                request.space_switch = true;
+                request.url_override = Some(String::new());
             }
             AppCommand::Layout(LayoutCommand::Stack(StackCommand::Close)) => {
                 request.should_dismiss = true;
@@ -552,6 +553,25 @@ fn command_bar_cancel_pending_stack_for_active_open(
     Some((stack, previous_stack))
 }
 
+/// Whether an open should focus the `vmux://start/` launcher input instead of opening
+/// the modal command bar. True only for a normal open (not a new-stack open) whose active
+/// page is the start launcher. A space-switch open (`<leader> s`) always uses the modal so
+/// the switcher behaves the same on the start page as everywhere else.
+fn command_bar_should_focus_start(
+    is_new_stack: bool,
+    space_switch: bool,
+    active_page_is_start: bool,
+) -> bool {
+    !is_new_stack && !space_switch && active_page_is_start
+}
+
+/// Whether a toggle-style open should (re)open the modal command bar: when it is currently
+/// closed, or always for a space-switch open so `<leader> s` re-drives space-switch mode
+/// even when the command bar is already visible (rather than no-opping).
+fn command_bar_toggle_should_open(is_open: bool, space_switch: bool) -> bool {
+    !is_open || space_switch
+}
+
 fn handle_open_command_bar(
     mut reader: MessageReader<AppCommand>,
     mut modal_q: Query<
@@ -606,14 +626,14 @@ fn handle_open_command_bar(
     let pages_snap = snapshot_params.p5().clone();
     let work_snap = snapshot_params.p6().clone();
 
-    let request =
-        command_bar_open_request(reader.read().cloned(), &spaces_snapshot.spaces_page_url);
+    let request = command_bar_open_request(reader.read().cloned());
     let mut should_open = false;
     let should_toggle = request.should_toggle;
     let should_dismiss = request.should_dismiss;
     let should_dismiss_nav = request.should_dismiss_nav;
     let replace_active_stack = request.replace_active_stack;
     let url_override = request.url_override;
+    let space_switch = request.space_switch;
 
     let mut active_stack_override = None;
     let canceled_pending_stack = {
@@ -744,7 +764,7 @@ fn handle_open_command_bar(
                 command_bar_modal_is_visible(n.display, *visibility, has_keyboard_target)
             })
             .unwrap_or(false);
-        if !is_open {
+        if command_bar_toggle_should_open(is_open, space_switch) {
             should_open = true;
         }
         // If already open, do nothing — the shortcut should not close the bar.
@@ -780,7 +800,9 @@ fn handle_open_command_bar(
                 })
             })
         });
-        if let Some(browser_e) = start_browser {
+        if command_bar_should_focus_start(is_new_stack, space_switch, start_browser.is_some())
+            && let Some(browser_e) = start_browser
+        {
             commands.trigger(BinHostEmitEvent::from_rkyv(
                 browser_e,
                 START_FOCUS_INPUT_EVENT,
@@ -901,7 +923,7 @@ fn handle_open_command_bar(
     } else {
         None
     };
-    let payload = build_command_bar_open_payload(
+    let mut payload = build_command_bar_open_payload(
         open_id,
         native_windowed,
         space_name,
@@ -914,6 +936,7 @@ fn handle_open_command_bar(
         bar_tabs,
         target,
     );
+    payload.space_switch = space_switch;
     let event = BinHostEmitEvent::from_rkyv(modal_e, COMMAND_BAR_OPEN_EVENT, &payload);
     let payload_bytes = event.payload.clone();
     let payload_bytes_len = payload_bytes.len();
@@ -982,6 +1005,7 @@ fn command_bar_open_payload(
         work_dirs,
         recent_files,
         target,
+        space_switch: false,
     }
 }
 
@@ -2299,37 +2323,46 @@ mod tests {
     }
 
     #[test]
-    fn space_open_command_prefills_spaces_url() {
-        let spaces_url = "vmux://spaces/";
-        let request = command_bar_open_request(
-            [AppCommand::Layout(LayoutCommand::Space(SpaceCommand::Open))],
-            spaces_url,
-        );
+    fn space_open_command_opens_space_switch_mode() {
+        let request = command_bar_open_request([AppCommand::Layout(LayoutCommand::Space(
+            SpaceCommand::Open,
+        ))]);
 
         assert!(request.should_toggle);
-        assert_eq!(request.url_override, Some(spaces_url.to_string()));
+        assert!(request.space_switch);
+        assert_eq!(request.url_override, Some(String::new()));
+    }
+
+    #[test]
+    fn command_bar_focuses_start_only_for_non_space_switch_open() {
+        assert!(command_bar_should_focus_start(false, false, true));
+        assert!(!command_bar_should_focus_start(false, true, true));
+        assert!(!command_bar_should_focus_start(true, false, true));
+        assert!(!command_bar_should_focus_start(false, false, false));
+    }
+
+    #[test]
+    fn space_switch_reopens_command_bar_even_when_visible() {
+        assert!(command_bar_toggle_should_open(false, false));
+        assert!(!command_bar_toggle_should_open(true, false));
+        assert!(command_bar_toggle_should_open(true, true));
+        assert!(command_bar_toggle_should_open(false, true));
     }
 
     #[test]
     fn open_in_new_stack_does_not_dismiss_command_bar() {
-        let request = command_bar_open_request(
-            [AppCommand::Browser(BrowserCommand::Open(
-                OpenCommand::InNewStack { url: None },
-            ))],
-            "vmux://spaces/",
-        );
+        let request = command_bar_open_request([AppCommand::Browser(BrowserCommand::Open(
+            OpenCommand::InNewStack { url: None },
+        ))]);
 
         assert!(!request.should_dismiss);
     }
 
     #[test]
     fn open_command_bar_forces_empty_url_override() {
-        let request = command_bar_open_request(
-            [AppCommand::Browser(BrowserCommand::Bar(
-                BrowserBarCommand::OpenCommandBar,
-            ))],
-            "vmux://spaces/",
-        );
+        let request = command_bar_open_request([AppCommand::Browser(BrowserCommand::Bar(
+            BrowserBarCommand::OpenCommandBar,
+        ))]);
 
         assert!(request.should_toggle);
         assert_eq!(request.url_override, Some(String::new()));
@@ -2337,12 +2370,9 @@ mod tests {
 
     #[test]
     fn open_page_in_command_bar_leaves_url_override_unset_so_current_url_is_prefilled() {
-        let request = command_bar_open_request(
-            [AppCommand::Browser(BrowserCommand::Bar(
-                BrowserBarCommand::OpenPageInCommandBar,
-            ))],
-            "vmux://spaces/",
-        );
+        let request = command_bar_open_request([AppCommand::Browser(BrowserCommand::Bar(
+            BrowserBarCommand::OpenPageInCommandBar,
+        ))]);
 
         assert!(request.should_toggle);
         assert_eq!(request.url_override, None);
@@ -2365,12 +2395,9 @@ mod tests {
     fn open_page_in_command_bar_cancels_pending_new_stack_context() {
         let pending_stack = Entity::from_bits(7);
         let previous_stack = Entity::from_bits(6);
-        let request = command_bar_open_request(
-            [AppCommand::Browser(BrowserCommand::Bar(
-                BrowserBarCommand::OpenPageInCommandBar,
-            ))],
-            "vmux://spaces/",
-        );
+        let request = command_bar_open_request([AppCommand::Browser(BrowserCommand::Bar(
+            BrowserBarCommand::OpenPageInCommandBar,
+        ))]);
         let mut ctx = NewStackContext {
             stack: Some(pending_stack),
             previous_stack: Some(previous_stack),

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -4,7 +4,9 @@ use crate::command_bar::keyboard::{
     CtrlEditAction, CtrlKeyCapture, caret_scroll_left, ctrl_key_capture_for_code,
     ignore_physical_rerouted_ctrl_keydown, utf16_offset_to_byte,
 };
-use crate::command_bar::results::{CommandBarResultItem as ResultItem, filter_results};
+use crate::command_bar::results::{
+    CommandBarResultItem as ResultItem, active_space_index, filter_results, space_switch_results,
+};
 use crate::command_bar::style::{
     command_bar_input_class, command_bar_input_row_class, command_bar_input_wrap_class,
     result_content_row_class, result_favicon_class, result_history_url_class, result_item_class,
@@ -76,7 +78,11 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
         if last_open_id() != s.open_id {
             last_open_id.set(s.open_id);
             query.set(s.url.clone());
-            selected.set(0);
+            selected.set(if s.space_switch {
+                active_space_index(&s.spaces)
+            } else {
+                0
+            });
             nav_mode.set(false);
             path_completions.set(Vec::new());
             history_suggestions.set(Vec::new());
@@ -155,10 +161,13 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let work_dirs = state_val.work_dirs.clone();
     let recent_files = state_val.recent_files.clone();
     let open_target = state_val.target;
+    let space_switch = state_val.space_switch;
     let is_new_tab = matches!(open_target, Some(OpenTarget::InNewStack));
 
     let q = query();
-    let results = {
+    let results: Vec<ResultItem> = if space_switch {
+        space_switch_results(&spaces, &pages, &q)
+    } else {
         let history = history_suggestions();
         let r = filter_results(
             &q,
@@ -176,7 +185,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
         } else {
             Vec::new()
         };
-        if completions.is_empty() {
+        let r = if completions.is_empty() {
             r
         } else {
             let mut combined: Vec<ResultItem> = completions
@@ -189,21 +198,20 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                 .collect();
             combined.extend(r);
             combined
+        };
+        if matches!(variant, PaletteVariant::Start) {
+            r.into_iter()
+                .filter(|item| {
+                    !matches!(
+                        item,
+                        ResultItem::Stack { url, .. } | ResultItem::Page { url, .. }
+                            if url.trim_end_matches('/') == "vmux://start"
+                    )
+                })
+                .collect()
+        } else {
+            r
         }
-    };
-    let results: Vec<ResultItem> = if matches!(variant, PaletteVariant::Start) {
-        results
-            .into_iter()
-            .filter(|item| {
-                !matches!(
-                    item,
-                    ResultItem::Stack { url, .. } | ResultItem::Page { url, .. }
-                        if url.trim_end_matches('/') == "vmux://start"
-                )
-            })
-            .collect()
-    } else {
-        results
     };
     let sel = selected().min(results.len().saturating_sub(1));
     let active_item = results.get(sel).cloned();
@@ -316,13 +324,17 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
         }
     };
 
-    let placeholder = match variant {
-        PaletteVariant::Start => "Search or ask\u{2026}",
-        PaletteVariant::Modal => {
-            if is_new_tab {
-                "Search or type a URL, or select Terminal..."
-            } else {
-                "Type a URL, search tabs, or > for commands..."
+    let placeholder = if space_switch {
+        "Switch space\u{2026}"
+    } else {
+        match variant {
+            PaletteVariant::Start => "Search or ask\u{2026}",
+            PaletteVariant::Modal => {
+                if is_new_tab {
+                    "Search or type a URL, or select Terminal..."
+                } else {
+                    "Type a URL, search tabs, or > for commands..."
+                }
             }
         }
     };
@@ -438,6 +450,27 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                                 e.prevent_default();
                                 return;
                             }
+                            if space_switch
+                                && !ctrl
+                                && q.trim().is_empty()
+                                && let Key::Character(s) = e.key()
+                                && let Some(idx) = s
+                                    .chars()
+                                    .next()
+                                    .filter(|c| c.is_ascii_digit())
+                                    .and_then(|c| c.to_digit(10))
+                            {
+                                let space_count = results
+                                    .iter()
+                                    .filter(|r| matches!(r, ResultItem::Space { .. }))
+                                    .count();
+                                if (idx as usize) < space_count {
+                                    e.prevent_default();
+                                    selected.set(idx as usize);
+                                    nav_mode.set(true);
+                                    return;
+                                }
+                            }
                             let go_down = (e.key() == Key::ArrowDown && !ctrl)
                                 || (ctrl && matches!(e.code(), Code::KeyN | Code::KeyJ));
                             let go_up = (e.key() == Key::ArrowUp && !ctrl)
@@ -457,21 +490,27 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                             {
                                 on_dismiss.call(());
                             } else if e.key() == Key::Enter {
-                                let prefer_page = matches!(
-                                    results.get(sel),
-                                    Some(ResultItem::Page { url, .. })
-                                        if q.trim().starts_with("vmux://")
-                                            && url.starts_with(q.trim())
-                                );
-                                if !prefer_page
-                                    && should_open_typed_query_on_enter(open_target, nav_mode(), &q)
-                                {
-                                    on_close.call(());
-                                    emit_action_with_target("open", &q, open_target);
-                                } else if let Some(item) = results.get(sel) {
-                                    execute(item);
-                                } else if !q.is_empty() {
-                                    emit_action_with_target("open", &q, open_target);
+                                if space_switch {
+                                    if let Some(item) = results.get(sel) {
+                                        execute(item);
+                                    }
+                                } else {
+                                    let prefer_page = matches!(
+                                        results.get(sel),
+                                        Some(ResultItem::Page { url, .. })
+                                            if q.trim().starts_with("vmux://")
+                                                && url.starts_with(q.trim())
+                                    );
+                                    if !prefer_page
+                                        && should_open_typed_query_on_enter(open_target, nav_mode(), &q)
+                                    {
+                                        on_close.call(());
+                                        emit_action_with_target("open", &q, open_target);
+                                    } else if let Some(item) = results.get(sel) {
+                                        execute(item);
+                                    } else if !q.is_empty() {
+                                        emit_action_with_target("open", &q, open_target);
+                                    }
                                 }
                             }
                         },
@@ -521,6 +560,9 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                                 }
                             },
                             ResultItem::Space { name, profile, is_active, tab_count, .. } => rsx! {
+                                if space_switch {
+                                    span { class: "w-5 shrink-0 text-center font-mono text-xs text-muted-foreground", "{i}" }
+                                }
                                 div { class: "flex min-w-0 flex-1 flex-col overflow-hidden",
                                     div { class: "flex min-w-0 items-center gap-2",
                                         span { class: result_primary_text_class(), "{name}" }

--- a/crates/vmux_layout/src/command_bar/results.rs
+++ b/crates/vmux_layout/src/command_bar/results.rs
@@ -162,6 +162,31 @@ fn space_list_items(spaces: &[CommandBarSpace], search_lower: &str) -> Vec<Comma
         .collect()
 }
 
+/// Build the space-switcher result list: every space in snapshot order (filtered by
+/// `query`), then a trailing "Manage spaces…" entry that opens the full spaces page.
+pub fn space_switch_results(
+    spaces: &[CommandBarSpace],
+    pages: &[CommandBarPage],
+    query: &str,
+) -> Vec<CommandBarResultItem> {
+    let search_lower = query.trim().to_lowercase();
+    let mut items = space_list_items(spaces, &search_lower);
+    if let Some(page) = pages.iter().find(|p| p.host == "spaces") {
+        items.push(CommandBarResultItem::Page {
+            url: page.url.clone(),
+            title: "Manage spaces\u{2026}".to_string(),
+            icon: page.icon.clone(),
+            shortcut: String::new(),
+        });
+    }
+    items
+}
+
+/// Index of the active space, for pre-selecting the current space in the switcher.
+pub fn active_space_index(spaces: &[CommandBarSpace]) -> usize {
+    spaces.iter().position(|s| s.is_active).unwrap_or(0)
+}
+
 fn query_targets_spaces_page(q: &str, pages: &[CommandBarPage]) -> bool {
     let Some(url) = pages
         .iter()
@@ -370,6 +395,50 @@ mod tests {
                 shortcut: String::new(),
             },
         ]
+    }
+
+    #[test]
+    fn space_switch_lists_spaces_in_order_then_manage() {
+        let spaces = vec![
+            space("space-1", "Space 1", false),
+            space("work", "Work", true),
+        ];
+        let results = space_switch_results(&spaces, &sample_pages(), "");
+        assert!(matches!(&results[0], CommandBarResultItem::Space { id, .. } if id == "space-1"));
+        assert!(matches!(&results[1], CommandBarResultItem::Space { id, .. } if id == "work"));
+        assert!(matches!(
+            results.last(),
+            Some(CommandBarResultItem::Page { title, .. }) if title == "Manage spaces\u{2026}"
+        ));
+    }
+
+    #[test]
+    fn space_switch_filters_spaces_by_name() {
+        let spaces = vec![
+            space("space-1", "Space 1", false),
+            space("work", "Work", true),
+        ];
+        let results = space_switch_results(&spaces, &sample_pages(), "wor");
+        let ids: Vec<_> = results
+            .iter()
+            .filter_map(|r| match r {
+                CommandBarResultItem::Space { id, .. } => Some(id.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(ids, vec!["work".to_string()]);
+        assert!(matches!(
+            results.last(),
+            Some(CommandBarResultItem::Page { title, .. }) if title == "Manage spaces\u{2026}"
+        ));
+    }
+
+    #[test]
+    fn active_space_index_finds_active_then_defaults_zero() {
+        let with_active = vec![space("space-1", "S1", false), space("work", "Work", true)];
+        assert_eq!(active_space_index(&with_active), 1);
+        let none_active = vec![space("space-1", "S1", false)];
+        assert_eq!(active_space_index(&none_active), 0);
     }
 
     #[test]

--- a/docs/specs/2026-07-07-space-switcher-command-bar-design.md
+++ b/docs/specs/2026-07-07-space-switcher-command-bar-design.md
@@ -1,0 +1,85 @@
+# Space Switcher in Command Bar — Design
+
+Date: 2026-07-07
+Status: Approved
+
+## Problem
+
+Switching spaces is tedious. `<leader> s` (`Ctrl+g, s` = `SpaceCommand::Open`) already
+opens the command bar, but it seeds the query with the `vmux://spaces/` URL and the
+default-selected first result is the *"open full spaces page"* nav item. A blind Enter
+therefore navigates to the full-page `vmux://spaces/` view instead of switching.
+
+Goal: `<leader> s` opens a clean, tmux-style space switcher inside the command bar —
+select with Ctrl+N/P (or ↑/↓), Enter to switch — as fast as tmux `choose-tree`.
+
+## Behavior
+
+On `<leader> s`, the command bar opens in **space-switch mode**:
+
+- Empty input, placeholder `Switch space…`.
+- Results = spaces only, in **consistent `Order`** (stable index order like tmux, never
+  MRU-reshuffled), followed by a trailing `Manage spaces…` row.
+- The **current (active) space is pre-highlighted**, orienting the list like tmux's
+  `choose-tree`. Ctrl+N/P / ↑/↓ move the selection; Enter switches.
+- Typing filters the space list by name (stays spaces-only + `Manage spaces…`). No URL,
+  history, tab, or command results appear in this mode.
+- Enter on a space → existing `attach` path → instant switch (toggles `Display` on the
+  persistent per-space container node; no reload).
+- Enter on `Manage spaces…` → opens the full `vmux://spaces/` page, where create / rename
+  / delete already live.
+
+Keybinding is unchanged: reuse `<leader> s` (`Ctrl+g, s`). No new chord.
+
+## Architecture
+
+Reuse the command-bar palette with an explicit mode flag, rather than the current
+URL-seeding hack. A flag keeps the visible query empty and avoids fragile
+`vmux://spaces/` string matching in the frontend, and matches the intent of "just do it
+in the command bar."
+
+Downstream switch machinery is untouched — the `"space"` action already maps to
+`SpaceCommandEvent { command: "attach" }`, handled by `on_space_command` in
+`vmux_space`.
+
+### Changes
+
+1. **Wire flag** — add `space_switch: bool` to `CommandBarOpenRequest` and to the
+   `CommandBarOpenEvent` rkyv payload (`vmux_command`). Append the field to preserve
+   rkyv layout stability.
+2. **Open mapping** — `command_bar_open_request` (`vmux_layout/.../handler.rs`):
+   `SpaceCommand::Open` sets `space_switch = true` and an empty url (drop the
+   `spaces_page_url` seed).
+3. **Results** — `filter_results` (`vmux_layout/.../results.rs`): add a `space_switch`
+   param. When set, return `space_list_items(spaces, filter)` in payload order plus a
+   single trailing `Manage spaces…` item, and nothing else. Remove the
+   `query_targets_spaces_page` seeding branch (superseded by the flag).
+4. **Palette** — `palette.rs`: thread `space_switch` from the payload; force empty query
+   and the `Switch space…` placeholder; on open in this mode, set `selected` to the
+   active space's index; render `Manage spaces…` → `emit_action("open", spaces_page_url)`.
+
+### Data already available
+
+- The command-bar spaces snapshot (`update_spaces_snapshot`) already sorts by `Order`
+  and marks the active space via `is_active`, so the frontend renders in order and
+  pre-selects the active index with no new backend query.
+
+## Out of scope / optional
+
+- tmux-style index badges (`0 1 2…`) on rows and digit-to-jump. Deferred; can be added
+  later without changing this design.
+- Creating / renaming / deleting spaces from within the switcher (remains on the full
+  `vmux://spaces/` page, reachable via `Manage spaces…`).
+
+## Testing
+
+Native tests (no runtime app needed):
+
+- `vmux_layout` (`results.rs`): space-switch mode returns spaces in `Order` + a trailing
+  `Manage spaces…`; name filter narrows the space list; no tab/command/url items leak in.
+- `vmux_layout` (`handler.rs`): `SpaceCommand::Open` produces `space_switch = true`
+  (update the existing test around `handler.rs:2305`).
+- Pre-selection: active-space index helper returns the `is_active` row's position.
+
+Manual verification (single pass at the end): `<leader> s` → Ctrl+N/P → Enter switches;
+`Manage spaces…` opens the full page.


### PR DESCRIPTION
## Context

Switching spaces was tedious. `<leader> s` opened the command bar but seeded it with the `vmux://spaces/` URL and defaulted the selection to the "open full spaces page" item — so a blind Enter navigated to the heavyweight page instead of switching. This turns `<leader> s` into a fast, tmux-style space switcher, done entirely in the command bar.

## Implementation

- New `space_switch` flag on the `CommandBarOpenEvent` payload. `SpaceCommand::Open` sets it (with an empty query) instead of seeding the spaces URL; the flag is carried onto the emitted payload.
- Palette renders a dedicated spaces-only mode: spaces in snapshot order (consistent, no MRU reshuffle), current space pre-highlighted, `Switch space…` placeholder, and a trailing `Manage spaces…` row that opens the full page for create/rename/delete. Typing filters by name; Enter always executes the selected row (never treats the input as a URL).
- Reuses the existing `"space"` action → `SpaceCommandEvent { command: "attach" }` path — the switch is instant (toggles `Display` on persistent per-space nodes, no reload).
- tmux-style index badges (`0 1 2…`) on rows, plus digit-jump: with the input empty, press a digit to jump to that space; once you start typing, digits are treated as filter text so names with digits still filter.
- Removed the now-dead `spaces_page_url` parameter from `command_bar_open_request`.

## Checks / QA

- `<leader> s` → spaces only, current highlighted, badges `0 1 2…`, `Manage spaces…` last.
- Ctrl+N/P and ↑/↓ move selection; Enter switches instantly.
- Digit-jump works with an empty input; typing a name filters (including names containing digits).
- `Manage spaces…` opens the full `vmux://spaces/` page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a space-switch mode in the command bar, letting you quickly jump between spaces with a dedicated search and selection flow.
  * The active space is now preselected, and number keys can be used for faster space selection when the query is empty.
  * Added a “Manage spaces…” entry at the end of space-switch results.

* **Bug Fixes**
  * Improved focus behavior so space-switch opens no longer interfere with normal command-bar input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->