### PR TITLE
feat(acp): add native terminal support

### DIFF
--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -325,11 +325,11 @@ fn apply_agent_compatibility_env(
         .iter()
         .rev()
         .find(|(key, _)| key == "CODEX_CONFIG")
-        .and_then(|(_, value)| serde_json::from_str::<serde_json::Value>(value).ok());
-    let mut config = match existing {
-        Some(serde_json::Value::Object(config)) => config,
-        _ => serde_json::Map::new(),
-    };
+        .map(|(_, value)| value.as_str());
+    let (mut config, warning) = parse_codex_config(existing);
+    if let Some(warning) = warning {
+        bevy::log::warn!("{warning}");
+    }
 
     let features = config
         .entry("features")
@@ -348,7 +348,7 @@ fn apply_agent_compatibility_env(
     }
     code_mode.as_object_mut().unwrap().insert(
         "direct_only_tool_namespaces".to_string(),
-        serde_json::json!(["mcp__vmux"]),
+        serde_json::json!([crate::client::cli::codex::DIRECT_ONLY_NAMESPACE]),
     );
 
     let tools = config
@@ -387,6 +387,39 @@ fn apply_agent_compatibility_env(
         serde_json::Value::Object(config).to_string(),
     ));
     env
+}
+
+fn parse_codex_config(
+    value: Option<&str>,
+) -> (serde_json::Map<String, serde_json::Value>, Option<String>) {
+    let Some(value) = value else {
+        return (serde_json::Map::new(), None);
+    };
+    match serde_json::from_str::<serde_json::Value>(value) {
+        Ok(serde_json::Value::Object(config)) => (config, None),
+        Ok(value) => {
+            let kind = match value {
+                serde_json::Value::Null => "null",
+                serde_json::Value::Bool(_) => "boolean",
+                serde_json::Value::Number(_) => "number",
+                serde_json::Value::String(_) => "string",
+                serde_json::Value::Array(_) => "array",
+                serde_json::Value::Object(_) => unreachable!(),
+            };
+            (
+                serde_json::Map::new(),
+                Some(format!(
+                    "acp: existing CODEX_CONFIG is not a JSON object ({kind}); discarding it"
+                )),
+            )
+        }
+        Err(err) => (
+            serde_json::Map::new(),
+            Some(format!(
+                "acp: existing CODEX_CONFIG is invalid JSON ({err}); discarding it"
+            )),
+        ),
+    }
 }
 
 /// Drain background-install updates: reflect progress/failure onto the session run-state, and on
