### PR TITLE
fix(command-bar): recover stalled native reveal

### DIFF
--- a/crates/vmux_layout/src/command_bar/handler.rs
+++ b/crates/vmux_layout/src/command_bar/handler.rs
@@ -81,6 +81,7 @@ impl PendingCommandBarReveal {
 
 const COMMAND_BAR_REVEAL_FRAMES: u8 = 2;
 const COMMAND_BAR_REVEAL_FALLBACK_FRAMES: u8 = 10;
+const COMMAND_BAR_NATIVE_REVEAL_TIMEOUT_FRAMES: u8 = 120;
 
 pub(crate) struct CommandBarInputPlugin;
 
@@ -343,14 +344,23 @@ fn next_command_bar_reveal_frames_for_backend(
     painted_open_id: Option<u64>,
     has_native_size: bool,
 ) -> Option<u8> {
-    if native_windowed && open_id != 0 && rendered_open_id != Some(open_id) {
-        return if has_native_size {
-            None
-        } else {
-            Some(frames.saturating_add(1))
-        };
+    if native_windowed && open_id != 0 && (rendered_open_id != Some(open_id) || !has_native_size) {
+        return Some(frames.saturating_add(1));
     }
     next_command_bar_reveal_frames(frames, open_id, rendered_open_id, painted_open_id)
+}
+
+fn native_command_bar_reveal_timed_out(
+    native_windowed: bool,
+    frames: u8,
+    open_id: u64,
+    rendered_open_id: Option<u64>,
+    has_native_size: bool,
+) -> bool {
+    native_windowed
+        && open_id != 0
+        && frames >= COMMAND_BAR_NATIVE_REVEAL_TIMEOUT_FRAMES
+        && (rendered_open_id != Some(open_id) || !has_native_size)
 }
 
 fn command_bar_reveal_start_frames(was_prewarmed: bool) -> u8 {
@@ -1750,6 +1760,24 @@ fn reveal_command_bar(
     {
         let rendered_open_id = rendered.map(|rendered| rendered.0);
         let painted_open_id = painted.map(|painted| painted.0);
+        if native_command_bar_reveal_timed_out(
+            native_windowed,
+            pending.frames,
+            pending.open_id,
+            rendered_open_id,
+            native_size.is_some(),
+        ) {
+            commands.entity(entity).remove::<PendingCommandBarReveal>();
+            commands.trigger(BinReceive::<CommandBarActionEvent> {
+                webview: entity,
+                payload: CommandBarActionEvent {
+                    action: "dismiss".to_string(),
+                    value: String::new(),
+                    target: None,
+                },
+            });
+            continue;
+        }
         match next_command_bar_reveal_frames_for_backend(
             native_windowed,
             pending.frames,
@@ -2174,14 +2202,85 @@ mod tests {
     }
 
     #[test]
-    fn native_command_bar_does_not_fallback_reveal_without_rendered_ack() {
+    fn native_command_bar_waits_for_size_and_rendered_ack() {
         assert_eq!(
-            next_command_bar_reveal_frames_for_backend(true, 10, 7, None, None, false),
+            next_command_bar_reveal_frames_for_backend(true, 10, 7, None, None, true),
             Some(11)
         );
         assert_eq!(
-            next_command_bar_reveal_frames_for_backend(false, 10, 7, None, None, false),
+            next_command_bar_reveal_frames_for_backend(true, 10, 7, Some(7), None, false),
+            Some(11)
+        );
+        assert_eq!(
+            next_command_bar_reveal_frames_for_backend(true, 2, 7, Some(7), None, true),
             None
+        );
+    }
+
+    #[test]
+    fn native_command_bar_aborts_stalled_reveal() {
+        assert!(!native_command_bar_reveal_timed_out(
+            true,
+            COMMAND_BAR_NATIVE_REVEAL_TIMEOUT_FRAMES - 1,
+            7,
+            None,
+            false,
+        ));
+        assert!(native_command_bar_reveal_timed_out(
+            true,
+            COMMAND_BAR_NATIVE_REVEAL_TIMEOUT_FRAMES,
+            7,
+            None,
+            false,
+        ));
+        assert!(native_command_bar_reveal_timed_out(
+            true,
+            COMMAND_BAR_NATIVE_REVEAL_TIMEOUT_FRAMES,
+            7,
+            Some(7),
+            false,
+        ));
+        assert!(!native_command_bar_reveal_timed_out(
+            true,
+            COMMAND_BAR_NATIVE_REVEAL_TIMEOUT_FRAMES,
+            7,
+            Some(7),
+            true,
+        ));
+        assert!(!native_command_bar_reveal_timed_out(
+            false,
+            COMMAND_BAR_NATIVE_REVEAL_TIMEOUT_FRAMES,
+            7,
+            None,
+            false,
+        ));
+    }
+
+    #[test]
+    fn native_command_bar_timeout_clears_pending_reveal() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_systems(Update, reveal_command_bar);
+        let modal = app
+            .world_mut()
+            .spawn((
+                Modal,
+                WebviewWindowed,
+                Visibility::Hidden,
+                PendingCommandBarReveal {
+                    frames: COMMAND_BAR_NATIVE_REVEAL_TIMEOUT_FRAMES,
+                    open_id: 7,
+                    payload: Some(b"payload".to_vec()),
+                },
+            ))
+            .id();
+
+        app.update();
+
+        assert!(app.world().get::<PendingCommandBarReveal>(modal).is_none());
+        assert_eq!(
+            app.world().get::<Visibility>(modal),
+            Some(&Visibility::Hidden)
         );
     }
 
@@ -2205,7 +2304,7 @@ mod tests {
         ));
         assert_eq!(
             next_command_bar_reveal_frames_for_backend(true, 0, 7, None, None, true),
-            None
+            Some(1)
         );
     }
 

--- a/crates/vmux_layout/src/command_bar/page.rs
+++ b/crates/vmux_layout/src/command_bar/page.rs
@@ -20,6 +20,7 @@ pub fn Page() -> Element {
     let mut is_open = use_signal(|| false);
     let mut current_open_id = use_signal(|| 0u64);
     let mut last_rendered_open_id = use_signal(|| 0u64);
+    let mut render_ack_scheduled_open_id = use_signal(|| 0u64);
     let mut ready_sent = use_signal(|| false);
     let mut observed_size_open_id = use_signal(|| None::<u64>);
     let mut outside_pointer_listener_installed = use_signal(|| false);
@@ -30,9 +31,6 @@ pub fn Page() -> Element {
             let should_reset_input =
                 command_bar_open_should_reset_input(current_open_id(), open_id);
             if !should_reset_input {
-                if command_bar_open_should_ack(open_id) {
-                    let _ = try_cef_bin_emit_rkyv(&CommandBarRenderedEvent { open_id });
-                }
                 return;
             }
             current_open_id.set(open_id);
@@ -40,6 +38,7 @@ pub fn Page() -> Element {
             is_open.set(true);
             if command_bar_open_should_ack(open_id) {
                 last_rendered_open_id.set(0);
+                render_ack_scheduled_open_id.set(0);
             }
         });
 
@@ -58,9 +57,17 @@ pub fn Page() -> Element {
         if open
             && open_id != 0
             && last_rendered_open_id() != open_id
-            && try_cef_bin_emit_rkyv(&CommandBarRenderedEvent { open_id }).is_ok()
+            && render_ack_scheduled_open_id() != open_id
         {
-            last_rendered_open_id.set(open_id);
+            render_ack_scheduled_open_id.set(open_id);
+            if !schedule_command_bar_rendered_emit(
+                open_id,
+                2,
+                last_rendered_open_id,
+                render_ack_scheduled_open_id,
+            ) {
+                render_ack_scheduled_open_id.set(0);
+            }
         }
     });
 
@@ -242,6 +249,40 @@ fn schedule_command_bar_size_emit() {
     }) as Box<dyn FnMut()>);
     let _ = window.request_animation_frame(callback.as_ref().unchecked_ref());
     callback.forget();
+}
+
+fn schedule_command_bar_rendered_emit(
+    open_id: u64,
+    frames_left: u8,
+    mut last_rendered_open_id: Signal<u64>,
+    mut scheduled_open_id: Signal<u64>,
+) -> bool {
+    let Some(window) = web_sys::window() else {
+        return false;
+    };
+    let callback = Closure::once(move || {
+        if frames_left > 1 {
+            if !schedule_command_bar_rendered_emit(
+                open_id,
+                frames_left - 1,
+                last_rendered_open_id,
+                scheduled_open_id,
+            ) {
+                scheduled_open_id.set(0);
+            }
+        } else if try_cef_bin_emit_rkyv(&CommandBarRenderedEvent { open_id }).is_ok() {
+            last_rendered_open_id.set(open_id);
+        } else {
+            scheduled_open_id.set(0);
+        }
+    });
+    match window.request_animation_frame(callback.as_ref().unchecked_ref()) {
+        Ok(_) => {
+            callback.forget();
+            true
+        }
+        Err(_) => false,
+    }
 }
 
 fn install_command_bar_size_observer() -> bool {

--- a/crates/vmux_layout/src/command_bar/style.rs
+++ b/crates/vmux_layout/src/command_bar/style.rs
@@ -253,6 +253,23 @@ mod tests {
     }
 
     #[test]
+    fn command_bar_rendered_ack_waits_for_two_animation_frames() {
+        let source = include_str!("page.rs");
+        let schedule_fn = source
+            .split("fn schedule_command_bar_rendered_emit")
+            .nth(1)
+            .and_then(|tail| tail.split("fn install_command_bar_size_observer").next())
+            .unwrap_or_default();
+
+        assert!(source.contains(
+            "schedule_command_bar_rendered_emit(\n                open_id,\n                2,"
+        ));
+        assert!(schedule_fn.contains("frames_left - 1"));
+        assert!(schedule_fn.contains("request_animation_frame"));
+        assert!(schedule_fn.contains("CommandBarRenderedEvent { open_id }"));
+    }
+
+    #[test]
     fn command_bar_input_handles_plain_meta_a() {
         let source = include_str!("palette.rs");
 


### PR DESCRIPTION
## Context

The native command bar could remain hidden when its render/size handshake stalled. The pending reveal then kept the reactive event loop awake indefinitely, leaving Cmd+K and Cmd+L ineffective while consuming CPU. A timeout-based fallback also exposed an unpainted blank native window.

## Implementation

Require both the rendered acknowledgment and measured native size before revealing the native command bar. Delay the rendered acknowledgment until two browser animation frames have elapsed, and abort a handshake that remains stalled instead of showing an unpainted fallback or waking forever.

## Checks / QA

1. Launch vmux with the native windowed browser backend.
2. Open the command bar repeatedly with Cmd+K and Cmd+L.
3. Confirm the populated bar appears without a blank flash and accepts input.
4. Dismiss with Escape and confirm vmux returns to idle CPU.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command bar opening reliability when the interface is slow to render or native window sizing is delayed.
  * Stalled command bar reveals now time out and dismiss cleanly instead of remaining stuck.
  * Improved synchronization between command bar animations and rendered state acknowledgments.

* **Tests**
  * Added coverage for delayed rendering, native sizing waits, and stalled reveal recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->