### PR TITLE
fix(terminal): stop follow-to-bottom clipping the top row

### DIFF
--- a/crates/vmux_core/src/scroll.rs
+++ b/crates/vmux_core/src/scroll.rs
@@ -67,6 +67,23 @@ pub fn doc_row_to_line(doc_row: u32, history_size: u32) -> i32 {
     doc_row as i32 - history_size as i32
 }
 
+/// Bottom alignment pad (px) for a terminal that follows by pinning to the
+/// scroll maximum.
+///
+/// A follow-to-bottom terminal scrolls to `scrollHeight`, so the fractional
+/// sub-row left over when `client_h` is not a whole multiple of the cell
+/// height `ch` lands as a clipped partial row at the *top* of the viewport.
+/// Adding this many pixels below the last row shifts that remainder to the
+/// bottom instead, so the pinned top edge falls on a row boundary and the top
+/// line renders whole. `pad` is the container's top inner padding (the row
+/// grid's y-origin). The result is in `[0, ch)`.
+pub fn follow_bottom_pad(client_h: f32, pad: f32, ch: f32) -> f32 {
+    if ch <= 0.0 {
+        return 0.0;
+    }
+    (client_h - pad).rem_euclid(ch)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -117,5 +134,38 @@ mod tests {
         assert_eq!(doc_row_to_line(0, 100), -100);
         assert_eq!(doc_row_to_line(100, 100), 0);
         assert_eq!(doc_row_to_line(149, 100), 49);
+    }
+
+    #[test]
+    fn follow_bottom_pad_aligns_pinned_top_edge_to_row_boundary() {
+        // For any viewport/pad/cell size, adding follow_bottom_pad below the
+        // rows must make the pinned (max-scroll) top edge land exactly on a
+        // row top: (max_scroll - pad) % ch == 0.
+        let cases = [
+            (790.0_f32, 4.0_f32, 18.0_f32),
+            (800.0, 4.0, 18.0), // already aligned (rem 0)
+            (1013.0, 6.0, 21.0),
+            (601.0, 8.0, 16.5),
+            (1234.0, 0.0, 19.0),
+        ];
+        for (client_h, pad, ch) in cases {
+            let e = follow_bottom_pad(client_h, pad, ch);
+            assert!((0.0..ch).contains(&e), "e={e} out of [0,{ch})");
+            // Enough rows to force scrolling.
+            let total = 200.0_f32;
+            let scroll_height = total * ch + 2.0 * pad + e;
+            let max_scroll = scroll_height - client_h;
+            let misalign = (max_scroll - pad).rem_euclid(ch);
+            let misalign = misalign.min(ch - misalign); // distance to nearest boundary
+            assert!(
+                misalign < 1e-2,
+                "client_h={client_h} pad={pad} ch={ch} e={e} misalign={misalign}"
+            );
+        }
+    }
+
+    #[test]
+    fn follow_bottom_pad_zero_ch_is_safe() {
+        assert_eq!(follow_bottom_pad(800.0, 4.0, 0.0), 0.0);
     }
 }

