### PR TITLE
fix(agent): make follow-pane auto-tidy fire for CLI and native-chat agents

### DIFF
--- a/crates/vmux_agent/src/client/cli/claude.rs
+++ b/crates/vmux_agent/src/client/cli/claude.rs
@@ -89,16 +89,21 @@ pub(crate) fn project_dir_name(cwd: &Path) -> String {
         .collect()
 }
 
-/// Inline `--settings` JSON merging two vmux hooks (merges with the user's
-/// `~/.claude/settings.json`, does not modify it): a Notification bell, and a
-/// PostToolUse hook that pings vmux on every file read/edit (`async` so it
-/// never blocks the agent).
+/// Inline `--settings` JSON merging three vmux hooks (merges with the user's
+/// `~/.claude/settings.json`, does not modify it): a Notification bell; a
+/// PostToolUse hook that pings vmux on every file read/edit; and a Stop hook
+/// that pings vmux at turn-end (drives follow-pane auto-tidy + the done-dot).
+/// Both vmux pings are `async` so they never block the agent.
 fn build_settings_json(mcp: &McpServerConfig) -> String {
-    let mut hook_args = vec![Value::String("notify-file-touch".into())];
-    if let Some(anchor) = anchor_from_mcp(mcp) {
-        hook_args.push(Value::String("--anchor".into()));
-        hook_args.push(Value::String(anchor.into()));
-    }
+    let anchor = anchor_from_mcp(mcp);
+    let args_for = |subcommand: &str| {
+        let mut a = vec![Value::String(subcommand.into())];
+        if let Some(anchor) = anchor {
+            a.push(Value::String("--anchor".into()));
+            a.push(Value::String(anchor.into()));
+        }
+        a
+    };
     let value = serde_json::json!({
         "hooks": {
             "Notification": [
@@ -108,9 +113,12 @@ fn build_settings_json(mcp: &McpServerConfig) -> String {
                 {
                     "matcher": FILE_TOUCH_MATCHER,
                     "hooks": [
-                        { "type": "command", "command": mcp.command, "args": hook_args, "async": true }
+                        { "type": "command", "command": mcp.command, "args": args_for("notify-file-touch"), "async": true }
                     ]
                 }
+            ],
+            "Stop": [
+                { "hooks": [ { "type": "command", "command": mcp.command, "args": args_for("notify-turn-end"), "async": true } ] }
             ]
         }
     });
@@ -323,6 +331,29 @@ mod tests {
         assert!(json.contains("notify-file-touch"));
         assert!(json.contains("\"--anchor\""));
         assert!(json.contains("\"42\""));
+    }
+
+    #[test]
+    fn build_args_injects_turn_end_stop_hook() {
+        let mcp = McpServerConfig {
+            command: "/bin/vmux".into(),
+            args: vec!["mcp".into(), "--anchor".into(), "42".into()],
+            cwd: None,
+        };
+        let args = ClaudeStrategy.build_args(&mcp, None);
+        let settings = args.iter().position(|a| a == "--settings").unwrap();
+        let json = &args[settings + 1];
+        let parsed: Value = serde_json::from_str(json).unwrap();
+        let stop = &parsed["hooks"]["Stop"][0]["hooks"][0];
+        assert_eq!(stop["command"].as_str().unwrap(), "/bin/vmux");
+        let stop_args: Vec<&str> = stop["args"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert_eq!(stop_args, vec!["notify-turn-end", "--anchor", "42"]);
+        assert_eq!(stop["async"].as_bool(), Some(true));
     }
 
     #[test]

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -200,6 +200,7 @@ impl Plugin for AgentPlugin {
                 Update,
                 (
                     agent_bell_to_attention,
+                    handle_agent_turn_ended,
                     tidy_on_agent_attention,
                     mark_agent_done,
                     clear_agent_done,
@@ -1017,6 +1018,29 @@ fn handle_agent_file_touch(
     }
 }
 
+/// CLI agents fire this from their `Stop` hook at turn-end: resolve the agent terminal by its
+/// `anchor` `ProcessId` and raise `AgentAttention`, which drives the follow-pane auto-tidy
+/// (`tidy_on_agent_attention`) and the done-dot. The terminal bell only fires on
+/// idle/permission, so it is not a reliable turn-end signal.
+fn handle_agent_turn_ended(
+    mut reader: MessageReader<AgentCommandRequest>,
+    agents: Query<(Entity, &vmux_service::protocol::ProcessId), With<vmux_core::team::Agent>>,
+    mut attention: MessageWriter<vmux_core::notify::AgentAttention>,
+) {
+    for request in reader.read() {
+        let ServiceAgentCommand::TurnEnded { anchor } = &request.command else {
+            continue;
+        };
+        if let Some((entity, _)) = agents.iter().find(|(_, pid)| *pid == anchor) {
+            attention.write(vmux_core::notify::AgentAttention {
+                entity,
+                title: None,
+                body: None,
+            });
+        }
+    }
+}
+
 /// Tidy one agent's `file://` follow-pane (the sibling `file:` pane of `agent_pane`): when it
 /// holds more than `tidy_files_max` previews, keep changed files + the active one and close
 /// the rest (silently if `tidy_files_auto`, else tag the pane for the confirm dialog). Shared
@@ -1276,6 +1300,7 @@ fn handle_agent_commands(
         };
         let result = match &request.command {
             ServiceAgentCommand::FileTouched { .. } => AgentCommandResult::Ok,
+            ServiceAgentCommand::TurnEnded { .. } => AgentCommandResult::Ok,
             ServiceAgentCommand::AppCommand { id, args_json } => {
                 let args: serde_json::Value = if args_json.is_empty() {
                     serde_json::json!({})
@@ -3319,6 +3344,47 @@ mod tests {
             .resource::<bevy::ecs::message::Messages<vmux_core::notify::AgentAttention>>();
         let mut cursor = messages.get_cursor();
         cursor.read(messages).map(|a| a.entity).collect()
+    }
+
+    fn turn_end_test_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<AgentCommandRequest>()
+            .add_message::<vmux_core::notify::AgentAttention>()
+            .add_systems(Update, handle_agent_turn_ended);
+        app
+    }
+
+    fn send_turn_ended(app: &mut App, anchor: vmux_service::protocol::ProcessId) {
+        app.world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<AgentCommandRequest>>()
+            .write(AgentCommandRequest {
+                request_id: vmux_service::protocol::AgentRequestId::new(),
+                origin: CommandOrigin::Agent {
+                    sid: None,
+                    anchor: Some(anchor),
+                },
+                command: ServiceAgentCommand::TurnEnded { anchor },
+            });
+    }
+
+    #[test]
+    fn turn_ended_resolves_to_agent_attention() {
+        let mut app = turn_end_test_app();
+        let pid = vmux_service::protocol::ProcessId::new();
+        let agent = spawn_agent_with_pid(&mut app, pid);
+        send_turn_ended(&mut app, pid);
+        app.update();
+        assert_eq!(attentions(&app), vec![agent]);
+    }
+
+    #[test]
+    fn turn_ended_unknown_anchor_emits_nothing() {
+        let mut app = turn_end_test_app();
+        let _agent = spawn_agent_with_pid(&mut app, vmux_service::protocol::ProcessId::new());
+        send_turn_ended(&mut app, vmux_service::protocol::ProcessId::new());
+        app.update();
+        assert!(attentions(&app).is_empty());
     }
 
     #[test]

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -209,7 +209,7 @@ impl Plugin for AgentPlugin {
             )
             .add_systems(
                 Update,
-                tidy_acp_on_idle.after(vmux_layout::stack::ComputeFocusSet),
+                (tidy_acp_on_idle, tidy_page_on_idle).after(vmux_layout::stack::ComputeFocusSet),
             )
             .add_systems(Startup, session::start_agent_session_watchers)
             .add_systems(
@@ -1017,13 +1017,14 @@ fn handle_agent_file_touch(
     }
 }
 
-/// Tidy one agent's `file://` follow-pane, anchored by its `ProcessId`: when the pane
-/// holds more than `tidy_files_max` previews, keep changed files + the active one and
-/// close the rest (silently if `tidy_files_auto`, else tag the pane for the confirm
-/// dialog). Shared by the CLI (`AgentAttention`) and ACP (`AgentRunState` → `Idle`) triggers.
+/// Tidy one agent's `file://` follow-pane (the sibling `file:` pane of `agent_pane`): when it
+/// holds more than `tidy_files_max` previews, keep changed files + the active one and close
+/// the rest (silently if `tidy_files_auto`, else tag the pane for the confirm dialog). Shared
+/// by the CLI-terminal bell (`AgentAttention`), ACP idle, and native-chat idle triggers, which
+/// each resolve `agent_pane` first.
 #[allow(clippy::too_many_arguments)]
 fn tidy_follow_pane(
-    anchor: vmux_service::protocol::ProcessId,
+    agent_pane: Entity,
     settings: &AppSettings,
     resolve: &AgentFileResolve,
     last_activated: &Query<&vmux_core::LastActivatedAt>,
@@ -1031,9 +1032,6 @@ fn tidy_follow_pane(
     close: &mut MessageWriter<vmux_layout::CloseStackRequest>,
     commands: &mut Commands,
 ) {
-    let Some(agent_pane) = resolve.agent_pane(anchor) else {
-        return;
-    };
     let Some((follow_pane, stacks)) = resolve.file_stacks_for(agent_pane) else {
         return;
     };
@@ -1100,8 +1098,11 @@ fn tidy_on_agent_attention(
         let Ok(pid) = agents.get(att.entity) else {
             continue;
         };
+        let Some(agent_pane) = resolve.agent_pane(*pid) else {
+            continue;
+        };
         tidy_follow_pane(
-            *pid,
+            agent_pane,
             &settings,
             &resolve,
             &last_activated,
@@ -1133,8 +1134,52 @@ fn tidy_acp_on_idle(
         if !matches!(state, crate::AgentRunState::Idle) {
             continue;
         }
+        let Some(agent_pane) = resolve.agent_pane(acp.anchor) else {
+            continue;
+        };
         tidy_follow_pane(
-            acp.anchor,
+            agent_pane,
+            &settings,
+            &resolve,
+            &last_activated,
+            &pending,
+            &mut close,
+            &mut commands,
+        );
+    }
+}
+
+/// Native-chat agents (CLI + Page variants) have no terminal bell; their turn-end is
+/// `AgentRunState` → `Idle` on the sid-keyed [`AgentSession`](crate::components::AgentSession)
+/// stack. That stack is a different entity from the `ProcessId`-anchored one `AgentAttention`
+/// resolves through, so [`tidy_on_agent_attention`] can't see it. Tidy the follow-pane on the
+/// idle transition, resolving `agent_pane` as the session stack's parent pane. Mirrors
+/// [`tidy_acp_on_idle`] for non-ACP agents.
+fn tidy_page_on_idle(
+    settings: Res<AppSettings>,
+    sessions: Query<
+        (&ChildOf, &crate::AgentRunState),
+        (
+            With<crate::components::AgentSession>,
+            Changed<crate::AgentRunState>,
+        ),
+    >,
+    resolve: AgentFileResolve,
+    last_activated: Query<&vmux_core::LastActivatedAt>,
+    pending: Query<(), With<crate::tidy::PendingTidy>>,
+    mut close: MessageWriter<vmux_layout::CloseStackRequest>,
+    mut commands: Commands,
+) {
+    use bevy::ecs::relationship::Relationship;
+    if !settings.agent.tidy_files {
+        return;
+    }
+    for (parent, state) in &sessions {
+        if !matches!(state, crate::AgentRunState::Idle) {
+            continue;
+        }
+        tidy_follow_pane(
+            parent.get(),
             &settings,
             &resolve,
             &last_activated,
@@ -4379,6 +4424,95 @@ mod tests {
             ..default()
         });
         stack
+    }
+
+    fn close_stack_requests(app: &App) -> Vec<Entity> {
+        let messages = app
+            .world()
+            .resource::<bevy::ecs::message::Messages<vmux_layout::CloseStackRequest>>();
+        let mut cursor = messages.get_cursor();
+        cursor.read(messages).map(|m| m.stack).collect()
+    }
+
+    fn spawn_file_preview_stack(app: &mut App, pane: Entity, ts: i64, url: &str) -> Entity {
+        let stack = app
+            .world_mut()
+            .spawn((
+                vmux_layout::stack::stack_bundle(),
+                vmux_core::LastActivatedAt(ts),
+                ChildOf(pane),
+            ))
+            .id();
+        app.world_mut().spawn((
+            PageMetadata {
+                url: url.to_string(),
+                ..default()
+            },
+            ChildOf(stack),
+        ));
+        stack
+    }
+
+    #[test]
+    fn tidy_page_on_idle_closes_clean_previews_for_native_chat_cli() {
+        let mut settings = test_settings();
+        settings.agent.tidy_files_auto = true;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<vmux_layout::CloseStackRequest>()
+            .add_message::<vmux_layout::OpenBesideRequest>()
+            .add_message::<vmux_layout::active_panes::ActivatePane>()
+            .insert_resource(settings)
+            .add_systems(Update, tidy_page_on_idle);
+
+        let parent = app.world_mut().spawn(vmux_layout::tab::Tab::default()).id();
+        let agent_pane = app.world_mut().spawn((Pane, ChildOf(parent))).id();
+        let agent_stack = app
+            .world_mut()
+            .spawn((
+                vmux_layout::stack::stack_bundle(),
+                crate::components::AgentSession {
+                    kind: vmux_core::agent::AgentKind::Claude,
+                    variant: crate::AgentVariant::Cli,
+                    sid: "sid-1".to_string(),
+                    provider: "claude".to_string(),
+                    model: "cli".to_string(),
+                },
+                crate::AgentRunState::Streaming,
+                ChildOf(agent_pane),
+            ))
+            .id();
+        let file_pane = app.world_mut().spawn((Pane, ChildOf(parent))).id();
+        let previews: Vec<Entity> = (0..6)
+            .map(|i| {
+                spawn_file_preview_stack(&mut app, file_pane, i, &format!("file:///clean/f{i}.rs"))
+            })
+            .collect();
+
+        app.update();
+        assert!(
+            close_stack_requests(&app).is_empty(),
+            "streaming (not idle) must not tidy"
+        );
+
+        *app.world_mut()
+            .get_mut::<crate::AgentRunState>(agent_stack)
+            .unwrap() = crate::AgentRunState::Idle;
+        app.update();
+
+        let mut closed = close_stack_requests(&app);
+        closed.sort();
+        let mut expected = previews[0..5].to_vec();
+        expected.sort();
+        assert_eq!(
+            closed, expected,
+            "clean non-active previews close; the active (max LastActivatedAt) preview is kept"
+        );
+        assert!(
+            !closed.contains(&previews[5]),
+            "active preview must be kept"
+        );
     }
 
     fn browser_claim_app() -> (App, ProcessId, Entity) {

--- a/crates/vmux_cli/src/commands.rs
+++ b/crates/vmux_cli/src/commands.rs
@@ -3,6 +3,7 @@ use clap::{Parser, Subcommand};
 pub mod mcp;
 pub mod notify;
 pub mod notify_file_touch;
+pub mod notify_turn_end;
 pub mod open;
 pub mod service;
 
@@ -30,6 +31,10 @@ pub enum Command {
         anchor: Option<String>,
     },
     NotifyFileTouch {
+        #[arg(long)]
+        anchor: Option<String>,
+    },
+    NotifyTurnEnd {
         #[arg(long)]
         anchor: Option<String>,
     },

--- a/crates/vmux_cli/src/commands/notify_turn_end.rs
+++ b/crates/vmux_cli/src/commands/notify_turn_end.rs
@@ -1,0 +1,56 @@
+use std::io::{self, Read};
+
+use vmux_service::client::ServiceConnection;
+use vmux_service::protocol::{
+    AGENT_COMMAND_TIMEOUT, AgentCommand, AgentRequestId, ClientMessage, ProcessId, ServiceMessage,
+};
+
+/// Fired from the CLI agent's `Stop` hook at turn-end: pings the daemon so the GUI raises
+/// `AgentAttention` for this agent, which drives the follow-pane auto-tidy and the done-dot.
+/// The hook payload on stdin is drained and ignored — only the `anchor` matters.
+pub async fn run(anchor: Option<String>) -> io::Result<()> {
+    let anchor = match anchor {
+        Some(raw) => raw.parse::<ProcessId>().ok(),
+        None => std::env::var("VMUX_ANCHOR")
+            .ok()
+            .and_then(|s| s.parse::<ProcessId>().ok()),
+    };
+    let Some(anchor) = anchor else {
+        return Ok(());
+    };
+
+    let mut buf = String::new();
+    let _ = io::stdin().read_to_string(&mut buf);
+
+    let Ok(connection) = ServiceConnection::connect().await else {
+        return Ok(());
+    };
+    let request_id = AgentRequestId::new();
+    if connection
+        .send(&ClientMessage::AgentCommand {
+            request_id,
+            anchor: Some(anchor),
+            command: AgentCommand::TurnEnded { anchor },
+        })
+        .await
+        .is_err()
+    {
+        return Ok(());
+    }
+
+    let _ = tokio::time::timeout(AGENT_COMMAND_TIMEOUT, async {
+        while let Ok(Some(message)) = connection.recv().await {
+            if let ServiceMessage::AgentCommandResult {
+                request_id: received,
+                ..
+            } = message
+                && received == request_id
+            {
+                break;
+            }
+        }
+    })
+    .await;
+
+    Ok(())
+}

--- a/crates/vmux_cli/src/main.rs
+++ b/crates/vmux_cli/src/main.rs
@@ -18,6 +18,7 @@ async fn main() -> std::io::Result<()> {
             anchor,
         }) => commands::notify::run(title, body, anchor).await,
         Some(Command::NotifyFileTouch { anchor }) => commands::notify_file_touch::run(anchor).await,
+        Some(Command::NotifyTurnEnd { anchor }) => commands::notify_turn_end::run(anchor).await,
         Some(Command::Service(args)) => {
             let code = commands::service::run(args)?;
             std::process::exit(code);

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -165,6 +165,13 @@ pub enum AgentCommand {
     CreateWorktree {
         anchor: ProcessId,
     },
+    /// The calling CLI agent finished a turn (fired from its `Stop` hook). Resolved to the agent
+    /// via `anchor`; the GUI raises `AgentAttention` so the follow-pane auto-tidy and the
+    /// done-dot fire at turn-end (the terminal bell only fires on idle/permission, not turn-end).
+    /// Appended at the end to keep rkyv's positional enum discriminants stable.
+    TurnEnded {
+        anchor: ProcessId,
+    },
 }
 
 pub const AGENT_QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);


### PR DESCRIPTION
Auto-tidy never closed clean file previews in the agent follow-pane. Root cause is that vmux hosts agents in **three different ways**, and tidy only had a working turn-end trigger for one of them (ACP). Screenshots showed 8+ clean previews piling up with no tidy banner on `vmux://agent/claude/cli`.

## The three hostings

| Hosting | URL | Entity shape | Turn-end signal |
|---|---|---|---|
| **CLI** | `agent/<kind>/cli` | PTY terminal: `ProcessId` + `team::Agent`, **no `AgentRunState`** | terminal bell → `AgentAttention` |
| **native-chat / Page** | `agent/<provider>/<model>` | stack: `AgentSession` + `AgentRunState` (no `ProcessId`) | `consume_page_agent_stream` Streaming→Idle |
| **ACP** | `agent/<id>/<sid>` | stack: `AcpSession` + `AgentRunState` | same idle stream |

On `main` only ACP had a working trigger (`tidy_acp_on_idle`). Both other hostings silently no-op'd.

## Fix 1 — native-chat / Page agents (`tidy_page_on_idle`)

Their turn-end raises `AgentAttention` carrying the **sid-keyed session stack**, which has no `ProcessId`, so `tidy_on_agent_attention` (`Query<&ProcessId, With<team::Agent>>`) skips it. Added `tidy_page_on_idle`, mirroring `tidy_acp_on_idle`: keyed on `AgentRunState → Idle` for `With<AgentSession>`, resolving the pane via `child_of(stack)`. `tidy_follow_pane` refactored to take the resolved `agent_pane` so all three triggers share it (no behavior change to the bell/ACP paths).

## Fix 2 — CLI agents (turn-end `Stop` hook)

The CLI agent is a **PTY terminal** with no `AgentRunState`, so Fix 1 can't apply. Its only trigger is the bell → `AgentAttention` → `tidy_on_agent_attention` — but vmux wired the bell to Claude Code's **`Notification`** hook, which fires on *idle-after-60s / permission*, **not** at turn-end. Confirmed with instrumentation: a full CLI turn (8 file reads) produced **zero** `BellReceived`/`AgentAttention`.

Added a real turn-end signal: a Claude Code **`Stop`** hook → `vmux notify-turn-end --anchor <pid>` (new `AgentCommand::TurnEnded` + CLI subcommand, mirroring the existing `notify-file-touch` `PostToolUse` bridge). `handle_agent_turn_ended` resolves the agent terminal by anchor and raises `AgentAttention`, so `tidy_on_agent_attention` fires reliably — and the done-dot / OS notification stop depending on the flaky idle bell. `AgentCommand::TurnEnded` is appended after `CreateWorktree` to keep rkyv's positional discriminants stable.

Codex/Vibe have the same CLI gap (different hook systems) — follow-up.

## Tests

- `tidy_page_on_idle_closes_clean_previews_for_native_chat_cli` — Page agent, `AgentRunState` Streaming→Idle → clean non-active previews close, active + dirty kept.
- `turn_ended_resolves_to_agent_attention` / `turn_ended_unknown_anchor_emits_nothing` — `TurnEnded` → `AgentAttention` for the anchored terminal.
- `build_args_injects_turn_end_stop_hook` — Claude `--settings` includes the `Stop` hook running `notify-turn-end --anchor`.

`cargo test -p vmux_agent -p vmux_cli -p vmux_service`, `cargo fmt --check`, `cargo clippy --all-targets`, and the pre-push full-workspace tests all pass. These are the first system-level tidy tests (prior coverage was only `decide_closable` units — why both gaps shipped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `notify-turn-end` CLI command to signal when an agent turn has ended.
  * Updated the agent hooks/settings to include a new turn-end “Stop” hook.
* **Bug Fixes**
  * Improved tidy/follow-pane behavior for file preview stacks when agents become idle.
  * Preview panes are now resolved more reliably, so only inactive, clean previews are closed while the active one stays open.
  * Native chat and ACP agent flows now apply idle cleanup consistently.
* **Tests**
  * Added coverage for turn-end attention routing and native-chat preview tidy correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->