@@ -721,7 +754,7 @@ mod tests {
         assert_eq!(config["tools"]["web_search"], false);
         assert_eq!(
             config["features"]["code_mode"]["direct_only_tool_namespaces"],
-            serde_json::json!(["mcp__vmux"])
+            serde_json::json!([crate::client::cli::codex::DIRECT_ONLY_NAMESPACE])
         );
         assert!(
             config["developer_instructions"]
@@ -750,6 +783,15 @@ mod tests {
         assert_eq!(config["features"]["custom_feature"], true);
         assert_eq!(config["features"]["code_mode"]["custom_setting"], "keep");
         assert_eq!(config["features"]["shell_tool"], false);
+    }
+
+    #[test]
+    fn codex_acp_reports_discarded_invalid_config() {
+        let (_, invalid_json) = parse_codex_config(Some("{not-json"));
+        assert!(invalid_json.unwrap().contains("invalid JSON"));
+
+        let (_, non_object) = parse_codex_config(Some("[]"));
+        assert!(non_object.unwrap().contains("not a JSON object"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -456,6 +456,7 @@ fn apply_acp_terminal_created(
             .id();
         commands.spawn((
             reattach_terminal_bundle(&mut meshes, &mut webview_mt, ev.process_id),
+            vmux_terminal::RetainOnProcessExit,
             ChildOf(tab),
         ));
     }

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -232,14 +232,20 @@ fn install_acp_session_when_focused(
                     sid,
                     command: r.command,
                     args: r.args,
-                    env: build_agent_env(r.env, login_env, r.path_prepend),
+                    env: apply_agent_compatibility_env(
+                        &agent_id,
+                        build_agent_env(r.env, login_env, r.path_prepend),
+                    ),
                 },
                 Err(reg_err) => match fallback {
                     Some(cfg) => InstallMsg::Ready {
                         sid,
                         command: cfg.command,
                         args: cfg.args,
-                        env: build_agent_env(cfg.env, login_env, None),
+                        env: apply_agent_compatibility_env(
+                            &agent_id,
+                            build_agent_env(cfg.env, login_env, None),
+                        ),
                     },
                     None => InstallMsg::Failed {
                         sid,
@@ -307,6 +313,82 @@ fn build_agent_env(
     apply_path_prepend(base, path_prepend)
 }
 
+fn apply_agent_compatibility_env(
+    agent_id: &str,
+    mut env: Vec<(String, String)>,
+) -> Vec<(String, String)> {
+    if agent_id != "codex" {
+        return env;
+    }
+
+    let existing = env
+        .iter()
+        .rev()
+        .find(|(key, _)| key == "CODEX_CONFIG")
+        .and_then(|(_, value)| serde_json::from_str::<serde_json::Value>(value).ok());
+    let mut config = match existing {
+        Some(serde_json::Value::Object(config)) => config,
+        _ => serde_json::Map::new(),
+    };
+
+    let features = config
+        .entry("features")
+        .or_insert_with(|| serde_json::json!({}));
+    if !features.is_object() {
+        *features = serde_json::json!({});
+    }
+    let features = features.as_object_mut().unwrap();
+    features.insert("shell_tool".to_string(), serde_json::Value::Bool(false));
+    features.insert("unified_exec".to_string(), serde_json::Value::Bool(false));
+    let code_mode = features
+        .entry("code_mode")
+        .or_insert_with(|| serde_json::json!({}));
+    if !code_mode.is_object() {
+        *code_mode = serde_json::json!({});
+    }
+    code_mode.as_object_mut().unwrap().insert(
+        "direct_only_tool_namespaces".to_string(),
+        serde_json::json!(["mcp__vmux"]),
+    );
+
+    let tools = config
+        .entry("tools")
+        .or_insert_with(|| serde_json::json!({}));
+    if !tools.is_object() {
+        *tools = serde_json::json!({});
+    }
+    tools
+        .as_object_mut()
+        .unwrap()
+        .insert("web_search".to_string(), serde_json::Value::Bool(false));
+
+    let instructions = config
+        .get("developer_instructions")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    let instructions = if instructions.contains("mcp__vmux__run") {
+        instructions.to_string()
+    } else if instructions.is_empty() {
+        crate::client::cli::codex::RUN_STEER_PROMPT.to_string()
+    } else {
+        format!(
+            "{instructions}\n\n{}",
+            crate::client::cli::codex::RUN_STEER_PROMPT
+        )
+    };
+    config.insert(
+        "developer_instructions".to_string(),
+        serde_json::Value::String(instructions),
+    );
+
+    env.retain(|(key, _)| key != "CODEX_CONFIG");
+    env.push((
+        "CODEX_CONFIG".to_string(),
+        serde_json::Value::Object(config).to_string(),
+    ));
+    env
+}
+
 /// Drain background-install updates: reflect progress/failure onto the session run-state, and on
 /// a resolved spec send `SpawnAcpAgent` (success run-state is then driven by the daemon stream).
 fn drain_acp_installs(
@@ -343,13 +425,17 @@ fn drain_acp_installs(
                     continue;
                 };
                 if let Some((session, _)) = q.iter().find(|(s, _)| s.sid == sid) {
-                    let mcp = crate::mcp::resolve_acp(&session.cwd, session.anchor)
-                        .inspect_err(|err| {
-                            bevy::log::warn!(
-                                "acp: vmux_mcp sidecar unresolved; agent runs without vmux tools: {err}"
-                            );
-                        })
-                        .ok();
+                    let mcp = crate::mcp::resolve_acp(
+                        &session.cwd,
+                        session.anchor,
+                        &session.agent_id,
+                    )
+                    .inspect_err(|err| {
+                        bevy::log::warn!(
+                            "acp: vmux_mcp sidecar unresolved; agent runs without vmux tools: {err}"
+                        );
+                    })
+                    .ok();
                     service.0.send(ClientMessage::SpawnAcpAgent {
                         sid,
                         agent_id: session.agent_id.clone(),
@@ -619,6 +705,51 @@ mod tests {
             app.world().get::<Profile>(matching).unwrap().name,
             "Antigravity"
         );
+    }
+
+    #[test]
+    fn codex_acp_routes_shell_commands_through_vmux_run() {
+        let env = apply_agent_compatibility_env("codex", Vec::new());
+        let config = env
+            .iter()
+            .find(|(key, _)| key == "CODEX_CONFIG")
+            .map(|(_, value)| serde_json::from_str::<serde_json::Value>(value).unwrap())
+            .expect("codex ACP compatibility config");
+
+        assert_eq!(config["features"]["shell_tool"], false);
+        assert_eq!(config["features"]["unified_exec"], false);
+        assert_eq!(config["tools"]["web_search"], false);
+        assert_eq!(
+            config["features"]["code_mode"]["direct_only_tool_namespaces"],
+            serde_json::json!(["mcp__vmux"])
+        );
+        assert!(
+            config["developer_instructions"]
+                .as_str()
+                .unwrap()
+                .contains("mcp__vmux__run")
+        );
+    }
+
+    #[test]
+    fn codex_acp_preserves_existing_config() {
+        let env = apply_agent_compatibility_env(
+            "codex",
+            vec![s(
+                "CODEX_CONFIG",
+                r#"{"model":"gpt-test","features":{"custom_feature":true,"code_mode":{"custom_setting":"keep"}}}"#,
+            )],
+        );
+        let config = env
+            .iter()
+            .find(|(key, _)| key == "CODEX_CONFIG")
+            .map(|(_, value)| serde_json::from_str::<serde_json::Value>(value).unwrap())
+            .unwrap();
+
+        assert_eq!(config["model"], "gpt-test");
+        assert_eq!(config["features"]["custom_feature"], true);
+        assert_eq!(config["features"]["code_mode"]["custom_setting"], "keep");
+        assert_eq!(config["features"]["shell_tool"], false);
     }
 
     #[test]

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -685,7 +685,9 @@ mod tests {
 
         let mut app = App::new();
         app.add_plugins(bevy::app::TaskPoolPlugin::default())
-            .add_plugins(AcpAgentPlugin);
+            .add_plugins(AcpAgentPlugin)
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>();
         let matching = app
             .world_mut()
             .spawn((

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -4,10 +4,16 @@
 //! `consume_page_agent_stream` system (ACP reuses the Page stream messages).
 
 use bevy::prelude::*;
+use bevy_cef::prelude::WebviewExtendStandardMaterial;
 use crossbeam_channel::{Receiver, Sender};
+use vmux_core::LastActivatedAt;
+use vmux_layout::event::TERMINAL_PAGE_URL;
+use vmux_layout::pane::{PlacementCtx, resolve_spiral_pane};
+use vmux_layout::stack::stack_bundle;
 use vmux_service::client::ServiceClient;
 use vmux_service::protocol::ClientMessage;
 use vmux_setting::AppSettings;
+use vmux_terminal::reattach_terminal_bundle;
 
 use crate::components::{AgentApprovalPolicy, PromptQueue};
 use crate::events::{AgentApprovalReply, AgentApprovalRequest, ApprovalDecision};
@@ -109,6 +115,7 @@ impl Plugin for AcpAgentPlugin {
             .init_resource::<AcpCatalog>()
             .add_message::<vmux_service::agent_events::PageAgentInfo>()
             .add_message::<vmux_service::agent_events::PageAgentSessionCreated>()
+            .add_message::<vmux_service::agent_events::PageAgentAcpTerminalCreated>()
             .add_systems(Startup, start_catalog_fetch)
             .add_systems(
                 Update,
@@ -119,6 +126,7 @@ impl Plugin for AcpAgentPlugin {
                     receive_catalog,
                     apply_acp_agent_info,
                     apply_acp_session_created,
+                    apply_acp_terminal_created,
                 ),
             )
             .add_observer(close_acp_session_on_remove)
@@ -335,7 +343,7 @@ fn drain_acp_installs(
                     continue;
                 };
                 if let Some((session, _)) = q.iter().find(|(s, _)| s.sid == sid) {
-                    let mcp = crate::mcp::resolve(&session.cwd, session.anchor)
+                    let mcp = crate::mcp::resolve_acp(&session.cwd, session.anchor)
                         .inspect_err(|err| {
                             bevy::log::warn!(
                                 "acp: vmux_mcp sidecar unresolved; agent runs without vmux tools: {err}"
@@ -407,6 +415,49 @@ fn apply_acp_session_created(
                 }
             }
         }
+    }
+}
+
+/// An ACP agent created a terminal (`terminal/create`): the daemon already spawned the PTY, so open
+/// a visible pane beside the agent and **attach** it to `process_id` (never create a second PTY).
+/// Reuses an existing terminal region when present (stacks over splits) and keeps keyboard focus on
+/// the agent.
+#[allow(clippy::too_many_arguments)]
+fn apply_acp_terminal_created(
+    mut reader: MessageReader<vmux_service::agent_events::PageAgentAcpTerminalCreated>,
+    sessions: Query<(Entity, &AcpSession)>,
+    ctx: PlacementCtx,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
+    mut commands: Commands,
+) {
+    let mut split_batch = std::collections::HashSet::new();
+    for ev in reader.read() {
+        let Some(stack) = sessions
+            .iter()
+            .find(|(_, session)| session.sid == ev.sid)
+            .map(|(entity, _)| entity)
+        else {
+            continue;
+        };
+        let Ok(agent_pane) = ctx.child_of_q.get(stack).map(|child_of| child_of.parent()) else {
+            continue;
+        };
+        let target_pane = resolve_spiral_pane(
+            &mut commands,
+            agent_pane,
+            TERMINAL_PAGE_URL,
+            false,
+            &mut split_batch,
+            &ctx,
+        );
+        let tab = commands
+            .spawn((stack_bundle(), LastActivatedAt::now(), ChildOf(target_pane)))
+            .id();
+        commands.spawn((
+            reattach_terminal_bundle(&mut meshes, &mut webview_mt, ev.process_id),
+            ChildOf(tab),
+        ));
     }
 }
 
@@ -573,7 +624,9 @@ mod tests {
     fn plugin_builds_and_runs_without_panic() {
         let mut app = App::new();
         app.add_plugins(bevy::app::TaskPoolPlugin::default())
-            .add_plugins(AcpAgentPlugin);
+            .add_plugins(AcpAgentPlugin)
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>();
         app.world_mut().spawn(AcpSession {
             agent_id: "vibe-acp".to_string(),
             sid: "s1".to_string(),

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -571,7 +571,7 @@ fn apply_acp_terminal_created(
             &ctx,
         );
         let tab = commands
-            .spawn((stack_bundle(), LastActivatedAt::now(), ChildOf(target_pane)))
+            .spawn((stack_bundle(), LastActivatedAt(0), ChildOf(target_pane)))
             .id();
         commands.spawn((
             reattach_terminal_bundle(&mut meshes, &mut webview_mt, ev.process_id),
@@ -739,6 +739,79 @@ mod tests {
         assert_eq!(
             app.world().get::<Profile>(matching).unwrap().name,
             "Antigravity"
+        );
+    }
+
+    #[test]
+    fn acp_terminal_stack_does_not_take_focus_from_agent() {
+        use vmux_layout::pane::leaf_pane_bundle;
+        use vmux_layout::stack::Stack;
+        use vmux_layout::tab::tab_bundle;
+        use vmux_service::agent_events::PageAgentAcpTerminalCreated;
+
+        let mut app = App::new();
+        app.add_message::<PageAgentAcpTerminalCreated>()
+            .add_systems(Update, apply_acp_terminal_created)
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>();
+        let tab = app.world_mut().spawn(tab_bundle()).id();
+        let pane = app
+            .world_mut()
+            .spawn((leaf_pane_bundle(), ChildOf(tab)))
+            .id();
+        let agent = app
+            .world_mut()
+            .spawn((
+                stack_bundle(),
+                LastActivatedAt(10),
+                ChildOf(pane),
+                AcpSession {
+                    agent_id: "claude".into(),
+                    sid: "s1".into(),
+                    cwd: "/tmp".into(),
+                    anchor: vmux_core::ProcessId::new(),
+                    resume: None,
+                },
+            ))
+            .id();
+        app.world_mut()
+            .entity_mut(agent)
+            .insert(vmux_core::PageMetadata {
+                url: "vmux://agent/claude".into(),
+                ..default()
+            });
+        app.world_mut().write_message(PageAgentAcpTerminalCreated {
+            sid: "s1".into(),
+            terminal_id: "terminal-1".into(),
+            process_id: vmux_core::ProcessId::new(),
+            command: "echo".into(),
+            args: vec!["hi".into()],
+            cwd: Some("/tmp".into()),
+        });
+
+        app.update();
+
+        let stack_times = {
+            let world = app.world_mut();
+            let mut query = world.query_filtered::<(Entity, &LastActivatedAt), With<Stack>>();
+            query
+                .iter(world)
+                .map(|(entity, activated)| (entity, activated.0))
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            stack_times
+                .iter()
+                .find(|(entity, _)| *entity == agent)
+                .map(|(_, activated)| *activated),
+            Some(10)
+        );
+        assert_eq!(
+            stack_times
+                .iter()
+                .find(|(entity, _)| *entity != agent)
+                .map(|(_, activated)| *activated),
+            Some(0)
         );
     }
 

--- a/crates/vmux_agent/src/client/cli/codex.rs
+++ b/crates/vmux_agent/src/client/cli/codex.rs
@@ -9,7 +9,7 @@ use crate::strategy::AgentStrategy;
 use crate::{AgentKind, AgentVariant, AssistantBlock, McpServerConfig, Message};
 
 const DISABLED_FEATURES: &[&str] = &["shell_tool", "unified_exec"];
-const DIRECT_ONLY_NAMESPACE: &str = "mcp__vmux";
+pub(crate) const DIRECT_ONLY_NAMESPACE: &str = "mcp__vmux";
 pub(crate) const RUN_STEER_PROMPT: &str = "The native shell and web search tools are disabled. Run ALL shell \
 commands via the mcp__vmux__run tool (a visible terminal the user can watch and take over). To READ \
 a file, use the mcp__vmux__read_file tool (it shows the file in a pane beside you and returns its \

--- a/crates/vmux_agent/src/client/cli/codex.rs
+++ b/crates/vmux_agent/src/client/cli/codex.rs
@@ -10,7 +10,7 @@ use crate::{AgentKind, AgentVariant, AssistantBlock, McpServerConfig, Message};
 
 const DISABLED_FEATURES: &[&str] = &["shell_tool", "unified_exec"];
 const DIRECT_ONLY_NAMESPACE: &str = "mcp__vmux";
-const RUN_STEER_PROMPT: &str = "The native shell and web search tools are disabled. Run ALL shell \
+pub(crate) const RUN_STEER_PROMPT: &str = "The native shell and web search tools are disabled. Run ALL shell \
 commands via the mcp__vmux__run tool (a visible terminal the user can watch and take over). To READ \
 a file, use the mcp__vmux__read_file tool (it shows the file in a pane beside you and returns its \
 text) - do NOT cat/sed/head/tail a file via run. To SEARCH code, use the mcp__vmux__grep tool (it \

--- a/crates/vmux_agent/src/mcp.rs
+++ b/crates/vmux_agent/src/mcp.rs
@@ -20,7 +20,7 @@ pub fn resolve_acp(
 }
 
 fn acp_uses_native_terminals(agent_id: &str) -> bool {
-    agent_id != "codex"
+    !matches!(agent_id, "claude" | "codex")
 }
 
 fn resolve_inner(
@@ -120,9 +120,10 @@ mod tests {
     }
 
     #[test]
-    fn codex_acp_keeps_vmux_terminal_tools() {
+    fn compatibility_acp_agents_keep_vmux_terminal_tools() {
         assert!(!acp_uses_native_terminals("codex"));
-        assert!(acp_uses_native_terminals("claude"));
+        assert!(!acp_uses_native_terminals("claude"));
+        assert!(acp_uses_native_terminals("vibe-acp"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/mcp.rs
+++ b/crates/vmux_agent/src/mcp.rs
@@ -9,10 +9,18 @@ pub fn resolve(cwd: &Path, anchor: ProcessId) -> Result<McpServerConfig, String>
     resolve_inner(cwd, anchor, false)
 }
 
-/// Like [`resolve`] but for ACP sessions: the sidecar serves the ACP toolset (`run` +
-/// `read_terminal` hidden in favor of ACP-native terminals; `terminal_send` kept).
-pub fn resolve_acp(cwd: &Path, anchor: ProcessId) -> Result<McpServerConfig, String> {
-    resolve_inner(cwd, anchor, true)
+/// Resolve the MCP sidecar for an ACP agent. Agents that use ACP client terminals hide the
+/// overlapping vmux terminal tools; compatibility adapters keep them available.
+pub fn resolve_acp(
+    cwd: &Path,
+    anchor: ProcessId,
+    agent_id: &str,
+) -> Result<McpServerConfig, String> {
+    resolve_inner(cwd, anchor, acp_uses_native_terminals(agent_id))
+}
+
+fn acp_uses_native_terminals(agent_id: &str) -> bool {
+    agent_id != "codex"
 }
 
 fn resolve_inner(
@@ -109,6 +117,12 @@ mod tests {
         let acp = mcp_subcommand_args(anchor, "personal", true);
         assert!(!plain.iter().any(|a| a == "--acp-terminals"));
         assert!(acp.iter().any(|a| a == "--acp-terminals"));
+    }
+
+    #[test]
+    fn codex_acp_keeps_vmux_terminal_tools() {
+        assert!(!acp_uses_native_terminals("codex"));
+        assert!(acp_uses_native_terminals("claude"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/mcp.rs
+++ b/crates/vmux_agent/src/mcp.rs
@@ -6,9 +6,23 @@ pub use vmux_core::agent::McpServerConfig;
 use crate::exec;
 
 pub fn resolve(cwd: &Path, anchor: ProcessId) -> Result<McpServerConfig, String> {
+    resolve_inner(cwd, anchor, false)
+}
+
+/// Like [`resolve`] but for ACP sessions: the sidecar serves the ACP toolset (`run` +
+/// `read_terminal` hidden in favor of ACP-native terminals; `terminal_send` kept).
+pub fn resolve_acp(cwd: &Path, anchor: ProcessId) -> Result<McpServerConfig, String> {
+    resolve_inner(cwd, anchor, true)
+}
+
+fn resolve_inner(
+    cwd: &Path,
+    anchor: ProcessId,
+    acp_terminals: bool,
+) -> Result<McpServerConfig, String> {
     let sidecar = vmux_sidecar_path()?;
     let profile = vmux_core::profile::active_profile_name();
-    resolve_with_sidecar(&sidecar, cwd, anchor, &profile)
+    resolve_with_sidecar(&sidecar, cwd, anchor, &profile, acp_terminals)
 }
 
 fn resolve_with_sidecar(
@@ -16,11 +30,12 @@ fn resolve_with_sidecar(
     cwd: &Path,
     anchor: ProcessId,
     profile: &str,
+    acp_terminals: bool,
 ) -> Result<McpServerConfig, String> {
     if exec::is_executable_path(sidecar) {
         return Ok(McpServerConfig {
             command: sidecar.to_string_lossy().to_string(),
-            args: mcp_subcommand_args(anchor, profile),
+            args: mcp_subcommand_args(anchor, profile, acp_terminals),
             cwd: None,
         });
     }
@@ -30,7 +45,7 @@ fn resolve_with_sidecar(
         .into_iter()
         .map(str::to_string)
         .collect();
-    args.extend(mcp_subcommand_args(anchor, profile));
+    args.extend(mcp_subcommand_args(anchor, profile, acp_terminals));
     Ok(McpServerConfig {
         command: "cargo".to_string(),
         args,
@@ -38,14 +53,18 @@ fn resolve_with_sidecar(
     })
 }
 
-fn mcp_subcommand_args(anchor: ProcessId, profile: &str) -> Vec<String> {
-    vec![
+fn mcp_subcommand_args(anchor: ProcessId, profile: &str, acp_terminals: bool) -> Vec<String> {
+    let mut args = vec![
         "mcp".to_string(),
         "--anchor".to_string(),
         anchor.to_string(),
         "--profile".to_string(),
         profile.to_string(),
-    ]
+    ];
+    if acp_terminals {
+        args.push("--acp-terminals".to_string());
+    }
+    args
 }
 
 fn find_workspace_dir(cwd: &Path) -> Option<PathBuf> {
@@ -75,12 +94,21 @@ mod tests {
     fn mcp_args_always_append_profile() {
         let anchor = ProcessId::new();
         for profile in ["personal", "gregor"] {
-            let args = mcp_subcommand_args(anchor, profile);
+            let args = mcp_subcommand_args(anchor, profile, false);
             assert!(
                 args.windows(2)
                     .any(|w| w[0] == "--profile" && w[1] == profile)
             );
         }
+    }
+
+    #[test]
+    fn acp_args_append_acp_terminals_flag() {
+        let anchor = ProcessId::new();
+        let plain = mcp_subcommand_args(anchor, "personal", false);
+        let acp = mcp_subcommand_args(anchor, "personal", true);
+        assert!(!plain.iter().any(|a| a == "--acp-terminals"));
+        assert!(acp.iter().any(|a| a == "--acp-terminals"));
     }
 
     #[test]
@@ -91,9 +119,14 @@ mod tests {
         std::fs::write(workspace.join("Cargo.toml"), b"[workspace]\n").unwrap();
 
         let anchor = ProcessId::new();
-        let config =
-            resolve_with_sidecar(&temp.join("missing-vmux"), &workspace, anchor, "personal")
-                .unwrap();
+        let config = resolve_with_sidecar(
+            &temp.join("missing-vmux"),
+            &workspace,
+            anchor,
+            "personal",
+            false,
+        )
+        .unwrap();
         let _ = std::fs::remove_dir_all(&temp);
 
         assert_eq!(config.command, "cargo");
@@ -125,9 +158,14 @@ mod tests {
         std::fs::write(workspace.join("Cargo.toml"), b"[workspace]\n").unwrap();
 
         let anchor = ProcessId::new();
-        let config =
-            resolve_with_sidecar(&temp.join("missing-vmux"), &workspace, anchor, "personal")
-                .unwrap();
+        let config = resolve_with_sidecar(
+            &temp.join("missing-vmux"),
+            &workspace,
+            anchor,
+            "personal",
+            false,
+        )
+        .unwrap();
         let _ = std::fs::remove_dir_all(&temp);
 
         assert!(config.args.windows(2).any(|w| w[0] == "--anchor"));

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -49,7 +49,6 @@ pub use vmux_space::cwd::{default_space_dir, space_dir, valid_cwd};
 
 const BUILTIN_AGENT_PROVIDERS: &[AgentKind] =
     &[AgentKind::Vibe, AgentKind::Claude, AgentKind::Codex];
-const AGENT_RUN_SHELL: &str = "/bin/sh";
 
 /// Per-[`AgentKind`] override for CLI executable resolution: `true` forces present, `false` forces
 /// missing, absent falls back to a real `PATH` lookup. Lets tests drive the spawn/setup-page flow
@@ -65,6 +64,7 @@ pub struct AgentTerminalRegions {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct RunTerminalCandidate {
+    terminal: Entity,
     pid: ProcessId,
     stack: Entity,
     pane: Entity,
@@ -1677,6 +1677,7 @@ fn run_terminal_candidates(
                 return None;
             }
             Some(RunTerminalCandidate {
+                terminal,
                 pid: *pid,
                 stack,
                 pane,
@@ -1745,23 +1746,26 @@ fn is_run_terminal_bucket_pane(
     candidates.iter().any(|c| c.pane == pane)
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct PendingRunTerminalSpawn {
     pid: ProcessId,
     request_index: usize,
+    shell: String,
 }
 
 fn append_pending_run_terminal_input(
     anchor: ProcessId,
     pending_spawns: &std::collections::HashMap<ProcessId, PendingRunTerminalSpawn>,
     terminal_spawns: &mut [TerminalStackSpawnRequest],
-    data: &[u8],
+    command: &str,
+    token: Option<&str>,
 ) -> Option<ProcessId> {
     let pending = pending_spawns.get(&anchor)?;
     let request = terminal_spawns.get_mut(pending.request_index)?;
+    let data = run_command_input(command, token, &pending.shell);
     match &mut request.pending_input {
         Some(input) => input.extend(data),
-        None => request.pending_input = Some(data.to_vec()),
+        None => request.pending_input = Some(data),
     }
     Some(pending.pid)
 }
@@ -1923,6 +1927,24 @@ fn run_command_input(command: &str, token: Option<&str>, shell: &str) -> Vec<u8>
     data
 }
 
+fn terminal_run_command_input(
+    command: &str,
+    token: Option<&str>,
+    launch: &TerminalLaunch,
+) -> Vec<u8> {
+    run_command_input(command, token, &launch.command)
+}
+
+fn new_run_terminal_command(
+    settings: &AppSettings,
+    command: &str,
+    token: Option<&str>,
+) -> (String, Vec<u8>) {
+    let shell = agent_terminal_shell(settings);
+    let input = run_command_input(command, token, &shell);
+    (shell, input)
+}
+
 fn run_terminal_cwd(agent_launch_cwd: Option<&str>, active_space: Option<&ActiveSpace>) -> PathBuf {
     if let Some(Ok(Some(path))) = agent_launch_cwd.map(valid_cwd) {
         return path;
@@ -2031,10 +2053,10 @@ fn handle_agent_self_commands(
                                 .flatten()
                         }) {
                             Some(launch) => {
-                                let data = run_command_input(
+                                let data = terminal_run_command_input(
                                     command,
                                     done_marker.as_deref(),
-                                    &launch.command,
+                                    launch,
                                 );
                                 service.0.send(ClientMessage::ProcessInput {
                                     process_id: *pid,
@@ -2048,8 +2070,6 @@ fn handle_agent_self_commands(
                         }
                     }
                     None => 'spawn: {
-                        let data =
-                            run_command_input(command, done_marker.as_deref(), AGENT_RUN_SHELL);
                         let Some((agent_term, self_pane)) =
                             resolve_self_pane(*anchor, &agent_terms, &ctx.child_of_q)
                         else {
@@ -2080,7 +2100,8 @@ fn handle_agent_self_commands(
                                 *anchor,
                                 &pending_run_spawns,
                                 &mut terminal_spawns,
-                                &data,
+                                command,
+                                done_marker.as_deref(),
                             )
                         {
                             break 'spawn AgentCommandResult::Text(pid.to_string());
@@ -2094,6 +2115,14 @@ fn handle_agent_self_commands(
                                 &candidates,
                             )
                         {
+                            let Ok(launch) = launch_q.get(candidate.terminal) else {
+                                break 'spawn AgentCommandResult::Error(format!(
+                                    "run terminal launch not found: {}",
+                                    candidate.pid
+                                ));
+                            };
+                            let data =
+                                terminal_run_command_input(command, done_marker.as_deref(), launch);
                             regions.run_terminals.insert(*anchor, candidate.pid);
                             regions.run_panes.insert(*anchor, candidate.pane);
                             touch_reused_run_pane_spawn_seq(
@@ -2192,10 +2221,12 @@ fn handle_agent_self_commands(
                         let agent_cwd = launch_q.get(agent_term).ok().map(|l| l.cwd.clone());
                         let cwd = run_terminal_cwd(agent_cwd.as_deref(), active_space.as_deref());
                         let request_index = terminal_spawns.len();
+                        let (shell, data) =
+                            new_run_terminal_command(&settings, command, done_marker.as_deref());
                         terminal_spawns.push(TerminalStackSpawnRequest {
                             pane: target_pane,
                             cwd: Some(cwd),
-                            shell: Some(AGENT_RUN_SHELL.to_string()),
+                            shell: Some(shell.clone()),
                             agent_run: true,
                             pending_input: Some(data),
                             process_id: Some(new_pid),
@@ -2210,6 +2241,7 @@ fn handle_agent_self_commands(
                                 PendingRunTerminalSpawn {
                                     pid: new_pid,
                                     request_index,
+                                    shell,
                                 },
                             );
                         }
@@ -4504,19 +4536,19 @@ mod tests {
         );
         // Unknown shells fall back to posix syntax.
         assert_eq!(
-            command_with_marker("/bin/bash", "ls", "abc"),
+            command_with_marker("/usr/bin/xonsh", "ls", "abc"),
             "export GIT_PAGER=cat PAGER=cat LESS=FRX; ls; __vmux_status=\"$?\"; printf '\\033]6973;abc;%s\\007' \"$__vmux_status\""
         );
     }
 
     #[test]
     fn run_command_line_noop_when_token_absent() {
-        assert_eq!(run_command_line("ls -la", None, AGENT_RUN_SHELL), "ls -la");
+        assert_eq!(run_command_line("ls -la", None, "/bin/zsh"), "ls -la");
     }
 
     #[test]
     fn run_command_line_embeds_marker_when_token_present() {
-        let out = run_command_line("ls -la", Some("tok9"), AGENT_RUN_SHELL);
+        let out = run_command_line("ls -la", Some("tok9"), "/bin/zsh");
         assert!(out.contains("ls -la"), "got: {out}");
         assert!(out.contains("]6973;tok9;"), "got: {out}");
         assert!(
@@ -4526,7 +4558,7 @@ mod tests {
     }
 
     #[test]
-    fn agent_run_uses_persistent_posix_shell_under_nushell_settings() {
+    fn new_agent_run_terminal_uses_configured_shell_for_launch_and_input() {
         let mut settings = test_settings();
         settings.terminal = Some(vmux_setting::TerminalSettings {
             default_theme: "default".to_string(),
@@ -4544,54 +4576,45 @@ mod tests {
             ..Default::default()
         });
 
-        assert_eq!(agent_terminal_shell(&settings), "/opt/homebrew/bin/nu");
-        assert_eq!(
-            run_command_line("cd /tmp", Some("tok9"), AGENT_RUN_SHELL),
-            "export GIT_PAGER=cat PAGER=cat LESS=FRX; cd /tmp; __vmux_status=\"$?\"; printf '\\033]6973;tok9;%s\\007' \"$__vmux_status\""
-        );
+        let (shell, input) = new_run_terminal_command(&settings, "cd /tmp", Some("tok9"));
+
+        assert_eq!(shell, "/opt/homebrew/bin/nu");
+        let input = String::from_utf8(input).unwrap();
+        assert!(input.contains("try { cd /tmp;"), "got: {input}");
+        assert!(input.contains("]6973;tok9;"), "got: {input}");
+        assert!(input.ends_with('\r'));
+        assert!(!input.contains("export GIT_PAGER"), "got: {input}");
     }
 
     #[test]
-    fn agent_run_terminal_spawn_requests_posix_shell() {
+    fn existing_agent_run_terminal_uses_launch_shell_for_input() {
+        let launch = TerminalLaunch {
+            command: "/usr/local/bin/fish".to_string(),
+            args: vec![],
+            cwd: String::new(),
+            env: vec![],
+            kind: vmux_terminal::launch::TerminalKind::Plain,
+        };
+
+        let input = terminal_run_command_input("pwd", Some("tok2"), &launch);
+        let input = String::from_utf8(input).unwrap();
+
+        assert!(input.contains("set __vmux_status $status"), "got: {input}");
+        assert!(input.contains("]6973;tok2;"), "got: {input}");
+        assert!(input.ends_with('\r'));
+    }
+
+    #[test]
+    fn agent_run_source_has_no_fixed_shell() {
         let source = include_str!("plugin.rs");
         let non_test_source = source
             .split("#[cfg(test)]")
             .next()
             .expect("non-test source");
 
-        assert!(
-            non_test_source.contains("shell: Some(AGENT_RUN_SHELL.to_string())")
-                && non_test_source.contains("agent_run: true"),
-            "agent run terminal spawn must pin the persistent POSIX shell"
-        );
-    }
-
-    #[test]
-    fn explicit_run_terminal_uses_its_launch_shell() {
-        let source = include_str!("plugin.rs");
-        let non_test_source = source
-            .split("#[cfg(test)]")
-            .next()
-            .expect("non-test source");
-        let handler = non_test_source
-            .split("fn handle_agent_self_commands")
-            .nth(1)
-            .expect("agent self command handler");
-        let run_handler = handler
-            .split("ServiceAgentCommand::Run {")
-            .nth(1)
-            .expect("run handler");
-        let explicit_terminal_arm = run_handler
-            .split("Some(pid) =>")
-            .nth(1)
-            .and_then(|source| source.split("None => 'spawn").next())
-            .expect("explicit terminal arm");
-
-        assert!(
-            explicit_terminal_arm.contains("run_command_input")
-                && explicit_terminal_arm.contains("&launch.command"),
-            "explicit run terminal must use its own shell marker syntax"
-        );
+        assert!(!non_test_source.contains("AGENT_RUN_SHELL"));
+        assert!(non_test_source.contains("new_run_terminal_command"));
+        assert!(non_test_source.contains("terminal_run_command_input"));
     }
 
     #[test]
@@ -4737,7 +4760,7 @@ mod tests {
             Terminal,
             ProcessId::new(),
             TerminalLaunch {
-                command: AGENT_RUN_SHELL.to_string(),
+                command: "/bin/zsh".to_string(),
                 args: vec![],
                 cwd: String::new(),
                 env: vec![],
@@ -4776,6 +4799,7 @@ mod tests {
             .id();
         let agent_pid = ProcessId::new();
         let user_pid = ProcessId::new();
+        let mut agent_terminal = None;
         for (sequence, pid, agent_run) in [(2, agent_pid, true), (3, user_pid, false)] {
             let pane = app
                 .world_mut()
@@ -4791,7 +4815,7 @@ mod tests {
                     Terminal,
                     pid,
                     TerminalLaunch {
-                        command: AGENT_RUN_SHELL.to_string(),
+                        command: "/bin/zsh".to_string(),
                         args: vec![],
                         cwd: String::new(),
                         env: vec![],
@@ -4804,6 +4828,7 @@ mod tests {
                 app.world_mut()
                     .entity_mut(terminal)
                     .insert(AgentRunTerminal);
+                agent_terminal = Some(terminal);
             }
         }
 
@@ -4813,6 +4838,7 @@ mod tests {
         let candidates = &app.world().resource::<RunTerminalCandidateOutput>().0;
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].pid, agent_pid);
+        assert_eq!(candidates[0].terminal, agent_terminal.unwrap());
     }
 
     #[derive(Resource)]
@@ -4882,7 +4908,7 @@ mod tests {
     }
 
     #[test]
-    fn pending_run_terminal_spawn_appends_same_frame_input() {
+    fn pending_run_terminal_spawn_uses_selected_shell() {
         let anchor = ProcessId::new();
         let terminal = ProcessId::new();
         let pane = Entity::from_bits(20);
@@ -4892,13 +4918,14 @@ mod tests {
             PendingRunTerminalSpawn {
                 pid: terminal,
                 request_index: 0,
+                shell: "/opt/homebrew/bin/nu".to_string(),
             },
         );
         let mut terminal_spawns = vec![TerminalStackSpawnRequest {
             pane,
             cwd: None,
-            shell: None,
-            agent_run: false,
+            shell: Some("/opt/homebrew/bin/nu".to_string()),
+            agent_run: true,
             pending_input: Some(b"one\r".to_vec()),
             process_id: Some(terminal),
             activate: false,
@@ -4908,14 +4935,15 @@ mod tests {
             anchor,
             &pending_spawns,
             &mut terminal_spawns,
-            b"two\r",
+            "pwd",
+            Some("tok2"),
         );
 
         assert_eq!(picked, Some(terminal));
-        assert_eq!(
-            terminal_spawns[0].pending_input.as_deref(),
-            Some(&b"one\rtwo\r"[..])
-        );
+        let input = String::from_utf8(terminal_spawns[0].pending_input.clone().unwrap()).unwrap();
+        assert!(input.starts_with("one\r"), "got: {input}");
+        assert!(input.contains("try { pwd;"), "got: {input}");
+        assert!(input.contains("]6973;tok2;"), "got: {input}");
         assert_eq!(terminal_spawns.len(), 1);
     }
 
@@ -5226,6 +5254,7 @@ mod tests {
         let terminal_pane = Entity::from_bits(20);
         let regions = AgentTerminalRegions::default();
         let candidates = [RunTerminalCandidate {
+            terminal: Entity::from_bits(19),
             pid: terminal,
             stack: Entity::from_bits(21),
             pane: terminal_pane,
@@ -5274,12 +5303,14 @@ mod tests {
         regions.run_panes.insert(anchor, cached_pane);
         let candidates = [
             RunTerminalCandidate {
+                terminal: Entity::from_bits(19),
                 pid: cached,
                 stack: Entity::from_bits(21),
                 pane: cached_pane,
                 pane_spawn_seq: 3,
             },
             RunTerminalCandidate {
+                terminal: Entity::from_bits(29),
                 pid: newer,
                 stack: Entity::from_bits(31),
                 pane: newer_pane,
@@ -5336,6 +5367,7 @@ mod tests {
             .id();
         app.insert_resource(ReusedRunTerminalFocusInput {
             candidate: RunTerminalCandidate {
+                terminal: Entity::from_bits(4),
                 pid: ProcessId::new(),
                 stack,
                 pane,
@@ -5359,6 +5391,7 @@ mod tests {
         let mut regions = AgentTerminalRegions::default();
         regions.run_panes.insert(anchor, terminal_pane);
         let candidates = [RunTerminalCandidate {
+            terminal: Entity::from_bits(19),
             pid: terminal,
             stack: Entity::from_bits(21),
             pane: terminal_pane,

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -25,8 +25,8 @@ use vmux_setting::AppSettings;
 use vmux_space::ActiveSpace;
 use vmux_terminal::launch::TerminalLaunch;
 use vmux_terminal::{
-    AgentRunTerminal, AwaitingProcessCreated, ProcessExited, ServiceMessageSet, Terminal,
-    TerminalGridSize, TerminalStackSpawnRequest, new_terminal_bundle_with_cwd,
+    AgentRunTerminal, ProcessExited, ServiceMessageSet, Terminal, TerminalGridSize,
+    TerminalStackSpawnRequest, new_terminal_bundle_with_cwd,
 };
 
 use crate::AgentVariant;
@@ -1936,6 +1936,23 @@ fn terminal_run_command_input(
     run_command_input(command, token, &launch.command)
 }
 
+fn explicit_run_terminal_launch(
+    process_id: ProcessId,
+    terminals: &Query<(Entity, &ProcessId), With<Terminal>>,
+    launches: &Query<&TerminalLaunch>,
+) -> Result<TerminalLaunch, String> {
+    let Some(entity) = terminals
+        .iter()
+        .find_map(|(entity, candidate)| (*candidate == process_id).then_some(entity))
+    else {
+        return Err(format!("run.terminal page not found: {process_id}"));
+    };
+    launches
+        .get(entity)
+        .cloned()
+        .map_err(|_| format!("run terminal launch not found: {process_id}"))
+}
+
 fn queue_terminal_run_command_input(
     writer: &mut MessageWriter<vmux_terminal::TerminalReinputRequest>,
     process_id: ProcessId,
@@ -1957,6 +1974,16 @@ fn new_run_terminal_command(
     let shell = agent_terminal_shell(settings);
     let input = run_command_input(command, token, &shell);
     (shell, input)
+}
+
+fn validate_agent_terminal_shell(shell: &str) -> Result<(), String> {
+    if crate::exec::find_executable(shell).is_some() {
+        Ok(())
+    } else {
+        Err(format!(
+            "terminal shell not found or not executable: {shell}"
+        ))
+    }
 }
 
 fn run_terminal_cwd(agent_launch_cwd: Option<&str>, active_space: Option<&ActiveSpace>) -> PathBuf {
@@ -2066,27 +2093,19 @@ fn handle_agent_self_commands(
                 }
                 let focus = requested_focus_for_origin(&request.origin, *focus);
                 match terminal {
-                    Some(pid) => {
-                        match term_pids.iter().find_map(|(entity, candidate_pid)| {
-                            (*candidate_pid == *pid)
-                                .then(|| launch_q.get(entity).ok())
-                                .flatten()
-                        }) {
-                            Some(launch) => {
-                                queue_terminal_run_command_input(
-                                    &mut writers.terminal_reinput,
-                                    *pid,
-                                    command,
-                                    done_marker.as_deref(),
-                                    launch,
-                                );
-                                AgentCommandResult::Text(pid.to_string())
-                            }
-                            None => AgentCommandResult::Error(format!(
-                                "run.terminal page not found: {pid}"
-                            )),
+                    Some(pid) => match explicit_run_terminal_launch(*pid, &term_pids, &launch_q) {
+                        Ok(launch) => {
+                            queue_terminal_run_command_input(
+                                &mut writers.terminal_reinput,
+                                *pid,
+                                command,
+                                done_marker.as_deref(),
+                                &launch,
+                            );
+                            AgentCommandResult::Text(pid.to_string())
                         }
-                    }
+                        Err(error) => AgentCommandResult::Error(error),
+                    },
                     None => 'spawn: {
                         let Some((agent_term, self_pane)) =
                             resolve_self_pane(*anchor, &agent_terms, &ctx.child_of_q)
@@ -2178,6 +2197,11 @@ fn handle_agent_self_commands(
                             }
                             None => None,
                         };
+                        let (shell, data) =
+                            new_run_terminal_command(&settings, command, done_marker.as_deref());
+                        if let Err(error) = validate_agent_terminal_shell(&shell) {
+                            break 'spawn AgentCommandResult::Error(error);
+                        }
                         use vmux_service::protocol::PlacementMode;
                         let target_pane = match (beside_pane, *mode) {
                             (anchor_pane, PlacementMode::Split) => {
@@ -2240,8 +2264,6 @@ fn handle_agent_self_commands(
                         let agent_cwd = launch_q.get(agent_term).ok().map(|l| l.cwd.clone());
                         let cwd = run_terminal_cwd(agent_cwd.as_deref(), active_space.as_deref());
                         let request_index = terminal_spawns.len();
-                        let (shell, data) =
-                            new_run_terminal_command(&settings, command, done_marker.as_deref());
                         terminal_spawns.push(TerminalStackSpawnRequest {
                             pane: target_pane,
                             cwd: Some(cwd),
@@ -3498,7 +3520,7 @@ fn handle_restart_agent_pty(
         });
 
         *pid = new_id;
-        commands.entity(msg.entity).insert(AwaitingProcessCreated);
+        vmux_terminal::plugin::mark_terminal_restarting(&mut commands, msg.entity);
         if let Some(l) = launch.as_mut() {
             l.args = args;
             l.env = env;
@@ -4606,6 +4628,18 @@ mod tests {
     }
 
     #[test]
+    fn new_agent_run_terminal_rejects_missing_configured_shell() {
+        let shell = "/definitely/missing/vmux-terminal-shell";
+
+        assert_eq!(
+            validate_agent_terminal_shell(shell),
+            Err(format!(
+                "terminal shell not found or not executable: {shell}"
+            ))
+        );
+    }
+
+    #[test]
     fn existing_agent_run_terminal_uses_launch_shell_for_input() {
         let launch = TerminalLaunch {
             command: "/usr/local/bin/fish".to_string(),
@@ -4621,6 +4655,40 @@ mod tests {
         assert!(input.contains("set __vmux_status $status"), "got: {input}");
         assert!(input.contains("]6973;tok2;"), "got: {input}");
         assert!(input.ends_with('\r'));
+    }
+
+    #[test]
+    fn explicit_run_terminal_errors_distinguish_missing_page_and_launch() {
+        use bevy::ecs::system::RunSystemOnce;
+
+        let mut app = App::new();
+        let terminal_pid = ProcessId::new();
+        let missing_pid = ProcessId::new();
+        app.world_mut().spawn((Terminal, terminal_pid));
+
+        let (missing_page, missing_launch) = app
+            .world_mut()
+            .run_system_once(
+                move |terminals: Query<(Entity, &ProcessId), With<Terminal>>,
+                      launches: Query<&TerminalLaunch>| {
+                    (
+                        explicit_run_terminal_launch(missing_pid, &terminals, &launches)
+                            .unwrap_err(),
+                        explicit_run_terminal_launch(terminal_pid, &terminals, &launches)
+                            .unwrap_err(),
+                    )
+                },
+            )
+            .unwrap();
+
+        assert_eq!(
+            missing_page,
+            format!("run.terminal page not found: {missing_pid}")
+        );
+        assert_eq!(
+            missing_launch,
+            format!("run terminal launch not found: {terminal_pid}")
+        );
     }
 
     #[test]

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -1935,6 +1935,19 @@ fn terminal_run_command_input(
     run_command_input(command, token, &launch.command)
 }
 
+fn queue_terminal_run_command_input(
+    writer: &mut MessageWriter<vmux_terminal::TerminalReinputRequest>,
+    process_id: ProcessId,
+    command: &str,
+    token: Option<&str>,
+    launch: &TerminalLaunch,
+) {
+    writer.write(vmux_terminal::TerminalReinputRequest {
+        process_id,
+        data: terminal_run_command_input(command, token, launch),
+    });
+}
+
 fn new_run_terminal_command(
     settings: &AppSettings,
     command: &str,
@@ -1954,6 +1967,13 @@ fn run_terminal_cwd(agent_launch_cwd: Option<&str>, active_space: Option<&Active
         .unwrap_or_else(default_space_dir)
 }
 
+#[derive(bevy::ecs::system::SystemParam)]
+struct AgentSelfCommandWriters<'w> {
+    open_beside: MessageWriter<'w, vmux_layout::OpenBesideRequest>,
+    terminal_stack_spawn: MessageWriter<'w, TerminalStackSpawnRequest>,
+    terminal_reinput: MessageWriter<'w, vmux_terminal::TerminalReinputRequest>,
+}
+
 #[allow(clippy::too_many_arguments)]
 fn handle_agent_self_commands(
     mut reader: MessageReader<AgentCommandRequest>,
@@ -1969,8 +1989,7 @@ fn handle_agent_self_commands(
     >,
     launch_q: Query<&TerminalLaunch>,
     ctx: vmux_layout::pane::PlacementCtx,
-    mut open_beside_writer: MessageWriter<vmux_layout::OpenBesideRequest>,
-    mut terminal_stack_spawn_writer: MessageWriter<TerminalStackSpawnRequest>,
+    mut writers: AgentSelfCommandWriters,
     mut commands: Commands,
     service: Option<Res<ServiceClient>>,
     active_space: Option<Res<ActiveSpace>>,
@@ -2005,7 +2024,7 @@ fn handle_agent_self_commands(
                 None => AgentCommandResult::Error("self process not found".to_string()),
                 Some((_, pane)) => {
                     let focus = requested_focus_for_origin(&request.origin, *focus);
-                    open_beside_writer.write(vmux_layout::OpenBesideRequest {
+                    writers.open_beside.write(vmux_layout::OpenBesideRequest {
                         pane,
                         direction: direction.as_ref().map(to_pane_direction),
                         url: url.clone(),
@@ -2053,15 +2072,13 @@ fn handle_agent_self_commands(
                                 .flatten()
                         }) {
                             Some(launch) => {
-                                let data = terminal_run_command_input(
+                                queue_terminal_run_command_input(
+                                    &mut writers.terminal_reinput,
+                                    *pid,
                                     command,
                                     done_marker.as_deref(),
                                     launch,
                                 );
-                                service.0.send(ClientMessage::ProcessInput {
-                                    process_id: *pid,
-                                    data,
-                                });
                                 AgentCommandResult::Text(pid.to_string())
                             }
                             None => AgentCommandResult::Error(format!(
@@ -2121,8 +2138,13 @@ fn handle_agent_self_commands(
                                     candidate.pid
                                 ));
                             };
-                            let data =
-                                terminal_run_command_input(command, done_marker.as_deref(), launch);
+                            queue_terminal_run_command_input(
+                                &mut writers.terminal_reinput,
+                                candidate.pid,
+                                command,
+                                done_marker.as_deref(),
+                                launch,
+                            );
                             regions.run_terminals.insert(*anchor, candidate.pid);
                             regions.run_panes.insert(*anchor, candidate.pane);
                             touch_reused_run_pane_spawn_seq(
@@ -2139,10 +2161,6 @@ fn handle_agent_self_commands(
                                     &ctx.tab_q,
                                 );
                             }
-                            service.0.send(ClientMessage::ProcessInput {
-                                process_id: candidate.pid,
-                                data,
-                            });
                             break 'spawn AgentCommandResult::Text(candidate.pid.to_string());
                         }
                         // Resolve an explicit `beside` anchor up front (errors if stale).
@@ -2326,7 +2344,7 @@ fn handle_agent_self_commands(
         });
     }
     for spawn in terminal_spawns {
-        terminal_stack_spawn_writer.write(spawn);
+        writers.terminal_stack_spawn.write(spawn);
     }
 }
 
@@ -4605,16 +4623,63 @@ mod tests {
     }
 
     #[test]
-    fn agent_run_source_has_no_fixed_shell() {
-        let source = include_str!("plugin.rs");
-        let non_test_source = source
-            .split("#[cfg(test)]")
-            .next()
-            .expect("non-test source");
+    fn existing_agent_run_terminal_routes_input_through_terminal_queue() {
+        #[derive(Resource)]
+        struct Input {
+            process_id: ProcessId,
+            launch: TerminalLaunch,
+        }
 
-        assert!(!non_test_source.contains("AGENT_RUN_SHELL"));
-        assert!(non_test_source.contains("new_run_terminal_command"));
-        assert!(non_test_source.contains("terminal_run_command_input"));
+        #[derive(Resource, Default)]
+        struct Captured(Vec<vmux_terminal::TerminalReinputRequest>);
+
+        fn emit(
+            input: Res<Input>,
+            mut writer: MessageWriter<vmux_terminal::TerminalReinputRequest>,
+        ) {
+            queue_terminal_run_command_input(
+                &mut writer,
+                input.process_id,
+                "pwd",
+                Some("tok4"),
+                &input.launch,
+            );
+        }
+
+        fn capture(
+            mut reader: MessageReader<vmux_terminal::TerminalReinputRequest>,
+            mut captured: ResMut<Captured>,
+        ) {
+            captured.0.extend(reader.read().cloned());
+        }
+
+        let process_id = ProcessId::new();
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<vmux_terminal::TerminalReinputRequest>()
+            .insert_resource(Input {
+                process_id,
+                launch: TerminalLaunch {
+                    command: "/usr/local/bin/fish".to_string(),
+                    args: vec![],
+                    cwd: String::new(),
+                    env: vec![],
+                    kind: vmux_terminal::launch::TerminalKind::Plain,
+                },
+            })
+            .init_resource::<Captured>()
+            .add_systems(Update, (emit, capture).chain());
+
+        app.update();
+
+        let captured = &app.world().resource::<Captured>().0;
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].process_id, process_id);
+        let input = String::from_utf8(captured[0].data.clone()).unwrap();
+
+        assert!(input.contains("set __vmux_status $status"), "got: {input}");
+        assert!(input.contains("]6973;tok4;"), "got: {input}");
+        assert!(input.ends_with('\r'));
     }
 
     #[test]

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -190,6 +190,7 @@ impl Plugin for AgentPlugin {
             .add_message::<PageAgentSpawnDefaultRequest>()
             .add_message::<PageAgentAttachDefaultRequest>()
             .add_message::<TerminalStackSpawnRequest>()
+            .add_message::<vmux_terminal::TerminalReinputRequest>()
             .add_message::<ProcessStackSpawnRequest>()
             .add_message::<RestartAgentPty>()
             .add_message::<vmux_core::agent::SwapStackSession>()

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -283,7 +283,7 @@ impl Plugin for AgentPlugin {
                     handle_rename_profile_requests.after(handle_agent_commands),
                     respond_process_stack_spawn.after(handle_agent_commands),
                     handle_agent_page_open.in_set(PageOpenSet::HandleKnownPages),
-                    handle_restart_agent_pty,
+                    handle_restart_agent_pty.before(ServiceMessageSet),
                     respond_page_agent_attach,
                     respond_page_agent_spawn_stack,
                     respond_page_agent_spawn_default,
@@ -4845,6 +4845,20 @@ mod tests {
             non_test_source[start..]
                 .contains(".before(vmux_terminal::plugin::respond_terminal_stack_spawn)"),
             "run terminal spawn requests must materialize before the next agent command frame"
+        );
+    }
+
+    #[test]
+    fn agent_restart_runs_before_terminal_service_messages() {
+        let source = include_str!("plugin.rs");
+        let non_test_source = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("non-test source");
+
+        assert!(
+            non_test_source.contains("handle_restart_agent_pty.before(ServiceMessageSet)"),
+            "restart state commands must apply before terminal input flush"
         );
     }
 

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -25,8 +25,8 @@ use vmux_setting::AppSettings;
 use vmux_space::ActiveSpace;
 use vmux_terminal::launch::TerminalLaunch;
 use vmux_terminal::{
-    AwaitingProcessCreated, ProcessExited, ServiceMessageSet, Terminal, TerminalGridSize,
-    TerminalStackSpawnRequest, new_terminal_bundle_with_cwd,
+    AgentRunTerminal, AwaitingProcessCreated, ProcessExited, ServiceMessageSet, Terminal,
+    TerminalGridSize, TerminalStackSpawnRequest, new_terminal_bundle_with_cwd,
 };
 
 use crate::AgentVariant;
@@ -49,6 +49,7 @@ pub use vmux_space::cwd::{default_space_dir, space_dir, valid_cwd};
 
 const BUILTIN_AGENT_PROVIDERS: &[AgentKind] =
     &[AgentKind::Vibe, AgentKind::Claude, AgentKind::Codex];
+const AGENT_RUN_SHELL: &str = "/bin/sh";
 
 /// Per-[`AgentKind`] override for CLI executable resolution: `true` forces present, `false` forces
 /// missing, absent falls back to a real `PATH` lookup. Lets tests drive the spawn/setup-page flow
@@ -1399,6 +1400,8 @@ fn handle_agent_commands(
                             terminal_stack_spawn_writer.write(TerminalStackSpawnRequest {
                                 pane,
                                 cwd: Some(cwd_path),
+                                shell: None,
+                                agent_run: false,
                                 pending_input: None,
                                 process_id: None,
                                 activate,
@@ -1644,7 +1647,7 @@ fn tab_of_run_pane(
 fn run_terminal_candidates(
     agent_pane: Entity,
     terminals: &Query<
-        (Entity, &ProcessId),
+        (Entity, &ProcessId, Has<AgentRunTerminal>),
         (
             With<Terminal>,
             Without<AgentSession>,
@@ -1661,7 +1664,10 @@ fn run_terminal_candidates(
     };
     terminals
         .iter()
-        .filter_map(|(terminal, pid)| {
+        .filter_map(|(terminal, pid, agent_run)| {
+            if !agent_run {
+                return None;
+            }
             let stack = child_of_q.get(terminal).ok()?.get();
             let pane = child_of_q.get(stack).ok()?.get();
             if pane == agent_pane {
@@ -1890,9 +1896,9 @@ fn pager_env_prefix(base: &str) -> &'static str {
     }
 }
 
-fn run_command_line(command: &str, token: Option<&str>, settings: &AppSettings) -> String {
+fn run_command_line(command: &str, token: Option<&str>, shell: &str) -> String {
     match token {
-        Some(token) => command_with_marker(&agent_terminal_shell(settings), command, token),
+        Some(token) => command_with_marker(shell, command, token),
         None => command.to_string(),
     }
 }
@@ -1911,6 +1917,12 @@ fn validate_run_placement_policy(
     }
 }
 
+fn run_command_input(command: &str, token: Option<&str>, shell: &str) -> Vec<u8> {
+    let mut data = run_command_line(command, token, shell).into_bytes();
+    data.push(b'\r');
+    data
+}
+
 fn run_terminal_cwd(agent_launch_cwd: Option<&str>, active_space: Option<&ActiveSpace>) -> PathBuf {
     if let Some(Ok(Some(path))) = agent_launch_cwd.map(valid_cwd) {
         return path;
@@ -1926,7 +1938,7 @@ fn handle_agent_self_commands(
     agent_terms: Query<(Entity, &ProcessId, &ChildOf)>,
     term_pids: Query<(Entity, &ProcessId), With<Terminal>>,
     run_terms: Query<
-        (Entity, &ProcessId),
+        (Entity, &ProcessId, Has<AgentRunTerminal>),
         (
             With<Terminal>,
             Without<AgentSession>,
@@ -2011,18 +2023,33 @@ fn handle_agent_self_commands(
                     break 'run AgentCommandResult::Error(error.to_string());
                 }
                 let focus = requested_focus_for_origin(&request.origin, *focus);
-                let mut data =
-                    run_command_line(command, done_marker.as_deref(), &settings).into_bytes();
-                data.push(b'\r');
                 match terminal {
                     Some(pid) => {
-                        service.0.send(ClientMessage::ProcessInput {
-                            process_id: *pid,
-                            data,
-                        });
-                        AgentCommandResult::Text(pid.to_string())
+                        match term_pids.iter().find_map(|(entity, candidate_pid)| {
+                            (*candidate_pid == *pid)
+                                .then(|| launch_q.get(entity).ok())
+                                .flatten()
+                        }) {
+                            Some(launch) => {
+                                let data = run_command_input(
+                                    command,
+                                    done_marker.as_deref(),
+                                    &launch.command,
+                                );
+                                service.0.send(ClientMessage::ProcessInput {
+                                    process_id: *pid,
+                                    data,
+                                });
+                                AgentCommandResult::Text(pid.to_string())
+                            }
+                            None => AgentCommandResult::Error(format!(
+                                "run.terminal page not found: {pid}"
+                            )),
+                        }
                     }
                     None => 'spawn: {
+                        let data =
+                            run_command_input(command, done_marker.as_deref(), AGENT_RUN_SHELL);
                         let Some((agent_term, self_pane)) =
                             resolve_self_pane(*anchor, &agent_terms, &ctx.child_of_q)
                         else {
@@ -2168,6 +2195,8 @@ fn handle_agent_self_commands(
                         terminal_spawns.push(TerminalStackSpawnRequest {
                             pane: target_pane,
                             cwd: Some(cwd),
+                            shell: Some(AGENT_RUN_SHELL.to_string()),
+                            agent_run: true,
                             pending_input: Some(data),
                             process_id: Some(new_pid),
                             activate: focus,
@@ -4482,19 +4511,86 @@ mod tests {
 
     #[test]
     fn run_command_line_noop_when_token_absent() {
-        let settings = test_settings();
-        assert_eq!(run_command_line("ls -la", None, &settings), "ls -la");
+        assert_eq!(run_command_line("ls -la", None, AGENT_RUN_SHELL), "ls -la");
     }
 
     #[test]
     fn run_command_line_embeds_marker_when_token_present() {
-        let settings = test_settings();
-        let out = run_command_line("ls -la", Some("tok9"), &settings);
+        let out = run_command_line("ls -la", Some("tok9"), AGENT_RUN_SHELL);
         assert!(out.contains("ls -la"), "got: {out}");
         assert!(out.contains("]6973;tok9;"), "got: {out}");
         assert!(
             !out.contains("__VMUX_DONE_"),
             "marker must be invisible: {out}"
+        );
+    }
+
+    #[test]
+    fn agent_run_uses_persistent_posix_shell_under_nushell_settings() {
+        let mut settings = test_settings();
+        settings.terminal = Some(vmux_setting::TerminalSettings {
+            default_theme: "default".to_string(),
+            themes: vec![vmux_setting::TerminalTheme {
+                name: "default".to_string(),
+                color_scheme: "catppuccin-mocha".to_string(),
+                font_family: "JetBrainsMono Nerd Font".to_string(),
+                font_size: 14.0,
+                line_height: 1.2,
+                padding: 4.0,
+                cursor_style: "block".to_string(),
+                cursor_blink: true,
+                shell: "/opt/homebrew/bin/nu".to_string(),
+            }],
+            ..Default::default()
+        });
+
+        assert_eq!(agent_terminal_shell(&settings), "/opt/homebrew/bin/nu");
+        assert_eq!(
+            run_command_line("cd /tmp", Some("tok9"), AGENT_RUN_SHELL),
+            "export GIT_PAGER=cat PAGER=cat LESS=FRX; cd /tmp; __vmux_status=\"$?\"; printf '\\033]6973;tok9;%s\\007' \"$__vmux_status\""
+        );
+    }
+
+    #[test]
+    fn agent_run_terminal_spawn_requests_posix_shell() {
+        let source = include_str!("plugin.rs");
+        let non_test_source = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("non-test source");
+
+        assert!(
+            non_test_source.contains("shell: Some(AGENT_RUN_SHELL.to_string())")
+                && non_test_source.contains("agent_run: true"),
+            "agent run terminal spawn must pin the persistent POSIX shell"
+        );
+    }
+
+    #[test]
+    fn explicit_run_terminal_uses_its_launch_shell() {
+        let source = include_str!("plugin.rs");
+        let non_test_source = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("non-test source");
+        let handler = non_test_source
+            .split("fn handle_agent_self_commands")
+            .nth(1)
+            .expect("agent self command handler");
+        let run_handler = handler
+            .split("ServiceAgentCommand::Run {")
+            .nth(1)
+            .expect("run handler");
+        let explicit_terminal_arm = run_handler
+            .split("Some(pid) =>")
+            .nth(1)
+            .and_then(|source| source.split("None => 'spawn").next())
+            .expect("explicit terminal arm");
+
+        assert!(
+            explicit_terminal_arm.contains("run_command_input")
+                && explicit_terminal_arm.contains("&launch.command"),
+            "explicit run terminal must use its own shell marker syntax"
         );
     }
 
@@ -4606,7 +4702,7 @@ mod tests {
     fn collect_run_terminal_candidates(
         input: Res<RunTerminalCandidateInput>,
         terminals: Query<
-            (Entity, &ProcessId),
+            (Entity, &ProcessId, Has<AgentRunTerminal>),
             (
                 With<Terminal>,
                 Without<AgentSession>,
@@ -4637,8 +4733,18 @@ mod tests {
             .world_mut()
             .spawn((vmux_layout::stack::stack_bundle(), ChildOf(terminal_pane)))
             .id();
-        app.world_mut()
-            .spawn((Terminal, ProcessId::new(), ChildOf(stack)));
+        app.world_mut().spawn((
+            Terminal,
+            ProcessId::new(),
+            TerminalLaunch {
+                command: AGENT_RUN_SHELL.to_string(),
+                args: vec![],
+                cwd: String::new(),
+                env: vec![],
+                kind: vmux_terminal::launch::TerminalKind::Plain,
+            },
+            ChildOf(stack),
+        ));
         let agent_pane = app
             .world_mut()
             .spawn((Pane, vmux_layout::pane::SpawnSeq(9)))
@@ -4654,6 +4760,59 @@ mod tests {
                 .is_empty(),
             "unresolved agent tab must not match terminals from other tabs"
         );
+    }
+
+    #[test]
+    fn run_terminal_candidates_require_agent_run_marker() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<RunTerminalCandidateOutput>()
+            .add_systems(Update, collect_run_terminal_candidates);
+
+        let tab = app.world_mut().spawn(vmux_layout::tab::Tab::default()).id();
+        let agent_pane = app
+            .world_mut()
+            .spawn((Pane, vmux_layout::pane::SpawnSeq(1), ChildOf(tab)))
+            .id();
+        let agent_pid = ProcessId::new();
+        let user_pid = ProcessId::new();
+        for (sequence, pid, agent_run) in [(2, agent_pid, true), (3, user_pid, false)] {
+            let pane = app
+                .world_mut()
+                .spawn((Pane, vmux_layout::pane::SpawnSeq(sequence), ChildOf(tab)))
+                .id();
+            let stack = app
+                .world_mut()
+                .spawn((vmux_layout::stack::stack_bundle(), ChildOf(pane)))
+                .id();
+            let terminal = app
+                .world_mut()
+                .spawn((
+                    Terminal,
+                    pid,
+                    TerminalLaunch {
+                        command: AGENT_RUN_SHELL.to_string(),
+                        args: vec![],
+                        cwd: String::new(),
+                        env: vec![],
+                        kind: vmux_terminal::launch::TerminalKind::Plain,
+                    },
+                    ChildOf(stack),
+                ))
+                .id();
+            if agent_run {
+                app.world_mut()
+                    .entity_mut(terminal)
+                    .insert(AgentRunTerminal);
+            }
+        }
+
+        app.insert_resource(RunTerminalCandidateInput { agent_pane });
+        app.update();
+
+        let candidates = &app.world().resource::<RunTerminalCandidateOutput>().0;
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].pid, agent_pid);
     }
 
     #[derive(Resource)]
@@ -4738,6 +4897,8 @@ mod tests {
         let mut terminal_spawns = vec![TerminalStackSpawnRequest {
             pane,
             cwd: None,
+            shell: None,
+            agent_run: false,
             pending_input: Some(b"one\r".to_vec()),
             process_id: Some(terminal),
             activate: false,

--- a/crates/vmux_agent/src/vibe/setup.rs
+++ b/crates/vmux_agent/src/vibe/setup.rs
@@ -209,6 +209,8 @@ fn on_agent_install_run(
     spawn.write(vmux_terminal::TerminalStackSpawnRequest {
         pane: install_pane,
         cwd: None,
+        shell: None,
+        agent_run: false,
         pending_input: Some(input),
         process_id: Some(process_id),
         activate: true,

--- a/crates/vmux_cli/src/commands.rs
+++ b/crates/vmux_cli/src/commands.rs
@@ -21,6 +21,10 @@ pub enum Command {
         anchor: Option<String>,
         #[arg(long)]
         profile: Option<String>,
+        /// Serve the ACP toolset: hide `run` + `read_terminal` (ACP sessions use ACP-native
+        /// terminals instead); `terminal_send` stays.
+        #[arg(long)]
+        acp_terminals: bool,
     },
     Notify {
         #[arg(long)]

--- a/crates/vmux_cli/src/commands/mcp.rs
+++ b/crates/vmux_cli/src/commands/mcp.rs
@@ -1,6 +1,10 @@
 use std::io;
 
-pub async fn run(anchor: Option<String>, profile: Option<String>) -> io::Result<()> {
+pub async fn run(
+    anchor: Option<String>,
+    profile: Option<String>,
+    acp_terminals: bool,
+) -> io::Result<()> {
     if let Some(p) = profile
         .map(|p| p.trim().to_string())
         .filter(|p| !p.is_empty())
@@ -8,5 +12,5 @@ pub async fn run(anchor: Option<String>, profile: Option<String>) -> io::Result<
         unsafe { std::env::set_var("VMUX_PROFILE", p) };
     }
     let anchor = anchor.and_then(|s| s.parse::<vmux_service::protocol::ProcessId>().ok());
-    vmux_mcp::protocol::run_stdio(anchor).await
+    vmux_mcp::protocol::run_stdio(anchor, acp_terminals).await
 }

--- a/crates/vmux_cli/src/main.rs
+++ b/crates/vmux_cli/src/main.rs
@@ -11,7 +11,11 @@ use commands::{Cli, Command, open::OpenAppLauncher};
 async fn main() -> std::io::Result<()> {
     let cli = Cli::parse();
     match cli.command {
-        Some(Command::Mcp { anchor, profile }) => commands::mcp::run(anchor, profile).await,
+        Some(Command::Mcp {
+            anchor,
+            profile,
+            acp_terminals,
+        }) => commands::mcp::run(anchor, profile, acp_terminals).await,
         Some(Command::Notify {
             title,
             body,

--- a/crates/vmux_mcp/src/protocol.rs
+++ b/crates/vmux_mcp/src/protocol.rs
@@ -23,14 +23,17 @@ pub fn read_json_line(reader: &mut impl BufRead) -> io::Result<Option<Value>> {
     Ok(Some(value))
 }
 
-pub async fn run_stdio(anchor: Option<vmux_service::protocol::ProcessId>) -> io::Result<()> {
+pub async fn run_stdio(
+    anchor: Option<vmux_service::protocol::ProcessId>,
+    acp_terminals: bool,
+) -> io::Result<()> {
     let stdin = io::stdin();
     let mut reader = stdin.lock();
     let stdout = io::stdout();
     let mut writer = stdout.lock();
 
     while let Some(message) = read_json_line(&mut reader)? {
-        if let Some(response) = handle_message(message, anchor).await {
+        if let Some(response) = handle_message(message, anchor, acp_terminals).await {
             serde_json::to_writer(&mut writer, &response)?;
             writer.write_all(b"\n")?;
             writer.flush()?;
@@ -42,6 +45,7 @@ pub async fn run_stdio(anchor: Option<vmux_service::protocol::ProcessId>) -> io:
 async fn handle_message(
     message: Value,
     anchor: Option<vmux_service::protocol::ProcessId>,
+    acp_terminals: bool,
 ) -> Option<Value> {
     let id = message.get("id").cloned()?;
     let method = message.get("method").and_then(Value::as_str).unwrap_or("");
@@ -49,7 +53,9 @@ async fn handle_message(
 
     let result = match method {
         "initialize" => Ok(initialize_result(&params)),
-        "tools/list" => Ok(json!({ "tools": crate::tools::tool_definitions() })),
+        "tools/list" => {
+            Ok(json!({ "tools": crate::tools::tool_definitions_filtered(acp_terminals) }))
+        }
         "tools/call" => tool_call_result(&params, anchor).await,
         _ => {
             return Some(json!({

--- a/crates/vmux_mcp/src/protocol.rs
+++ b/crates/vmux_mcp/src/protocol.rs
@@ -56,7 +56,7 @@ async fn handle_message(
         "tools/list" => {
             Ok(json!({ "tools": crate::tools::tool_definitions_filtered(acp_terminals) }))
         }
-        "tools/call" => tool_call_result(&params, anchor).await,
+        "tools/call" => tool_call_result(&params, anchor, acp_terminals).await,
         _ => {
             return Some(json!({
                 "jsonrpc": "2.0",
@@ -103,11 +103,15 @@ fn initialize_result(params: &Value) -> Value {
 async fn tool_call_result(
     params: &Value,
     anchor: Option<vmux_service::protocol::ProcessId>,
+    acp_terminals: bool,
 ) -> Result<Value, String> {
     let name = params
         .get("name")
         .and_then(Value::as_str)
         .ok_or_else(|| "tools/call missing name".to_string())?;
+    if acp_terminals && matches!(name, "run" | "read_terminal") {
+        return Err(format!("tool {name} is unavailable for ACP sessions"));
+    }
     let arguments = params
         .get("arguments")
         .cloned()
@@ -759,6 +763,30 @@ mod tests {
         let request = read_json_line(&mut lines).unwrap().unwrap();
 
         assert_eq!(request["method"], "tools/list");
+    }
+
+    #[tokio::test]
+    async fn acp_tools_call_rejects_hidden_terminal_tools() {
+        for name in ["run", "read_terminal"] {
+            let response = handle_message(
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tools/call",
+                    "params": { "name": name, "arguments": {} }
+                }),
+                None,
+                true,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(response["result"]["isError"], true);
+            assert_eq!(
+                response["result"]["content"][0]["text"],
+                format!("tool {name} is unavailable for ACP sessions")
+            );
+        }
     }
 
     #[test]

--- a/crates/vmux_mcp/src/protocol.rs
+++ b/crates/vmux_mcp/src/protocol.rs
@@ -9,6 +9,7 @@ use vmux_service::protocol::{
 /// How long `run` waits for a command to finish before returning a partial
 /// result. Kept under vibe's 60s default MCP tool timeout.
 const RUN_BLOCK_TIMEOUT: Duration = Duration::from_secs(50);
+const RUN_PROCESS_MATERIALIZE_TIMEOUT: Duration = Duration::from_secs(2);
 /// Interval between terminal reads while waiting for the completion marker.
 const RUN_POLL_INTERVAL: Duration = Duration::from_millis(200);
 
@@ -416,6 +417,30 @@ fn run_result(pid: &str, exit: Option<i32>, output: &str, timed_out: bool) -> Va
     json!({ "content": [{"type": "text", "text": text}] })
 }
 
+fn run_completion_exit(
+    result: AgentQueryResult,
+    token: &str,
+    process_id: vmux_service::protocol::ProcessId,
+    allow_missing_process: bool,
+) -> Result<Option<i32>, String> {
+    match result {
+        AgentQueryResult::RunCompletion {
+            token: Some(done_token),
+            exit: Some(exit),
+        } if done_token == token => Ok(Some(exit)),
+        AgentQueryResult::RunCompletion { .. } => Ok(None),
+        AgentQueryResult::Error(message)
+            if allow_missing_process && message == format!("process not found: {process_id}") =>
+        {
+            Ok(None)
+        }
+        AgentQueryResult::Error(message) => Err(message),
+        other => Err(format!(
+            "run: unexpected run-completion result for {process_id}: {other:?}"
+        )),
+    }
+}
+
 /// Send `run`, then block (polling `RunCompletion`) until the invisible OSC
 /// completion escape for this run's token is seen, returning the output + exit
 /// code in one response.
@@ -468,19 +493,18 @@ async fn run_blocking(run: AgentCommand) -> Result<Value, String> {
     let start = Instant::now();
     let baseline_text = read_full_text(&connection, process_id).await;
     let deadline = start + RUN_BLOCK_TIMEOUT;
+    let materialize_deadline = start + RUN_PROCESS_MATERIALIZE_TIMEOUT;
+    let mut process_materialized = false;
     loop {
-        match agent_query(&connection, AgentQuery::RunCompletion { process_id }).await? {
-            AgentQueryResult::RunCompletion {
-                token: Some(done_token),
-                exit: Some(exit),
-            } if done_token == token => {
-                let final_text = read_full_text(&connection, process_id).await;
-                let output = output_since(&baseline_text, &final_text);
-                return Ok(run_result(&pid, Some(exit), &output, false));
-            }
-            AgentQueryResult::RunCompletion { .. } => {}
-            AgentQueryResult::Error(message) => return Err(message),
-            other => return Err(format!("run: unexpected run-completion result: {other:?}")),
+        let result = agent_query(&connection, AgentQuery::RunCompletion { process_id }).await?;
+        let materialized_now = matches!(&result, AgentQueryResult::RunCompletion { .. });
+        let allow_missing_process = !process_materialized && Instant::now() < materialize_deadline;
+        let exit = run_completion_exit(result, &token, process_id, allow_missing_process)?;
+        process_materialized |= materialized_now;
+        if let Some(exit) = exit {
+            let final_text = read_full_text(&connection, process_id).await;
+            let output = output_since(&baseline_text, &final_text);
+            return Ok(run_result(&pid, Some(exit), &output, false));
         }
         if Instant::now() >= deadline {
             let final_text = read_full_text(&connection, process_id).await;
@@ -908,5 +932,28 @@ mod tests {
             }
             _ => panic!("expected run placement override command"),
         }
+    }
+
+    #[test]
+    fn blocking_run_waits_for_new_terminal_process_to_materialize() {
+        let process_id = vmux_service::protocol::ProcessId::new();
+        let result = AgentQueryResult::Error(format!("process not found: {process_id}"));
+
+        assert_eq!(
+            run_completion_exit(result, "token", process_id, true).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn blocking_run_surfaces_process_missing_after_startup_grace() {
+        let process_id = vmux_service::protocol::ProcessId::new();
+        let message = format!("process not found: {process_id}");
+        let result = AgentQueryResult::Error(message.clone());
+
+        assert_eq!(
+            run_completion_exit(result, "token", process_id, false),
+            Err(message)
+        );
     }
 }

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -594,6 +594,13 @@ name=<feature> to drop a demo straight into the repo."
 }
 
 pub fn tool_definitions() -> Vec<ToolDefinition> {
+    tool_definitions_filtered(false)
+}
+
+/// Build the MCP tool list. When `acp_terminals` is set (ACP sessions, which get terminals through
+/// the ACP terminal methods), `run` + `read_terminal` are omitted; `terminal_send` (no ACP
+/// equivalent for keystrokes/TUIs) is always kept.
+pub fn tool_definitions_filtered(acp_terminals: bool) -> Vec<ToolDefinition> {
     let mut defs: Vec<ToolDefinition> = AppCommand::mcp_tool_entries()
         .into_iter()
         .chain(McpParamTool::mcp_tool_entries())
@@ -611,9 +618,13 @@ pub fn tool_definitions() -> Vec<ToolDefinition> {
     defs.push(open_file_definition());
     defs.push(read_file_definition());
     defs.push(grep_definition());
-    defs.push(run_definition());
+    if !acp_terminals {
+        defs.push(run_definition());
+    }
     defs.push(create_worktree_definition());
-    defs.push(read_terminal_definition());
+    if !acp_terminals {
+        defs.push(read_terminal_definition());
+    }
     defs.push(screenshot_definition());
     defs.push(browser_snapshot_definition());
     defs.push(browser_scroll_definition());
@@ -1296,6 +1307,18 @@ mod tests {
     fn list_tools_includes_terminal_send() {
         let names = tool_names();
         assert!(names.contains(&"terminal_send".to_string()));
+    }
+
+    #[test]
+    fn acp_terminals_toolset_hides_run_and_read_terminal_keeps_send() {
+        let names: Vec<String> = tool_definitions_filtered(true)
+            .into_iter()
+            .map(|def| def.name)
+            .collect();
+        assert!(!names.contains(&"run".to_string()));
+        assert!(!names.contains(&"read_terminal".to_string()));
+        assert!(names.contains(&"terminal_send".to_string()));
+        assert!(names.contains(&"open_page".to_string()));
     }
 
     #[test]

--- a/crates/vmux_service/src/acp.rs
+++ b/crates/vmux_service/src/acp.rs
@@ -35,6 +35,7 @@ impl AcpSessionManager {
     pub fn spawn(
         &mut self,
         sid: String,
+        agent_id: String,
         command: String,
         args: Vec<String>,
         env: Vec<(String, String)>,
@@ -62,6 +63,7 @@ impl AcpSessionManager {
             command,
             args,
             env,
+            agent_id,
             mcp_servers,
             resume,
             shared.clone(),

--- a/crates/vmux_service/src/acp.rs
+++ b/crates/vmux_service/src/acp.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use tokio::sync::{broadcast, mpsc};
 use vmux_core::ProcessId;
 
+use crate::process::{ProcessManager, PtyInputWriter};
 use crate::protocol::ServiceMessage;
 
 struct AcpHandle {
@@ -39,6 +40,8 @@ impl AcpSessionManager {
         env: Vec<(String, String)>,
         cwd: PathBuf,
         anchor: ProcessId,
+        manager: Arc<tokio::sync::Mutex<ProcessManager>>,
+        input_writers: Arc<tokio::sync::Mutex<HashMap<ProcessId, PtyInputWriter>>>,
         mcp_servers: Vec<agent_client_protocol::schema::v1::McpServer>,
         resume: Option<String>,
     ) {
@@ -47,7 +50,14 @@ impl AcpSessionManager {
         }
         let (input_tx, input_rx) = mpsc::unbounded_channel();
         let (stream_tx, _) = broadcast::channel(256);
-        let shared = Arc::new(AcpShared::new(sid.clone(), cwd, anchor, stream_tx));
+        let shared = Arc::new(AcpShared::new(
+            sid.clone(),
+            cwd,
+            anchor,
+            stream_tx,
+            manager,
+            input_writers,
+        ));
         tokio::spawn(driver::run(
             command,
             args,

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -10,21 +10,24 @@ use std::sync::{Arc, Mutex};
 
 use agent_client_protocol::schema::ProtocolVersion;
 use agent_client_protocol::schema::v1::{
-    CancelNotification, ContentBlock, CreateTerminalRequest, Implementation, InitializeRequest,
-    KillTerminalRequest, LoadSessionRequest, McpServer, NewSessionRequest, PermissionOption,
-    PermissionOptionId, PromptRequest, ReadTextFileRequest, ReadTextFileResponse,
-    ReleaseTerminalRequest, RequestPermissionOutcome, RequestPermissionRequest,
+    CancelNotification, ContentBlock, CreateTerminalRequest, CreateTerminalResponse,
+    Implementation, InitializeRequest, KillTerminalRequest, KillTerminalResponse,
+    LoadSessionRequest, McpServer, NewSessionRequest, PermissionOption, PermissionOptionId,
+    PromptRequest, ReadTextFileRequest, ReadTextFileResponse, ReleaseTerminalRequest,
+    ReleaseTerminalResponse, RequestPermissionOutcome, RequestPermissionRequest,
     RequestPermissionResponse, SelectedPermissionOutcome, SessionId, SessionNotification,
-    TerminalOutputRequest, TextContent, WaitForTerminalExitRequest, WriteTextFileRequest,
+    TerminalExitStatus, TerminalId, TerminalOutputRequest, TerminalOutputResponse, TextContent,
+    WaitForTerminalExitRequest, WaitForTerminalExitResponse, WriteTextFileRequest,
     WriteTextFileResponse,
 };
 use agent_client_protocol::{Client, Responder};
 use tokio::process::Command;
-use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::sync::{broadcast, mpsc, oneshot, watch};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use vmux_core::ProcessId;
 
 use super::projector::{AcpProjector, Intent};
+use crate::process::{ProcessManager, PtyInputWriter};
 use crate::protocol::{
     AgentCommand, AgentRequestId, AgentRunStatus, ApprovalDecision, ServiceMessage,
     compose_agent_prompt,
@@ -45,6 +48,14 @@ pub enum AcpInput {
     Close,
 }
 
+/// A live ACP-native terminal: the vmux process backing it plus a receiver that resolves with the
+/// child's exit code (`None` until it exits), driving `terminal/wait_for_exit` and the exit status
+/// in `terminal/output`.
+pub struct AcpTerminal {
+    pub process_id: ProcessId,
+    pub exit_rx: watch::Receiver<Option<i32>>,
+}
+
 /// State shared between the driver's request handlers and its prompt loop.
 pub struct AcpShared {
     pub sid: String,
@@ -53,7 +64,14 @@ pub struct AcpShared {
     pub stream_tx: broadcast::Sender<ServiceMessage>,
     pub projector: Mutex<AcpProjector>,
     pub pending_perms: Mutex<HashMap<String, oneshot::Sender<ApprovalDecision>>>,
-    pub terminals: Mutex<HashMap<String, ProcessId>>,
+    /// ACP-native terminals keyed by their ACP `terminalId` (the vmux `ProcessId` string).
+    pub terminals: Mutex<HashMap<String, AcpTerminal>>,
+    /// Daemon process manager (shared with the IPC server) so terminal handlers spawn / read / kill
+    /// PTYs directly, without a GUI round-trip.
+    pub manager: Arc<tokio::sync::Mutex<ProcessManager>>,
+    /// PTY input writers (shared with the server) so the user can take over an ACP terminal by
+    /// typing into its pane.
+    pub input_writers: Arc<tokio::sync::Mutex<HashMap<ProcessId, PtyInputWriter>>>,
     agent_name: Mutex<Option<String>>,
     /// Set by `AcpInput::Cancel`; read (and reset) when the in-flight prompt resolves so it
     /// reports `Interrupted` rather than `Idle`.
@@ -66,6 +84,8 @@ impl AcpShared {
         cwd: PathBuf,
         anchor: ProcessId,
         stream_tx: broadcast::Sender<ServiceMessage>,
+        manager: Arc<tokio::sync::Mutex<ProcessManager>>,
+        input_writers: Arc<tokio::sync::Mutex<HashMap<ProcessId, PtyInputWriter>>>,
     ) -> Self {
         Self {
             sid,
@@ -75,6 +95,8 @@ impl AcpShared {
             projector: Mutex::new(AcpProjector::new()),
             pending_perms: Mutex::new(HashMap::new()),
             terminals: Mutex::new(HashMap::new()),
+            manager,
+            input_writers,
             agent_name: Mutex::new(None),
             cancel_requested: AtomicBool::new(false),
         }
@@ -156,6 +178,11 @@ pub async fn run(
     let perm_shared = shared.clone();
     let update_shared = shared.clone();
     let main_shared = shared.clone();
+    let create_shared = shared.clone();
+    let output_shared = shared.clone();
+    let wait_shared = shared.clone();
+    let kill_shared = shared.clone();
+    let release_shared = shared.clone();
     let read_cwd = shared.cwd.clone();
     let write_cwd = shared.cwd.clone();
 
@@ -220,33 +247,57 @@ pub async fn run(
             agent_client_protocol::on_receive_request!(),
         )
         .on_receive_request(
-            async move |_req: CreateTerminalRequest, responder: Responder<_>, _cx| {
-                responder.respond_with_internal_error("acp: terminal/create not yet implemented")
+            async move |req: CreateTerminalRequest,
+                        responder: Responder<CreateTerminalResponse>,
+                        _cx| {
+                match create_terminal(&create_shared, req).await {
+                    Ok(resp) => responder.respond(resp),
+                    Err(err) => responder.respond_with_internal_error(err),
+                }
             },
             agent_client_protocol::on_receive_request!(),
         )
         .on_receive_request(
-            async move |_req: TerminalOutputRequest, responder: Responder<_>, _cx| {
-                responder.respond_with_internal_error("acp: terminal/output not yet implemented")
+            async move |req: TerminalOutputRequest,
+                        responder: Responder<TerminalOutputResponse>,
+                        _cx| {
+                match terminal_output(&output_shared, req).await {
+                    Ok(resp) => responder.respond(resp),
+                    Err(err) => responder.respond_with_internal_error(err),
+                }
             },
             agent_client_protocol::on_receive_request!(),
         )
         .on_receive_request(
-            async move |_req: WaitForTerminalExitRequest, responder: Responder<_>, _cx| {
-                responder
-                    .respond_with_internal_error("acp: terminal/wait_for_exit not yet implemented")
+            async move |req: WaitForTerminalExitRequest,
+                        responder: Responder<WaitForTerminalExitResponse>,
+                        _cx| {
+                match wait_for_terminal_exit(&wait_shared, req).await {
+                    Ok(resp) => responder.respond(resp),
+                    Err(err) => responder.respond_with_internal_error(err),
+                }
             },
             agent_client_protocol::on_receive_request!(),
         )
         .on_receive_request(
-            async move |_req: KillTerminalRequest, responder: Responder<_>, _cx| {
-                responder.respond_with_internal_error("acp: terminal/kill not yet implemented")
+            async move |req: KillTerminalRequest,
+                        responder: Responder<KillTerminalResponse>,
+                        _cx| {
+                match kill_terminal(&kill_shared, req).await {
+                    Ok(resp) => responder.respond(resp),
+                    Err(err) => responder.respond_with_internal_error(err),
+                }
             },
             agent_client_protocol::on_receive_request!(),
         )
         .on_receive_request(
-            async move |_req: ReleaseTerminalRequest, responder: Responder<_>, _cx| {
-                responder.respond_with_internal_error("acp: terminal/release not yet implemented")
+            async move |req: ReleaseTerminalRequest,
+                        responder: Responder<ReleaseTerminalResponse>,
+                        _cx| {
+                match release_terminal(&release_shared, req) {
+                    Ok(resp) => responder.respond(resp),
+                    Err(err) => responder.respond_with_internal_error(err),
+                }
             },
             agent_client_protocol::on_receive_request!(),
         )
@@ -296,8 +347,9 @@ pub async fn run(
             let mut init = InitializeRequest::new(ProtocolVersion::V1);
             init.client_capabilities.fs.read_text_file = true;
             init.client_capabilities.fs.write_text_file = true;
-            // Terminals are provided via the vmux_mcp `run` tool (real panes), not ACP-native.
-            init.client_capabilities.terminal = false;
+            // ACP-native terminals: the agent's shell/Bash execution flows through vmux's five
+            // terminal methods, backed by real visible panes (see `create_terminal` et al.).
+            init.client_capabilities.terminal = true;
             let init_resp = cx.send_request(init).block_task().await?;
 
             if let Some(name) = acp_display_name(init_resp.agent_info.as_ref()) {
@@ -462,6 +514,178 @@ async fn drain_stderr(stderr: tokio::process::ChildStderr) {
     }
 }
 
+/// Default PTY geometry for an ACP-native terminal. ACP `terminal/create` is size-less; the GUI
+/// pane resizes the PTY (`ResizeProcess`) once it mounts.
+const ACP_TERMINAL_COLS: u16 = 80;
+const ACP_TERMINAL_ROWS: u16 = 24;
+
+/// `terminal/create`: spawn a real (visible) PTY on the daemon's process manager, register it as an
+/// ACP terminal, and tell the GUI to open a pane bound to it. Returns the ACP `terminalId` (the
+/// vmux `ProcessId` string).
+async fn create_terminal(
+    shared: &AcpShared,
+    req: CreateTerminalRequest,
+) -> Result<CreateTerminalResponse, String> {
+    let CreateTerminalRequest {
+        command,
+        args,
+        env,
+        cwd,
+        ..
+    } = req;
+    let env: Vec<(String, String)> = env.into_iter().map(|var| (var.name, var.value)).collect();
+    let cwd = cwd
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_else(|| shared.cwd.to_string_lossy().into_owned());
+    let id = ProcessId::new();
+
+    let (exit_stream, writer) = {
+        let mut mgr = shared.manager.lock().await;
+        mgr.create_process_keep_alive(
+            id,
+            command.clone(),
+            args.clone(),
+            cwd.clone(),
+            env,
+            ACP_TERMINAL_COLS,
+            ACP_TERMINAL_ROWS,
+        )?;
+        let exit_stream = mgr.processes.get(&id).map(|process| process.subscribe());
+        (exit_stream, mgr.input_writer(&id))
+    };
+
+    // Let the user take over the pane by typing.
+    if let Some(writer) = writer {
+        shared.input_writers.lock().await.insert(id, writer);
+    }
+
+    // Resolve the child's exit code once, off the process broadcast, for wait_for_exit / output.
+    let (exit_tx, exit_rx) = watch::channel(None);
+    if let Some(mut exit_stream) = exit_stream {
+        tokio::spawn(async move {
+            loop {
+                match exit_stream.recv().await {
+                    Ok(ServiceMessage::ProcessExited { exit_code, .. }) => {
+                        let _ = exit_tx.send(exit_code);
+                        break;
+                    }
+                    Ok(_) => {}
+                    Err(broadcast::error::RecvError::Lagged(_)) => {}
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+    }
+
+    let terminal_id = id.to_string();
+    shared.terminals.lock().unwrap().insert(
+        terminal_id.clone(),
+        AcpTerminal {
+            process_id: id,
+            exit_rx,
+        },
+    );
+    shared.emit(ServiceMessage::AcpTerminalCreated {
+        sid: shared.sid.clone(),
+        terminal_id: terminal_id.clone(),
+        process_id: id,
+        command,
+        args,
+        cwd: Some(cwd),
+    });
+    Ok(CreateTerminalResponse::new(TerminalId::new(terminal_id)))
+}
+
+/// Look up the vmux `ProcessId` and last-known exit code for an ACP `terminalId`.
+fn lookup_terminal(
+    shared: &AcpShared,
+    terminal_id: &TerminalId,
+) -> Result<(ProcessId, Option<i32>), String> {
+    let key = terminal_id.0.to_string();
+    let terminals = shared.terminals.lock().unwrap();
+    let terminal = terminals
+        .get(&key)
+        .ok_or_else(|| format!("acp: unknown terminal {key}"))?;
+    Ok((terminal.process_id, *terminal.exit_rx.borrow()))
+}
+
+fn terminal_exit_status(code: Option<i32>) -> TerminalExitStatus {
+    let status = TerminalExitStatus::new();
+    match code {
+        Some(code) => status.exit_code(code as u32),
+        None => status,
+    }
+}
+
+/// `terminal/output`: current scrollback of the backing process plus its exit status (if it ended).
+async fn terminal_output(
+    shared: &AcpShared,
+    req: TerminalOutputRequest,
+) -> Result<TerminalOutputResponse, String> {
+    let (process_id, exit) = lookup_terminal(shared, &req.terminal_id)?;
+    let output = {
+        let mgr = shared.manager.lock().await;
+        mgr.processes
+            .get(&process_id)
+            .map(|process| process.full_text())
+            .unwrap_or_default()
+    };
+    let mut resp = TerminalOutputResponse::new(output, false);
+    if let Some(code) = exit {
+        resp = resp.exit_status(terminal_exit_status(Some(code)));
+    }
+    Ok(resp)
+}
+
+/// `terminal/wait_for_exit`: block until the backing child exits, then report its status.
+async fn wait_for_terminal_exit(
+    shared: &AcpShared,
+    req: WaitForTerminalExitRequest,
+) -> Result<WaitForTerminalExitResponse, String> {
+    let key = req.terminal_id.0.to_string();
+    let mut exit_rx = {
+        let terminals = shared.terminals.lock().unwrap();
+        terminals
+            .get(&key)
+            .map(|terminal| terminal.exit_rx.clone())
+            .ok_or_else(|| format!("acp: unknown terminal {key}"))?
+    };
+    let code = loop {
+        let current = *exit_rx.borrow();
+        if current.is_some() {
+            break current;
+        }
+        if exit_rx.changed().await.is_err() {
+            break None;
+        }
+    };
+    Ok(WaitForTerminalExitResponse::new(terminal_exit_status(code)))
+}
+
+/// `terminal/kill`: kill the child but keep the pane (its output stays readable).
+async fn kill_terminal(
+    shared: &AcpShared,
+    req: KillTerminalRequest,
+) -> Result<KillTerminalResponse, String> {
+    let (process_id, _) = lookup_terminal(shared, &req.terminal_id)?;
+    shared.manager.lock().await.kill_process(&process_id);
+    Ok(KillTerminalResponse::new())
+}
+
+/// `terminal/release`: stop tracking the terminal. The pane + process are left for the user (they
+/// may still want to watch or take over); the GUI reaps the pane when the user closes it.
+fn release_terminal(
+    shared: &AcpShared,
+    req: ReleaseTerminalRequest,
+) -> Result<ReleaseTerminalResponse, String> {
+    shared
+        .terminals
+        .lock()
+        .unwrap()
+        .remove(&req.terminal_id.0.to_string());
+    Ok(ReleaseTerminalResponse::new())
+}
+
 /// Maps a host decision (the wire `Allow`/`Deny`) onto an ACP permission option, preferring the
 /// one-shot kind, then the always-kind. Returns `None` (→ the request is cancelled) when the agent
 /// offers no option matching the decision — never falls back to an option that could approve a
@@ -595,6 +819,8 @@ mod tests {
             PathBuf::from("/tmp"),
             ProcessId::new(),
             stream_tx,
+            Arc::new(tokio::sync::Mutex::new(ProcessManager::default())),
+            Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         );
 
         shared.publish_agent_info("Antigravity".into());
@@ -749,5 +975,98 @@ mod tests {
         assert_eq!(slice_lines(text, Some(2), None), "b\nc\nd");
         assert_eq!(slice_lines(text, Some(2), Some(2)), "b\nc");
         assert_eq!(slice_lines(text, Some(10), Some(2)), "");
+    }
+
+    fn test_shared(
+        manager: Arc<tokio::sync::Mutex<ProcessManager>>,
+    ) -> (Arc<AcpShared>, broadcast::Receiver<ServiceMessage>) {
+        let (stream_tx, stream_rx) = broadcast::channel(64);
+        let shared = Arc::new(AcpShared::new(
+            "s1".to_string(),
+            std::env::temp_dir(),
+            ProcessId::new(),
+            stream_tx,
+            manager,
+            Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        ));
+        (shared, stream_rx)
+    }
+
+    /// End-to-end of the daemon terminal path: `terminal/create` spawns a real PTY + emits
+    /// `AcpTerminalCreated`; `wait_for_exit` resolves with the child's code; `output` reads the
+    /// completed command's text after exit (kept alive); `release` stops tracking it.
+    #[tokio::test]
+    async fn acp_terminal_create_wait_output_release() {
+        let manager = Arc::new(tokio::sync::Mutex::new(ProcessManager::default()));
+        let (shared, mut stream_rx) = test_shared(manager.clone());
+
+        // Drive PTY output + exit detection like the server poll loop (which keeps ACP terminals).
+        let poll_mgr = manager.clone();
+        let poll = tokio::spawn(async move {
+            loop {
+                poll_mgr.lock().await.poll_all();
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        });
+
+        let req = CreateTerminalRequest::new("s1", "/bin/sh").args(vec![
+            "-c".to_string(),
+            "printf hi; sleep 0.1; exit 7".to_string(),
+        ]);
+        let created = create_terminal(&shared, req).await.expect("create");
+        let tid = created.terminal_id.0.to_string();
+        assert!(shared.terminals.lock().unwrap().contains_key(&tid));
+
+        let (emitted_id, emitted_pid) = loop {
+            match stream_rx.recv().await.expect("stream open") {
+                ServiceMessage::AcpTerminalCreated {
+                    terminal_id,
+                    process_id,
+                    ..
+                } => break (terminal_id, process_id),
+                _ => continue,
+            }
+        };
+        assert_eq!(emitted_id, tid);
+        assert_eq!(emitted_pid.to_string(), tid);
+
+        let wait = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            wait_for_terminal_exit(
+                &shared,
+                WaitForTerminalExitRequest::new("s1", TerminalId::new(tid.clone())),
+            ),
+        )
+        .await
+        .expect("wait_for_exit timed out")
+        .expect("wait_for_exit");
+        assert_eq!(wait.exit_status.exit_code, Some(7));
+
+        let out = terminal_output(
+            &shared,
+            TerminalOutputRequest::new("s1", TerminalId::new(tid.clone())),
+        )
+        .await
+        .expect("output");
+        assert!(out.output.contains("hi"), "output was {:?}", out.output);
+        assert_eq!(out.exit_status.and_then(|status| status.exit_code), Some(7));
+
+        release_terminal(
+            &shared,
+            ReleaseTerminalRequest::new("s1", TerminalId::new(tid.clone())),
+        )
+        .expect("release");
+        assert!(!shared.terminals.lock().unwrap().contains_key(&tid));
+
+        poll.abort();
+    }
+
+    #[tokio::test]
+    async fn terminal_output_unknown_terminal_errors() {
+        let manager = Arc::new(tokio::sync::Mutex::new(ProcessManager::default()));
+        let (shared, _rx) = test_shared(manager);
+        let result =
+            terminal_output(&shared, TerminalOutputRequest::new("s1", "does-not-exist")).await;
+        assert!(result.is_err());
     }
 }

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -722,8 +722,8 @@ fn truncate_terminal_output(output: String, output_byte_limit: Option<u64>) -> (
     (output[start..].to_string(), true)
 }
 
-/// `terminal/release`: stop tracking the terminal. The pane + process are left for the user (they
-/// may still want to watch or take over); the GUI reaps the pane when the user closes it.
+/// `terminal/release`: stop tracking the terminal and kill the backing process. The visible pane is
+/// left in place; the GUI reaps it when the user closes it.
 async fn release_terminal(
     shared: &AcpShared,
     req: ReleaseTerminalRequest,

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -48,12 +48,18 @@ pub enum AcpInput {
     Close,
 }
 
-/// A live ACP-native terminal: the vmux process backing it plus a receiver that resolves with the
-/// child's exit code (`None` until it exits), driving `terminal/wait_for_exit` and the exit status
-/// in `terminal/output`.
+#[derive(Clone, Copy)]
+pub enum AcpTerminalExit {
+    Pending,
+    Exited(Option<i32>),
+    Removed,
+}
+
+/// A live ACP-native terminal and its process exit state.
 pub struct AcpTerminal {
     pub process_id: ProcessId,
-    pub exit_rx: watch::Receiver<Option<i32>>,
+    pub exit_rx: watch::Receiver<AcpTerminalExit>,
+    pub output_byte_limit: Option<u64>,
 }
 
 /// State shared between the driver's request handlers and its prompt loop.
@@ -294,7 +300,7 @@ pub async fn run(
             async move |req: ReleaseTerminalRequest,
                         responder: Responder<ReleaseTerminalResponse>,
                         _cx| {
-                match release_terminal(&release_shared, req) {
+                match release_terminal(&release_shared, req).await {
                     Ok(resp) => responder.respond(resp),
                     Err(err) => responder.respond_with_internal_error(err),
                 }
@@ -531,12 +537,24 @@ async fn create_terminal(
         args,
         env,
         cwd,
+        output_byte_limit,
         ..
     } = req;
     let env: Vec<(String, String)> = env.into_iter().map(|var| (var.name, var.value)).collect();
-    let cwd = cwd
-        .map(|path| path.to_string_lossy().into_owned())
-        .unwrap_or_else(|| shared.cwd.to_string_lossy().into_owned());
+    let cwd = cwd.unwrap_or_else(|| shared.cwd.clone());
+    if !cwd.is_absolute() {
+        return Err(format!(
+            "acp: terminal cwd must be absolute: {}",
+            cwd.display()
+        ));
+    }
+    if !cwd.is_dir() {
+        return Err(format!(
+            "acp: terminal cwd is not a directory: {}",
+            cwd.display()
+        ));
+    }
+    let cwd = cwd.to_string_lossy().into_owned();
     let id = ProcessId::new();
 
     let (exit_stream, writer) = {
@@ -560,18 +578,21 @@ async fn create_terminal(
     }
 
     // Resolve the child's exit code once, off the process broadcast, for wait_for_exit / output.
-    let (exit_tx, exit_rx) = watch::channel(None);
+    let (exit_tx, exit_rx) = watch::channel(AcpTerminalExit::Pending);
     if let Some(mut exit_stream) = exit_stream {
         tokio::spawn(async move {
             loop {
                 match exit_stream.recv().await {
                     Ok(ServiceMessage::ProcessExited { exit_code, .. }) => {
-                        let _ = exit_tx.send(exit_code);
+                        let _ = exit_tx.send(AcpTerminalExit::Exited(exit_code));
                         break;
                     }
                     Ok(_) => {}
                     Err(broadcast::error::RecvError::Lagged(_)) => {}
-                    Err(broadcast::error::RecvError::Closed) => break,
+                    Err(broadcast::error::RecvError::Closed) => {
+                        let _ = exit_tx.send(AcpTerminalExit::Removed);
+                        break;
+                    }
                 }
             }
         });
@@ -583,6 +604,7 @@ async fn create_terminal(
         AcpTerminal {
             process_id: id,
             exit_rx,
+            output_byte_limit,
         },
     );
     shared.emit(ServiceMessage::AcpTerminalCreated {
@@ -600,13 +622,17 @@ async fn create_terminal(
 fn lookup_terminal(
     shared: &AcpShared,
     terminal_id: &TerminalId,
-) -> Result<(ProcessId, Option<i32>), String> {
+) -> Result<(ProcessId, AcpTerminalExit, Option<u64>), String> {
     let key = terminal_id.0.to_string();
     let terminals = shared.terminals.lock().unwrap();
     let terminal = terminals
         .get(&key)
         .ok_or_else(|| format!("acp: unknown terminal {key}"))?;
-    Ok((terminal.process_id, *terminal.exit_rx.borrow()))
+    let exit = *terminal.exit_rx.borrow();
+    if matches!(exit, AcpTerminalExit::Removed) {
+        return Err(format!("acp: terminal {key} process no longer exists"));
+    }
+    Ok((terminal.process_id, exit, terminal.output_byte_limit))
 }
 
 fn terminal_exit_status(code: Option<i32>) -> TerminalExitStatus {
@@ -622,17 +648,23 @@ async fn terminal_output(
     shared: &AcpShared,
     req: TerminalOutputRequest,
 ) -> Result<TerminalOutputResponse, String> {
-    let (process_id, exit) = lookup_terminal(shared, &req.terminal_id)?;
+    let (process_id, exit, output_byte_limit) = lookup_terminal(shared, &req.terminal_id)?;
     let output = {
         let mgr = shared.manager.lock().await;
         mgr.processes
             .get(&process_id)
             .map(|process| process.full_text())
-            .unwrap_or_default()
+            .ok_or_else(|| {
+                format!(
+                    "acp: terminal {} process no longer exists",
+                    req.terminal_id.0
+                )
+            })?
     };
-    let mut resp = TerminalOutputResponse::new(output, false);
-    if let Some(code) = exit {
-        resp = resp.exit_status(terminal_exit_status(Some(code)));
+    let (output, truncated) = truncate_terminal_output(output, output_byte_limit);
+    let mut resp = TerminalOutputResponse::new(output, truncated);
+    if let AcpTerminalExit::Exited(code) = exit {
+        resp = resp.exit_status(terminal_exit_status(code));
     }
     Ok(resp)
 }
@@ -651,12 +683,15 @@ async fn wait_for_terminal_exit(
             .ok_or_else(|| format!("acp: unknown terminal {key}"))?
     };
     let code = loop {
-        let current = *exit_rx.borrow();
-        if current.is_some() {
-            break current;
+        match *exit_rx.borrow() {
+            AcpTerminalExit::Pending => {}
+            AcpTerminalExit::Exited(code) => break code,
+            AcpTerminalExit::Removed => {
+                return Err(format!("acp: terminal {key} process no longer exists"));
+            }
         }
         if exit_rx.changed().await.is_err() {
-            break None;
+            return Err(format!("acp: terminal {key} exit state closed"));
         }
     };
     Ok(WaitForTerminalExitResponse::new(terminal_exit_status(code)))
@@ -667,22 +702,43 @@ async fn kill_terminal(
     shared: &AcpShared,
     req: KillTerminalRequest,
 ) -> Result<KillTerminalResponse, String> {
-    let (process_id, _) = lookup_terminal(shared, &req.terminal_id)?;
+    let (process_id, _, _) = lookup_terminal(shared, &req.terminal_id)?;
     shared.manager.lock().await.kill_process(&process_id);
     Ok(KillTerminalResponse::new())
 }
 
+fn truncate_terminal_output(output: String, output_byte_limit: Option<u64>) -> (String, bool) {
+    let Some(limit) = output_byte_limit else {
+        return (output, false);
+    };
+    let limit = usize::try_from(limit).unwrap_or(usize::MAX);
+    if output.len() <= limit {
+        return (output, false);
+    }
+    let mut start = output.len().saturating_sub(limit);
+    while !output.is_char_boundary(start) {
+        start += 1;
+    }
+    (output[start..].to_string(), true)
+}
+
 /// `terminal/release`: stop tracking the terminal. The pane + process are left for the user (they
 /// may still want to watch or take over); the GUI reaps the pane when the user closes it.
-fn release_terminal(
+async fn release_terminal(
     shared: &AcpShared,
     req: ReleaseTerminalRequest,
 ) -> Result<ReleaseTerminalResponse, String> {
-    shared
+    let terminal = shared
         .terminals
         .lock()
         .unwrap()
-        .remove(&req.terminal_id.0.to_string());
+        .remove(&req.terminal_id.0.to_string())
+        .ok_or_else(|| format!("acp: unknown terminal {}", req.terminal_id.0))?;
+    shared
+        .manager
+        .lock()
+        .await
+        .kill_process(&terminal.process_id);
     Ok(ReleaseTerminalResponse::new())
 }
 
@@ -1055,6 +1111,7 @@ mod tests {
             &shared,
             ReleaseTerminalRequest::new("s1", TerminalId::new(tid.clone())),
         )
+        .await
         .expect("release");
         assert!(!shared.terminals.lock().unwrap().contains_key(&tid));
 
@@ -1068,5 +1125,169 @@ mod tests {
         let result =
             terminal_output(&shared, TerminalOutputRequest::new("s1", "does-not-exist")).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn create_terminal_rejects_nonexistent_cwd() {
+        let manager = Arc::new(tokio::sync::Mutex::new(ProcessManager::default()));
+        let (shared, _rx) = test_shared(manager.clone());
+        let cwd = std::env::temp_dir().join(format!(
+            "vmux-acp-missing-cwd-{}-{}",
+            std::process::id(),
+            ProcessId::new()
+        ));
+
+        let result = create_terminal(
+            &shared,
+            CreateTerminalRequest::new("s1", "/bin/sh").cwd(cwd),
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(manager.lock().await.processes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn create_terminal_rejects_relative_cwd() {
+        let manager = Arc::new(tokio::sync::Mutex::new(ProcessManager::default()));
+        let (shared, _rx) = test_shared(manager.clone());
+
+        let result = create_terminal(
+            &shared,
+            CreateTerminalRequest::new("s1", "/bin/sh").cwd("."),
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(manager.lock().await.processes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn removed_terminal_errors_for_wait_and_output() {
+        let manager = Arc::new(tokio::sync::Mutex::new(ProcessManager::default()));
+        let (shared, _rx) = test_shared(manager.clone());
+        let created = create_terminal(
+            &shared,
+            CreateTerminalRequest::new("s1", "/bin/sh")
+                .args(vec!["-c".to_string(), "sleep 30".to_string()]),
+        )
+        .await
+        .expect("create");
+        let terminal_id = created.terminal_id.0.to_string();
+        let process_id = terminal_id.parse().expect("process id");
+        manager.lock().await.remove_process(&process_id);
+
+        let wait = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            wait_for_terminal_exit(
+                &shared,
+                WaitForTerminalExitRequest::new("s1", TerminalId::new(terminal_id.clone())),
+            ),
+        )
+        .await
+        .expect("wait timeout");
+        assert!(wait.is_err());
+
+        let output = terminal_output(
+            &shared,
+            TerminalOutputRequest::new("s1", TerminalId::new(terminal_id.clone())),
+        )
+        .await;
+        assert!(output.is_err());
+        shared.terminals.lock().unwrap().remove(&terminal_id);
+    }
+
+    #[tokio::test]
+    async fn release_terminal_kills_running_command() {
+        let manager = Arc::new(tokio::sync::Mutex::new(ProcessManager::default()));
+        let (shared, _rx) = test_shared(manager.clone());
+        let created = create_terminal(
+            &shared,
+            CreateTerminalRequest::new("s1", "/bin/sh")
+                .args(vec!["-c".to_string(), "sleep 30".to_string()]),
+        )
+        .await
+        .expect("create");
+        let terminal_id = created.terminal_id.0.to_string();
+        let process_id = terminal_id.parse().expect("process id");
+
+        release_terminal(
+            &shared,
+            ReleaseTerminalRequest::new("s1", TerminalId::new(terminal_id)),
+        )
+        .await
+        .expect("release");
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
+        let exited = loop {
+            let exited = {
+                let mut manager = manager.lock().await;
+                manager.poll_all();
+                manager
+                    .processes
+                    .get(&process_id)
+                    .and_then(|process| process.process_exit())
+                    .is_some()
+            };
+            if exited || std::time::Instant::now() >= deadline {
+                break exited;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        };
+        if !exited {
+            manager.lock().await.remove_process(&process_id);
+        }
+
+        assert!(exited, "release must kill a running terminal command");
+    }
+
+    #[tokio::test]
+    async fn terminal_output_respects_byte_limit_at_char_boundary() {
+        let manager = Arc::new(tokio::sync::Mutex::new(ProcessManager::default()));
+        let (shared, _rx) = test_shared(manager.clone());
+        let poll_manager = manager.clone();
+        let poll = tokio::spawn(async move {
+            loop {
+                poll_manager.lock().await.poll_all();
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        });
+        let created = create_terminal(
+            &shared,
+            CreateTerminalRequest::new("s1", "/bin/sh")
+                .args(vec!["-c".to_string(), "printf 'abécd'".to_string()])
+                .output_byte_limit(3),
+        )
+        .await
+        .expect("create");
+        let terminal_id = created.terminal_id.0.to_string();
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            wait_for_terminal_exit(
+                &shared,
+                WaitForTerminalExitRequest::new("s1", TerminalId::new(terminal_id.clone())),
+            ),
+        )
+        .await
+        .expect("wait timeout")
+        .expect("wait");
+        let output = terminal_output(
+            &shared,
+            TerminalOutputRequest::new("s1", TerminalId::new(terminal_id.clone())),
+        )
+        .await
+        .expect("output");
+
+        assert_eq!(output.output, "cd");
+        assert!(output.truncated);
+
+        release_terminal(
+            &shared,
+            ReleaseTerminalRequest::new("s1", TerminalId::new(terminal_id)),
+        )
+        .await
+        .expect("release");
+        poll.abort();
     }
 }

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -154,11 +154,13 @@ pub async fn run(
     command: String,
     args: Vec<String>,
     env: Vec<(String, String)>,
+    agent_id: String,
     mcp_servers: Vec<McpServer>,
     resume: Option<String>,
     shared: Arc<AcpShared>,
     mut input_rx: mpsc::UnboundedReceiver<AcpInput>,
 ) {
+    let session_meta = session_meta_for_agent(&agent_id);
     let mut child = match Command::new(&command)
         .args(&args)
         .envs(env)
@@ -366,6 +368,7 @@ pub async fn run(
                 load_requested_session(resume, init_resp.agent_capabilities.load_session, |sid| {
                     let mut load = LoadSessionRequest::new(sid, main_shared.cwd.clone());
                     load.mcp_servers = mcp_servers.clone();
+                    load.meta = session_meta.clone();
                     async { cx.send_request(load).block_task().await.map(|_| ()) }
                 })
                 .await;
@@ -391,6 +394,7 @@ pub async fn run(
                         let ensured = ensure_session(&mut session_id, || {
                             let mut new_session = NewSessionRequest::new(main_shared.cwd.clone());
                             new_session.mcp_servers = mcp_servers.clone();
+                            new_session.meta = session_meta.clone();
                             async {
                                 cx.send_request(new_session)
                                     .block_task()
@@ -510,6 +514,39 @@ where
     let sid = create().await?;
     *session_id = Some(sid.clone());
     Ok((sid, true))
+}
+
+const CLAUDE_ACP_STEER_PROMPT: &str = "The native Bash, WebSearch, and WebFetch tools are disabled. \
+Run ALL shell commands via the mcp__vmux__run tool, which opens a visible terminal the user can \
+watch and take over. Use mcp__vmux__read_terminal to inspect continued output. Omit the pane \
+argument because it targets your own terminal pane. Do ALL web access via the vmux browser tools. \
+If you invoke a required Skill tool, continue the original user request in the same turn after \
+the skill loads. Never end the turn after skill activation or answer only Ready.";
+
+fn session_meta_for_agent(agent_id: &str) -> Option<serde_json::Map<String, serde_json::Value>> {
+    if agent_id != "claude" {
+        return None;
+    }
+    let serde_json::Value::Object(meta) = serde_json::json!({
+        "systemPrompt": {
+            "append": CLAUDE_ACP_STEER_PROMPT,
+        },
+        "claudeCode": {
+            "options": {
+                "disallowedTools": ["Bash", "Monitor", "WebSearch", "WebFetch"],
+                "allowedTools": [
+                    "mcp__vmux__run",
+                    "mcp__vmux__read_terminal",
+                    "mcp__vmux__browser_navigate",
+                    "mcp__vmux__browser_snapshot",
+                    "mcp__vmux__browser_scroll",
+                ],
+            },
+        },
+    }) else {
+        unreachable!()
+    };
+    Some(meta)
 }
 
 async fn drain_stderr(stderr: tokio::process::ChildStderr) {
@@ -979,6 +1016,28 @@ mod tests {
         assert!(wire.contains("prior conversation"));
         assert!(wire.ends_with("continue here"));
         assert_eq!(compose_agent_prompt("plain", None), "plain");
+    }
+
+    #[test]
+    fn claude_acp_disables_native_shell_and_steers_skill_continuation() {
+        let meta = session_meta_for_agent("claude").expect("Claude ACP metadata");
+        let options = &meta["claudeCode"]["options"];
+
+        assert_eq!(
+            options["disallowedTools"],
+            serde_json::json!(["Bash", "Monitor", "WebSearch", "WebFetch"])
+        );
+        assert!(
+            options["allowedTools"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|tool| tool == "mcp__vmux__run")
+        );
+        let prompt = meta["systemPrompt"]["append"].as_str().unwrap();
+        assert!(prompt.contains("mcp__vmux__run"));
+        assert!(prompt.contains("continue the original user request"));
+        assert!(session_meta_for_agent("vibe-acp").is_none());
     }
 
     #[test]

--- a/crates/vmux_service/src/acp/projector.rs
+++ b/crates/vmux_service/src/acp/projector.rs
@@ -558,4 +558,22 @@ mod tests {
                 if call_id == "c1" && content.contains("pane")
         )));
     }
+
+    #[test]
+    fn tool_call_with_terminal_and_text_prefers_text_output() {
+        use agent_client_protocol::schema::v1::Content;
+        let mut p = AcpProjector::new();
+        let tc = ToolCall::new("c1", "Run").content(vec![
+            ToolCallContent::Terminal(Terminal::new("t1")),
+            ToolCallContent::Content(Content::new(ContentBlock::Text(TextContent::new(
+                "real output",
+            )))),
+        ]);
+        p.apply(SessionUpdate::ToolCall(tc));
+        assert!(p.messages().iter().any(|m| matches!(
+            m,
+            Message::ToolResult { call_id, content, .. }
+                if call_id == "c1" && content == "real output"
+        )));
+    }
 }

--- a/crates/vmux_service/src/acp/projector.rs
+++ b/crates/vmux_service/src/acp/projector.rs
@@ -219,21 +219,34 @@ impl AcpProjector {
         failed: bool,
     ) -> Vec<Intent> {
         let mut intents = Vec::new();
+        let mut has_terminal = false;
         for item in content {
-            if let ToolCallContent::Diff(diff) = item {
-                let path = diff.path.to_string_lossy().into_owned();
-                self.upsert_diff(call_id, &path, diff.old_text.clone(), diff.new_text.clone());
-                intents.push(Intent::ProposedDiff {
-                    call_id: call_id.to_string(),
-                    path,
-                    old_text: diff.old_text.clone(),
-                    new_text: diff.new_text.clone(),
-                });
+            match item {
+                ToolCallContent::Diff(diff) => {
+                    let path = diff.path.to_string_lossy().into_owned();
+                    self.upsert_diff(call_id, &path, diff.old_text.clone(), diff.new_text.clone());
+                    intents.push(Intent::ProposedDiff {
+                        call_id: call_id.to_string(),
+                        path,
+                        old_text: diff.old_text.clone(),
+                        new_text: diff.new_text.clone(),
+                    });
+                }
+                // An embedded ACP terminal renders as a live pane; point the transcript card at it.
+                // Real captured text (if the agent also sends `Content`) overwrites this below.
+                ToolCallContent::Terminal(_) => has_terminal = true,
+                _ => {}
             }
         }
         let output = tool_output_text(content);
         if !output.is_empty() {
             self.upsert_tool_result(call_id, output, failed);
+        } else if has_terminal {
+            self.upsert_tool_result(
+                call_id,
+                "[terminal output shown in the attached pane]".to_string(),
+                failed,
+            );
         }
         intents
     }
@@ -359,7 +372,7 @@ fn tool_output_text(content: &[ToolCallContent]) -> String {
 mod tests {
     use super::*;
     use agent_client_protocol::schema::v1::{
-        ContentChunk, Diff, SessionUpdate, TextContent, ToolCall, ToolCallContent,
+        ContentChunk, Diff, SessionUpdate, Terminal, TextContent, ToolCall, ToolCallContent,
     };
 
     fn chunk(text: &str) -> SessionUpdate {
@@ -530,6 +543,19 @@ mod tests {
             m,
             Message::ToolResult { call_id, content, is_error: false }
                 if call_id == "c1" && content == "hello output"
+        )));
+    }
+
+    #[test]
+    fn tool_call_with_terminal_folds_to_pane_pointer_result() {
+        let mut p = AcpProjector::new();
+        let tc = ToolCall::new("c1", "Run")
+            .content(vec![ToolCallContent::Terminal(Terminal::new("t1"))]);
+        p.apply(SessionUpdate::ToolCall(tc));
+        assert!(p.messages().iter().any(|m| matches!(
+            m,
+            Message::ToolResult { call_id, content, .. }
+                if call_id == "c1" && content.contains("pane")
         )));
     }
 }

--- a/crates/vmux_service/src/agent_events.rs
+++ b/crates/vmux_service/src/agent_events.rs
@@ -92,3 +92,15 @@ pub struct PageAgentSessionCreated {
     pub sid: String,
     pub acp_session_id: String,
 }
+
+/// An ACP agent created a terminal (`terminal/create`); the GUI opens a visible pane beside the
+/// agent (`sid`) bound to the daemon-spawned `process_id` (attach only — the PTY already exists).
+#[derive(Message)]
+pub struct PageAgentAcpTerminalCreated {
+    pub sid: String,
+    pub terminal_id: String,
+    pub process_id: ProcessId,
+    pub command: String,
+    pub args: Vec<String>,
+    pub cwd: Option<String>,
+}

--- a/crates/vmux_service/src/process.rs
+++ b/crates/vmux_service/src/process.rs
@@ -7,13 +7,16 @@ use alacritty_terminal::{
     vte::ansi::{Color, NamedColor, Processor},
 };
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
+#[cfg(unix)]
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
     collections::HashMap,
     io::{Read, Write},
-    path::PathBuf,
     sync::{Arc, Mutex},
-    time::Instant,
+    time::{Duration, Instant},
 };
+#[cfg(unix)]
+use std::{os::unix::ffi::OsStrExt, path::Component};
 use tokio::sync::{broadcast, mpsc};
 use vmux_core::event::*;
 
@@ -21,6 +24,109 @@ const MAX_PTY_CHUNKS_PER_POLL: usize = 64;
 const _: () = assert!(MAX_PTY_CHUNKS_PER_POLL <= 256);
 
 pub type PtyInputWriter = Arc<Mutex<Box<dyn Write + Send>>>;
+
+#[cfg(unix)]
+fn is_executable(path: &std::path::Path) -> bool {
+    if path.is_dir() {
+        return false;
+    }
+    let Ok(path) = std::ffi::CString::new(path.as_os_str().as_bytes()) else {
+        return false;
+    };
+    unsafe { libc::access(path.as_ptr(), libc::X_OK) == 0 }
+}
+
+#[cfg(unix)]
+fn resolve_executable(
+    command: &str,
+    cwd: &str,
+    env: &[(String, String)],
+) -> Result<std::path::PathBuf, String> {
+    let command_path = std::path::Path::new(command);
+    let explicit_cwd = matches!(
+        command_path.components().next(),
+        Some(Component::CurDir | Component::ParentDir)
+    );
+    if command_path.is_absolute() || explicit_cwd {
+        let candidate = if command_path.is_absolute() {
+            command_path.to_path_buf()
+        } else {
+            std::path::Path::new(cwd).join(command_path)
+        };
+        return is_executable(&candidate)
+            .then_some(candidate)
+            .ok_or_else(|| format!("unable to execute command: {command}"));
+    }
+
+    let path = env
+        .iter()
+        .rev()
+        .find(|(name, _)| name == "PATH")
+        .map(|(_, value)| std::ffi::OsString::from(value))
+        .or_else(|| std::env::var_os("PATH"))
+        .ok_or_else(|| format!("unable to resolve command without PATH: {command}"))?;
+    for path_entry in std::env::split_paths(&path) {
+        let candidate = std::path::Path::new(cwd)
+            .join(path_entry)
+            .join(command_path);
+        if is_executable(&candidate) {
+            return Ok(candidate);
+        }
+    }
+    Err(format!("unable to resolve executable: {command}"))
+}
+
+#[cfg(unix)]
+fn run_pty_reader(
+    mut reader: Box<dyn Read + Send>,
+    reader_fd: std::os::fd::RawFd,
+    pty_tx: mpsc::UnboundedSender<Vec<u8>>,
+    wake_tx: mpsc::UnboundedSender<ProcessId>,
+    process_id: ProcessId,
+    in_flight: Arc<AtomicBool>,
+    send_delay: Duration,
+) {
+    let mut buf = [0u8; 4096];
+    loop {
+        let mut poll_fd = libc::pollfd {
+            fd: reader_fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let ready = unsafe { libc::poll(&mut poll_fd, 1, -1) };
+        if ready < 0 {
+            if std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            break;
+        }
+        in_flight.store(true, Ordering::Release);
+        match reader.read(&mut buf) {
+            Ok(0) => {
+                in_flight.store(false, Ordering::Release);
+                break;
+            }
+            Ok(n) => {
+                if !send_delay.is_zero() {
+                    std::thread::sleep(send_delay);
+                }
+                let sent = pty_tx.send(buf[..n].to_vec()).is_ok();
+                in_flight.store(false, Ordering::Release);
+                if !sent {
+                    break;
+                }
+                let _ = wake_tx.send(process_id);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {
+                in_flight.store(false, Ordering::Release);
+            }
+            Err(_) => {
+                in_flight.store(false, Ordering::Release);
+                break;
+            }
+        }
+    }
+}
 
 #[derive(Clone)]
 struct ServiceEventProxy {
@@ -90,6 +196,8 @@ pub struct Process {
     master: Box<dyn portable_pty::MasterPty + Send>,
     child: Box<dyn portable_pty::Child + Send + Sync>,
     pty_rx: mpsc::UnboundedReceiver<Vec<u8>>,
+    #[cfg(unix)]
+    pty_reader_in_flight: Arc<AtomicBool>,
     /// Broadcasts viewport patches to all attached GUI clients.
     patch_tx: broadcast::Sender<ServiceMessage>,
     line_hashes: Vec<u64>,
@@ -122,9 +230,10 @@ pub struct Process {
     /// being reaped by the poll loop. Set for ACP-native terminals so `terminal/output` can read
     /// the completed command's scrollback until the agent calls `terminal/release`.
     keep_after_exit: bool,
-    /// Set once the child has exited and `ProcessExited` has been broadcast. Guards `poll` from
-    /// re-broadcasting or re-processing a dead child every tick when `keep_after_exit` is set.
+    /// Set once the child has exited and all PTY output has been drained.
     exited: bool,
+    /// Set once `ProcessExited` has been broadcast for the child.
+    exit_reported: bool,
     /// The child's exit code, recorded when it exits. Surfaced to ACP `terminal/output`.
     exit_code: Option<i32>,
 }
@@ -259,12 +368,37 @@ impl Process {
     pub fn new_with_wake(
         id: ProcessId,
         command: String,
+        args: Vec<String>,
+        cwd: String,
+        env: Vec<(String, String)>,
+        cols: u16,
+        rows: u16,
+        wake_tx: mpsc::UnboundedSender<ProcessId>,
+    ) -> Result<Self, String> {
+        Self::new_with_wake_and_reader_delay(
+            id,
+            command,
+            args,
+            cwd,
+            env,
+            cols,
+            rows,
+            wake_tx,
+            Duration::ZERO,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_with_wake_and_reader_delay(
+        id: ProcessId,
+        command: String,
         mut args: Vec<String>,
         cwd: String,
         mut env: Vec<(String, String)>,
         cols: u16,
         rows: u16,
         wake_tx: mpsc::UnboundedSender<ProcessId>,
+        reader_send_delay: Duration,
     ) -> Result<Self, String> {
         crate::shell_integration::inject(
             &command,
@@ -282,8 +416,45 @@ impl Process {
             })
             .map_err(|e| format!("failed to open PTY: {e}"))?;
 
-        let mut cmd = CommandBuilder::new(&command);
-        cmd.args(&args);
+        #[cfg(unix)]
+        let mut cmd = if cwd.is_empty() {
+            let mut cmd = CommandBuilder::new(&command);
+            cmd.args(&args);
+            cmd
+        } else {
+            let executable = resolve_executable(&command, &cwd, &env)?;
+            let original_home = env
+                .iter()
+                .rev()
+                .find(|(name, _)| name == "HOME")
+                .map(|(_, value)| value.clone())
+                .or_else(|| std::env::var("HOME").ok());
+            let mut cmd = CommandBuilder::new("/bin/sh");
+            cmd.arg("-c");
+            cmd.arg(
+                "if [ \"$1\" = 1 ]; then export HOME=\"$2\"; else unset HOME; fi; shift 2; exec \"$@\"",
+            );
+            cmd.arg("vmux-cwd");
+            cmd.arg(if original_home.is_some() { "1" } else { "0" });
+            cmd.arg(original_home.as_deref().unwrap_or_default());
+            cmd.arg(executable);
+            cmd.args(&args);
+            cmd.cwd(&cwd);
+            cmd
+        };
+        #[cfg(not(unix))]
+        let mut cmd = {
+            let mut cmd = CommandBuilder::new(&command);
+            cmd.args(&args);
+            if !cwd.is_empty() {
+                let cwd_path = std::path::Path::new(&cwd);
+                if !cwd_path.is_dir() {
+                    return Err(format!("cwd is not a directory: {cwd}"));
+                }
+                cmd.cwd(cwd_path);
+            }
+            cmd
+        };
         cmd.env("TERM", "xterm-256color");
         cmd.env("COLORTERM", "truecolor");
         cmd.env("LANG", "en_US.UTF-8");
@@ -291,9 +462,9 @@ impl Process {
         for (k, v) in &env {
             cmd.env(k, v);
         }
-        let cwd_path = PathBuf::from(&cwd);
-        if !cwd.is_empty() && cwd_path.exists() {
-            cmd.cwd(&cwd_path);
+        #[cfg(unix)]
+        if !cwd.is_empty() {
+            cmd.env("HOME", &cwd);
         }
 
         let child = pair
@@ -307,6 +478,11 @@ impl Process {
             .master
             .try_clone_reader()
             .map_err(|e| format!("failed to clone PTY reader: {e}"))?;
+        #[cfg(unix)]
+        let reader_fd = pair
+            .master
+            .as_raw_fd()
+            .ok_or_else(|| "PTY master has no file descriptor".to_string())?;
         let writer: PtyInputWriter = Arc::new(Mutex::new(
             pair.master
                 .take_writer()
@@ -316,6 +492,26 @@ impl Process {
 
         let (pty_tx, pty_rx) = mpsc::unbounded_channel();
         let wake_process_id = id;
+        #[cfg(unix)]
+        let pty_reader_in_flight = Arc::new(AtomicBool::new(false));
+        #[cfg(unix)]
+        let thread_reader_in_flight = Arc::clone(&pty_reader_in_flight);
+        #[cfg(unix)]
+        std::thread::Builder::new()
+            .name(format!("pty-reader-{}", &id.to_string()[..8]))
+            .spawn(move || {
+                run_pty_reader(
+                    reader,
+                    reader_fd,
+                    pty_tx,
+                    wake_tx,
+                    wake_process_id,
+                    thread_reader_in_flight,
+                    reader_send_delay,
+                );
+            })
+            .map_err(|e| format!("failed to spawn PTY reader: {e}"))?;
+        #[cfg(not(unix))]
         std::thread::Builder::new()
             .name(format!("pty-reader-{}", &id.to_string()[..8]))
             .spawn(move || {
@@ -325,6 +521,9 @@ impl Process {
                     match reader.read(&mut buf) {
                         Ok(0) => break,
                         Ok(n) => {
+                            if !reader_send_delay.is_zero() {
+                                std::thread::sleep(reader_send_delay);
+                            }
                             if pty_tx.send(buf[..n].to_vec()).is_err() {
                                 break;
                             }
@@ -364,6 +563,8 @@ impl Process {
             master: pair.master,
             child,
             pty_rx,
+            #[cfg(unix)]
+            pty_reader_in_flight,
             patch_tx,
             line_hashes: Vec::new(),
             win_hashes: HashMap::new(),
@@ -379,6 +580,7 @@ impl Process {
             copy_mode: None,
             keep_after_exit: false,
             exited: bool::default(),
+            exit_reported: false,
             exit_code: None,
         })
     }
@@ -1246,6 +1448,27 @@ impl Process {
         }
     }
 
+    fn pty_reader_drained(&self) -> bool {
+        #[cfg(unix)]
+        {
+            if self.pty_reader_in_flight.load(Ordering::Acquire) {
+                return false;
+            }
+            let Some(fd) = self.master.as_raw_fd() else {
+                return false;
+            };
+            let mut available: libc::c_int = 0;
+            if unsafe { libc::ioctl(fd, libc::FIONREAD as _, &mut available) } < 0 {
+                return false;
+            }
+            available == 0 && !self.pty_reader_in_flight.load(Ordering::Acquire)
+        }
+        #[cfg(not(unix))]
+        {
+            true
+        }
+    }
+
     /// Drain PTY output, process through VTE, broadcast viewport patches.
     /// Returns true if the child process has exited.
     pub fn poll(&mut self) -> bool {
@@ -1255,10 +1478,35 @@ impl Process {
             return false;
         }
         let mut got_data = false;
-        for _ in 0..MAX_PTY_CHUNKS_PER_POLL {
-            let Ok(data) = self.pty_rx.try_recv() else {
-                break;
+        let mut pty_closed = false;
+        let mut remaining = MAX_PTY_CHUNKS_PER_POLL;
+        let mut drained_after_exit = false;
+        loop {
+            if remaining == 0 {
+                if self.exit_code.is_none()
+                    && let Ok(Some(status)) = self.child.try_wait()
+                {
+                    self.exit_code = Some(status.exit_code() as i32);
+                }
+                if self.exit_code.is_some() && !drained_after_exit {
+                    remaining = self.pty_rx.len();
+                    drained_after_exit = true;
+                    if remaining == 0 {
+                        break;
+                    }
+                } else {
+                    break;
+                }
+            }
+            let data = match self.pty_rx.try_recv() {
+                Ok(data) => data,
+                Err(tokio::sync::mpsc::error::TryRecvError::Empty) => break,
+                Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                    pty_closed = true;
+                    break;
+                }
             };
+            remaining -= 1;
             self.processor.advance(&mut self.term, &data);
             for event in self.osc133.feed(&data) {
                 let kind = match event {
@@ -1288,14 +1536,24 @@ impl Process {
             self.sync_viewport();
         }
         self.maybe_broadcast_mode();
-        if let Ok(Some(status)) = self.child.try_wait() {
-            let code = status.exit_code() as i32;
-            self.exited = true;
-            self.exit_code = Some(code);
+        if self.exit_code.is_none()
+            && let Ok(Some(status)) = self.child.try_wait()
+        {
+            self.exit_code = Some(status.exit_code() as i32);
+        }
+        if !self.exit_reported
+            && let Some(code) = self.exit_code
+            && self.pty_reader_drained()
+            && self.pty_rx.is_empty()
+        {
+            self.exit_reported = true;
             let _ = self.patch_tx.send(ServiceMessage::ProcessExited {
                 process_id: self.id,
                 exit_code: Some(code),
             });
+        }
+        if pty_closed && self.exit_code.is_some() {
+            self.exited = true;
             return true;
         }
         false
@@ -1578,8 +1836,13 @@ impl Process {
     }
 
     pub fn kill(&mut self) {
+        if self.exit_code.is_some() {
+            return;
+        }
         let _ = self.child.kill();
-        let _ = self.child.wait();
+        if let Ok(status) = self.child.wait() {
+            self.exit_code = Some(status.exit_code() as i32);
+        }
     }
 }
 
@@ -1869,7 +2132,7 @@ mod tests {
         let (wake_tx, mut wake_rx) = mpsc::unbounded_channel();
         let mut process = Process::new_with_wake(
             ProcessId::new(),
-            "/bin/sh".to_string(),
+            "sh".to_string(),
             vec![],
             String::new(),
             Vec::new(),
@@ -1900,13 +2163,14 @@ mod tests {
         let temp = std::env::temp_dir().join(format!("vmux-process-cwd-{}", std::process::id()));
         std::fs::create_dir_all(&temp).unwrap();
         let cwd = temp.to_string_lossy().into_owned();
+        let home = temp.join("home-marker").to_string_lossy().into_owned();
         let (wake_tx, _) = mpsc::unbounded_channel();
         let mut process = Process::new_with_wake(
             ProcessId::new(),
             "/bin/sh".to_string(),
             vec![],
             cwd.clone(),
-            Vec::new(),
+            vec![("HOME".to_string(), home.clone())],
             120,
             24,
             wake_tx,
@@ -1914,14 +2178,97 @@ mod tests {
         .expect("process should spawn");
 
         drain_process_output(&mut process, Duration::from_millis(300));
-        process.write_input(b"pwd\r");
+        process.write_input(b"printf 'HOME=%s\\n' \"$HOME\"; pwd\r");
         let text = wait_for_snapshot_text(&mut process, &cwd);
 
         process.kill();
         let _ = std::fs::remove_dir_all(&temp);
 
         assert!(text.contains(&cwd));
+        assert!(text.contains(&format!("HOME={home}")));
         assert!(!text.contains(&format!("cd {cwd}")));
+    }
+
+    #[test]
+    fn process_rejects_invalid_cwd_at_spawn() {
+        let mut mgr = ProcessManager::default();
+        let cwd = std::env::temp_dir().join(format!(
+            "vmux-process-missing-cwd-{}-{}",
+            std::process::id(),
+            ProcessId::new()
+        ));
+
+        let result = mgr.create_process(
+            ProcessId::new(),
+            "/bin/sh".into(),
+            vec!["-c".into(), "exit 0".into()],
+            cwd.to_string_lossy().into_owned(),
+            Vec::new(),
+            80,
+            24,
+        );
+
+        assert!(result.is_err());
+        assert!(mgr.processes.is_empty());
+
+        let file = std::env::temp_dir().join(format!(
+            "vmux-process-file-cwd-{}-{}",
+            std::process::id(),
+            ProcessId::new()
+        ));
+        std::fs::write(&file, b"not a directory").expect("write cwd file");
+        let result = mgr.create_process(
+            ProcessId::new(),
+            "/bin/sh".into(),
+            vec!["-c".into(), "exit 0".into()],
+            file.to_string_lossy().into_owned(),
+            Vec::new(),
+            80,
+            24,
+        );
+        let _ = std::fs::remove_file(file);
+
+        assert!(result.is_err());
+        assert!(mgr.processes.is_empty());
+    }
+
+    #[test]
+    fn process_with_cwd_rejects_missing_executable_at_spawn() {
+        let mut mgr = ProcessManager::default();
+        let cwd = std::env::temp_dir().join(format!(
+            "vmux-process-command-cwd-{}-{}",
+            std::process::id(),
+            ProcessId::new()
+        ));
+        std::fs::create_dir_all(&cwd).expect("create cwd");
+
+        let result = mgr.create_process(
+            ProcessId::new(),
+            "/definitely/missing/vmux-command".into(),
+            Vec::new(),
+            cwd.to_string_lossy().into_owned(),
+            Vec::new(),
+            80,
+            24,
+        );
+        assert!(result.is_err());
+        assert!(mgr.processes.is_empty());
+
+        let command = cwd.join("not-executable");
+        std::fs::write(&command, b"#!/bin/sh\nexit 0\n").expect("write command");
+        let result = mgr.create_process(
+            ProcessId::new(),
+            command.to_string_lossy().into_owned(),
+            Vec::new(),
+            cwd.to_string_lossy().into_owned(),
+            Vec::new(),
+            80,
+            24,
+        );
+        let _ = std::fs::remove_dir_all(cwd);
+
+        assert!(result.is_err());
+        assert!(mgr.processes.is_empty());
     }
 
     #[test]
@@ -2398,5 +2745,181 @@ mod tests {
         assert_eq!(exits, 1);
 
         mgr.remove_process(&id);
+    }
+
+    #[test]
+    fn process_exit_drains_all_queued_pty_output() {
+        let (wake_tx, _wake_rx) = mpsc::unbounded_channel();
+        let mut mgr = ProcessManager::new(wake_tx);
+        let id = ProcessId::new();
+        mgr.create_process_keep_alive(
+            id,
+            "/bin/sh".into(),
+            vec![
+                "-c".into(),
+                "awk 'BEGIN { for (i = 0; i < 70000; i++) print \"abcdefgh\"; print \"TAIL-SENTINEL\" }'"
+                    .into(),
+            ],
+            String::new(),
+            Vec::new(),
+            80,
+            24,
+        )
+        .expect("spawn");
+        std::thread::sleep(Duration::from_millis(500));
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut saw_exit = false;
+        while Instant::now() < deadline {
+            if mgr.poll_all().contains(&id) {
+                saw_exit = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
+        assert!(saw_exit, "process should exit");
+        assert!(
+            mgr.processes
+                .get(&id)
+                .expect("process retained")
+                .full_text()
+                .contains("TAIL-SENTINEL"),
+            "exit must not discard queued PTY output"
+        );
+        mgr.remove_process(&id);
+    }
+
+    #[test]
+    fn process_exit_is_reported_after_queued_pty_output_is_drained() {
+        let (wake_tx, _wake_rx) = mpsc::unbounded_channel();
+        let mut mgr = ProcessManager::new(wake_tx);
+        let id = ProcessId::new();
+        mgr.create_process_keep_alive(
+            id,
+            "/bin/sh".into(),
+            vec![
+                "-c".into(),
+                "awk 'BEGIN { for (i = 0; i < 70000; i++) print \"abcdefgh\"; print \"TAIL-SENTINEL\" }'"
+                    .into(),
+            ],
+            String::new(),
+            Vec::new(),
+            80,
+            24,
+        )
+        .expect("spawn");
+        let mut rx = mgr.processes.get(&id).expect("process").subscribe();
+        std::thread::sleep(Duration::from_millis(500));
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut reported = false;
+        while Instant::now() < deadline {
+            mgr.poll_all();
+            while let Ok(message) = rx.try_recv() {
+                if matches!(message, ServiceMessage::ProcessExited { .. }) {
+                    reported = true;
+                }
+            }
+            if reported {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
+        assert!(reported, "process exit should be reported");
+        assert!(
+            mgr.processes
+                .get(&id)
+                .expect("process retained")
+                .full_text()
+                .contains("TAIL-SENTINEL"),
+            "exit must not be reported while queued PTY output remains"
+        );
+        mgr.remove_process(&id);
+    }
+
+    #[test]
+    fn process_exit_waits_for_pty_reader_catch_up() {
+        let (wake_tx, _wake_rx) = mpsc::unbounded_channel();
+        let mut process = Process::new_with_wake_and_reader_delay(
+            ProcessId::new(),
+            "/bin/sh".into(),
+            vec!["-c".into(), "printf READER-TAIL".into()],
+            String::new(),
+            Vec::new(),
+            80,
+            24,
+            wake_tx,
+            Duration::from_millis(100),
+        )
+        .expect("spawn");
+        let mut rx = process.subscribe();
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut reported = false;
+        while Instant::now() < deadline {
+            process.poll();
+            while let Ok(message) = rx.try_recv() {
+                if matches!(message, ServiceMessage::ProcessExited { .. }) {
+                    reported = true;
+                }
+            }
+            if reported {
+                break;
+            }
+            std::thread::yield_now();
+        }
+
+        assert!(reported, "process exit should be reported");
+        assert!(
+            process.full_text().contains("READER-TAIL"),
+            "exit raced with the PTY reader"
+        );
+        process.kill();
+    }
+
+    #[test]
+    fn process_exit_is_reported_before_background_descendant_closes_pty() {
+        let (wake_tx, _wake_rx) = mpsc::unbounded_channel();
+        let mut mgr = ProcessManager::new(wake_tx);
+        let id = ProcessId::new();
+        mgr.create_process_keep_alive(
+            id,
+            "/bin/sh".into(),
+            vec!["-c".into(), "exit 0".into()],
+            String::new(),
+            Vec::new(),
+            80,
+            24,
+        )
+        .expect("spawn");
+        std::thread::sleep(Duration::from_millis(50));
+        let (pty_tx, pty_rx) = mpsc::unbounded_channel();
+        let process = mgr.processes.get_mut(&id).expect("process");
+        process.pty_rx = pty_rx;
+        let mut rx = process.subscribe();
+
+        let deadline = Instant::now() + Duration::from_millis(500);
+        let mut reported = false;
+        while Instant::now() < deadline {
+            assert!(
+                !mgr.poll_all().contains(&id),
+                "process must remain until PTY output is drained"
+            );
+            while let Ok(message) = rx.try_recv() {
+                if matches!(message, ServiceMessage::ProcessExited { .. }) {
+                    reported = true;
+                }
+            }
+            if reported {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
+        drop(pty_tx);
+        mgr.remove_process(&id);
+        assert!(reported, "child exit must not wait for PTY closure");
     }
 }

--- a/crates/vmux_service/src/process.rs
+++ b/crates/vmux_service/src/process.rs
@@ -118,6 +118,15 @@ pub struct Process {
     last_terminal_mode: Option<(bool, bool, bool, bool)>,
     /// Active copy-mode state (cursor, anchor, visual state). None when not in copy mode.
     copy_mode: Option<CopyModeState>,
+    /// Keep the process (and its final grid) in the manager after the child exits instead of
+    /// being reaped by the poll loop. Set for ACP-native terminals so `terminal/output` can read
+    /// the completed command's scrollback until the agent calls `terminal/release`.
+    keep_after_exit: bool,
+    /// Set once the child has exited and `ProcessExited` has been broadcast. Guards `poll` from
+    /// re-broadcasting or re-processing a dead child every tick when `keep_after_exit` is set.
+    exited: bool,
+    /// The child's exit code, recorded when it exits. Surfaced to ACP `terminal/output`.
+    exit_code: Option<i32>,
 }
 
 /// Per-process state held while the user is in copy mode.
@@ -368,7 +377,26 @@ impl Process {
             last_viewport_copy_mode: None,
             last_terminal_mode: None,
             copy_mode: None,
+            keep_after_exit: false,
+            exited: bool::default(),
+            exit_code: None,
         })
+    }
+
+    /// Mark this process to survive child exit (ACP-native terminal). The poll loop must not reap
+    /// it; `terminal/release` removes it explicitly.
+    pub fn set_keep_after_exit(&mut self) {
+        self.keep_after_exit = true;
+    }
+
+    /// Whether this process should survive child exit instead of being reaped.
+    pub fn keep_after_exit(&self) -> bool {
+        self.keep_after_exit
+    }
+
+    /// The child's exit code once it has exited, else `None`.
+    pub fn process_exit(&self) -> Option<i32> {
+        self.exit_code
     }
 
     pub fn subscribe(&self) -> broadcast::Receiver<ServiceMessage> {
@@ -1221,6 +1249,11 @@ impl Process {
     /// Drain PTY output, process through VTE, broadcast viewport patches.
     /// Returns true if the child process has exited.
     pub fn poll(&mut self) -> bool {
+        // A kept-after-exit process (ACP terminal) stays in the manager with its final grid; skip
+        // re-processing and re-broadcasting `ProcessExited` on every subsequent tick.
+        if self.exited {
+            return false;
+        }
         let mut got_data = false;
         for _ in 0..MAX_PTY_CHUNKS_PER_POLL {
             let Ok(data) = self.pty_rx.try_recv() else {
@@ -1257,6 +1290,8 @@ impl Process {
         self.maybe_broadcast_mode();
         if let Ok(Some(status)) = self.child.try_wait() {
             let code = status.exit_code() as i32;
+            self.exited = true;
+            self.exit_code = Some(code);
             let _ = self.patch_tx.send(ServiceMessage::ProcessExited {
                 process_id: self.id,
                 exit_code: Some(code),
@@ -1592,6 +1627,36 @@ impl ProcessManager {
         let pid = process.pid;
         self.processes.insert(id, process);
         Ok((id, pid))
+    }
+
+    /// Like [`create_process`](Self::create_process) but marks the process to survive child exit
+    /// (ACP-native terminal): the poll loop must not reap it, so `terminal/output` can read the
+    /// completed command's scrollback until `terminal/release`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_process_keep_alive(
+        &mut self,
+        id: ProcessId,
+        command: String,
+        args: Vec<String>,
+        cwd: String,
+        env: Vec<(String, String)>,
+        cols: u16,
+        rows: u16,
+    ) -> Result<(ProcessId, u32), String> {
+        let created = self.create_process(id, command, args, cwd, env, cols, rows)?;
+        if let Some(process) = self.processes.get_mut(&id) {
+            process.set_keep_after_exit();
+        }
+        Ok(created)
+    }
+
+    /// Kill a process's child without removing it from the manager (keeps its final grid for ACP
+    /// `terminal/output`). Distinct from [`remove_process`](Self::remove_process), which also drops
+    /// it.
+    pub fn kill_process(&mut self, id: &ProcessId) {
+        if let Some(process) = self.processes.get_mut(id) {
+            process.kill();
+        }
     }
 
     pub fn poll_all(&mut self) -> Vec<ProcessId> {
@@ -2285,5 +2350,53 @@ mod tests {
             ServiceMessage::Bell { process_id: got_id } => assert_eq!(got_id, process_id),
             other => panic!("expected Bell, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn keep_after_exit_retains_process_and_exit_code() {
+        let (wake_tx, _wake_rx) = mpsc::unbounded_channel();
+        let mut mgr = ProcessManager::new(wake_tx);
+        let id = ProcessId::new();
+        mgr.create_process_keep_alive(
+            id,
+            "/bin/sh".into(),
+            vec!["-c".into(), "exit 5".into()],
+            String::new(),
+            Vec::new(),
+            80,
+            24,
+        )
+        .expect("spawn");
+        let mut rx = mgr.processes.get(&id).unwrap().subscribe();
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut saw_exit = false;
+        while Instant::now() < deadline {
+            if mgr.poll_all().contains(&id) {
+                saw_exit = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(saw_exit, "process should have exited");
+
+        // Kept in the manager (not reaped by poll) with its exit code recorded.
+        let process = mgr.processes.get(&id).expect("kept after exit");
+        assert_eq!(process.process_exit(), Some(5));
+
+        // Further polls neither report the exit again nor drop the process.
+        assert!(mgr.poll_all().is_empty());
+        assert!(mgr.processes.contains_key(&id));
+
+        // Exactly one ProcessExited was broadcast.
+        let mut exits = 0;
+        while let Ok(msg) = rx.try_recv() {
+            if matches!(msg, ServiceMessage::ProcessExited { .. }) {
+                exits += 1;
+            }
+        }
+        assert_eq!(exits, 1);
+
+        mgr.remove_process(&id);
     }
 }

--- a/crates/vmux_service/src/server.rs
+++ b/crates/vmux_service/src/server.rs
@@ -843,7 +843,7 @@ async fn handle_client(
 
             ClientMessage::SpawnAcpAgent {
                 sid,
-                agent_id: _,
+                agent_id,
                 command,
                 args,
                 env,
@@ -866,6 +866,7 @@ async fn handle_client(
                     .unwrap_or_default();
                 acp_manager.lock().await.spawn(
                     sid.clone(),
+                    agent_id,
                     command,
                     args,
                     env,

--- a/crates/vmux_service/src/server.rs
+++ b/crates/vmux_service/src/server.rs
@@ -82,17 +82,27 @@ pub async fn run_server(listener: UnixListener) {
                 }
             }
 
-            let exited = {
+            let reaped = {
                 let mut mgr = poll_mgr.lock().await;
                 let exited = mgr.poll_all();
+                let mut reaped = Vec::new();
                 for id in &exited {
-                    mgr.remove_process(id);
+                    // ACP-native terminals keep their final grid until `terminal/release`; don't
+                    // reap them here.
+                    let keep = mgr
+                        .processes
+                        .get(id)
+                        .is_some_and(|process| process.keep_after_exit());
+                    if !keep {
+                        mgr.remove_process(id);
+                        reaped.push(*id);
+                    }
                 }
-                exited
+                reaped
             };
-            if !exited.is_empty() {
+            if !reaped.is_empty() {
                 let mut writers = poll_input_writers.lock().await;
-                for id in exited {
+                for id in reaped {
                     writers.remove(&id);
                 }
             }
@@ -861,6 +871,8 @@ async fn handle_client(
                     env,
                     std::path::PathBuf::from(cwd),
                     anchor,
+                    Arc::clone(&manager),
+                    Arc::clone(&input_writers),
                     mcp_servers,
                     resume_acp_session_id,
                 );

--- a/crates/vmux_terminal/src/component.rs
+++ b/crates/vmux_terminal/src/component.rs
@@ -1,1 +1,4 @@
 pub use vmux_core::terminal::{ProcessExited, PtyExited, Terminal};
+
+#[derive(bevy::prelude::Component)]
+pub struct RetainOnProcessExit;

--- a/crates/vmux_terminal/src/component.rs
+++ b/crates/vmux_terminal/src/component.rs
@@ -1,4 +1,7 @@
 pub use vmux_core::terminal::{ProcessExited, PtyExited, Terminal};
 
 #[derive(bevy::prelude::Component)]
+pub struct AgentRunTerminal;
+
+#[derive(bevy::prelude::Component)]
 pub struct RetainOnProcessExit;

--- a/crates/vmux_terminal/src/lib.rs
+++ b/crates/vmux_terminal/src/lib.rs
@@ -25,7 +25,7 @@ mod link;
 pub mod pid;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use component::{ProcessExited, PtyExited, RetainOnProcessExit, Terminal};
+pub use component::{AgentRunTerminal, ProcessExited, PtyExited, RetainOnProcessExit, Terminal};
 #[cfg(not(target_arch = "wasm32"))]
 pub mod plugin;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/vmux_terminal/src/lib.rs
+++ b/crates/vmux_terminal/src/lib.rs
@@ -25,7 +25,7 @@ mod link;
 pub mod pid;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use component::{ProcessExited, PtyExited, Terminal};
+pub use component::{ProcessExited, PtyExited, RetainOnProcessExit, Terminal};
 #[cfg(not(target_arch = "wasm32"))]
 pub mod plugin;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -447,7 +447,9 @@ fn add_terminal_update_systems(app: &mut App) -> &mut App {
         .add_message::<vmux_core::notify::BellReceived>()
         .add_systems(
             Update,
-            handle_terminal_reinput_requests.after(poll_service_messages),
+            handle_terminal_reinput_requests
+                .after(poll_service_messages)
+                .before(flush_pending_terminal_input),
         )
         .add_systems(Update, apply_osc_title.after(poll_service_messages))
         .add_systems(Update, clear_osc_title_on_exit.after(poll_service_messages))
@@ -1765,15 +1767,27 @@ fn flush_pending_terminal_input(
 fn handle_terminal_reinput_requests(
     mut requests: MessageReader<TerminalReinputRequest>,
     terminals: Query<(Entity, &ProcessId), With<Terminal>>,
+    mut pending_inputs: Query<&mut PendingTerminalInput>,
     mut commands: Commands,
 ) {
+    let mut queued = std::collections::HashMap::<Entity, Vec<u8>>::new();
     for req in requests.read() {
         for (entity, pid) in &terminals {
             if *pid == req.process_id {
-                commands.entity(entity).insert(PendingTerminalInput {
-                    data: req.data.clone(),
-                });
+                queued
+                    .entry(entity)
+                    .or_default()
+                    .extend_from_slice(&req.data);
             }
+        }
+    }
+    for (entity, data) in queued {
+        if let Ok(mut pending) = pending_inputs.get_mut(entity) {
+            pending.data.extend(data);
+        } else {
+            commands
+                .entity(entity)
+                .insert(PendingTerminalInput { data });
         }
     }
 }
@@ -3853,6 +3867,73 @@ mod tests {
 
     fn process_id(byte: u8) -> ProcessId {
         ProcessId([byte; 16])
+    }
+
+    #[test]
+    fn terminal_reinput_appends_to_existing_pending_input() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<TerminalReinputRequest>()
+            .add_systems(Update, handle_terminal_reinput_requests);
+        let pid = process_id(7);
+        let terminal = app
+            .world_mut()
+            .spawn((
+                Terminal,
+                pid,
+                PendingTerminalInput {
+                    data: b"initial\r".to_vec(),
+                },
+            ))
+            .id();
+
+        app.world_mut()
+            .resource_mut::<Messages<TerminalReinputRequest>>()
+            .write(TerminalReinputRequest {
+                process_id: pid,
+                data: b"next\r".to_vec(),
+            });
+        app.update();
+
+        assert_eq!(
+            app.world()
+                .get::<PendingTerminalInput>(terminal)
+                .unwrap()
+                .data,
+            b"initial\rnext\r"
+        );
+    }
+
+    #[test]
+    fn terminal_reinput_preserves_multiple_messages_in_order() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<TerminalReinputRequest>()
+            .add_systems(Update, handle_terminal_reinput_requests);
+        let pid = process_id(8);
+        let terminal = app.world_mut().spawn((Terminal, pid)).id();
+
+        app.world_mut()
+            .resource_mut::<Messages<TerminalReinputRequest>>()
+            .write(TerminalReinputRequest {
+                process_id: pid,
+                data: b"one\r".to_vec(),
+            });
+        app.world_mut()
+            .resource_mut::<Messages<TerminalReinputRequest>>()
+            .write(TerminalReinputRequest {
+                process_id: pid,
+                data: b"two\r".to_vec(),
+            });
+        app.update();
+
+        assert_eq!(
+            app.world()
+                .get::<PendingTerminalInput>(terminal)
+                .unwrap()
+                .data,
+            b"one\rtwo\r"
+        );
     }
 
     #[test]

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -277,6 +277,8 @@ pub struct RunShellRequest {
 pub struct TerminalStackSpawnRequest {
     pub pane: Entity,
     pub cwd: Option<PathBuf>,
+    pub shell: Option<String>,
+    pub agent_run: bool,
     pub pending_input: Option<Vec<u8>>,
     /// Pin this `ProcessId` on the spawned terminal (so the caller can address
     /// it later); `None` lets the bundle mint a fresh one.
@@ -705,11 +707,23 @@ pub fn new_terminal_bundle_with_cwd(
     settings: &AppSettings,
     cwd: Option<&std::path::Path>,
 ) -> impl Bundle {
-    let shell = settings
-        .terminal
-        .as_ref()
-        .map(|t| t.resolve_theme(&t.default_theme).shell)
-        .unwrap_or_else(default_shell);
+    new_terminal_bundle_with_cwd_and_shell(meshes, webview_mt, settings, cwd, None)
+}
+
+fn new_terminal_bundle_with_cwd_and_shell(
+    meshes: &mut ResMut<Assets<Mesh>>,
+    webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
+    settings: &AppSettings,
+    cwd: Option<&std::path::Path>,
+    shell: Option<&str>,
+) -> impl Bundle {
+    let shell = shell.map(str::to_string).unwrap_or_else(|| {
+        settings
+            .terminal
+            .as_ref()
+            .map(|t| t.resolve_theme(&t.default_theme).shell)
+            .unwrap_or_else(default_shell)
+    });
 
     let cwd_str = cwd
         .filter(|d| !d.to_string_lossy().contains("://"))
@@ -800,16 +814,20 @@ pub fn respond_terminal_stack_spawn(
         });
         let terminal = commands
             .spawn((
-                new_terminal_bundle_with_cwd(
+                new_terminal_bundle_with_cwd_and_shell(
                     &mut meshes,
                     &mut webview_mt,
                     &settings,
                     request.cwd.as_deref(),
+                    request.shell.as_deref(),
                 ),
                 ChildOf(stack),
             ))
             .id();
         commands.entity(terminal).insert(CefKeyboardTarget);
+        if request.agent_run {
+            commands.entity(terminal).insert(crate::AgentRunTerminal);
+        }
         if let Some(pid) = request.process_id {
             commands.entity(terminal).insert(pid);
         }
@@ -1240,7 +1258,12 @@ fn sync_agent_focus(
 
 fn poll_service_messages(
     pending_create: Query<
-        (Entity, &ProcessId, &crate::launch::TerminalLaunch),
+        (
+            Entity,
+            &ProcessId,
+            &crate::launch::TerminalLaunch,
+            Has<crate::AgentRunTerminal>,
+        ),
         (With<Terminal>, With<PendingServiceCreate>),
     >,
     pending_attach: Query<(Entity, &ProcessId), (With<Terminal>, With<PendingServiceAttach>)>,
@@ -1274,13 +1297,13 @@ fn poll_service_messages(
         awaiting_create.iter().count(),
         MAX_CONCURRENT_PROCESS_CREATES,
     );
-    for (entity, process_id, launch) in pending_create.iter().take(create_budget) {
+    for (entity, process_id, launch, agent_run) in pending_create.iter().take(create_budget) {
         // Agents run as bare executables and don't load the user's shell config
         // the way a terminal does, so merge in the login-shell env (API keys
         // etc.). Done here (at spawn) rather than at launch-build time so it
         // also covers agents restored from a persisted space or restarted.
         let mut env = launch.env.clone();
-        if agent_sessions.contains(entity) {
+        if should_merge_login_shell_env(agent_sessions.contains(entity), agent_run) {
             crate::shell_env::merge_login_shell_env(&mut env, &terminal_shell(&settings));
         }
         service.0.send(ClientMessage::CreateProcess {
@@ -1699,6 +1722,10 @@ fn poll_service_messages(
             _ => {}
         }
     }
+}
+
+fn should_merge_login_shell_env(agent_session: bool, agent_run: bool) -> bool {
+    agent_session || agent_run
 }
 
 type ServiceTerminalFilter = (
@@ -3485,6 +3512,7 @@ fn on_restart_pty(
         Option<&mut crate::launch::TerminalLaunch>,
         Option<&vmux_core::agent::AgentSession>,
         Option<&TerminalGridSize>,
+        Has<crate::AgentRunTerminal>,
     )>,
     service: Option<Res<ServiceClient>>,
     settings: Res<AppSettings>,
@@ -3493,7 +3521,8 @@ fn on_restart_pty(
 ) {
     let entity = trigger.event().entity;
     let Some(service) = service else { return };
-    let Ok((mut pid, mut meta, mut launch, agent_session, grid)) = q.get_mut(entity) else {
+    let Ok((mut pid, mut meta, mut launch, agent_session, grid, agent_run)) = q.get_mut(entity)
+    else {
         return;
     };
 
@@ -3506,7 +3535,7 @@ fn on_restart_pty(
         .0
         .send(ClientMessage::KillProcess { process_id: *pid });
 
-    let (command, args, cwd, env) = match launch.as_deref() {
+    let (command, args, cwd, mut env) = match launch.as_deref() {
         Some(l) => (
             l.command.clone(),
             l.args.clone(),
@@ -3522,6 +3551,9 @@ fn on_restart_pty(
             (shell, vec![], String::new(), Vec::new())
         }
     };
+    if should_merge_login_shell_env(false, agent_run) {
+        crate::shell_env::merge_login_shell_env(&mut env, &terminal_shell(&settings));
+    }
 
     let (cols, rows) = grid.map(|g| (g.cols, g.rows)).unwrap_or((80, 24));
     let new_id = ProcessId::new();
@@ -3760,6 +3792,8 @@ pub fn handle_run_shell_requests(
             terminal_stack_spawns.write(TerminalStackSpawnRequest {
                 pane,
                 cwd: cwd_path,
+                shell: None,
+                agent_run: false,
                 pending_input: Some(input),
                 process_id: None,
                 activate: true,
@@ -3913,6 +3947,42 @@ mod tests {
             .get::<PendingTerminalInput>(terminal)
             .expect("input routed to terminal by process id uuid");
         assert_eq!(pending.data, b"hi".to_vec());
+    }
+
+    #[test]
+    fn terminal_stack_spawn_uses_requested_shell() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<TerminalStackSpawnRequest>()
+            .insert_resource(test_settings())
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+            .add_systems(Update, respond_terminal_stack_spawn);
+
+        let pane = app.world_mut().spawn_empty().id();
+        app.world_mut()
+            .resource_mut::<Messages<TerminalStackSpawnRequest>>()
+            .write(TerminalStackSpawnRequest {
+                pane,
+                cwd: None,
+                shell: Some("/bin/agent-sh".to_string()),
+                agent_run: true,
+                pending_input: None,
+                process_id: None,
+                activate: false,
+            });
+        app.update();
+
+        let mut launches = app
+            .world_mut()
+            .query_filtered::<(Entity, &crate::launch::TerminalLaunch), With<Terminal>>();
+        let (terminal, launch) = launches.iter(app.world()).next().expect("terminal spawned");
+        assert_eq!(launch.command, "/bin/agent-sh");
+        assert!(
+            app.world()
+                .get::<crate::AgentRunTerminal>(terminal)
+                .is_some()
+        );
     }
 
     #[test]
@@ -5150,6 +5220,13 @@ mod tests {
     #[test]
     fn retained_terminal_does_not_close_stack_on_exit() {
         assert!(!should_close_terminal_stack_on_exit(false, true));
+    }
+
+    #[test]
+    fn agent_run_terminal_inherits_login_shell_environment() {
+        assert!(should_merge_login_shell_env(false, true));
+        assert!(should_merge_login_shell_env(true, false));
+        assert!(!should_merge_login_shell_env(false, false));
     }
 
     fn term_theme(font_size: f32) -> vmux_setting::TerminalTheme {

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -1158,6 +1158,8 @@ struct PollServiceWriters<'w> {
     page_agent_info: MessageWriter<'w, vmux_service::agent_events::PageAgentInfo>,
     page_agent_session_created:
         MessageWriter<'w, vmux_service::agent_events::PageAgentSessionCreated>,
+    page_agent_acp_terminal_created:
+        MessageWriter<'w, vmux_service::agent_events::PageAgentAcpTerminalCreated>,
     agent_command_results: MessageWriter<'w, vmux_service::agent_events::AgentCommandResultEvent>,
     agent_query_results: MessageWriter<'w, vmux_service::agent_events::AgentQueryResultEvent>,
     process_exited: MessageWriter<'w, ProcessExitedEvent>,
@@ -1676,6 +1678,25 @@ fn poll_service_messages(
                     vmux_service::agent_events::PageAgentSessionCreated {
                         sid,
                         acp_session_id,
+                    },
+                );
+            }
+            ServiceMessage::AcpTerminalCreated {
+                sid,
+                terminal_id,
+                process_id,
+                command,
+                args,
+                cwd,
+            } => {
+                writers.page_agent_acp_terminal_created.write(
+                    vmux_service::agent_events::PageAgentAcpTerminalCreated {
+                        sid,
+                        terminal_id,
+                        process_id,
+                        command,
+                        args,
+                        cwd,
                     },
                 );
             }

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -34,7 +34,7 @@ use vmux_setting::{AppSettings, SettingsSaveRequest};
 use crate::event::*;
 use crate::pid::{self, Pid};
 use crate::processes_monitor::ProcessesMonitor;
-use crate::{ProcessExited, Terminal};
+use crate::{ProcessExited, RetainOnProcessExit, Terminal};
 
 const MULTI_CLICK_WINDOW: std::time::Duration = std::time::Duration::from_millis(300);
 const MULTI_CLICK_CELL_TOLERANCE: i32 = 1;
@@ -1249,12 +1249,8 @@ fn poll_service_messages(
         (With<Terminal>, With<AwaitingProcessCreated>),
     >,
     terminals: Query<
-        (Entity, &ProcessId, &ChildOf),
-        (
-            With<Terminal>,
-            Without<ProcessExited>,
-            Without<AwaitingProcessCreated>,
-        ),
+        (Entity, &ProcessId, &ChildOf, Has<RetainOnProcessExit>),
+        ServiceTerminalFilter,
     >,
     service: Option<Res<ServiceClient>>,
     browsers: NonSend<Browsers>,
@@ -1360,7 +1356,7 @@ fn poll_service_messages(
                 mouse,
                 evicted_total,
             } => {
-                for (entity, pid, _) in &terminals {
+                for (entity, pid, _, _) in &terminals {
                     if *pid == process_id {
                         if !output_seen.contains(entity) {
                             let has_content =
@@ -1409,7 +1405,7 @@ fn poll_service_messages(
                     process_id,
                     title: title.clone(),
                 });
-                for (entity, pid, _) in &terminals {
+                for (entity, pid, _, _) in &terminals {
                     if *pid == process_id {
                         if !browsers.has_browser(entity) || !browsers.host_emit_ready(&entity) {
                             continue;
@@ -1431,7 +1427,7 @@ fn poll_service_messages(
                 cols,
                 rows,
             } => {
-                for (entity, pid, _) in &terminals {
+                for (entity, pid, _, _) in &terminals {
                     if *pid == process_id {
                         if !output_seen.contains(entity) {
                             let has_content = lines.iter().any(line_has_content);
@@ -1480,7 +1476,7 @@ fn poll_service_messages(
                 mode_map.modes.remove(&process_id);
                 set_local_copy_mode(&mut local_copy_mode, process_id, false);
                 mouse_state.per_process.remove(&process_id);
-                for (entity, pid, child_of) in &terminals {
+                for (entity, pid, child_of, retain_on_exit) in &terminals {
                     if *pid == process_id {
                         commands
                             .entity(entity)
@@ -1505,7 +1501,7 @@ fn poll_service_messages(
                         // terminals are closed by the agent crate (it
                         // force-closes the whole pane), so skip the stack close
                         // here to avoid a double close collapsing the wrong pane.
-                        if !is_agent {
+                        if should_close_terminal_stack_on_exit(is_agent, retain_on_exit) {
                             let tab = child_of.get();
                             commands.entity(tab).insert(LastActivatedAt::now());
                             writers
@@ -1526,7 +1522,7 @@ fn poll_service_messages(
                 if let Some(stale_pid) = missing_process_id(&message)
                     && !restarted_missing_processes.contains(&stale_pid)
                 {
-                    let candidates = terminals.iter().map(|(entity, terminal_pid, _)| {
+                    let candidates = terminals.iter().map(|(entity, terminal_pid, _, _)| {
                         let launch = launches.get(entity).cloned().unwrap_or_else(|_| {
                             crate::launch::TerminalLaunch {
                                 command: terminal_shell(&settings),
@@ -1703,6 +1699,16 @@ fn poll_service_messages(
             _ => {}
         }
     }
+}
+
+type ServiceTerminalFilter = (
+    With<Terminal>,
+    Or<(Without<ProcessExited>, With<RetainOnProcessExit>)>,
+    Without<AwaitingProcessCreated>,
+);
+
+fn should_close_terminal_stack_on_exit(is_agent: bool, retain_on_exit: bool) -> bool {
+    !is_agent && !retain_on_exit
 }
 
 fn flush_pending_terminal_input(
@@ -5128,6 +5134,22 @@ mod tests {
             .write(ProcessExitedEvent { process_id: pid });
         app.update();
         assert!(app.world().get::<vmux_core::OscTitle>(e).is_none());
+    }
+
+    #[test]
+    fn retained_terminal_stays_in_service_query_after_exit() {
+        let mut world = World::new();
+        let entity = world
+            .spawn((Terminal, ProcessExited, RetainOnProcessExit))
+            .id();
+        let mut query = world.query_filtered::<Entity, ServiceTerminalFilter>();
+
+        assert!(query.get(&world, entity).is_ok());
+    }
+
+    #[test]
+    fn retained_terminal_does_not_close_stack_on_exit() {
+        assert!(!should_close_terminal_stack_on_exit(false, true));
     }
 
     fn term_theme(font_size: f32) -> vmux_setting::TerminalTheme {

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -925,6 +925,14 @@ fn shell_prompt_ready(has_content: bool, cursor_col: u16) -> bool {
 #[derive(Component)]
 pub struct AwaitingProcessCreated;
 
+/// Resets prompt readiness while retaining any queued terminal input for the replacement process.
+pub fn mark_terminal_restarting(commands: &mut Commands, entity: Entity) {
+    commands
+        .entity(entity)
+        .remove::<ShellOutputSeen>()
+        .insert(AwaitingProcessCreated);
+}
+
 pub fn apply_process_created(
     commands: &mut Commands,
     entity: Entity,
@@ -1567,15 +1575,16 @@ fn poll_service_messages(
                         let new_id = restart.new_id;
                         let entity = restart.entity;
                         service.0.send(restart.command);
-                        let mut ec = commands.entity(entity);
-                        ec.insert(new_id);
-                        ec.insert(AwaitingProcessCreated);
+                        commands.entity(entity).insert(new_id);
+                        mark_terminal_restarting(&mut commands, entity);
                         if let Some(kind) = agent_kind {
-                            ec.insert(vmux_core::agent::PendingAgentSession {
-                                kind,
-                                spawn_time: std::time::SystemTime::now(),
-                                cwd: std::path::PathBuf::from(&cwd),
-                            });
+                            commands
+                                .entity(entity)
+                                .insert(vmux_core::agent::PendingAgentSession {
+                                    kind,
+                                    spawn_time: std::time::SystemTime::now(),
+                                    cwd: std::path::PathBuf::from(&cwd),
+                                });
                         }
                     }
                 }
@@ -3582,7 +3591,7 @@ fn on_restart_pty(
     });
 
     *pid = new_id;
-    commands.entity(entity).insert(AwaitingProcessCreated);
+    mark_terminal_restarting(&mut commands, entity);
     if let Some(l) = launch.as_mut() {
         l.args = args;
     } else {
@@ -4829,6 +4838,41 @@ mod tests {
         }
 
         assert!(!local_copy_mode.active.contains(&process_id));
+    }
+
+    #[test]
+    fn restart_state_clears_shell_output_seen_and_preserves_pending_input() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        let entity = app
+            .world_mut()
+            .spawn((
+                Terminal,
+                ShellOutputSeen,
+                PendingTerminalInput {
+                    data: b"queued\r".to_vec(),
+                },
+            ))
+            .id();
+
+        app.world_mut()
+            .run_system_cached_with(
+                |In(entity): In<Entity>, mut commands: Commands| {
+                    mark_terminal_restarting(&mut commands, entity);
+                },
+                entity,
+            )
+            .unwrap();
+
+        assert!(app.world().get::<ShellOutputSeen>(entity).is_none());
+        assert!(app.world().get::<AwaitingProcessCreated>(entity).is_some());
+        assert_eq!(
+            app.world()
+                .get::<PendingTerminalInput>(entity)
+                .unwrap()
+                .data,
+            b"queued\r"
+        );
     }
 
     #[test]

--- a/docs/specs/2026-07-13-agent-run-user-shell-design.md
+++ b/docs/specs/2026-07-13-agent-run-user-shell-design.md
@@ -1,0 +1,80 @@
+# Agent Runs in the User's Terminal Shell — Design
+
+**Date:** 2026-07-13
+**Status:** Approved
+**Ships in:** PR #245
+
+## Problem
+
+Agent `run` commands open a visible native terminal, but that terminal is currently pinned to
+`/bin/sh`. This differs from normal vmux terminals and exposes an implementation shell instead of
+the user's configured terminal environment. It is especially confusing in a co-working app where
+the user watches and can continue interacting with the same terminal.
+
+## Chosen approach
+
+Follow the Cursor model: agent commands run directly in a visible vmux terminal using the same
+shell selection as a terminal opened by the user.
+
+This is general behavior, not Nushell-specific behavior. Shell resolution remains:
+
+1. The shell configured by the active terminal theme.
+2. The user's `SHELL` environment variable when terminal settings are unavailable.
+3. The existing platform fallback.
+
+No separate agent-shell setting and no fixed command-runner shell are introduced.
+
+## Alternatives considered
+
+### Fixed POSIX runner
+
+Keep `/bin/sh` for predictable command syntax. Rejected because the visible terminal would not be
+the user's terminal and would continue exposing implementation details.
+
+### Separate configurable agent shell
+
+Add an agent-specific shell setting. Rejected because it duplicates terminal configuration and
+creates two competing definitions of the user's terminal environment.
+
+## Command flow
+
+1. Resolve the destination terminal: an explicitly requested terminal, a reusable agent-run
+   terminal, or a newly created terminal.
+2. For an existing terminal, use its actual `TerminalLaunch.command` as the shell identity.
+3. For a new terminal, resolve the shell through the normal vmux terminal settings path.
+4. Build the completion-marker wrapper for that exact shell. Nushell, Fish, and POSIX-style shells
+   retain their existing marker syntax. The command itself is not translated between shells.
+5. Spawn a new terminal with the same resolved shell used to build its initial input. Keep the
+   initial input pending until the terminal reports that its prompt is ready.
+6. For a ready existing terminal, write the command directly to its PTY.
+7. Preserve existing cwd selection, login-shell environment capture, pager suppression, terminal
+   reuse, placement, focus, output display, and exit-status reporting.
+
+Using the destination terminal's launch shell prevents marker syntax from becoming stale if the
+user changes terminal settings while an older agent-run terminal remains open.
+
+## Failure behavior
+
+- Missing explicit terminal, process startup failure, and stale placement errors keep their current
+  responses.
+- Shell startup failures remain visible in the native terminal.
+- Unknown shell names keep the existing POSIX marker fallback.
+- The initial command must never be submitted before a newly spawned shell reaches prompt-ready
+  state.
+
+## Testing
+
+- Replace tests asserting `/bin/sh` pinning with tests asserting normal shell resolution.
+- Verify a newly spawned agent-run terminal uses the same shell for `TerminalLaunch` and completion
+  marker formatting.
+- Verify explicit and reused terminals format commands from their actual launch shell.
+- Cover Nushell, Fish, POSIX, and unknown-shell marker selection.
+- Preserve regression coverage that the first command waits for prompt readiness and executes once.
+- Preserve cwd, environment, terminal reuse, placement, output, and non-zero exit-code tests.
+
+## Out of scope
+
+- Translating model-generated commands between shell languages.
+- Adding an agent-specific shell preference.
+- Running commands in a hidden or detached shell process.
+- Changing normal terminal shell configuration.


### PR DESCRIPTION
## Context

ACP agents currently run shell commands invisibly because vmux does not expose the ACP terminal capability. This adds standards-compliant client terminals backed by visible vmux panes.

## Implementation

Implements the five ACP terminal methods using the daemon process manager, preserves completed output with ACP byte-limit semantics, and attaches visible panes to existing process IDs. ACP sessions no longer receive the custom `run` or `read_terminal` MCP tools, while `terminal_send` remains available for interactive input.

## Checks / QA

- Launch vmux from this branch with `make`.
- Open an installed ACP agent and ask it to run a slow shell loop.
- Confirm a terminal pane appears beside chat, streams output, and remains visible after exit.
- Confirm subsequent ACP commands create usable terminal panes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ACP-native terminal support, including terminal creation events, safe terminal reattachment to the existing PTY, and full lifecycle handling (output streaming, exit state, and release).
  * Added an MCP CLI option `--acp-terminals` to tailor the toolset for ACP sessions (hides `run`/`read_terminal`, keeps terminal messaging).

* **Bug Fixes**
  * Improved process/PTY exit sequencing and “retain on exit” behavior to prevent lost output and ensure correct terminal cleanup.
  * Enhanced `codex` ACP install by validating/rewriting `CODEX_CONFIG` and enforcing the expected configuration.

* **Other**
  * Added ACP-specific MCP sidecar resolution and improved ACP terminal content handling in tool recording.

* **Tests**
  * Expanded coverage for ACP terminal behavior, MCP tool availability, and `CODEX_CONFIG` rewriting cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->