### PR TITLE
fix(run): enforce automatic pane placement

### DIFF
--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -4706,9 +4706,7 @@ mod tests {
         let settings = test_settings();
         assert_eq!(
             validate_run_placement_policy(&settings, true),
-            Err(
-                "run placement overrides are disabled; omit mode, direction, and beside and retry"
-            )
+            Err("run placement overrides are disabled; omit mode, direction, and beside and retry")
         );
     }
 

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -1548,6 +1548,7 @@ fn handle_agent_commands(
             }
             ServiceAgentCommand::OpenBeside { .. }
             | ServiceAgentCommand::Run { .. }
+            | ServiceAgentCommand::RunWithPlacementOverride { .. }
             | ServiceAgentCommand::CreateWorktree { .. } => {
                 continue;
             }
@@ -1946,7 +1947,16 @@ fn handle_agent_self_commands(
             ServiceAgentCommand::Run {
                 anchor,
                 command,
-                placement_override,
+                direction,
+                focus,
+                beside,
+                mode,
+                terminal,
+                done_marker,
+            }
+            | ServiceAgentCommand::RunWithPlacementOverride {
+                anchor,
+                command,
                 direction,
                 focus,
                 beside,
@@ -1954,7 +1964,13 @@ fn handle_agent_self_commands(
                 terminal,
                 done_marker,
             } => 'run: {
-                if let Err(error) = validate_run_placement_policy(&settings, *placement_override) {
+                let placement_override = matches!(
+                    &request.command,
+                    ServiceAgentCommand::RunWithPlacementOverride { .. }
+                ) || beside.is_some()
+                    || *mode != vmux_service::protocol::PlacementMode::Auto
+                    || *direction != vmux_service::protocol::AgentPaneDirection::Right;
+                if let Err(error) = validate_run_placement_policy(&settings, placement_override) {
                     break 'run AgentCommandResult::Error(error.to_string());
                 }
                 let focus = requested_focus_for_origin(&request.origin, *focus);

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -1859,6 +1859,20 @@ fn run_command_line(command: &str, token: Option<&str>, settings: &AppSettings) 
     }
 }
 
+const RUN_PLACEMENT_OVERRIDE_DISABLED: &str =
+    "run placement overrides are disabled; omit mode, direction, and beside and retry";
+
+fn validate_run_placement_policy(
+    settings: &AppSettings,
+    placement_override: bool,
+) -> Result<(), &'static str> {
+    if placement_override && !settings.agent.allow_run_placement_override {
+        Err(RUN_PLACEMENT_OVERRIDE_DISABLED)
+    } else {
+        Ok(())
+    }
+}
+
 fn run_terminal_cwd(agent_launch_cwd: Option<&str>, active_space: Option<&ActiveSpace>) -> PathBuf {
     if let Some(Ok(Some(path))) = agent_launch_cwd.map(valid_cwd) {
         return path;
@@ -1932,13 +1946,17 @@ fn handle_agent_self_commands(
             ServiceAgentCommand::Run {
                 anchor,
                 command,
+                placement_override,
                 direction,
                 focus,
                 beside,
                 mode,
                 terminal,
                 done_marker,
-            } => {
+            } => 'run: {
+                if let Err(error) = validate_run_placement_policy(&settings, *placement_override) {
+                    break 'run AgentCommandResult::Error(error.to_string());
+                }
                 let focus = requested_focus_for_origin(&request.origin, *focus);
                 let mut data =
                     run_command_line(command, done_marker.as_deref(), &settings).into_bytes();
@@ -4681,6 +4699,30 @@ mod tests {
 
         assert_eq!(picked.pid, terminal);
         assert_eq!(picked.pane, terminal_pane);
+    }
+
+    #[test]
+    fn run_placement_policy_rejects_override_by_default() {
+        let settings = test_settings();
+        assert_eq!(
+            validate_run_placement_policy(&settings, true),
+            Err(
+                "run placement overrides are disabled; omit mode, direction, and beside and retry"
+            )
+        );
+    }
+
+    #[test]
+    fn run_placement_policy_allows_bare_run() {
+        let settings = test_settings();
+        assert_eq!(validate_run_placement_policy(&settings, false), Ok(()));
+    }
+
+    #[test]
+    fn run_placement_policy_honors_user_opt_out() {
+        let mut settings = test_settings();
+        settings.agent.allow_run_placement_override = true;
+        assert_eq!(validate_run_placement_policy(&settings, true), Ok(()));
     }
 
     #[test]

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -3739,7 +3739,7 @@ mod tests {
     }
 
     #[test]
-    fn agent_cannot_enable_run_placement_override_through_settings_update() {
+    fn run_placement_override_settings_update_rejects_agents_and_allows_users() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, vmux_command::CommandPlugin, AgentPlugin))
             .add_message::<vmux_layout::BrowserNavigateRequest>()
@@ -3793,6 +3793,24 @@ mod tests {
                 "agent update unexpectedly enabled override through {path}"
             );
         }
+
+        app.world_mut()
+            .resource_mut::<Messages<AgentCommandRequest>>()
+            .write(AgentCommandRequest {
+                request_id: AgentRequestId::new(),
+                origin: CommandOrigin::User,
+                command: ServiceAgentCommand::UpdateSettings {
+                    path: "agent.allow_run_placement_override".to_string(),
+                    value_json: serde_json::json!(true).to_string(),
+                },
+            });
+        app.update();
+        assert!(
+            app.world()
+                .resource::<AppSettings>()
+                .agent
+                .allow_run_placement_override
+        );
     }
 
     #[test]

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -1484,12 +1484,23 @@ fn handle_agent_commands(
             ServiceAgentCommand::UpdateSettings { path, value_json } => {
                 match serde_json::from_str::<serde_json::Value>(value_json) {
                     Ok(value) => {
-                        match vmux_setting::apply_settings_update(sp.settings.as_mut(), path, value)
-                        {
+                        let mut updated = (*sp.settings).clone();
+                        match vmux_setting::apply_settings_update(&mut updated, path, value) {
                             Ok(ron_bytes) => {
-                                sp.writes
-                                    .write(vmux_setting::SettingsWriteRequest { ron_bytes });
-                                AgentCommandResult::Ok
+                                if origin_is_agent(&request.origin)
+                                    && updated.agent.allow_run_placement_override
+                                        != sp.settings.agent.allow_run_placement_override
+                                {
+                                    AgentCommandResult::Error(
+                                        "update_settings: agent.allow_run_placement_override can only be changed in Settings"
+                                            .to_string(),
+                                    )
+                                } else {
+                                    *sp.settings = updated;
+                                    sp.writes
+                                        .write(vmux_setting::SettingsWriteRequest { ron_bytes });
+                                    AgentCommandResult::Ok
+                                }
                             }
                             Err(message) => AgentCommandResult::Error(message),
                         }
@@ -3725,6 +3736,63 @@ mod tests {
         // sparse RON includes only sections that differ from the embedded
         // defaults; this override differs, so it appears.
         assert!(ron_bytes.contains("https://example.com/custom"));
+    }
+
+    #[test]
+    fn agent_cannot_enable_run_placement_override_through_settings_update() {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, vmux_command::CommandPlugin, AgentPlugin))
+            .add_message::<vmux_layout::BrowserNavigateRequest>()
+            .add_message::<vmux_layout::BrowserGoBackRequest>()
+            .add_message::<vmux_layout::BrowserGoForwardRequest>()
+            .add_message::<vmux_layout::OpenInNewStackRequest>()
+            .add_message::<vmux_layout::ExtensionInstallRequest>()
+            .add_message::<vmux_layout::OpenBesideRequest>()
+            .add_message::<vmux_layout::reconcile::LayoutApplyRequest>()
+            .add_message::<vmux_layout::reconcile::LayoutApplyResponse>()
+            .add_message::<vmux_layout::reconcile::LayoutSnapshotRequest>()
+            .add_message::<vmux_layout::reconcile::LayoutSnapshotResponse>()
+            .add_message::<vmux_terminal::TerminalSendRequest>()
+            .add_message::<vmux_terminal::RunShellRequest>()
+            .add_message::<vmux_setting::SettingsWriteRequest>()
+            .add_message::<vmux_space::SpaceCommandRequest>()
+            .add_message::<vmux_history::query::HistoryOpenIntent>()
+            .insert_resource(FocusedStack::default())
+            .insert_resource(test_settings())
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>();
+
+        let mut agent_value = serde_json::to_value(vmux_setting::AgentSettings::default()).unwrap();
+        agent_value["allow_run_placement_override"] = serde_json::json!(true);
+        for (path, value_json) in [
+            (
+                "agent.allow_run_placement_override",
+                serde_json::json!(true).to_string(),
+            ),
+            ("agent", agent_value.to_string()),
+        ] {
+            app.world_mut()
+                .resource_mut::<Messages<AgentCommandRequest>>()
+                .write(AgentCommandRequest {
+                    request_id: AgentRequestId::new(),
+                    origin: CommandOrigin::Agent {
+                        sid: Some("test-agent".to_string()),
+                        anchor: None,
+                    },
+                    command: ServiceAgentCommand::UpdateSettings {
+                        path: path.to_string(),
+                        value_json,
+                    },
+                });
+            app.update();
+            assert!(
+                !app.world()
+                    .resource::<AppSettings>()
+                    .agent
+                    .allow_run_placement_override,
+                "agent update unexpectedly enabled override through {path}"
+            );
+        }
     }
 
     #[test]

--- a/crates/vmux_mcp/src/protocol.rs
+++ b/crates/vmux_mcp/src/protocol.rs
@@ -119,6 +119,7 @@ async fn tool_call_result(
         crate::tools::DispatchTarget::Command(AgentCommand::Run {
             anchor,
             command,
+            placement_override,
             direction,
             focus,
             beside,
@@ -129,6 +130,7 @@ async fn tool_call_result(
             let run = AgentCommand::Run {
                 anchor,
                 command,
+                placement_override,
                 direction,
                 focus,
                 beside,
@@ -848,6 +850,7 @@ mod tests {
         let run = AgentCommand::Run {
             anchor,
             command: "git status".into(),
+            placement_override: false,
             direction: vmux_service::protocol::AgentPaneDirection::Right,
             focus: false,
             beside: None,

--- a/crates/vmux_mcp/src/protocol.rs
+++ b/crates/vmux_mcp/src/protocol.rs
@@ -116,30 +116,10 @@ async fn tool_call_result(
     }
 
     match crate::tools::dispatch_with_anchor(name, arguments, anchor)? {
-        crate::tools::DispatchTarget::Command(AgentCommand::Run {
-            anchor,
-            command,
-            placement_override,
-            direction,
-            focus,
-            beside,
-            mode,
-            terminal,
-            ..
-        }) => {
-            let run = AgentCommand::Run {
-                anchor,
-                command,
-                placement_override,
-                direction,
-                focus,
-                beside,
-                mode,
-                terminal,
-                done_marker: None,
-            };
-            run_blocking(run).await
-        }
+        crate::tools::DispatchTarget::Command(command @ AgentCommand::Run { .. })
+        | crate::tools::DispatchTarget::Command(
+            command @ AgentCommand::RunWithPlacementOverride { .. },
+        ) => run_blocking(command).await,
         crate::tools::DispatchTarget::Command(command) => run_agent_command(command, anchor).await,
         crate::tools::DispatchTarget::Query(query) => run_agent_query(query).await,
     }
@@ -401,8 +381,12 @@ fn run_done_token(request_id: AgentRequestId) -> String {
 }
 
 fn blocking_run_with_marker(mut run: AgentCommand, request_id: AgentRequestId) -> AgentCommand {
-    if let AgentCommand::Run { done_marker, .. } = &mut run {
-        *done_marker = Some(run_done_token(request_id));
+    match &mut run {
+        AgentCommand::Run { done_marker, .. }
+        | AgentCommand::RunWithPlacementOverride { done_marker, .. } => {
+            *done_marker = Some(run_done_token(request_id));
+        }
+        _ => {}
     }
     run
 }
@@ -850,7 +834,6 @@ mod tests {
         let run = AgentCommand::Run {
             anchor,
             command: "git status".into(),
-            placement_override: false,
             direction: vmux_service::protocol::AgentPaneDirection::Right,
             focus: false,
             beside: None,
@@ -866,6 +849,30 @@ mod tests {
                 assert_eq!(done_marker, Some(run_done_token(request_id)));
             }
             _ => panic!("expected run command"),
+        }
+    }
+
+    #[test]
+    fn blocking_placement_override_run_sets_done_marker_token() {
+        let request_id = AgentRequestId([9; 16]);
+        let run = AgentCommand::RunWithPlacementOverride {
+            anchor: vmux_service::protocol::ProcessId::new(),
+            command: "git status".into(),
+            direction: vmux_service::protocol::AgentPaneDirection::Bottom,
+            focus: false,
+            beside: None,
+            mode: vmux_service::protocol::PlacementMode::Split,
+            terminal: None,
+            done_marker: None,
+        };
+
+        let marked = blocking_run_with_marker(run, request_id);
+
+        match marked {
+            AgentCommand::RunWithPlacementOverride { done_marker, .. } => {
+                assert_eq!(done_marker, Some(run_done_token(request_id)));
+            }
+            _ => panic!("expected run placement override command"),
         }
     }
 }

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -411,7 +411,9 @@ PLACEMENT — by DEFAULT you don't need to think about this: a bare `run` reuses
 beside you — the SAME shell across calls, so its working directory and environment persist. Do NOT `cd` \
 into your project on every run; the shell stays where it was. The first `run` opens it; later ones run \
 in that same shell. Rule of thumb: don't open a new pane unless you actually need one. \
-Override only when you mean to: \
+Placement overrides are disabled by default: omit `mode`, `direction`, and `beside`. If vmux rejects \
+them, retry the bare run. Users can enable overrides with `agent.allow_run_placement_override`. \
+When enabled, override only when you mean to: \
 - `mode`: `auto` (default, reuse your one persistent shell) | `split` (force a NEW pane) | `stack` \
 (force a new stacked terminal in the anchor's pane). \
 - `beside`: anchor to a specific page — a terminal id a previous run returned, or \"self\" for your own \
@@ -735,17 +737,30 @@ pub fn dispatch_with_anchor(
             "stack" => vmux_service::protocol::PlacementMode::Stack,
             other => return Err(format!("unknown mode: {other}")),
         };
-        return Ok(DispatchTarget::Command(AgentCommand::Run {
-            anchor,
-            command,
-            placement_override,
-            direction,
-            focus,
-            beside,
-            mode,
-            terminal,
-            done_marker: None,
-        }));
+        let command = if placement_override {
+            AgentCommand::RunWithPlacementOverride {
+                anchor,
+                command,
+                direction,
+                focus,
+                beside,
+                mode,
+                terminal,
+                done_marker: None,
+            }
+        } else {
+            AgentCommand::Run {
+                anchor,
+                command,
+                direction,
+                focus,
+                beside,
+                mode,
+                terminal,
+                done_marker: None,
+            }
+        };
+        return Ok(DispatchTarget::Command(command));
     }
     if name == "create_worktree" {
         let anchor = anchor
@@ -1621,9 +1636,7 @@ mod tests {
         )
         .unwrap();
         match bare {
-            DispatchTarget::Command(AgentCommand::Run {
-                placement_override, ..
-            }) => assert!(!placement_override),
+            DispatchTarget::Command(AgentCommand::Run { .. }) => {}
             other => panic!("expected Run, got {other:?}"),
         }
 
@@ -1634,12 +1647,26 @@ mod tests {
         ] {
             let explicit = dispatch_with_anchor("run", arguments, Some(anchor)).unwrap();
             match explicit {
-                DispatchTarget::Command(AgentCommand::Run {
-                    placement_override, ..
-                }) => assert!(placement_override),
-                other => panic!("expected Run, got {other:?}"),
+                DispatchTarget::Command(AgentCommand::RunWithPlacementOverride { .. }) => {}
+                other => panic!("expected RunWithPlacementOverride, got {other:?}"),
             }
         }
+    }
+
+    #[test]
+    fn run_tool_documents_default_placement_policy() {
+        let run = tool_definitions()
+            .into_iter()
+            .find(|definition| definition.name == "run")
+            .expect("run definition");
+        assert!(
+            run.description
+                .contains("agent.allow_run_placement_override")
+        );
+        assert!(
+            run.description
+                .contains("omit `mode`, `direction`, and `beside`")
+        );
     }
 
     #[test]
@@ -1654,12 +1681,9 @@ mod tests {
         .unwrap();
         match target {
             DispatchTarget::Command(AgentCommand::Run {
-                terminal: Some(t),
-                placement_override,
-                ..
+                terminal: Some(t), ..
             }) => {
                 assert_eq!(t, term);
-                assert!(!placement_override);
             }
             other => panic!("expected Run with terminal, got {other:?}"),
         }

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -1622,8 +1622,7 @@ mod tests {
         .unwrap();
         match bare {
             DispatchTarget::Command(AgentCommand::Run {
-                placement_override,
-                ..
+                placement_override, ..
             }) => assert!(!placement_override),
             other => panic!("expected Run, got {other:?}"),
         }
@@ -1636,8 +1635,7 @@ mod tests {
             let explicit = dispatch_with_anchor("run", arguments, Some(anchor)).unwrap();
             match explicit {
                 DispatchTarget::Command(AgentCommand::Run {
-                    placement_override,
-                    ..
+                    placement_override, ..
                 }) => assert!(placement_override),
                 other => panic!("expected Run, got {other:?}"),
             }

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -1711,7 +1711,7 @@ mod tests {
         )
         .unwrap();
         match target {
-            DispatchTarget::Command(AgentCommand::Run {
+            DispatchTarget::Command(AgentCommand::RunWithPlacementOverride {
                 beside: Some(b),
                 mode,
                 ..
@@ -1719,7 +1719,7 @@ mod tests {
                 assert_eq!(b, beside);
                 assert_eq!(mode, PlacementMode::Stack);
             }
-            other => panic!("expected Run with beside+stack, got {other:?}"),
+            other => panic!("expected RunWithPlacementOverride with beside+stack, got {other:?}"),
         }
 
         // beside="self" => None; mode defaults to Auto (reuse the region).
@@ -1730,10 +1730,12 @@ mod tests {
         )
         .unwrap();
         match target {
-            DispatchTarget::Command(AgentCommand::Run {
-                beside: None, mode, ..
+            DispatchTarget::Command(AgentCommand::RunWithPlacementOverride {
+                beside: None,
+                mode,
+                ..
             }) => assert_eq!(mode, PlacementMode::Auto),
-            other => panic!("expected Run with self+auto, got {other:?}"),
+            other => panic!("expected RunWithPlacementOverride with self+auto, got {other:?}"),
         }
 
         // explicit mode=split is honored.
@@ -1744,10 +1746,10 @@ mod tests {
         )
         .unwrap();
         match target {
-            DispatchTarget::Command(AgentCommand::Run { mode, .. }) => {
+            DispatchTarget::Command(AgentCommand::RunWithPlacementOverride { mode, .. }) => {
                 assert_eq!(mode, PlacementMode::Split)
             }
-            other => panic!("expected Run with split, got {other:?}"),
+            other => panic!("expected RunWithPlacementOverride with split, got {other:?}"),
         }
 
         // unknown mode errors.

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -703,6 +703,9 @@ pub fn dispatch_with_anchor(
         if command.trim().is_empty() {
             return Err("run.command is empty".to_string());
         }
+        let placement_override = ["mode", "direction", "beside"]
+            .iter()
+            .any(|key| arguments.get(*key).is_some());
         let direction = parse_direction(&arguments)?.unwrap_or(AgentPaneDirection::Right);
         let focus = arguments
             .get("focus")
@@ -735,6 +738,7 @@ pub fn dispatch_with_anchor(
         return Ok(DispatchTarget::Command(AgentCommand::Run {
             anchor,
             command,
+            placement_override,
             direction,
             focus,
             beside,
@@ -1605,6 +1609,39 @@ mod tests {
             dispatch_with_anchor("run", serde_json::json!({"command": " "}), Some(anchor)).is_err()
         );
         assert!(dispatch_with_anchor("run", serde_json::json!({"command": "x"}), None).is_err());
+    }
+
+    #[test]
+    fn run_dispatch_tracks_explicit_placement_override() {
+        let anchor = vmux_service::protocol::ProcessId::new();
+        let bare = dispatch_with_anchor(
+            "run",
+            serde_json::json!({"command": "echo hi"}),
+            Some(anchor),
+        )
+        .unwrap();
+        match bare {
+            DispatchTarget::Command(AgentCommand::Run {
+                placement_override,
+                ..
+            }) => assert!(!placement_override),
+            other => panic!("expected Run, got {other:?}"),
+        }
+
+        for arguments in [
+            serde_json::json!({"command": "echo hi", "direction": "bottom"}),
+            serde_json::json!({"command": "echo hi", "mode": "auto"}),
+            serde_json::json!({"command": "echo hi", "beside": "self"}),
+        ] {
+            let explicit = dispatch_with_anchor("run", arguments, Some(anchor)).unwrap();
+            match explicit {
+                DispatchTarget::Command(AgentCommand::Run {
+                    placement_override,
+                    ..
+                }) => assert!(placement_override),
+                other => panic!("expected Run, got {other:?}"),
+            }
+        }
     }
 
     #[test]

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -707,7 +707,7 @@ pub fn dispatch_with_anchor(
         }
         let placement_override = ["mode", "direction", "beside"]
             .iter()
-            .any(|key| arguments.get(*key).is_some());
+            .any(|key| arguments.get(*key).is_some_and(|value| !value.is_null()));
         let direction = parse_direction(&arguments)?.unwrap_or(AgentPaneDirection::Right);
         let focus = arguments
             .get("focus")
@@ -1638,6 +1638,22 @@ mod tests {
         match bare {
             DispatchTarget::Command(AgentCommand::Run { .. }) => {}
             other => panic!("expected Run, got {other:?}"),
+        }
+
+        let nulls = dispatch_with_anchor(
+            "run",
+            serde_json::json!({
+                "command": "echo hi",
+                "mode": null,
+                "direction": null,
+                "beside": null
+            }),
+            Some(anchor),
+        )
+        .unwrap();
+        match nulls {
+            DispatchTarget::Command(AgentCommand::Run { .. }) => {}
+            other => panic!("expected Run for null placement values, got {other:?}"),
         }
 
         for arguments in [

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -1656,8 +1656,13 @@ mod tests {
         .unwrap();
         match target {
             DispatchTarget::Command(AgentCommand::Run {
-                terminal: Some(t), ..
-            }) => assert_eq!(t, term),
+                terminal: Some(t),
+                placement_override,
+                ..
+            }) => {
+                assert_eq!(t, term);
+                assert!(!placement_override);
+            }
             other => panic!("expected Run with terminal, got {other:?}"),
         }
         assert!(

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -126,6 +126,8 @@ pub enum AgentCommand {
     Run {
         anchor: ProcessId,
         command: String,
+        /// Whether the MCP caller explicitly supplied `mode`, `direction`, or `beside`.
+        placement_override: bool,
         direction: AgentPaneDirection,
         focus: bool,
         /// Anchor a newly opened terminal next to this page (a terminal's

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -126,8 +126,6 @@ pub enum AgentCommand {
     Run {
         anchor: ProcessId,
         command: String,
-        /// Whether the MCP caller explicitly supplied `mode`, `direction`, or `beside`.
-        placement_override: bool,
         direction: AgentPaneDirection,
         focus: bool,
         /// Anchor a newly opened terminal next to this page (a terminal's
@@ -173,6 +171,18 @@ pub enum AgentCommand {
     /// Appended at the end to keep rkyv's positional enum discriminants stable.
     TurnEnded {
         anchor: ProcessId,
+    },
+    /// Run with caller-requested pane placement. Appended to keep existing rkyv variant layouts
+    /// and positional discriminants stable across daemon upgrades.
+    RunWithPlacementOverride {
+        anchor: ProcessId,
+        command: String,
+        direction: AgentPaneDirection,
+        focus: bool,
+        beside: Option<ProcessId>,
+        mode: PlacementMode,
+        terminal: Option<ProcessId>,
+        done_marker: Option<String>,
     },
 }
 
@@ -327,7 +337,10 @@ pub fn validate_agent_command(command: &AgentCommand) -> Result<(), &'static str
         AgentCommand::OpenBeside { url, .. } if url.trim().is_empty() => {
             Err("open_beside_me.url is empty")
         }
-        AgentCommand::Run { command, .. } if command.trim().is_empty() => {
+        AgentCommand::Run { command, .. }
+        | AgentCommand::RunWithPlacementOverride { command, .. }
+            if command.trim().is_empty() =>
+        {
             Err("run.command is empty")
         }
         AgentCommand::FileTouched { path, .. } if path.trim().is_empty() => {
@@ -1133,6 +1146,23 @@ mod tests {
         let cmd = AgentCommand::UpdateSettings {
             path: "layout.pane.gap".to_string(),
             value_json: "12.0".to_string(),
+        };
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&cmd).unwrap();
+        let decoded = rkyv::from_bytes::<AgentCommand, rkyv::rancor::Error>(&bytes).unwrap();
+        assert_eq!(decoded, cmd);
+    }
+
+    #[test]
+    fn run_with_placement_override_rkyv_roundtrip() {
+        let cmd = AgentCommand::RunWithPlacementOverride {
+            anchor: ProcessId::new(),
+            command: "cargo test".into(),
+            direction: AgentPaneDirection::Bottom,
+            focus: false,
+            beside: None,
+            mode: PlacementMode::Split,
+            terminal: None,
+            done_marker: Some("token".into()),
         };
         let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&cmd).unwrap();
         let decoded = rkyv::from_bytes::<AgentCommand, rkyv::rancor::Error>(&bytes).unwrap();

--- a/crates/vmux_setting/src/plugin/runtime.rs
+++ b/crates/vmux_setting/src/plugin/runtime.rs
@@ -127,6 +127,9 @@ pub struct SpaceOverrides {
 pub struct AgentSettings {
     #[serde(default)]
     pub app_providers: Vec<AppProviderSettings>,
+    /// Allow agents to override vmux run-terminal placement with mode, direction, or beside.
+    #[serde(default)]
+    pub allow_run_placement_override: bool,
     /// When true (default), an agent reading/editing a file opens it in a
     /// `file://` follow-pane beside that agent.
     #[serde(default = "default_true")]
@@ -159,6 +162,7 @@ fn default_agent_settings() -> AgentSettings {
             kind: "vibe".to_string(),
             models: vec!["echo".to_string()],
         }],
+        allow_run_placement_override: false,
         follow_files: true,
         tidy_files: true,
         tidy_files_max: 5,
@@ -1215,6 +1219,25 @@ mod tests {
         assert!(s.tidy_files);
         assert_eq!(s.tidy_files_max, 5);
         assert!(!s.tidy_files_auto);
+    }
+
+    #[test]
+    fn agent_defaults_disable_run_placement_override() {
+        assert!(!AgentSettings::default().allow_run_placement_override);
+    }
+
+    #[test]
+    fn apply_update_enables_run_placement_override() {
+        let mut settings = base_settings();
+        let ron = apply_settings_update(
+            &mut settings,
+            "agent.allow_run_placement_override",
+            serde_json::json!(true),
+        )
+        .expect("update ok");
+        assert!(settings.agent.allow_run_placement_override);
+        let reparsed: AppSettings = ron::de::from_str(&ron).expect("RON parses");
+        assert!(reparsed.agent.allow_run_placement_override);
     }
 
     #[test]

--- a/crates/vmux_setting/src/plugin/runtime.rs
+++ b/crates/vmux_setting/src/plugin/runtime.rs
@@ -1227,6 +1227,12 @@ mod tests {
     }
 
     #[test]
+    fn legacy_agent_settings_default_run_placement_override_to_disabled() {
+        let settings = parse_settings("(agent: (follow_files: true))").unwrap();
+        assert!(!settings.agent.allow_run_placement_override);
+    }
+
+    #[test]
     fn apply_update_enables_run_placement_override() {
         let mut settings = base_settings();
         let ron = apply_settings_update(

--- a/crates/vmux_setting/src/plugin/view.rs
+++ b/crates/vmux_setting/src/plugin/view.rs
@@ -506,10 +506,7 @@ mod agent_schema_tests {
         let field = schema
             .field("agent.allow_run_placement_override")
             .expect("run placement override field");
-        assert_eq!(
-            field.label.as_deref(),
-            Some("Allow run placement override")
-        );
+        assert_eq!(field.label.as_deref(), Some("Allow run placement override"));
     }
 }
 

--- a/crates/vmux_setting/src/plugin/view.rs
+++ b/crates/vmux_setting/src/plugin/view.rs
@@ -263,6 +263,13 @@ fn build_settings_schema() -> SettingsSchema {
                 root_path: "layout".to_string(),
             },
             SectionSpec {
+                id: "agent".to_string(),
+                title: "Agent".to_string(),
+                description: Some("Agent behavior and tool permissions.".to_string()),
+                synthetic_keys: vec![],
+                root_path: "agent".to_string(),
+            },
+            SectionSpec {
                 id: "shortcuts".to_string(),
                 title: "Shortcuts".to_string(),
                 description: Some(
@@ -378,6 +385,29 @@ fn build_settings_schema() -> SettingsSchema {
                 },
             ),
             field(
+                "agent",
+                FieldSpec {
+                    order: vec![
+                        "allow_run_placement_override".into(),
+                        "follow_files".into(),
+                        "tidy_files".into(),
+                        "tidy_files_max".into(),
+                        "tidy_files_auto".into(),
+                        "app_providers".into(),
+                        "acp".into(),
+                    ],
+                    ..Default::default()
+                },
+            ),
+            field(
+                "agent.allow_run_placement_override",
+                FieldSpec {
+                    label: Some("Allow run placement override".into()),
+                    hint: Some("Let agents choose run pane mode, direction, and anchor.".into()),
+                    ..Default::default()
+                },
+            ),
+            field(
                 "shortcuts",
                 FieldSpec {
                     order: vec![
@@ -462,6 +492,24 @@ mod appearance_schema_tests {
         assert_eq!(mode.widget, Some(WidgetKind::Select));
         let vals: Vec<_> = mode.options.iter().map(|o| o.value.as_str()).collect();
         assert_eq!(vals, vec!["device", "light", "dark"]);
+    }
+}
+
+#[cfg(test)]
+mod agent_schema_tests {
+    use super::*;
+
+    #[test]
+    fn schema_exposes_run_placement_override_under_agent() {
+        let schema = build_settings_schema();
+        assert!(schema.sections.iter().any(|section| section.id == "agent"));
+        let field = schema
+            .field("agent.allow_run_placement_override")
+            .expect("run placement override field");
+        assert_eq!(
+            field.label.as_deref(),
+            Some("Allow run placement override")
+        );
     }
 }
 

--- a/crates/vmux_setting/src/settings.ron
+++ b/crates/vmux_setting/src/settings.ron
@@ -58,6 +58,7 @@
         app_providers: [
             (provider: "stub", kind: "vibe", models: ["echo"]),
         ],
+        allow_run_placement_override: false,
         follow_files: true,
         tidy_files: true,
         tidy_files_max: 5,

--- a/docs/specs/2026-07-10-agent-run-placement-design.md
+++ b/docs/specs/2026-07-10-agent-run-placement-design.md
@@ -1,0 +1,35 @@
+# Agent Run Placement Design
+
+## Goal
+
+Keep `vmux.run` pane placement deterministic when agents request poor split directions, while allowing users to restore agent-requested placement.
+
+## Settings
+
+Add `agent.run_placement` with two values:
+
+- `auto` (default): vmux owns run-terminal placement.
+- `requested`: vmux honors the tool's `mode`, `beside`, and `direction` arguments.
+
+Expose the setting in `vmux://settings/` under Agent.
+
+## Validation
+
+The MCP layer preserves whether `direction` was omitted instead of converting omission to `right`.
+
+With `agent.run_placement = "auto"`, a run is accepted only when placement arguments are omitted or use their defaults. Explicit `direction`, `beside`, or a non-`auto` `mode` returns an error instructing the agent to omit placement arguments and retry. This avoids silently ignoring intent and gives the agent a recoverable correction.
+
+Runs targeting an existing `terminal` remain unchanged when no placement override is supplied. Explicit placement arguments are still rejected because they conflict with the configured policy.
+
+With `agent.run_placement = "requested"`, current behavior remains: `mode`, `beside`, and `direction` are honored, and omitted direction falls back to `right` when a split needs one.
+
+## Placement
+
+Auto placement continues using the existing persistent terminal-region and spiral-placement logic. The first bare run creates or selects the terminal bucket; later bare runs reuse its shell. No split direction from the agent can bypass this while auto placement is configured.
+
+## Testing
+
+- Settings default and serialization tests for `agent.run_placement`.
+- MCP dispatch test proving omitted direction stays omitted.
+- Agent command handling tests proving auto rejects explicit placement and requested mode honors it.
+- Existing-terminal test proving terminal reuse remains allowed.

--- a/docs/specs/2026-07-10-agent-run-placement-design.md
+++ b/docs/specs/2026-07-10-agent-run-placement-design.md
@@ -6,22 +6,24 @@ Keep `vmux.run` pane placement deterministic when agents request poor split dire
 
 ## Settings
 
-Add `agent.run_placement` with two values:
+Replace the current agent-controlled default with vmux auto placement. Add
+`agent.allow_run_placement_override`, defaulting to `false`, as an explicit
+opt-out:
 
-- `auto` (default): vmux owns run-terminal placement.
-- `requested`: vmux honors the tool's `mode`, `beside`, and `direction` arguments.
+- `false` (default): vmux owns run-terminal placement.
+- `true`: vmux honors the tool's `mode`, `beside`, and `direction` arguments.
 
 Expose the setting in `vmux://settings/` under Agent.
 
 ## Validation
 
-The MCP layer preserves whether `direction` was omitted instead of converting omission to `right`.
+The MCP layer records whether any placement argument (`direction`, `beside`, or `mode`) was explicitly supplied before applying protocol defaults. This lets the app distinguish a bare run from an agent placement override.
 
-With `agent.run_placement = "auto"`, a run is accepted only when placement arguments are omitted or use their defaults. Explicit `direction`, `beside`, or a non-`auto` `mode` returns an error instructing the agent to omit placement arguments and retry. This avoids silently ignoring intent and gives the agent a recoverable correction.
+With `agent.allow_run_placement_override = false`, a run is accepted only when placement arguments are omitted. Explicit `direction`, `beside`, or `mode` returns an error instructing the agent to omit placement arguments and retry. This avoids silently ignoring intent and gives the agent a recoverable correction.
 
 Runs targeting an existing `terminal` remain unchanged when no placement override is supplied. Explicit placement arguments are still rejected because they conflict with the configured policy.
 
-With `agent.run_placement = "requested"`, current behavior remains: `mode`, `beside`, and `direction` are honored, and omitted direction falls back to `right` when a split needs one.
+With `agent.allow_run_placement_override = true`, current behavior remains: `mode`, `beside`, and `direction` are honored, and omitted direction falls back to `right` when a split needs one.
 
 ## Placement
 
@@ -29,7 +31,7 @@ Auto placement continues using the existing persistent terminal-region and spira
 
 ## Testing
 
-- Settings default and serialization tests for `agent.run_placement`.
-- MCP dispatch test proving omitted direction stays omitted.
-- Agent command handling tests proving auto rejects explicit placement and requested mode honors it.
+- Settings default and serialization tests for `agent.allow_run_placement_override`.
+- MCP dispatch tests proving bare runs and explicit placement are distinguishable.
+- Agent command handling tests proving the default rejects explicit placement and the opt-out honors it.
 - Existing-terminal test proving terminal reuse remains allowed.


### PR DESCRIPTION
## Context
Agents sometimes request explicit right splits for `vmux.run`, producing poor three-column layouts. Vmux should own run-terminal placement by default while retaining a user opt-out.

## Implementation
Bare runs continue through the existing persistent terminal bucket and spiral placement. Explicit `mode`, `direction`, or `beside` arguments use a wire-compatible appended command variant and are rejected unless `agent.allow_run_placement_override` is enabled in Settings.

## Checks / QA
- Run a bare command and confirm repeated runs reuse the same terminal.
- Request an explicit split with the default setting and confirm vmux returns a retryable error.
- Enable “Allow run placement override” under Agent settings and confirm explicit split placement works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `agent.allow_run_placement_override` setting (default: disabled) to control whether agents may request pane placement.
  - Added placement-aware agent run support via the `run` tool, including clearer dispatch behavior.

- **Bug Fixes**
  - Placement override requests are now validated consistently and rejected with actionable feedback when disabled.
  - Updated blocking execution so placement-override runs are handled with the same completion marker behavior.

- **Documentation**
  - Documented the new placement-policy rules, including retry expectations when overrides are refused.

- **Tests**
  - Added/updated unit coverage for placement validation, settings updates, dispatch selection, and marker injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->