### PR TITLE
chore(release): v0.0.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10032,7 +10032,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10076,7 +10076,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_browser"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "base64 0.22.1",
  "bevy",
@@ -10102,7 +10102,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -10115,7 +10115,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -10130,7 +10130,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10149,7 +10149,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10214,7 +10214,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_editor"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "arboard",
  "bevy",
@@ -10257,7 +10257,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_git"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10275,7 +10275,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10296,7 +10296,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -10332,7 +10332,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "muda",
  "proc-macro2",
@@ -10342,7 +10342,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -10355,7 +10355,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_server"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "dioxus",
  "regex",
@@ -10376,7 +10376,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "agent-client-protocol",
  "alacritty_terminal",
@@ -10414,7 +10414,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10437,7 +10437,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10462,7 +10462,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_team"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10483,7 +10483,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10517,7 +10517,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "dioxus",
  "dioxus-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.23"
+version = "0.0.24"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "GPL-3.0-or-later"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.23"
-  sha256 "f581e688c429432ee077caa39e95924eefc615f17834e592ffbd4d1944644086"
+  version "0.0.24"
+  sha256 "991edceaddea936a8a64921d512c97842400fab75a312cf15b0448ff60a2cc8f"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.23/Vmux_0.0.23_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.24/Vmux_0.0.24_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai/"

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.23",
-  "pub_date": "2026-07-08T10:03:09Z",
+  "version": "v0.0.24",
+  "pub_date": "2026-07-15T06:42:47Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.23/Vmux-v0.0.23-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzBrU3grMkVPL094Y0U2Y21SNnBKVExJaGx3TXVENUpsVjlkV3FZSUhBcGRjNTU2TmNpMHVyWXdLdzA1b2VhckQrcHh2VjErQ2xQT2xzUDIrVFprS3dBPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgzNTAyNTU3CWZpbGU6Vm11eC12MC4wLjIzLWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKTmJ5L2lZYllyQTI1VUFtL0tsTldSK2FIU25wNktxSWVkUk1IYVpiOS8vdmc1WkFOTCt3WTZ6cjg1aFZaYlROK0lZRzdteUlPa285TWUvOG9QNERSQnc9PQo=",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.24/Vmux-v0.0.24-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzgvWkdnQ0c4YldZWXF3elFwWjhKUFphZU5LOWhLUXl1V21oVjBoakNudlFFNHBEQnZqZXVXQ3lXRWhVbXhzN0JwZUZjR05nNUVEamdKVnhQRDl1a1FJPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg0MDk3MDEzCWZpbGU6Vm11eC12MC4wLjI0LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKNTIybk0reGpXeG9iUWdMMlhlY2dkL1pNWlVPV2xqSTAyWitXakh0QWcwUkphN3l3V0tlSW5FUWdQeWRlT1A1WVRzeDFYTzlFOGJCcUthRDh1U2VtQUE9PQo=",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.23/Vmux_0.0.23_aarch64.dmg",
-      "filename": "Vmux_0.0.23_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.24/Vmux_0.0.24_aarch64.dmg",
+      "filename": "Vmux_0.0.24_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
Patch release. Bumps workspace version 0.0.23 -> 0.0.24. Releases on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.0.24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->