### PR TITLE
fix(agent): align activity timeline

### DIFF
--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -129,11 +129,6 @@ fn approval_detail_label(path: &str) -> String {
         .join(" · ")
 }
 
-#[cfg(any(test, target_arch = "wasm32"))]
-fn has_collapsible_steps(turn: &event::ChatTurn) -> bool {
-    !turn.steps.is_empty()
-}
-
 #[cfg(not(target_arch = "wasm32"))]
 pub struct AgentChatPagePlugin;
 
@@ -1047,18 +1042,6 @@ mod native_tests {
             ]
         );
         assert!(approval_details("{}").is_empty());
-    }
-
-    #[test]
-    fn empty_turn_has_no_collapsible_content() {
-        let empty = event::ChatTurn::default();
-        assert!(!has_collapsible_steps(&empty));
-
-        let populated = event::ChatTurn {
-            steps: vec![event::ChatBlock::Thinking("working".into())],
-            ..Default::default()
-        };
-        assert!(has_collapsible_steps(&populated));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -249,7 +249,7 @@ pub struct RuntimeSwitchRequest {
 }
 
 /// The page's block type inside a [`ChatTurn`]. Mirrors `vmux_service::message::AssistantBlock`
-/// plus `ToolResult`, which `group_turns` folds in from the top-level tool-result message.
+/// plus folded tool results and reconnect progress.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub enum ChatBlock {
     Text(String),
@@ -269,8 +269,13 @@ pub enum ChatBlock {
         steps: Vec<ChatPlanStep>,
     },
     ToolResult {
+        call_id: String,
         content: String,
         is_error: bool,
+    },
+    Reconnect {
+        attempt: u32,
+        total: u32,
     },
 }
 
@@ -289,18 +294,16 @@ pub enum ChatItem {
     Turn(ChatTurn),
 }
 
-/// One assistant turn: its collapsed step tree, its inline prose answer, and run-state.
+/// One assistant turn: its ordered prose/activity timeline and run-state.
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct ChatTurn {
-    /// Thinking / tool-use / tool-result / plan / diff — the collapsible "context tree".
-    pub steps: Vec<ChatBlock>,
-    /// Assistant prose — always rendered inline, never hidden.
-    pub answer: Vec<ChatBlock>,
+    /// Prose, thinking, tools, reconnects, plans, and diffs in transcript order.
+    pub blocks: Vec<ChatBlock>,
     /// True only for the live (tail) turn while the run is active.
     pub running: bool,
     /// Final wall-clock seconds for a turn that finished this process; `None` otherwise.
     pub duration_secs: Option<u32>,
-    /// `steps.len()`, sent explicitly for the header label.
+    /// Number of non-prose activity blocks.
     pub step_count: u32,
 }
 
