### PR TITLE
feat(ui): unify agent and tool managers

### DIFF
--- a/crates/vmux_agent/src/agents_page.rs
+++ b/crates/vmux_agent/src/agents_page.rs
@@ -21,10 +21,12 @@ use crate::acp_registry::Runtime;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::agents_page::event::{
     AGENTS_CATALOG_EVENT, AgentEntry, AgentsCatalog, AgentsCatalogRequest, AgentsInstall,
-    AgentsUninstall,
+    AgentsOpen, AgentsUninstall,
 };
 #[cfg(not(target_arch = "wasm32"))]
-use crate::client::acp::AcpCatalog;
+use crate::client::acp::{AcpCatalog, AcpInstallGeneration};
+#[cfg(not(target_arch = "wasm32"))]
+use vmux_core::agent::AgentKind;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
@@ -87,16 +89,31 @@ impl Plugin for AgentsManagerPlugin {
         app.init_resource::<AgentsPageWebview>()
             .init_resource::<AgentsStatus>()
             .init_resource::<AgentsInstallChannel>()
+            .init_resource::<AcpInstallGeneration>()
             .add_plugins(BinEventEmitterPlugin::<(
                 AgentsCatalogRequest,
                 AgentsInstall,
                 AgentsUninstall,
+                AgentsOpen,
             )>::for_hosts(&["agents"]))
             .add_observer(on_catalog_request)
             .add_observer(on_install_request)
             .add_observer(on_uninstall_request)
+            .add_observer(on_open_request)
             .add_systems(Update, (push_agents, drain_agent_installs));
     }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn on_open_request(
+    trigger: On<BinReceive<AgentsOpen>>,
+    mut commands: MessageWriter<vmux_command::AppCommand>,
+) {
+    commands.write(vmux_command::AppCommand::Browser(
+        vmux_command::BrowserCommand::Open(vmux_command::open::OpenCommand::InNewStack {
+            url: Some(trigger.event().payload.url.clone()),
+        }),
+    ));
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -119,6 +136,9 @@ fn catalog_snapshot(catalog: &AcpCatalog, status: &AgentsStatus) -> AgentsCatalo
                 name: a.name.clone(),
                 icon: a.icon.clone().unwrap_or_default(),
                 description: a.description.clone().unwrap_or_default(),
+                source: "acp".to_string(),
+                launch_url: format!("vmux://agent/{}", a.id),
+                uninstallable: true,
                 runtime: match a.preferred_runtime() {
                     Runtime::None => "native",
                     Runtime::Node => "node",
@@ -130,8 +150,37 @@ fn catalog_snapshot(catalog: &AcpCatalog, status: &AgentsStatus) -> AgentsCatalo
             }
         })
         .collect();
+    agents.extend(cli_agent_entries(|kind| {
+        crate::exec::find_executable(kind.executable()).is_some()
+    }));
     agents.sort_by_key(|a| a.name.to_lowercase());
     AgentsCatalog { agents }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn cli_agent_entries(mut is_installed: impl FnMut(AgentKind) -> bool) -> Vec<AgentEntry> {
+    AgentKind::all()
+        .into_iter()
+        .map(|kind| {
+            let segment = kind.as_url_segment();
+            AgentEntry {
+                id: format!("cli:{segment}"),
+                name: format!("{} CLI", kind.display_name()),
+                icon: String::new(),
+                description: "Terminal-based coding agent".to_string(),
+                source: "cli".to_string(),
+                launch_url: format!("{}cli", kind.cli_url_prefix()),
+                uninstallable: false,
+                runtime: "cli".to_string(),
+                status: if is_installed(kind) {
+                    "installed".to_string()
+                } else {
+                    "available".to_string()
+                },
+                detail: String::new(),
+            }
+        })
+        .collect()
 }
 
 /// Remember which webview asked for the catalog; the push system delivers it.