--- a/crates/vmux_terminal/src/page.rs
+++ b/crates/vmux_terminal/src/page.rs
@@ -42,6 +42,7 @@ pub fn Page() -> Element {
     let mut service_error = use_signal(String::new);
     let mut loading = use_signal(|| None::<(String, String)>);
     let mut prompt_draft = use_signal(|| (String::new(), false));
+    let client_h = use_signal(|| 0.0f64);
 
     let _err_listener = use_bin_event_listener::<ServiceUnavailableEvent, _>(
         SERVICE_UNAVAILABLE_EVENT,
@@ -99,6 +100,7 @@ pub fn Page() -> Element {
 
     use_effect(move || {
         let _ = total_rows();
+        let _ = client_h();
         if following() {
             pin_scroll_to_bottom();
         }
@@ -141,7 +143,7 @@ pub fn Page() -> Element {
     let mut wheel_accum = use_signal(|| 0.0f64);
     // Set up character measurement span and ResizeObserver (runs once after mount).
     use_effect(move || {
-        setup_measurement(cell_dims);
+        setup_measurement(cell_dims, client_h);
     });
 
     let theme_style = {
@@ -193,7 +195,13 @@ pub fn Page() -> Element {
     } else {
         "overflow-auto"
     };
-    let spacer_h = total_rows() as f64 * ch;
+    let content_h = total_rows() as f64 * ch;
+    let bottom_pad = if ch > 0.0 && content_h + 2.0 * padding > client_h() {
+        vmux_core::scroll::follow_bottom_pad(client_h() as f32, padding as f32, ch as f32) as f64
+    } else {
+        0.0
+    };
+    let spacer_h = content_h + bottom_pad;
 
     rsx! {
         div {
@@ -559,7 +567,7 @@ fn TerminalRow(
 /// Create a hidden measurement span, measure character dimensions, set CSS
 /// custom properties, emit a resize event to Bevy, and install a
 /// ResizeObserver to repeat on layout changes.
-fn setup_measurement(cell_dims: Signal<(f64, f64)>) {
+fn setup_measurement(cell_dims: Signal<(f64, f64)>, client_h: Signal<f64>) {
     let Some(window) = web_sys::window() else {
         return;
     };
@@ -586,7 +594,7 @@ fn setup_measurement(cell_dims: Signal<(f64, f64)>) {
     measure
         .set_attribute(
             "style",
-            "position:absolute;visibility:hidden;white-space:pre;font:inherit",
+            "position:absolute;top:0;left:0;visibility:hidden;white-space:pre;font:inherit",
         )
         .unwrap();
     measure.set_attribute("id", MEASURE_ID).unwrap();
@@ -595,12 +603,12 @@ fn setup_measurement(cell_dims: Signal<(f64, f64)>) {
     container.append_child(&measure).unwrap();
 
     // Run initial measurement.
-    do_measure(cell_dims);
+    do_measure(cell_dims, client_h);
 
     // Install ResizeObserver on container + measure span to catch both
     // viewport resizes and font-load-triggered reflows.
     let callback = Closure::wrap(Box::new(move |_entries: JsValue| {
-        do_measure(cell_dims);
+        do_measure(cell_dims, client_h);
     }) as Box<dyn FnMut(JsValue)>);
 
     if let Ok(observer) = web_sys::ResizeObserver::new(callback.as_ref().unchecked_ref()) {
@@ -615,7 +623,7 @@ fn setup_measurement(cell_dims: Signal<(f64, f64)>) {
 /// Measure character dimensions from the hidden span, update CSS custom
 /// properties on the container, update the Dioxus signal, and emit a
 /// TermResizeEvent to the Bevy host.
-fn do_measure(mut cell_dims: Signal<(f64, f64)>) {
+fn do_measure(mut cell_dims: Signal<(f64, f64)>, mut client_h: Signal<f64>) {
     let Some(window) = web_sys::window() else {
         return;
     };
@@ -666,8 +674,10 @@ fn do_measure(mut cell_dims: Signal<(f64, f64)>) {
         })
         .unwrap_or((0.0, 0.0));
 
+    let viewport_client_h = container.client_height() as f64;
     let vw = container.client_width() as f64 - pad_x;
-    let vh = container.client_height() as f64 - pad_y;
+    let vh = viewport_client_h - pad_y;
+    client_h.set(viewport_client_h);
 
     let _ = try_cef_bin_emit_rkyv(&TermResizeEvent {
         char_width: cw as f32,


### PR DESCRIPTION
## Problem
A terminal pinned to the bottom (following output) clipped its top line — a partial row cut off at the top edge. Seen on fresh/near-full terminals and on agent panes with scrollback.

## Root causes
1. **Phantom row from the measurement span.** The hidden 80-char span used to measure cell dimensions was appended to the scroll container as `position:absolute` with no `top`/`left`, so its static position sat *below* the content flow and inflated `scrollHeight` by ~one row. Pinning `scrollTop = scrollHeight` over-scrolled into that phantom row, clipping the real top line.
2. **Sub-row remainder.** When the viewport height is not a whole multiple of the cell height, pinning to the scroll maximum leaves the fractional remainder as a clipped partial row at the top. (The editor never hits this — it top-anchors, never follows.)

## Fix
1. Pin the measurement span to `top:0;left:0` so it never extends `scrollHeight`.
2. Add `vmux_core::scroll::follow_bottom_pad()` — a bottom alignment pad `(client_h − pad) mod ch` applied to the scroll spacer when content overflows, so max-scroll lands the top edge on a row boundary. The remainder becomes invisible term-bg below the last line (how real terminals letterbox).

## Verify
- `cargo test -p vmux_core` — new property test asserts the pinned top edge lands on a row boundary for arbitrary viewport/pad/cell sizes.
- clippy clean (native + wasm), fmt clean.
- Runtime-confirmed: top line renders whole on fresh, near-full, and scrollback-following terminals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)