### PR TITLE
feat(editor): add reactive shared diff view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10266,6 +10266,7 @@ dependencies = [
  "dioxus",
  "rkyv",
  "serde",
+ "similar",
  "syntect",
  "tempfile",
  "two-face",

--- a/crates/vmux_core/src/event.rs
+++ b/crates/vmux_core/src/event.rs
@@ -41,6 +41,8 @@ pub const FILE_KEY_EVENT: &str = "file_key";
 pub const FILE_POINTER_EVENT: &str = "file_pointer";
 pub const FILE_CURSOR_EVENT: &str = "file_cursor";
 pub const FILE_DIRTY_EVENT: &str = "file_dirty";
+pub const FILE_VIEW_MODE_EVENT: &str = "file_view_mode";
+pub const FILE_VIEW_MODE_SET_EVENT: &str = "file_view_mode_set";
 /// Host → file page: show the auto-tidy prompt banner (N unchanged previews).
 pub const FILE_TIDY_PROMPT_EVENT: &str = "file_tidy_prompt";
 /// File page → host: the user's choice on the tidy prompt banner.
@@ -1608,6 +1610,60 @@ pub struct FileDirtyEvent {
     pub dirty: bool,
 }
 
+/// Shared rendering mode for all open file editors.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Default,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub enum FileViewMode {
+    #[default]
+    Editor,
+    Diff,
+}
+
+/// Host → file page: update the shared rendering mode.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct FileViewModeEvent {
+    pub mode: FileViewMode,
+}
+
+/// File page → host: set the shared rendering mode.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct FileViewModeSet {
+    pub mode: FileViewMode,
+}
+
 /// Host → file page: show the follow-pane auto-tidy prompt with `count` closable previews.
 #[derive(
     Debug,
@@ -1919,6 +1975,16 @@ mod tests {
         let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&e).unwrap();
         let back = rkyv::from_bytes::<FileCursorEvent, rkyv::rancor::Error>(&bytes).unwrap();
         assert_eq!(back, e);
