### PR TITLE
feat(agent): show task-aware dynamic page titles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9665,6 +9665,7 @@ dependencies = [
  "similar",
  "tokio",
  "toml",
+ "unicode-segmentation",
  "url",
  "uuid",
  "vmux_command",

--- a/crates/vmux_agent/Cargo.toml
+++ b/crates/vmux_agent/Cargo.toml
@@ -13,6 +13,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 rkyv = { workspace = true }
 similar = "2"
+unicode-segmentation = "1"
 vmux_terminal = { path = "../vmux_terminal" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/vmux_agent/src/chat_page/composer.rs
+++ b/crates/vmux_agent/src/chat_page/composer.rs
@@ -1,4 +1,7 @@
-use super::event::{ResumableSessionEntry, SlashCommandEntry};
+use super::event::{ChatItem, ResumableSessionEntry, SlashCommandEntry};
+use unicode_segmentation::UnicodeSegmentation;
+
+const CHAT_PAGE_TITLE_MAX_GRAPHEMES: usize = 64;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum SelectorMode<'a> {
@@ -129,6 +132,88 @@ pub(crate) fn should_clear_draft_on_escape(
     !streaming && queue_empty && !draft_empty
 }
 
+pub(crate) fn chat_page_title(items: &[ChatItem], status: &str, agent_name: &str) -> String {
+    let topic = items
+        .iter()
+        .filter_map(|item| match item {
+            ChatItem::User { text } => Some(text.as_str()),
+            ChatItem::Turn(_) => None,
+        })
+        .map(normalize_chat_page_title)
+        .find(|title| !title.is_empty())
+        .unwrap_or_else(|| normalize_chat_page_title(agent_name));
+
+    match status {
+        "streaming" => format!("👷 {topic}"),
+        "installing" => format!("📦 {topic}"),
+        "awaiting" => format!("✋ {topic}"),
+        "errored" => format!("❌ {topic}"),
+        _ => topic,
+    }
+}
+
+fn normalize_chat_page_title(value: &str) -> String {
+    let mut title = String::new();
+    let mut graphemes_written = 0;
+    let mut pending_space = false;
+    let mut truncated = false;
+
+    for grapheme in value.graphemes(true) {
+        if grapheme.chars().all(char::is_whitespace) {
+            pending_space = !title.is_empty();
+            continue;
+        }
+        let grapheme = grapheme
+            .chars()
+            .filter(|character| !is_disallowed_chat_page_title_char(*character))
+            .collect::<String>();
+        if grapheme.is_empty() {
+            continue;
+        }
+        if pending_space {
+            if graphemes_written >= CHAT_PAGE_TITLE_MAX_GRAPHEMES {
+                truncated = true;
+                break;
+            }
+            title.push(' ');
+            graphemes_written += 1;
+            pending_space = false;
+        }
+        if graphemes_written >= CHAT_PAGE_TITLE_MAX_GRAPHEMES {
+            truncated = true;
+            break;
+        }
+        title.push_str(&grapheme);
+        graphemes_written += 1;
+    }
+
+    if truncated {
+        if let Some((start, _)) = title.grapheme_indices(true).next_back() {
+            title.truncate(start);
+        }
+        title.push('…');
+    }
+    title
+}
+
+fn is_disallowed_chat_page_title_char(character: char) -> bool {
+    character.is_control()
+        || matches!(
+            character,
+            '\u{00AD}'
+                | '\u{034F}'
+                | '\u{061C}'
+                | '\u{180E}'
+                | '\u{200B}'
+                | '\u{200E}'..='\u{200F}'
+                | '\u{202A}'..='\u{202E}'
+                | '\u{2060}'..='\u{206F}'
+                | '\u{FEFF}'
+                | '\u{FFF9}'..='\u{FFFB}'
+                | '\u{1BCA0}'..='\u{1BCA3}'
+        )
+}
+
 pub(crate) fn edit_prompt(
     value: &str,
     selection_start: u32,
@@ -187,7 +272,7 @@ fn utf16_to_byte(value: &str, offset: u32) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::chat_page::event::SlashCommandEntry;
+    use crate::chat_page::event::{ChatTurn, SlashCommandEntry};
 
     fn session(sid: &str, title: &str, cwd: &str) -> ResumableSessionEntry {
         ResumableSessionEntry {
@@ -281,6 +366,66 @@ mod tests {
         assert!(!should_clear_draft_on_escape(true, true, false));
         assert!(!should_clear_draft_on_escape(false, false, false));
         assert!(!should_clear_draft_on_escape(false, true, true));
+    }
+
+    #[test]
+    fn chat_page_title_uses_first_prompt_as_stable_topic() {
+        let items = vec![
+            ChatItem::User {
+                text: "  Fix the\ndynamic   agent page title  ".into(),
+            },
+            ChatItem::Turn(ChatTurn::default()),
+            ChatItem::User {
+                text: "continue".into(),
+            },
+        ];
+
+        assert_eq!(
+            chat_page_title(&items, "streaming", "Codex"),
+            "👷 Fix the dynamic agent page title"
+        );
+        assert_eq!(
+            chat_page_title(&items, "awaiting", "Codex"),
+            "✋ Fix the dynamic agent page title"
+        );
+    }
+
+    #[test]
+    fn chat_page_title_falls_back_to_agent_and_truncates_topic() {
+        assert_eq!(chat_page_title(&[], "idle", "Codex"), "Codex");
+
+        let items = vec![ChatItem::User {
+            text: "a".repeat(CHAT_PAGE_TITLE_MAX_GRAPHEMES + 10),
+        }];
+        let title = chat_page_title(&items, "idle", "Codex");
+        assert_eq!(title.graphemes(true).count(), CHAT_PAGE_TITLE_MAX_GRAPHEMES);
+        assert!(title.ends_with('…'));
+        assert_eq!(
+            chat_page_title(
+                &[ChatItem::User {
+                    text: "Fix \u{202E}\x1b title".into(),
+                }],
+                "idle",
+                "Codex"
+            ),
+            "Fix title"
+        );
+        assert_eq!(
+            chat_page_title(
+                &[
+                    ChatItem::User {
+                        text: "\u{202E}".into(),
+                    },
+                    ChatItem::User {
+                        text: "Keep 👩‍💻 and فارسی\u{200C}".into(),
+                    },
+                ],
+                "errored",
+                "Codex"
+            ),
+            "❌ Keep 👩‍💻 and فارسی\u{200C}"
+        );
+        assert_eq!(chat_page_title(&[], "installing", "Codex"), "📦 Codex");
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/composer.rs
+++ b/crates/vmux_agent/src/chat_page/composer.rs
@@ -1,4 +1,4 @@
-use super::event::{ChatItem, ResumableSessionEntry, SlashCommandEntry};
+use super::event::{ChatBlock, ChatItem, ResumableSessionEntry, SlashCommandEntry};
 use unicode_segmentation::UnicodeSegmentation;
 
 const CHAT_PAGE_TITLE_MAX_GRAPHEMES: usize = 64;
@@ -29,6 +29,17 @@ pub(crate) enum ResumeMenuState {
     Empty,
     NoMatch,
     Results,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ToolActivity {
+    Guardian,
+    ReadFile,
+    Image,
+    Browser,
+    Search,
+    Command,
+    Other,
 }
 
 pub(crate) fn selector_mode(draft: &str) -> SelectorMode<'_> {
@@ -144,11 +155,73 @@ pub(crate) fn chat_page_title(items: &[ChatItem], status: &str, agent_name: &str
         .unwrap_or_else(|| normalize_chat_page_title(agent_name));
 
     match status {
-        "streaming" => format!("👷 {topic}"),
+        "streaming" => format!("{} {topic}", streaming_title_emoji(items)),
         "installing" => format!("📦 {topic}"),
         "awaiting" => format!("✋ {topic}"),
         "errored" => format!("❌ {topic}"),
         _ => topic,
+    }
+}
+
+fn streaming_title_emoji(items: &[ChatItem]) -> &'static str {
+    let block = items
+        .iter()
+        .rev()
+        .find_map(|item| match item {
+            ChatItem::Turn(turn) if turn.running => Some(turn.blocks.last()),
+            _ => None,
+        })
+        .flatten();
+
+    match block {
+        Some(ChatBlock::Text(_)) => "✍️",
+        Some(ChatBlock::Thinking(_)) | Some(ChatBlock::ToolResult { .. }) | None => "🧠",
+        Some(ChatBlock::ToolUse { name, .. }) => tool_activity_emoji(tool_activity(name)),
+        Some(ChatBlock::Diff { .. }) => "✏️",
+        Some(ChatBlock::Plan { .. }) => "📋",
+        Some(ChatBlock::Reconnect { .. }) => "🛜",
+    }
+}
+
+pub(crate) fn tool_activity(name: &str) -> ToolActivity {
+    let lower = name.to_ascii_lowercase();
+    if lower.contains("guardian")
+        || lower.contains("approval")
+        || lower == "review"
+        || lower.ends_with("_review")
+        || lower.ends_with(".review")
+        || lower.ends_with(":review")
+    {
+        ToolActivity::Guardian
+    } else if lower.contains("read_file") || lower.contains("read file") {
+        ToolActivity::ReadFile
+    } else if lower.contains("view_image") || lower.contains("view image") {
+        ToolActivity::Image
+    } else if lower.contains("browser") || lower.contains("navigate") || lower.contains("web_") {
+        ToolActivity::Browser
+    } else if lower.contains("grep") || lower.contains("search") || lower.contains("find") {
+        ToolActivity::Search
+    } else if lower.contains("run")
+        || lower.contains("exec")
+        || lower.contains("command")
+        || lower.contains("shell")
+        || lower.contains("terminal")
+    {
+        ToolActivity::Command
+    } else {
+        ToolActivity::Other
+    }
+}
+
+fn tool_activity_emoji(activity: ToolActivity) -> &'static str {
+    match activity {
+        ToolActivity::Guardian => "🛡️",
+        ToolActivity::ReadFile => "📄",
+        ToolActivity::Image => "🖼️",
+        ToolActivity::Browser => "🌐",
+        ToolActivity::Search => "🔎",
+        ToolActivity::Command => "💻",
+        ToolActivity::Other => "🛠️",
     }
 }
 
@@ -374,7 +447,10 @@ mod tests {
             ChatItem::User {
                 text: "  Fix the\ndynamic   agent page title  ".into(),
             },
-            ChatItem::Turn(ChatTurn::default()),
+            ChatItem::Turn(ChatTurn {
+                running: true,
+                ..Default::default()
+            }),
             ChatItem::User {
                 text: "continue".into(),
             },
@@ -382,11 +458,76 @@ mod tests {
 
         assert_eq!(
             chat_page_title(&items, "streaming", "Codex"),
-            "👷 Fix the dynamic agent page title"
+            "🧠 Fix the dynamic agent page title"
         );
         assert_eq!(
             chat_page_title(&items, "awaiting", "Codex"),
             "✋ Fix the dynamic agent page title"
+        );
+    }
+
+    #[test]
+    fn chat_page_title_tracks_live_timeline_activity() {
+        fn title(block: ChatBlock) -> String {
+            chat_page_title(
+                &[
+                    ChatItem::User {
+                        text: "Ship dynamic titles".into(),
+                    },
+                    ChatItem::Turn(ChatTurn {
+                        blocks: vec![block],
+                        running: true,
+                        ..Default::default()
+                    }),
+                ],
+                "streaming",
+                "Codex",
+            )
+        }
+
+        assert_eq!(
+            title(ChatBlock::Thinking("hmm".into())),
+            "🧠 Ship dynamic titles"
+        );
+        assert_eq!(
+            title(ChatBlock::ToolUse {
+                call_id: "1".into(),
+                name: "functions.exec_command".into(),
+                args: "{}".into(),
+            }),
+            "💻 Ship dynamic titles"
+        );
+        assert_eq!(
+            title(ChatBlock::ToolUse {
+                call_id: "2".into(),
+                name: "search_files".into(),
+                args: "{}".into(),
+            }),
+            "🔎 Ship dynamic titles"
+        );
+        assert_eq!(
+            title(ChatBlock::Plan { steps: Vec::new() }),
+            "📋 Ship dynamic titles"
+        );
+        assert_eq!(
+            title(ChatBlock::Diff {
+                call_id: "3".into(),
+                path: "page.rs".into(),
+                old_text: None,
+                new_text: String::new(),
+            }),
+            "✏️ Ship dynamic titles"
+        );
+        assert_eq!(
+            title(ChatBlock::Text("done soon".into())),
+            "✍️ Ship dynamic titles"
+        );
+        assert_eq!(
+            title(ChatBlock::Reconnect {
+                attempt: 2,
+                total: 5,
+            }),
+            "🛜 Ship dynamic titles"
         );
     }
 

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -1,9 +1,9 @@
 #![allow(non_snake_case)]
 
 use crate::chat_page::composer::{
-    PromptEdit, ResumeMenuState, SelectorMode, edit_prompt, filter_sessions, is_handoff_boundary,
-    menu_direction, move_selection, resume_menu_state, selector_mode, should_clear_draft_on_escape,
-    should_fetch_resume,
+    PromptEdit, ResumeMenuState, SelectorMode, chat_page_title, edit_prompt, filter_sessions,
+    is_handoff_boundary, menu_direction, move_selection, resume_menu_state, selector_mode,
+    should_clear_draft_on_escape, should_fetch_resume,
 };
 use crate::chat_page::event::{
     CHAT_SNAPSHOT_EVENT, ChatApproval, ChatBlock, ChatCancel, ChatCancelQueuedPrompt,
@@ -263,21 +263,15 @@ pub fn Page() -> Element {
         }
     });
 
-    // Drive the document (→ tab) title from the agent + its live run-state, so the user can see
-    // what each agent is doing without opening the pane.
     use_effect(move || {
         let name = {
             let n = agent_name();
             if n.is_empty() { current_agent() } else { n }
         };
-        let title = match status().as_str() {
-            "streaming" => format!("● {name}"),
-            "installing" => format!("{name} — Installing…"),
-            "awaiting" => format!("{name} — Approve?"),
-            "errored" => format!("{name} — Error"),
-            _ => name,
-        };
-        if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
+        let title = chat_page_title(&items.read(), &status(), &name);
+        if let Some(doc) = web_sys::window().and_then(|w| w.document())
+            && doc.title() != title
+        {
             doc.set_title(&title);
         }
     });

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -1,9 +1,9 @@
 #![allow(non_snake_case)]
 
 use crate::chat_page::composer::{
-    PromptEdit, ResumeMenuState, SelectorMode, chat_page_title, edit_prompt, filter_sessions,
-    is_handoff_boundary, menu_direction, move_selection, resume_menu_state, selector_mode,
-    should_clear_draft_on_escape, should_fetch_resume,
+    PromptEdit, ResumeMenuState, SelectorMode, ToolActivity, chat_page_title, edit_prompt,
+    filter_sessions, is_handoff_boundary, menu_direction, move_selection, resume_menu_state,
+    selector_mode, should_clear_draft_on_escape, should_fetch_resume, tool_activity,
 };
 use crate::chat_page::event::{
     CHAT_SNAPSHOT_EVENT, ChatApproval, ChatBlock, ChatCancel, ChatCancelQueuedPrompt,
@@ -1018,32 +1018,14 @@ fn render_activity_icon(kind: ActivityIcon) -> Element {
 }
 
 fn tool_presentation(name: &str) -> (ActivityIcon, Cow<'static, str>) {
-    let lower = name.to_ascii_lowercase();
-    if lower.contains("guardian")
-        || lower.contains("approval")
-        || lower == "review"
-        || lower.ends_with("_review")
-        || lower.ends_with(".review")
-        || lower.ends_with(":review")
-    {
-        (ActivityIcon::Guardian, Cow::Borrowed("Guardian Review"))
-    } else if lower.contains("read_file") || lower.contains("read file") {
-        (ActivityIcon::ReadFile, Cow::Borrowed("Read files"))
-    } else if lower.contains("view_image") || lower.contains("view image") {
-        (ActivityIcon::Image, Cow::Borrowed("Viewed image"))
-    } else if lower.contains("browser") || lower.contains("navigate") || lower.contains("web_") {
-        (ActivityIcon::Browser, Cow::Borrowed("Used browser"))
-    } else if lower.contains("grep") || lower.contains("search") || lower.contains("find") {
-        (ActivityIcon::Search, Cow::Borrowed("Searched files"))
-    } else if lower.contains("run")
-        || lower.contains("exec")
-        || lower.contains("command")
-        || lower.contains("shell")
-        || lower.contains("terminal")
-    {
-        (ActivityIcon::Command, Cow::Borrowed("Ran commands"))
-    } else {
-        (
+    match tool_activity(name) {
+        ToolActivity::Guardian => (ActivityIcon::Guardian, Cow::Borrowed("Guardian Review")),
+        ToolActivity::ReadFile => (ActivityIcon::ReadFile, Cow::Borrowed("Read files")),
+        ToolActivity::Image => (ActivityIcon::Image, Cow::Borrowed("Viewed image")),
+        ToolActivity::Browser => (ActivityIcon::Browser, Cow::Borrowed("Used browser")),
+        ToolActivity::Search => (ActivityIcon::Search, Cow::Borrowed("Searched files")),
+        ToolActivity::Command => (ActivityIcon::Command, Cow::Borrowed("Ran commands")),
+        ToolActivity::Other => (
             ActivityIcon::Tool,
             Cow::Owned(
                 name.rsplit(['.', ':'])
@@ -1051,7 +1033,7 @@ fn tool_presentation(name: &str) -> (ActivityIcon, Cow<'static, str>) {
                     .unwrap_or(name)
                     .replace('_', " "),
             ),
-        )
+        ),
     }
 }
 

--- a/crates/vmux_layout/src/cef.rs
+++ b/crates/vmux_layout/src/cef.rs
@@ -382,7 +382,7 @@ mod apply_cef_state_tests {
             ev(
                 Some("● Codex"),
                 Some("https://example.com/favicon.ico"),
-                Some("vmux://agent/codex"),
+                None,
             ),
         );
         assert_eq!(meta.title, "● Codex");

--- a/crates/vmux_layout/src/cef.rs
+++ b/crates/vmux_layout/src/cef.rs
@@ -76,8 +76,12 @@ pub(crate) fn apply_cef_state_to_meta(
     ev: bevy_cef_core::prelude::WebviewCefStateEvent,
 ) {
     let on_native_view = meta.url.starts_with("vmux://");
+    let accepts_dynamic_title = meta.url.starts_with("vmux://agent/");
     let navigating_away = ev.url.as_deref().is_some_and(|u| !u.starts_with("vmux://"));
     if on_native_view && !navigating_away {
+        if accepts_dynamic_title && let Some(title) = ev.title {
+            meta.title = title;
+        }
         return;
     }
     if let Some(url) = ev.url {
@@ -363,6 +367,30 @@ mod apply_cef_state_tests {
         let mut meta = vmux_meta();
         apply_cef_state_to_meta(&mut meta, ev(Some("vmux history POC"), None, None));
         assert_eq!(meta.title, "History");
+    }
+
+    #[test]
+    fn vmux_agent_url_accepts_dynamic_title_only() {
+        let mut meta = PageMetadata {
+            url: "vmux://agent/codex".into(),
+            title: "Codex".into(),
+            icon: vmux_core::PageIcon::Builtin(vmux_core::BuiltinIcon::Sparkles),
+            bg_color: None,
+        };
+        apply_cef_state_to_meta(
+            &mut meta,
+            ev(
+                Some("● Codex"),
+                Some("https://example.com/favicon.ico"),
+                Some("vmux://agent/codex"),
+            ),
+        );
+        assert_eq!(meta.title, "● Codex");
+        assert_eq!(meta.url, "vmux://agent/codex");
+        assert_eq!(
+            meta.icon,
+            vmux_core::PageIcon::Builtin(vmux_core::BuiltinIcon::Sparkles)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Context

Agent tabs need to reveal both the task and current activity without opening the pane. Static names and animated indicators either lacked context or required unnecessary periodic wakeups.

## Implementation

Use the first meaningful user prompt as a stable title, normalize whitespace and control characters, and cap it at 64 graphemes. Derive live prefixes from the merged agent timeline: 🧠 thinking, ✍️ writing, 📋 planning, ✏️ editing, 🛜 reconnecting, and semantic tool emojis for commands, search, files, images, browser, review, and generic tools. Installing, approval, and error states remain 📦, ✋, and ❌. Idle titles keep the task alone. Allow title-only CEF metadata updates for vmux://agent/ pages while preserving their URL and favicon, and skip duplicate document title writes.

## Checks / QA

Open a vmux://agent/ page and submit a prompt. Confirm the tab keeps the first prompt as its topic while the prefix follows thinking, tool calls, planning, edits, writing, reconnecting, approval, and error states. Confirm the URL and icon remain unchanged and the title does not animate periodically.