@@ -180,15 +229,21 @@ fn on_install_request(
 fn on_uninstall_request(
     trigger: On<BinReceive<AgentsUninstall>>,
     mut status: ResMut<AgentsStatus>,
+    mut install_generation: ResMut<AcpInstallGeneration>,
 ) {
     let id = trigger.event().payload.id.clone();
     let _ = crate::acp_install::uninstall(&id);
     status.0.remove(&id);
+    install_generation.bump();
 }
 
 /// Fold background-install updates into the session status map.
 #[cfg(not(target_arch = "wasm32"))]
-fn drain_agent_installs(installs: Res<AgentsInstallChannel>, mut status: ResMut<AgentsStatus>) {
+fn drain_agent_installs(
+    installs: Res<AgentsInstallChannel>,
+    mut status: ResMut<AgentsStatus>,
+    mut install_generation: ResMut<AcpInstallGeneration>,
+) {
     while let Ok(msg) = installs.rx.try_recv() {
         match msg {
             AgentMsg::Progress { id, pct, message } => {
@@ -200,6 +255,7 @@ fn drain_agent_installs(installs: Res<AgentsInstallChannel>, mut status: ResMut<
             }
             AgentMsg::Done { id } => {
                 status.0.remove(&id);
+                install_generation.bump();
             }
             AgentMsg::Failed { id, message } => {
                 status.0.insert(id, ("error".to_string(), message));
@@ -232,4 +288,26 @@ fn push_agents(
         AGENTS_CATALOG_EVENT,
         &catalog_snapshot(&catalog, &status),
     ));
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_catalog_rows_report_install_state() {
+        let rows = cli_agent_entries(|kind| kind == AgentKind::Codex);
+
+        assert_eq!(rows.len(), 3);
+        let codex = rows.iter().find(|row| row.id == "cli:codex").unwrap();
+        assert_eq!(codex.source, "cli");
+        assert_eq!(codex.launch_url, "vmux://agent/codex/cli");
+        assert_eq!(codex.status, "installed");
+        assert!(!codex.uninstallable);
+        assert!(
+            rows.iter()
+                .filter(|row| row.id != "cli:codex")
+                .all(|row| row.status == "available")
+        );
+    }
 }

--- a/crates/vmux_agent/src/agents_page/event.rs
+++ b/crates/vmux_agent/src/agents_page/event.rs
@@ -35,7 +35,13 @@ pub struct AgentEntry {
     pub name: String,
     pub icon: String,
     pub description: String,
-    /// `native` | `node` | `python` — the runtime this agent's distribution needs.
+    /// `acp` | `cli`.
+    pub source: String,
+    /// URL opened after installation or from the installed row.
+    pub launch_url: String,
+    /// Whether vmux owns enough state to remove this installation safely.
+    pub uninstallable: bool,
+    /// `native` | `node` | `python` | `cli`.
     pub runtime: String,
     /// `available` | `installing` | `installed` | `update` | `error`.
     pub status: String,
@@ -84,4 +90,18 @@ pub struct AgentsInstall {
 )]
 pub struct AgentsUninstall {
     pub id: String,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct AgentsOpen {
+    pub url: String,
 }

--- a/crates/vmux_agent/src/agents_page/page.rs
+++ b/crates/vmux_agent/src/agents_page/page.rs
@@ -2,169 +2,207 @@
 
 use crate::agents_page::event::{
     AGENTS_CATALOG_EVENT, AgentEntry, AgentsCatalog, AgentsCatalogRequest, AgentsInstall,
-    AgentsUninstall,
+    AgentsOpen, AgentsUninstall,
+};
+use crate::vibe::setup::event::{
+    AGENT_SETUP_RESULT_EVENT, AgentInstallRunRequest, AgentSetupResult,
 };
 use dioxus::prelude::*;
+use vmux_ui::components::manager::{
+    ManagerBadge, ManagerButton, ManagerButtonVariant, ManagerEmpty, ManagerHeader, ManagerList,
+    ManagerPage, ManagerRow, ManagerSkeleton, ManagerSpinner, ManagerTone,
+};
+use vmux_ui::favicon::Favicon;
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_theme};
 
-fn install(id: String) {
-    let _ = try_cef_bin_emit_rkyv(&AgentsInstall { id });
+fn request_catalog() {
+    let _ = try_cef_bin_emit_rkyv(&AgentsCatalogRequest {});
 }
 
-fn uninstall(id: String) {
-    let _ = try_cef_bin_emit_rkyv(&AgentsUninstall { id });
-}
-
-/// Optimistically reflect an action in the local list so the row reacts instantly, before the
-/// host pushes the authoritative catalog.
 fn set_status(mut agents: Signal<Vec<AgentEntry>>, id: &str, status: &str, detail: &str) {
     agents.with_mut(|list| {
-        if let Some(a) = list.iter_mut().find(|a| a.id == id) {
-            a.status = status.to_string();
-            a.detail = detail.to_string();
+        if let Some(agent) = list.iter_mut().find(|agent| agent.id == id) {
+            agent.status = status.to_string();
+            agent.detail = detail.to_string();
         }
     });
 }
 
-fn runtime_pill(runtime: &str) -> &'static str {
+fn runtime_tone(runtime: &str) -> ManagerTone {
     match runtime {
-        "native" => "text-emerald-300 bg-emerald-400/10 ring-emerald-400/20",
-        "node" => "text-lime-300 bg-lime-400/10 ring-lime-400/20",
-        "python" => "text-amber-300 bg-amber-400/10 ring-amber-400/20",
-        _ => "text-muted-foreground bg-foreground/10 ring-foreground/15",
+        "native" => ManagerTone::Green,
+        "node" => ManagerTone::Cyan,
+        "python" => ManagerTone::Amber,
+        _ => ManagerTone::Neutral,
     }
+}
+
+fn matches_search(agent: &AgentEntry, query: &str) -> bool {
+    let query = query.trim().to_lowercase();
+    query.is_empty()
+        || agent.name.to_lowercase().contains(&query)
+        || agent.id.to_lowercase().contains(&query)
+        || agent.description.to_lowercase().contains(&query)
+        || agent.runtime.to_lowercase().contains(&query)
+        || agent.source.to_lowercase().contains(&query)
 }
 
 #[component]
 pub fn Page() -> Element {
     use_theme();
     let mut agents = use_signal(Vec::<AgentEntry>::new);
-    let mut mounted = use_signal(|| false);
+    let mut query = use_signal(String::new);
+    let mut loaded = use_signal(|| false);
 
-    let _listener = use_bin_event_listener::<AgentsCatalog, _>(AGENTS_CATALOG_EVENT, move |snap| {
-        agents.set(snap.agents);
-    });
+    let _catalog =
+        use_bin_event_listener::<AgentsCatalog, _>(AGENTS_CATALOG_EVENT, move |catalog| {
+            agents.set(catalog.agents);
+            loaded.set(true);
+        });
+    let _setup =
+        use_bin_event_listener::<AgentSetupResult, _>(AGENT_SETUP_RESULT_EVENT, move |result| {
+            let id = format!("cli:{}", result.agent);
+            if result.ok {
+                set_status(agents, &id, "installed", "");
+                request_catalog();
+            } else {
+                set_status(agents, &id, "error", "Install failed");
+            }
+        });
 
     use_effect(move || {
-        let _ = try_cef_bin_emit_rkyv(&AgentsCatalogRequest {});
-        mounted.set(true);
+        if let Some(doc) = web_sys::window().and_then(|window| window.document()) {
+            doc.set_title("Agents");
+        }
+        request_catalog();
     });
 
-    let reveal = if mounted() {
-        "opacity-100 blur-0 translate-y-0"
-    } else {
-        "opacity-0 blur-sm translate-y-4"
-    };
-    let count = agents.read().len();
+    let all_agents = agents();
+    let filtered: Vec<AgentEntry> = all_agents
+        .iter()
+        .filter(|agent| matches_search(agent, &query()))
+        .cloned()
+        .collect();
 
     rsx! {
-        main {
-            class: "relative isolate flex h-screen flex-col overflow-hidden bg-background text-foreground",
-            style: "background-image:radial-gradient(120% 90% at 50% -10%, rgba(129,140,248,0.06), transparent 55%);",
-            div { class: "pointer-events-none absolute inset-0 -z-10 overflow-hidden",
-                div { class: "absolute left-1/2 top-[-8%] h-[34rem] w-[34rem] -translate-x-1/2 rounded-full blur-[150px] dark:bg-indigo-500/12" }
-                div { class: "absolute right-[8%] top-1/4 h-72 w-72 rounded-full blur-[130px] dark:bg-violet-500/10" }
+        ManagerPage {
+            ManagerHeader {
+                title: "Agents",
+                count: all_agents.len(),
+                search_value: query(),
+                search_placeholder: "Search ACP and CLI agents…",
+                onsearch: move |event: FormEvent| query.set(event.value()),
+                onkeydown: None,
+                actions: rsx! {},
             }
-            header {
-                class: "relative shrink-0 px-8 pt-10 pb-6 transition-all duration-700 ease-out motion-reduce:transition-none {reveal}",
-                h1 { class: "bg-gradient-to-b from-foreground to-foreground/55 bg-clip-text text-3xl font-semibold tracking-tight text-transparent",
-                    "Agents"
-                }
-                p { class: "mt-1.5 text-sm text-muted-foreground",
-                    "Install a coding agent — vmux brings the runtime. "
-                    span { class: "text-foreground/70", "{count} available." }
-                }
-            }
-            div { class: "relative flex-1 overflow-y-auto px-8 pb-10",
-                div { class: "mx-auto flex max-w-3xl flex-col gap-2.5 transition-all duration-700 ease-out motion-reduce:transition-none {reveal}",
-                    for a in agents.read().iter() {
-                        {render_agent(a, agents)}
+            ManagerList {
+                if !loaded() {
+                    ManagerSkeleton {}
+                } else if filtered.is_empty() {
+                    ManagerEmpty {
+                        title: "No matching agents",
+                        detail: "Try a name, runtime, or ACP/CLI.",
                     }
+                }
+                for agent in filtered.iter() {
+                    {render_agent(agent, agents)}
                 }
             }
         }
     }
 }
 
-fn render_agent(a: &AgentEntry, agents: Signal<Vec<AgentEntry>>) -> Element {
+fn render_agent(agent: &AgentEntry, agents: Signal<Vec<AgentEntry>>) -> Element {
+    let icon_url = agent.icon.clone();
+    let launch_url = agent.launch_url.clone();
     rsx! {
-        div {
-            key: "{a.id}",
-            class: "group flex items-center gap-4 rounded-2xl bg-foreground/[0.035] px-5 py-4 ring-1 ring-inset ring-foreground/10 backdrop-blur-xl transition-colors hover:bg-foreground/[0.07]",
-            div { class: "flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-foreground/[0.06] ring-1 ring-inset ring-foreground/10",
-                if !a.icon.is_empty() {
-                    img { class: "h-6 w-6 object-contain", src: "{a.icon}" }
+        ManagerRow {
+            icon: rsx! {
+                Favicon {
+                    favicon_url: icon_url,
+                    url: launch_url,
+                    class: "h-6 w-6 rounded-md object-contain".to_string(),
+                    globe_class: "h-5 w-5 text-muted-foreground".to_string(),
                 }
-            }
-            div { class: "min-w-0 flex-1",
-                div { class: "flex items-center gap-2",
-                    span { class: "truncate text-sm font-medium", "{a.name}" }
-                    span { class: "shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ring-1 ring-inset {runtime_pill(&a.runtime)}",
-                        "{a.runtime}"
-                    }
+            },
+            title: agent.name.clone(),
+            subtitle: agent.description.clone(),
+            meta: rsx! {
+                ManagerBadge { tone: ManagerTone::Neutral, "{agent.source}" }
+                if agent.runtime != agent.source {
+                    ManagerBadge { tone: runtime_tone(&agent.runtime), "{agent.runtime}" }
                 }
-                if !a.description.is_empty() {
-                    p { class: "mt-0.5 truncate text-xs leading-relaxed text-muted-foreground",
-                        "{a.description}"
-                    }
-                }
-            }
-            div { class: "shrink-0", {render_action(a, agents)} }
+            },
+            actions: render_action(agent, agents),
         }
     }
 }
 
-fn render_action(a: &AgentEntry, agents: Signal<Vec<AgentEntry>>) -> Element {
-    let id = a.id.clone();
-    match a.status.as_str() {
-        "installing" => rsx! {
-            div { class: "flex items-center gap-2 text-xs text-muted-foreground",
-                span { class: "h-3.5 w-3.5 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-foreground" }
-                span { class: "max-w-[11rem] truncate", "{a.detail}" }
-            }
-        },
+fn render_action(agent: &AgentEntry, agents: Signal<Vec<AgentEntry>>) -> Element {
+    let id = agent.id.clone();
+    let install_id = agent.id.clone();
+    let uninstall_id = agent.id.clone();
+    let launch_url = agent.launch_url.clone();
+    let source = agent.source.clone();
+    match agent.status.as_str() {
+        "installing" => rsx! { ManagerSpinner { detail: agent.detail.clone() } },
         "installed" => rsx! {
-            div { class: "flex items-center gap-3",
-                span { class: "text-xs font-medium text-emerald-400", "Installed" }
-                button {
-                    class: "rounded-full px-3 py-1.5 text-xs text-muted-foreground opacity-0 transition hover:bg-foreground/10 hover:text-foreground group-hover:opacity-100",
+            span { class: "text-xs font-medium text-emerald-600 dark:text-emerald-400", "Installed" }
+            ManagerButton {
+                variant: ManagerButtonVariant::Secondary,
+                onclick: move |_| {
+                    let _ = try_cef_bin_emit_rkyv(&AgentsOpen { url: launch_url.clone() });
+                },
+                "Open"
+            }
+            if agent.uninstallable {
+                ManagerButton {
+                    variant: ManagerButtonVariant::Danger,
                     onclick: move |_| {
-                        set_status(agents, &id, "available", "");
-                        uninstall(id.clone());
+                        set_status(agents, &uninstall_id, "available", "");
+                        let _ = try_cef_bin_emit_rkyv(&AgentsUninstall { id: uninstall_id.clone() });
                     },
                     "Uninstall"
                 }
             }
         },
         "update" => rsx! {
-            button {
-                class: "rounded-full bg-amber-400/15 px-3.5 py-1.5 text-xs font-medium text-amber-300 ring-1 ring-inset ring-amber-400/25 transition hover:bg-amber-400/25",
+            ManagerButton {
+                variant: ManagerButtonVariant::Primary,
                 onclick: move |_| {
                     set_status(agents, &id, "installing", "Updating…");
-                    install(id.clone());
+                    let _ = try_cef_bin_emit_rkyv(&AgentsInstall { id: id.clone() });
                 },
                 "Update"
             }
         },
         "error" => rsx! {
-            div { class: "flex items-center gap-2",
-                span { class: "max-w-[9rem] truncate text-xs text-red-400", title: "{a.detail}", "Failed" }
-                button {
-                    class: "rounded-full bg-foreground/10 px-3.5 py-1.5 text-xs transition hover:bg-foreground/20",
-                    onclick: move |_| {
-                        set_status(agents, &id, "installing", "Retrying…");
-                        install(id.clone());
-                    },
-                    "Retry"
-                }
+            span { class: "max-w-36 truncate text-xs text-red-500", title: "{agent.detail}", "Failed" }
+            ManagerButton {
+                variant: ManagerButtonVariant::Secondary,
+                onclick: move |_| {
+                    set_status(agents, &install_id, "installing", "Retrying…");
+                    if source == "cli" {
+                        let segment = install_id.trim_start_matches("cli:").to_string();
+                        let _ = try_cef_bin_emit_rkyv(&AgentInstallRunRequest { agent: segment });
+                    } else {
+                        let _ = try_cef_bin_emit_rkyv(&AgentsInstall { id: install_id.clone() });
+                    }
+                },
+                "Retry"
             }
         },
         _ => rsx! {
-            button {
-                class: "rounded-full bg-foreground px-4 py-1.5 text-xs font-medium text-background shadow-sm transition hover:brightness-110 active:scale-[0.98]",
+            ManagerButton {
+                variant: ManagerButtonVariant::Primary,
                 onclick: move |_| {
-                    set_status(agents, &id, "installing", "Preparing…");
-                    install(id.clone());
+                    set_status(agents, &install_id, "installing", "Preparing…");
+                    if source == "cli" {
+                        let segment = install_id.trim_start_matches("cli:").to_string();
+                        let _ = try_cef_bin_emit_rkyv(&AgentInstallRunRequest { agent: segment });
+                    } else {
+                        let _ = try_cef_bin_emit_rkyv(&AgentsInstall { id: install_id.clone() });
+                    }
                 },
                 "Install"
             }

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -89,6 +89,15 @@ pub struct AcpCatalog {
     pub agents: Vec<crate::acp_registry::RegistryAgent>,
 }
 
+#[derive(Resource, Default)]
+pub(crate) struct AcpInstallGeneration(u64);
+
+impl AcpInstallGeneration {
+    pub(crate) fn bump(&mut self) {
+        self.0 = self.0.wrapping_add(1);
+    }
+}
+
 /// One-shot receiver for the startup catalog fetch.
 #[derive(Resource)]
 struct AcpCatalogChannel {
@@ -125,6 +134,7 @@ impl Plugin for AcpAgentPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<AcpInstallChannel>()
             .init_resource::<AcpCatalog>()
+            .init_resource::<AcpInstallGeneration>()
             .add_message::<vmux_service::agent_events::PageAgentInfo>()
             .add_message::<vmux_service::agent_events::PageAgentSessionCreated>()
             .add_message::<vmux_service::agent_events::PageAgentAcpTerminalCreated>()
@@ -440,6 +450,7 @@ fn parse_codex_config(
 fn drain_acp_installs(
     installs: Res<AcpInstallChannel>,
     service: Option<Res<ServiceClient>>,
+    mut install_generation: ResMut<AcpInstallGeneration>,
     mut q: Query<(&AcpSession, &mut AgentRunState)>,
 ) {
     while let Ok(msg) = installs.rx.try_recv() {
@@ -467,6 +478,7 @@ fn drain_acp_installs(
                 args,
                 env,
             } => {
+                install_generation.bump();
                 let Some(service) = service.as_ref() else {
                     continue;
                 };

--- a/crates/vmux_agent/src/lib.rs
+++ b/crates/vmux_agent/src/lib.rs
@@ -102,3 +102,5 @@ pub use tools::mcp_tool_defs;
 pub use url::{AgentKind, AgentUrl};
 #[cfg(not(target_arch = "wasm32"))]
 pub use variant::AgentVariant;
+#[cfg(not(target_arch = "wasm32"))]
+pub use vibe::setup::AgentSetupPlugin;

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -428,28 +428,31 @@ pub fn attach_acp_agent_to_stack(
 }
 
 /// The registry icon URL for an ACP agent id, if the catalog is loaded and lists it.
-fn acp_icon_for_id(catalog: Option<&crate::client::acp::AcpCatalog>, id: &str) -> Option<String> {
-    catalog?
-        .agents
-        .iter()
-        .find(|a| a.id == id)
-        .and_then(|a| a.icon.clone())
+fn acp_registry_agent_for_id<'a>(
+    catalog: Option<&'a crate::client::acp::AcpCatalog>,
+    id: &str,
+) -> Option<&'a crate::acp_registry::RegistryAgent> {
+    let registry_id = crate::acp_install::registry_id_alias(id);
+    catalog?.agents.iter().find(|agent| agent.id == registry_id)
 }
 
-fn acp_profile_name(
-    config: &vmux_setting::AcpAgentConfig,
+fn acp_icon_for_id(catalog: Option<&crate::client::acp::AcpCatalog>, id: &str) -> Option<String> {
+    acp_registry_agent_for_id(catalog, id).and_then(|agent| agent.icon.clone())
+}
+
+fn acp_profile_name_for_id(
+    id: &str,
+    config: Option<&vmux_setting::AcpAgentConfig>,
     catalog: Option<&crate::client::acp::AcpCatalog>,
 ) -> String {
-    let registry_id = crate::acp_install::registry_id_alias(&config.id);
-    catalog
-        .and_then(|catalog| catalog.agents.iter().find(|agent| agent.id == registry_id))
+    acp_registry_agent_for_id(catalog, id)
         .map(|agent| agent.name.trim())
         .filter(|name| !name.is_empty())
         .or_else(|| {
-            let name = config.name.trim();
+            let name = config?.name.trim();
             (!name.is_empty()).then_some(name)
         })
-        .unwrap_or(config.id.as_str())
+        .unwrap_or(id)
         .to_string()
 }
 
@@ -2958,8 +2961,9 @@ fn handle_swap_stack_session(
         };
         if let crate::AgentUrl::Acp { id, .. } = &target
             && !settings.agent.acp.iter().any(|cfg| cfg.id == *id)
+            && acp_registry_agent_for_id(catalog.as_deref(), id).is_none()
         {
-            bevy::log::warn!("swap: no ACP agent configured for '{id}'");
+            bevy::log::warn!("swap: ACP agent unavailable for '{id}'");
             continue;
         }
         if ev.handoff.is_some() && !matches!(target, crate::AgentUrl::Acp { .. }) {
@@ -3022,18 +3026,13 @@ fn handle_swap_stack_session(
                 });
             }
             crate::AgentUrl::Acp { id, sid } => {
-                let cfg = settings
-                    .agent
-                    .acp
-                    .iter()
-                    .find(|cfg| cfg.id == id)
-                    .expect("ACP target validated before teardown");
+                let cfg = settings.agent.acp.iter().find(|cfg| cfg.id == id);
                 let routing_sid = uuid::Uuid::new_v4().to_string();
-                let icon = acp_icon_for_id(catalog.as_deref(), &cfg.id);
-                let name = acp_profile_name(cfg, catalog.as_deref());
+                let icon = acp_icon_for_id(catalog.as_deref(), &id);
+                let name = acp_profile_name_for_id(&id, cfg, catalog.as_deref());
                 attach_acp_agent_to_stack(
                     ev.stack,
-                    &cfg.id,
+                    &id,
                     &name,
                     &routing_sid,
                     &ev.cwd,
@@ -3148,7 +3147,8 @@ fn handle_agent_page_open_task(
         Some(crate::AgentUrl::Acp { id, sid }) => {
             // ACP agents own the canonical single-segment names (claude/codex/…) plus the
             // two-segment `<id>/<acp-session-id>` session form.
-            let Some(cfg) = acp_configs.iter().find(|c| c.id == id) else {
+            let cfg = acp_configs.iter().find(|config| config.id == id);
+            if cfg.is_none() && acp_registry_agent_for_id(catalog, &id).is_none() {
                 // Not an ACP agent. A bare `vmux://agent/<kind>` for a built-in CLI kind falls
                 // back to a fresh CLI session (CLI's own url is `<kind>/cli`); this keeps the
                 // legacy bare-url entry point (and the missing-binary setup flow) working.
@@ -3166,13 +3166,13 @@ fn handle_agent_page_open_task(
                     }
                     return Ok(());
                 }
-                return Err(format!("no ACP agent configured for '{id}'"));
-            };
+                return Err(format!("ACP agent unavailable for '{id}'"));
+            }
             // Already attached to this agent on this stack? A repeat open (or the post-spawn url
             // redirect) is a no-op instead of re-spawning the session.
             if acp_sessions
                 .get(task.stack)
-                .is_ok_and(|session| session.agent_id == cfg.id)
+                .is_ok_and(|session| session.agent_id == id)
             {
                 return Ok(());
             }
@@ -3180,11 +3180,11 @@ fn handle_agent_page_open_task(
             // `sid` (when present) is the agent-assigned ACP session id from a restored url — pass
             // it as the resume target. Fresh opens mint a routing sid and load nothing.
             let routing_sid = uuid::Uuid::new_v4().to_string();
-            let icon = acp_icon_for_id(catalog, &cfg.id);
-            let name = acp_profile_name(cfg, catalog);
+            let icon = acp_icon_for_id(catalog, &id);
+            let name = acp_profile_name_for_id(&id, cfg, catalog);
             attach_acp_agent_to_stack(
                 task.stack,
-                &cfg.id,
+                &id,
                 &name,
                 &routing_sid,
                 default_cwd,
@@ -3802,19 +3802,34 @@ mod tests {
     fn acp_icon_for_id_reads_catalog() {
         use crate::acp_registry::{Distribution, RegistryAgent};
         let catalog = crate::client::acp::AcpCatalog {
-            agents: vec![RegistryAgent {
-                id: "mistral-vibe".to_string(),
-                name: "Mistral Vibe".to_string(),
-                version: None,
-                description: None,
-                icon: Some("https://cdn.example/vibe.svg".to_string()),
-                repository: None,
-                distribution: Distribution::default(),
-            }],
+            agents: vec![
+                RegistryAgent {
+                    id: "mistral-vibe".to_string(),
+                    name: "Mistral Vibe".to_string(),
+                    version: None,
+                    description: None,
+                    icon: Some("https://cdn.example/vibe.svg".to_string()),
+                    repository: None,
+                    distribution: Distribution::default(),
+                },
+                RegistryAgent {
+                    id: "claude-acp".to_string(),
+                    name: "Claude Agent".to_string(),
+                    version: None,
+                    description: None,
+                    icon: Some("https://cdn.example/claude.svg".to_string()),
+                    repository: None,
+                    distribution: Distribution::default(),
+                },
+            ],
         };
         assert_eq!(
             acp_icon_for_id(Some(&catalog), "mistral-vibe").as_deref(),
             Some("https://cdn.example/vibe.svg")
+        );
+        assert_eq!(
+            acp_icon_for_id(Some(&catalog), "claude").as_deref(),
+            Some("https://cdn.example/claude.svg")
         );
         assert_eq!(acp_icon_for_id(Some(&catalog), "absent"), None);
         assert_eq!(acp_icon_for_id(None, "mistral-vibe"), None);
@@ -3845,10 +3860,19 @@ mod tests {
             }],
         };
 
-        assert_eq!(acp_profile_name(&config, Some(&catalog)), "Claude");
-        assert_eq!(acp_profile_name(&config, None), "Configured Claude");
+        assert_eq!(
+            acp_profile_name_for_id(&config.id, Some(&config), Some(&catalog)),
+            "Claude"
+        );
+        assert_eq!(
+            acp_profile_name_for_id(&config.id, Some(&config), None),
+            "Configured Claude"
+        );
         config.name = "   ".into();
-        assert_eq!(acp_profile_name(&config, None), "claude");
+        assert_eq!(
+            acp_profile_name_for_id(&config.id, Some(&config), None),
+            "claude"
+        );
     }
     use vmux_layout::settings::{
         FocusRingSettings, LayoutSettings, PaneSettings, SideSheetSettings, WindowSettings,
@@ -4807,6 +4831,58 @@ mod tests {
                 format!("Set up {} CLI", kind.display_name())
             );
         }
+    }
+
+    #[test]
+    fn registry_acp_opens_without_settings_entry() {
+        use crate::acp_registry::{Distribution, RegistryAgent};
+
+        let mut settings = test_settings();
+        settings.agent.acp.clear();
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<SpawnAgentInStackRequest>()
+            .insert_resource(settings)
+            .insert_resource(crate::client::acp::AcpCatalog {
+                agents: vec![RegistryAgent {
+                    id: "custom-acp".to_string(),
+                    name: "Custom ACP".to_string(),
+                    version: None,
+                    description: None,
+                    icon: Some("https://cdn.example/custom.svg".to_string()),
+                    repository: None,
+                    distribution: Distribution::default(),
+                }],
+            })
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+            .add_systems(Update, handle_agent_page_open);
+
+        let stack = app
+            .world_mut()
+            .spawn(vmux_layout::stack::stack_bundle())
+            .id();
+        let task = app
+            .world_mut()
+            .spawn(PageOpenTask {
+                id: vmux_core::PageOpenId::new(),
+                stack,
+                url: "vmux://agent/custom-acp".to_string(),
+                request_id: None,
+            })
+            .id();
+
+        app.update();
+
+        assert!(app.world().get::<PageOpenHandled>(task).is_some());
+        let session = app
+            .world()
+            .get::<crate::client::acp::AcpSession>(stack)
+            .unwrap();
+        assert_eq!(session.agent_id, "custom-acp");
+        let meta = app.world().get::<PageMetadata>(stack).unwrap();
+        assert_eq!(meta.title, "Custom ACP");
+        assert_eq!(meta.icon.favicon_url(), "https://cdn.example/custom.svg");
     }
 
     #[test]

--- a/crates/vmux_agent/src/snapshot_updater.rs
+++ b/crates/vmux_agent/src/snapshot_updater.rs
@@ -9,7 +9,7 @@ use vmux_core::agent::AgentProviderTargetKind;
 use crate::client::page::strategy_index::PageStrategyIndex;
 
 #[allow(clippy::type_complexity)]
-pub fn update_agents_snapshot(
+pub(crate) fn update_agents_snapshot(
     providers_q: Query<(&AgentProviderTargetKind, &Name), With<Ready>>,
     changed_q: Query<
         Entity,
@@ -21,6 +21,7 @@ pub fn update_agents_snapshot(
     page_idx: Option<Res<PageStrategyIndex>>,
     settings: Option<Res<vmux_setting::AppSettings>>,
     catalog: Option<Res<crate::client::acp::AcpCatalog>>,
+    install_generation: Option<Res<crate::client::acp::AcpInstallGeneration>>,
     mut snapshot: ResMut<CommandBarAgentsSnapshot>,
 ) {
     let providers_changed = !changed_q.is_empty();
@@ -36,10 +37,15 @@ pub fn update_agents_snapshot(
         .as_ref()
         .map(|r| r.is_changed() || r.is_added())
         .unwrap_or(false);
+    let installs_changed = install_generation
+        .as_ref()
+        .map(|r| r.is_changed() || r.is_added())
+        .unwrap_or(false);
     if !providers_changed
         && !idx_changed
         && !settings_changed
         && !catalog_changed
+        && !installs_changed
         && (!snapshot.providers.is_empty()
             || !snapshot.strategies.is_empty()
             || !snapshot.acp.is_empty())
@@ -51,27 +57,13 @@ pub fn update_agents_snapshot(
         .as_ref()
         .map(|c| c.agents.as_slice())
         .unwrap_or_default();
-    snapshot.acp = settings
+    let configured = settings
         .as_ref()
-        .map(|s| {
-            s.agent
-                .acp
-                .iter()
-                .map(|cfg| {
-                    let reg_id = crate::acp_install::registry_id_alias(&cfg.id);
-                    let reg = catalog_agents.iter().find(|a| a.id == reg_id);
-                    AgentProviderSummary {
-                        id: cfg.id.clone(),
-                        name: reg
-                            .map(|a| a.name.clone())
-                            .unwrap_or_else(|| cfg.name.clone()),
-                        url: format!("vmux://agent/{}", cfg.id),
-                        icon: reg.and_then(|a| a.icon.clone()).unwrap_or_default(),
-                    }
-                })
-                .collect()
-        })
+        .map(|s| s.agent.acp.as_slice())
         .unwrap_or_default();
+    snapshot.acp = acp_agent_summaries(configured, catalog_agents, |agent| {
+        crate::acp_install::is_agent_installed(agent)
+    });
 
     let mut providers: Vec<AgentProviderSummary> = providers_q
         .iter()
@@ -99,6 +91,44 @@ pub fn update_agents_snapshot(
         .unwrap_or_default();
 }
 
+fn acp_agent_summaries(
+    configured: &[vmux_setting::AcpAgentConfig],
+    catalog: &[crate::acp_registry::RegistryAgent],
+    is_installed: impl Fn(&crate::acp_registry::RegistryAgent) -> bool,
+) -> Vec<AgentProviderSummary> {
+    let mut seen_registry_ids = std::collections::HashSet::new();
+    let mut agents = Vec::new();
+    for cfg in configured {
+        let registry_id = crate::acp_install::registry_id_alias(&cfg.id);
+        let registry = catalog.iter().find(|agent| agent.id == registry_id);
+        seen_registry_ids.insert(registry_id.to_string());
+        agents.push(AgentProviderSummary {
+            id: cfg.id.clone(),
+            name: registry
+                .map(|agent| agent.name.clone())
+                .unwrap_or_else(|| cfg.name.clone()),
+            url: format!("vmux://agent/{}", cfg.id),
+            icon: registry
+                .and_then(|agent| agent.icon.clone())
+                .unwrap_or_default(),
+        });
+    }
+    agents.extend(
+        catalog
+            .iter()
+            .filter(|agent| !seen_registry_ids.contains(&agent.id))
+            .filter(|agent| is_installed(agent))
+            .map(|agent| AgentProviderSummary {
+                id: agent.id.clone(),
+                name: agent.name.clone(),
+                url: format!("vmux://agent/{}", agent.id),
+                icon: agent.icon.clone().unwrap_or_default(),
+            }),
+    );
+    agents.sort_by_key(|agent| agent.name.to_lowercase());
+    agents
+}
+
 use crate::session::AgentSessionToEntity;
 use vmux_command::snapshot::CommandBarTerminalsSnapshot;
 
@@ -120,6 +150,29 @@ pub fn update_agent_sessions_snapshot(
 mod tests {
     use super::*;
 
+    fn registry_agent(id: &str, name: &str) -> crate::acp_registry::RegistryAgent {
+        crate::acp_registry::RegistryAgent {
+            id: id.to_string(),
+            name: name.to_string(),
+            version: None,
+            description: None,
+            icon: None,
+            repository: None,
+            distribution: crate::acp_registry::Distribution::default(),
+        }
+    }
+
+    fn configured_agent(id: &str, name: &str) -> vmux_setting::AcpAgentConfig {
+        vmux_setting::AcpAgentConfig {
+            id: id.to_string(),
+            name: name.to_string(),
+            command: "agent".to_string(),
+            args: Vec::new(),
+            env: Vec::new(),
+            cwd: None,
+        }
+    }
+
     #[test]
     fn writes_empty_snapshot_when_no_resources() {
         let mut app = App::new();
@@ -139,5 +192,28 @@ mod tests {
         app.update();
         let snap = app.world().resource::<CommandBarTerminalsSnapshot>();
         assert!(snap.agent_session_to_entity.is_empty());
+    }
+
+    #[test]
+    fn installed_unconfigured_acp_is_in_snapshot() {
+        let catalog = vec![registry_agent("new-agent", "New Agent")];
+
+        let agents = acp_agent_summaries(&[], &catalog, |_| true);
+
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].id, "new-agent");
+        assert_eq!(agents[0].url, "vmux://agent/new-agent");
+    }
+
+    #[test]
+    fn configured_acp_alias_is_not_duplicated() {
+        let configured = vec![configured_agent("claude", "Claude Code")];
+        let catalog = vec![registry_agent("claude-acp", "Claude Agent")];
+
+        let agents = acp_agent_summaries(&configured, &catalog, |_| true);
+
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].id, "claude");
+        assert_eq!(agents[0].name, "Claude Agent");
     }
 }

--- a/crates/vmux_agent/src/vibe/setup.rs
+++ b/crates/vmux_agent/src/vibe/setup.rs
@@ -17,15 +17,6 @@ use crate::vibe::setup::event::{
 use vmux_core::agent::AgentKind;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
-    host: "agent",
-    title: "Agent",
-    keywords: &["ai", "chat", "assistant"],
-    icon: Some(vmux_core::BuiltinIcon::Sparkles),
-    command_bar: false,
-};
-
-#[cfg(not(target_arch = "wasm32"))]
 #[derive(Component)]
 struct AgentInstallPane {
     setup_stack: Entity,
@@ -45,11 +36,10 @@ pub struct AgentSetupPlugin;
 #[cfg(not(target_arch = "wasm32"))]
 impl Plugin for AgentSetupPlugin {
     fn build(&self, app: &mut App) {
-        app.world_mut().spawn(PAGE_MANIFEST);
         app.add_plugins(BinEventEmitterPlugin::<(
             AgentInstallRunRequest,
             AgentSetupPrereqRequest,
-        )>::for_hosts(&["agent"]))
+        )>::for_hosts(&["agent", "agents"]))
             .add_observer(on_agent_install_run)
             .add_observer(on_agent_setup_prereq_request)
             .add_systems(Update, auto_redirect_agent_setup_when_installed)
@@ -106,15 +96,21 @@ fn install_outcome(armed: bool, installed: bool) -> Option<bool> {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+fn close_install_pane_after_success(url: &str) -> bool {
+    url.trim_end_matches('/') == "vmux://agents"
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 fn detect_agent_install_outcome(
     mut events: MessageReader<vmux_terminal::CommandLifecycleEvent>,
-    mut install_panes: Query<&mut AgentInstallPane>,
+    mut install_panes: Query<(Entity, &mut AgentInstallPane)>,
+    setup_stacks: Query<&vmux_core::PageMetadata, With<vmux_layout::stack::Stack>>,
     browsers: NonSend<Browsers>,
     mut commands: Commands,
 ) {
     use vmux_service::protocol::CommandLifecycleKind;
     for ev in events.read() {
-        for mut pane in &mut install_panes {
+        for (install_pane, mut pane) in &mut install_panes {
             if pane.process_id != ev.process_id {
                 continue;
             }
@@ -122,15 +118,27 @@ fn detect_agent_install_outcome(
                 CommandLifecycleKind::Started => pane.armed = true,
                 CommandLifecycleKind::Ended { .. } => {
                     let installed = crate::exec::find_executable(pane.agent.executable()).is_some();
-                    if let Some(false) = install_outcome(pane.armed, installed) {
+                    if let Some(ok) = install_outcome(pane.armed, installed) {
                         if browsers.has_browser(pane.setup_webview)
                             && browsers.host_emit_ready(&pane.setup_webview)
                         {
                             commands.trigger(BinHostEmitEvent::from_rkyv(
                                 pane.setup_webview,
                                 AGENT_SETUP_RESULT_EVENT,
-                                &AgentSetupResult { ok: false },
+                                &AgentSetupResult {
+                                    agent: pane.agent.as_url_segment().to_string(),
+                                    ok,
+                                },
                             ));
+                        }
+                        if ok
+                            && setup_stacks
+                                .get(pane.setup_stack)
+                                .is_ok_and(|meta| close_install_pane_after_success(&meta.url))
+                        {
+                            commands
+                                .entity(install_pane)
+                                .insert(vmux_layout::pane::ForcePaneClose);
                         }
                         pane.armed = false;
                     }
@@ -166,7 +174,7 @@ fn on_agent_install_run(
     let input = vmux_terminal::shell_input::shell_command_input(&command);
 
     for mut pane in &mut install_panes {
-        if pane.setup_webview == webview {
+        if pane.setup_webview == webview && pane.agent == kind {
             reinput.write(vmux_terminal::TerminalReinputRequest {
                 process_id: pane.process_id,
                 data: input.clone(),
@@ -288,5 +296,14 @@ mod tests {
         assert_eq!(install_outcome(false, false), None);
         assert_eq!(install_outcome(true, true), Some(true));
         assert_eq!(install_outcome(true, false), Some(false));
+    }
+
+    #[test]
+    fn successful_manager_install_closes_terminal_pane() {
+        assert!(close_install_pane_after_success("vmux://agents"));
+        assert!(close_install_pane_after_success("vmux://agents/"));
+        assert!(!close_install_pane_after_success(
+            "vmux://agent/codex/setup"
+        ));
     }
 }

--- a/crates/vmux_agent/src/vibe/setup/event.rs
+++ b/crates/vmux_agent/src/vibe/setup/event.rs
@@ -60,6 +60,7 @@ pub struct AgentSetupPrereqStatus {
     rkyv::Deserialize,
 )]
 pub struct AgentSetupResult {
+    pub agent: String,
     pub ok: bool,
 }
 
@@ -79,9 +80,13 @@ mod tests {
 
     #[test]
     fn result_rkyv_roundtrip() {
-        let v = AgentSetupResult { ok: false };
+        let v = AgentSetupResult {
+            agent: "codex".to_string(),
+            ok: false,
+        };
         let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&v).unwrap();
         let back = rkyv::from_bytes::<AgentSetupResult, rkyv::rancor::Error>(&bytes).unwrap();
+        assert_eq!(back.agent, "codex");
         assert!(!back.ok);
     }
 }

--- a/crates/vmux_desktop/src/lib.rs
+++ b/crates/vmux_desktop/src/lib.rs
@@ -134,6 +134,7 @@ impl Plugin for VmuxPlugin {
                 vmux_history::HistoryPlugin,
                 vmux_agent::AgentChatPagePlugin,
                 vmux_agent::AgentsManagerPlugin,
+                vmux_agent::AgentSetupPlugin,
                 vmux_layout::start::StartPlugin,
                 LayoutCefPlugin,
                 vmux_browser::ExtensionsPlugin,

--- a/crates/vmux_editor/src/lsp_page.rs
+++ b/crates/vmux_editor/src/lsp_page.rs
@@ -4,9 +4,14 @@ use std::collections::HashMap;
 
 use dioxus::prelude::*;
 use vmux_core::event::*;
+use vmux_ui::components::manager::{
+    ManagerBadge, ManagerButton, ManagerButtonVariant, ManagerEmpty, ManagerHeader, ManagerList,
+    ManagerPage, ManagerRow, ManagerSpinner, ManagerTone,
+};
+use vmux_ui::file_icon::{FileIcon, file_icon_kind, type_icon};
+use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_theme};
 
 use crate::page_model::{PkgAction, pkg_action, pkg_status_class, pkg_status_label};
-use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_theme};
 
 fn request_catalog(query: String, refresh: bool) {
     let _ = try_cef_bin_emit_rkyv(&LspCatalogRequest {
@@ -26,148 +31,214 @@ pub fn Page() -> Element {
     let mut progress = use_signal(HashMap::<String, LspInstallProgress>::new);
     let mut loading = use_signal(|| true);
 
-    let _cat = use_bin_event_listener::<LspCatalogEvent, _>(LSP_CATALOG_EVENT, move |e| {
-        packages.set(e.packages);
+    let _catalog = use_bin_event_listener::<LspCatalogEvent, _>(LSP_CATALOG_EVENT, move |event| {
+        packages.set(event.packages);
         loading.set(false);
     });
-
-    let _prog =
-        use_bin_event_listener::<LspInstallProgress, _>(LSP_INSTALL_PROGRESS_EVENT, move |p| {
-            let name = p.name.clone();
-            let phase = p.phase;
-            progress.write().insert(name.clone(), p);
-            if let Some(pk) = packages.write().iter_mut().find(|x| x.name == name) {
-                pk.status = match phase {
+    let _progress =
+        use_bin_event_listener::<LspInstallProgress, _>(LSP_INSTALL_PROGRESS_EVENT, move |item| {
+            let name = item.name.clone();
+            let phase = item.phase;
+            progress.write().insert(name.clone(), item);
+            if let Some(package) = packages
+                .write()
+                .iter_mut()
+                .find(|package| package.name == name)
+            {
+                package.status = match phase {
                     InstallPhase::Failed => LspPkgStatus::Failed,
                     InstallPhase::Done => LspPkgStatus::Installed,
                     _ => LspPkgStatus::Installing,
                 };
             }
         });
-
-    let _stat = use_bin_event_listener::<LspPkgStatusEvent, _>(LSP_PKG_STATUS_EVENT, move |s| {
-        let name = s.name.clone();
-        if let Some(pk) = packages.write().iter_mut().find(|x| x.name == name) {
-            pk.status = s.status;
-            pk.version = s.version;
-        }
-        progress.write().remove(&name);
-    });
+    let _status =
+        use_bin_event_listener::<LspPkgStatusEvent, _>(LSP_PKG_STATUS_EVENT, move |status| {
+            let name = status.name.clone();
+            if let Some(package) = packages
+                .write()
+                .iter_mut()
+                .find(|package| package.name == name)
+            {
+                package.status = status.status;
+                package.version = status.version;
+            }
+            progress.write().remove(&name);
+        });
 
     use_effect(move || {
-        if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
+        if let Some(doc) = web_sys::window().and_then(|window| window.document()) {
             doc.set_title("Language Servers");
         }
         request_catalog(String::new(), false);
     });
 
-    let pkgs = packages();
-    let total = pkgs.len();
-
+    let visible = packages();
     rsx! {
-        div {
-            class: "flex h-full w-full flex-col overflow-hidden bg-background text-foreground font-sans text-sm",
-            style: "background-image:radial-gradient(120% 80% at 50% -10%, rgba(34,211,238,0.05), transparent 60%);",
-
-            div { class: "flex shrink-0 items-center gap-3 border-b border-foreground/[0.07] px-5 py-3",
-                div { class: "text-base font-semibold tracking-tight", "Language Servers" }
-                div { class: "rounded-full bg-foreground/[0.06] px-2 py-0.5 text-xs text-muted-foreground", "{total}" }
-                div { class: "flex-1" }
-                button {
-                    class: "rounded-lg bg-foreground/[0.05] px-3 py-1.5 text-xs text-foreground/80 ring-1 ring-inset ring-foreground/10 transition-colors hover:bg-foreground/[0.09]",
-                    onclick: move |_| { loading.set(true); request_catalog(query(), true); },
-                    "Refresh"
-                }
-            }
-
-            div { class: "shrink-0 px-5 py-3",
-                input {
-                    r#type: "text",
-                    value: "{query}",
-                    placeholder: "Search language servers, linters, formatters…",
-                    class: "w-full rounded-xl bg-foreground/[0.04] px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground/60 ring-1 ring-inset ring-foreground/10 outline-none focus:ring-cyan-400/30",
-                    oninput: move |e| { query.set(e.value()); request_catalog(e.value(), false); },
-                }
-            }
-
-            div { class: "min-h-0 flex-1 overflow-auto px-3 pb-4",
-                if loading() && pkgs.is_empty() {
-                    div { class: "px-3 py-6 text-center text-xs text-muted-foreground", "Loading catalog…" }
-                }
-                for pkg in pkgs.iter() {
-                    {
-                        let p = pkg.clone();
-                        let prog = progress().get(&p.name).cloned();
-                        let action = pkg_action(p.status, p.installable);
-                        let name_for_btn = p.name.clone();
-                        rsx! {
-                            div {
-                                key: "{p.name}",
-                                class: "flex items-center gap-3 rounded-xl px-3 py-2.5 transition-colors hover:bg-foreground/[0.04]",
-
-                                div { class: "flex min-w-0 flex-1 flex-col gap-0.5",
-                                    div { class: "flex items-center gap-2",
-                                        span { class: "truncate font-medium text-foreground/95", "{p.name}" }
-                                        if let Some(v) = p.version.as_ref() {
-                                            span { class: "text-xs text-muted-foreground/70", "{v}" }
-                                        }
-                                    }
-                                    div { class: "flex flex-wrap items-center gap-1.5",
-                                        for lang in p.languages.iter().take(3) {
-                                            span { class: "rounded-full bg-foreground/[0.05] px-2 py-0.5 text-[10px] text-foreground/60", "{lang}" }
-                                        }
-                                        for cat in p.categories.iter().take(2) {
-                                            span { class: "rounded-full bg-cyan-400/10 px-2 py-0.5 text-[10px] text-cyan-700/80 dark:text-cyan-300/80", "{cat}" }
-                                        }
-                                    }
-                                    if let Some(pr) = prog.as_ref() {
-                                        div { class: "mt-0.5 truncate text-[10px] text-muted-foreground/70",
-                                            {format!("{}{}", pr.message, pr.pct.map(|p| format!(" {p}%")).unwrap_or_default())}
-                                        }
-                                    }
-                                }
-
-                                span { class: "shrink-0 text-xs {pkg_status_class(p.status)}", "{pkg_status_label(p.status)}" }
-
-                                {render_action(action, &name_for_btn, p.requires.as_deref())}
-                            }
-                        }
+        ManagerPage {
+            ManagerHeader {
+                title: "Language Servers",
+                count: visible.len(),
+                search_value: query(),
+                search_placeholder: "Search language servers, linters, formatters…",
+                onsearch: move |event: FormEvent| {
+                    let value = event.value();
+                    query.set(value.clone());
+                    request_catalog(value, false);
+                },
+                onkeydown: None,
+                actions: rsx! {
+                    ManagerButton {
+                        variant: ManagerButtonVariant::Secondary,
+                        onclick: move |_| {
+                            loading.set(true);
+                            request_catalog(query(), true);
+                        },
+                        "Refresh"
                     }
+                },
+            }
+            ManagerList {
+                if loading() && visible.is_empty() {
+                    ManagerSpinner { detail: "Loading catalog…" }
+                } else if visible.is_empty() {
+                    ManagerEmpty {
+                        title: "No matching language servers",
+                        detail: "Try another language, linter, or formatter.",
+                    }
+                }
+                for package in visible.iter() {
+                    {render_package(package, progress)}
                 }
             }
         }
     }
 }
 
+fn render_package(
+    package: &LspPackage,
+    progress: Signal<HashMap<String, LspInstallProgress>>,
+) -> Element {
+    let item = package.clone();
+    let install_progress = progress().get(&item.name).cloned();
+    let action = pkg_action(item.status, item.installable);
+    let action_name = item.name.clone();
+    let mut subtitle = item.version.clone().unwrap_or_default();
+    if let Some(progress) = install_progress.as_ref() {
+        subtitle = format!(
+            "{}{}",
+            progress.message,
+            progress
+                .pct
+                .map(|percent| format!(" {percent}%"))
+                .unwrap_or_default()
+        );
+    }
+    let icon_path = language_icon_path(&item.languages);
+    let show_icon = icon_path.is_some();
+    rsx! {
+        ManagerRow {
+            show_icon,
+            icon: rsx! {
+                if let Some(path) = icon_path.as_ref() {
+                    {type_icon(path, false, "h-6 w-6 text-foreground/80")}
+                }
+            },
+            title: item.name.clone(),
+            subtitle,
+            meta: rsx! {
+                for language in item.languages.iter().take(3) {
+                    ManagerBadge { tone: ManagerTone::Neutral, "{language}" }
+                }
+                for category in item.categories.iter().take(2) {
+                    ManagerBadge { tone: ManagerTone::Cyan, "{category}" }
+                }
+            },
+            actions: rsx! {
+                span { class: "shrink-0 text-xs {pkg_status_class(item.status)}", "{pkg_status_label(item.status)}" }
+                {render_action(action, &action_name, item.requires.as_deref())}
+            },
+        }
+    }
+}
+
+fn language_icon_path(languages: &[String]) -> Option<String> {
+    languages.iter().find_map(|language| {
+        let normalized = language.trim().to_ascii_lowercase();
+        let extension = match normalized.as_str() {
+            "rust" => "rs",
+            "typescript" => "ts",
+            "typescriptreact" | "typescript react" => "tsx",
+            "javascript" => "js",
+            "javascriptreact" | "javascript react" => "jsx",
+            "python" => "py",
+            "ruby" => "rb",
+            "shell" | "bash" | "zsh" => "sh",
+            "c++" | "cpp" => "cpp",
+            "kotlin" => "kt",
+            "elixir" => "ex",
+            "haskell" => "hs",
+            "ocaml" => "ml",
+            "clojure" => "clj",
+            "erlang" => "erl",
+            "julia" => "jl",
+            "perl" => "pl",
+            "f#" | "fsharp" => "fs",
+            "markdown" => "md",
+            "sass" => "scss",
+            "graphql" => "graphql",
+            "yml" => "yaml",
+            "docker" => "dockerfile",
+            "terraform" | "hcl" => "tf",
+            "nix" | "nixos" => "nix",
+            "jupyter" => "ipynb",
+            "webassembly" => "wasm",
+            "powershell" => "ps1",
+            "sql" => "sqlite",
+            other => other,
+        };
+        let path = format!("language.{extension}");
+        matches!(file_icon_kind(&path, false), FileIcon::Logo(_)).then_some(path)
+    })
+}
+
 fn render_action(action: PkgAction, name: &str, requires: Option<&str>) -> Element {
-    let n = name.to_string();
+    let install_name = name.to_string();
+    let update_name = name.to_string();
+    let uninstall_name = name.to_string();
     match action {
         PkgAction::Install => rsx! {
-            button {
-                class: "shrink-0 rounded-lg bg-cyan-400/15 px-3 py-1.5 text-xs font-medium text-cyan-700 dark:text-cyan-200 ring-1 ring-inset ring-cyan-400/30 transition-colors hover:bg-cyan-400/25",
-                onclick: move |_| { let _ = try_cef_bin_emit_rkyv(&LspInstallRequest { name: n.clone() }); },
+            ManagerButton {
+                variant: ManagerButtonVariant::Primary,
+                onclick: move |_| {
+                    let _ = try_cef_bin_emit_rkyv(&LspInstallRequest { name: install_name.clone() });
+                },
                 "Install"
             }
         },
         PkgAction::Update => rsx! {
-            button {
-                class: "shrink-0 rounded-lg bg-amber-400/15 px-3 py-1.5 text-xs font-medium text-amber-200 ring-1 ring-inset ring-amber-400/30 transition-colors hover:bg-amber-400/25",
-                onclick: move |_| { let _ = try_cef_bin_emit_rkyv(&LspUpdateRequest { name: n.clone() }); },
+            ManagerButton {
+                variant: ManagerButtonVariant::Secondary,
+                onclick: move |_| {
+                    let _ = try_cef_bin_emit_rkyv(&LspUpdateRequest { name: update_name.clone() });
+                },
                 "Update"
             }
         },
         PkgAction::Uninstall => rsx! {
-            button {
-                class: "shrink-0 rounded-lg bg-foreground/[0.05] px-3 py-1.5 text-xs text-foreground/70 ring-1 ring-inset ring-foreground/10 transition-colors hover:bg-ansi-1/15 hover:text-ansi-1",
-                onclick: move |_| { let _ = try_cef_bin_emit_rkyv(&LspUninstallRequest { name: n.clone() }); },
+            ManagerButton {
+                variant: ManagerButtonVariant::Danger,
+                onclick: move |_| {
+                    let _ = try_cef_bin_emit_rkyv(&LspUninstallRequest { name: uninstall_name.clone() });
+                },
                 "Uninstall"
             }
         },
         PkgAction::None => match requires {
-            Some(tool) => rsx! {
-                span { class: "shrink-0 rounded-lg px-3 py-1.5 text-[10px] text-muted-foreground/60", "needs {tool}" }
-            },
-            None => rsx! { span {} },
+            Some(tool) => {
+                rsx! { span { class: "text-[10px] text-muted-foreground/60", "needs {tool}" } }
+            }
+            None => rsx! {},
         },
     }
 }

--- a/crates/vmux_layout/src/extensions_page.rs
+++ b/crates/vmux_layout/src/extensions_page.rs
@@ -4,6 +4,10 @@ use std::collections::HashMap;
 
 use dioxus::prelude::*;
 use vmux_core::event::extension::*;
+use vmux_ui::components::manager::{
+    ManagerBadge, ManagerButton, ManagerButtonVariant, ManagerEmpty, ManagerHeader, ManagerList,
+    ManagerPage, ManagerRow, ManagerSkeleton, ManagerTone,
+};
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_theme};
 
 #[component]
@@ -14,128 +18,147 @@ pub fn Page() -> Element {
     let mut loaded = use_signal(|| false);
     let mut search = use_signal(String::new);
 
-    let _list = use_bin_event_listener::<ExtensionsEvent, _>(EXTENSIONS_LIST_EVENT, move |e| {
-        state.set(e);
+    let _list = use_bin_event_listener::<ExtensionsEvent, _>(EXTENSIONS_LIST_EVENT, move |event| {
+        state.set(event);
         loaded.set(true);
     });
-    let _prog =
-        use_bin_event_listener::<ExtInstallProgress, _>(EXT_INSTALL_PROGRESS_EVENT, move |p| {
-            let done = matches!(p.phase, ExtInstallPhase::Done | ExtInstallPhase::Failed);
-            if done {
-                progress.write().remove(&p.key);
+    let _progress =
+        use_bin_event_listener::<ExtInstallProgress, _>(EXT_INSTALL_PROGRESS_EVENT, move |item| {
+            if matches!(item.phase, ExtInstallPhase::Done | ExtInstallPhase::Failed) {
+                progress.write().remove(&item.key);
             } else {
-                progress.write().insert(p.key.clone(), p);
+                progress.write().insert(item.key.clone(), item);
             }
         });
-    let _stat = use_bin_event_listener::<ExtStatusEvent, _>(EXT_STATUS_EVENT, move |_s| {});
+    let _status = use_bin_event_listener::<ExtStatusEvent, _>(EXT_STATUS_EVENT, move |_| {});
 
     use_effect(move || {
-        if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
+        if let Some(doc) = web_sys::window().and_then(|window| window.document()) {
             doc.set_title("Extensions");
         }
         let _ = try_cef_bin_emit_rkyv(&ExtListRequest);
     });
 
-    let snap = state();
+    let snapshot = state();
+    let query = search().trim().to_lowercase();
+    let visible: Vec<ExtRow> = snapshot
+        .extensions
+        .iter()
+        .filter(|extension| {
+            query.is_empty()
+                || extension.name.to_lowercase().contains(&query)
+                || extension.id.to_lowercase().contains(&query)
+                || extension.version.to_lowercase().contains(&query)
+        })
+        .cloned()
+        .collect();
     let installing: Vec<ExtInstallProgress> = progress().values().cloned().collect();
 
     rsx! {
-        div {
-            class: "flex h-full w-full flex-col overflow-hidden bg-background text-foreground font-sans text-sm",
-            style: "background-image:radial-gradient(120% 80% at 50% -10%, rgba(34,211,238,0.05), transparent 60%);",
-
-            div { class: "flex shrink-0 items-center gap-3 border-b border-foreground/[0.07] px-5 py-3",
-                div { class: "text-base font-semibold tracking-tight", "Extensions" }
-                div { class: "rounded-full bg-foreground/[0.06] px-2 py-0.5 text-xs text-muted-foreground", "{snap.extensions.len()}" }
-                div { class: "flex min-w-0 flex-1 items-center",
-                    input {
-                        r#type: "search",
-                        class: "w-full max-w-80 rounded-lg bg-foreground/[0.05] px-3 py-1.5 text-xs text-foreground outline-none ring-1 ring-inset ring-foreground/10 transition-colors placeholder:text-muted-foreground/60 focus:bg-foreground/[0.08] focus:ring-cyan-400/30",
-                        placeholder: "Search the Chrome Web Store…",
-                        value: "{search}",
-                        oninput: move |e| search.set(e.value()),
-                        onkeydown: move |e: KeyboardEvent| {
-                            if e.key() == Key::Enter {
-                                let q = search();
-                                if !q.trim().is_empty() {
-                                    let _ = try_cef_bin_emit_rkyv(&ExtBrowseStoreRequest { query: q });
-                                }
-                            }
+        ManagerPage {
+            ManagerHeader {
+                title: "Extensions",
+                count: snapshot.extensions.len(),
+                search_value: search(),
+                search_placeholder: "Search installed or Chrome Web Store…",
+                onsearch: move |event: FormEvent| search.set(event.value()),
+                onkeydown: move |event: KeyboardEvent| {
+                    if event.key() == Key::Enter {
+                        let query = search();
+                        if !query.trim().is_empty() {
+                            let _ = try_cef_bin_emit_rkyv(&ExtBrowseStoreRequest { query });
+                        }
+                    }
+                },
+                actions: rsx! {
+                    if snapshot.pending {
+                        ManagerButton {
+                            variant: ManagerButtonVariant::Primary,
+                            onclick: move |_| {
+                                let _ = try_cef_bin_emit_rkyv(&crate::event::RestartRequestEvent);
+                            },
+                            "Relaunch to apply"
+                        }
+                    }
+                },
+            }
+            if !installing.is_empty() {
+                div { class: "shrink-0 px-5 pt-3",
+                    for item in installing.iter() {
+                        div { class: "truncate text-[10px] text-muted-foreground/70",
+                            {format!(
+                                "{}: {}{}",
+                                item.key,
+                                item.message,
+                                item.pct.map(|percent| format!(" {percent}%")).unwrap_or_default()
+                            )}
+                        }
+                    }
+                }
+            }
+            ManagerList {
+                if !loaded() {
+                    ManagerSkeleton {}
+                } else if visible.is_empty() {
+                    ManagerEmpty {
+                        title: if snapshot.extensions.is_empty() { "No extensions installed" } else { "No matching extensions" },
+                        detail: if snapshot.extensions.is_empty() {
+                            "Search the Chrome Web Store above and press Return."
+                        } else {
+                            "Try another name or extension ID."
                         },
                     }
                 }
-                if snap.pending {
-                    button {
-                        class: "rounded-lg bg-cyan-400/15 px-3 py-1.5 text-xs font-medium text-cyan-200 ring-1 ring-inset ring-cyan-400/30 transition-colors hover:bg-cyan-400/25",
-                        onclick: move |_| { let _ = try_cef_bin_emit_rkyv(&crate::event::RestartRequestEvent); },
-                        "Relaunch to apply"
-                    }
+                for extension in visible.iter() {
+                    {render_extension(extension)}
                 }
             }
+        }
+    }
+}
 
-            if !installing.is_empty() {
-                div { class: "shrink-0 px-5 pb-2",
-                    for pr in installing.iter() {
-                        div { class: "truncate text-[10px] text-muted-foreground/70",
-                            {format!("{}: {}{}", pr.key, pr.message, pr.pct.map(|p| format!(" {p}%")).unwrap_or_default())}
-                        }
-                    }
+fn render_extension(extension: &ExtRow) -> Element {
+    let item = extension.clone();
+    let toggle_id = item.id.clone();
+    let toggle_enabled = item.enabled;
+    let remove_id = item.id.clone();
+    let icon = item.icon.clone();
+    rsx! {
+        ManagerRow {
+            icon: rsx! {
+                if let Some(icon) = icon.as_ref() {
+                    img { class: "h-6 w-6 rounded object-contain", src: "{icon}" }
+                } else {
+                    span { class: "font-mono text-[10px] text-muted-foreground", "EXT" }
                 }
-            }
-
-            div { class: "min-h-0 flex-1 overflow-auto px-3 pb-4",
-                if !loaded() {
-                    for i in 0..3 {
-                        div {
-                            key: "{i}",
-                            class: "flex items-center gap-3 rounded-xl px-3 py-2.5",
-                            div { class: "h-6 w-6 shrink-0 animate-pulse rounded bg-foreground/[0.06]" }
-                            div { class: "flex min-w-0 flex-1 flex-col gap-1.5",
-                                div { class: "h-3 w-32 animate-pulse rounded bg-foreground/[0.06]" }
-                                div { class: "h-2.5 w-16 animate-pulse rounded bg-foreground/[0.05]" }
-                            }
-                        }
-                    }
-                } else if snap.extensions.is_empty() {
-                    div { class: "flex flex-col items-center gap-3 px-3 py-16 text-center",
-                        div { class: "text-sm text-muted-foreground", "No extensions installed yet." }
-                        div { class: "text-xs text-muted-foreground/70",
-                            "Search the Chrome Web Store above, then click \"Add to Vmux\"."
-                        }
-                    }
+            },
+            title: item.name.clone(),
+            subtitle: format!("v{}", item.version),
+            meta: rsx! {
+                ManagerBadge {
+                    tone: if item.enabled { ManagerTone::Green } else { ManagerTone::Neutral },
+                    if item.enabled { "On" } else { "Off" }
                 }
-                for ext in snap.extensions.iter() {
-                    {
-                        let e = ext.clone();
-                        let toggle_id = e.id.clone();
-                        let toggle_enabled = e.enabled;
-                        let remove_id = e.id.clone();
-                        rsx! {
-                            div {
-                                key: "{e.id}",
-                                class: "flex items-center gap-3 rounded-xl px-3 py-2.5 transition-colors hover:bg-foreground/[0.04]",
-                                if let Some(icon) = e.icon.as_ref() {
-                                    img { class: "h-6 w-6 shrink-0 rounded", src: "{icon}" }
-                                }
-                                div { class: "flex min-w-0 flex-1 flex-col gap-0.5",
-                                    span { class: "truncate font-medium text-foreground/95", "{e.name}" }
-                                    span { class: "text-xs text-muted-foreground/70", "v{e.version}" }
-                                }
-                                button {
-                                    class: "shrink-0 rounded-lg px-3 py-1.5 text-xs ring-1 ring-inset ring-foreground/10 transition-colors hover:bg-foreground/[0.09]",
-                                    onclick: move |_| { let _ = try_cef_bin_emit_rkyv(&ExtToggleRequest { id: toggle_id.clone(), enabled: !toggle_enabled }); },
-                                    if e.enabled { "On" } else { "Off" }
-                                }
-                                button {
-                                    class: "shrink-0 rounded-lg bg-foreground/[0.05] px-3 py-1.5 text-xs text-foreground/70 ring-1 ring-inset ring-foreground/10 transition-colors hover:bg-ansi-1/15 hover:text-ansi-1",
-                                    onclick: move |_| { let _ = try_cef_bin_emit_rkyv(&ExtUninstallRequest { id: remove_id.clone() }); },
-                                    "Remove"
-                                }
-                            }
-                        }
-                    }
+            },
+            actions: rsx! {
+                ManagerButton {
+                    variant: ManagerButtonVariant::Secondary,
+                    onclick: move |_| {
+                        let _ = try_cef_bin_emit_rkyv(&ExtToggleRequest {
+                            id: toggle_id.clone(),
+                            enabled: !toggle_enabled,
+                        });
+                    },
+                    if item.enabled { "Disable" } else { "Enable" }
                 }
-            }
+                ManagerButton {
+                    variant: ManagerButtonVariant::Danger,
+                    onclick: move |_| {
+                        let _ = try_cef_bin_emit_rkyv(&ExtUninstallRequest { id: remove_id.clone() });
+                    },
+                    "Remove"
+                }
+            },
         }
     }
 }

--- a/crates/vmux_ui/src/components.rs
+++ b/crates/vmux_ui/src/components.rs
@@ -20,6 +20,7 @@ pub mod hover_card;
 pub mod icon;
 pub mod input;
 pub mod label;
+pub mod manager;
 pub mod menubar;
 pub mod navbar;
 pub mod pagination;

--- a/crates/vmux_ui/src/components/manager.rs
+++ b/crates/vmux_ui/src/components/manager.rs
@@ -1,0 +1,200 @@
+use dioxus::prelude::*;
+
+#[derive(Clone, Copy, Default, PartialEq)]
+pub enum ManagerTone {
+    #[default]
+    Neutral,
+    Cyan,
+    Green,
+    Amber,
+}
+
+impl ManagerTone {
+    fn classes(self) -> &'static str {
+        match self {
+            Self::Neutral => "bg-foreground/[0.06] text-muted-foreground ring-foreground/10",
+            Self::Cyan => "bg-cyan-400/10 text-cyan-700 dark:text-cyan-300 ring-cyan-400/20",
+            Self::Green => {
+                "bg-emerald-400/10 text-emerald-700 dark:text-emerald-300 ring-emerald-400/20"
+            }
+            Self::Amber => "bg-amber-400/10 text-amber-700 dark:text-amber-300 ring-amber-400/20",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Default, PartialEq)]
+pub enum ManagerButtonVariant {
+    #[default]
+    Primary,
+    Secondary,
+    Danger,
+    Ghost,
+}
+
+impl ManagerButtonVariant {
+    fn classes(self) -> &'static str {
+        match self {
+            Self::Primary => {
+                "bg-cyan-400/15 text-cyan-700 dark:text-cyan-200 ring-cyan-400/30 hover:bg-cyan-400/25"
+            }
+            Self::Secondary => {
+                "bg-foreground/[0.05] text-foreground/80 ring-foreground/10 hover:bg-foreground/[0.09]"
+            }
+            Self::Danger => {
+                "bg-foreground/[0.05] text-foreground/70 ring-foreground/10 hover:bg-ansi-1/15 hover:text-ansi-1"
+            }
+            Self::Ghost => {
+                "text-muted-foreground ring-transparent hover:bg-foreground/[0.08] hover:text-foreground"
+            }
+        }
+    }
+}
+
+#[component]
+pub fn ManagerPage(children: Element) -> Element {
+    rsx! {
+        main {
+            class: "flex h-full w-full flex-col overflow-hidden bg-background text-foreground font-sans text-sm",
+            style: "background-image:radial-gradient(120% 80% at 50% -10%, rgba(34,211,238,0.05), transparent 60%);",
+            {children}
+        }
+    }
+}
+
+#[component]
+pub fn ManagerHeader(
+    title: String,
+    count: usize,
+    search_value: String,
+    search_placeholder: String,
+    onsearch: EventHandler<FormEvent>,
+    onkeydown: Option<EventHandler<KeyboardEvent>>,
+    actions: Element,
+) -> Element {
+    rsx! {
+        header { class: "shrink-0 border-b border-foreground/[0.07] px-5 py-3",
+            div { class: "flex items-center gap-3",
+                h1 { class: "text-base font-semibold tracking-tight", "{title}" }
+                span { class: "rounded-full bg-foreground/[0.06] px-2 py-0.5 text-xs text-muted-foreground", "{count}" }
+                div { class: "flex-1" }
+                {actions}
+            }
+            input {
+                r#type: "search",
+                class: "mt-3 w-full rounded-xl bg-foreground/[0.04] px-4 py-2.5 text-sm text-foreground outline-none ring-1 ring-inset ring-foreground/10 transition-colors placeholder:text-muted-foreground/60 focus:bg-foreground/[0.06] focus:ring-cyan-400/30",
+                placeholder: "{search_placeholder}",
+                value: "{search_value}",
+                oninput: move |event| onsearch.call(event),
+                onkeydown: move |event| {
+                    if let Some(handler) = &onkeydown {
+                        handler.call(event);
+                    }
+                },
+            }
+        }
+    }
+}
+
+#[component]
+pub fn ManagerList(children: Element) -> Element {
+    rsx! {
+        div { class: "min-h-0 flex-1 overflow-auto px-5 py-5",
+            div { class: "mx-auto flex max-w-3xl flex-col gap-2.5", {children} }
+        }
+    }
+}
+
+#[component]
+pub fn ManagerRow(
+    icon: Element,
+    title: String,
+    subtitle: String,
+    meta: Element,
+    actions: Element,
+    #[props(default = true)] show_icon: bool,
+) -> Element {
+    rsx! {
+        div { class: "group flex items-center gap-4 rounded-2xl bg-foreground/[0.035] px-5 py-4 ring-1 ring-inset ring-foreground/10 backdrop-blur-xl transition-colors hover:bg-foreground/[0.07]",
+            if show_icon {
+                div { class: "flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-foreground/[0.06] ring-1 ring-inset ring-foreground/10",
+                    {icon}
+                }
+            }
+            div { class: "flex min-w-0 flex-1 flex-col gap-1",
+                div { class: "flex min-w-0 items-center gap-2",
+                    span { class: "truncate font-medium text-foreground/95", "{title}" }
+                    {meta}
+                }
+                if !subtitle.is_empty() {
+                    span { class: "truncate text-xs text-muted-foreground/70", "{subtitle}" }
+                }
+            }
+            div { class: "flex shrink-0 items-center gap-2", {actions} }
+        }
+    }
+}
+
+#[component]
+pub fn ManagerBadge(#[props(default)] tone: ManagerTone, children: Element) -> Element {
+    rsx! {
+        span { class: "shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ring-1 ring-inset {tone.classes()}",
+            {children}
+        }
+    }
+}
+
+#[component]
+pub fn ManagerButton(
+    #[props(default)] variant: ManagerButtonVariant,
+    #[props(default)] disabled: bool,
+    onclick: EventHandler<MouseEvent>,
+    children: Element,
+) -> Element {
+    rsx! {
+        button {
+            class: "shrink-0 rounded-lg px-3 py-1.5 text-xs font-medium ring-1 ring-inset transition-colors disabled:pointer-events-none disabled:opacity-50 {variant.classes()}",
+            disabled,
+            onclick: move |event| onclick.call(event),
+            {children}
+        }
+    }
+}
+
+#[component]
+pub fn ManagerSpinner(detail: String) -> Element {
+    rsx! {
+        div { class: "flex items-center gap-2 text-xs text-muted-foreground",
+            span { class: "h-3.5 w-3.5 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-foreground" }
+            if !detail.is_empty() {
+                span { class: "max-w-44 truncate", "{detail}" }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn ManagerEmpty(title: String, detail: String) -> Element {
+    rsx! {
+        div { class: "flex flex-col items-center gap-2 px-3 py-16 text-center",
+            div { class: "text-sm text-muted-foreground", "{title}" }
+            if !detail.is_empty() {
+                div { class: "text-xs text-muted-foreground/70", "{detail}" }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn ManagerSkeleton() -> Element {
+    rsx! {
+        for i in 0..3 {
+            div { key: "{i}", class: "flex items-center gap-4 rounded-2xl bg-foreground/[0.035] px-5 py-4 ring-1 ring-inset ring-foreground/10",
+                div { class: "h-10 w-10 shrink-0 animate-pulse rounded-xl bg-foreground/[0.06]" }
+                div { class: "flex min-w-0 flex-1 flex-col gap-1.5",
+                    div { class: "h-3 w-32 animate-pulse rounded bg-foreground/[0.06]" }
+                    div { class: "h-2.5 w-48 animate-pulse rounded bg-foreground/[0.05]" }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Context
Agent management is split between ACP discovery and separate CLI setup pages, while installed ACP agents are missing from the start page. Agents, language servers, and extensions also use inconsistent list designs. This PR is stacked on #251.

## Implementation
Uses shared searchable glass-card manager components across agents, language servers, and extensions. The agents page manages ACP agents plus Claude, Codex, and Vibe CLIs; installed ACPs appear on the start page and can open without a settings entry. Language-server rows use bundled language icons and omit the thumbnail when no matching icon exists.

## Checks / QA
- Open vmux://agents, search agents, and verify ACP and CLI install/open/uninstall actions.
- Open vmux://start and launch an installed ACP agent.
- Open vmux://lsp and verify language icons appear without generic placeholder thumbnails.
- Open vmux://extensions and verify its cards and search match the other manager pages.