### PR TITLE
fix(agent): hide run completion markers via invisible OSC escape

### DIFF
--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -1735,9 +1735,13 @@ fn agent_terminal_shell(settings: &AppSettings) -> String {
         .unwrap_or_else(|| std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string()))
 }
 
-/// Wrap a `run` command so the shell prints a completion marker carrying the
-/// exit code once the command finishes (success OR failure). `token` is a unique
-/// per-run id; the printed marker is `__VMUX_DONE_<token>_<exit_code>__`.
+/// Wrap a `run` command so the shell emits an invisible OSC completion escape
+/// carrying the exit code once the command finishes (success OR failure).
+/// `token` is a unique per-run id; the escape is
+/// `ESC ] <VMUX_RUN_OSC> ; <token> ; <exit_code> BEL` (see
+/// [`vmux_service::run_marker`]). Because it is an OSC sequence the terminal
+/// parser consumes it — it never renders as text, unlike the old
+/// `__VMUX_DONE_…__` printf markers.
 ///
 /// The command is prefixed with [`pager_env_prefix`] so an interactive command that would
 /// normally open a pager (e.g. `git log` → `less`) prints straight to the terminal instead of
@@ -1745,7 +1749,7 @@ fn agent_terminal_shell(settings: &AppSettings) -> String {
 ///
 /// posix/fish chain with `;` (which continues after a non-zero command). nushell
 /// aborts the rest of a `;` line when an external command fails, so it needs a
-/// `try`/`catch` wrapper to always print the marker and recover the exit code
+/// `try`/`catch` wrapper to always emit the escape and recover the exit code
 /// from the caught error.
 fn command_with_marker(shell: &str, command: &str, token: &str) -> String {
     let base = std::path::Path::new(shell)
@@ -1753,15 +1757,16 @@ fn command_with_marker(shell: &str, command: &str, token: &str) -> String {
         .and_then(|s| s.to_str())
         .unwrap_or(shell);
     let pager = pager_env_prefix(base);
+    let osc = vmux_service::run_marker::VMUX_RUN_OSC;
     match base {
         "nu" | "nushell" => format!(
-            "{pager}print \"\\n__VMUX_START_{token}__\"; try {{ {command}; print $\"\\n__VMUX_DONE_{token}_($env.LAST_EXIT_CODE)__\" }} catch {{ |e| print $\"\\n__VMUX_DONE_{token}_($e.exit_code? | default 1)__\" }}"
+            "{pager}try {{ {command}; print -rn $\"\\u{{1b}}]{osc};{token};($env.LAST_EXIT_CODE)\\u{{7}}\" }} catch {{ |e| print -rn $\"\\u{{1b}}]{osc};{token};($e.exit_code? | default 1)\\u{{7}}\" }}"
         ),
         "fish" => format!(
-            "{pager}printf '\\n__VMUX_START_{token}__\\n'; {command}; set vmux_status $status; printf '\\n__VMUX_DONE_{token}_%s__\\n' $vmux_status"
+            "{pager}{command}; set __vmux_status $status; printf '\\033]{osc};{token};%s\\007' $__vmux_status"
         ),
         _ => format!(
-            "{pager}printf '\\n__VMUX_START_{token}__\\n'; {command}; vmux_status=\"$?\"; printf '\\n__VMUX_DONE_{token}_%s__\\n' \"$vmux_status\""
+            "{pager}{command}; __vmux_status=\"$?\"; printf '\\033]{osc};{token};%s\\007' \"$__vmux_status\""
         ),
     }
 }
@@ -2357,11 +2362,12 @@ fn handle_agent_queries(
                     name: name.clone(),
                 });
             }
-            // ReadTerminal/ReadTerminalFull/CommandExit are answered by the
-            // service directly; they never reach the GUI.
+            // ReadTerminal/ReadTerminalFull/CommandExit/RunCompletion are
+            // answered by the service directly; they never reach the GUI.
             AgentQuery::ReadTerminal { .. }
             | AgentQuery::ReadTerminalFull { .. }
-            | AgentQuery::CommandExit { .. } => {}
+            | AgentQuery::CommandExit { .. }
+            | AgentQuery::RunCompletion { .. } => {}
         }
     }
 }
