### PR TITLE
fix(agent): enable Codex and Vibe CLI handoff

### DIFF
--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -41,7 +41,7 @@ use crate::handoff::{
 #[cfg(not(target_arch = "wasm32"))]
 use crate::run_state::{AgentRunState, AgentTurnMeta};
 #[cfg(not(target_arch = "wasm32"))]
-use crate::strategy::{AgentStrategies, kind_supports_cross_runtime};
+use crate::strategy::{AgentStrategies, acp_agent_kind, kind_supports_cross_runtime};
 #[cfg(not(target_arch = "wasm32"))]
 use vmux_core::PageMetadata;
 #[cfg(not(target_arch = "wasm32"))]
@@ -276,7 +276,7 @@ fn sync_chat_to_ready_views(
         let cross = acp_sessions
             .get(stack)
             .ok()
-            .and_then(|acp| AgentKind::from_url_segment(&acp.agent_id))
+            .and_then(|acp| acp_agent_kind(&acp.agent_id))
             .map(kind_supports_cross_runtime)
             .unwrap_or(false);
         commands.trigger(BinHostEmitEvent::from_rkyv(
@@ -600,7 +600,7 @@ fn slash_commands_for(cross_runtime: bool) -> Vec<SlashCommandEntry> {
 }
 
 /// The target url + cwd for an ACP↔CLI runtime handoff of the current session, or `None` when
-/// the handoff is unavailable (unknown/non-cross-runtime kind, no session id yet, bad `to`).
+/// the handoff is unavailable (unknown agent, no session id yet, bad `to`).
 #[cfg(not(target_arch = "wasm32"))]
 fn runtime_switch_target(
     agent_id: &str,
@@ -609,7 +609,7 @@ fn runtime_switch_target(
     to: &str,
     acp_ids: &[String],
 ) -> Option<(String, std::path::PathBuf)> {
-    let kind = AgentKind::from_url_segment(agent_id)?;
+    let kind = acp_agent_kind(agent_id)?;
     if !kind_supports_cross_runtime(kind) {
         return None;
     }
@@ -703,7 +703,7 @@ fn on_resume_list_request(
     let stack = child_of.get(webview).ok().map(ChildOf::parent);
     let acp = stack.and_then(|stack| acp_sessions.get(stack).ok());
     let kind = acp
-        .and_then(|acp| AgentKind::from_url_segment(&acp.agent_id))
+        .and_then(|acp| acp_agent_kind(&acp.agent_id))
         .or_else(|| {
             stack.and_then(|stack| agent_sessions.get(stack).ok().map(|session| session.kind))
         });
@@ -787,11 +787,8 @@ fn on_resume_session(
         return;
     };
     if let Ok(acp) = acp_sessions.get(stack)
-        && let Some(target_url) = foreign_handoff_target(
-            &acp.agent_id,
-            AgentKind::from_url_segment(&acp.agent_id),
-            kind,
-        )
+        && let Some(target_url) =
+            foreign_handoff_target(&acp.agent_id, acp_agent_kind(&acp.agent_id), kind)
     {
         let strategies = strategies
             .map(|strategies| (*strategies).clone())
@@ -878,16 +875,29 @@ mod native_tests {
     use std::path::Path;
 
     #[test]
-    fn runtime_switch_claude_acp_to_cli() {
-        let ids = vec!["claude".to_string()];
-        let got = runtime_switch_target("claude", Some("sid-9"), Path::new("/w"), "cli", &ids);
-        assert_eq!(
-            got,
-            Some((
-                "vmux://agent/claude/cli/sid-9".to_string(),
-                std::path::PathBuf::from("/w")
-            ))
-        );
+    fn runtime_switch_builtin_acp_agents_to_cli() {
+        let cases = [
+            ("claude", "claude"),
+            ("claude-acp", "claude"),
+            ("codex", "codex"),
+            ("codex-acp", "codex"),
+            ("vibe", "vibe"),
+            ("mistral-vibe", "vibe"),
+        ];
+        let ids = cases
+            .iter()
+            .map(|(id, _)| (*id).to_string())
+            .collect::<Vec<_>>();
+        for (agent_id, cli_segment) in cases {
+            let got = runtime_switch_target(agent_id, Some("sid-9"), Path::new("/w"), "cli", &ids);
+            assert_eq!(
+                got,
+                Some((
+                    format!("vmux://agent/{cli_segment}/cli/sid-9"),
+                    std::path::PathBuf::from("/w")
+                ))
+            );
+        }
     }
 
     #[test]
@@ -900,10 +910,10 @@ mod native_tests {
     }
 
     #[test]
-    fn runtime_switch_gated_for_non_cross_runtime_kind() {
+    fn runtime_switch_gated_for_unknown_agent() {
         let ids = vec!["claude".to_string()];
         assert_eq!(
-            runtime_switch_target("codex", Some("s"), Path::new("/w"), "cli", &ids),
+            runtime_switch_target("custom", Some("s"), Path::new("/w"), "cli", &ids),
             None
         );
     }

--- a/crates/vmux_agent/src/client/cli/codex.rs
+++ b/crates/vmux_agent/src/client/cli/codex.rs
@@ -280,7 +280,7 @@ pub(crate) fn list_codex_sessions(root: &Path) -> Vec<ResumableSession> {
             cwd: PathBuf::from(&head.payload.cwd),
             mtime,
             title,
-            cross_runtime: false,
+            cross_runtime: true,
         });
     });
     out
@@ -564,7 +564,7 @@ mod tests {
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].sid, "cx-1");
         assert_eq!(out[0].cwd, PathBuf::from("/w/x"));
-        assert!(!out[0].cross_runtime);
+        assert!(out[0].cross_runtime);
         let _ = std::fs::remove_dir_all(&tmp);
     }
 

--- a/crates/vmux_agent/src/client/cli/strategy.rs
+++ b/crates/vmux_agent/src/client/cli/strategy.rs
@@ -18,7 +18,7 @@ pub struct ResumableSession {
     pub mtime: SystemTime,
     /// First user message / summary, or a short sid fallback.
     pub title: String,
-    /// True when this kind's ACP and CLI runtimes share the session id (Claude only, for now).
+    /// True when this kind's ACP and CLI runtimes share the session id.
     pub cross_runtime: bool,
 }
 

--- a/crates/vmux_agent/src/client/cli/vibe.rs
+++ b/crates/vmux_agent/src/client/cli/vibe.rs
@@ -374,7 +374,7 @@ pub(crate) fn list_vibe_sessions(root: &Path) -> Vec<ResumableSession> {
             cwd,
             mtime,
             title: short_id.to_string(),
-            cross_runtime: false,
+            cross_runtime: true,
         });
     }
     out
@@ -797,7 +797,7 @@ mod tests {
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].sid, "vb-1");
         assert_eq!(out[0].cwd, PathBuf::from("/w/y"));
-        assert!(!out[0].cross_runtime);
+        assert!(out[0].cross_runtime);
         let _ = std::fs::remove_dir_all(&tmp);
     }
 

--- a/crates/vmux_agent/src/strategy.rs
+++ b/crates/vmux_agent/src/strategy.rs
@@ -50,7 +50,15 @@ impl AgentStrategies {
 /// Whether a kind's ACP and CLI runtimes share the same session id (so a session can be
 /// handed off between them). Single source of truth for the `cross_runtime` flag.
 pub fn kind_supports_cross_runtime(kind: AgentKind) -> bool {
-    matches!(kind, AgentKind::Claude)
+    matches!(kind, AgentKind::Vibe | AgentKind::Claude | AgentKind::Codex)
+}
+
+/// Maps a built-in launcher id or its ACP registry id to the shared agent kind.
+pub(crate) fn acp_agent_kind(agent_id: &str) -> Option<AgentKind> {
+    AgentKind::all().into_iter().find(|kind| {
+        let segment = kind.as_url_segment();
+        agent_id == segment || agent_id == crate::acp_install::registry_id_alias(segment)
+    })
 }
 
 /// Sort newest-first and drop duplicate `(kind, sid)` keeping the newest.
@@ -121,5 +129,23 @@ mod tests {
             got.iter().map(|s| s.sid.as_str()).collect::<Vec<_>>(),
             vec!["b", "a"]
         );
+    }
+
+    #[test]
+    fn all_builtin_kinds_support_cross_runtime_handoff() {
+        for kind in AgentKind::all() {
+            assert!(kind_supports_cross_runtime(kind));
+        }
+    }
+
+    #[test]
+    fn acp_agent_kind_maps_launcher_and_registry_ids() {
+        assert_eq!(acp_agent_kind("claude"), Some(AgentKind::Claude));
+        assert_eq!(acp_agent_kind("claude-acp"), Some(AgentKind::Claude));
+        assert_eq!(acp_agent_kind("codex"), Some(AgentKind::Codex));
+        assert_eq!(acp_agent_kind("codex-acp"), Some(AgentKind::Codex));
+        assert_eq!(acp_agent_kind("vibe"), Some(AgentKind::Vibe));
+        assert_eq!(acp_agent_kind("mistral-vibe"), Some(AgentKind::Vibe));
+        assert_eq!(acp_agent_kind("custom"), None);
     }
 }

--- a/docs/specs/2026-07-08-acp-cli-resume-design.md
+++ b/docs/specs/2026-07-08-acp-cli-resume-design.md
@@ -72,7 +72,10 @@ Resume plumbing already exists on both sides; what's missing is discovery/picker
   both directions.
 - **Hard constraint: same cwd.** Sessions are keyed by encoded cwd. A handoff (or resume)
   from a different cwd silently starts a fresh session. cwd MUST travel with the session.
-- Codex/Vibe id-sharing across ACP and CLI is **unverified** — treat as false for now.
+- Codex ACP writes to the CLI's `~/.codex/sessions` store using the Codex session id.
+- Vibe ACP uses the same `AgentLoop.session_id` and session logger as the CLI.
+  ⇒ Claude, Codex, and Vibe all support ACP↔CLI handoff.
+- ACP registry ids (`claude-acp`, `codex-acp`, `mistral-vibe`) map to their canonical CLI kinds.
 
 ## Model — runtime-agnostic session identity
 
@@ -102,7 +105,7 @@ pub struct ResumableSession {
     pub cwd: PathBuf,
     pub mtime: SystemTime,
     pub title: String,        // first user message / summary; falls back to short sid
-    pub cross_runtime: bool,  // ACP↔CLI handoff safe for this kind (claude=true)
+    pub cross_runtime: bool,  // ACP↔CLI handoff safe for this kind
 }
 ```
 
@@ -112,9 +115,9 @@ pub struct ResumableSession {
 - vibe: `~/.vibe/logs/session/session_*/meta.json` → id, cwd, times.
 
 A backend collector unions across registered strategies, sorts by mtime desc, dedups by
-`(kind, sid)`. Claude's store is shared by ACP+CLI, so one scan covers both runtimes.
+`(kind, sid)`. Each built-in kind's store is shared by ACP+CLI, so one scan covers both runtimes.
 **Scan on demand** (when `/resume` is invoked), not eagerly. `cross_runtime` is a per-kind
-capability: claude=true; codex/vibe=false until verified.
+capability: true for Claude, Codex, and Vibe.
 
 ### 2. Composer slash mechanism (frontend — ACP agent page)
 
@@ -187,7 +190,8 @@ teardown-then-attach so both `/resume` and `/cli` share it without adding a
 `/cli` in the ACP composer emits `SwapStackSession` with a CLI `target_url`, current sid,
 and cwd → CLI PTY resumes the same conversation, same page.
 
-- Gated by `ResumableSession.cross_runtime` / a per-kind capability. Claude only for v1.
+- Gated by `ResumableSession.cross_runtime` / a per-kind capability. Claude, Codex, and Vibe
+  share their ACP session ids with their CLI runtimes.
 - cwd is taken from the live `AcpSession.cwd` (never `default_cwd`).
 - Reverse (`/acp` from a CLI pane) is deferred because CLI panes have no vmux composer.
 


### PR DESCRIPTION
## Context
ACP composer only exposed `/cli` for Claude, despite Codex ACP and Vibe ACP sharing their session stores and identifiers with their CLI runtimes. Codex and Vibe users could not continue the current ACP conversation in the terminal runtime.

## Implementation
Treat all built-in agent kinds as cross-runtime capable, map canonical and ACP registry identifiers to the same agent kind, and mark discovered Codex and Vibe sessions as safe for runtime handoff. Update the session handoff design with the verified storage behavior.

## Checks / QA
- Open Codex and Vibe ACP sessions, type `/`, and confirm `/cli` appears.
- Send a prompt, select `/cli`, and confirm the same conversation resumes in the CLI with the same working directory.