+    }
+
+    #[test]
+    fn file_view_mode_event_roundtrips() {
+        let event = FileViewModeEvent {
+            mode: FileViewMode::Diff,
+        };
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&event).unwrap();
+        let back = rkyv::from_bytes::<FileViewModeEvent, rkyv::rancor::Error>(&bytes).unwrap();
+        assert_eq!(back, event);
     }
 
     fn patch(changed_rows: Vec<u32>, cols: u16, rows: u16, full: bool) -> TermViewportPatch {

--- a/crates/vmux_editor/Cargo.toml
+++ b/crates/vmux_editor/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/lib.rs"
 serde = { workspace = true }
 rkyv = { workspace = true }
 vmux_core = { path = "../vmux_core" }
+vmux_git = { path = "../vmux_git" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bevy = { workspace = true }
@@ -54,7 +55,6 @@ url = { workspace = true }
 dioxus = { workspace = true }
 js-sys = "0.3"
 unicode-width = "0.2"
-vmux_git = { path = "../vmux_git" }
 vmux_ui = { path = "../vmux_ui", default-features = false }
 wasm-bindgen = { workspace = true }
 web-sys = { version = "0.3", features = [

--- a/crates/vmux_editor/src/page.rs
+++ b/crates/vmux_editor/src/page.rs
@@ -11,6 +11,7 @@ use dioxus::prelude::*;
 use vmux_core::event::*;
 use vmux_core::media::MediaKind;
 use vmux_git::ui::{DiffView, GitBar, GitFooter};
+use vmux_git::view::EditorDiffMarker;
 use vmux_ui::file_icon::type_icon;
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_theme};
 use wasm_bindgen::JsCast;
@@ -21,6 +22,7 @@ const MEASURE_ID: &str = "file-measure";
 const VIDEO_HOST_ID: &str = "vmux-video-host";
 const INPUT_ID: &str = "file-input";
 const SCROLL_ID: &str = "file-scroll";
+const GIT_REFRESH_DEBOUNCE_MS: i32 = 120;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Mode {
@@ -83,6 +85,25 @@ fn open_path(path: String) {
     let _ = try_cef_bin_emit_rkyv(&FileOpenEvent { path });
 }
 
+fn schedule_git_refresh(mut generation: Signal<u32>, mut nonce: Signal<u32>) {
+    let next = generation().wrapping_add(1);
+    generation.set(next);
+    let Some(window) = web_sys::window() else {
+        nonce.set(nonce().wrapping_add(1));
+        return;
+    };
+    let closure = Closure::once(move || {
+        if generation() == next {
+            nonce.set(nonce().wrapping_add(1));
+        }
+    });
+    let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(
+        closure.as_ref().unchecked_ref(),
+        GIT_REFRESH_DEBOUNCE_MS,
+    );
+    closure.forget();
+}
+
 fn parent_of(path: &str) -> String {
     match path.trim_end_matches('/').rsplit_once('/') {
         Some(("", _)) => "/".to_string(),
@@ -118,6 +139,15 @@ fn row_class(selected: bool) -> String {
         )
     } else {
         format!("{base} text-foreground/75 hover:bg-foreground/[0.05]")
+    }
+}
+
+fn diff_marker_class(marker: EditorDiffMarker) -> &'static str {
+    match marker {
+        EditorDiffMarker::Added => "bg-ansi-2",
+        EditorDiffMarker::Modified => "bg-cyan-400",
+        EditorDiffMarker::Deleted => "bg-ansi-1",
+        EditorDiffMarker::Staged => "bg-ansi-2/60",
     }
 }
 
@@ -280,8 +310,11 @@ pub fn Page() -> Element {
     let mut theme_style = use_signal(String::new);
     let cell_dims = use_signal(|| (0.0f64, 0.0f64));
     let mut git_path = use_signal(String::new);
-    let show_diff = use_signal(|| false);
+    let mut git_has_diff = use_signal(|| false);
+    let mut git_line_markers = use_signal(HashMap::<u32, EditorDiffMarker>::new);
+    let mut file_view_mode = use_signal(|| FileViewMode::Editor);
     let mut git_nonce = use_signal(|| 0u32);
+    let git_refresh_generation = use_signal(|| 0u32);
     let git_display = use_signal(String::new);
     let git_branch = use_signal(String::new);
     let git_ahead = use_signal(|| 0u32);
@@ -334,6 +367,10 @@ pub fn Page() -> Element {
         diagnostics.set(Vec::new());
         hover_diag.set(None);
         lsp_status.set(None);
+        if git_path() != m.abs_path {
+            git_has_diff.set(false);
+            git_line_markers.set(HashMap::new());
+        }
         git_path.set(m.abs_path);
         total_lines.set(m.total_lines);
         mode.set(Mode::Text);
@@ -361,7 +398,13 @@ pub fn Page() -> Element {
 
     let _dirty = use_bin_event_listener::<FileDirtyEvent, _>(FILE_DIRTY_EVENT, move |d| {
         dirty.set(d.dirty);
+        schedule_git_refresh(git_refresh_generation, git_nonce);
     });
+
+    let _view_mode =
+        use_bin_event_listener::<FileViewModeEvent, _>(FILE_VIEW_MODE_EVENT, move |event| {
+            file_view_mode.set(event.mode);
+        });
 
     let _hov = use_bin_event_listener::<FileHoverEvent, _>(FILE_HOVER_EVENT, move |h| {
         lsp_hover.set(Some(h));
@@ -414,6 +457,10 @@ pub fn Page() -> Element {
             doc.set_title(&name);
         }
         parent_path.set(d.parent_path);
+        if git_path() != d.abs_path {
+            git_has_diff.set(false);
+            git_line_markers.set(HashMap::new());
+        }
         git_path.set(d.abs_path);
         git_nonce.set(git_nonce() + 1);
         mode.set(Mode::Dir);
@@ -762,6 +809,37 @@ pub fn Page() -> Element {
                     span { class: "h-1.5 w-1.5 shrink-0 rounded-full bg-cyan-300", title: "unsaved" }
                 }
                 div { class: "flex-1" }
+                if mode() == Mode::Text && git_has_diff() {
+                    button {
+                        class: "relative grid shrink-0 grid-cols-2 overflow-hidden rounded-md bg-foreground/[0.06] p-0.5 text-[10px] font-medium ring-1 ring-inset ring-foreground/10",
+                        title: if file_view_mode() == FileViewMode::Diff { "Show editor in all open files" } else { "Show diffs in all open files" },
+                        aria_pressed: file_view_mode() == FileViewMode::Diff,
+                        onclick: move |_| {
+                            let next = if file_view_mode() == FileViewMode::Diff {
+                                FileViewMode::Editor
+                            } else {
+                                FileViewMode::Diff
+                            };
+                            file_view_mode.set(next);
+                            if next == FileViewMode::Diff {
+                                git_nonce.set(git_nonce().wrapping_add(1));
+                            }
+                            let _ = try_cef_bin_emit_rkyv(&FileViewModeSet { mode: next });
+                        },
+                        span {
+                            class: if file_view_mode() == FileViewMode::Diff { "pointer-events-none absolute inset-y-0.5 left-0.5 translate-x-full rounded bg-cyan-400/15 shadow-sm transition-transform duration-150 ease-out" } else { "pointer-events-none absolute inset-y-0.5 left-0.5 translate-x-0 rounded bg-background/80 shadow-sm transition-transform duration-150 ease-out" },
+                            style: "width:calc(50% - 0.125rem);",
+                        }
+                        span {
+                            class: if file_view_mode() == FileViewMode::Editor { "relative z-[1] rounded px-1.5 py-0.5 text-foreground transition-colors duration-150" } else { "relative z-[1] rounded px-1.5 py-0.5 text-foreground/45 transition-colors duration-150" },
+                            "Editor"
+                        }
+                        span {
+                            class: if file_view_mode() == FileViewMode::Diff { "relative z-[1] rounded px-1.5 py-0.5 text-cyan-700 transition-colors duration-150 dark:text-cyan-200" } else { "relative z-[1] rounded px-1.5 py-0.5 text-foreground/45 transition-colors duration-150" },
+                            "Diff"
+                        }
+                    }
+                }
                 {
                     let lbl = ed_label();
                     (!lbl.is_empty() && mode() == Mode::Text).then(|| rsx! {
@@ -813,7 +891,7 @@ pub fn Page() -> Element {
 
             GitBar {
                 path: git_path,
-                show_diff,
+                has_diff: git_has_diff,
                 nonce: git_nonce,
                 display_path: git_display,
                 branch: git_branch,
@@ -930,9 +1008,15 @@ pub fn Page() -> Element {
                     }
                 },
                 Mode::Text => rsx! {
-                    if show_diff() {
-                        DiffView { path: git_path, nonce: git_nonce }
-                    } else {
+                    if git_has_diff() {
+                        DiffView {
+                            path: git_path,
+                            nonce: git_nonce,
+                            visible: file_view_mode() == FileViewMode::Diff,
+                            markers: git_line_markers,
+                        }
+                    }
+                    if file_view_mode() != FileViewMode::Diff || !git_has_diff() {
                         {
                             let (cw, ch) = cell_dims();
                             let gutter = gw as f64 * cw + 36.0;
@@ -977,6 +1061,7 @@ pub fn Page() -> Element {
                                                 let fold = line.fold;
                                                 let diags = diagnostics();
                                                 let sev = line_severity(&diags, ln);
+                                                let diff_marker = git_line_markers().get(&(ln + 1)).copied();
                                                 let line_diags: Vec<FileDiagnostic> = diags
                                                     .iter()
                                                     .filter(|d| d.line == ln)
@@ -1081,6 +1166,12 @@ pub fn Page() -> Element {
                                                         span {
                                                             class: "sticky left-0 z-[1] relative flex shrink-0 select-none items-center justify-end bg-background pl-4 pr-5 tabular-nums",
                                                             style: "min-width:calc(var(--cw, 1ch) * {gw} + 2.25rem);",
+                                                            if let Some(marker) = diff_marker {
+                                                                span {
+                                                                    class: "pointer-events-none absolute inset-y-0 left-0 w-0.5 {diff_marker_class(marker)}",
+                                                                    title: "Changed line",
+                                                                }
+                                                            }
                                                             if let Some(s) = sev {
                                                                 span { class: "pointer-events-none absolute left-1 {severity_color_class(s)}", "●" }
                                                             }

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -116,6 +116,12 @@ struct ExplorerChrome {
 #[derive(Resource, Default)]
 struct ExplorerChromeSynced(bool);
 
+#[derive(Resource, Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct SharedFileViewMode(FileViewMode);
+
+#[derive(Component)]
+struct FileViewModeSent;
+
 type PendingPageOpen = (Without<PageOpenHandled>, Without<PageOpenError>);
 type UnloadedFileView = (
     Without<FileBuffer>,
@@ -130,6 +136,16 @@ type ReadyUnsentMeta = (
 type ReadyUnsentTheme = (
     With<FileView>,
     Without<FileThemeSent>,
+    With<vmux_core::page::PageReady>,
+);
+type ReadyUnsentViewMode = (
+    With<FileView>,
+    Without<FileViewModeSent>,
+    With<vmux_core::page::PageReady>,
+);
+type ReadySentViewMode = (
+    With<FileView>,
+    With<FileViewModeSent>,
     With<vmux_core::page::PageReady>,
 );
 type TreeDirtyReady = (With<ExplorerTreeDirty>, With<vmux_core::page::PageReady>);
@@ -352,9 +368,14 @@ fn load_file_buffers(
             folds.reconcile();
         }
         core.fold_view = folds.view(core.buffer.len_lines() as u32);
-        commands
-            .entity(entity)
-            .insert((EditState { core, hl, folds }, EditorKeymap(kind.make())));
+        commands.entity(entity).insert((
+            EditState { core, hl, folds },
+            EditorKeymap(kind.make()),
+            vmux_git::GitDiffSource {
+                content: text,
+                dirty: false,
+            },
+        ));
     }
 }
 
@@ -489,6 +510,39 @@ fn send_file_theme(
             },
         ));
         commands.entity(entity).insert(FileThemeSent);
+    }
+}
+
+fn send_file_view_mode(
+    mode: Res<SharedFileViewMode>,
+    pending: Query<Entity, ReadyUnsentViewMode>,
+    sent: Query<Entity, ReadySentViewMode>,
+    browsers: NonSend<Browsers>,
+    mut commands: Commands,
+) {
+    let event = FileViewModeEvent { mode: mode.0 };
+    for entity in &pending {
+        if !browsers.has_browser(entity) || !browsers.host_emit_ready(&entity) {
+            continue;
+        }
+        commands.trigger(BinHostEmitEvent::from_rkyv(
+            entity,
+            FILE_VIEW_MODE_EVENT,
+            &event,
+        ));
+        commands.entity(entity).insert(FileViewModeSent);
+    }
+    if mode.is_changed() {
+        for entity in &sent {
+            if !browsers.has_browser(entity) || !browsers.host_emit_ready(&entity) {
+                continue;
+            }
+            commands.trigger(BinHostEmitEvent::from_rkyv(
+                entity,
+                FILE_VIEW_MODE_EVENT,
+                &event,
+            ));
+        }
     }
 }
 
@@ -629,6 +683,7 @@ fn reset_file_sent_markers_on_page_ready(
         .entity(entity)
         .remove::<FileInitialMetaSent>()
         .remove::<FileThemeSent>()
+        .remove::<FileViewModeSent>()
         .remove::<crate::lsp::manager::LspStatusSent>()
         .remove::<crate::lsp::manager::DiagSent>()
         .remove::<ExplorerChromeSent>()
@@ -636,6 +691,16 @@ fn reset_file_sent_markers_on_page_ready(
         .insert(OpenEditorsDirty);
     if crate::explorer_model::is_markdown(&fv.path) {
         commands.entity(entity).insert(OutlineDirty);
+    }
+}
+
+fn on_file_view_mode_set(
+    trigger: On<BinReceive<FileViewModeSet>>,
+    views: Query<(), With<FileView>>,
+    mut mode: ResMut<SharedFileViewMode>,
+) {
+    if views.contains(trigger.event().webview) {
+        mode.0 = trigger.event().payload.mode;
     }
 }
 
@@ -1006,6 +1071,7 @@ fn navigate_file_view(
         .remove::<FileBuffer>()
         .remove::<FileMedia>()
         .remove::<EditState>()
+        .remove::<vmux_git::GitDiffSource>()
         .remove::<EditorKeymap>()
         .remove::<LspEditDirty>()
         .remove::<FileInitialMetaSent>()
@@ -1203,6 +1269,7 @@ fn reload_changed_files(
         commands
             .entity(entity)
             .remove::<EditState>()
+            .remove::<vmux_git::GitDiffSource>()
             .remove::<FileBuffer>()
             .remove::<FileInitialMetaSent>()
             .remove::<crate::lsp::manager::LintRan>();
@@ -1255,6 +1322,7 @@ fn run_commands(
     entity: Entity,
     cmds: Vec<EditCommand>,
     edit: &mut EditState,
+    diff_source: &mut vmux_git::GitDiffSource,
     keymap: &dyn Keymap,
     vp: &mut FileViewport,
     clipboard: &mut ClipboardHandle,
@@ -1419,7 +1487,9 @@ fn run_commands(
     if fold_changed {
         commands.entity(entity).insert(FoldsDirty);
     }
-    if dirty_changed {
+    if text_changed || dirty_changed {
+        diff_source.content = edit.core.buffer.text();
+        diff_source.dirty = edit.core.dirty;
         commands.trigger(BinHostEmitEvent::from_rkyv(
             entity,
             FILE_DIRTY_EVENT,
@@ -1439,7 +1509,12 @@ fn run_commands(
 
 fn on_file_key(
     trigger: On<BinReceive<FileKeyEvent>>,
-    mut q: Query<(&mut EditState, &mut EditorKeymap, &mut FileViewport)>,
+    mut q: Query<(
+        &mut EditState,
+        &mut EditorKeymap,
+        &mut FileViewport,
+        &mut vmux_git::GitDiffSource,
+    )>,
     mut clipboard: NonSendMut<ClipboardHandle>,
     mut self_writes: NonSendMut<SelfWrites>,
     mut manager: NonSendMut<crate::lsp::manager::LspManager>,
@@ -1448,7 +1523,7 @@ fn on_file_key(
 ) {
     let entity = trigger.event().webview;
     let evt = &trigger.event().payload;
-    let Ok((mut edit, mut keymap, mut vp)) = q.get_mut(entity) else {
+    let Ok((mut edit, mut keymap, mut vp, mut diff_source)) = q.get_mut(entity) else {
         return;
     };
     let input = KeyInput {
@@ -1469,6 +1544,7 @@ fn on_file_key(
         entity,
         cmds,
         &mut edit,
+        &mut diff_source,
         keymap.0.as_ref(),
         &mut vp,
         &mut clipboard,
@@ -1481,7 +1557,12 @@ fn on_file_key(
 
 fn on_file_text_input(
     trigger: On<BinReceive<FileTextInput>>,
-    mut q: Query<(&mut EditState, &EditorKeymap, &mut FileViewport)>,
+    mut q: Query<(
+        &mut EditState,
+        &EditorKeymap,
+        &mut FileViewport,
+        &mut vmux_git::GitDiffSource,
+    )>,
     mut clipboard: NonSendMut<ClipboardHandle>,
     mut self_writes: NonSendMut<SelfWrites>,
     mut manager: NonSendMut<crate::lsp::manager::LspManager>,
@@ -1493,7 +1574,7 @@ fn on_file_text_input(
     if text.is_empty() {
         return;
     }
-    let Ok((mut edit, keymap, mut vp)) = q.get_mut(entity) else {
+    let Ok((mut edit, keymap, mut vp, mut diff_source)) = q.get_mut(entity) else {
         return;
     };
     if !keymap.0.mode().accepts_text() {
@@ -1503,6 +1584,7 @@ fn on_file_text_input(
         entity,
         vec![EditCommand::InsertText(text)],
         &mut edit,
+        &mut diff_source,
         keymap.0.as_ref(),
         &mut vp,
         &mut clipboard,
@@ -1646,7 +1728,12 @@ fn on_file_goto_request(
 
 fn on_file_completion_commit(
     trigger: On<BinReceive<FileCompletionCommit>>,
-    mut q: Query<(&mut EditState, &EditorKeymap, &mut FileViewport)>,
+    mut q: Query<(
+        &mut EditState,
+        &EditorKeymap,
+        &mut FileViewport,
+        &mut vmux_git::GitDiffSource,
+    )>,
     mut clipboard: NonSendMut<ClipboardHandle>,
     mut self_writes: NonSendMut<SelfWrites>,
     mut manager: NonSendMut<crate::lsp::manager::LspManager>,
@@ -1655,7 +1742,7 @@ fn on_file_completion_commit(
 ) {
     let entity = trigger.event().webview;
     let req = trigger.event().payload.clone();
-    let Ok((mut edit, keymap, mut vp)) = q.get_mut(entity) else {
+    let Ok((mut edit, keymap, mut vp, mut diff_source)) = q.get_mut(entity) else {
         return;
     };
     let start = edit
@@ -1672,6 +1759,7 @@ fn on_file_completion_commit(
             EditCommand::InsertText(req.text),
         ],
         &mut edit,
+        &mut diff_source,
         keymap.0.as_ref(),
         &mut vp,
         &mut clipboard,
@@ -1746,6 +1834,7 @@ fn apply_goto(
             commands
                 .entity(g.entity)
                 .remove::<EditState>()
+                .remove::<vmux_git::GitDiffSource>()
                 .remove::<FileBuffer>()
                 .remove::<FileMedia>()
                 .remove::<FileDir>()
@@ -2179,6 +2268,7 @@ impl Plugin for EditorPlugin {
                 width: vmux_setting::EXPLORER_DEFAULT_WIDTH,
             })
             .init_resource::<ExplorerChromeSynced>()
+            .init_resource::<SharedFileViewMode>()
             .add_message::<vmux_core::event::RecordVisitRequest>()
             .add_plugins(crate::lsp::LspPlugin)
             .add_plugins(BinEventEmitterPlugin::<(
@@ -2200,6 +2290,7 @@ impl Plugin for EditorPlugin {
                 FileCompletionCommit,
                 FileOpenExternalRequest,
                 FileVideoRect,
+                FileViewModeSet,
             )>::default())
             .add_plugins(BinEventEmitterPlugin::<(
                 ExplorerTreeToggle,
@@ -2223,6 +2314,7 @@ impl Plugin for EditorPlugin {
                     send_initial_media.after(sync_media_allowlist),
                     (detach_video_overlays, attach_video_overlays).chain(),
                     send_file_theme,
+                    send_file_view_mode,
                     rehighlight_on_color_scheme,
                     drain_thumb_tasks,
                     reconcile_file_watches,
@@ -2266,6 +2358,7 @@ impl Plugin for EditorPlugin {
             .add_observer(on_file_goto_request)
             .add_observer(on_file_completion_commit)
             .add_observer(on_file_fold_toggle)
+            .add_observer(on_file_view_mode_set)
             .add_observer(on_explorer_tree_toggle)
             .add_observer(on_explorer_panel_toggle)
             .add_observer(on_explorer_panel_width)
@@ -2278,6 +2371,60 @@ impl Plugin for EditorPlugin {
 mod edit_flow_tests {
     use super::*;
     use crate::keymap::{KeyInput, KeymapKindExt, Mods};
+
+    #[test]
+    fn file_view_mode_is_shared_across_editors() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<SharedFileViewMode>()
+            .add_observer(on_file_view_mode_set);
+        let first = app
+            .world_mut()
+            .spawn(FileView {
+                path: PathBuf::from("/a.rs"),
+            })
+            .id();
+        let second = app
+            .world_mut()
+            .spawn(FileView {
+                path: PathBuf::from("/b.rs"),
+            })
+            .id();
+
+        app.world_mut().trigger(BinReceive {
+            webview: first,
+            payload: FileViewModeSet {
+                mode: FileViewMode::Diff,
+            },
+        });
+
+        assert_eq!(
+            app.world().resource::<SharedFileViewMode>().0,
+            FileViewMode::Diff
+        );
+        assert!(app.world().get::<FileView>(second).is_some());
+    }
+
+    #[test]
+    fn non_editor_cannot_change_file_view_mode() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<SharedFileViewMode>()
+            .add_observer(on_file_view_mode_set);
+        let other = app.world_mut().spawn_empty().id();
+
+        app.world_mut().trigger(BinReceive {
+            webview: other,
+            payload: FileViewModeSet {
+                mode: FileViewMode::Diff,
+            },
+        });
+
+        assert_eq!(
+            app.world().resource::<SharedFileViewMode>().0,
+            FileViewMode::Editor
+        );
+    }
 
     #[test]
     fn parse_goto_fragment_line_and_select() {

--- a/crates/vmux_editor/tests/page_source.rs
+++ b/crates/vmux_editor/tests/page_source.rs
@@ -31,3 +31,19 @@ fn page_mounts_panel_and_wires_toggle() {
     assert!(s.contains("ExplorerChromeEvent"));
     assert!(s.contains("ExplorerPanelWidth"));
 }
+
+#[test]
+fn page_wires_shared_editor_diff_toggle() {
+    let s = page_source();
+    assert!(s.contains("FileViewModeEvent"));
+    assert!(s.contains("FileViewModeSet"));
+    assert!(s.contains("Show diffs in all open files"));
+    assert!(s.contains("file_view_mode.set(next)"));
+    assert!(s.contains("if next == FileViewMode::Diff"));
+    assert!(s.contains("visible: file_view_mode() == FileViewMode::Diff"));
+    assert!(s.contains("markers: git_line_markers"));
+    assert!(s.contains("diff_marker_class(marker)"));
+    assert!(s.contains("schedule_git_refresh(git_refresh_generation, git_nonce)"));
+    assert!(s.contains("transition-transform duration-150"));
+    assert!(s.contains("if git_path() != m.abs_path"));
+}

--- a/crates/vmux_git/Cargo.toml
+++ b/crates/vmux_git/Cargo.toml
@@ -21,6 +21,7 @@ bevy_ecs = { workspace = true }
 bevy_cef = { workspace = true }
 bevy_cef_core = { workspace = true }
 syntect = { workspace = true }
+similar = "2"
 two-face = { version = "0.5", default-features = false, features = ["syntect-fancy"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/crates/vmux_git/src/job.rs
+++ b/crates/vmux_git/src/job.rs
@@ -7,11 +7,13 @@ use crate::{parse, runner};
 pub enum JobKind {
     Status {
         path: PathBuf,
+        dirty: bool,
     },
     Diff {
         path: PathBuf,
         top_line: u32,
         rows: u32,
+        content: Option<String>,
     },
     Stage {
         path: PathBuf,
@@ -84,15 +86,29 @@ fn mutate(
 
 pub fn run_job(job: JobKind) -> Vec<Emit> {
     match job {
-        JobKind::Status { path } => match runner::status(&path) {
-            Ok(ev) => vec![Emit::Status(ev)],
+        JobKind::Status { path, dirty } => match runner::status(&path) {
+            Ok(mut ev) => {
+                if dirty {
+                    ev.file_status = match ev.file_status {
+                        FileStatus::Clean => FileStatus::Modified,
+                        FileStatus::Staged => FileStatus::StagedModified,
+                        status => status,
+                    };
+                }
+                vec![Emit::Status(ev)]
+            }
             Err(e) => vec![Emit::Error(GitErrorEvent { message: e.0 })],
         },
         JobKind::Diff {
             path,
             top_line,
             rows,
-        } => match runner::diff_lines(&path) {
+            content,
+        } => match content
+            .as_deref()
+            .map(|content| runner::diff_lines_with_content(&path, content))
+            .unwrap_or_else(|| runner::diff_lines(&path))
+        {
             Ok(lines) => {
                 let (total, win) = parse::window(&lines, top_line, rows);
                 vec![
@@ -153,7 +169,10 @@ mod tests {
     #[test]
     fn status_job_emits_status() {
         let (_repo, file) = dirty_repo();
-        let emits = run_job(JobKind::Status { path: file });
+        let emits = run_job(JobKind::Status {
+            path: file,
+            dirty: false,
+        });
         assert!(matches!(emits.as_slice(), [Emit::Status(_)]));
     }
 
@@ -164,6 +183,7 @@ mod tests {
             path: file,
             top_line: 0,
             rows: 50,
+            content: None,
         });
         assert!(matches!(emits[0], Emit::DiffMeta(_)));
         assert!(matches!(emits[1], Emit::DiffViewport(_)));
@@ -186,7 +206,31 @@ mod tests {
     fn job_on_non_repo_emits_error() {
         let dir = tempfile::tempdir().unwrap();
         let file = test_repo::write(dir.path(), "loose.txt", "x");
-        let emits = run_job(JobKind::Status { path: file });
+        let emits = run_job(JobKind::Status {
+            path: file,
+            dirty: false,
+        });
         assert!(matches!(emits.as_slice(), [Emit::Error(_)]));
+    }
+
+    #[test]
+    fn dirty_buffer_changes_clean_status_to_modified() {
+        let repo = test_repo::init();
+        let file = test_repo::write(repo.path(), "a.txt", "one\n");
+        test_repo::run(repo.path(), &["add", "a.txt"]);
+        test_repo::run(repo.path(), &["commit", "-qm", "init"]);
+
+        let emits = run_job(JobKind::Status {
+            path: file,
+            dirty: true,
+        });
+
+        assert!(matches!(
+            emits.as_slice(),
+            [Emit::Status(GitStatusEvent {
+                file_status: FileStatus::Modified,
+                ..
+            })]
+        ));
     }
 }

--- a/crates/vmux_git/src/lib.rs
+++ b/crates/vmux_git/src/lib.rs
@@ -2,6 +2,7 @@
 //! to the `files://` editor page.
 
 pub mod event;
+pub mod view;
 
 #[cfg(target_arch = "wasm32")]
 pub mod ui;
@@ -19,6 +20,13 @@ pub mod worktree;
 
 #[cfg(not(target_arch = "wasm32"))]
 use bevy::prelude::*;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Component, Clone, Debug, Default)]
+pub struct GitDiffSource {
+    pub content: String,
+    pub dirty: bool,
+}
 
 pub const FILES_HOST: &str = "files";
 

--- a/crates/vmux_git/src/plugin.rs
+++ b/crates/vmux_git/src/plugin.rs
@@ -6,7 +6,7 @@ use crate::event::{
     GitCommitRequest, GitDiffRequest, GitDiscardRequest, GitHunkRequest, GitPushRequest,
     GitStageRequest, GitStatusRequest, GitUnstageRequest,
 };
-use crate::job::{emit_event_name, run_job, Emit, JobKind};
+use crate::job::{Emit, JobKind, emit_event_name, run_job};
 
 pub type OutboxQueue = Vec<(Entity, Vec<Emit>)>;
 
@@ -52,18 +52,34 @@ fn spawn_job(outbox: &GitOutbox, webview: Entity, job: JobKind) {
     });
 }
 
-fn on_status_request(trigger: On<BinReceive<GitStatusRequest>>, outbox: Res<GitOutbox>) {
+fn on_status_request(
+    trigger: On<BinReceive<GitStatusRequest>>,
+    sources: Query<&GitDiffSource>,
+    outbox: Res<GitOutbox>,
+) {
     spawn_job(&outbox, trigger.event().webview, JobKind::Status {
         path: trigger.event().payload.path.clone().into(),
+        dirty: sources
+            .get(trigger.event().webview)
+            .is_ok_and(|source| source.dirty),
     });
 }
 
-fn on_diff_request(trigger: On<BinReceive<GitDiffRequest>>, outbox: Res<GitOutbox>) {
+fn on_diff_request(
+    trigger: On<BinReceive<GitDiffRequest>>,
+    sources: Query<&GitDiffSource>,
+    outbox: Res<GitOutbox>,
+) {
     let p = &trigger.event().payload;
     spawn_job(&outbox, trigger.event().webview, JobKind::Diff {
         path: p.path.clone().into(),
         top_line: p.top_line,
         rows: p.rows,
+        content: sources
+            .get(trigger.event().webview)
+            .ok()
+            .filter(|source| source.dirty)
+            .map(|source| source.content.clone()),
     });
 }
 

--- a/crates/vmux_git/src/runner.rs
+++ b/crates/vmux_git/src/runner.rs
@@ -3,6 +3,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
 
+use similar::{ChangeTag, TextDiff};
+
 use crate::event::*;
 use crate::parse;
 
@@ -245,6 +247,71 @@ fn staged_only_lines(
             }
         })
         .collect();
+    Ok(lines)
+}
+
+fn index_text(root: &Path, target: &str) -> Result<String, GitError> {
+    let spec = format!(":{target}");
+    let (out, _, ok) = git(root, &["show", &spec])?;
+    if ok { Ok(out) } else { Ok(String::new()) }
+}
+
+pub fn diff_lines_with_content(file: &Path, content: &str) -> Result<Vec<DiffLine>, GitError> {
+    let root = repo_root(file)?;
+    let target = rel(&root, file);
+    let baseline = index_text(&root, &target)?;
+    let staged = staged_lineset(&root, &target);
+    let new_spans = crate::highlight::highlight_file(content, file);
+    let mut old_no = 1u32;
+    let mut new_no = 1u32;
+    let mut lines = Vec::new();
+
+    for change in TextDiff::from_lines(baseline.as_str(), content).iter_all_changes() {
+        let text = change.value().trim_end_matches(['\n', '\r']);
+        match change.tag() {
+            ChangeTag::Equal => {
+                lines.push(DiffLine {
+                    kind: if staged.contains(&old_no) {
+                        DiffKind::Staged
+                    } else {
+                        DiffKind::Context
+                    },
+                    old_no: Some(old_no),
+                    new_no: Some(new_no),
+                    hunk: None,
+                    spans: new_spans
+                        .get(new_no.saturating_sub(1) as usize)
+                        .cloned()
+                        .unwrap_or_else(|| crate::highlight::highlight_line(text, file)),
+                });
+                old_no += 1;
+                new_no += 1;
+            }
+            ChangeTag::Delete => {
+                lines.push(DiffLine {
+                    kind: DiffKind::Remove,
+                    old_no: Some(old_no),
+                    new_no: None,
+                    hunk: None,
+                    spans: crate::highlight::highlight_line(text, file),
+                });
+                old_no += 1;
+            }
+            ChangeTag::Insert => {
+                lines.push(DiffLine {
+                    kind: DiffKind::Add,
+                    old_no: None,
+                    new_no: Some(new_no),
+                    hunk: None,
+                    spans: new_spans
+                        .get(new_no.saturating_sub(1) as usize)
+                        .cloned()
+                        .unwrap_or_else(|| crate::highlight::highlight_line(text, file)),
+                });
+                new_no += 1;
+            }
+        }
+    }
     Ok(lines)
 }
 
@@ -510,6 +577,28 @@ mod tests {
         let lines = diff_lines(&file).unwrap();
         assert!(lines.iter().any(|l| matches!(l.kind, DiffKind::Add)));
         assert!(lines.iter().any(|l| matches!(l.kind, DiffKind::Remove)));
+    }
+
+    #[test]
+    fn diff_lines_with_content_reads_unsaved_buffer() {
+        let repo = test_repo::init();
+        let file = test_repo::write(repo.path(), "a.txt", "one\ntwo\nthree\n");
+        test_repo::run(repo.path(), &["add", "a.txt"]);
+        test_repo::run(repo.path(), &["commit", "-qm", "init"]);
+
+        let lines = diff_lines_with_content(&file, "one\nchanged\nthree\n").unwrap();
+
+        assert!(
+            lines
+                .iter()
+                .any(|line| { matches!(line.kind, DiffKind::Remove) && line.old_no == Some(2) })
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|line| { matches!(line.kind, DiffKind::Add) && line.new_no == Some(2) })
+        );
+        assert_eq!(std::fs::read_to_string(file).unwrap(), "one\ntwo\nthree\n");
     }
 
     #[test]

--- a/crates/vmux_git/src/ui.rs
+++ b/crates/vmux_git/src/ui.rs
@@ -1,14 +1,17 @@
 #![allow(non_snake_case)]
 
+use std::collections::{HashMap, HashSet};
+
 use dioxus::prelude::*;
 use vmux_ui::components::icon::Icon;
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener};
 
 use crate::event::*;
+use crate::view::{DiffViewRow, EditorDiffMarker, diff_view_rows, editor_diff_markers};
 
 const DIFF_WINDOW_ROWS: u32 = 200_000;
 
-fn is_dirty(s: FileStatus) -> bool {
+fn status_has_diff(s: FileStatus) -> bool {
     matches!(
         s,
         FileStatus::Modified
@@ -106,7 +109,7 @@ fn sign_style(kind: DiffKind) -> &'static str {
 #[component]
 pub fn GitBar(
     path: ReadSignal<String>,
-    show_diff: Signal<bool>,
+    has_diff: Signal<bool>,
     nonce: Signal<u32>,
     display_path: Signal<String>,
     branch: Signal<String>,
@@ -123,7 +126,7 @@ pub fn GitBar(
         ahead.set(s.ahead);
         behind.set(s.behind);
         staged_count.set(s.staged_count);
-        show_diff.set(is_dirty(s.file_status));
+        has_diff.set(status_has_diff(s.file_status));
         file_status.set(s.file_status);
         display_path.set(repo_display_path(&path(), &s.repo_root));
     });
@@ -289,18 +292,38 @@ pub fn GitFooter(
 }
 
 #[component]
-pub fn DiffView(path: ReadSignal<String>, nonce: ReadSignal<u32>) -> Element {
+pub fn DiffView(
+    path: ReadSignal<String>,
+    nonce: ReadSignal<u32>,
+    visible: bool,
+    markers: Signal<HashMap<u32, EditorDiffMarker>>,
+) -> Element {
     let mut lines = use_signal(Vec::<DiffLine>::new);
+    let mut expanded = use_signal(HashSet::<(usize, usize)>::new);
+    let mut loading = use_signal(|| true);
+    let mut error = use_signal(String::new);
 
     let _vp =
         use_bin_event_listener::<GitDiffViewportEvent, _>(GIT_DIFF_VIEWPORT_EVENT, move |p| {
+            markers.set(editor_diff_markers(&p.lines));
             lines.set(p.lines);
+            expanded.set(HashSet::new());
+            loading.set(false);
+            error.set(String::new());
         });
+    let _error = use_bin_event_listener::<GitErrorEvent, _>(GIT_ERROR_EVENT, move |event| {
+        error.set(event.message);
+        loading.set(false);
+    });
 
     use_effect(move || {
         let p = path();
         let _ = nonce();
         if !p.is_empty() {
+            loading.set(true);
+            error.set(String::new());
+            lines.set(Vec::new());
+            expanded.set(HashSet::new());
             let _ = try_cef_bin_emit_rkyv(&GitDiffRequest {
                 path: p,
                 top_line: 0,
@@ -310,6 +333,7 @@ pub fn DiffView(path: ReadSignal<String>, nonce: ReadSignal<u32>) -> Element {
     });
 
     let rows = lines();
+    let display_rows = diff_view_rows(&rows, &expanded());
     let maxno = rows
         .iter()
         .flat_map(|l| [l.old_no, l.new_no])
@@ -328,55 +352,95 @@ pub fn DiffView(path: ReadSignal<String>, nonce: ReadSignal<u32>) -> Element {
 
     rsx! {
         div {
-            class: "min-h-0 flex-1 overflow-auto",
+            class: if visible { "min-h-0 flex-1 overflow-auto" } else { "hidden" },
 
-            if rows.is_empty() {
+            if loading() {
+                div { class: "flex h-20 items-center justify-center font-sans text-xs text-muted-foreground",
+                    span { class: "animate-pulse", "Loading diff…" }
+                }
+            } else if !error().is_empty() {
+                div { class: "p-3 font-sans text-xs text-ansi-1", "{error}" }
+            } else if rows.is_empty() {
                 div { class: "p-3 text-xs text-muted-foreground", "No changes to show" }
             }
 
-            for (i, line) in rows.iter().enumerate() {
-                div { key: "{line.kind:?}-{line.old_no:?}-{line.new_no:?}",
-                div { class: "flex whitespace-pre", style: "{row_bg(line.kind)}",
-                    span {
-                        class: "shrink-0 select-none px-1 text-right tabular-nums opacity-30",
-                        style: "width:calc(var(--cw, 1ch) * {gw});",
-                        "{opt_no(line.old_no)}"
-                    }
-                    span {
-                        class: "shrink-0 select-none px-1 text-right tabular-nums opacity-30",
-                        style: "width:calc(var(--cw, 1ch) * {gw});",
-                        "{opt_no(line.new_no)}"
-                    }
-                    span {
-                        class: "shrink-0 select-none px-1 text-center",
-                        style: "{sign_style(line.kind)}",
-                        "{sign(line.kind)}"
-                    }
-                    span { class: "pr-6",
-                        for (j, s) in line.spans.iter().enumerate() {
-                            span { key: "{j}", style: "{span_style(s)}", "{s.text}" }
+            for display_row in display_rows {
+                match display_row {
+                    DiffViewRow::Line(i) => {
+                        let line = &rows[i];
+                        rsx! {
+                            div { key: "line-{i}-{line.kind:?}-{line.old_no:?}-{line.new_no:?}",
+                                div { class: "flex whitespace-pre", style: "{row_bg(line.kind)}",
+                                    span {
+                                        class: "shrink-0 select-none border-r border-foreground/[0.06] bg-foreground/[0.025] px-1 text-right tabular-nums opacity-40",
+                                        style: "width:calc(var(--cw, 1ch) * {gw});",
+                                        "{opt_no(line.old_no)}"
+                                    }
+                                    span {
+                                        class: "shrink-0 select-none border-r border-foreground/[0.06] bg-foreground/[0.025] px-1 text-right tabular-nums opacity-40",
+                                        style: "width:calc(var(--cw, 1ch) * {gw});",
+                                        "{opt_no(line.new_no)}"
+                                    }
+                                    span {
+                                        class: "shrink-0 select-none px-1 text-center",
+                                        style: "{sign_style(line.kind)}",
+                                        "{sign(line.kind)}"
+                                    }
+                                    span { class: "pr-6",
+                                        for (j, styled) in line.spans.iter().enumerate() {
+                                            span { key: "{j}", style: "{span_style(styled)}", "{styled.text}" }
+                                        }
+                                    }
+                                }
+                                if let Some(h) = ends[i] {
+                                    div {
+                                        class: "flex items-center justify-end gap-2 border-y border-foreground/[0.05] bg-foreground/[0.02] px-2 py-0.5 pr-6 font-sans text-xs select-none",
+                                        button {
+                                            class: "rounded px-1.5 py-0.5 text-ansi-2 hover:bg-ansi-2/15",
+                                            onclick: move |_| {
+                                                let _ = try_cef_bin_emit_rkyv(&GitHunkRequest { path: path(), hunk: h, accept: true });
+                                            },
+                                            "\u{2713} accept"
+                                        }
+                                        button {
+                                            class: "rounded px-1.5 py-0.5 text-ansi-1 hover:bg-ansi-1/15",
+                                            onclick: move |_| {
+                                                let _ = try_cef_bin_emit_rkyv(&GitHunkRequest { path: path(), hunk: h, accept: false });
+                                            },
+                                            "\u{2717} deny"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    DiffViewRow::Gap { start, end } => {
+                        let hidden = end - start;
+                        rsx! {
+                            div {
+                                key: "gap-{start}-{end}",
+                                class: "border-y border-cyan-400/10 bg-cyan-400/[0.035] font-sans",
+                                button {
+                                    class: "group flex h-7 w-full items-center gap-2 px-2 text-[11px] text-cyan-700/75 hover:bg-cyan-400/[0.08] hover:text-cyan-700 dark:text-cyan-200/70 dark:hover:text-cyan-100",
+                                    title: "Show {hidden} unchanged lines",
+                                    onclick: move |_| {
+                                        expanded.write().insert((start, end));
+                                    },
+                                    svg {
+                                        class: "h-3.5 w-3.5 shrink-0 transition-transform group-hover:translate-y-0.5",
+                                        view_box: "0 0 24 24",
+                                        fill: "none",
+                                        stroke: "currentColor",
+                                        stroke_width: "2",
+                                        stroke_linecap: "round",
+                                        stroke_linejoin: "round",
+                                        path { d: "m6 9 6 6 6-6" }
+                                    }
+                                    span { "Show {hidden} unchanged lines" }
+                                }
+                            }
                         }
                     }
-                }
-                if let Some(h) = ends[i] {
-                    div {
-                        class: "flex items-center justify-end gap-2 px-2 pr-6 py-0.5 font-sans text-xs select-none",
-                        button {
-                            class: "rounded px-1.5 py-0.5 text-ansi-2 hover:bg-ansi-2/15",
-                            onclick: move |_| {
-                                let _ = try_cef_bin_emit_rkyv(&GitHunkRequest { path: path(), hunk: h, accept: true });
-                            },
-                            "\u{2713} accept"
-                        }
-                        button {
-                            class: "rounded px-1.5 py-0.5 text-ansi-1 hover:bg-ansi-1/15",
-                            onclick: move |_| {
-                                let _ = try_cef_bin_emit_rkyv(&GitHunkRequest { path: path(), hunk: h, accept: false });
-                            },
-                            "\u{2717} deny"
-                        }
-                    }
-                }
                 }
             }
         }

--- a/crates/vmux_git/src/view.rs
+++ b/crates/vmux_git/src/view.rs
@@ -1,0 +1,238 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::event::{DiffKind, DiffLine};
+
+pub const DEFAULT_CONTEXT_LINES: usize = 3;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DiffViewRow {
+    Line(usize),
+    Gap { start: usize, end: usize },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EditorDiffMarker {
+    Added,
+    Modified,
+    Deleted,
+    Staged,
+}
+
+fn insert_marker(
+    markers: &mut HashMap<u32, EditorDiffMarker>,
+    line: u32,
+    marker: EditorDiffMarker,
+) {
+    let priority = |marker| match marker {
+        EditorDiffMarker::Staged => 0,
+        EditorDiffMarker::Deleted => 1,
+        EditorDiffMarker::Added => 2,
+        EditorDiffMarker::Modified => 3,
+    };
+    match markers.get(&line) {
+        Some(current) if priority(*current) >= priority(marker) => {}
+        _ => {
+            markers.insert(line, marker);
+        }
+    }
+}
+
+pub fn editor_diff_markers(lines: &[DiffLine]) -> HashMap<u32, EditorDiffMarker> {
+    let mut markers = HashMap::new();
+    let mut hunk_kinds = HashMap::<u32, (bool, bool)>::new();
+    for line in lines {
+        let Some(hunk) = line.hunk else {
+            continue;
+        };
+        let kinds = hunk_kinds.entry(hunk).or_default();
+        match line.kind {
+            DiffKind::Add => kinds.0 = true,
+            DiffKind::Remove => kinds.1 = true,
+            _ => {}
+        }
+    }
+    let mut replacement_lines = HashSet::new();
+    let mut i = 0;
+    while i < lines.len() {
+        if matches!(lines[i].kind, DiffKind::Context | DiffKind::Staged) || lines[i].hunk.is_some()
+        {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        while i < lines.len()
+            && !matches!(lines[i].kind, DiffKind::Context | DiffKind::Staged)
+            && lines[i].hunk.is_none()
+        {
+            i += 1;
+        }
+        let range = start..i;
+        let has_add = range
+            .clone()
+            .any(|index| matches!(lines[index].kind, DiffKind::Add));
+        let has_remove = range
+            .clone()
+            .any(|index| matches!(lines[index].kind, DiffKind::Remove));
+        if has_add && has_remove {
+            replacement_lines.extend(range);
+        }
+    }
+
+    for (i, line) in lines.iter().enumerate() {
+        match line.kind {
+            DiffKind::Add => {
+                let Some(new_no) = line.new_no else {
+                    continue;
+                };
+                let modified = line
+                    .hunk
+                    .and_then(|hunk| hunk_kinds.get(&hunk))
+                    .is_some_and(|(added, removed)| *added && *removed)
+                    || replacement_lines.contains(&i);
+                insert_marker(
+                    &mut markers,
+                    new_no,
+                    if modified {
+                        EditorDiffMarker::Modified
+                    } else {
+                        EditorDiffMarker::Added
+                    },
+                );
+            }
+            DiffKind::Remove => {
+                let next = lines[i + 1..].iter().find_map(|next| next.new_no);
+                let previous = lines[..i].iter().rev().find_map(|previous| previous.new_no);
+                if let Some(anchor) = next.or(previous) {
+                    insert_marker(&mut markers, anchor, EditorDiffMarker::Deleted);
+                }
+            }
+            DiffKind::Staged => {
+                if let Some(new_no) = line.new_no {
+                    insert_marker(&mut markers, new_no, EditorDiffMarker::Staged);
+                }
+            }
+            DiffKind::Context | DiffKind::Hunk => {}
+        }
+    }
+    markers
+}
+
+pub fn diff_view_rows(lines: &[DiffLine], expanded: &HashSet<(usize, usize)>) -> Vec<DiffViewRow> {
+    let mut visible = vec![false; lines.len()];
+    for (i, line) in lines.iter().enumerate() {
+        if matches!(line.kind, DiffKind::Context) {
+            continue;
+        }
+        let start = i.saturating_sub(DEFAULT_CONTEXT_LINES);
+        let end = (i + DEFAULT_CONTEXT_LINES + 1).min(lines.len());
+        visible[start..end].fill(true);
+    }
+
+    let mut rows = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        if visible[i] {
+            rows.push(DiffViewRow::Line(i));
+            i += 1;
+            continue;
+        }
+        let start = i;
+        while i < lines.len() && !visible[i] {
+            i += 1;
+        }
+        let end = i;
+        if expanded.contains(&(start, end)) {
+            rows.extend((start..end).map(DiffViewRow::Line));
+        } else {
+            rows.push(DiffViewRow::Gap { start, end });
+        }
+    }
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::StyledSpan;
+
+    fn line(kind: DiffKind, no: u32) -> DiffLine {
+        DiffLine {
+            kind,
+            old_no: Some(no),
+            new_no: Some(no),
+            hunk: None,
+            spans: Vec::<StyledSpan>::new(),
+        }
+    }
+
+    #[test]
+    fn collapses_context_outside_changed_hunks() {
+        let mut lines = (1..=20)
+            .map(|no| line(DiffKind::Context, no))
+            .collect::<Vec<_>>();
+        lines[9].kind = DiffKind::Add;
+
+        let rows = diff_view_rows(&lines, &HashSet::new());
+
+        assert_eq!(rows.first(), Some(&DiffViewRow::Gap { start: 0, end: 6 }));
+        assert_eq!(rows.last(), Some(&DiffViewRow::Gap { start: 13, end: 20 }));
+        assert!(rows.contains(&DiffViewRow::Line(9)));
+    }
+
+    #[test]
+    fn expands_selected_context_gap() {
+        let mut lines = (1..=20)
+            .map(|no| line(DiffKind::Context, no))
+            .collect::<Vec<_>>();
+        lines[9].kind = DiffKind::Add;
+        let expanded = HashSet::from([(0, 6)]);
+
+        let rows = diff_view_rows(&lines, &expanded);
+
+        assert_eq!(rows.first(), Some(&DiffViewRow::Line(0)));
+        assert!(!rows.contains(&DiffViewRow::Gap { start: 0, end: 6 }));
+        assert!(rows.contains(&DiffViewRow::Gap { start: 13, end: 20 }));
+    }
+
+    #[test]
+    fn editor_markers_classify_modified_added_and_deleted_lines() {
+        let lines = vec![
+            DiffLine {
+                kind: DiffKind::Remove,
+                old_no: Some(2),
+                new_no: None,
+                hunk: None,
+                spans: Vec::new(),
+            },
+            DiffLine {
+                kind: DiffKind::Add,
+                old_no: None,
+                new_no: Some(2),
+                hunk: None,
+                spans: Vec::new(),
+            },
+            line(DiffKind::Context, 3),
+            DiffLine {
+                kind: DiffKind::Add,
+                old_no: None,
+                new_no: Some(8),
+                hunk: Some(1),
+                spans: Vec::new(),
+            },
+            DiffLine {
+                kind: DiffKind::Remove,
+                old_no: Some(12),
+                new_no: None,
+                hunk: Some(2),
+                spans: Vec::new(),
+            },
+            line(DiffKind::Context, 12),
+        ];
+
+        let markers = editor_diff_markers(&lines);
+
+        assert_eq!(markers.get(&2), Some(&EditorDiffMarker::Modified));
+        assert_eq!(markers.get(&8), Some(&EditorDiffMarker::Added));
+        assert_eq!(markers.get(&12), Some(&EditorDiffMarker::Deleted));
+    }
+}


### PR DESCRIPTION
## Context\n\nAgent and manual file edits need a focused review mode without leaving the editor. The previous diff experience was per-file, showed too much unchanged content, and could briefly display stale or empty state.\n\n## Implementation\n\nAdds a shared Editor/Diff mode across all open changed files. Diffs preload and react to disk changes plus unsaved editor buffers, render compact GitHub-style hunks with expandable context, and feed changed-line gutter markers back into editor mode. Clean files remain in the full editor.\n\n## Checks / QA\n\n- Open multiple changed and unchanged files, then toggle Editor/Diff and verify all changed files switch together while clean files stay in Editor.\n- Edit a file in the editor and externally while Diff is open; verify the displayed hunks and editor gutter markers refresh.\n- Expand collapsed unchanged ranges and verify line numbers, syntax colors, and hunk actions remain correct.