### PR TITLE
feat(agent): turn-end tidy parity for codex + vibe CLI agents

### DIFF
--- a/crates/vmux_agent/src/client/cli/codex.rs
+++ b/crates/vmux_agent/src/client/cli/codex.rs
@@ -66,6 +66,8 @@ impl CliAgentStrategy for CodexStrategy {
         args.push("features.hooks=true".into());
         args.push("-c".into());
         args.push(build_file_touch_hook_override(mcp));
+        args.push("-c".into());
+        args.push(build_turn_end_hook_override(mcp));
         for feature in DISABLED_FEATURES {
             args.push("--disable".into());
             args.push((*feature).to_string());
@@ -126,6 +128,25 @@ fn build_file_touch_hook_override(mcp: &McpServerConfig) -> String {
     format!(
         "hooks.PostToolUse=[{{matcher={},hooks=[{{type={},command={},args=[{}]}}]}}]",
         quote_toml(FILE_TOUCH_MATCHER),
+        quote_toml("command"),
+        quote_toml(&mcp.command),
+        hook_args.join(","),
+    )
+}
+
+/// `-c` override registering a Stop hook that pings vmux at turn-end (drives
+/// follow-pane auto-tidy + the done-dot). Codex's `Stop` fires when the agent
+/// finishes a turn; it takes no tool matcher. Inline TOML array-of-tables.
+fn build_turn_end_hook_override(mcp: &McpServerConfig) -> String {
+    let mut hook_args = vec![quote_toml("notify-turn-end")];
+    if let Some(i) = mcp.args.iter().position(|a| a == "--anchor")
+        && let Some(anchor) = mcp.args.get(i + 1)
+    {
+        hook_args.push(quote_toml("--anchor"));
+        hook_args.push(quote_toml(anchor));
+    }
+    format!(
+        "hooks.Stop=[{{hooks=[{{type={},command={},args=[{}]}}]}}]",
         quote_toml("command"),
         quote_toml(&mcp.command),
         hook_args.join(","),
@@ -284,6 +305,27 @@ mod tests {
         assert!(hook.contains("notify-file-touch"));
         assert!(hook.contains("--anchor"));
         assert!(hook.contains("\"42\""));
+    }
+
+    #[test]
+    fn build_args_injects_turn_end_stop_hook() {
+        let mcp = McpServerConfig {
+            command: "/bin/vmux".into(),
+            args: vec!["mcp".into(), "--anchor".into(), "42".into()],
+            cwd: None,
+        };
+        let args = CodexStrategy.build_args(&mcp, None);
+        let hook = args
+            .iter()
+            .find(|a| a.starts_with("hooks.Stop="))
+            .expect("Stop hook override present");
+        assert!(hook.contains("notify-turn-end"), "hook: {hook}");
+        assert!(hook.contains("--anchor"));
+        assert!(hook.contains("\"42\""));
+        assert!(
+            !hook.contains("matcher"),
+            "Stop hook takes no matcher: {hook}"
+        );
     }
 
     #[test]

--- a/crates/vmux_agent/src/client/cli/vibe.rs
+++ b/crates/vmux_agent/src/client/cli/vibe.rs
@@ -63,7 +63,7 @@ impl CliAgentStrategy for VibeStrategy {
     }
 
     fn prepare_launch(&self, mcp: &McpServerConfig) {
-        ensure_vibe_file_touch_hook(&mcp.command);
+        ensure_vibe_hooks(&mcp.command);
     }
 
     fn discover_session(
@@ -135,6 +135,7 @@ fn vibe_config_path() -> PathBuf {
 }
 
 const VMUX_HOOK_NAME: &str = "vmux-file-follow";
+const VMUX_TURN_END_HOOK_NAME: &str = "vmux-turn-end";
 
 fn vibe_hooks_path() -> PathBuf {
     std::env::var("VIBE_HOME")
@@ -146,16 +147,18 @@ fn vibe_hooks_path() -> PathBuf {
         .join("hooks.toml")
 }
 
-/// Idempotently register a vmux-managed `after_tool` hook in `~/.vibe/hooks.toml`
-/// that pings vmux on file read/edit. The hook command no-ops without
-/// `VMUX_ANCHOR`, so manual vibe use is unaffected. Adds our named hook if
-/// absent and reconciles its command in place when stale (e.g. after the vmux
-/// binary moves) — never clobbers user-authored hooks.
-fn ensure_vibe_file_touch_hook(vmux_command: &str) {
-    write_vmux_hook(&vibe_hooks_path(), vmux_command);
+/// Idempotently register vmux-managed hooks in `~/.vibe/hooks.toml`: an
+/// `after_tool` hook that pings vmux on file read/edit, and a `post_agent_turn`
+/// hook that pings vmux at turn-end (drives follow-pane auto-tidy + the
+/// done-dot). Both commands no-op without `VMUX_ANCHOR`, so manual vibe use is
+/// unaffected. Adds each named hook if absent and reconciles its command in
+/// place when stale (e.g. after the vmux binary moves) — never clobbers
+/// user-authored hooks.
+fn ensure_vibe_hooks(vmux_command: &str) {
+    write_vmux_hooks(&vibe_hooks_path(), vmux_command);
 }
 
-fn write_vmux_hook(path: &Path, vmux_command: &str) {
+fn write_vmux_hooks(path: &Path, vmux_command: &str) {
     let mut doc: toml::Table = std::fs::read_to_string(path)
         .ok()
         .and_then(|text| text.parse().ok())
@@ -166,35 +169,63 @@ fn write_vmux_hook(path: &Path, vmux_command: &str) {
     let toml::Value::Array(hooks) = entry else {
         return;
     };
-    let command = format!("{vmux_command} notify-file-touch");
-    if let Some(existing) = hooks
-        .iter_mut()
-        .find(|h| h.get("name").and_then(|n| n.as_str()) == Some(VMUX_HOOK_NAME))
-    {
-        if existing.get("command").and_then(|c| c.as_str()) == Some(command.as_str()) {
-            return;
-        }
-        let toml::Value::Table(table) = existing else {
-            return;
-        };
-        table.insert("type".into(), "after_tool".into());
-        table.insert("match".into(), "re:^(read|edit|write)$".into());
-        table.insert("command".into(), command.into());
-        table.insert("strict".into(), false.into());
-    } else {
-        let mut hook = toml::Table::new();
-        hook.insert("name".into(), VMUX_HOOK_NAME.into());
-        hook.insert("type".into(), "after_tool".into());
-        hook.insert("match".into(), "re:^(read|edit|write)$".into());
-        hook.insert("command".into(), command.into());
-        hook.insert("strict".into(), false.into());
-        hooks.push(toml::Value::Table(hook));
-    }
+    upsert_vmux_hook(
+        hooks,
+        VMUX_HOOK_NAME,
+        "after_tool",
+        Some("re:^(read|edit|write)$"),
+        &format!("{vmux_command} notify-file-touch"),
+    );
+    // `post_agent_turn` is not a tool hook, so vibe rejects `match`/`strict` on it.
+    upsert_vmux_hook(
+        hooks,
+        VMUX_TURN_END_HOOK_NAME,
+        "post_agent_turn",
+        None,
+        &format!("{vmux_command} notify-turn-end"),
+    );
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
     if let Ok(text) = toml::to_string(&doc) {
         let _ = std::fs::write(path, text);
+    }
+}
+
+fn upsert_vmux_hook(
+    hooks: &mut Vec<toml::Value>,
+    name: &str,
+    hook_type: &str,
+    match_re: Option<&str>,
+    command: &str,
+) {
+    let table = match hooks
+        .iter_mut()
+        .find(|h| h.get("name").and_then(|n| n.as_str()) == Some(name))
+    {
+        Some(toml::Value::Table(table)) => table,
+        Some(_) => return,
+        None => {
+            let mut hook = toml::Table::new();
+            hook.insert("name".into(), name.into());
+            hooks.push(toml::Value::Table(hook));
+            let toml::Value::Table(table) = hooks.last_mut().expect("just pushed") else {
+                return;
+            };
+            table
+        }
+    };
+    table.insert("type".into(), hook_type.into());
+    table.insert("command".into(), command.into());
+    match match_re {
+        Some(re) => {
+            table.insert("match".into(), re.into());
+            table.insert("strict".into(), false.into());
+        }
+        None => {
+            table.remove("match");
+            table.remove("strict");
+        }
     }
 }
 
@@ -391,13 +422,13 @@ mod tests {
     fn vmux_hook_written_idempotently() {
         let tmp = unique_tmp("vibe-hooks");
         let path = tmp.join("hooks.toml");
-        write_vmux_hook(&path, "/bin/vmux");
+        write_vmux_hooks(&path, "/bin/vmux");
         let text = std::fs::read_to_string(&path).unwrap();
         assert!(text.contains("vmux-file-follow"), "text: {text}");
         assert!(text.contains("after_tool"));
         assert!(text.contains("notify-file-touch"));
 
-        write_vmux_hook(&path, "/bin/vmux");
+        write_vmux_hooks(&path, "/bin/vmux");
         let doc: toml::Table = std::fs::read_to_string(&path).unwrap().parse().unwrap();
         let count = doc
             .get("hooks")
@@ -411,11 +442,52 @@ mod tests {
     }
 
     #[test]
+    fn vmux_turn_end_hook_written_without_match_or_strict() {
+        let tmp = unique_tmp("vibe-hooks-turn");
+        let path = tmp.join("hooks.toml");
+        write_vmux_hooks(&path, "/bin/vmux");
+        let doc: toml::Table = std::fs::read_to_string(&path).unwrap().parse().unwrap();
+        let hooks = doc.get("hooks").and_then(|h| h.as_array()).unwrap();
+        let turn = hooks
+            .iter()
+            .find(|h| h.get("name").and_then(|n| n.as_str()) == Some("vmux-turn-end"))
+            .expect("turn-end hook present");
+        assert_eq!(
+            turn.get("type").and_then(|t| t.as_str()),
+            Some("post_agent_turn")
+        );
+        assert_eq!(
+            turn.get("command").and_then(|c| c.as_str()),
+            Some("/bin/vmux notify-turn-end")
+        );
+        assert!(
+            turn.get("match").is_none(),
+            "post_agent_turn must not carry match"
+        );
+        assert!(
+            turn.get("strict").is_none(),
+            "post_agent_turn must not carry strict"
+        );
+
+        write_vmux_hooks(&path, "/bin/vmux");
+        let doc: toml::Table = std::fs::read_to_string(&path).unwrap().parse().unwrap();
+        let count = doc
+            .get("hooks")
+            .and_then(|h| h.as_array())
+            .unwrap()
+            .iter()
+            .filter(|h| h.get("name").and_then(|n| n.as_str()) == Some("vmux-turn-end"))
+            .count();
+        assert_eq!(count, 1, "idempotent: no duplicate turn-end hook");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
     fn vmux_hook_reconciles_stale_command() {
         let tmp = unique_tmp("vibe-hooks-stale");
         let path = tmp.join("hooks.toml");
-        write_vmux_hook(&path, "/old/path/vmux");
-        write_vmux_hook(&path, "/new/path/vmux");
+        write_vmux_hooks(&path, "/old/path/vmux");
+        write_vmux_hooks(&path, "/new/path/vmux");
         let doc: toml::Table = std::fs::read_to_string(&path).unwrap().parse().unwrap();
         let hooks = doc.get("hooks").and_then(|h| h.as_array()).unwrap();
         let ours: Vec<_> = hooks
@@ -440,7 +512,7 @@ mod tests {
             "[[hooks]]\nname = \"mine\"\ntype = \"before_tool\"\nmatch = \"bash\"\ncommand = \"echo hi\"\n",
         )
         .unwrap();
-        write_vmux_hook(&path, "/bin/vmux");
+        write_vmux_hooks(&path, "/bin/vmux");
         let text = std::fs::read_to_string(&path).unwrap();
         assert!(text.contains("mine"), "user hook preserved: {text}");
         assert!(text.contains("vmux-file-follow"));


### PR DESCRIPTION
Follow-up to #236, which gave the **Claude** CLI agent a real turn-end signal (a `Stop` hook → `vmux notify-turn-end` → `AgentAttention` → follow-pane auto-tidy + reliable done-dot). This extends that to the other two CLI agents so **all agent hostings have parity**.

## Changes

- **codex** (`codex.rs`): inject a `hooks.Stop` `-c` override running `vmux notify-turn-end --anchor <pid>`. Codex's `Stop` event fires at turn-end and takes no tool matcher. Mirrors the existing `hooks.PostToolUse` file-touch override (same trust path — already working for file-touch).
- **vibe** (`vibe.rs`): register a `post_agent_turn` hook in `~/.vibe/hooks.toml` running `vmux notify-turn-end`. `match`/`strict` are omitted because vibe's `HookConfig` rejects them on non-tool hooks. Refactored `write_vmux_hook` → `write_vmux_hooks` + `upsert_vmux_hook`, upserting both the file-touch and turn-end hooks idempotently (never clobbers user hooks; reconciles stale commands in place).

Both reuse the `AgentCommand::TurnEnded` bridge from #236. The anchor comes from `--anchor` (codex) / `VMUX_ANCHOR` env (vibe), which `launch.rs` sets for every CLI agent.

## Parity summary

| Hosting | Turn-end signal | Status |
|---|---|---|
| Claude CLI | `Stop` hook → `TurnEnded` | #236 |
| **Codex CLI** | `Stop` hook → `TurnEnded` | **this PR** |
| **Vibe CLI** | `post_agent_turn` hook → `TurnEnded` | **this PR** |
| native-chat / Page | `consume_page_agent_stream` Streaming→Idle | already ✓ |
| ACP | `consume_page_agent_stream` Streaming→Idle | already ✓ |

ACP + Page agents already raise `AgentAttention` at turn-end via `consume_page_agent_stream`, so no change was needed there — every agent hosting now fires the follow-pane auto-tidy and the done-dot at turn-end.

## Tests

- `codex::build_args_injects_turn_end_stop_hook` — `-c hooks.Stop=…notify-turn-end --anchor…`, no matcher.
- `vibe::vmux_turn_end_hook_written_without_match_or_strict` — `post_agent_turn` hook present, correct command, **no** `match`/`strict`, idempotent.
- Existing vibe hook tests updated for the two-hook writer; Claude's turn-end test still green.

`cargo test -p vmux_agent`, `cargo fmt --check`, `cargo clippy -p vmux_agent --all-targets`, and the pre-push workspace tests all pass.

Hook event names were read from the installed CLIs themselves (codex `Stop` from its binary's hook schema; vibe `post_agent_turn` from `vibe/core/hooks/models.py`), not assumed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new turn-end hook so Vibe can run an action when an agent turn completes.
  * Improved hook setup so both file-touch and turn-end behaviors are configured automatically.

* **Bug Fixes**
  * Hook registration is now updated safely and consistently, preserving existing user hooks while reconciling outdated settings.
  * Added support for optional anchor values in launch configuration passed to the CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->