### PR TITLE
chore(release): v0.0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10032,7 +10032,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10074,7 +10074,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_browser"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "base64 0.22.1",
  "bevy",
@@ -10100,7 +10100,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -10113,7 +10113,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -10128,7 +10128,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10147,7 +10147,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10212,7 +10212,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_editor"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "arboard",
  "bevy",
@@ -10255,7 +10255,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_git"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10272,7 +10272,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10293,7 +10293,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -10329,7 +10329,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "muda",
  "proc-macro2",
@@ -10339,7 +10339,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -10352,7 +10352,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_server"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "dioxus",
  "regex",
@@ -10373,7 +10373,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "agent-client-protocol",
  "alacritty_terminal",
@@ -10411,7 +10411,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10434,7 +10434,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10459,7 +10459,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_team"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10480,7 +10480,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10514,7 +10514,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "dioxus",
  "dioxus-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.22"
+version = "0.0.23"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "GPL-3.0-or-later"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.22"
-  sha256 "056127700925bf6bc22d5ac891a8a27affb46581e279bd2db7f08b6bd83d8237"
+  version "0.0.23"
+  sha256 "f581e688c429432ee077caa39e95924eefc615f17834e592ffbd4d1944644086"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.22/Vmux_0.0.22_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.23/Vmux_0.0.23_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai/"

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.22",
-  "pub_date": "2026-07-07T12:24:26Z",
+  "version": "v0.0.23",
+  "pub_date": "2026-07-08T10:03:09Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.22/Vmux-v0.0.22-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HT3prdytzQUhwUFJ6N0NDbWsvNm1DNFZJck1IVE9mM2U0NlBhOGNSenAxUDJTanBNa1dlcXBUSmVndmg4VlRvSGtDR3FUY2NHK1kvUjlWVXcwTHNWNXcwPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgzNDI1MTQxCWZpbGU6Vm11eC12MC4wLjIyLWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKdlBqSEdNVVBhS1B1cTFGWUV6YVdRMjRoYkN1WUtaZlg5U2Z6WGZYbElLd0dyQVd5YnFGRktyUTVLK0xSV2pna3FKU09CU2hYN2ZRcER1WFNyNWVYREE9PQo=",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.23/Vmux-v0.0.23-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzBrU3grMkVPL094Y0U2Y21SNnBKVExJaGx3TXVENUpsVjlkV3FZSUhBcGRjNTU2TmNpMHVyWXdLdzA1b2VhckQrcHh2VjErQ2xQT2xzUDIrVFprS3dBPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgzNTAyNTU3CWZpbGU6Vm11eC12MC4wLjIzLWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKTmJ5L2lZYllyQTI1VUFtL0tsTldSK2FIU25wNktxSWVkUk1IYVpiOS8vdmc1WkFOTCt3WTZ6cjg1aFZaYlROK0lZRzdteUlPa285TWUvOG9QNERSQnc9PQo=",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.22/Vmux_0.0.22_aarch64.dmg",
-      "filename": "Vmux_0.0.22_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.23/Vmux_0.0.23_aarch64.dmg",
+      "filename": "Vmux_0.0.23_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
Patch release. Bumps workspace version 0.0.22 -> 0.0.23. Releases on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app to version `0.0.23`.
  * Refreshed macOS AArch64 download details, including the installer file name, checksum, and signature.
  * Updated the website release information to show the new version and publication date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->