### PR TITLE
feat(acp): match CLI loading and prompt design

### DIFF
--- a/crates/vmux_agent/Cargo.toml
+++ b/crates/vmux_agent/Cargo.toml
@@ -13,6 +13,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 rkyv = { workspace = true }
 similar = "2"
+vmux_terminal = { path = "../vmux_terminal" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bevy = { workspace = true }
@@ -39,7 +40,6 @@ vmux_mcp = { path = "../vmux_mcp" }
 vmux_service = { path = "../vmux_service" }
 vmux_setting = { path = "../vmux_setting" }
 vmux_space = { path = "../vmux_space" }
-vmux_terminal = { path = "../vmux_terminal" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 dioxus = { workspace = true }

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -1244,6 +1244,15 @@ mod native_tests {
     }
 
     #[test]
+    fn installing_chat_uses_matrix_loading_composer() {
+        let source = include_str!("chat_page/page.rs");
+        assert!(source.contains("MatrixRain {"));
+        assert!(source.contains("PromptGhost {"));
+        assert!(source.contains("absolute inset-0 z-20 flex items-center justify-center"));
+        assert!(source.contains("type a prompt · runs when ready"));
+    }
+
+    #[test]
     fn composer_slash_items_support_mouse_selection() {
         let source = include_str!("chat_page/page.rs");
         assert!(source.contains("onclick: move |_| run_slash_command"));

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -1248,6 +1248,7 @@ mod native_tests {
         let source = include_str!("chat_page/page.rs");
         assert!(source.contains("MatrixRain {"));
         assert!(source.contains("PromptGhost {"));
+        assert!(source.contains("terminal: false"));
         assert!(source.contains("absolute inset-0 z-20 flex items-center justify-center"));
         assert!(source.contains("type a prompt · runs when ready"));
     }

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -294,12 +294,6 @@ pub fn Page() -> Element {
             detail
         }
     };
-    let dot_style = if accent().is_empty() {
-        String::new()
-    } else {
-        format!("background:{}", accent())
-    };
-
     let draft_val = draft();
     let selector = selector_mode(&draft_val);
     let command_query = match selector {

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -12,6 +12,9 @@ use crate::chat_page::event::{
     RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SlashCommandEntry, SlashCommands, WORKING_VERBS,
 };
 use dioxus::prelude::*;
+use vmux_terminal::matrix_rain::MatrixRain;
+use vmux_terminal::page::PromptGhost;
+use vmux_ui::agent_accent::agent_accent;
 use vmux_ui::favicon::favicon_src_for_url;
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_theme};
 use wasm_bindgen::{JsCast, closure::Closure};
@@ -147,7 +150,7 @@ pub fn Page() -> Element {
     use_theme();
     let agent = current_agent();
     let mut items = use_signal(Vec::<ChatItem>::new);
-    let mut status = use_signal(|| "idle".to_string());
+    let mut status = use_signal(|| "installing".to_string());
     let mut error = use_signal(String::new);
     let mut approval = use_signal(|| Option::<(String, String, String)>::None);
     let mut agent_name = use_signal(String::new);
@@ -281,6 +284,16 @@ pub fn Page() -> Element {
         let n = agent_name();
         if n.is_empty() { agent.clone() } else { n }
     };
+    let agent_accent = agent_accent(&agent);
+    let installing = status() == "installing";
+    let install_detail = {
+        let detail = error();
+        if detail.is_empty() {
+            "Preparing agent…".to_string()
+        } else {
+            detail
+        }
+    };
     let dot_style = if accent().is_empty() {
         String::new()
     } else {
@@ -343,89 +356,90 @@ pub fn Page() -> Element {
             class: "relative isolate flex h-screen flex-col overflow-hidden bg-background text-foreground",
             style: "background-image:radial-gradient(120% 80% at 50% -10%, rgba(129,140,248,0.05), transparent 55%);",
             style { dangerous_inner_html: MD_CSS }
-            div { class: "pointer-events-none absolute inset-0 -z-10 overflow-hidden",
-                div { class: "absolute left-1/2 top-[-10%] h-[30rem] w-[30rem] -translate-x-1/2 rounded-full blur-[150px] dark:bg-indigo-500/10" }
-            }
-            header { class: "relative z-10 flex items-center gap-2.5 border-b border-foreground/10 bg-background/50 px-5 py-3 backdrop-blur-xl",
-                {avatar_node(&agent_icon(), &accent(), &agent, &header_name, "h-6 w-6 text-[11px]")}
-                span { class: "h-2.5 w-2.5 rounded-full {status_dot_class(&status())}" }
-                span { class: "bg-gradient-to-b from-foreground to-foreground/60 bg-clip-text text-sm font-semibold capitalize text-transparent",
-                    "{header_name}"
+            if installing {
+                div { class: "pointer-events-none absolute inset-0 z-0 overflow-hidden bg-background",
+                    MatrixRain {
+                        accent_rgb: agent_accent.rain_rgb.to_string(),
+                        words: vec![header_name.to_uppercase()],
+                    }
+                }
+            } else {
+                div { class: "pointer-events-none absolute inset-0 -z-10 overflow-hidden",
+                    div { class: "absolute left-1/2 top-[-10%] h-[30rem] w-[30rem] -translate-x-1/2 rounded-full blur-[150px] dark:bg-indigo-500/10" }
+                }
+                header { class: "relative z-10 flex items-center gap-2.5 border-b border-foreground/10 bg-background/50 px-5 py-3 backdrop-blur-xl",
+                    {avatar_node(&agent_icon(), &accent(), &agent, &header_name, "h-6 w-6 text-[11px]")}
+                    span { class: "h-2.5 w-2.5 rounded-full {status_dot_class(&status())}" }
+                    span { class: "bg-gradient-to-b from-foreground to-foreground/60 bg-clip-text text-sm font-semibold capitalize text-transparent",
+                        "{header_name}"
+                    }
                 }
             }
-            div {
-                id: "chat-scroll",
-                class: "relative z-10 flex-1 overflow-y-auto px-4 py-6",
-                onscroll: move |_| {
-                    if let Some(el) = web_sys::window()
-                        .and_then(|w| w.document())
-                        .and_then(|d| d.get_element_by_id("chat-scroll"))
-                    {
-                        let top = el.scroll_top();
-                        let dist = el.scroll_height() - top - el.client_height();
-                        // Re-pin once the user reaches the bottom; unpin only when they scroll UP
-                        // (scroll_top decreases). Never unpin from our own programmatic
-                        // scroll-to-bottom, which only moves down and would otherwise poison
-                        // `at_bottom` with a stale, mid-stream scroll height.
-                        if dist <= 48 {
-                            at_bottom.set(true);
-                        } else if top < *last_top.peek() - 4 {
-                            at_bottom.set(false);
-                        }
-                        last_top.set(top);
-                    }
-                },
-                div { class: "mx-auto flex max-w-3xl flex-col gap-4",
-                    if items.read().is_empty() && status() == "idle" {
-                        div { class: "flex flex-col items-center gap-3 py-24 text-center",
-                            {avatar_node(&agent_icon(), &accent(), &agent, &header_name, "h-14 w-14 text-xl")}
-                            h2 { class: "bg-gradient-to-b from-foreground to-foreground/50 bg-clip-text text-3xl font-semibold capitalize tracking-tight text-transparent",
-                                "{header_name}"
-                            }
-                            p { class: "text-sm text-muted-foreground", "Ready when you are." }
-                        }
-                    }
-                    for (i , item) in items.read().iter().enumerate() {
-                        {render_item(i, item, &verb(), elapsed())}
-                        if !handoff_source().is_empty()
-                            && is_handoff_boundary(i, handoff_message_count())
+            if !installing {
+                div {
+                    id: "chat-scroll",
+                    class: "relative z-10 flex-1 overflow-y-auto px-4 py-6",
+                    onscroll: move |_| {
+                        if let Some(el) = web_sys::window()
+                            .and_then(|w| w.document())
+                            .and_then(|d| d.get_element_by_id("chat-scroll"))
                         {
-                            div { class: "flex items-center gap-2 py-1 text-xs text-muted-foreground",
-                                span { class: "h-px flex-1 bg-foreground/10" }
-                                span { "Continued from {handoff_source}" }
-                                if handoff_truncated() {
-                                    span { class: "text-amber-500/80", "· older context omitted" }
+                            let top = el.scroll_top();
+                            let dist = el.scroll_height() - top - el.client_height();
+                            // Re-pin once the user reaches the bottom; unpin only when they scroll UP
+                            // (scroll_top decreases). Never unpin from our own programmatic
+                            // scroll-to-bottom, which only moves down and would otherwise poison
+                            // `at_bottom` with a stale, mid-stream scroll height.
+                            if dist <= 48 {
+                                at_bottom.set(true);
+                            } else if top < *last_top.peek() - 4 {
+                                at_bottom.set(false);
+                            }
+                            last_top.set(top);
+                        }
+                    },
+                    div { class: "mx-auto flex max-w-3xl flex-col gap-4",
+                        if items.read().is_empty() && status() == "idle" {
+                            div { class: "flex flex-col items-center gap-3 py-24 text-center",
+                                {avatar_node(&agent_icon(), &accent(), &agent, &header_name, "h-14 w-14 text-xl")}
+                                h2 { class: "bg-gradient-to-b from-foreground to-foreground/50 bg-clip-text text-3xl font-semibold capitalize tracking-tight text-transparent",
+                                    "{header_name}"
                                 }
+                                p { class: "text-sm text-muted-foreground", "Ready when you are." }
+                            }
+                        }
+                        for (i , item) in items.read().iter().enumerate() {
+                            {render_item(i, item, &verb(), elapsed())}
+                            if !handoff_source().is_empty()
+                                && is_handoff_boundary(i, handoff_message_count())
+                            {
+                                div { class: "flex items-center gap-2 py-1 text-xs text-muted-foreground",
+                                    span { class: "h-px flex-1 bg-foreground/10" }
+                                    span { "Continued from {handoff_source}" }
+                                    if handoff_truncated() {
+                                        span { class: "text-amber-500/80", "· older context omitted" }
+                                    }
+                                    span { class: "h-px flex-1 bg-foreground/10" }
+                                }
+                            }
+                        }
+                        if status() == "errored" {
+                            div { class: "rounded-xl bg-red-500/10 px-4 py-3 text-sm text-red-600 ring-1 ring-inset ring-red-500/20 dark:text-red-300",
+                                "{error}"
+                            }
+                        }
+                        if paused() {
+                            div { class: "flex items-center gap-3 py-1 text-xs text-muted-foreground",
+                                span { class: "h-px flex-1 bg-foreground/10" }
+                                span { class: "shrink-0", "interrupted" }
                                 span { class: "h-px flex-1 bg-foreground/10" }
                             }
-                        }
-                    }
-                    if status() == "installing" {
-                        div { class: "flex items-center gap-2.5 text-sm",
-                            span { class: "flex items-end gap-1",
-                                span { class: "h-1.5 w-1.5 animate-bounce rounded-full bg-foreground/70 [animation-delay:-0.32s]", style: "{dot_style}" }
-                                span { class: "h-1.5 w-1.5 animate-bounce rounded-full bg-foreground/70 [animation-delay:-0.16s]", style: "{dot_style}" }
-                                span { class: "h-1.5 w-1.5 animate-bounce rounded-full bg-foreground/70", style: "{dot_style}" }
-                            }
-                            span { class: "animate-pulse bg-gradient-to-r from-foreground/45 via-foreground to-foreground/45 bg-clip-text font-medium text-transparent", "{error}" }
-                        }
-                    }
-                    if status() == "errored" {
-                        div { class: "rounded-xl bg-red-500/10 px-4 py-3 text-sm text-red-600 ring-1 ring-inset ring-red-500/20 dark:text-red-300",
-                            "{error}"
-                        }
-                    }
-                    if paused() {
-                        div { class: "flex items-center gap-3 py-1 text-xs text-muted-foreground",
-                            span { class: "h-px flex-1 bg-foreground/10" }
-                            span { class: "shrink-0", "interrupted" }
-                            span { class: "h-px flex-1 bg-foreground/10" }
                         }
                     }
                 }
             }
 
-            if let Some((call_id, name, args_json)) = approval() {
+            if !installing && let Some((call_id, name, args_json)) = approval() {
                 {
                     let details = super::approval_details(&args_json);
                     rsx! {
@@ -482,8 +496,21 @@ pub fn Page() -> Element {
                 }
             }
 
-            div { class: "relative z-10 border-t border-foreground/10 bg-background/50 px-4 py-3 backdrop-blur-xl",
-                div { class: "relative mx-auto flex max-w-3xl flex-col gap-2",
+            div {
+                class: if installing { "absolute inset-0 z-20 flex items-center justify-center px-4" } else { "relative z-10 border-t border-foreground/10 bg-background/50 px-4 py-3 backdrop-blur-xl" },
+                div {
+                    class: if installing { "relative flex w-full max-w-md flex-col gap-2 rounded-2xl bg-white/70 p-4 ring-1 ring-inset ring-black/10 backdrop-blur-md dark:bg-black/40 dark:ring-white/10" } else { "relative mx-auto flex max-w-3xl flex-col gap-2" },
+                    if installing {
+                        div { class: "mb-1 flex items-center gap-3",
+                            div { class: "flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-foreground/[0.06] ring-1 ring-inset ring-foreground/10",
+                                {avatar_node(&agent_icon(), &accent(), &agent, &header_name, "h-5 w-5 text-[10px]")}
+                            }
+                            div { class: "min-w-0 flex-1",
+                                div { class: "truncate text-sm font-semibold {agent_accent.accent_text}", "{header_name}" }
+                                div { class: "truncate text-xs text-muted-foreground", "{install_detail}" }
+                            }
+                        }
+                    }
                     if cmd_menu_open {
                         div { class: "absolute bottom-full left-0 z-20 mb-2 w-full overflow-hidden rounded-xl border border-foreground/10 bg-background/95 shadow-xl backdrop-blur-xl",
                             for (i , command) in filtered_cmds.iter().enumerate() {
@@ -585,112 +612,119 @@ pub fn Page() -> Element {
                             }
                         }
                     }
-                    div { class: "flex items-end gap-2",
-                        textarea {
-                            id: PROMPT_ID,
-                            class: "max-h-40 flex-1 resize-none rounded-xl bg-foreground/[0.06] px-3.5 py-2.5 text-sm ring-1 ring-inset ring-foreground/10 transition focus:bg-foreground/[0.09] focus:outline-none focus:ring-foreground/25",
-                            rows: "1",
-                            placeholder: "Message the agent…",
-                            value: "{draft}",
-                            oninput: move |e| {
-                                draft.set(e.value());
-                                menu_sel.set(0);
-                            },
-                            onkeydown: move |e| {
-                                let streaming = matches!(status().as_str(), "streaming" | "awaiting");
-                                let draft_now = draft.peek().clone();
-                                let (cmd_items, sess_items, session_selector_open) = match selector_mode(&draft_now) {
-                                    SelectorMode::Commands(query) => {
-                                        let query = query.to_lowercase();
-                                        (
-                                            slash_cmds
-                                                .peek()
-                                                .iter()
-                                                .filter(|command| command.name.starts_with(&query))
-                                                .cloned()
-                                                .collect::<Vec<_>>(),
-                                            Vec::new(),
-                                            false,
-                                        )
-                                    }
-                                    SelectorMode::Resume(query) => (
-                                        Vec::new(),
-                                        filter_sessions(&sessions.peek(), query),
-                                        true,
-                                    ),
-                                    SelectorMode::None => (Vec::new(), Vec::new(), false),
-                                };
-                                let selector_open = session_selector_open || !cmd_items.is_empty();
-                                let selector_len = if session_selector_open {
-                                    sess_items.len()
-                                } else {
-                                    cmd_items.len()
-                                };
-                                let key = e.key().to_string();
-                                let command_modifier = e.modifiers().meta()
-                                    || e.modifiers().ctrl()
-                                    || e.modifiers().alt();
-                                let direction = if e.modifiers().meta() || e.modifiers().alt() {
-                                    None
-                                } else {
-                                    menu_direction(&key, e.modifiers().ctrl())
-                                };
-
-                                if selector_open && let Some(direction) = direction {
-                                    e.prevent_default();
-                                    let selected = *menu_sel.peek();
-                                    menu_sel.set(move_selection(selected, selector_len, direction));
-                                    return;
+                    div { class: if installing { "flex items-end gap-2 rounded-xl bg-foreground/[0.04] px-3 py-2 ring-1 ring-inset ring-foreground/10" } else { "flex items-end gap-2" },
+                        div { class: "relative min-w-0 flex-1 overflow-hidden",
+                            if installing && draft.read().is_empty() {
+                                div { class: "pointer-events-none absolute inset-0 flex items-center overflow-hidden px-1",
+                                    PromptGhost { accent_bg: agent_accent.accent_bg.to_string() }
                                 }
-                                if selector_open
-                                    && e.key() == Key::Enter
-                                    && !e.modifiers().shift()
-                                    && !command_modifier
-                                {
-                                    e.prevent_default();
-                                    let selected = *menu_sel.peek();
-                                    if session_selector_open {
-                                        if let Some(session) = sess_items.get(selected) {
-                                            select_resume_session(session, draft);
-                                        }
-                                    } else if let Some(command) = cmd_items.get(selected) {
-                                        run_slash_command(&command.name, draft, menu_sel);
-                                    }
-                                    return;
-                                }
-                                if selector_open && e.key() == Key::Escape && !command_modifier {
-                                    e.prevent_default();
-                                    draft.set(String::new());
+                            }
+                            textarea {
+                                id: PROMPT_ID,
+                                class: if installing { "relative z-10 max-h-40 min-h-9 w-full resize-none bg-transparent px-1 py-2 font-mono text-sm placeholder:text-transparent focus:outline-none" } else { "max-h-40 w-full resize-none rounded-xl bg-foreground/[0.06] px-3.5 py-2.5 text-sm ring-1 ring-inset ring-foreground/10 transition focus:bg-foreground/[0.09] focus:outline-none focus:ring-foreground/25" },
+                                rows: "1",
+                                placeholder: "Message the agent…",
+                                value: "{draft}",
+                                oninput: move |e| {
+                                    draft.set(e.value());
                                     menu_sel.set(0);
-                                    return;
-                                }
-                                if session_selector_open
-                                    && matches!(e.key(), Key::Enter | Key::Escape)
-                                {
-                                    return;
-                                }
+                                },
+                                onkeydown: move |e| {
+                                    let streaming = matches!(status().as_str(), "streaming" | "awaiting");
+                                    let draft_now = draft.peek().clone();
+                                    let (cmd_items, sess_items, session_selector_open) = match selector_mode(&draft_now) {
+                                        SelectorMode::Commands(query) => {
+                                            let query = query.to_lowercase();
+                                            (
+                                                slash_cmds
+                                                    .peek()
+                                                    .iter()
+                                                    .filter(|command| command.name.starts_with(&query))
+                                                    .cloned()
+                                                    .collect::<Vec<_>>(),
+                                                Vec::new(),
+                                                false,
+                                            )
+                                        }
+                                        SelectorMode::Resume(query) => (
+                                            Vec::new(),
+                                            filter_sessions(&sessions.peek(), query),
+                                            true,
+                                        ),
+                                        SelectorMode::None => (Vec::new(), Vec::new(), false),
+                                    };
+                                    let selector_open = session_selector_open || !cmd_items.is_empty();
+                                    let selector_len = if session_selector_open {
+                                        sess_items.len()
+                                    } else {
+                                        cmd_items.len()
+                                    };
+                                    let key = e.key().to_string();
+                                    let command_modifier = e.modifiers().meta()
+                                        || e.modifiers().ctrl()
+                                        || e.modifiers().alt();
+                                    let direction = if e.modifiers().meta() || e.modifiers().alt() {
+                                        None
+                                    } else {
+                                        menu_direction(&key, e.modifiers().ctrl())
+                                    };
 
-                                if e.key() == Key::Enter && !e.modifiers().shift() {
-                                    e.prevent_default();
-                                    do_submit(draft, at_bottom);
-                                } else if e.key() == Key::Escape {
-                                    e.prevent_default();
-                                    let _ = try_cef_bin_emit_rkyv(&ChatEscape);
-                                    if should_clear_draft_on_escape(
-                                        streaming,
-                                        queued.peek().is_empty(),
-                                        draft.peek().is_empty(),
-                                    ) {
-                                        draft.set(String::new());
+                                    if selector_open && let Some(direction) = direction {
+                                        e.prevent_default();
+                                        let selected = *menu_sel.peek();
+                                        menu_sel.set(move_selection(selected, selector_len, direction));
+                                        return;
                                     }
-                                } else if e.modifiers().ctrl()
-                                    && matches!(e.key(), Key::Character(c) if c == "c")
-                                    && !has_text_selection()
-                                {
-                                    e.prevent_default();
-                                    let _ = try_cef_bin_emit_rkyv(&ChatCancel);
-                                }
-                            },
+                                    if selector_open
+                                        && e.key() == Key::Enter
+                                        && !e.modifiers().shift()
+                                        && !command_modifier
+                                    {
+                                        e.prevent_default();
+                                        let selected = *menu_sel.peek();
+                                        if session_selector_open {
+                                            if let Some(session) = sess_items.get(selected) {
+                                                select_resume_session(session, draft);
+                                            }
+                                        } else if let Some(command) = cmd_items.get(selected) {
+                                            run_slash_command(&command.name, draft, menu_sel);
+                                        }
+                                        return;
+                                    }
+                                    if selector_open && e.key() == Key::Escape && !command_modifier {
+                                        e.prevent_default();
+                                        draft.set(String::new());
+                                        menu_sel.set(0);
+                                        return;
+                                    }
+                                    if session_selector_open
+                                        && matches!(e.key(), Key::Enter | Key::Escape)
+                                    {
+                                        return;
+                                    }
+
+                                    if e.key() == Key::Enter && !e.modifiers().shift() {
+                                        e.prevent_default();
+                                        do_submit(draft, at_bottom);
+                                    } else if e.key() == Key::Escape {
+                                        e.prevent_default();
+                                        let _ = try_cef_bin_emit_rkyv(&ChatEscape);
+                                        if should_clear_draft_on_escape(
+                                            streaming,
+                                            queued.peek().is_empty(),
+                                            draft.peek().is_empty(),
+                                        ) {
+                                            draft.set(String::new());
+                                        }
+                                    } else if e.modifiers().ctrl()
+                                        && matches!(e.key(), Key::Character(c) if c == "c")
+                                        && !has_text_selection()
+                                    {
+                                        e.prevent_default();
+                                        let _ = try_cef_bin_emit_rkyv(&ChatCancel);
+                                    }
+                                },
+                            }
                         }
                         if matches!(status().as_str(), "streaming" | "awaiting") {
                             if queued.read().is_empty() {
@@ -743,6 +777,15 @@ pub fn Page() -> Element {
                                     path { d: "M12 19V5" }
                                     path { d: "M5 12l7-7 7 7" }
                                 }
+                            }
+                        }
+                    }
+                    if installing {
+                        div { class: "px-1 text-[10px] text-muted-foreground/70",
+                            if draft.read().is_empty() {
+                                "type a prompt · runs when ready"
+                            } else {
+                                "runs when ready · Enter sends"
                             }
                         }
                     }

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -616,7 +616,10 @@ pub fn Page() -> Element {
                         div { class: "relative min-w-0 flex-1 overflow-hidden",
                             if installing && draft.read().is_empty() {
                                 div { class: "pointer-events-none absolute inset-0 flex items-center overflow-hidden px-1",
-                                    PromptGhost { accent_bg: agent_accent.accent_bg.to_string() }
+                                    PromptGhost {
+                                        accent_bg: agent_accent.accent_bg.to_string(),
+                                        terminal: false,
+                                    }
                                 }
                             }
                             textarea {

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -6,7 +6,7 @@
 use bevy::prelude::*;
 use bevy_cef::prelude::WebviewExtendStandardMaterial;
 use crossbeam_channel::{Receiver, Sender};
-use vmux_core::LastActivatedAt;
+use vmux_core::{LastActivatedAt, event::InstallPhase};
 use vmux_layout::event::TERMINAL_PAGE_URL;
 use vmux_layout::pane::{PlacementCtx, resolve_spiral_pane};
 use vmux_layout::stack::stack_bundle;
@@ -61,6 +61,18 @@ enum InstallMsg {
 struct AcpInstallChannel {
     tx: Sender<InstallMsg>,
     rx: Receiver<InstallMsg>,
+}
+
+fn display_install_progress(
+    phase: InstallPhase,
+    pct: Option<u8>,
+    message: &str,
+) -> (Option<u8>, String) {
+    if matches!(phase, InstallPhase::Done) {
+        (None, "Starting agent…".to_string())
+    } else {
+        (pct, message.to_string())
+    }
 }
 
 impl Default for AcpInstallChannel {
@@ -219,11 +231,12 @@ fn install_acp_session_when_focused(
 
         std::thread::spawn(move || {
             let resolved =
-                crate::acp_install::resolve_from_registry(&agent_id, |_phase, pct, msg| {
+                crate::acp_install::resolve_from_registry(&agent_id, |phase, pct, msg| {
+                    let (pct, message) = display_install_progress(phase, pct, msg);
                     let _ = progress.send(InstallMsg::Progress {
                         sid: sid.clone(),
                         pct,
-                        message: msg.to_string(),
+                        message,
                     });
                 });
             let login_env = vmux_terminal::shell_env::login_shell_env(&shell);
@@ -675,6 +688,18 @@ mod tests {
                 .find(|(k, _)| k == "PATH")
                 .map(|(_, v)| v.as_str()),
             Some("/managed:/from/login")
+        );
+    }
+
+    #[test]
+    fn completed_install_progress_describes_agent_startup() {
+        assert_eq!(
+            display_install_progress(InstallPhase::Done, Some(100), "ready"),
+            (None, "Starting agent…".to_string())
+        );
+        assert_eq!(
+            display_install_progress(InstallPhase::Downloading, Some(42), "downloading"),
+            (Some(42), "downloading".to_string())
         );
     }
 

--- a/crates/vmux_terminal/src/page.rs
+++ b/crates/vmux_terminal/src/page.rs
@@ -413,7 +413,10 @@ pub fn Page() -> Element {
                                         } else {
                                             div {
                                                 class: "mt-0.5",
-                                                PromptGhost { accent_bg: accent.accent_bg.to_string() }
+                                                PromptGhost {
+                                                    accent_bg: accent.accent_bg.to_string(),
+                                                    terminal: true,
+                                                }
                                             }
                                             div {
                                                 class: "mt-1 text-[10px] text-muted-foreground/70",
@@ -994,19 +997,28 @@ fn row_selection_cols(
     }
 }
 
-/// Example prompts cycled by [`PromptGhost`] while the boot prompt is empty.
-const PROMPT_EXAMPLES: &[&str] = &[
+const AGENT_PROMPT_EXAMPLES: &[&str] = &[
     "Find me a hotel with AC near Paris for this weekend",
     "Find the best flight from Paris to Tokyo next month",
     "Build a landing site for my new restaurant — make it themeable",
     "Open a PR for my staged changes",
 ];
 
-/// Placeholder that types out [`PROMPT_EXAMPLES`] one character at a time with a
-/// blinking caret while the agent boot prompt is empty. The live draft replaces
-/// it the moment the user types; unmounting clears the interval.
+const TERMINAL_PROMPT_EXAMPLES: &[&str] = &[
+    "Fix the failing tests in this project",
+    "Find and explain the cause of this error",
+    "Refactor this module without changing behavior",
+    "Open a PR for my staged changes",
+];
+
+/// Placeholder that types example prompts one character at a time with a blinking caret.
 #[component]
-pub fn PromptGhost(accent_bg: String) -> Element {
+pub fn PromptGhost(accent_bg: String, terminal: bool) -> Element {
+    let examples = if terminal {
+        TERMINAL_PROMPT_EXAMPLES
+    } else {
+        AGENT_PROMPT_EXAMPLES
+    };
     let ex_idx = use_signal(|| 0usize);
     let typed = use_signal(|| 0usize);
     let cb: Rc<RefCell<Option<Closure<dyn FnMut()>>>> = use_hook(|| Rc::new(RefCell::new(None)));
@@ -1014,7 +1026,7 @@ pub fn PromptGhost(accent_bg: String) -> Element {
     use_effect({
         let cb = cb.clone();
         let timer = timer.clone();
-        move || start_prompt_typewriter(ex_idx, typed, cb.clone(), timer.clone())
+        move || start_prompt_typewriter(examples, ex_idx, typed, cb.clone(), timer.clone())
     });
     use_drop({
         let cb = cb.clone();
@@ -1028,7 +1040,7 @@ pub fn PromptGhost(accent_bg: String) -> Element {
             *cb.borrow_mut() = None;
         }
     });
-    let example = PROMPT_EXAMPLES[ex_idx() % PROMPT_EXAMPLES.len()];
+    let example = examples[ex_idx() % examples.len()];
     let full = example.chars().count();
     let shown: String = example.chars().take(typed().min(full)).collect();
     rsx! {
@@ -1041,6 +1053,7 @@ pub fn PromptGhost(accent_bg: String) -> Element {
 }
 
 fn start_prompt_typewriter(
+    examples: &'static [&'static str],
     mut ex_idx: Signal<usize>,
     mut typed: Signal<usize>,
     cb_cell: Rc<RefCell<Option<Closure<dyn FnMut()>>>>,
@@ -1049,11 +1062,11 @@ fn start_prompt_typewriter(
     const PAUSE_TICKS: usize = 28;
     let cb = Closure::wrap(Box::new(move || {
         let idx = *ex_idx.peek();
-        let full = PROMPT_EXAMPLES[idx % PROMPT_EXAMPLES.len()].chars().count();
+        let full = examples[idx % examples.len()].chars().count();
         let t = *typed.peek();
         if t >= full + PAUSE_TICKS {
             typed.set(0);
-            ex_idx.set((idx + 1) % PROMPT_EXAMPLES.len());
+            ex_idx.set((idx + 1) % examples.len());
         } else {
             typed.set(t + 1);
         }

--- a/crates/vmux_terminal/src/page.rs
+++ b/crates/vmux_terminal/src/page.rs
@@ -420,7 +420,7 @@ pub fn Page() -> Element {
                                             }
                                             div {
                                                 class: "mt-1 text-[10px] text-muted-foreground/70",
-                                                "type a prompt · runs when ready · Esc skips"
+                                                "type a command · runs when ready · Esc skips"
                                             }
                                         }
                                     }
@@ -1005,10 +1005,10 @@ const AGENT_PROMPT_EXAMPLES: &[&str] = &[
 ];
 
 const TERMINAL_PROMPT_EXAMPLES: &[&str] = &[
-    "Fix the failing tests in this project",
-    "Find and explain the cause of this error",
-    "Refactor this module without changing behavior",
-    "Open a PR for my staged changes",
+    "git status --short",
+    "rg \"TODO|FIXME\" .",
+    "find . -type f -size +100M",
+    "git log --oneline -10",
 ];
 
 /// Placeholder that types example prompts one character at a time with a blinking caret.

--- a/crates/vmux_terminal/src/page.rs
+++ b/crates/vmux_terminal/src/page.rs
@@ -1006,7 +1006,7 @@ const PROMPT_EXAMPLES: &[&str] = &[
 /// blinking caret while the agent boot prompt is empty. The live draft replaces
 /// it the moment the user types; unmounting clears the interval.
 #[component]
-fn PromptGhost(accent_bg: String) -> Element {
+pub fn PromptGhost(accent_bg: String) -> Element {
     let ex_idx = use_signal(|| 0usize);
     let typed = use_signal(|| 0usize);
     let cb: Rc<RefCell<Option<Closure<dyn FnMut()>>>> = use_hook(|| Rc::new(RefCell::new(None)));

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -4582,7 +4582,8 @@ mod tests {
         assert!(page.contains("MatrixRain {"));
         assert!(page.contains("accent.rain_rgb"));
         assert!(page.contains("terminal: true"));
-        assert!(page.contains("Fix the failing tests in this project"));
+        assert!(page.contains("git status --short"));
+        assert!(page.contains("type a command · runs when ready"));
 
         let rain = include_str!("matrix_rain.rs");
         assert!(rain.contains("request_animation_frame"));

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -4581,6 +4581,8 @@ mod tests {
         let page = include_str!("page.rs");
         assert!(page.contains("MatrixRain {"));
         assert!(page.contains("accent.rain_rgb"));
+        assert!(page.contains("terminal: true"));
+        assert!(page.contains("Fix the failing tests in this project"));
 
         let rain = include_str!("matrix_rain.rs");
         assert!(rain.contains("request_animation_frame"));


### PR DESCRIPTION
## Context

ACP agent pages use a generic installation state that feels disconnected from the branded CLI agent startup experience. The prompt remains available, but its placement and styling do not communicate that input can be queued while the agent initializes.

## Implementation

Reuse the terminal Matrix rain and animated prompt example components in the shared chat page. During installation, center the existing functional composer in the branded glass loading card, preserve queue and slash-command behavior, and return to the normal transcript layout when the agent becomes ready.

## Checks / QA

- Open an ACP agent that needs initialization and confirm the branded Matrix loading screen appears immediately.
- Type and submit a prompt while initialization is in progress; confirm it queues and runs when the agent becomes ready.
- Confirm the normal chat header, transcript, selectors, and composer return after initialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved the chat initial experience to show an “installing/starting” screen with Matrix-style rain and an installing-focused layout.
  - Enhanced loading guidance with context-aware prompt ghosting (chat vs terminal) and example typing that cycles appropriately.
- **Refactor**
  - Standardized agent install progress messaging so completion transitions cleanly to “Starting agent…”.
- **Tests**
  - Added/updated native and unit tests to verify the installing UI, terminal hints, and progress display behavior.
- **Chores**
  - Adjusted dependency placement so the terminal component is available consistently across build targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->