@@ -3945,26 +3951,26 @@ mod tests {
 
     #[test]
     fn command_with_marker_is_shell_aware() {
-        // nushell aborts `;` on failure, so it wraps in try/catch and reads the
-        // exit code from the caught error. Success uses `($env.LAST_EXIT_CODE)`
-        // (not a literal digit) so the echoed command line can't be matched as a
-        // completion marker.
+        // The completion marker is an invisible OSC escape
+        // (ESC ] 6973 ; token ; exit BEL), consumed by the terminal parser so it
+        // never renders. nushell aborts `;` on failure, so it wraps in try/catch
+        // and reads the exit code from the caught error.
         assert_eq!(
             command_with_marker("/opt/homebrew/bin/nu", "ls", "abc"),
-            "$env.GIT_PAGER = \"cat\"; $env.PAGER = \"cat\"; $env.LESS = \"FRX\"; print \"\\n__VMUX_START_abc__\"; try { ls; print $\"\\n__VMUX_DONE_abc_($env.LAST_EXIT_CODE)__\" } catch { |e| print $\"\\n__VMUX_DONE_abc_($e.exit_code? | default 1)__\" }"
+            "$env.GIT_PAGER = \"cat\"; $env.PAGER = \"cat\"; $env.LESS = \"FRX\"; try { ls; print -rn $\"\\u{1b}]6973;abc;($env.LAST_EXIT_CODE)\\u{7}\" } catch { |e| print -rn $\"\\u{1b}]6973;abc;($e.exit_code? | default 1)\\u{7}\" }"
         );
         assert_eq!(
             command_with_marker("/usr/local/bin/fish", "ls", "abc"),
-            "set -gx GIT_PAGER cat; set -gx PAGER cat; set -gx LESS FRX; printf '\\n__VMUX_START_abc__\\n'; ls; set vmux_status $status; printf '\\n__VMUX_DONE_abc_%s__\\n' $vmux_status"
+            "set -gx GIT_PAGER cat; set -gx PAGER cat; set -gx LESS FRX; ls; set __vmux_status $status; printf '\\033]6973;abc;%s\\007' $__vmux_status"
         );
         assert_eq!(
             command_with_marker("/bin/zsh", "ls", "abc"),
-            "export GIT_PAGER=cat PAGER=cat LESS=FRX; printf '\\n__VMUX_START_abc__\\n'; ls; vmux_status=\"$?\"; printf '\\n__VMUX_DONE_abc_%s__\\n' \"$vmux_status\""
+            "export GIT_PAGER=cat PAGER=cat LESS=FRX; ls; __vmux_status=\"$?\"; printf '\\033]6973;abc;%s\\007' \"$__vmux_status\""
         );
         // Unknown shells fall back to posix syntax.
         assert_eq!(
             command_with_marker("/bin/bash", "ls", "abc"),
-            "export GIT_PAGER=cat PAGER=cat LESS=FRX; printf '\\n__VMUX_START_abc__\\n'; ls; vmux_status=\"$?\"; printf '\\n__VMUX_DONE_abc_%s__\\n' \"$vmux_status\""
+            "export GIT_PAGER=cat PAGER=cat LESS=FRX; ls; __vmux_status=\"$?\"; printf '\\033]6973;abc;%s\\007' \"$__vmux_status\""
         );
     }
 
@@ -3979,7 +3985,11 @@ mod tests {
         let settings = test_settings();
         let out = run_command_line("ls -la", Some("tok9"), &settings);
         assert!(out.contains("ls -la"), "got: {out}");
-        assert!(out.contains("__VMUX_DONE_tok9_"), "got: {out}");
+        assert!(out.contains("]6973;tok9;"), "got: {out}");
+        assert!(
+            !out.contains("__VMUX_DONE_"),
+            "marker must be invisible: {out}"
+        );
     }
 
     #[test]

--- a/crates/vmux_mcp/src/protocol.rs
+++ b/crates/vmux_mcp/src/protocol.rs
@@ -377,7 +377,9 @@ fn byte_to_utf16(line: &str, byte: usize) -> u32 {
     line[..idx].encode_utf16().count() as u32
 }
 
-#[cfg(test)]
+/// The tail of `final_text` after the `baseline` prefix captured before the
+/// command ran. Falls back to the full text if the prefix shifted (e.g. the
+/// screen scrolled or was cleared).
 fn output_since(baseline: &str, final_text: &str) -> String {
     final_text
         .strip_prefix(baseline)
@@ -403,22 +405,6 @@ fn blocking_run_with_marker(mut run: AgentCommand, request_id: AgentRequestId) -
     run
 }
 
-fn extract_done_marker_output(token: &str, text: &str) -> Option<(i32, String)> {
-    let start_marker = format!("__VMUX_START_{token}__");
-    let done_prefix = format!("__VMUX_DONE_{token}_");
-    let start_index = text.rfind(&start_marker)?;
-    let after_start = &text[start_index + start_marker.len()..];
-    let done_index = after_start.find(&done_prefix)?;
-    let after_prefix = &after_start[done_index + done_prefix.len()..];
-    let code_end = after_prefix.find("__")?;
-    let exit = after_prefix[..code_end].parse().ok()?;
-    let output = after_start[..done_index]
-        .trim_matches(|c| c == '\n' || c == '\r')
-        .trim_end()
-        .to_string();
-    Some((exit, output))
-}
-
 fn run_result(pid: &str, exit: Option<i32>, output: &str, timed_out: bool) -> Value {
     let mut text = format!("terminal: {pid}\n");
     match exit {
@@ -434,8 +420,9 @@ fn run_result(pid: &str, exit: Option<i32>, output: &str, timed_out: bool) -> Va
     json!({ "content": [{"type": "text", "text": text}] })
 }
 
-/// Send `run`, then block (polling the full terminal buffer) until the command's
-/// completion marker appears, returning the output + exit code in one response.
+/// Send `run`, then block (polling `RunCompletion`) until the invisible OSC
+/// completion escape for this run's token is seen, returning the output + exit
+/// code in one response.
 async fn run_blocking(run: AgentCommand) -> Result<Value, String> {
     let connection = vmux_service::client::ServiceConnection::connect()
         .await
@@ -483,14 +470,26 @@ async fn run_blocking(run: AgentCommand) -> Result<Value, String> {
         .map_err(|_| format!("run: service returned an invalid terminal id: {pid}"))?;
 
     let start = Instant::now();
+    let baseline_text = read_full_text(&connection, process_id).await;
     let deadline = start + RUN_BLOCK_TIMEOUT;
     loop {
-        let text = read_full_text(&connection, process_id).await;
-        if let Some((exit, output)) = extract_done_marker_output(&token, &text) {
-            return Ok(run_result(&pid, Some(exit), &output, false));
+        match agent_query(&connection, AgentQuery::RunCompletion { process_id }).await? {
+            AgentQueryResult::RunCompletion {
+                token: Some(done_token),
+                exit: Some(exit),
+            } if done_token == token => {
+                let final_text = read_full_text(&connection, process_id).await;
+                let output = output_since(&baseline_text, &final_text);
+                return Ok(run_result(&pid, Some(exit), &output, false));
+            }
+            AgentQueryResult::RunCompletion { .. } => {}
+            AgentQueryResult::Error(message) => return Err(message),
+            other => return Err(format!("run: unexpected run-completion result: {other:?}")),
         }
         if Instant::now() >= deadline {
-            return Ok(run_result(&pid, None, &text, true));
+            let final_text = read_full_text(&connection, process_id).await;
+            let output = output_since(&baseline_text, &final_text);
+            return Ok(run_result(&pid, None, &output, true));
         }
         tokio::time::sleep(RUN_POLL_INTERVAL).await;
     }
@@ -652,6 +651,13 @@ pub fn query_result_to_mcp_response(result: vmux_service::protocol::AgentQueryRe
             let exit = exit.map_or_else(|| "null".to_string(), |code| code.to_string());
             json!({
                 "content": [{"type": "text", "text": format!("{{\"seq\":{seq},\"exit\":{exit}}}")}]
+            })
+        }
+        AgentQueryResult::RunCompletion { token, exit } => {
+            let token = token.map_or_else(|| "null".to_string(), |t| format!("\"{t}\""));
+            let exit = exit.map_or_else(|| "null".to_string(), |code| code.to_string());
+            json!({
+                "content": [{"type": "text", "text": format!("{{\"token\":{token},\"exit\":{exit}}}")}]
             })
         }
         AgentQueryResult::Image {
@@ -858,14 +864,5 @@ mod tests {
             }
             _ => panic!("expected run command"),
         }
-    }
-
-    #[test]
-    fn done_marker_output_extracts_between_start_and_done() {
-        let text = "old output\n__VMUX_START_tok__\nhello\nworld\n__VMUX_DONE_tok_7__\nprompt";
-
-        let parsed = extract_done_marker_output("tok", text);
-
-        assert_eq!(parsed, Some((7, "hello\nworld".to_string())));
     }
 }

--- a/crates/vmux_service/src/lib.rs
+++ b/crates/vmux_service/src/lib.rs
@@ -43,6 +43,8 @@ pub mod providers;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod registry;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod run_marker;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod server;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod service;

--- a/crates/vmux_service/src/process.rs
+++ b/crates/vmux_service/src/process.rs
@@ -84,6 +84,8 @@ pub struct Process {
     osc133: crate::osc133::Osc133Scanner,
     command_ended_seq: u64,
     last_command_exit: Option<i32>,
+    run_marker: crate::run_marker::RunMarkerScanner,
+    last_run_completion: Option<(String, i32)>,
     pty_writer: PtyInputWriter,
     master: Box<dyn portable_pty::MasterPty + Send>,
     child: Box<dyn portable_pty::Child + Send + Sync>,
@@ -347,6 +349,8 @@ impl Process {
             osc133: crate::osc133::Osc133Scanner::new(),
             command_ended_seq: 0,
             last_command_exit: None,
+            run_marker: crate::run_marker::RunMarkerScanner::new(),
+            last_run_completion: None,
             pty_writer: writer,
             master: pair.master,
             child,
@@ -373,6 +377,13 @@ impl Process {
 
     pub fn command_status(&self) -> (u64, Option<i32>) {
         (self.command_ended_seq, self.last_command_exit)
+    }
+
+    /// Last agent `run` completion `(token, exit)` parsed from a
+    /// [`crate::run_marker::VMUX_RUN_OSC`] escape. The token lets a blocking
+    /// `run` correlate the exit code to its own command.
+    pub fn run_completion(&self) -> Option<(String, i32)> {
+        self.last_run_completion.clone()
     }
 
     pub fn write_input(&self, data: &[u8]) {
@@ -1231,6 +1242,9 @@ impl Process {
                     process_id: self.id,
                     kind,
                 });
+            }
+            for marker in self.run_marker.feed(&data) {
+                self.last_run_completion = Some((marker.token, marker.exit));
             }
             got_data = true;
         }

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -203,6 +203,11 @@ pub enum AgentQuery {
     CommandExit {
         process_id: ProcessId,
     },
+    /// Last agent `run` completion for this process, correlated by the per-run
+    /// token carried in the [`crate::run_marker::VMUX_RUN_OSC`] escape.
+    RunCompletion {
+        process_id: ProcessId,
+    },
     GetSettings,
     ListSpaces,
     Screenshot {
@@ -237,6 +242,10 @@ pub enum AgentQueryResult {
     Spaces(String),
     CommandExit {
         seq: u64,
+        exit: Option<i32>,
+    },
+    RunCompletion {
+        token: Option<String>,
         exit: Option<i32>,
     },
     Image {

--- a/crates/vmux_service/src/run_marker.rs
+++ b/crates/vmux_service/src/run_marker.rs
@@ -1,0 +1,155 @@
+use vte::{Parser, Perform};
+
+/// vmux-private OSC code emitted by the agent `run` wrapper to signal command
+/// completion invisibly: `ESC ] 6973 ; <token> ; <exit> BEL`.
+///
+/// Distinct from OSC `133` so it never disturbs the OSC 133 command lifecycle
+/// (which drives the vibe "armed" pane). The token travels inline with the exact
+/// command, so completion is correlated per-run without a seq baseline.
+pub const VMUX_RUN_OSC: &str = "6973";
+
+/// A completed `run`, parsed from a [`VMUX_RUN_OSC`] escape.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunMarker {
+    pub token: String,
+    pub exit: i32,
+}
+
+/// Scans a PTY byte stream for [`VMUX_RUN_OSC`] completion escapes, reassembling
+/// sequences split across feeds.
+pub struct RunMarkerScanner {
+    parser: Parser,
+}
+
+impl RunMarkerScanner {
+    pub fn new() -> Self {
+        Self {
+            parser: Parser::new(),
+        }
+    }
+
+    pub fn feed(&mut self, bytes: &[u8]) -> Vec<RunMarker> {
+        let mut collector = Collector::default();
+        self.parser.advance(&mut collector, bytes);
+        collector.markers
+    }
+}
+
+impl Default for RunMarkerScanner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Default)]
+struct Collector {
+    markers: Vec<RunMarker>,
+}
+
+impl Perform for Collector {
+    fn osc_dispatch(&mut self, params: &[&[u8]], _bell_terminated: bool) {
+        if params.first().copied() != Some(VMUX_RUN_OSC.as_bytes()) {
+            return;
+        }
+        let token = params
+            .get(1)
+            .and_then(|p| std::str::from_utf8(p).ok())
+            .filter(|t| !t.is_empty());
+        let exit = params
+            .get(2)
+            .and_then(|p| std::str::from_utf8(p).ok())
+            .and_then(|s| s.trim().parse::<i32>().ok());
+        if let (Some(token), Some(exit)) = (token, exit) {
+            self.markers.push(RunMarker {
+                token: token.to_string(),
+                exit,
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn esc(seq: &str) -> Vec<u8> {
+        seq.replace("\\e", "\u{1b}")
+            .replace("\\a", "\u{07}")
+            .into_bytes()
+    }
+
+    #[test]
+    fn extracts_token_and_exit() {
+        let mut s = RunMarkerScanner::new();
+        assert_eq!(
+            s.feed(&esc("\\e]6973;abc123;0\\a")),
+            vec![RunMarker {
+                token: "abc123".to_string(),
+                exit: 0
+            }]
+        );
+    }
+
+    #[test]
+    fn extracts_nonzero_exit() {
+        let mut s = RunMarkerScanner::new();
+        assert_eq!(
+            s.feed(&esc("\\e]6973;tok;130\\a")),
+            vec![RunMarker {
+                token: "tok".to_string(),
+                exit: 130
+            }]
+        );
+    }
+
+    #[test]
+    fn accepts_st_terminator() {
+        let mut s = RunMarkerScanner::new();
+        assert_eq!(
+            s.feed(&esc("\\e]6973;tok;1\\e\\")),
+            vec![RunMarker {
+                token: "tok".to_string(),
+                exit: 1
+            }]
+        );
+    }
+
+    #[test]
+    fn reassembles_sequence_split_across_feeds() {
+        let mut s = RunMarkerScanner::new();
+        assert_eq!(s.feed(&esc("\\e]6973;tok")), vec![]);
+        assert_eq!(
+            s.feed(&esc(";7\\a")),
+            vec![RunMarker {
+                token: "tok".to_string(),
+                exit: 7
+            }]
+        );
+    }
+
+    #[test]
+    fn ignores_osc133_and_other_osc() {
+        let mut s = RunMarkerScanner::new();
+        assert_eq!(s.feed(&esc("\\e]133;D;0\\a")), vec![]);
+        assert_eq!(s.feed(&esc("\\e]0;window title\\a")), vec![]);
+    }
+
+    #[test]
+    fn ignores_plain_text() {
+        let mut s = RunMarkerScanner::new();
+        assert_eq!(s.feed(b"__VMUX_DONE_tok_0__\n"), vec![]);
+    }
+
+    #[test]
+    fn drops_marker_with_missing_or_bad_exit() {
+        let mut s = RunMarkerScanner::new();
+        assert_eq!(s.feed(&esc("\\e]6973;tok\\a")), vec![]);
+        assert_eq!(s.feed(&esc("\\e]6973;tok;notanumber\\a")), vec![]);
+    }
+
+    #[test]
+    fn drops_marker_with_empty_token() {
+        let mut s = RunMarkerScanner::new();
+        assert_eq!(s.feed(&esc("\\e]6973;;0\\a")), vec![]);
+    }
+}

--- a/crates/vmux_service/src/server.rs
+++ b/crates/vmux_service/src/server.rs
@@ -182,6 +182,11 @@ fn query_result_to_content(result: crate::protocol::AgentQueryResult) -> (String
             let exit = exit.map_or_else(|| "null".to_string(), |code| code.to_string());
             (format!("{{\"seq\":{seq},\"exit\":{exit}}}"), false)
         }
+        AgentQueryResult::RunCompletion { token, exit } => {
+            let token = token.map_or_else(|| "null".to_string(), |t| format!("\"{t}\""));
+            let exit = exit.map_or_else(|| "null".to_string(), |code| code.to_string());
+            (format!("{{\"token\":{token},\"exit\":{exit}}}"), false)
+        }
         AgentQueryResult::Image {
             path,
             width,
@@ -622,6 +627,27 @@ async fn handle_client(
                                 Some(process) => {
                                     let (seq, exit) = process.command_status();
                                     crate::protocol::AgentQueryResult::CommandExit { seq, exit }
+                                }
+                                None => crate::protocol::AgentQueryResult::Error(format!(
+                                    "process not found: {process_id}"
+                                )),
+                            }
+                        };
+                        let resp = ServiceMessage::AgentQueryResult { request_id, result };
+                        let mut w = writer.lock().await;
+                        write_message!(&mut *w, &resp)?;
+                        continue;
+                    }
+                    crate::protocol::AgentQuery::RunCompletion { process_id } => {
+                        let result = {
+                            let mgr = manager.lock().await;
+                            match mgr.processes.get(&process_id) {
+                                Some(process) => {
+                                    let (token, exit) = match process.run_completion() {
+                                        Some((token, exit)) => (Some(token), Some(exit)),
+                                        None => (None, None),
+                                    };
+                                    crate::protocol::AgentQueryResult::RunCompletion { token, exit }
                                 }
                                 None => crate::protocol::AgentQueryResult::Error(format!(
                                     "process not found: {process_id}"

--- a/docs/specs/2026-07-07-hide-run-markers-design.md
+++ b/docs/specs/2026-07-07-hide-run-markers-design.md
@@ -1,0 +1,104 @@
+# Hide agent `run` completion markers (D1: tokened OSC escape)
+
+## Problem
+
+The agent `run` tool (CLI blocking + ACP) wraps each command with visible printf
+markers:
+
+```
+printf '\n__VMUX_START_<token>__\n'; <cmd>; printf '\n__VMUX_DONE_<token>_<exit>__\n'
+```
+
+`run_blocking` greps the terminal grid for `__VMUX_DONE_<token>_<exit>__` to learn
+the exit code. The markers render as literal text lines in the terminal (seen in
+v0.0.22).
+
+They were invisible once: `355a431b` used OSC 133 shell-integration hooks +
+`CommandExit` seq baseline. `5bc425f9` (#221) reverted to visible printf markers.
+
+### Why #221 reverted (root cause)
+
+The OSC 133 completion path captured `baseline_seq` by polling `CommandExit`
+**after** the command was already dispatched to the PTY — a TOCTOU race. A fast
+command emits `133;D` before the client snapshots the baseline, so the client
+waits for a `D` that already passed → timeout / "still running". A fresh shell's
+`precmd` also fires a spurious `133;D` at its first prompt. OSC 133's `D` carries
+an exit code but **no per-command token**, so completion could not be correlated
+to a specific run — the seq delta raced.
+
+## Approach: tokened OSC completion escape (D1)
+
+Keep a per-run token (what made the printf markers robust) but deliver it as an
+**invisible OSC escape** instead of visible text.
+
+The `run` wrapper appends, after the command:
+
+```
+ESC ] 6973 ; <token> ; <exit> BEL
+```
+
+`6973` is a vmux-private OSC code (distinct from `133`, so it does not disturb the
+existing OSC 133 lifecycle used by the vibe "armed" pane). The escape is consumed
+by the VTE parser — never rendered.
+
+A new service-side scanner (`run_marker.rs`, sibling of `osc133.rs`) extracts
+`(token, exit)` from the PTY byte stream. Because the token travels inline with the
+exact command, completion detection is:
+
+- **race-free** — no baseline; the client matches its own token whenever the slot holds it
+- **interleave-proof** — user-typed commands don't carry the token (matters for the shared/unified terminal direction)
+- **`-c`-proof** — does not depend on shell-integration hook injection
+
+## Components
+
+1. **`crates/vmux_service/src/run_marker.rs`** (new)
+   - `RunMarkerScanner` (VTE `Parser` + `Perform`), `pub const VMUX_RUN_OSC = b"6973"`.
+   - `feed(&[u8]) -> Vec<RunMarker { token, exit }>`. Handles sequences split across feeds.
+
+2. **`crates/vmux_service/src/process.rs`**
+   - New fields: `run_marker: RunMarkerScanner`, `last_run_completion: Option<(String, i32)>`.
+   - `poll()` feeds PTY bytes to the scanner; each marker sets `last_run_completion`.
+   - `pub fn run_completion(&self) -> Option<(String, i32)>`.
+
+3. **`crates/vmux_service/src/protocol.rs`**
+   - `AgentQuery::RunCompletion { process_id }`.
+   - `AgentQueryResult::RunCompletion { token: Option<String>, exit: Option<i32> }`.
+
+4. **`crates/vmux_service/src/server.rs`**
+   - Serve `RunCompletion` from `process.run_completion()`.
+   - Add arm to `query_result_to_content`.
+
+5. **`crates/vmux_agent/src/plugin.rs`**
+   - `command_with_marker` emits the OSC escape per shell (bash/zsh/sh, fish, nu)
+     instead of visible printf. Token flow (`done_marker = Some(token)`) unchanged.
+
+6. **`crates/vmux_mcp/src/protocol.rs`**
+   - `run_blocking` polls `AgentQuery::RunCompletion` and matches its own token
+     instead of grepping the grid. Output via `output_since(baseline, final)`.
+   - Remove `extract_done_marker_output`. `output_since` becomes live.
+
+## Kept as-is
+
+- OSC 133 shell-integration hooks (`shell_integration.rs`) + `CommandLifecycle` —
+  load-bearing for the vibe "armed" pane (`vibe/setup.rs`). D1 uses a separate OSC
+  code, so no double-count.
+- Per-run token generation (`run_done_token`, `blocking_run_with_marker`).
+
+## Known limitations / follow-ups
+
+- **Output capture** is `output_since` (baseline/final grid diff), matching the
+  OSC-133 era. Slightly noisier than the printf-slice (may include command echo /
+  trailing prompt). Exit code is token-exact. Exact output extraction is a possible
+  follow-up.
+- **Wrapper echo**: the wrapped command source may still echo (pre-existing shell
+  behavior). D1 removes the executed marker *output* lines (the reported symptom);
+  runtime-verify no visible OSC-source residue remains.
+
+## Testing
+
+- `run_marker.rs`: unit tests — extract token+exit, split-across-feeds, ignore
+  other OSC / `133`, malformed exit.
+- `command_with_marker`: emits the OSC escape (no `__VMUX_` text) per shell.
+- `run_blocking` token match (existing test infra).
+- Targeted: `cargo test -p vmux_service -p vmux_mcp -p vmux_agent`; fmt; clippy.
+- Runtime: user confirms markers gone and `run` still reports exit codes.


### PR DESCRIPTION
## Problem

The agent `run` tool wrapped commands with visible printf markers (`__VMUX_START_<token>__` / `__VMUX_DONE_<token>_<exit>__`) that render as literal text lines in the terminal — visible in **v0.0.22**.

## Root cause

`355a431b` once made completion detection invisible via OSC 133 hooks. `5bc425f9` (#221) reverted to visible printf markers because the OSC 133 completion path **raced**: `run_blocking` captured `baseline_seq` by polling `CommandExit` *after* the command was already dispatched to the PTY, so a fast command's `133;D` was missed (→ timeout / "still running") and a fresh shell's startup `133;D` was miscounted. OSC 133 `D` also carries **no per-run token**, so completion can't be correlated on a shared terminal.

## Fix (D1 — tokened OSC escape)

Emit the per-run token + exit code as an **invisible** OSC escape instead: `ESC ]6973;<token>;<exit> BEL`.

- New service-side scanner `vmux_service::run_marker` parses it inline from the PTY stream.
- `run_blocking` correlates completion by matching **its own token** via a new `AgentQuery::RunCompletion` — no seq baseline, so **no race**, **interleave-proof** (user-typed commands carry no token), and **`-c`-proof** (no dependency on shell-integration hook injection).
- OSC 133 hooks stay in place — still drive the vibe "armed" pane (`vibe/setup.rs`).

## Testing

- New `run_marker` unit tests: token/exit extraction, split-across-feeds, ignores OSC 133 / other OSC, malformed/empty.
- Updated `command_with_marker` shell-aware test to the OSC form (bash/zsh/fish/nu).
- `cargo test -p vmux_service -p vmux_mcp -p vmux_agent` green; pre-push `fmt` + `clippy -D warnings` + `--workspace` tests green.
- **Runtime: pending** — confirm markers no longer render and `run` still reports exit codes.

Spec: `docs/specs/2026-07-07-hide-run-markers-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)