### PR TITLE
fix(layout): refine side sheet stack hover and folding

### DIFF
--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -1541,6 +1541,23 @@ struct LayoutHoverRefreshState {
     in_region: bool,
 }
 
+fn reset_layout_cef_hover(
+    browsers: &Browsers,
+    buttons: &ButtonInput<MouseButton>,
+    layout: Entity,
+    state: &mut LayoutHoverRefreshState,
+) {
+    if state.in_region {
+        browsers.send_mouse_move(
+            &layout,
+            buttons.get_pressed(),
+            state.position.unwrap_or_default(),
+            true,
+        );
+    }
+    *state = LayoutHoverRefreshState::default();
+}
+
 fn refresh_layout_cef_hover(
     browsers: NonSend<Browsers>,
     buttons: Res<ButtonInput<MouseButton>>,
@@ -1559,28 +1576,23 @@ fn refresh_layout_cef_hover(
     };
     if suppress.0 || !modal_pointer_targets.is_empty() {
         clear_native_layout_pointer_regions();
-        if state.in_region {
-            browsers.send_mouse_move(
-                &layout,
-                buttons.get_pressed(),
-                state.position.unwrap_or_default(),
-                true,
-            );
-        }
-        *state = LayoutHoverRefreshState::default();
+        reset_layout_cef_hover(&browsers, &buttons, layout, &mut state);
         return;
     }
     let Some(window_entity) = primary_window.single().ok() else {
         clear_native_layout_pointer_regions();
+        reset_layout_cef_hover(&browsers, &buttons, layout, &mut state);
         return;
     };
     let Ok(window) = windows.get(window_entity) else {
         clear_native_layout_pointer_regions();
+        reset_layout_cef_hover(&browsers, &buttons, layout, &mut state);
         return;
     };
     let scale = window.resolution.scale_factor();
     if !scale.is_finite() || scale <= 0.0 {
         clear_native_layout_pointer_regions();
+        reset_layout_cef_hover(&browsers, &buttons, layout, &mut state);
         return;
     }
     set_native_layout_pointer_regions(
@@ -1598,6 +1610,7 @@ fn refresh_layout_cef_hover(
     );
     let Some(cursor_px) = vmux_layout::pane::pane_hover_cursor_position(window_entity, window)
     else {
+        reset_layout_cef_hover(&browsers, &buttons, layout, &mut state);
         return;
     };
     let position = cursor_px / scale;
@@ -5417,6 +5430,7 @@ mod tests {
         assert!(refresh_fn.contains("window.resolution.scale_factor()"));
         assert!(refresh_fn.contains("set_native_layout_pointer_regions"));
         assert!(refresh_fn.contains("browsers.send_mouse_move"));
+        assert!(refresh_fn.matches("reset_layout_cef_hover").count() >= 5);
     }
 
     #[test]

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -228,7 +228,10 @@ impl Plugin for BrowserPlugin {
                     .after(UiSystems::Layout)
                     .before(render_standard_materials),
             )
-            .add_systems(Last, refresh_active_windowed_hover)
+            .add_systems(
+                Last,
+                (refresh_layout_cef_hover, refresh_active_windowed_hover),
+            )
             .init_resource::<HostFocusIntent>()
             .init_resource::<PendingNavSnapshots>()
             .init_resource::<HostSpawnRegistry>()
@@ -1477,6 +1480,67 @@ fn windowed_hover_refresh_position(
         (cursor_px.x - frame.left_px) / frame.scale,
         (cursor_px.y - frame.top_px) / frame.scale,
     ))
+}
+
+#[derive(Default)]
+struct LayoutHoverRefreshState {
+    position: Option<Vec2>,
+    in_region: bool,
+}
+
+fn refresh_layout_cef_hover(
+    browsers: NonSend<Browsers>,
+    buttons: Res<ButtonInput<MouseButton>>,
+    windows: Query<&Window>,
+    primary_window: Query<Entity, With<PrimaryWindow>>,
+    suppress: Res<CefSuppressPointerInput>,
+    layout_q: Query<Entity, With<LayoutCef>>,
+    cef_regions: CefPointerRegionQuery<'_, '_>,
+    modal_pointer_targets: Query<(), (With<Modal>, With<CefPointerTarget>)>,
+    mut state: Local<LayoutHoverRefreshState>,
+) {
+    let Ok(layout) = layout_q.single() else {
+        *state = LayoutHoverRefreshState::default();
+        return;
+    };
+    if suppress.0 || !modal_pointer_targets.is_empty() {
+        if state.in_region {
+            browsers.send_mouse_move(
+                &layout,
+                buttons.get_pressed(),
+                state.position.unwrap_or_default(),
+                true,
+            );
+        }
+        *state = LayoutHoverRefreshState::default();
+        return;
+    }
+    let Some(window_entity) = primary_window.single().ok() else {
+        return;
+    };
+    let Ok(window) = windows.get(window_entity) else {
+        return;
+    };
+    let Some(cursor_px) = vmux_layout::pane::pane_hover_cursor_position(window_entity, window)
+    else {
+        return;
+    };
+    let scale = window.resolution.scale_factor();
+    if !scale.is_finite() || scale <= 0.0 {
+        return;
+    }
+    let position = cursor_px / scale;
+    let in_region = cef_pointer_regions_contains(position, &cef_regions);
+    if state.position == Some(position) && state.in_region == in_region {
+        return;
+    }
+    if in_region {
+        browsers.send_mouse_move(&layout, buttons.get_pressed(), position, false);
+    } else if state.in_region {
+        browsers.send_mouse_move(&layout, buttons.get_pressed(), position, true);
+    }
+    state.position = Some(position);
+    state.in_region = in_region;
 }
 
 fn refresh_active_windowed_hover(
@@ -5260,10 +5324,26 @@ mod tests {
             .and_then(|tail| tail.split("fn sync_windowed_layout").next())
             .unwrap_or_default();
 
-        assert!(plugin_build.contains("add_systems(Last, refresh_active_windowed_hover)"));
+        assert!(plugin_build.contains("refresh_layout_cef_hover"));
+        assert!(plugin_build.contains("refresh_active_windowed_hover"));
         assert!(refresh_fn.contains("With<CefKeyboardTarget>"));
         assert!(refresh_fn.contains("With<WebviewWindowed>"));
         assert!(refresh_fn.contains("vmux_layout::pane::pane_hover_cursor_position"));
+        assert!(refresh_fn.contains("browsers.send_mouse_move"));
+    }
+
+    #[test]
+    fn browser_plugin_refreshes_layout_hover_from_native_cursor() {
+        let source = include_str!("lib.rs");
+        let refresh_fn = source
+            .split("fn refresh_layout_cef_hover")
+            .nth(1)
+            .and_then(|tail| tail.split("fn refresh_active_windowed_hover").next())
+            .unwrap_or_default();
+
+        assert!(refresh_fn.contains("pane_hover_cursor_position"));
+        assert!(refresh_fn.contains("cef_pointer_regions_contains"));
+        assert!(refresh_fn.contains("window.resolution.scale_factor()"));
         assert!(refresh_fn.contains("browsers.send_mouse_move"));
     }
 

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -318,6 +318,15 @@ struct CefPointerHitRect {
     interactive: bool,
 }
 
+#[derive(Default)]
+struct NativeLayoutPointerState {
+    regions: Vec<CefPointerHitRect>,
+    pointer_inside: bool,
+}
+
+static NATIVE_LAYOUT_POINTER_STATE: LazyLock<Mutex<NativeLayoutPointerState>> =
+    LazyLock::new(|| Mutex::new(NativeLayoutPointerState::default()));
+
 fn cef_pointer_hit_rect_contains(rect: CefPointerHitRect, point: Vec2) -> bool {
     if !rect.interactive {
         return false;
@@ -326,6 +335,50 @@ fn cef_pointer_hit_rect_contains(rect: CefPointerHitRect, point: Vec2) -> bool {
     let min = rect.center - half;
     let max = rect.center + half;
     point.x >= min.x && point.x <= max.x && point.y >= min.y && point.y <= max.y
+}
+
+fn physical_cef_pointer_hit_rect(mut rect: CefPointerHitRect, scale: f32) -> CefPointerHitRect {
+    rect.center *= scale;
+    rect.size *= scale;
+    rect
+}
+
+fn set_native_layout_pointer_regions(regions: impl IntoIterator<Item = CefPointerHitRect>) {
+    let mut state = NATIVE_LAYOUT_POINTER_STATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    state.regions.clear();
+    state.regions.extend(regions);
+}
+
+fn clear_native_layout_pointer_regions() {
+    let mut state = NATIVE_LAYOUT_POINTER_STATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    state.regions.clear();
+    state.pointer_inside = false;
+}
+
+fn layout_pointer_move_should_wake(was_inside: bool, inside: bool) -> bool {
+    was_inside || inside
+}
+
+/// Returns whether native pointer motion needs a layout hover update.
+pub fn native_layout_pointer_move_should_wake(x_px: f32, y_px: f32) -> bool {
+    if !x_px.is_finite() || !y_px.is_finite() {
+        return false;
+    }
+    let mut state = NATIVE_LAYOUT_POINTER_STATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let inside = state
+        .regions
+        .iter()
+        .copied()
+        .any(|rect| cef_pointer_hit_rect_contains(rect, Vec2::new(x_px, y_px)));
+    let should_wake = layout_pointer_move_should_wake(state.pointer_inside, inside);
+    state.pointer_inside = inside;
+    should_wake
 }
 
 fn cef_pointer_hit_rect(
@@ -1500,10 +1553,12 @@ fn refresh_layout_cef_hover(
     mut state: Local<LayoutHoverRefreshState>,
 ) {
     let Ok(layout) = layout_q.single() else {
+        clear_native_layout_pointer_regions();
         *state = LayoutHoverRefreshState::default();
         return;
     };
     if suppress.0 || !modal_pointer_targets.is_empty() {
+        clear_native_layout_pointer_regions();
         if state.in_region {
             browsers.send_mouse_move(
                 &layout,
@@ -1516,19 +1571,35 @@ fn refresh_layout_cef_hover(
         return;
     }
     let Some(window_entity) = primary_window.single().ok() else {
+        clear_native_layout_pointer_regions();
         return;
     };
     let Ok(window) = windows.get(window_entity) else {
-        return;
-    };
-    let Some(cursor_px) = vmux_layout::pane::pane_hover_cursor_position(window_entity, window)
-    else {
+        clear_native_layout_pointer_regions();
         return;
     };
     let scale = window.resolution.scale_factor();
     if !scale.is_finite() || scale <= 0.0 {
+        clear_native_layout_pointer_regions();
         return;
     }
+    set_native_layout_pointer_regions(
+        cef_regions
+            .iter()
+            .map(
+                |(header, side_sheet, node, computed, transform, visibility, open)| {
+                    cef_pointer_hit_rect(
+                        header, side_sheet, node, computed, transform, visibility, open,
+                    )
+                },
+            )
+            .filter(|rect| rect.interactive)
+            .map(|rect| physical_cef_pointer_hit_rect(rect, scale)),
+    );
+    let Some(cursor_px) = vmux_layout::pane::pane_hover_cursor_position(window_entity, window)
+    else {
+        return;
+    };
     let position = cursor_px / scale;
     let in_region = cef_pointer_regions_contains(position, &cef_regions);
     if state.position == Some(position) && state.in_region == in_region {
@@ -5344,7 +5415,31 @@ mod tests {
         assert!(refresh_fn.contains("pane_hover_cursor_position"));
         assert!(refresh_fn.contains("cef_pointer_regions_contains"));
         assert!(refresh_fn.contains("window.resolution.scale_factor()"));
+        assert!(refresh_fn.contains("set_native_layout_pointer_regions"));
         assert!(refresh_fn.contains("browsers.send_mouse_move"));
+    }
+
+    #[test]
+    fn native_layout_pointer_regions_use_physical_coordinates() {
+        let rect = physical_cef_pointer_hit_rect(
+            CefPointerHitRect {
+                center: Vec2::new(50.0, 25.0),
+                size: Vec2::new(20.0, 10.0),
+                interactive: true,
+            },
+            2.0,
+        );
+
+        assert!(cef_pointer_hit_rect_contains(rect, Vec2::new(100.0, 50.0)));
+        assert!(!cef_pointer_hit_rect_contains(rect, Vec2::new(79.0, 50.0)));
+    }
+
+    #[test]
+    fn native_layout_pointer_wakes_inside_and_once_on_exit() {
+        assert!(!layout_pointer_move_should_wake(false, false));
+        assert!(layout_pointer_move_should_wake(false, true));
+        assert!(layout_pointer_move_should_wake(true, true));
+        assert!(layout_pointer_move_should_wake(true, false));
     }
 
     #[test]

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -75,6 +75,10 @@ static LIVE_RESIZE_MONITOR_INSTALLED: AtomicBool = AtomicBool::new(false);
 #[cfg(target_os = "macos")]
 static HOVER_OVER_PANE: AtomicBool = AtomicBool::new(false);
 
+fn native_mouse_move_should_wake(layout_should_wake: bool, pane_should_wake: bool) -> bool {
+    layout_should_wake || pane_should_wake
+}
+
 #[cfg(target_os = "macos")]
 fn activate_primary_window_on_startup(
     primary_window: Query<(Entity, &Window), With<bevy::window::PrimaryWindow>>,
@@ -279,7 +283,13 @@ fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) 
                 HOVER_OVER_PANE.store(true, Ordering::Relaxed);
             }
             let should_wake = location
-                .map(|(x, y)| vmux_layout::pane::wake_on_move(x, y))
+                .map(|(x, y)| {
+                    let layout_should_wake =
+                        vmux_browser::native_layout_pointer_move_should_wake(x, y);
+                    let pane_should_wake =
+                        !layout_should_wake && vmux_layout::pane::wake_on_move(x, y);
+                    native_mouse_move_should_wake(layout_should_wake, pane_should_wake)
+                })
                 .unwrap_or(false);
             if should_wake {
                 local_wake(NATIVE_MOUSE_MOVE_WAKE_INTERVAL);
@@ -791,6 +801,15 @@ mod tests {
         assert!(monitor.contains("NSEventMask::MouseMoved"));
         assert!(monitor.contains("NSEventMask::LeftMouseDown"));
         assert!(monitor.contains("WinitUserEvent::WakeUp"));
+        assert!(monitor.contains("vmux_browser::native_layout_pointer_move_should_wake"));
+        assert!(monitor.contains("vmux_layout::pane::wake_on_move"));
+    }
+
+    #[test]
+    fn native_mouse_motion_skips_active_page_without_layout() {
+        assert!(native_mouse_move_should_wake(true, false));
+        assert!(native_mouse_move_should_wake(false, true));
+        assert!(!native_mouse_move_should_wake(false, false));
     }
 
     #[test]

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -75,6 +75,7 @@ static LIVE_RESIZE_MONITOR_INSTALLED: AtomicBool = AtomicBool::new(false);
 #[cfg(target_os = "macos")]
 static HOVER_OVER_PANE: AtomicBool = AtomicBool::new(false);
 
+#[cfg(any(target_os = "macos", test))]
 fn native_mouse_move_should_wake(layout_should_wake: bool, pane_should_wake: bool) -> bool {
     layout_should_wake || pane_should_wake
 }

--- a/crates/vmux_layout/src/page.rs
+++ b/crates/vmux_layout/src/page.rs
@@ -886,9 +886,9 @@ fn SideSheetStackRow(stack: StackNode, pane_id: u64) -> Element {
         div {
             id: "sidesheet-stack-{pane_id}-{stack_index}",
             class: if is_active {
-                "glass group flex h-9 cursor-default items-center gap-2 rounded-md px-2"
+                "glass group/stack flex h-9 cursor-default items-center gap-2 rounded-md px-2"
             } else {
-                "group flex h-9 cursor-pointer items-center gap-2 rounded-md px-2 border border-transparent text-muted-foreground hover:bg-glass-hover hover:text-foreground"
+                "group/stack flex h-9 cursor-pointer items-center gap-2 rounded-md px-2 border border-transparent text-muted-foreground hover:bg-glass-hover hover:text-foreground"
             },
             onclick: move |_| {
                 let _ = try_cef_bin_emit_rkyv(&crate::event::SideSheetCommandEvent {
@@ -910,7 +910,7 @@ fn SideSheetStackRow(stack: StackNode, pane_id: u64) -> Element {
                 r#type: "button",
                 aria_label: "Close stack",
                 title: "Close stack",
-                class: "ml-auto flex h-6 w-6 cursor-pointer shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 hover:bg-foreground/10",
+                class: "ml-auto flex h-6 w-6 cursor-pointer shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity group-hover/stack:opacity-100 focus-visible:opacity-100 hover:bg-foreground/10",
                 onmousedown: move |evt| {
                     evt.prevent_default();
                     evt.stop_propagation();

--- a/crates/vmux_layout/src/page.rs
+++ b/crates/vmux_layout/src/page.rs
@@ -886,15 +886,18 @@ fn NewStackRow(pane_id: u64) -> Element {
 fn SideSheetStackRow(stack: StackNode, pane_id: u64) -> Element {
     let is_active = stack.is_active;
     let stack_index = stack.stack_index;
+    let mut hovered = use_signal(|| false);
 
     rsx! {
         div {
             id: "sidesheet-stack-{pane_id}-{stack_index}",
             class: if is_active {
-                "side-sheet-stack-row glass flex h-9 cursor-default items-center gap-2 rounded-md px-2"
+                "glass flex h-9 cursor-default items-center gap-2 rounded-md px-2"
             } else {
-                "side-sheet-stack-row flex h-9 cursor-pointer items-center gap-2 rounded-md px-2 border border-transparent text-muted-foreground hover:bg-glass-hover hover:text-foreground"
+                "flex h-9 cursor-pointer items-center gap-2 rounded-md px-2 border border-transparent text-muted-foreground hover:bg-glass-hover hover:text-foreground"
             },
+            onmouseenter: move |_| hovered.set(true),
+            onmouseleave: move |_| hovered.set(false),
             onclick: move |_| {
                 let _ = try_cef_bin_emit_rkyv(&crate::event::SideSheetCommandEvent {
                     command: "activate_stack".to_string(),
@@ -915,7 +918,11 @@ fn SideSheetStackRow(stack: StackNode, pane_id: u64) -> Element {
                 r#type: "button",
                 aria_label: "Close stack",
                 title: "Close stack",
-                class: "side-sheet-stack-close ml-auto flex h-6 w-6 cursor-pointer shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity focus-visible:opacity-100 hover:bg-foreground/10",
+                class: if hovered() {
+                    "ml-auto flex h-6 w-6 cursor-pointer shrink-0 items-center justify-center rounded-sm opacity-100 transition-opacity focus-visible:opacity-100 hover:bg-foreground/10"
+                } else {
+                    "ml-auto flex h-6 w-6 cursor-pointer shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity focus-visible:opacity-100 hover:bg-foreground/10"
+                },
                 onmousedown: move |evt| {
                     evt.prevent_default();
                     evt.stop_propagation();

--- a/crates/vmux_layout/src/page.rs
+++ b/crates/vmux_layout/src/page.rs
@@ -841,7 +841,7 @@ fn PaneSection(pane: PaneNode, index: usize) -> Element {
                 }
             }
             if folded() {
-                if let Some(stack) = folded_stack.clone() {
+                if let Some(stack) = folded_stack {
                     SideSheetStackRow { stack, pane_id }
                 }
             } else {

--- a/crates/vmux_layout/src/page.rs
+++ b/crates/vmux_layout/src/page.rs
@@ -801,6 +801,7 @@ fn PaneSection(pane: PaneNode, index: usize) -> Element {
     let label = format!("Stack {}", index + 1);
     let pane_id = pane.id;
     let any_loading = pane.stacks.iter().any(|s| s.is_loading);
+    let folded_stack = pane.stacks.iter().find(|stack| stack.is_active).cloned();
     let mut folded = use_signal(|| false);
 
     rsx! {
@@ -839,7 +840,11 @@ fn PaneSection(pane: PaneNode, index: usize) -> Element {
                     }
                 }
             }
-            if !folded() {
+            if folded() {
+                if let Some(stack) = folded_stack.clone() {
+                    SideSheetStackRow { stack, pane_id }
+                }
+            } else {
                 div { class: "flex flex-col gap-1",
                     for stack in pane
                         .stacks
@@ -886,9 +891,9 @@ fn SideSheetStackRow(stack: StackNode, pane_id: u64) -> Element {
         div {
             id: "sidesheet-stack-{pane_id}-{stack_index}",
             class: if is_active {
-                "glass group/stack flex h-9 cursor-default items-center gap-2 rounded-md px-2"
+                "side-sheet-stack-row glass flex h-9 cursor-default items-center gap-2 rounded-md px-2"
             } else {
-                "group/stack flex h-9 cursor-pointer items-center gap-2 rounded-md px-2 border border-transparent text-muted-foreground hover:bg-glass-hover hover:text-foreground"
+                "side-sheet-stack-row flex h-9 cursor-pointer items-center gap-2 rounded-md px-2 border border-transparent text-muted-foreground hover:bg-glass-hover hover:text-foreground"
             },
             onclick: move |_| {
                 let _ = try_cef_bin_emit_rkyv(&crate::event::SideSheetCommandEvent {
@@ -910,7 +915,7 @@ fn SideSheetStackRow(stack: StackNode, pane_id: u64) -> Element {
                 r#type: "button",
                 aria_label: "Close stack",
                 title: "Close stack",
-                class: "ml-auto flex h-6 w-6 cursor-pointer shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity group-hover/stack:opacity-100 focus-visible:opacity-100 hover:bg-foreground/10",
+                class: "side-sheet-stack-close ml-auto flex h-6 w-6 cursor-pointer shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity focus-visible:opacity-100 hover:bg-foreground/10",
                 onmousedown: move |evt| {
                     evt.prevent_default();
                     evt.stop_propagation();

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -2161,14 +2161,12 @@ mod hover_wake {
             .iter()
             .find(|region| region_contains(region, x, y))
             .map(|(entity, ..)| *entity);
-        match hit {
-            Some(entity) if Some(entity) == regions.active => false,
-            Some(entity) => {
-                PENDING.store(entity, Ordering::Relaxed);
-                true
-            }
-            None => true,
+        if let Some(entity) = hit
+            && Some(entity) != regions.active
+        {
+            PENDING.store(entity, Ordering::Relaxed);
         }
+        true
     }
 
     pub fn cursor_over_pane(x: f32, y: f32) -> bool {
@@ -5404,12 +5402,13 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn wake_on_move_suppresses_only_over_active_pane() {
+    fn wake_on_move_wakes_without_retargeting_active_pane() {
         super::hover_wake::publish(
             vec![(1, 0.0, 0.0, 100.0, 100.0), (2, 200.0, 0.0, 300.0, 100.0)],
             Some(1),
         );
-        assert!(!super::wake_on_move(50.0, 50.0));
+        assert!(super::wake_on_move(50.0, 50.0));
+        assert_eq!(super::hover_wake::take_pending_target(), None);
         assert!(super::wake_on_move(250.0, 50.0));
         assert_eq!(super::hover_wake::take_pending_target(), Some(2));
         assert!(super::wake_on_move(150.0, 50.0));

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -2161,12 +2161,14 @@ mod hover_wake {
             .iter()
             .find(|region| region_contains(region, x, y))
             .map(|(entity, ..)| *entity);
-        if let Some(entity) = hit
-            && Some(entity) != regions.active
-        {
-            PENDING.store(entity, Ordering::Relaxed);
+        match hit {
+            Some(entity) if Some(entity) == regions.active => false,
+            Some(entity) => {
+                PENDING.store(entity, Ordering::Relaxed);
+                true
+            }
+            None => true,
         }
-        true
     }
 
     pub fn cursor_over_pane(x: f32, y: f32) -> bool {
@@ -5402,12 +5404,12 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn wake_on_move_wakes_without_retargeting_active_pane() {
+    fn wake_on_move_suppresses_active_pane() {
         super::hover_wake::publish(
             vec![(1, 0.0, 0.0, 100.0, 100.0), (2, 200.0, 0.0, 300.0, 100.0)],
             Some(1),
         );
-        assert!(super::wake_on_move(50.0, 50.0));
+        assert!(!super::wake_on_move(50.0, 50.0));
         assert_eq!(super::hover_wake::take_pending_target(), None);
         assert!(super::wake_on_move(250.0, 50.0));
         assert_eq!(super::hover_wake::take_pending_target(), Some(2));

--- a/crates/vmux_layout/tests/page_source.rs
+++ b/crates/vmux_layout/tests/page_source.rs
@@ -76,6 +76,15 @@ fn inactive_tabs_add_horizontal_padding_on_hover() {
 }
 
 #[test]
+fn side_sheet_close_button_uses_stack_row_hover_group() {
+    let row = side_sheet_stack_row_component_source();
+
+    assert_eq!(row.matches("group/stack flex h-9").count(), 2);
+    assert!(row.contains("group-hover/stack:opacity-100"));
+    assert!(!row.contains("group-hover:opacity-100"));
+}
+
+#[test]
 fn embedded_header_css_has_fixed_tab_utilities() {
     let css_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../vmux_server/dist/assets/index.css");
@@ -202,4 +211,12 @@ fn tab_component_source() -> &'static str {
         .nth(1)
         .and_then(|rest| rest.split("fn NewTabButton()").next())
         .expect("tab component")
+}
+
+fn side_sheet_stack_row_component_source() -> &'static str {
+    include_str!("../src/page.rs")
+        .split("fn SideSheetStackRow(stack: StackNode, pane_id: u64)")
+        .nth(1)
+        .and_then(|rest| rest.split("fn download_pct").next())
+        .expect("side sheet stack row component")
 }

--- a/crates/vmux_layout/tests/page_source.rs
+++ b/crates/vmux_layout/tests/page_source.rs
@@ -95,7 +95,7 @@ fn folded_pane_shows_its_active_stack() {
 
     assert!(pane.contains(".find(|stack| stack.is_active"));
     assert!(pane.contains("if folded()"));
-    assert!(pane.contains("if let Some(stack) = folded_stack.clone()"));
+    assert!(pane.contains("if let Some(stack) = folded_stack"));
     assert!(pane.contains("SideSheetStackRow { stack, pane_id }"));
 }
 

--- a/crates/vmux_layout/tests/page_source.rs
+++ b/crates/vmux_layout/tests/page_source.rs
@@ -76,13 +76,15 @@ fn inactive_tabs_add_horizontal_padding_on_hover() {
 }
 
 #[test]
-fn side_sheet_close_button_uses_stack_row_hover_selector() {
+fn side_sheet_close_button_tracks_stack_row_hover() {
     let row = side_sheet_stack_row_component_source();
-    let css = include_str!("../../vmux_server/assets/index.css");
 
-    assert_eq!(row.matches("side-sheet-stack-row").count(), 2);
-    assert!(row.contains("side-sheet-stack-close"));
-    assert!(css.contains(".side-sheet-stack-row:hover > .side-sheet-stack-close"));
+    assert!(row.contains("let mut hovered = use_signal(|| false)"));
+    assert!(row.contains("onmouseenter: move |_| hovered.set(true)"));
+    assert!(row.contains("onmouseleave: move |_| hovered.set(false)"));
+    assert!(row.contains("class: if hovered()"));
+    assert!(row.contains("opacity-100"));
+    assert!(row.contains("opacity-0"));
     assert!(!row.contains("group-hover:opacity-100"));
     assert!(!row.contains("group-hover/stack:opacity-100"));
 }

--- a/crates/vmux_layout/tests/page_source.rs
+++ b/crates/vmux_layout/tests/page_source.rs
@@ -76,12 +76,25 @@ fn inactive_tabs_add_horizontal_padding_on_hover() {
 }
 
 #[test]
-fn side_sheet_close_button_uses_stack_row_hover_group() {
+fn side_sheet_close_button_uses_stack_row_hover_selector() {
     let row = side_sheet_stack_row_component_source();
+    let css = include_str!("../../vmux_server/assets/index.css");
 
-    assert_eq!(row.matches("group/stack flex h-9").count(), 2);
-    assert!(row.contains("group-hover/stack:opacity-100"));
+    assert_eq!(row.matches("side-sheet-stack-row").count(), 2);
+    assert!(row.contains("side-sheet-stack-close"));
+    assert!(css.contains(".side-sheet-stack-row:hover > .side-sheet-stack-close"));
     assert!(!row.contains("group-hover:opacity-100"));
+    assert!(!row.contains("group-hover/stack:opacity-100"));
+}
+
+#[test]
+fn folded_pane_shows_its_active_stack() {
+    let pane = pane_section_component_source();
+
+    assert!(pane.contains(".find(|stack| stack.is_active"));
+    assert!(pane.contains("if folded()"));
+    assert!(pane.contains("if let Some(stack) = folded_stack.clone()"));
+    assert!(pane.contains("SideSheetStackRow { stack, pane_id }"));
 }
 
 #[test]
@@ -219,4 +232,12 @@ fn side_sheet_stack_row_component_source() -> &'static str {
         .nth(1)
         .and_then(|rest| rest.split("fn download_pct").next())
         .expect("side sheet stack row component")
+}
+
+fn pane_section_component_source() -> &'static str {
+    include_str!("../src/page.rs")
+        .split("fn PaneSection(pane: PaneNode, index: usize)")
+        .nth(1)
+        .and_then(|rest| rest.split("fn NewStackRow").next())
+        .expect("pane section component")
 }

--- a/crates/vmux_server/assets/index.css
+++ b/crates/vmux_server/assets/index.css
@@ -127,6 +127,10 @@
   animation: loading-sweep 2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
 }
 
+.side-sheet-stack-row:hover > .side-sheet-stack-close {
+  opacity: 1;
+}
+
 @keyframes update-indeterminate {
   0% {
     transform: translateX(-100%);

--- a/crates/vmux_server/assets/index.css
+++ b/crates/vmux_server/assets/index.css
@@ -127,10 +127,6 @@
   animation: loading-sweep 2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
 }
 
-.side-sheet-stack-row:hover > .side-sheet-stack-close {
-  opacity: 1;
-}
-
 @keyframes update-indeterminate {
   0% {
     transform: translateX(-100%);


### PR DESCRIPTION
## Context

Hovering a pane card in the side sheet exposed close buttons on every stack row, making the close target unclear. Folding a pane also hid every stack, including that pane's active stack.

## Implementation

Track hover state inside each stack-row component so only that row reveals its close button. Keep each pane's active stack visible while the pane is folded, independent of which pane has global focus.

## Checks / QA

- Open the side sheet with multiple stacks in one pane.
- Hover the pane card outside a stack row; no stack close buttons should appear.
- Hover each stack row; only that row's close button should appear.
- Fold active and inactive panes; each should retain its own active stack row.
- Keyboard-focus a close button; it should remain visible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Folded panes now display the currently active side-sheet stack.
  - Side-sheet close buttons respond to hover on their individual rows.

- **Bug Fixes**
  - Improved pointer tracking and hover responsiveness for interactive native layout regions.
  - Mouse movement now reliably wakes layout updates when entering or leaving interactive areas.
  - Refined hover behavior when keyboard input is suppressed or modal content is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->