### PR TITLE
fix(start): stop hidden autofocus retry loop

### DIFF
--- a/crates/vmux_layout/src/start/page.rs
+++ b/crates/vmux_layout/src/start/page.rs
@@ -9,6 +9,8 @@ use wasm_bindgen::prelude::*;
 use crate::command_bar::palette::{CommandPalette, PaletteVariant};
 use crate::start::event::{START_FOCUS_INPUT_EVENT, StartDataRequest, StartFocusInput};
 
+const START_FOCUS_PENDING: &str = "_startFocusPending";
+
 /// The `vmux://start/` launcher page: a cinematic centered hero that requests its
 /// entries on mount and renders [`CommandPalette`] in [`PaletteVariant::Start`].
 #[component]
@@ -38,7 +40,6 @@ pub fn Page() -> Element {
     use_effect(|| {
         install_window_focus_refocus();
         install_keep_input_focused_on_click();
-        focus_start_input();
     });
 
     let reveal = if mounted() {
@@ -79,25 +80,46 @@ pub fn Page() -> Element {
     }
 }
 
-/// Focus the launcher input, re-asserting focus once per animation frame until the document
-/// actually holds focus. CEF grants the OSR browser native keyboard focus (`SetFocus`) several
-/// frames after the page mounts — a single deferred `input.focus()` runs too early and is dropped,
-/// and CEF OSR emits no JS `window` focus event to hook — so a bounded retry keeps the input as
-/// the active element through that window and lands the caret as soon as native focus arrives.
+/// Focus the launcher input after the host reveals the page, re-asserting focus once per animation
+/// frame until the document actually holds focus. Concurrent requests share one bounded retry.
 fn focus_start_input() {
-    focus_start_input_retry(90);
-}
-
-fn focus_start_input_retry(frames_left: u32) {
     let Some(window) = web_sys::window() else {
         return;
     };
-    let cb = Closure::once_into_js(move || {
+    if start_focus_pending(&window) {
+        return;
+    }
+    set_start_focus_pending(&window, true);
+    focus_start_input_retry(window, 90);
+}
+
+fn focus_start_input_retry(window: web_sys::Window, frames_left: u32) {
+    let retry_window = window.clone();
+    let cb = Closure::once(move || {
         if !try_focus_command_input_once() && frames_left > 1 {
-            focus_start_input_retry(frames_left - 1);
+            focus_start_input_retry(retry_window, frames_left - 1);
+        } else {
+            set_start_focus_pending(&retry_window, false);
         }
     });
-    let _ = window.request_animation_frame(cb.unchecked_ref());
+    match window.request_animation_frame(cb.as_ref().unchecked_ref()) {
+        Ok(_) => cb.forget(),
+        Err(_) => set_start_focus_pending(&window, false),
+    }
+}
+
+fn start_focus_pending(window: &web_sys::Window) -> bool {
+    js_sys::Reflect::get(window, &JsValue::from_str(START_FOCUS_PENDING))
+        .map(|v| v.is_truthy())
+        .unwrap_or(false)
+}
+
+fn set_start_focus_pending(window: &web_sys::Window, pending: bool) {
+    let _ = js_sys::Reflect::set(
+        window,
+        &JsValue::from_str(START_FOCUS_PENDING),
+        &JsValue::from_bool(pending),
+    );
 }
 
 /// Focus the input if it is not already the active element; returns true once the document holds

--- a/crates/vmux_layout/src/start/plugin.rs
+++ b/crates/vmux_layout/src/start/plugin.rs
@@ -96,16 +96,23 @@ fn sync_live_start_pages(
     pages_snapshot: Res<CommandBarPagesSnapshot>,
     work_snapshot: Res<CommandBarWorkSnapshot>,
     focused: Res<crate::stack::FocusedStack>,
-    starts: Query<(Entity, &WebviewSource, Has<StartWorkSynced>)>,
+    starts: Query<(
+        Entity,
+        &WebviewSource,
+        Has<StartWorkSynced>,
+        Has<CefKeyboardTarget>,
+    )>,
+    added_keyboard_targets: Query<(), Added<CefKeyboardTarget>>,
     browsers: NonSend<Browsers>,
     mut commands: Commands,
 ) {
     // Refresh on work-snapshot changes and on focus/tab changes (so the tabs list
     // and active markers stay current), plus first-sync for newly-ready pages.
-    let changed = work_snapshot.is_changed() || focused.is_changed();
-    let targets: Vec<Entity> = starts
+    let focus_changed = focused.is_changed();
+    let changed = work_snapshot.is_changed() || focus_changed;
+    let targets: Vec<(Entity, bool)> = starts
         .iter()
-        .filter_map(|(e, src, synced)| {
+        .filter_map(|(e, src, synced, keyboard_target)| {
             let WebviewSource::Url(url) = src else {
                 return None;
             };
@@ -115,7 +122,13 @@ fn sync_live_start_pages(
             if !browsers.has_browser(e) || !browsers.host_emit_ready(&e) {
                 return None;
             }
-            (changed || !synced).then_some(e)
+            let focus_requested = should_focus_start_sync(
+                synced,
+                keyboard_target,
+                added_keyboard_targets.contains(e),
+                focus_changed,
+            );
+            (changed || !synced || focus_requested).then_some((e, focus_requested))
         })
         .collect();
     if targets.is_empty() {
@@ -128,16 +141,32 @@ fn sync_live_start_pages(
         &pages_snapshot,
         &work_snapshot,
     );
-    for e in targets {
+    for (e, focus_requested) in targets {
         commands.trigger(BinHostEmitEvent::from_rkyv(
             e,
             COMMAND_BAR_OPEN_EVENT,
             &payload,
         ));
+        if focus_requested {
+            commands.trigger(BinHostEmitEvent::from_rkyv(
+                e,
+                START_FOCUS_INPUT_EVENT,
+                &StartFocusInput,
+            ));
+        }
         // The start page can be despawned this frame (e.g. selecting an agent opens in-place over
         // it) before this command applies — `try_insert` skips silently instead of panicking.
         commands.entity(e).try_insert(StartWorkSynced);
     }
+}
+
+fn should_focus_start_sync(
+    synced: bool,
+    keyboard_target: bool,
+    keyboard_target_added: bool,
+    focus_changed: bool,
+) -> bool {
+    keyboard_target && (!synced || keyboard_target_added || focus_changed)
 }
 
 /// Claim `vmux://start/` page-open tasks. When a warm spare is available it is reparented
@@ -256,6 +285,7 @@ fn on_start_spare_revealed(
 fn on_start_data_request(
     trigger: On<BinReceive<StartDataRequest>>,
     spares: Query<(), With<WarmStartSpare>>,
+    keyboard_targets: Query<(), With<CefKeyboardTarget>>,
     tab_gather: TabGatherParams,
     spaces_snapshot: Res<CommandBarSpacesSnapshot>,
     agents_snapshot: Res<CommandBarAgentsSnapshot>,
@@ -264,7 +294,8 @@ fn on_start_data_request(
     mut commands: Commands,
 ) {
     let webview = trigger.event().webview;
-    if spares.contains(webview) {
+    let is_spare = spares.contains(webview);
+    if is_spare {
         commands.entity(webview).insert(WarmStartReady);
     }
     let payload = build_start_payload(
@@ -279,6 +310,13 @@ fn on_start_data_request(
         COMMAND_BAR_OPEN_EVENT,
         &payload,
     ));
+    if keyboard_targets.contains(webview) {
+        commands.trigger(BinHostEmitEvent::from_rkyv(
+            webview,
+            START_FOCUS_INPUT_EVENT,
+            &StartFocusInput,
+        ));
+    }
 }
 
 /// Build the launcher payload shared by the on-mount data feed and warm-spare refresh.
@@ -330,8 +368,36 @@ fn clear_stack_children(stack: Entity, children_q: &Query<&Children>, commands: 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bevy_cef::prelude::BinReceive;
     use vmux_core::PageOpenId;
     use vmux_core::page::PageManifest;
+
+    #[derive(Resource, Default)]
+    struct EmittedIds(Vec<String>);
+
+    fn capture_emit(trigger: On<BinHostEmitEvent>, mut emitted: ResMut<EmittedIds>) {
+        emitted.0.push(trigger.id.clone());
+    }
+
+    fn start_ready_app() -> App {
+        let mut app = App::new();
+        app.init_resource::<CommandBarSpacesSnapshot>()
+            .init_resource::<CommandBarAgentsSnapshot>()
+            .init_resource::<CommandBarPagesSnapshot>()
+            .init_resource::<CommandBarWorkSnapshot>()
+            .init_resource::<EmittedIds>()
+            .add_observer(on_start_data_request)
+            .add_observer(capture_emit);
+        app
+    }
+
+    fn emit_start_ready(app: &mut App, webview: Entity) {
+        app.world_mut().trigger(BinReceive {
+            webview,
+            payload: StartDataRequest,
+        });
+        app.update();
+    }
 
     #[test]
     fn start_plugin_spawns_manifest() {
@@ -339,6 +405,65 @@ mod tests {
         app.add_plugins(StartPlugin);
         let mut q = app.world_mut().query::<&PageManifest>();
         assert!(q.iter(app.world()).any(|m| m.host == "start"));
+    }
+
+    #[test]
+    fn page_mount_does_not_start_focus_retry() {
+        let source = include_str!("page.rs");
+        let setup_effect = source
+            .split_once("use_effect(|| {")
+            .expect("start page setup effect")
+            .1
+            .split_once("});")
+            .expect("end of start page setup effect")
+            .0;
+
+        assert!(setup_effect.contains("install_window_focus_refocus();"));
+        assert!(setup_effect.contains("install_keep_input_focused_on_click();"));
+        assert!(!setup_effect.contains("focus_start_input();"));
+    }
+
+    #[test]
+    fn cold_start_focuses_after_page_ready() {
+        let mut app = start_ready_app();
+        let webview = app.world_mut().spawn(CefKeyboardTarget).id();
+
+        emit_start_ready(&mut app, webview);
+
+        let emitted = &app.world().resource::<EmittedIds>().0;
+        assert_eq!(emitted, &[COMMAND_BAR_OPEN_EVENT, START_FOCUS_INPUT_EVENT]);
+    }
+
+    #[test]
+    fn warm_start_waits_for_reveal_before_focusing() {
+        let mut app = start_ready_app();
+        let webview = app.world_mut().spawn(WarmStartSpare).id();
+
+        emit_start_ready(&mut app, webview);
+
+        assert!(app.world().get::<WarmStartReady>(webview).is_some());
+        let emitted = &app.world().resource::<EmittedIds>().0;
+        assert_eq!(emitted, &[COMMAND_BAR_OPEN_EVENT]);
+    }
+
+    #[test]
+    fn inactive_cold_start_waits_for_activation_before_focusing() {
+        let mut app = start_ready_app();
+        let webview = app.world_mut().spawn_empty().id();
+
+        emit_start_ready(&mut app, webview);
+
+        let emitted = &app.world().resource::<EmittedIds>().0;
+        assert_eq!(emitted, &[COMMAND_BAR_OPEN_EVENT]);
+    }
+
+    #[test]
+    fn start_sync_focuses_only_active_pages_on_first_sync_or_activation() {
+        assert!(!should_focus_start_sync(false, false, false, false));
+        assert!(should_focus_start_sync(false, true, false, false));
+        assert!(should_focus_start_sync(true, true, true, false));
+        assert!(should_focus_start_sync(true, true, false, true));
+        assert!(!should_focus_start_sync(true, true, false, false));
     }
 
     fn start_task(stack: Entity) -> PageOpenTask {


### PR DESCRIPTION
## Context

Vmux prewarms a hidden `vmux://start/` page. The page started autofocus retries while hidden, which could overlap and peg renderer CPU near 100%.

## Implementation

Only active start pages receive focus events. Warm and inactive pages wait until reveal, activation, or first ready synchronization, and overlapping animation-frame retries are deduplicated. Failed animation-frame scheduling drops its callback instead of leaking it.

## Checks / QA

1. Launch vmux with the warm start pool enabled and leave it idle.
2. Verify the hidden start renderer remains near 0% CPU.
3. Open or reactivate a start page and verify the search input receives focus.