@@ -360,14 +363,15 @@ mod tests {
         let items = vec![
             ChatItem::User { text: "hi".into() },
             ChatItem::Turn(ChatTurn {
-                steps: vec![
+                blocks: vec![
                     ChatBlock::Thinking("hmm".into()),
                     ChatBlock::ToolResult {
+                        call_id: "call-1".into(),
                         content: "ok".into(),
                         is_error: false,
                     },
+                    ChatBlock::Text("done".into()),
                 ],
-                answer: vec![ChatBlock::Text("done".into())],
                 running: false,
                 duration_secs: Some(12),
                 step_count: 2,
@@ -381,9 +385,9 @@ mod tests {
         };
         assert_eq!(turn.step_count, 2);
         assert_eq!(turn.duration_secs, Some(12));
-        assert_eq!(turn.answer.len(), 1);
+        assert_eq!(turn.blocks.len(), 3);
         assert!(matches!(
-            turn.steps[1],
+            turn.blocks[1],
             ChatBlock::ToolResult {
                 is_error: false,
                 ..

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -868,6 +868,8 @@ fn render_turn(key: usize, turn: &ChatTurn, verb: &str, elapsed: u32) -> Element
                     span {}
                     if turn.step_count == 0 {
                         span { class: "tabular-nums", "Worked for {fmt_elapsed(duration)}" }
+                    } else if turn.step_count == 1 {
+                        span { class: "tabular-nums", "Worked for {fmt_elapsed(duration)} · 1 step" }
                     } else {
                         span { class: "tabular-nums", "Worked for {fmt_elapsed(duration)} · {turn.step_count} steps" }
                     }
@@ -904,30 +906,38 @@ fn render_working(verb: &str, elapsed: u32) -> Element {
     }
 }
 
-fn render_activity_icon(kind: &str) -> Element {
+enum ActivityIcon {
+    Thinking,
+    Tool,
+    Output,
+    Plan,
+    Diff,
+    Reconnect,
+}
+
+fn render_activity_icon(kind: ActivityIcon) -> Element {
     let paths: &[&str] = match kind {
-        "thinking" => &[
+        ActivityIcon::Thinking => &[
             "m12 3-1.9 5.8a2 2 0 0 1-1.3 1.3L3 12l5.8 1.9a2 2 0 0 1 1.3 1.3L12 21l1.9-5.8a2 2 0 0 1 1.3-1.3L21 12l-5.8-1.9a2 2 0 0 1-1.3-1.3Z",
         ],
-        "tool" => &[
+        ActivityIcon::Tool => &[
             "M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76Z",
         ],
-        "output" => &["m4 17 6-6-6-6", "M12 19h8"],
-        "plan" => &[
+        ActivityIcon::Output => &["m4 17 6-6-6-6", "M12 19h8"],
+        ActivityIcon::Plan => &[
             "M4 19.5A2.5 2.5 0 0 1 6.5 17H20",
             "M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2Z",
         ],
-        "diff" => &[
+        ActivityIcon::Diff => &[
             "M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z",
             "M14 2v4a2 2 0 0 0 2 2h4",
         ],
-        "reconnect" => &[
+        ActivityIcon::Reconnect => &[
             "M5 12.55a11 11 0 0 1 14.08 0",
             "M1.42 9a16 16 0 0 1 21.16 0",
             "M8.53 16.11a6 6 0 0 1 6.95 0",
             "M12 20h.01",
         ],
-        _ => &[],
     };
     rsx! {
         span { class: "flex h-5 w-5 shrink-0 items-center justify-center text-muted-foreground", aria_hidden: "true",
@@ -978,7 +988,7 @@ fn render_block(key: usize, block: &ChatBlock) -> Element {
         },
         ChatBlock::Thinking(text) => rsx! {
             div { key: "{key}", class: "grid grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-2.5 py-1",
-                {render_activity_icon("thinking")}
+                {render_activity_icon(ActivityIcon::Thinking)}
                 details { class: "disclosure min-w-0 text-sm text-muted-foreground",
                     summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
                         span { class: "font-medium", "Thinking" }
@@ -990,7 +1000,7 @@ fn render_block(key: usize, block: &ChatBlock) -> Element {
         },
         ChatBlock::ToolUse { name, args, .. } => rsx! {
             div { key: "{key}", class: "grid grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-2.5 py-1",
-                {render_activity_icon("tool")}
+                {render_activity_icon(ActivityIcon::Tool)}
                 details { class: "disclosure min-w-0 text-sm text-muted-foreground",
                     summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
                         span { class: "font-medium", "{tool_label(name)}" }
@@ -1007,7 +1017,7 @@ fn render_block(key: usize, block: &ChatBlock) -> Element {
             let n = steps.len();
             rsx! {
                 div { key: "{key}", class: "grid grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-2.5 py-1",
-                    {render_activity_icon("plan")}
+                    {render_activity_icon(ActivityIcon::Plan)}
                     details { open: true, class: "disclosure min-w-0 text-sm",
                         summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
                             span { class: "font-medium text-foreground/80", "Plan" }
@@ -1051,7 +1061,7 @@ fn render_block(key: usize, block: &ChatBlock) -> Element {
             let fname = path.rsplit('/').next().unwrap_or(path.as_str()).to_string();
             rsx! {
                 div { key: "{key}", class: "grid grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-2.5 py-1",
-                    {render_activity_icon("diff")}
+                    {render_activity_icon(ActivityIcon::Diff)}
                     details { class: "disclosure min-w-0 text-sm text-muted-foreground",
                         summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
                             span { class: "font-medium", "Edited " }
@@ -1080,7 +1090,7 @@ fn render_block(key: usize, block: &ChatBlock) -> Element {
             let label = if *is_error { "Error" } else { "Output" };
             rsx! {
                 div { key: "{key}", class: "grid grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-2.5 py-1",
-                    {render_activity_icon("output")}
+                    {render_activity_icon(ActivityIcon::Output)}
                     details { class: "disclosure min-w-0 text-sm {tone}",
                         summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
                             span { class: "font-medium", "{label}" }
@@ -1093,7 +1103,7 @@ fn render_block(key: usize, block: &ChatBlock) -> Element {
         }
         ChatBlock::Reconnect { attempt, total } => rsx! {
             div { key: "{key}", class: "grid grid-cols-[1.25rem_minmax(0,1fr)] items-center gap-2.5 py-1 text-sm text-muted-foreground",
-                {render_activity_icon("reconnect")}
+                {render_activity_icon(ActivityIcon::Reconnect)}
                 span { class: "font-medium tabular-nums", "Reconnecting {attempt}/{total}" }
             }
         },

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -854,14 +854,24 @@ fn render_item(key: usize, item: &ChatItem, verb: &str, elapsed: u32) -> Element
 }
 
 fn render_turn(key: usize, turn: &ChatTurn, verb: &str, elapsed: u32) -> Element {
-    let show_header = turn.step_count > 0 || (turn.running && turn.answer.is_empty());
+    let reconnecting = matches!(turn.blocks.last(), Some(ChatBlock::Reconnect { .. }));
     rsx! {
-        div { key: "{key}", class: "flex max-w-[85%] flex-col gap-2 self-start",
-            if show_header {
-                {render_turn_header(turn, verb, elapsed)}
-            }
-            for (j , block) in turn.answer.iter().enumerate() {
+        div { key: "{key}", class: "flex max-w-[90%] flex-col gap-2.5 self-start",
+            for (j , block) in turn.blocks.iter().enumerate() {
                 {render_block(j, block)}
+            }
+            if turn.running && !reconnecting {
+                {render_working(verb, elapsed)}
+            }
+            if !turn.running && let Some(duration) = turn.duration_secs {
+                div { class: "grid grid-cols-[1.25rem_minmax(0,1fr)] gap-2.5 text-[11px] text-muted-foreground/70",
+                    span {}
+                    if turn.step_count == 0 {
+                        span { class: "tabular-nums", "Worked for {fmt_elapsed(duration)}" }
+                    } else {
+                        span { class: "tabular-nums", "Worked for {fmt_elapsed(duration)} · {turn.step_count} steps" }
+                    }
+                }
             }
         }
     }
@@ -876,66 +886,84 @@ fn render_disclosure_icon() -> Element {
     }
 }
 
-fn render_turn_header(turn: &ChatTurn, verb: &str, elapsed: u32) -> Element {
-    if !super::has_collapsible_steps(turn) {
-        return rsx! {
-            div { class: "rounded-xl bg-foreground/[0.04] px-3 py-2 ring-1 ring-inset ring-foreground/10",
-                div { class: "flex select-none items-center gap-2.5 text-sm",
-                    span { class: "flex items-end gap-1",
-                        span { class: "h-1.5 w-1.5 animate-bounce rounded-full bg-foreground/70 [animation-delay:-0.32s]" }
-                        span { class: "h-1.5 w-1.5 animate-bounce rounded-full bg-foreground/70 [animation-delay:-0.16s]" }
-                        span { class: "h-1.5 w-1.5 animate-bounce rounded-full bg-foreground/70" }
-                    }
-                    span { class: "animate-pulse bg-gradient-to-r from-foreground/45 via-foreground to-foreground/45 bg-clip-text font-medium text-transparent", "{verb}…" }
-                    span { class: "tabular-nums text-xs text-muted-foreground", "{fmt_elapsed(elapsed)}" }
+fn render_working(verb: &str, elapsed: u32) -> Element {
+    rsx! {
+        div { class: "grid grid-cols-[1.25rem_minmax(0,1fr)] items-center gap-2.5 py-1 text-sm text-muted-foreground",
+            span { class: "flex h-5 w-5 items-center justify-center",
+                span { class: "flex items-end gap-0.5",
+                    span { class: "h-1 w-1 animate-bounce rounded-full bg-current [animation-delay:-0.32s]" }
+                    span { class: "h-1 w-1 animate-bounce rounded-full bg-current [animation-delay:-0.16s]" }
+                    span { class: "h-1 w-1 animate-bounce rounded-full bg-current" }
                 }
             }
-        };
-    }
-    if turn.running {
-        rsx! {
-            details { class: "disclosure rounded-xl bg-foreground/[0.04] px-3 py-2 ring-1 ring-inset ring-foreground/10",
-                summary { class: "flex cursor-pointer select-none items-center gap-2.5 text-sm list-none [&::-webkit-details-marker]:hidden",
-                    {render_disclosure_icon()}
-                    span { class: "flex items-end gap-1",
-                        span { class: "h-1.5 w-1.5 animate-bounce rounded-full bg-foreground/70 [animation-delay:-0.32s]" }
-                        span { class: "h-1.5 w-1.5 animate-bounce rounded-full bg-foreground/70 [animation-delay:-0.16s]" }
-                        span { class: "h-1.5 w-1.5 animate-bounce rounded-full bg-foreground/70" }
-                    }
-                    span { class: "animate-pulse bg-gradient-to-r from-foreground/45 via-foreground to-foreground/45 bg-clip-text font-medium text-transparent", "{verb}…" }
-                    span { class: "tabular-nums text-xs text-muted-foreground", "{fmt_elapsed(elapsed)}" }
-                }
-                {render_steps(turn)}
-            }
-        }
-    } else {
-        let label = match turn.duration_secs {
-            Some(secs) => format!(
-                "Worked for {} · {} steps",
-                fmt_elapsed(secs),
-                turn.step_count
-            ),
-            None => format!("{} steps", turn.step_count),
-        };
-        rsx! {
-            details { class: "disclosure rounded-xl bg-foreground/[0.04] px-3 py-2 ring-1 ring-inset ring-foreground/10",
-                summary { class: "flex cursor-pointer select-none items-center gap-2 text-xs text-muted-foreground list-none [&::-webkit-details-marker]:hidden",
-                    {render_disclosure_icon()}
-                    span { class: "font-medium", "{label}" }
-                }
-                {render_steps(turn)}
+            div { class: "flex items-baseline gap-2",
+                span { class: "animate-pulse font-medium text-foreground/75", "{verb}" }
+                span { class: "tabular-nums text-xs", "{fmt_elapsed(elapsed)}" }
             }
         }
     }
 }
 
-fn render_steps(turn: &ChatTurn) -> Element {
+fn render_activity_icon(kind: &str) -> Element {
+    let paths: &[&str] = match kind {
+        "thinking" => &[
+            "m12 3-1.9 5.8a2 2 0 0 1-1.3 1.3L3 12l5.8 1.9a2 2 0 0 1 1.3 1.3L12 21l1.9-5.8a2 2 0 0 1 1.3-1.3L21 12l-5.8-1.9a2 2 0 0 1-1.3-1.3Z",
+        ],
+        "tool" => &[
+            "M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76Z",
+        ],
+        "output" => &["m4 17 6-6-6-6", "M12 19h8"],
+        "plan" => &[
+            "M4 19.5A2.5 2.5 0 0 1 6.5 17H20",
+            "M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2Z",
+        ],
+        "diff" => &[
+            "M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z",
+            "M14 2v4a2 2 0 0 0 2 2h4",
+        ],
+        "reconnect" => &[
+            "M5 12.55a11 11 0 0 1 14.08 0",
+            "M1.42 9a16 16 0 0 1 21.16 0",
+            "M8.53 16.11a6 6 0 0 1 6.95 0",
+            "M12 20h.01",
+        ],
+        _ => &[],
+    };
     rsx! {
-        div { class: "mt-2 flex flex-col gap-2",
-            for (j , block) in turn.steps.iter().enumerate() {
-                {render_block(j, block)}
+        span { class: "flex h-5 w-5 shrink-0 items-center justify-center text-muted-foreground", aria_hidden: "true",
+            svg {
+                class: "h-[17px] w-[17px]",
+                view_box: "0 0 24 24",
+                fill: "none",
+                stroke: "currentColor",
+                stroke_width: "1.8",
+                stroke_linecap: "round",
+                stroke_linejoin: "round",
+                for path in paths {
+                    path { d: "{path}" }
+                }
             }
         }
+    }
+}
+
+fn tool_label(name: &str) -> String {
+    let lower = name.to_ascii_lowercase();
+    if lower.contains("read_file") || lower.contains("read file") {
+        "Read files".to_string()
+    } else if lower.contains("grep") || lower.contains("search") {
+        "Searched files".to_string()
+    } else if lower.contains("view_image") || lower.contains("view image") {
+        "Viewed image".to_string()
+    } else if lower.contains("run") || lower.contains("exec") || lower.contains("command") {
+        "Ran commands".to_string()
+    } else if lower.contains("browser") {
+        "Used browser".to_string()
+    } else {
+        name.rsplit(['.', ':'])
+            .next()
+            .unwrap_or(name)
+            .replace('_', " ")
     }
 }
 
@@ -949,46 +977,49 @@ fn render_block(key: usize, block: &ChatBlock) -> Element {
             }
         },
         ChatBlock::Thinking(text) => rsx! {
-            details {
-                key: "{key}",
-                class: "disclosure rounded-xl bg-foreground/[0.03] px-3 py-2 ring-1 ring-inset ring-foreground/10",
-                summary { class: "flex cursor-pointer select-none items-center gap-2 text-xs text-muted-foreground list-none [&::-webkit-details-marker]:hidden",
-                    {render_disclosure_icon()}
-                    span { class: "font-medium", "Thinking" }
+            div { key: "{key}", class: "grid grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-2.5 py-1",
+                {render_activity_icon("thinking")}
+                details { class: "disclosure min-w-0 text-sm text-muted-foreground",
+                    summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
+                        span { class: "font-medium", "Thinking" }
+                        {render_disclosure_icon()}
+                    }
+                    div { class: "mt-2 whitespace-pre-wrap border-l border-foreground/15 pl-3 text-xs leading-relaxed", "{text}" }
                 }
-                div { class: "mt-2 whitespace-pre-wrap border-l-2 border-foreground/10 pl-3 text-xs italic leading-relaxed text-muted-foreground", "{text}" }
             }
         },
         ChatBlock::ToolUse { name, args, .. } => rsx! {
-            details {
-                key: "{key}",
-                class: "disclosure rounded-xl bg-foreground/[0.05] px-3 py-2 ring-1 ring-inset ring-foreground/10",
-                summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
-                    {render_disclosure_icon()}
-                    span { class: "font-mono text-xs text-amber-500", "{name}" }
-                }
-                if !args.is_empty() && args != "{}" {
-                    pre { class: "mt-1.5 overflow-x-auto font-mono text-[11px] text-muted-foreground", "{args}" }
+            div { key: "{key}", class: "grid grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-2.5 py-1",
+                {render_activity_icon("tool")}
+                details { class: "disclosure min-w-0 text-sm text-muted-foreground",
+                    summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
+                        span { class: "font-medium", "{tool_label(name)}" }
+                        {render_disclosure_icon()}
+                    }
+                    div { class: "mt-1 text-[11px] font-medium text-foreground/45", "{name}" }
+                    if !args.is_empty() && args != "{}" {
+                        pre { class: "mt-1.5 max-h-56 overflow-auto whitespace-pre-wrap rounded-lg bg-foreground/[0.04] p-2 font-mono text-[11px] text-muted-foreground ring-1 ring-inset ring-foreground/10", "{args}" }
+                    }
                 }
             }
         },
         ChatBlock::Plan { steps } => {
             let n = steps.len();
             rsx! {
-                details {
-                    key: "{key}",
-                    open: true,
-                    class: "disclosure rounded-xl bg-foreground/[0.04] px-3 py-2 ring-1 ring-inset ring-foreground/10",
-                    summary { class: "flex cursor-pointer select-none items-center gap-2 text-xs list-none [&::-webkit-details-marker]:hidden",
-                        {render_disclosure_icon()}
-                        span { class: "font-medium text-foreground", "Plan" }
-                        span { class: "text-muted-foreground", "· {n} tasks" }
-                    }
-                    ul { class: "mt-2 flex flex-col gap-1.5",
-                        for (i , step) in steps.iter().enumerate() {
-                            li { key: "{i}", class: "flex items-start gap-2 text-xs",
-                                span { class: "mt-px {plan_glyph_class(&step.status)}", "{plan_glyph(&step.status)}" }
-                                span { class: plan_text_class(&step.status), "{step.content}" }
+                div { key: "{key}", class: "grid grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-2.5 py-1",
+                    {render_activity_icon("plan")}
+                    details { open: true, class: "disclosure min-w-0 text-sm",
+                        summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
+                            span { class: "font-medium text-foreground/80", "Plan" }
+                            span { class: "text-xs text-muted-foreground", "{n} tasks" }
+                            {render_disclosure_icon()}
+                        }
+                        ul { class: "mt-2 flex flex-col gap-1.5 border-l border-foreground/15 pl-3",
+                            for (i , step) in steps.iter().enumerate() {
+                                li { key: "{i}", class: "flex items-start gap-2 text-xs",
+                                    span { class: "mt-px {plan_glyph_class(&step.status)}", "{plan_glyph(&step.status)}" }
+                                    span { class: plan_text_class(&step.status), "{step.content}" }
+                                }
                             }
                         }
                     }
@@ -1019,22 +1050,28 @@ fn render_block(key: usize, block: &ChatBlock) -> Element {
                     .collect();
             let fname = path.rsplit('/').next().unwrap_or(path.as_str()).to_string();
             rsx! {
-                div {
-                    key: "{key}",
-                    class: "overflow-hidden rounded-xl ring-1 ring-inset ring-foreground/10",
-                    div { class: "flex items-center gap-2 border-b border-foreground/10 bg-foreground/[0.05] px-3 py-1.5",
-                        span { class: "font-mono text-xs font-medium text-amber-400", "{fname}" }
-                        span { class: "text-[10px] uppercase tracking-wide text-muted-foreground", "proposed edit" }
-                    }
-                    div { class: "overflow-x-auto bg-foreground/[0.02] py-1 font-mono text-[11px] leading-relaxed",
-                        for (i , (line , cls)) in lines.iter().enumerate() {
-                            div { key: "{i}", class: "{cls}", "{line}" }
+                div { key: "{key}", class: "grid grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-2.5 py-1",
+                    {render_activity_icon("diff")}
+                    details { class: "disclosure min-w-0 text-sm text-muted-foreground",
+                        summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
+                            span { class: "font-medium", "Edited " }
+                            code { class: "truncate font-mono text-xs text-foreground/70", "{fname}" }
+                            {render_disclosure_icon()}
+                        }
+                        div { class: "mt-2 overflow-hidden rounded-lg ring-1 ring-inset ring-foreground/10",
+                            div { class: "overflow-x-auto bg-foreground/[0.02] py-1 font-mono text-[11px] leading-relaxed",
+                                for (i , (line , cls)) in lines.iter().enumerate() {
+                                    div { key: "{i}", class: "{cls}", "{line}" }
+                                }
+                            }
                         }
                     }
                 }
             }
         }
-        ChatBlock::ToolResult { content, is_error } => {
+        ChatBlock::ToolResult {
+            content, is_error, ..
+        } => {
             let tone = if *is_error {
                 "text-red-500"
             } else {
@@ -1042,17 +1079,24 @@ fn render_block(key: usize, block: &ChatBlock) -> Element {
             };
             let label = if *is_error { "Error" } else { "Output" };
             rsx! {
-                details {
-                    key: "{key}",
-                    class: "disclosure rounded-xl bg-foreground/[0.05] px-3 py-2 ring-1 ring-inset ring-foreground/10",
-                    summary { class: "flex cursor-pointer select-none items-center gap-2 text-xs {tone} list-none [&::-webkit-details-marker]:hidden",
-                        {render_disclosure_icon()}
-                        span { "{label}" }
+                div { key: "{key}", class: "grid grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-2.5 py-1",
+                    {render_activity_icon("output")}
+                    details { class: "disclosure min-w-0 text-sm {tone}",
+                        summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
+                            span { class: "font-medium", "{label}" }
+                            {render_disclosure_icon()}
+                        }
+                        pre { class: "mt-1.5 max-h-72 overflow-auto whitespace-pre-wrap rounded-lg bg-foreground/[0.04] p-2 font-mono text-[11px] text-muted-foreground ring-1 ring-inset ring-foreground/10", "{content}" }
                     }
-                    pre { class: "mt-1.5 max-h-72 overflow-auto whitespace-pre-wrap font-mono text-[11px] text-muted-foreground", "{content}" }
                 }
             }
         }
+        ChatBlock::Reconnect { attempt, total } => rsx! {
+            div { key: "{key}", class: "grid grid-cols-[1.25rem_minmax(0,1fr)] items-center gap-2.5 py-1 text-sm text-muted-foreground",
+                {render_activity_icon("reconnect")}
+                span { class: "font-medium tabular-nums", "Reconnecting {attempt}/{total}" }
+            }
+        },
     }
 }
 

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -12,6 +12,7 @@ use crate::chat_page::event::{
     RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SlashCommandEntry, SlashCommands, WORKING_VERBS,
 };
 use dioxus::prelude::*;
+use std::borrow::Cow;
 use vmux_terminal::matrix_rain::MatrixRain;
 use vmux_terminal::page::PromptGhost;
 use vmux_ui::agent_accent::agent_accent;
@@ -906,10 +907,18 @@ fn render_working(verb: &str, elapsed: u32) -> Element {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ActivityIcon {
     Thinking,
+    ReadFile,
+    Search,
+    Image,
+    Command,
+    Browser,
+    Guardian,
     Tool,
     Output,
+    Error,
     Plan,
     Diff,
     Reconnect,
@@ -920,10 +929,43 @@ fn render_activity_icon(kind: ActivityIcon) -> Element {
         ActivityIcon::Thinking => &[
             "m12 3-1.9 5.8a2 2 0 0 1-1.3 1.3L3 12l5.8 1.9a2 2 0 0 1 1.3 1.3L12 21l1.9-5.8a2 2 0 0 1 1.3-1.3L21 12l-5.8-1.9a2 2 0 0 1-1.3-1.3Z",
         ],
+        ActivityIcon::ReadFile => &[
+            "M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z",
+            "M14 2v4a2 2 0 0 0 2 2h4",
+            "M16 13H8",
+            "M16 17H8",
+            "M10 9H8",
+        ],
+        ActivityIcon::Search => &["M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z", "m21 21-4.35-4.35"],
+        ActivityIcon::Image => &[
+            "M19 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2Z",
+            "M10.5 8.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z",
+            "m21 15-5-5L5 21",
+        ],
+        ActivityIcon::Command => &["m4 17 6-6-6-6", "M12 19h8"],
+        ActivityIcon::Browser => &[
+            "M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Z",
+            "M2 12h20",
+            "M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10Z",
+        ],
+        ActivityIcon::Guardian => &[
+            "M20 13c0 5-3.5 7.5-8 9-4.5-1.5-8-4-8-9V5l8-3 8 3v8Z",
+            "m9 12 2 2 4-4",
+        ],
         ActivityIcon::Tool => &[
             "M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76Z",
         ],
-        ActivityIcon::Output => &["m4 17 6-6-6-6", "M12 19h8"],
+        ActivityIcon::Output => &[
+            "M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5Z",
+            "M14 2v6h6",
+            "m10 17 3-3-3-3",
+            "M13 14H7",
+        ],
+        ActivityIcon::Error => &[
+            "M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20Z",
+            "M12 8v4",
+            "M12 16h.01",
+        ],
         ActivityIcon::Plan => &[
             "M4 19.5A2.5 2.5 0 0 1 6.5 17H20",
             "M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2Z",
@@ -939,8 +981,13 @@ fn render_activity_icon(kind: ActivityIcon) -> Element {
             "M12 20h.01",
         ],
     };
+    let tone = if kind == ActivityIcon::Error {
+        "text-red-500"
+    } else {
+        "text-muted-foreground"
+    };
     rsx! {
-        span { class: "flex h-5 w-5 shrink-0 items-center justify-center text-muted-foreground", aria_hidden: "true",
+        span { class: "flex h-5 w-5 shrink-0 items-center justify-center {tone}", aria_hidden: "true",
             svg {
                 class: "h-[17px] w-[17px]",
                 view_box: "0 0 24 24",
@@ -957,23 +1004,41 @@ fn render_activity_icon(kind: ActivityIcon) -> Element {
     }
 }
 
-fn tool_label(name: &str) -> String {
+fn tool_presentation(name: &str) -> (ActivityIcon, Cow<'static, str>) {
     let lower = name.to_ascii_lowercase();
-    if lower.contains("read_file") || lower.contains("read file") {
-        "Read files".to_string()
-    } else if lower.contains("grep") || lower.contains("search") {
-        "Searched files".to_string()
+    if lower.contains("guardian")
+        || lower.contains("approval")
+        || lower == "review"
+        || lower.ends_with("_review")
+        || lower.ends_with(".review")
+        || lower.ends_with(":review")
+    {
+        (ActivityIcon::Guardian, Cow::Borrowed("Guardian Review"))
+    } else if lower.contains("read_file") || lower.contains("read file") {
+        (ActivityIcon::ReadFile, Cow::Borrowed("Read files"))
     } else if lower.contains("view_image") || lower.contains("view image") {
-        "Viewed image".to_string()
-    } else if lower.contains("run") || lower.contains("exec") || lower.contains("command") {
-        "Ran commands".to_string()
-    } else if lower.contains("browser") {
-        "Used browser".to_string()
+        (ActivityIcon::Image, Cow::Borrowed("Viewed image"))
+    } else if lower.contains("browser") || lower.contains("navigate") || lower.contains("web_") {
+        (ActivityIcon::Browser, Cow::Borrowed("Used browser"))
+    } else if lower.contains("grep") || lower.contains("search") || lower.contains("find") {
+        (ActivityIcon::Search, Cow::Borrowed("Searched files"))
+    } else if lower.contains("run")
+        || lower.contains("exec")
+        || lower.contains("command")
+        || lower.contains("shell")
+        || lower.contains("terminal")
+    {
+        (ActivityIcon::Command, Cow::Borrowed("Ran commands"))
     } else {
-        name.rsplit(['.', ':'])
-            .next()
-            .unwrap_or(name)
-            .replace('_', " ")
+        (
+            ActivityIcon::Tool,
+            Cow::Owned(
+                name.rsplit(['.', ':'])
+                    .next()
+                    .unwrap_or(name)
+                    .replace('_', " "),
+            ),
+        )
     }
 }
 
@@ -998,21 +1063,24 @@ fn render_block(key: usize, block: &ChatBlock) -> Element {
                 }
             }
         },
-        ChatBlock::ToolUse { name, args, .. } => rsx! {
-            div { key: "{key}", class: "grid grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-2.5 py-1",
-                {render_activity_icon(ActivityIcon::Tool)}
-                details { class: "disclosure min-w-0 text-sm text-muted-foreground",
-                    summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
-                        span { class: "font-medium", "{tool_label(name)}" }
-                        {render_disclosure_icon()}
-                    }
-                    div { class: "mt-1 text-[11px] font-medium text-foreground/45", "{name}" }
-                    if !args.is_empty() && args != "{}" {
-                        pre { class: "mt-1.5 max-h-56 overflow-auto whitespace-pre-wrap rounded-lg bg-foreground/[0.04] p-2 font-mono text-[11px] text-muted-foreground ring-1 ring-inset ring-foreground/10", "{args}" }
+        ChatBlock::ToolUse { name, args, .. } => {
+            let (icon, label) = tool_presentation(name);
+            rsx! {
+                div { key: "{key}", class: "grid grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-2.5 py-1",
+                    {render_activity_icon(icon)}
+                    details { class: "disclosure min-w-0 text-sm text-muted-foreground",
+                        summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
+                            span { class: "font-medium", "{label}" }
+                            {render_disclosure_icon()}
+                        }
+                        div { class: "mt-1 text-[11px] font-medium text-foreground/45", "{name}" }
+                        if !args.is_empty() && args != "{}" {
+                            pre { class: "mt-1.5 max-h-56 overflow-auto whitespace-pre-wrap rounded-lg bg-foreground/[0.04] p-2 font-mono text-[11px] text-muted-foreground ring-1 ring-inset ring-foreground/10", "{args}" }
+                        }
                     }
                 }
             }
-        },
+        }
         ChatBlock::Plan { steps } => {
             let n = steps.len();
             rsx! {
@@ -1088,9 +1156,14 @@ fn render_block(key: usize, block: &ChatBlock) -> Element {
                 "text-muted-foreground"
             };
             let label = if *is_error { "Error" } else { "Output" };
+            let icon = if *is_error {
+                ActivityIcon::Error
+            } else {
+                ActivityIcon::Output
+            };
             rsx! {
                 div { key: "{key}", class: "grid grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-2.5 py-1",
-                    {render_activity_icon(ActivityIcon::Output)}
+                    {render_activity_icon(icon)}
                     details { class: "disclosure min-w-0 text-sm {tone}",
                         summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
                             span { class: "font-medium", "{label}" }

--- a/crates/vmux_agent/src/chat_page/turns.rs
+++ b/crates/vmux_agent/src/chat_page/turns.rs
@@ -25,15 +25,15 @@ pub fn group_turns(messages: &[Message], durations: &[u32], running: bool) -> Ve
                 let turn = current.get_or_insert_with(ChatTurn::default);
                 for block in blocks {
                     match block {
-                        AssistantBlock::Text(t) => turn.answer.push(ChatBlock::Text(t.clone())),
+                        AssistantBlock::Text(t) => push_assistant_text(turn, t),
                         AssistantBlock::Thinking(t) => {
-                            turn.steps.push(ChatBlock::Thinking(t.clone()))
+                            turn.blocks.push(ChatBlock::Thinking(t.clone()))
                         }
                         AssistantBlock::ToolUse {
                             call_id,
                             name,
                             args,
-                        } => turn.steps.push(ChatBlock::ToolUse {
+                        } => turn.blocks.push(ChatBlock::ToolUse {
                             call_id: call_id.clone(),
                             name: name.clone(),
                             args: args.clone(),
@@ -43,23 +43,26 @@ pub fn group_turns(messages: &[Message], durations: &[u32], running: bool) -> Ve
                             path,
                             old_text,
                             new_text,
-                        } => turn.steps.push(ChatBlock::Diff {
+                        } => turn.blocks.push(ChatBlock::Diff {
                             call_id: call_id.clone(),
                             path: path.clone(),
                             old_text: old_text.clone(),
                             new_text: new_text.clone(),
                         }),
-                        AssistantBlock::Plan { steps } => turn.steps.push(ChatBlock::Plan {
+                        AssistantBlock::Plan { steps } => turn.blocks.push(ChatBlock::Plan {
                             steps: steps.iter().map(map_plan_step).collect(),
                         }),
                     }
                 }
             }
             Message::ToolResult {
-                content, is_error, ..
+                call_id,
+                content,
+                is_error,
             } => {
                 let turn = current.get_or_insert_with(ChatTurn::default);
-                turn.steps.push(ChatBlock::ToolResult {
+                turn.blocks.push(ChatBlock::ToolResult {
+                    call_id: call_id.clone(),
                     content: content.clone(),
                     is_error: *is_error,
                 });
@@ -82,11 +85,53 @@ fn flush(
     durations: &[u32],
 ) {
     if let Some(mut turn) = current.take() {
-        turn.step_count = turn.steps.len() as u32;
+        turn.step_count = turn
+            .blocks
+            .iter()
+            .filter(|block| !matches!(block, ChatBlock::Text(_)))
+            .count() as u32;
         turn.duration_secs = durations.get(*ordinal).copied();
         *ordinal += 1;
         items.push(ChatItem::Turn(turn));
     }
+}
+
+fn push_assistant_text(turn: &mut ChatTurn, text: &str) {
+    let mut prose = String::new();
+    for line in text.split_inclusive('\n') {
+        if let Some((attempt, total)) = reconnect_progress(line.trim()) {
+            push_prose(turn, &mut prose);
+            push_reconnect(turn, attempt, total);
+        } else {
+            prose.push_str(line);
+        }
+    }
+    push_prose(turn, &mut prose);
+}
+
+fn push_prose(turn: &mut ChatTurn, prose: &mut String) {
+    if prose.trim().is_empty() {
+        prose.clear();
+        return;
+    }
+    turn.blocks
+        .push(ChatBlock::Text(std::mem::take(prose).trim().to_string()));
+}
+
+fn push_reconnect(turn: &mut ChatTurn, attempt: u32, total: u32) {
+    let block = ChatBlock::Reconnect { attempt, total };
+    if matches!(turn.blocks.last(), Some(ChatBlock::Reconnect { .. })) {
+        *turn.blocks.last_mut().expect("reconnect tail") = block;
+    } else {
+        turn.blocks.push(block);
+    }
+}
+
+fn reconnect_progress(text: &str) -> Option<(u32, u32)> {
+    let rest = text.strip_prefix("Reconnecting")?;
+    let rest = rest.trim_start_matches('.').trim_start_matches('…').trim();
+    let (attempt, total) = rest.split_once('/')?;
+    Some((attempt.trim().parse().ok()?, total.trim().parse().ok()?))
 }
 
 fn map_plan_step(step: &PlanStep) -> ChatPlanStep {
@@ -130,9 +175,9 @@ mod tests {
             panic!()
         };
         assert_eq!(t.step_count, 3);
-        assert_eq!(t.steps.len(), 3);
-        assert!(matches!(t.steps[2], ChatBlock::ToolResult { .. }));
-        assert_eq!(t.answer.len(), 1);
+        assert_eq!(t.blocks.len(), 4);
+        assert!(matches!(t.blocks[2], ChatBlock::ToolResult { .. }));
+        assert!(matches!(&t.blocks[3], ChatBlock::Text(text) if text == "done"));
         assert!(!t.running);
     }
 
@@ -195,6 +240,71 @@ mod tests {
         };
         assert!(t.running);
         assert_eq!(t.step_count, 0);
-        assert!(t.answer.is_empty());
+        assert!(t.blocks.is_empty());
+    }
+
+    #[test]
+    fn preserves_step_and_prose_order() {
+        let msgs = vec![
+            Message::User { text: "a".into() },
+            assistant(vec![
+                AssistantBlock::Text("before".into()),
+                tool("c1"),
+                AssistantBlock::Text("after".into()),
+            ]),
+        ];
+        let items = group_turns(&msgs, &[], false);
+        let ChatItem::Turn(turn) = &items[1] else {
+            panic!()
+        };
+        assert!(matches!(&turn.blocks[0], ChatBlock::Text(text) if text == "before"));
+        assert!(matches!(&turn.blocks[1], ChatBlock::ToolUse { .. }));
+        assert!(matches!(&turn.blocks[2], ChatBlock::Text(text) if text == "after"));
+    }
+
+    #[test]
+    fn collapses_consecutive_reconnect_updates() {
+        let msgs = vec![
+            Message::User { text: "a".into() },
+            assistant(vec![AssistantBlock::Text(
+                "Reconnecting... 1/5\n\nReconnecting… 2/5\nReconnecting 3/5".into(),
+            )]),
+        ];
+        let items = group_turns(&msgs, &[], true);
+        let ChatItem::Turn(turn) = &items[1] else {
+            panic!()
+        };
+        assert_eq!(turn.blocks.len(), 1);
+        assert!(matches!(
+            turn.blocks[0],
+            ChatBlock::Reconnect {
+                attempt: 3,
+                total: 5
+            }
+        ));
+        assert_eq!(turn.step_count, 1);
+    }
+
+    #[test]
+    fn reconnect_updates_do_not_swallow_prose() {
+        let msgs = vec![
+            Message::User { text: "a".into() },
+            assistant(vec![AssistantBlock::Text(
+                "before\nReconnecting... 2/5\nafter".into(),
+            )]),
+        ];
+        let items = group_turns(&msgs, &[], false);
+        let ChatItem::Turn(turn) = &items[1] else {
+            panic!()
+        };
+        assert!(matches!(&turn.blocks[0], ChatBlock::Text(text) if text == "before"));
+        assert!(matches!(
+            turn.blocks[1],
+            ChatBlock::Reconnect {
+                attempt: 2,
+                total: 5
+            }
+        ));
+        assert!(matches!(&turn.blocks[2], ChatBlock::Text(text) if text == "after"));
     }
 }


### PR DESCRIPTION
## Context
Agent thinking and tool activity rendered in a separate collapsed group, breaking transcript order and producing an uneven timeline. Reconnect progress also accumulated as repeated assistant text instead of one live status.

## Implementation
Preserve prose and activity blocks in transcript order, render activity on a shared icon grid, and keep details expandable. Parse reconnect progress into a typed activity and replace consecutive attempts with the latest state.

## Checks / QA
- Run an agent turn containing thinking, file reads, commands, and prose; verify rows share one icon column and remain in chronological order.
- Trigger reconnect attempts; verify only the latest `Reconnecting N/5` row remains visible.
- Expand thinking, tool, output, plan, and diff rows; verify details remain readable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat activity is now displayed in a unified chronological timeline.
  * Added reconnect progress indicators with attempt counts.
  * Improved visual labels and icons for thinking, plans, tool activity, file edits, and outputs.
  * Tool results now distinguish between successful output and errors.
* **Improvements**
  * Completed activities show their elapsed duration.
  * Consecutive reconnect updates are consolidated for a cleaner transcript.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->