### PR TITLE
feat(agent): flush queued prompts with Esc

### DIFF
--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -18,8 +18,8 @@ use bevy_cef::prelude::{BinEventEmitterPlugin, BinHostEmitEvent, BinReceive, Bro
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::chat_page::event::{
-    CHAT_SNAPSHOT_EVENT, ChatApproval, ChatCancel, ChatClearQueue, ChatResume, ChatSnapshot,
-    ChatSubmit, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions,
+    CHAT_SNAPSHOT_EVENT, ChatApproval, ChatCancel, ChatClearQueue, ChatEscape, ChatResume,
+    ChatSnapshot, ChatSubmit, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions,
     ResumeListRequest, ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT,
     SlashCommandEntry, SlashCommands,
 };
@@ -70,6 +70,7 @@ impl Plugin for AgentChatPagePlugin {
             ChatCancel,
             ChatResume,
             ChatClearQueue,
+            ChatEscape,
             ResumeListRequest,
             ResumeSession,
             RuntimeSwitchRequest,
@@ -79,6 +80,7 @@ impl Plugin for AgentChatPagePlugin {
             .add_observer(on_chat_cancel)
             .add_observer(on_chat_resume)
             .add_observer(on_chat_clear_queue)
+            .add_observer(on_chat_escape)
             .add_observer(on_resume_list_request)
             .add_observer(on_resume_session)
             .add_observer(on_runtime_switch_request)
@@ -316,36 +318,47 @@ fn on_chat_submit(
 
 #[cfg(not(target_arch = "wasm32"))]
 fn enqueue_prompt(queue: &mut PromptQueue, state: &mut AgentRunState, text: String) {
-    queue.items.push_back(text);
-    queue.paused = false;
+    queue.enqueue(text);
     if matches!(state, AgentRunState::Errored(_)) {
         *state = AgentRunState::Idle;
     }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn on_chat_cancel(
-    trigger: On<BinReceive<ChatCancel>>,
-    child_of: Query<&ChildOf>,
-    sessions: Query<(Option<&AcpSession>, Option<&AgentSession>)>,
-    service: Option<Res<ServiceClient>>,
+fn cancel_session(
+    service: Option<&ServiceClient>,
+    acp: Option<&AcpSession>,
+    page: Option<&AgentSession>,
 ) {
     let Some(service) = service else {
         return;
     };
-    let Ok(parent) = child_of.get(trigger.event().webview) else {
-        return;
-    };
-    let Ok((acp, page)) = sessions.get(parent.parent()) else {
-        return;
-    };
     let Some(sid) = acp
-        .map(|s| s.sid.clone())
-        .or_else(|| page.map(|s| s.sid.clone()))
+        .map(|session| session.sid.clone())
+        .or_else(|| page.map(|session| session.sid.clone()))
     else {
         return;
     };
     service.0.send(ClientMessage::AgentCancel { sid });
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn on_chat_cancel(
+    trigger: On<BinReceive<ChatCancel>>,
+    child_of: Query<&ChildOf>,
+    mut sessions: Query<(&mut PromptQueue, Option<&AcpSession>, Option<&AgentSession>)>,
+    service: Option<Res<ServiceClient>>,
+) {
+    let Ok(parent) = child_of.get(trigger.event().webview) else {
+        return;
+    };
+    let Ok((mut queue, acp, page)) = sessions.get_mut(parent.parent()) else {
+        return;
+    };
+    if queue.flush_pending() {
+        queue.cancel_flush();
+    }
+    cancel_session(service.as_deref(), acp, page);
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -358,7 +371,7 @@ fn on_chat_resume(
         return;
     };
     if let Ok(mut queue) = queues.get_mut(parent.parent()) {
-        queue.paused = false;
+        queue.resume();
     }
 }
 
@@ -372,8 +385,45 @@ fn on_chat_clear_queue(
         return;
     };
     if let Ok(mut queue) = queues.get_mut(parent.parent()) {
-        queue.items.clear();
-        queue.paused = false;
+        queue.clear();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn on_chat_escape(
+    trigger: On<BinReceive<ChatEscape>>,
+    child_of: Query<&ChildOf>,
+    mut sessions: Query<(
+        &mut PromptQueue,
+        &mut AgentRunState,
+        Option<&AcpSession>,
+        Option<&AgentSession>,
+    )>,
+    service: Option<Res<ServiceClient>>,
+) {
+    let Ok(parent) = child_of.get(trigger.event().webview) else {
+        return;
+    };
+    let Ok((mut queue, mut state, acp, page)) = sessions.get_mut(parent.parent()) else {
+        return;
+    };
+    let running = matches!(
+        *state,
+        AgentRunState::Streaming | AgentRunState::AwaitingApproval { .. }
+    );
+    let flush = if queue.items.is_empty() {
+        if queue.flush_pending() {
+            queue.cancel_flush();
+        }
+        false
+    } else {
+        queue.request_flush()
+    };
+    if flush && matches!(*state, AgentRunState::Errored(_)) {
+        *state = AgentRunState::Idle;
+    }
+    if running {
+        cancel_session(service.as_deref(), acp, page);
     }
 }
 
@@ -831,6 +881,92 @@ mod native_tests {
     }
 
     #[test]
+    fn normal_cancel_overrides_pending_flush() {
+        use bevy_cef::prelude::BinReceive;
+
+        let mut app = App::new();
+        app.add_observer(on_chat_cancel);
+        let mut queue = PromptQueue::default();
+        queue.items.push_back("queued".into());
+        assert!(queue.request_flush());
+        let stack = app.world_mut().spawn(queue).id();
+        let webview = app.world_mut().spawn(ChildOf(stack)).id();
+
+        app.world_mut().trigger(BinReceive::<ChatCancel> {
+            webview,
+            payload: ChatCancel,
+        });
+        app.world_mut().flush();
+
+        assert!(
+            !app.world()
+                .get::<PromptQueue>(stack)
+                .unwrap()
+                .flush_pending()
+        );
+    }
+
+    #[test]
+    fn escape_flush_rearms_errored_queue() {
+        use bevy_cef::prelude::BinReceive;
+
+        let mut app = App::new();
+        app.add_observer(on_chat_escape);
+        let mut queue = PromptQueue::default();
+        queue.items.push_back("retry".into());
+        queue.paused = true;
+        let stack = app
+            .world_mut()
+            .spawn((queue, AgentRunState::Errored("failed".into())))
+            .id();
+        let webview = app.world_mut().spawn(ChildOf(stack)).id();
+
+        app.world_mut().trigger(BinReceive::<ChatEscape> {
+            webview,
+            payload: ChatEscape,
+        });
+        app.world_mut().flush();
+
+        assert!(matches!(
+            app.world().get::<AgentRunState>(stack),
+            Some(AgentRunState::Idle)
+        ));
+        let queue = app.world().get::<PromptQueue>(stack).unwrap();
+        assert!(queue.flush_pending());
+        assert!(!queue.paused);
+    }
+
+    #[test]
+    fn escape_without_queue_clears_stale_flush() {
+        use bevy_cef::prelude::BinReceive;
+
+        let mut app = App::new();
+        app.add_observer(on_chat_escape);
+        let mut queue = PromptQueue::default();
+        queue.items.push_back("queued".into());
+        assert!(queue.request_flush());
+        queue.items.clear();
+        let stack = app
+            .world_mut()
+            .spawn((queue, AgentRunState::Streaming))
+            .id();
+        let webview = app.world_mut().spawn(ChildOf(stack)).id();
+
+        app.world_mut().trigger(BinReceive::<ChatEscape> {
+            webview,
+            payload: ChatEscape,
+        });
+        app.world_mut().flush();
+
+        assert!(
+            !app.world()
+                .get::<PromptQueue>(stack)
+                .unwrap()
+                .flush_pending()
+        );
+    }
+
+    #[test]
     fn resume_agent_name_prefers_profile_then_kind_then_id() {
         let profile = Profile::registry("Antigravity", "antigravity");
         assert_eq!(
@@ -901,6 +1037,38 @@ mod native_tests {
         let source = include_str!("chat_page/page.rs");
         assert!(source.contains("onclick: move |_| run_slash_command"));
         assert!(source.contains("onclick: move |_| select_resume_session"));
+    }
+
+    #[test]
+    fn composer_escape_defers_queue_state_to_native() {
+        let source = include_str!("chat_page/page.rs");
+        assert!(source.contains("try_cef_bin_emit_rkyv(&ChatEscape)"));
+        assert!(!source.contains("ChatFlush"));
+    }
+
+    #[test]
+    fn queued_flush_controls_repurpose_composer_button() {
+        let source = include_str!("chat_page/page.rs");
+        assert!(source.contains("kbd {"));
+        assert!(source.contains("if queued.read().is_empty()"));
+        assert!(source.contains("title: \"Stop\""));
+        assert!(source.contains("rect { x: \"6\", y: \"6\""));
+        assert!(source.contains("\"Send all queued prompts now (Esc)\""));
+        assert!(source.contains("path { d: \"M12 19V5\" }"));
+    }
+
+    #[test]
+    fn composer_ctrl_c_cancel_does_not_use_streaming_snapshot() {
+        let source = include_str!("chat_page/page.rs");
+        let handler = source
+            .split("} else if e.modifiers().ctrl()")
+            .nth(1)
+            .expect("ctrl-c handler")
+            .split("},")
+            .next()
+            .expect("ctrl-c handler body");
+        assert!(handler.contains("try_cef_bin_emit_rkyv(&ChatCancel)"));
+        assert!(!handler.contains("&& streaming"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/composer.rs
+++ b/crates/vmux_agent/src/chat_page/composer.rs
@@ -121,6 +121,14 @@ pub(crate) fn is_handoff_boundary(message_index: usize, imported_message_count: 
     imported_message_count != 0 && message_index + 1 == imported_message_count as usize
 }
 
+pub(crate) fn should_clear_draft_on_escape(
+    streaming: bool,
+    queue_empty: bool,
+    draft_empty: bool,
+) -> bool {
+    !streaming && queue_empty && !draft_empty
+}
+
 pub(crate) fn edit_prompt(
     value: &str,
     selection_start: u32,
@@ -265,6 +273,14 @@ mod tests {
         assert_eq!(menu_direction("p", true), Some(MenuDirection::Previous));
         assert_eq!(menu_direction("n", false), None);
         assert_eq!(menu_direction("ArrowDown", true), None);
+    }
+
+    #[test]
+    fn escape_clears_only_idle_unqueued_draft() {
+        assert!(should_clear_draft_on_escape(false, true, false));
+        assert!(!should_clear_draft_on_escape(true, true, false));
+        assert!(!should_clear_draft_on_escape(false, false, false));
+        assert!(!should_clear_draft_on_escape(false, true, true));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -73,7 +73,7 @@ pub struct ChatApproval {
     pub decision: u8,
 }
 
-/// Page → native: interrupt the in-flight turn (Esc / Ctrl+C / Stop).
+/// Page → native: interrupt the in-flight turn from Ctrl+C or Stop.
 #[derive(
     Clone,
     Debug,
@@ -111,6 +111,19 @@ pub struct ChatResume;
     rkyv::Deserialize,
 )]
 pub struct ChatClearQueue;
+
+/// Page → native: apply Escape to the authoritative native queue and run state.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatEscape;
 
 /// Bin-event id: native → page, the resumable-session list (answer to [`ResumeListRequest`]).
 pub const RESUMABLE_SESSIONS_EVENT: &str = "resumable_sessions";

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -2,13 +2,14 @@
 
 use crate::chat_page::composer::{
     PromptEdit, ResumeMenuState, SelectorMode, edit_prompt, filter_sessions, is_handoff_boundary,
-    menu_direction, move_selection, resume_menu_state, selector_mode, should_fetch_resume,
+    menu_direction, move_selection, resume_menu_state, selector_mode, should_clear_draft_on_escape,
+    should_fetch_resume,
 };
 use crate::chat_page::event::{
-    CHAT_SNAPSHOT_EVENT, ChatApproval, ChatBlock, ChatCancel, ChatClearQueue, ChatMessage,
-    ChatResume, ChatSnapshot, ChatSubmit, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry,
-    ResumableSessions, ResumeListRequest, ResumeSession, RuntimeSwitchRequest,
-    SLASH_COMMANDS_EVENT, SlashCommandEntry, SlashCommands,
+    CHAT_SNAPSHOT_EVENT, ChatApproval, ChatBlock, ChatCancel, ChatClearQueue, ChatEscape,
+    ChatMessage, ChatResume, ChatSnapshot, ChatSubmit, RESUMABLE_SESSIONS_EVENT,
+    ResumableSessionEntry, ResumableSessions, ResumeListRequest, ResumeSession,
+    RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SlashCommandEntry, SlashCommands,
 };
 use dioxus::prelude::*;
 use vmux_ui::favicon::favicon_src_for_url;
@@ -555,6 +556,10 @@ pub fn Page() -> Element {
                                     }
                                 }
                             }
+                            div { class: "flex items-center gap-2 pr-1 text-[10px] text-foreground/40",
+                                kbd { class: "inline-flex h-5 items-center rounded border border-foreground/15 bg-foreground/[0.06] px-1.5 font-mono text-[10px] font-medium text-foreground/60 shadow-sm", "Esc" }
+                                span { "send all now" }
+                            }
                         }
                     }
                     div { class: "flex items-end gap-2",
@@ -646,15 +651,17 @@ pub fn Page() -> Element {
                                     e.prevent_default();
                                     do_submit(draft, at_bottom);
                                 } else if e.key() == Key::Escape {
-                                    if streaming {
-                                        e.prevent_default();
-                                        let _ = try_cef_bin_emit_rkyv(&ChatCancel);
-                                    } else if !draft.peek().is_empty() {
+                                    e.prevent_default();
+                                    let _ = try_cef_bin_emit_rkyv(&ChatEscape);
+                                    if should_clear_draft_on_escape(
+                                        streaming,
+                                        queued.peek().is_empty(),
+                                        draft.peek().is_empty(),
+                                    ) {
                                         draft.set(String::new());
                                     }
                                 } else if e.modifiers().ctrl()
                                     && matches!(e.key(), Key::Character(c) if c == "c")
-                                    && streaming
                                     && !has_text_selection()
                                 {
                                     e.prevent_default();
@@ -663,17 +670,38 @@ pub fn Page() -> Element {
                             },
                         }
                         if matches!(status().as_str(), "streaming" | "awaiting") {
-                            button {
-                                class: "flex items-center justify-center rounded-xl p-2.5 text-muted-foreground transition hover:bg-foreground/10 hover:text-foreground active:scale-[0.98]",
-                                title: "Interrupt (Esc)",
-                                onclick: move |_| {
-                                    let _ = try_cef_bin_emit_rkyv(&ChatCancel);
-                                },
-                                svg {
-                                    class: "h-4 w-4",
-                                    view_box: "0 0 24 24",
-                                    fill: "currentColor",
-                                    rect { x: "6", y: "6", width: "12", height: "12", rx: "2.5" }
+                            if queued.read().is_empty() {
+                                button {
+                                    class: "flex items-center justify-center rounded-xl p-2.5 text-muted-foreground transition hover:bg-foreground/10 hover:text-foreground active:scale-[0.98]",
+                                    title: "Stop",
+                                    onclick: move |_| {
+                                        let _ = try_cef_bin_emit_rkyv(&ChatCancel);
+                                    },
+                                    svg {
+                                        class: "h-4 w-4",
+                                        view_box: "0 0 24 24",
+                                        fill: "currentColor",
+                                        rect { x: "6", y: "6", width: "12", height: "12", rx: "2.5" }
+                                    }
+                                }
+                            } else {
+                                button {
+                                    class: "flex items-center justify-center rounded-xl p-2.5 text-muted-foreground transition hover:bg-foreground/10 hover:text-foreground active:scale-[0.98]",
+                                    title: "Send all queued prompts now (Esc)",
+                                    onclick: move |_| {
+                                        let _ = try_cef_bin_emit_rkyv(&ChatEscape);
+                                    },
+                                    svg {
+                                        class: "h-4 w-4",
+                                        view_box: "0 0 24 24",
+                                        fill: "none",
+                                        stroke: "currentColor",
+                                        stroke_width: "2",
+                                        stroke_linecap: "round",
+                                        stroke_linejoin: "round",
+                                        path { d: "M12 19V5" }
+                                        path { d: "M5 12l7-7 7 7" }
+                                    }
                                 }
                             }
                         } else {

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -598,7 +598,7 @@ fn send_acp_input(
         if !queue.ready(matches!(*state, AgentRunState::Idle)) {
             continue;
         }
-        let Some(text) = queue.items.pop_front() else {
+        let Some(text) = queue.take_next() else {
             continue;
         };
         let context = pending

--- a/crates/vmux_agent/src/client/page/plugin.rs
+++ b/crates/vmux_agent/src/client/page/plugin.rs
@@ -126,7 +126,7 @@ fn send_page_agent_input(
         if !queue.ready(matches!(*state, AgentRunState::Idle)) {
             continue;
         }
-        let Some(text) = queue.items.pop_front() else {
+        let Some(text) = queue.take_next() else {
             continue;
         };
         service.0.send(ClientMessage::AgentInput {
@@ -239,10 +239,16 @@ fn consume_page_agent_stream(
                 AgentRunStatus::Streaming => *state = AgentRunState::Streaming,
                 AgentRunStatus::Interrupted => {
                     *state = AgentRunState::Idle;
-                    queue.paused = true;
+                    if !queue.flush_pending() {
+                        queue.paused = true;
+                    }
                 }
                 AgentRunStatus::Errored(message) => {
-                    *state = AgentRunState::Errored(message.clone());
+                    if queue.flush_pending() {
+                        *state = AgentRunState::Idle;
+                    } else {
+                        *state = AgentRunState::Errored(message.clone());
+                    }
                     if let Some(pending) = pending.as_deref_mut() {
                         pending.retry();
                     }
@@ -346,6 +352,118 @@ mod tests {
         let q = world.get::<PromptQueue>(e).unwrap();
         assert!(q.paused, "queue must pause after interrupt");
         assert_eq!(q.items.len(), 1, "held item must not auto-advance");
+    }
+
+    #[test]
+    fn flush_pending_interrupt_does_not_pause() {
+        use crate::client::acp::AcpSession;
+        use crate::components::PromptQueue;
+        use vmux_service::agent_events::{
+            PageAgentAwaitingApproval, PageAgentDelta, PageAgentRunStatus, PageAgentSnapshot,
+        };
+        use vmux_service::protocol::AgentRunStatus;
+
+        let mut app = App::new();
+        app.add_plugins(bevy::app::TaskPoolPlugin::default())
+            .add_message::<PageAgentDelta>()
+            .add_message::<PageAgentRunStatus>()
+            .add_message::<PageAgentAwaitingApproval>()
+            .add_message::<PageAgentSnapshot>()
+            .add_message::<vmux_core::notify::AgentAttention>()
+            .add_systems(Update, consume_page_agent_stream);
+
+        let mut queue = PromptQueue::default();
+        queue.items.push_back("a".into());
+        queue.items.push_back("b".into());
+        assert!(queue.request_flush());
+        let e = app
+            .world_mut()
+            .spawn((
+                AcpSession {
+                    agent_id: "a".into(),
+                    sid: "s1".into(),
+                    cwd: std::path::PathBuf::from("/tmp"),
+                    anchor: vmux_core::ProcessId::new(),
+                    resume: None,
+                },
+                AgentMessages::default(),
+                AgentRunState::Streaming,
+                queue,
+            ))
+            .id();
+        app.world_mut().write_message(PageAgentRunStatus {
+            sid: "s1".into(),
+            status: AgentRunStatus::Interrupted,
+        });
+        app.update();
+
+        let world = app.world();
+        assert!(matches!(
+            world.get::<AgentRunState>(e),
+            Some(AgentRunState::Idle)
+        ));
+        let q = world.get::<PromptQueue>(e).unwrap();
+        assert!(
+            !q.paused,
+            "flush interrupt must leave the queue running to drain"
+        );
+        assert_eq!(
+            q.items.len(),
+            2,
+            "items wait for the idle drain to batch them"
+        );
+    }
+
+    #[test]
+    fn flush_pending_error_rearms_queue() {
+        use crate::client::acp::AcpSession;
+        use crate::components::PromptQueue;
+        use vmux_service::agent_events::{
+            PageAgentAwaitingApproval, PageAgentDelta, PageAgentRunStatus, PageAgentSnapshot,
+        };
+        use vmux_service::protocol::AgentRunStatus;
+
+        let mut app = App::new();
+        app.add_plugins(bevy::app::TaskPoolPlugin::default())
+            .add_message::<PageAgentDelta>()
+            .add_message::<PageAgentRunStatus>()
+            .add_message::<PageAgentAwaitingApproval>()
+            .add_message::<PageAgentSnapshot>()
+            .add_message::<vmux_core::notify::AgentAttention>()
+            .add_systems(Update, consume_page_agent_stream);
+
+        let mut queue = PromptQueue::default();
+        queue.items.push_back("retry".into());
+        assert!(queue.request_flush());
+        let entity = app
+            .world_mut()
+            .spawn((
+                AcpSession {
+                    agent_id: "a".into(),
+                    sid: "s1".into(),
+                    cwd: std::path::PathBuf::from("/tmp"),
+                    anchor: vmux_core::ProcessId::new(),
+                    resume: None,
+                },
+                AgentMessages::default(),
+                AgentRunState::Streaming,
+                queue,
+            ))
+            .id();
+        app.world_mut().write_message(PageAgentRunStatus {
+            sid: "s1".into(),
+            status: AgentRunStatus::Errored("cancel race".into()),
+        });
+        app.update();
+
+        assert!(matches!(
+            app.world().get::<AgentRunState>(entity),
+            Some(AgentRunState::Idle)
+        ));
+        let queue = app.world().get::<PromptQueue>(entity).unwrap();
+        assert!(queue.flush_pending());
+        assert!(!queue.paused);
+        assert_eq!(queue.items.front().map(String::as_str), Some("retry"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/components.rs
+++ b/crates/vmux_agent/src/components.rs
@@ -25,19 +25,74 @@ pub struct AgentApprovalPolicy {
     pub auto: HashSet<String>,
 }
 
-/// FIFO of prompts waiting to be dispatched to this session's agent. Drained one at a time
-/// while the session is idle; `paused` holds the queue after an interrupt until the user
-/// resumes, clears, or submits again.
+/// FIFO of prompts waiting to be dispatched to this session's agent. Normal dispatch takes one
+/// prompt per idle turn. `paused` holds the queue after an interrupt until the user resumes,
+/// clears, or submits again; `flush_pending` combines all queued prompts for an Esc flush.
 #[derive(Component, Clone, Debug, Default)]
 pub struct PromptQueue {
     pub items: VecDeque<String>,
     pub paused: bool,
+    flush_pending: bool,
 }
 
 impl PromptQueue {
     /// The gate for dispatching the next prompt: idle, not paused, and something queued.
     pub fn ready(&self, idle: bool) -> bool {
         idle && !self.paused && !self.items.is_empty()
+    }
+
+    /// Whether the next dispatch should combine every queued prompt.
+    pub fn flush_pending(&self) -> bool {
+        self.flush_pending
+    }
+
+    /// Append one prompt and allow dispatch to continue.
+    pub fn enqueue(&mut self, text: String) {
+        self.items.push_back(text);
+        self.paused = false;
+    }
+
+    /// Mark all currently queued prompts for one combined dispatch.
+    pub fn request_flush(&mut self) -> bool {
+        if self.items.is_empty() {
+            return false;
+        }
+        self.paused = false;
+        self.flush_pending = true;
+        true
+    }
+
+    /// Cancel a pending combined dispatch without modifying queued prompts.
+    pub fn cancel_flush(&mut self) {
+        self.flush_pending = false;
+    }
+
+    /// Drop queued prompts and reset queue control state.
+    pub fn clear(&mut self) {
+        self.items.clear();
+        self.paused = false;
+        self.flush_pending = false;
+    }
+
+    /// Resume normal FIFO dispatch after an interrupt.
+    pub fn resume(&mut self) {
+        self.paused = false;
+        self.flush_pending = false;
+    }
+
+    /// Take one FIFO prompt, or all prompts joined by blank lines for a pending flush.
+    pub fn take_next(&mut self) -> Option<String> {
+        if !self.flush_pending {
+            return self.items.pop_front();
+        }
+        self.flush_pending = false;
+        let mut text = self.items.pop_front()?;
+        text.reserve(self.items.iter().map(|item| item.len() + 2).sum());
+        for item in self.items.drain(..) {
+            text.push_str("\n\n");
+            text.push_str(&item);
+        }
+        Some(text)
     }
 }
 
@@ -61,5 +116,76 @@ mod tests {
         assert!(!q.ready(false));
         q.paused = true;
         assert!(!q.ready(true));
+    }
+
+    #[test]
+    fn take_next_preserves_fifo_without_flush() {
+        let mut q = PromptQueue::default();
+        q.items.push_back("first".into());
+        q.items.push_back("second".into());
+        assert_eq!(q.take_next(), Some("first".to_string()));
+        assert_eq!(q.items.front().map(String::as_str), Some("second"));
+    }
+
+    #[test]
+    fn take_next_merges_all_items_for_flush() {
+        let mut q = PromptQueue::default();
+        q.items.push_back("first".into());
+        q.items.push_back("second".into());
+
+        assert!(q.request_flush());
+        assert_eq!(q.take_next(), Some("first\n\nsecond".to_string()));
+        assert!(q.items.is_empty());
+        assert!(!q.flush_pending);
+    }
+
+    #[test]
+    fn enqueue_preserves_pending_flush() {
+        let mut q = PromptQueue::default();
+        q.items.push_back("first".into());
+        assert!(q.request_flush());
+
+        q.enqueue("second".into());
+
+        assert!(q.flush_pending);
+        assert_eq!(q.take_next(), Some("first\n\nsecond".to_string()));
+    }
+
+    #[test]
+    fn cancel_flush_clears_pending_flush() {
+        let mut q = PromptQueue::default();
+        q.items.push_back("first".into());
+        assert!(q.request_flush());
+
+        q.cancel_flush();
+
+        assert!(!q.flush_pending);
+    }
+
+    #[test]
+    fn clear_resets_queue_state() {
+        let mut q = PromptQueue::default();
+        q.items.push_back("first".into());
+        assert!(q.request_flush());
+        q.paused = true;
+
+        q.clear();
+
+        assert!(q.items.is_empty());
+        assert!(!q.paused);
+        assert!(!q.flush_pending);
+    }
+
+    #[test]
+    fn resume_resets_pause_and_flush() {
+        let mut q = PromptQueue::default();
+        q.items.push_back("first".into());
+        assert!(q.request_flush());
+        q.paused = true;
+
+        q.resume();
+
+        assert!(!q.paused);
+        assert!(!q.flush_pending);
     }
 }

--- a/docs/specs/2026-07-14-esc-flush-queue-design.md
+++ b/docs/specs/2026-07-14-esc-flush-queue-design.md
@@ -1,0 +1,103 @@
+# Esc flush queue
+
+Date: 2026-07-14
+Status: Approved
+
+## Problem
+
+Agent prompts submitted while a turn is running remain queued until the turn settles. Pressing Esc should interrupt the active turn and send all queued prompts immediately as one combined turn. Normal completion should preserve FIFO behavior and dispatch one queued prompt per turn.
+
+The current branch has four correctness gaps:
+
+- the page chooses flush versus cancel from a delayed `ChatSnapshot`, so Enter→Esc and snapshot-lag races can emit the wrong event;
+- `flush_pending` remains set when Stop or Ctrl+C follows an Esc flush, so the later explicit cancellation can still drain the queue;
+- flushing queued prompts from `AgentRunState::Errored` does not restore `Idle`, leaving the queue blocked;
+- both normal and Esc-triggered drains call `take_merged`, changing ordinary FIFO queue semantics.
+
+## Approaches
+
+### Chosen: one native Escape intent
+
+Replace the page-side flush-versus-cancel decision with one `ChatEscape` event. Native code reads the authoritative `PromptQueue` and `AgentRunState`, then chooses whether to flush queued prompts or perform a normal cancellation.
+
+This removes the snapshot race and keeps queue transitions in the native state owner.
+
+### Rejected: optimistic page queue state
+
+Update the page's queued state immediately after submit and continue emitting separate `ChatFlush` and `ChatCancel` events. This reduces one race window but retains two sources of truth and remains vulnerable to delayed native state transitions.
+
+### Rejected: cancellation generations
+
+Attach generation identifiers to flush and cancellation requests. This can define ordering precisely but adds protocol and state-machine complexity that is unnecessary when native code can handle Escape atomically.
+
+## Design
+
+### Page event flow
+
+The chat page emits `ChatEscape` for Escape after selector handling. Native code decides the queue action. The page may still clear an idle draft locally when its latest snapshot reports no active turn or queued prompts, but it does not select between flush and cancel.
+
+The Stop button and Ctrl+C continue to emit `ChatCancel`. These are explicit normal cancellations and override any pending flush request.
+
+### Native Escape handling
+
+`on_chat_escape` resolves the stack from the webview and inspects its queue and run state.
+
+When the queue is non-empty:
+
+1. mark the queue for flush and unpause it;
+2. change `Errored` to `Idle` so dispatch can resume;
+3. cancel the service turn only for `Streaming` or `AwaitingApproval`;
+4. let the existing ACP or Page dispatch system send the merged queue after the state becomes idle.
+
+When the queue is empty and the state is `Streaming` or `AwaitingApproval`, clear any stale flush request and perform a normal cancellation.
+
+Other states require no native action.
+
+### Queue transitions
+
+Encapsulate queue state changes in `PromptQueue` methods:
+
+- normal enqueue appends one prompt and unpauses without discarding an active flush request;
+- requesting a flush requires a non-empty queue, sets `flush_pending`, and unpauses;
+- normal cancellation clears `flush_pending` before sending `AgentCancel`;
+- clear empties the queue and resets pause and flush state;
+- resume clears pause and flush state;
+- dispatch pops one prompt during normal FIFO operation;
+- dispatch drains and joins every prompt with a blank line only when `flush_pending` is set, then clears the flag.
+
+An `Interrupted` status pauses the queue when no flush is pending. A flush-triggered interruption leaves it running so the merged dispatch can proceed.
+
+### Error handling
+
+An Esc flush from `Errored` reuses the existing submit-after-error recovery rule by setting the run state to `Idle`. If no service connection or session ID is available, queue state remains intact instead of dropping prompts; normal dispatch or a later state transition can retry.
+
+No new queue-size limit is introduced. Aggregate IPC limits are broader queue-policy work and are not required to fix the state and ordering defects.
+
+## Testing
+
+Follow red-green TDD for each transition.
+
+Add `PromptQueue` unit coverage for:
+
+- normal dispatch pops only the first prompt;
+- flush dispatch merges all prompts and clears `flush_pending`;
+- normal cancellation, clear, and resume reset flush state;
+- enqueue during a pending flush remains part of the flush batch.
+
+Add Bevy observer/system coverage for:
+
+- Escape with queued prompts marks a flush;
+- Escape with queued prompts from `Errored` restores `Idle`;
+- normal cancel after an Esc flush clears the flush request;
+- `Interrupted` pauses a normal queue but not a pending flush;
+- ACP and Page dispatch preserve FIFO normally and merge only for flush.
+
+Add page-source coverage ensuring Escape emits the single native `ChatEscape` intent rather than choosing `ChatFlush` or `ChatCancel` from snapshot queue state.
+
+Run `cargo test -p vmux_agent`, `cargo clippy -p vmux_agent --all-targets -- -D warnings`, formatting checks, and a wasm32 check for the page event changes.
+
+## Risks
+
+- Escape during a narrow transition from queued to newly dispatched work may become a normal cancellation once native state shows an empty queue and active turn. This matches the authoritative state at event handling time.
+- New submissions arriving after an Esc request but before interruption completion join the pending flush batch. This preserves the meaning of “send all queued prompts now.”
+- Event renaming must stay synchronized between wasm page emission and native `BinEventEmitterPlugin` registration.


### PR DESCRIPTION
## Context

Queued prompts currently wait one turn at a time, while Esc only interrupts the active turn. This makes it cumbersome to immediately send everything already queued.

## Implementation

Esc is handled atomically by native queue state: queued prompts are combined into one dispatch, active work is interrupted, and normal Ctrl+C or Stop still cancels without flushing. The composer preserves drafts, shows an Esc keycap hint, and swaps the prompt action from Stop to Send once prompts are queued.

## Checks / QA

1. Start an agent turn and queue multiple prompts.
2. Confirm the prompt action remains Stop until the first prompt is queued, then changes to the send arrow.
3. Press Esc or click the send arrow and confirm the active turn stops and all queued prompts are sent together.
4. Confirm Ctrl+C and Stop cancel without flushing queued prompts.