### PR TITLE
fix(agent): preserve resumed thread history

### DIFF
--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -1290,6 +1290,7 @@ mod native_tests {
     #[test]
     fn installing_chat_uses_matrix_loading_composer() {
         let source = include_str!("chat_page/page.rs");
+        assert!(source.contains("let installing_splash = installing && items.read().is_empty();"));
         assert!(source.contains("MatrixRain {"));
         assert!(source.contains("PromptGhost {"));
         assert!(source.contains("terminal: false"));

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -288,6 +288,7 @@ pub fn Page() -> Element {
     };
     let agent_accent = agent_accent(&agent);
     let installing = status() == "installing";
+    let installing_splash = installing && items.read().is_empty();
     let install_detail = {
         let detail = error();
         if detail.is_empty() {
@@ -352,7 +353,7 @@ pub fn Page() -> Element {
             class: "relative isolate flex h-screen flex-col overflow-hidden bg-background text-foreground",
             style: "background-image:radial-gradient(120% 80% at 50% -10%, rgba(129,140,248,0.05), transparent 55%);",
             style { dangerous_inner_html: MD_CSS }
-            if installing {
+            if installing_splash {
                 div { class: "pointer-events-none absolute inset-0 z-0 overflow-hidden bg-background",
                     MatrixRain {
                         accent_rgb: agent_accent.rain_rgb.to_string(),
@@ -371,7 +372,7 @@ pub fn Page() -> Element {
                     }
                 }
             }
-            if !installing {
+            if !installing_splash {
                 div {
                     id: "chat-scroll",
                     class: "relative z-10 flex-1 overflow-y-auto px-4 py-6",
@@ -493,9 +494,9 @@ pub fn Page() -> Element {
             }
 
             div {
-                class: if installing { "absolute inset-0 z-20 flex items-center justify-center px-4" } else { "relative z-10 border-t border-foreground/10 bg-background/50 px-4 py-3 backdrop-blur-xl" },
+                class: if installing_splash { "absolute inset-0 z-20 flex items-center justify-center px-4" } else { "relative z-10 border-t border-foreground/10 bg-background/50 px-4 py-3 backdrop-blur-xl" },
                 div {
-                    class: if installing { "relative flex w-full max-w-md flex-col gap-2 rounded-2xl bg-white/70 p-4 ring-1 ring-inset ring-black/10 backdrop-blur-md dark:bg-black/40 dark:ring-white/10" } else { "relative mx-auto flex max-w-3xl flex-col gap-2" },
+                    class: if installing_splash { "relative flex w-full max-w-md flex-col gap-2 rounded-2xl bg-white/70 p-4 ring-1 ring-inset ring-black/10 backdrop-blur-md dark:bg-black/40 dark:ring-white/10" } else { "relative mx-auto flex max-w-3xl flex-col gap-2" },
                     if installing {
                         div { class: "mb-1 flex items-center gap-3",
                             div { class: "flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-foreground/[0.06] ring-1 ring-inset ring-foreground/10",

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -75,6 +75,14 @@ fn display_install_progress(
     }
 }
 
+fn ready_agent_message(resume: Option<&str>) -> &'static str {
+    if resume.is_some() {
+        "Loading session history…"
+    } else {
+        "Starting agent…"
+    }
+}
+
 impl Default for AcpInstallChannel {
     fn default() -> Self {
         let (tx, rx) = crossbeam_channel::unbounded();
@@ -482,7 +490,11 @@ fn drain_acp_installs(
                 let Some(service) = service.as_ref() else {
                     continue;
                 };
-                if let Some((session, _)) = q.iter().find(|(s, _)| s.sid == sid) {
+                if let Some((session, mut state)) = q.iter_mut().find(|(s, _)| s.sid == sid) {
+                    *state = AgentRunState::Installing {
+                        pct: None,
+                        message: ready_agent_message(session.resume.as_deref()).to_string(),
+                    };
                     let mcp = crate::mcp::resolve_acp(
                         &session.cwd,
                         session.anchor,
@@ -712,6 +724,11 @@ mod tests {
         assert_eq!(
             display_install_progress(InstallPhase::Downloading, Some(42), "downloading"),
             (Some(42), "downloading".to_string())
+        );
+        assert_eq!(ready_agent_message(None), "Starting agent…");
+        assert_eq!(
+            ready_agent_message(Some("session-1")),
+            "Loading session history…"
         );
     }
 

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -196,7 +196,7 @@ fn auto_allow_acp_approval(
 /// Marks an `AcpSession` whose install has already been kicked off, so
 /// [`install_acp_session_when_focused`] starts it exactly once.
 #[derive(Component)]
-struct AcpInstallStarted;
+pub(crate) struct AcpInstallStarted;
 
 /// Install (and spawn) an ACP agent only once its stack is actually focused — i.e. the user
 /// opened it. Background or restored agent tabs stay idle until visited, so vmux never installs

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -3093,6 +3093,7 @@ fn handle_swap_stack_session(
         commands
             .entity(ev.stack)
             .remove::<crate::client::acp::AcpSession>()
+            .remove::<crate::client::acp::AcpInstallStarted>()
             .remove::<crate::components::AgentSession>()
             .remove::<crate::AgentMessages>()
             .remove::<crate::AgentApprovalPolicy>()
@@ -3844,6 +3845,33 @@ mod tests {
             .unwrap();
         assert_eq!(pending.context, "prior conversation");
         assert!(!pending.sent);
+    }
+
+    #[test]
+    fn acp_swap_resets_install_marker() {
+        let mut app = swap_test_app();
+        let (stack, _child) = spawn_stack_child(&mut app);
+        app.world_mut()
+            .entity_mut(stack)
+            .insert(crate::client::acp::AcpInstallStarted);
+        app.world_mut()
+            .resource_mut::<Messages<vmux_core::agent::SwapStackSession>>()
+            .write(vmux_core::agent::SwapStackSession {
+                stack,
+                target_url: "vmux://agent/codex/session-2".to_string(),
+                cwd: std::path::PathBuf::from("/work"),
+                handoff: None,
+            });
+
+        app.update();
+
+        assert!(
+            app.world()
+                .get::<crate::client::acp::AcpInstallStarted>(stack)
+                .is_none()
+        );
+        let session = app.world().get::<crate::AcpSession>(stack).unwrap();
+        assert_eq!(session.resume.as_deref(), Some("session-2"));
     }
 
     #[test]

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -3666,6 +3666,7 @@ fn handle_page_open_requests(
 }
 
 fn normalize_vmux_url(url: &str) -> String {
+    let url = url.trim();
     if let Some(rest) = url.strip_prefix("vmux://")
         && !rest.is_empty()
         && !rest.contains('/')
@@ -4159,7 +4160,7 @@ mod tests {
     }
 
     #[test]
-    fn normalize_vmux_url_adds_trailing_slash_to_bare_host() {
+    fn normalize_vmux_url_trims_and_adds_trailing_slash_to_bare_host() {
         assert_eq!(normalize_vmux_url("vmux://lsp"), "vmux://lsp/");
         assert_eq!(normalize_vmux_url("vmux://terminal"), "vmux://terminal/");
         assert_eq!(normalize_vmux_url("vmux://lsp/"), "vmux://lsp/");
@@ -4174,6 +4175,10 @@ mod tests {
         assert_eq!(
             normalize_vmux_url("file:///tmp/main.rs"),
             "file:///tmp/main.rs"
+        );
+        assert_eq!(
+            normalize_vmux_url("  vmux://agent/codex/session-id  "),
+            "vmux://agent/codex/session-id"
         );
     }
 

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -140,17 +140,32 @@ impl AcpShared {
     }
 
     fn begin_history_replay(&self) {
+        let mut projector = self.projector.lock().unwrap();
         self.history_replay.store(true, Ordering::SeqCst);
-        *self.projector.lock().unwrap() = AcpProjector::new();
+        *projector = AcpProjector::new();
     }
 
     fn finish_history_replay(&self, loaded: bool) {
-        if loaded {
-            self.emit(self.snapshot_message());
-        } else {
-            *self.projector.lock().unwrap() = AcpProjector::new();
+        let snapshot = {
+            let mut projector = self.projector.lock().unwrap();
+            let msg = loaded.then(|| {
+                let messages_json = serde_json::to_string(projector.messages())
+                    .unwrap_or_else(|_| "[]".to_string());
+                ServiceMessage::AgentMessagesSnapshot {
+                    sid: self.sid.clone(),
+                    messages_json,
+                }
+            });
+            if !loaded {
+                *projector = AcpProjector::new();
+            }
+            self.history_replay.store(false, Ordering::SeqCst);
+            msg
+        };
+
+        if let Some(msg) = snapshot {
+            self.emit(msg);
         }
-        self.history_replay.store(false, Ordering::SeqCst);
     }
 
     fn emit(&self, msg: ServiceMessage) {
@@ -166,10 +181,14 @@ impl AcpShared {
 }
 
 fn project_session_update(shared: &AcpShared, update: SessionUpdate) {
-    let intents = shared.projector.lock().unwrap().apply(update);
-    if shared.history_replay.load(Ordering::SeqCst) {
-        return;
-    }
+    let intents = {
+        let mut projector = shared.projector.lock().unwrap();
+        let intents = projector.apply(update);
+        if shared.history_replay.load(Ordering::SeqCst) {
+            return;
+        }
+        intents
+    };
     for intent in intents {
         match intent {
             Intent::Delta(text) => shared.emit(ServiceMessage::AgentDelta {

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -16,8 +16,8 @@ use agent_client_protocol::schema::v1::{
     PromptRequest, ReadTextFileRequest, ReadTextFileResponse, ReleaseTerminalRequest,
     ReleaseTerminalResponse, RequestPermissionOutcome, RequestPermissionRequest,
     RequestPermissionResponse, SelectedPermissionOutcome, SessionId, SessionNotification,
-    TerminalExitStatus, TerminalId, TerminalOutputRequest, TerminalOutputResponse, TextContent,
-    WaitForTerminalExitRequest, WaitForTerminalExitResponse, WriteTextFileRequest,
+    SessionUpdate, TerminalExitStatus, TerminalId, TerminalOutputRequest, TerminalOutputResponse,
+    TextContent, WaitForTerminalExitRequest, WaitForTerminalExitResponse, WriteTextFileRequest,
     WriteTextFileResponse,
 };
 use agent_client_protocol::{Client, Responder};
@@ -79,6 +79,7 @@ pub struct AcpShared {
     /// typing into its pane.
     pub input_writers: Arc<tokio::sync::Mutex<HashMap<ProcessId, PtyInputWriter>>>,
     agent_name: Mutex<Option<String>>,
+    history_replay: AtomicBool,
     /// Set by `AcpInput::Cancel`; read (and reset) when the in-flight prompt resolves so it
     /// reports `Interrupted` rather than `Idle`.
     pub cancel_requested: AtomicBool,
@@ -104,6 +105,7 @@ impl AcpShared {
             manager,
             input_writers,
             agent_name: Mutex::new(None),
+            history_replay: AtomicBool::new(false),
             cancel_requested: AtomicBool::new(false),
         }
     }
@@ -137,6 +139,20 @@ impl AcpShared {
         });
     }
 
+    fn begin_history_replay(&self) {
+        self.history_replay.store(true, Ordering::SeqCst);
+        *self.projector.lock().unwrap() = AcpProjector::new();
+    }
+
+    fn finish_history_replay(&self, loaded: bool) {
+        if loaded {
+            self.emit(self.snapshot_message());
+        } else {
+            *self.projector.lock().unwrap() = AcpProjector::new();
+        }
+        self.history_replay.store(false, Ordering::SeqCst);
+    }
+
     fn emit(&self, msg: ServiceMessage) {
         let _ = self.stream_tx.send(msg);
     }
@@ -146,6 +162,48 @@ impl AcpShared {
             sid: self.sid.clone(),
             status,
         });
+    }
+}
+
+fn project_session_update(shared: &AcpShared, update: SessionUpdate) {
+    let intents = shared.projector.lock().unwrap().apply(update);
+    if shared.history_replay.load(Ordering::SeqCst) {
+        return;
+    }
+    for intent in intents {
+        match intent {
+            Intent::Delta(text) => shared.emit(ServiceMessage::AgentDelta {
+                sid: shared.sid.clone(),
+                text,
+            }),
+            Intent::Snapshot => shared.emit(shared.snapshot_message()),
+            Intent::ProposedDiff {
+                call_id,
+                path,
+                old_text,
+                new_text,
+            } => shared.emit(ServiceMessage::AcpProposedDiff {
+                sid: shared.sid.clone(),
+                call_id,
+                path,
+                old_text,
+                new_text,
+            }),
+            Intent::FileTouched { path, line, kind } => {
+                shared.emit(ServiceMessage::AgentCommand {
+                    request_id: AgentRequestId::new(),
+                    anchor: Some(shared.anchor),
+                    command: AgentCommand::FileTouched {
+                        anchor: shared.anchor,
+                        path,
+                        line,
+                        col: None,
+                        end_col: None,
+                        kind,
+                    },
+                });
+            }
+        }
     }
 }
 
@@ -335,42 +393,7 @@ pub async fn run(
         )
         .on_receive_notification(
             async move |note: SessionNotification, _cx| {
-                let intents = update_shared.projector.lock().unwrap().apply(note.update);
-                for intent in intents {
-                    match intent {
-                        Intent::Delta(text) => update_shared.emit(ServiceMessage::AgentDelta {
-                            sid: update_shared.sid.clone(),
-                            text,
-                        }),
-                        Intent::Snapshot => update_shared.emit(update_shared.snapshot_message()),
-                        Intent::ProposedDiff {
-                            call_id,
-                            path,
-                            old_text,
-                            new_text,
-                        } => update_shared.emit(ServiceMessage::AcpProposedDiff {
-                            sid: update_shared.sid.clone(),
-                            call_id,
-                            path,
-                            old_text,
-                            new_text,
-                        }),
-                        Intent::FileTouched { path, line, kind } => {
-                            update_shared.emit(ServiceMessage::AgentCommand {
-                                request_id: AgentRequestId::new(),
-                                anchor: Some(update_shared.anchor),
-                                command: AgentCommand::FileTouched {
-                                    anchor: update_shared.anchor,
-                                    path,
-                                    line,
-                                    col: None,
-                                    end_col: None,
-                                    kind,
-                                },
-                            });
-                        }
-                    }
-                }
+                project_session_update(&update_shared, note.update);
                 Ok(())
             },
             agent_client_protocol::on_receive_notification!(),
@@ -388,6 +411,10 @@ pub async fn run(
                 main_shared.publish_agent_info(name);
             }
 
+            let resume_requested = resume.is_some() && init_resp.agent_capabilities.load_session;
+            if resume_requested {
+                main_shared.begin_history_replay();
+            }
             let mut session_id =
                 load_requested_session(resume, init_resp.agent_capabilities.load_session, |sid| {
                     let mut load = LoadSessionRequest::new(sid, main_shared.cwd.clone());
@@ -396,6 +423,9 @@ pub async fn run(
                     async { cx.send_request(load).block_task().await.map(|_| ()) }
                 })
                 .await;
+            if resume_requested {
+                main_shared.finish_history_replay(session_id.is_some());
+            }
             if let Some(sid) = &session_id {
                 main_shared.emit(ServiceMessage::AcpSessionCreated {
                     sid: main_shared.sid.clone(),
@@ -894,7 +924,7 @@ fn status_after_prompt(cancelled: bool, errored: Option<String>) -> AgentRunStat
 mod tests {
     use super::*;
     use agent_client_protocol::schema::v1::{
-        Implementation, PermissionOptionKind, ToolCall, ToolCallUpdateFields,
+        ContentChunk, Implementation, PermissionOptionKind, ToolCall, ToolCallUpdateFields,
     };
 
     fn opt(id: &str, kind: PermissionOptionKind) -> PermissionOption {
@@ -951,6 +981,87 @@ mod tests {
             }
             other => panic!("expected replayable ACP agent info, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn history_replay_emits_one_final_snapshot() {
+        let (stream_tx, mut stream_rx) = broadcast::channel(64);
+        let shared = Arc::new(AcpShared::new(
+            "s1".into(),
+            PathBuf::from("/tmp"),
+            ProcessId::new(),
+            stream_tx,
+            Arc::new(tokio::sync::Mutex::new(ProcessManager::default())),
+            Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        ));
+        shared.begin_history_replay();
+
+        project_session_update(
+            &shared,
+            SessionUpdate::UserMessageChunk(ContentChunk::new(ContentBlock::Text(
+                TextContent::new("hello"),
+            ))),
+        );
+        for _ in 0..300 {
+            project_session_update(
+                &shared,
+                SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(
+                    TextContent::new("x"),
+                ))),
+            );
+        }
+
+        assert!(matches!(
+            stream_rx.try_recv(),
+            Err(broadcast::error::TryRecvError::Empty)
+        ));
+
+        shared.finish_history_replay(true);
+
+        let ServiceMessage::AgentMessagesSnapshot { messages_json, .. } =
+            stream_rx.try_recv().expect("final snapshot")
+        else {
+            panic!("expected snapshot");
+        };
+        let messages: Vec<crate::message::Message> = serde_json::from_str(&messages_json).unwrap();
+        assert_eq!(messages.len(), 2);
+        assert!(matches!(
+            &messages[1],
+            crate::message::Message::Assistant { blocks }
+                if matches!(blocks.as_slice(), [crate::message::AssistantBlock::Text(text)] if text.len() == 300)
+        ));
+        assert!(matches!(
+            stream_rx.try_recv(),
+            Err(broadcast::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[test]
+    fn failed_history_replay_discards_partial_transcript() {
+        let (stream_tx, mut stream_rx) = broadcast::channel(64);
+        let shared = Arc::new(AcpShared::new(
+            "s1".into(),
+            PathBuf::from("/tmp"),
+            ProcessId::new(),
+            stream_tx,
+            Arc::new(tokio::sync::Mutex::new(ProcessManager::default())),
+            Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        ));
+        shared.begin_history_replay();
+        project_session_update(
+            &shared,
+            SessionUpdate::UserMessageChunk(ContentChunk::new(ContentBlock::Text(
+                TextContent::new("partial"),
+            ))),
+        );
+
+        shared.finish_history_replay(false);
+
+        assert!(shared.projector.lock().unwrap().messages().is_empty());
+        assert!(matches!(
+            stream_rx.try_recv(),
+            Err(broadcast::error::TryRecvError::Empty)
+        ));
     }
 
     #[test]

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::path::PathBuf;
 use std::process::Stdio;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use agent_client_protocol::schema::ProtocolVersion;
@@ -32,6 +32,8 @@ use crate::protocol::{
     AgentCommand, AgentRequestId, AgentRunStatus, ApprovalDecision, ServiceMessage,
     compose_agent_prompt,
 };
+
+const HISTORY_REPLAY_SNAPSHOT_INTERVAL: usize = 8;
 
 /// A command pushed into a live ACP session from the GUI side.
 pub enum AcpInput {
@@ -80,6 +82,7 @@ pub struct AcpShared {
     pub input_writers: Arc<tokio::sync::Mutex<HashMap<ProcessId, PtyInputWriter>>>,
     agent_name: Mutex<Option<String>>,
     history_replay: AtomicBool,
+    history_replay_updates: AtomicUsize,
     /// Set by `AcpInput::Cancel`; read (and reset) when the in-flight prompt resolves so it
     /// reports `Interrupted` rather than `Idle`.
     pub cancel_requested: AtomicBool,
@@ -106,6 +109,7 @@ impl AcpShared {
             input_writers,
             agent_name: Mutex::new(None),
             history_replay: AtomicBool::new(false),
+            history_replay_updates: AtomicUsize::new(0),
             cancel_requested: AtomicBool::new(false),
         }
     }
@@ -141,31 +145,24 @@ impl AcpShared {
 
     fn begin_history_replay(&self) {
         let mut projector = self.projector.lock().unwrap();
+        self.history_replay_updates.store(0, Ordering::SeqCst);
         self.history_replay.store(true, Ordering::SeqCst);
         *projector = AcpProjector::new();
     }
 
     fn finish_history_replay(&self, loaded: bool) {
-        let snapshot = {
-            let mut projector = self.projector.lock().unwrap();
-            let msg = loaded.then(|| {
-                let messages_json = serde_json::to_string(projector.messages())
-                    .unwrap_or_else(|_| "[]".to_string());
-                ServiceMessage::AgentMessagesSnapshot {
-                    sid: self.sid.clone(),
-                    messages_json,
-                }
-            });
-            if !loaded {
-                *projector = AcpProjector::new();
-            }
-            self.history_replay.store(false, Ordering::SeqCst);
-            msg
-        };
-
-        if let Some(msg) = snapshot {
-            self.emit(msg);
+        let mut projector = self.projector.lock().unwrap();
+        if !loaded {
+            *projector = AcpProjector::new();
         }
+        let messages_json =
+            serde_json::to_string(projector.messages()).unwrap_or_else(|_| "[]".to_string());
+        self.history_replay_updates.store(0, Ordering::SeqCst);
+        self.history_replay.store(false, Ordering::SeqCst);
+        self.emit(ServiceMessage::AgentMessagesSnapshot {
+            sid: self.sid.clone(),
+            messages_json,
+        });
     }
 
     fn emit(&self, msg: ServiceMessage) {
@@ -181,14 +178,21 @@ impl AcpShared {
 }
 
 fn project_session_update(shared: &AcpShared, update: SessionUpdate) {
-    let intents = {
-        let mut projector = shared.projector.lock().unwrap();
-        let intents = projector.apply(update);
-        if shared.history_replay.load(Ordering::SeqCst) {
-            return;
+    let mut projector = shared.projector.lock().unwrap();
+    let intents = projector.apply(update);
+    if shared.history_replay.load(Ordering::SeqCst) {
+        let update_count = shared.history_replay_updates.fetch_add(1, Ordering::SeqCst) + 1;
+        if update_count == 1 || update_count.is_multiple_of(HISTORY_REPLAY_SNAPSHOT_INTERVAL) {
+            let messages_json =
+                serde_json::to_string(projector.messages()).unwrap_or_else(|_| "[]".to_string());
+            shared.emit(ServiceMessage::AgentMessagesSnapshot {
+                sid: shared.sid.clone(),
+                messages_json,
+            });
         }
-        intents
-    };
+        return;
+    }
+    drop(projector);
     for intent in intents {
         match intent {
             Intent::Delta(text) => shared.emit(ServiceMessage::AgentDelta {
@@ -1003,7 +1007,7 @@ mod tests {
     }
 
     #[test]
-    fn history_replay_emits_one_final_snapshot() {
+    fn history_replay_emits_progressive_and_final_snapshots() {
         let (stream_tx, mut stream_rx) = broadcast::channel(64);
         let shared = Arc::new(AcpShared::new(
             "s1".into(),
@@ -1021,6 +1025,13 @@ mod tests {
                 TextContent::new("hello"),
             ))),
         );
+        let ServiceMessage::AgentMessagesSnapshot { messages_json, .. } =
+            stream_rx.try_recv().expect("first progressive snapshot")
+        else {
+            panic!("expected snapshot");
+        };
+        let messages: Vec<crate::message::Message> = serde_json::from_str(&messages_json).unwrap();
+        assert_eq!(messages.len(), 1);
         for _ in 0..300 {
             project_session_update(
                 &shared,
@@ -1030,11 +1041,10 @@ mod tests {
             );
         }
 
-        assert!(matches!(
-            stream_rx.try_recv(),
-            Err(broadcast::error::TryRecvError::Empty)
-        ));
-
+        let snapshots: Vec<ServiceMessage> =
+            std::iter::from_fn(|| stream_rx.try_recv().ok()).collect();
+        assert!(snapshots.len() > 1);
+        assert!(snapshots.len() < 64);
         shared.finish_history_replay(true);
 
         let ServiceMessage::AgentMessagesSnapshot { messages_json, .. } =
@@ -1074,9 +1084,24 @@ mod tests {
             ))),
         );
 
+        let ServiceMessage::AgentMessagesSnapshot { messages_json, .. } =
+            stream_rx.try_recv().expect("progressive snapshot")
+        else {
+            panic!("expected snapshot");
+        };
+        let messages: Vec<crate::message::Message> = serde_json::from_str(&messages_json).unwrap();
+        assert_eq!(messages.len(), 1);
+
         shared.finish_history_replay(false);
 
         assert!(shared.projector.lock().unwrap().messages().is_empty());
+        let ServiceMessage::AgentMessagesSnapshot { messages_json, .. } =
+            stream_rx.try_recv().expect("clearing snapshot")
+        else {
+            panic!("expected snapshot");
+        };
+        let messages: Vec<crate::message::Message> = serde_json::from_str(&messages_json).unwrap();
+        assert!(messages.is_empty());
         assert!(matches!(
             stream_rx.try_recv(),
             Err(broadcast::error::TryRecvError::Empty)


### PR DESCRIPTION
## Context

Resuming a long Codex ACP session could reopen the correct thread with an empty chat. The ACP adapter replays the full transcript, but vmux forwarded every replay update through a bounded broadcast channel and dropped early history once the channel lagged.

## Implementation

Accumulate ACP session updates in the projector while `session/load` replays history, suppress intermediate UI events, then emit one authoritative transcript snapshot after loading succeeds. Failed loads discard partial replay state. Live session updates keep their existing delta, snapshot, diff, and file-touch behavior.

## Checks / QA

- Open a Codex ACP pane with an existing long thread.
- Use `/resume` to select that same thread.
- Confirm prior user and assistant turns appear after loading.
- Send a new prompt and confirm live updates continue normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session resume by replaying history while suppressing intermediate session-update projections, then emitting a single final transcript snapshot on success.
  * Session restoration failures no longer surface partial or incomplete replayed content.
  * Stack swap teardown now fully resets ACP install state to prevent stale install markers.
  * VMUX URLs with surrounding whitespace are now normalized correctly.
  * Installing splash UI now shows only during install when the chat list is still empty.
  * ACP session messaging now reflects whether session history is being loaded.

* **Tests**
  * Added coverage for progressive snapshot emissions during history replay and replay failure handling.
  * Added/updated tests for ACP swap reset behavior and resume/non-resume messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->