### PR TITLE
fix(browser): persist cookie logins across updates via real keychain

### DIFF
--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -21,7 +21,9 @@ use bevy::{
     winit::{EventLoopProxyWrapper, WinitUserEvent},
 };
 use bevy_cef::prelude::*;
-use bevy_cef_core::prelude::{CefEmbeddedHosts, RenderTextureMessage, webview_debug_log};
+use bevy_cef_core::prelude::{
+    CefEmbeddedHosts, CommandLineConfig, RenderTextureMessage, webview_debug_log,
+};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{LazyLock, Mutex};
 use vmux_command::{
@@ -100,6 +102,10 @@ impl Plugin for BrowserPlugin {
                 .collect(),
         );
         webview_debug_log(format!("BrowserPlugin embedded_hosts={embedded_hosts:?}"));
+        let cef_command_line = CommandLineConfig {
+            switches: vmux_core::profile::cef_keychain_switches().to_vec(),
+            switch_values: Vec::new(),
+        };
         configure_cef_backend_sync(app)
             .add_message::<bevy_cef_core::prelude::WebviewCommittedNavigationEvent>()
             .add_message::<PageOpenRequest>()
@@ -119,6 +125,7 @@ impl Plugin for BrowserPlugin {
             .add_plugins(
                 (
                     CefPlugin {
+                        command_line_config: cef_command_line,
                         root_cache_path: cef_root_cache_path(),
                         embedded_hosts,
                         ..default()

--- a/crates/vmux_core/src/profile.rs
+++ b/crates/vmux_core/src/profile.rs
@@ -172,6 +172,37 @@ pub fn cef_cache_path() -> Option<String> {
     profile_dir().to_str().map(|s| s.to_owned())
 }
 
+/// CEF command-line switches selecting how cookies and passwords are encrypted
+/// at rest.
+///
+/// On macOS the encryption key lives in the login Keychain under the shared,
+/// framework-default `Chromium Safe Storage` item (CEF exposes no way to rename
+/// it), and access is gated by the requesting binary's code-signing identity.
+/// All interactive builds — `dev`, `local`, and `release` — use the real
+/// Keychain (no switches) so saved credentials stay securely encrypted.
+/// Persistence across updates relies on a stable signing identity: Developer-ID
+/// for `release`/`local`, and the reused self-signed `Vmux Dev` certificate that
+/// `make dev` applies. Both yield a designated requirement that survives
+/// rebuilds, so access sticks after a one-time "Always Allow" per identity.
+///
+/// Automated test sessions (`VMUX_TEST`) instead pass `use-mock-keychain`, which
+/// derives the key from a constant. Those runs are often headless (no one to
+/// approve the Keychain prompt) and use throwaway, frequently ad-hoc-signed
+/// profiles whose changing identity would otherwise churn the ACL of the shared
+/// item real logins depend on. Weak at-rest encryption is irrelevant for
+/// disposable test data.
+pub fn cef_keychain_switches() -> &'static [&'static str] {
+    cef_keychain_switches_for(is_test_session())
+}
+
+fn cef_keychain_switches_for(is_test_session: bool) -> &'static [&'static str] {
+    if is_test_session {
+        &["use-mock-keychain"]
+    } else {
+        &[]
+    }
+}
+
 fn store_dir_for(base: &std::path::Path, _profile: &str) -> PathBuf {
     base.to_path_buf()
 }
@@ -440,6 +471,19 @@ mod tests {
     #[test]
     fn local_and_release_share_one_space() {
         assert_eq!(data_dir_suffix_for("local"), data_dir_suffix_for("release"));
+    }
+
+    #[test]
+    fn test_sessions_use_mock_keychain() {
+        assert_eq!(
+            cef_keychain_switches_for(true),
+            ["use-mock-keychain"].as_slice()
+        );
+    }
+
+    #[test]
+    fn interactive_sessions_use_real_keychain() {
+        assert!(cef_keychain_switches_for(false).is_empty());
     }
 
     #[test]

--- a/docs/specs/2026-07-08-cef-keychain-cookie-persistence-design.md
+++ b/docs/specs/2026-07-08-cef-keychain-cookie-persistence-design.md
@@ -1,0 +1,101 @@
+# CEF cookie-encryption keychain persistence
+
+Status: implemented · 2026-07-08 (revised 2026-07-12)
+
+## Problem
+
+Website logins vanish after "every update." Cookies are not deleted — they become
+undecryptable.
+
+## Root cause
+
+On macOS, CEF/Chromium encrypts saved cookies and passwords (`v10` records) with a
+key stored in the login **Keychain**, not in the profile. vmux's cookie DB and its
+`root_cache_path` are stable across updates:
+
+```
+~/Library/Application Support/Vmux/profiles/<profile>/Default/Cookies   (persists fine)
+```
+
+The key lives in the Keychain item **`Chromium Safe Storage`** (account `Chromium`),
+shared by every CEF app that does not set a product name. vmux never sets one —
+`CefSettings` (`_cef_settings_t`) has **no** field for it, and CEF exposes no override
+(Bitbucket #2692 is an unresolved feature request; the framework is a prebuilt binary
+we cannot patch). So the name is the framework default.
+
+Access to that item is gated by the requesting binary's **code-signing identity** via
+the item's ACL. The key itself is stable (created once, never rewritten), so the loss
+is at *decrypt time*: when a binary whose identity is not "Always Allow"-trusted asks
+for the key, macOS prompts; the browser process performs OSCrypt and, if the prompt is
+missed/denied (or the binary's designated requirement no longer matches), the key is
+unreadable and every login appears gone.
+
+What breaks the trust:
+
+- **Ad-hoc / unstable signatures.** An ad-hoc binary's designated requirement is
+  pinned to its exact code hash, so it changes on every rebuild and re-prompts. A plain
+  `cargo build` / IDE-run `target/debug/vmux_desktop` is ad-hoc (`flags=…adhoc`).
+- **Throwaway test runs** (`VMUX_TEST`, e.g. `make test-app` with the `gregor` profile)
+  touching the shared item under a disposable identity churn its ACL.
+- Historically, an early ad-hoc build created the item (2026-04-29), leaving a stale ACL.
+
+Interactive, stably-signed builds do persist across updates once "Always Allow"-ed:
+`release`/`local` are Developer-ID signed; `dev` is signed by `make dev` with the reused
+self-signed `Vmux Dev` certificate. A cert-signed binary's designated requirement is
+pinned to the *certificate*, not the code hash, so it survives rebuilds.
+
+Not the cause (ruled out): version-keyed paths, data wiped on update, empty `os_crypt`
+in `Local State` (normal on macOS — the key is in the Keychain), and the
+`process_requirement.cc -67030` log line (a benign CEF self-validation warning).
+
+## Constraints
+
+- Prebuilt CEF: cannot rename `Chromium Safe Storage` → a dedicated `Vmux Safe Storage`.
+- `release` and `local` **share one data dir** (`Vmux`), so they must use the *same*
+  cookie-encryption scheme. `dev` has its own dir (`Vmux/dev`). The Keychain item is
+  global (one key per user, shared by all profiles — the normal Chromium model).
+- Safe at-rest encryption must be preserved for every profile a real account logs into,
+  including `dev`.
+
+## Decision
+
+Encrypt cookies with the real Keychain for all interactive use; use a mock keychain only
+for automated test runs.
+
+| Session                    | Keychain              | Rationale |
+|----------------------------|-----------------------|-----------|
+| `release` / `local` (interactive) | real (secure) | Developer-ID DR is stable → persists across updates after one "Always Allow". |
+| `dev` (interactive, `make dev`)   | real (secure) | Signed with the stable `Vmux Dev` cert → cert-pinned DR survives rebuilds; safe for real logins (e.g. testing a Google sign-in). |
+| any profile with `VMUX_TEST` set  | `--use-mock-keychain` | Headless (no one to approve the prompt) and disposable; keeps throwaway/ad-hoc test identities off the shared item so they can't churn the ACL real logins depend on. |
+
+Mock keychain is deliberately **not** used for any interactive build: its key is a public
+constant, i.e. cookies would be effectively unencrypted at rest.
+
+## Implementation
+
+- `vmux_core::profile::cef_keychain_switches()` → `["use-mock-keychain"]` when
+  `is_test_session()` (i.e. `VMUX_TEST`), else `[]` (pure
+  `cef_keychain_switches_for(is_test_session: bool)` + unit tests, no CEF build).
+- `vmux_browser::BrowserPlugin` builds `CommandLineConfig` from those switches and
+  passes it as `CefPlugin.command_line_config`. Applied in the browser process via
+  `OnBeforeCommandLineProcessing`; the browser process obtains the OSCrypt key and
+  forwards it to the network service, so no child-process propagation is needed.
+
+## Operational requirements
+
+- **Always launch `dev` via `make dev`** (signs with `Vmux Dev`). A bare `cargo run` /
+  IDE-debug binary is ad-hoc and will re-prompt / lose the key on every rebuild.
+- **One dev identity.** Keep a single self-signed dev cert (`Vmux Dev`); delete stale
+  duplicates (e.g. `Vmux Development`) so `make dev` signing is consistent.
+
+## One-time reset (existing installs)
+
+The current `Chromium Safe Storage` ACL is poisoned by mixed historical identities.
+Once, after installing a build with this change:
+
+1. Quit vmux.
+2. Delete the item: `security delete-generic-password -s "Chromium Safe Storage"`.
+3. Relaunch each interactive build you use and click **Always Allow** on the prompt —
+   once for the Developer-ID identity (`release`/`local`) and once for `Vmux Dev`
+   (`dev`). Existing cookies encrypted with the old key are lost once; logins persist
+   across updates thereafter.


### PR DESCRIPTION
## Context

Saved website logins vanish after "every update." The cookies are not deleted — they become undecryptable. On macOS, CEF/Chromium encrypts saved cookies and passwords with a key kept in the login Keychain (item `Chromium Safe Storage`), and access is gated by the requesting binary's code-signing identity via the item ACL. CEF exposes no way to rename the item to an app-specific one (prebuilt framework; Bitbucket #2692 unresolved). Logins break when the running binary's identity is not trusted on the item: ad-hoc/unstable signatures (whose designated requirement is pinned to the exact code hash) re-prompt on every rebuild, and throwaway `VMUX_TEST` runs churn the ACL that real logins depend on.

## Implementation

Encrypt cookies with the real Keychain for all interactive builds; use a mock keychain only for automated test runs.

- **`dev` / `local` / `release` (interactive)** → real Keychain, no switches. Credentials stay securely encrypted at rest — safe for real logins (e.g. testing a Google sign-in in `dev`). Persistence across updates relies on a stable signing identity: Developer-ID for `release`/`local`, and the reused self-signed `Vmux Dev` cert that `make dev` applies (a cert-pinned designated requirement survives rebuilds). Sticks after a one-time "Always Allow" per identity.
- **`VMUX_TEST` sessions** → `--use-mock-keychain` (constant key). Headless and disposable; keeps throwaway/ad-hoc test identities off the shared item so they can't churn the ACL real logins depend on.

Gated by `is_test_session()` in `vmux_core::profile::cef_keychain_switches()` (pure, unit-tested, no CEF build), wired into `CefPlugin.command_line_config` in `vmux_browser`. Applied in the browser process via `OnBeforeCommandLineProcessing`; it obtains the OSCrypt key and forwards it to the network service, so no child-process propagation is needed. Design notes: `docs/specs/2026-07-08-cef-keychain-cookie-persistence-design.md`.

## Checks / QA

Existing installs carry a poisoned ACL from historical identities; a one-time reset is required, then it persists:

1. Quit vmux. Delete the stale item: `security delete-generic-password -s "Chromium Safe Storage"`.
2. Launch each interactive build you use, log into a site, and click **Always Allow** on the Keychain prompt — once for the Developer-ID identity (`release`/`local`) and once for `Vmux Dev` (`dev`).
3. Rebuild + reinstall / `make dev` again (simulates an update); confirm you are still logged in (no re-login).

Operational: always launch `dev` via `make dev` (signed); a bare `cargo run` / IDE-debug binary is ad-hoc and will re-prompt. Keep a single dev cert (`Vmux Dev`); delete stale duplicates (e.g. `Vmux Development`).
