### PR TITLE
fix(git): refresh diffs after external git changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         run: TAILWINDCSS_INSTALL_DIR="$HOME/.local/bin" ./scripts/install-tailwindcss.sh
 
       - name: Clippy
-        run: env -u CEF_PATH cargo clippy ${{ steps.pkgs.outputs.args }} --all-targets -- -D warnings
+        run: env -u CEF_PATH VMUX_SKIP_DX_BUILD=1 cargo clippy ${{ steps.pkgs.outputs.args }} --all-targets -- -D warnings
 
   test-rust:
     name: Test (rust)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10264,6 +10264,7 @@ dependencies = [
  "bevy_cef_core",
  "bevy_ecs",
  "dioxus",
+ "notify 6.1.1",
  "rkyv",
  "serde",
  "similar",

--- a/crates/vmux_editor/src/page.rs
+++ b/crates/vmux_editor/src/page.rs
@@ -143,12 +143,11 @@ fn row_class(selected: bool) -> String {
     }
 }
 
-fn diff_marker_class(marker: EditorDiffMarker) -> &'static str {
+fn diff_marker_sign(marker: EditorDiffMarker) -> &'static str {
     match marker {
-        EditorDiffMarker::Added => "bg-ansi-2",
-        EditorDiffMarker::Modified => "bg-cyan-400",
-        EditorDiffMarker::Deleted => "bg-ansi-1",
-        EditorDiffMarker::Staged => "bg-ansi-2/60",
+        EditorDiffMarker::Added => "+",
+        EditorDiffMarker::Modified | EditorDiffMarker::Staged => "~",
+        EditorDiffMarker::Deleted => "-",
     }
 }
 
@@ -1209,14 +1208,15 @@ pub fn Page() -> Element {
                                                         span {
                                                             class: "sticky left-0 z-[1] relative flex shrink-0 select-none items-center justify-end bg-background pl-4 pr-5 tabular-nums",
                                                             style: "min-width:calc(var(--cw, 1ch) * {gw} + 2.25rem);",
-                                                            if let Some(marker) = diff_marker {
-                                                                span {
-                                                                    class: "pointer-events-none absolute inset-y-0 left-0 w-0.5 {diff_marker_class(marker)}",
-                                                                    title: "Changed line",
-                                                                }
-                                                            }
                                                             if let Some(s) = sev {
                                                                 span { class: "pointer-events-none absolute left-1 {severity_color_class(s)}", "●" }
+                                                            }
+                                                            if let Some(marker) = diff_marker {
+                                                                span {
+                                                                    class: "mr-1 w-[1ch] text-center font-semibold {diff_marker_text_class(marker)}",
+                                                                    title: "Changed line",
+                                                                    "{diff_marker_sign(marker)}"
+                                                                }
                                                             }
                                                             span {
                                                                 class: if let Some(marker) = diff_marker { "text-right opacity-90 {diff_marker_text_class(marker)}" } else { "text-right opacity-40 group-hover:opacity-90" },

--- a/crates/vmux_editor/src/page.rs
+++ b/crates/vmux_editor/src/page.rs
@@ -10,6 +10,7 @@ use crate::page_model::{
 use dioxus::prelude::*;
 use vmux_core::event::*;
 use vmux_core::media::MediaKind;
+use vmux_git::event::{GIT_CHANGED_EVENT, GitChangedEvent};
 use vmux_git::ui::{DiffView, GitBar, GitFooter};
 use vmux_git::view::EditorDiffMarker;
 use vmux_ui::file_icon::type_icon;
@@ -398,6 +399,10 @@ pub fn Page() -> Element {
 
     let _dirty = use_bin_event_listener::<FileDirtyEvent, _>(FILE_DIRTY_EVENT, move |d| {
         dirty.set(d.dirty);
+        schedule_git_refresh(git_refresh_generation, git_nonce);
+    });
+
+    let _git_changed = use_bin_event_listener::<GitChangedEvent, _>(GIT_CHANGED_EVENT, move |_| {
         schedule_git_refresh(git_refresh_generation, git_nonce);
     });
 

--- a/crates/vmux_editor/src/page.rs
+++ b/crates/vmux_editor/src/page.rs
@@ -152,6 +152,42 @@ fn diff_marker_class(marker: EditorDiffMarker) -> &'static str {
     }
 }
 
+fn diff_marker_text_class(marker: EditorDiffMarker) -> &'static str {
+    match marker {
+        EditorDiffMarker::Added => "text-ansi-2",
+        EditorDiffMarker::Modified => "text-cyan-500 dark:text-cyan-300",
+        EditorDiffMarker::Deleted => "text-ansi-1",
+        EditorDiffMarker::Staged => "text-ansi-2/80",
+    }
+}
+
+fn diff_marker_row_class(marker: EditorDiffMarker) -> &'static str {
+    match marker {
+        EditorDiffMarker::Added => "bg-ansi-2/[0.06] hover:bg-ansi-2/[0.10]",
+        EditorDiffMarker::Modified => "bg-cyan-400/[0.06] hover:bg-cyan-400/[0.10]",
+        EditorDiffMarker::Deleted => "bg-ansi-1/[0.06] hover:bg-ansi-1/[0.10]",
+        EditorDiffMarker::Staged => "bg-ansi-2/[0.035] hover:bg-ansi-2/[0.07]",
+    }
+}
+
+fn reveal_git_change(
+    markers: Signal<HashMap<u32, EditorDiffMarker>>,
+    cell_dims: Signal<(f64, f64)>,
+) {
+    let Some(line) = markers.read().keys().min().copied() else {
+        return;
+    };
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let closure = Closure::once(move || {
+        ensure_line_visible(line.saturating_sub(1), cell_dims().1);
+    });
+    let _ = window
+        .set_timeout_with_callback_and_timeout_and_arguments_0(closure.as_ref().unchecked_ref(), 0);
+    closure.forget();
+}
+
 fn visible_entries(all: &[FileDirEntry], show_hidden: bool) -> Vec<FileDirEntry> {
     if show_hidden {
         all.to_vec()
@@ -828,6 +864,8 @@ pub fn Page() -> Element {
                             file_view_mode.set(next);
                             if next == FileViewMode::Diff {
                                 git_nonce.set(git_nonce().wrapping_add(1));
+                            } else {
+                                reveal_git_change(git_line_markers, cell_dims);
                             }
                             let _ = try_cef_bin_emit_rkyv(&FileViewModeSet { mode: next });
                         },
@@ -1075,7 +1113,7 @@ pub fn Page() -> Element {
                                                 rsx! {
                                                     div {
                                                         key: "{ln}",
-                                                        class: "group flex hover:bg-foreground/[0.035]",
+                                                        class: if let Some(marker) = diff_marker { "group flex {diff_marker_row_class(marker)}" } else { "group flex hover:bg-foreground/[0.035]" },
                                                         style: "position:absolute;left:0;right:0;top:{lt}px;",
                                                         onmousedown: move |e: Event<MouseData>| {
                                                             e.prevent_default();
@@ -1180,7 +1218,10 @@ pub fn Page() -> Element {
                                                             if let Some(s) = sev {
                                                                 span { class: "pointer-events-none absolute left-1 {severity_color_class(s)}", "●" }
                                                             }
-                                                            span { class: "text-right opacity-40 group-hover:opacity-90", "{ln + 1}" }
+                                                            span {
+                                                                class: if let Some(marker) = diff_marker { "text-right opacity-90 {diff_marker_text_class(marker)}" } else { "text-right opacity-40 group-hover:opacity-90" },
+                                                                "{ln + 1}"
+                                                            }
                                                             match fold {
                                                                 FoldGutter::Open => {
                                                                     let vis = if gutter_hover() { "opacity-100" } else { "opacity-0" };

--- a/crates/vmux_editor/src/page.rs
+++ b/crates/vmux_editor/src/page.rs
@@ -154,18 +154,18 @@ fn diff_marker_sign(marker: EditorDiffMarker) -> &'static str {
 fn diff_marker_text_class(marker: EditorDiffMarker) -> &'static str {
     match marker {
         EditorDiffMarker::Added => "text-ansi-2",
-        EditorDiffMarker::Modified => "text-cyan-500 dark:text-cyan-300",
+        EditorDiffMarker::Modified => "text-ansi-3",
         EditorDiffMarker::Deleted => "text-ansi-1",
-        EditorDiffMarker::Staged => "text-ansi-2/80",
+        EditorDiffMarker::Staged => "text-ansi-3/80",
     }
 }
 
 fn diff_marker_row_class(marker: EditorDiffMarker) -> &'static str {
     match marker {
         EditorDiffMarker::Added => "bg-ansi-2/[0.06] hover:bg-ansi-2/[0.10]",
-        EditorDiffMarker::Modified => "bg-cyan-400/[0.06] hover:bg-cyan-400/[0.10]",
+        EditorDiffMarker::Modified => "bg-ansi-3/[0.06] hover:bg-ansi-3/[0.10]",
         EditorDiffMarker::Deleted => "bg-ansi-1/[0.06] hover:bg-ansi-1/[0.10]",
-        EditorDiffMarker::Staged => "bg-ansi-2/[0.035] hover:bg-ansi-2/[0.07]",
+        EditorDiffMarker::Staged => "bg-ansi-3/[0.035] hover:bg-ansi-3/[0.07]",
     }
 }
 
@@ -1061,7 +1061,7 @@ pub fn Page() -> Element {
                     if file_view_mode() != FileViewMode::Diff || !git_has_diff() {
                         {
                             let (cw, ch) = cell_dims();
-                            let gutter = gw as f64 * cw + 36.0;
+                            let gutter = gw as f64 * cw + 48.0;
                             let cx = gutter + cursor().col as f64 * cw;
                             let cy = cursor().row as f64 * ch;
                             let spacer = total_rows() as f64 * ch;
@@ -1118,7 +1118,7 @@ pub fn Page() -> Element {
                                                             e.prevent_default();
                                                             ctx_menu.set(None);
                                                             let (cw, _) = cell_dims();
-                                                            let g = gw as f64 * cw + 36.0;
+                                                            let g = gw as f64 * cw + 48.0;
                                                             let dd = e.data();
                                                             if let Some(raw) = dd.downcast::<web_sys::MouseEvent>()
                                                                 && let Some(t) = raw
@@ -1150,7 +1150,7 @@ pub fn Page() -> Element {
                                                         oncontextmenu: move |e: Event<MouseData>| {
                                                             e.prevent_default();
                                                             let (cw, _) = cell_dims();
-                                                            let g = gw as f64 * cw + 36.0;
+                                                            let g = gw as f64 * cw + 48.0;
                                                             let dd = e.data();
                                                             if let Some(raw) = dd.downcast::<web_sys::MouseEvent>()
                                                                 && let Some(t) = raw
@@ -1174,7 +1174,7 @@ pub fn Page() -> Element {
                                                         },
                                                         onmousemove: move |e: Event<MouseData>| {
                                                             let (cw, _) = cell_dims();
-                                                            let g = gw as f64 * cw + 36.0;
+                                                            let g = gw as f64 * cw + 48.0;
                                                             let dd = e.data();
                                                             if let Some(raw) = dd.downcast::<web_sys::MouseEvent>()
                                                                 && let Some(t) = raw
@@ -1207,20 +1207,23 @@ pub fn Page() -> Element {
                                                         },
                                                         span {
                                                             class: "sticky left-0 z-[1] relative flex shrink-0 select-none items-center justify-end bg-background pl-4 pr-5 tabular-nums",
-                                                            style: "min-width:calc(var(--cw, 1ch) * {gw} + 2.25rem);",
+                                                            style: "min-width:calc(var(--cw, 1ch) * {gw} + 3rem);",
                                                             if let Some(s) = sev {
                                                                 span { class: "pointer-events-none absolute left-1 {severity_color_class(s)}", "●" }
                                                             }
-                                                            if let Some(marker) = diff_marker {
-                                                                span {
-                                                                    class: "mr-1 w-[1ch] text-center font-semibold {diff_marker_text_class(marker)}",
-                                                                    title: "Changed line",
-                                                                    "{diff_marker_sign(marker)}"
-                                                                }
+                                                            span {
+                                                                class: if let Some(marker) = diff_marker { "shrink-0 text-right opacity-90 {diff_marker_text_class(marker)}" } else { "shrink-0 text-right opacity-40 group-hover:opacity-90" },
+                                                                style: "width:calc(var(--cw, 1ch) * {gw});",
+                                                                "{ln + 1}"
                                                             }
                                                             span {
-                                                                class: if let Some(marker) = diff_marker { "text-right opacity-90 {diff_marker_text_class(marker)}" } else { "text-right opacity-40 group-hover:opacity-90" },
-                                                                "{ln + 1}"
+                                                                class: if let Some(marker) = diff_marker { "ml-1 w-[1ch] shrink-0 text-center font-semibold {diff_marker_text_class(marker)}" } else { "ml-1 w-[1ch] shrink-0" },
+                                                                if let Some(marker) = diff_marker {
+                                                                    span {
+                                                                        title: "Changed line",
+                                                                        "{diff_marker_sign(marker)}"
+                                                                    }
+                                                                }
                                                             }
                                                             match fold {
                                                                 FoldGutter::Open => {
@@ -1394,7 +1397,7 @@ pub fn Page() -> Element {
                                                 };
                                                 let hrow = first_row() + i as u32;
                                                 let top = hrow as f64 * ch + ch;
-                                                let left = gw as f64 * cw + 36.0 + h.col as f64 * cw;
+                                                let left = gw as f64 * cw + 48.0 + h.col as f64 * cw;
                                                 rsx! {
                                                     div {
                                                         class: "pointer-events-none absolute z-30 max-w-2xl overflow-hidden rounded-xl bg-foreground/[0.05] px-3 py-2 text-xs leading-snug text-foreground/90 ring-1 ring-inset ring-cyan-400/20 backdrop-blur-2xl shadow-lg dark:shadow-[0_8px_40px_-12px_rgba(0,0,0,0.7)]",

--- a/crates/vmux_editor/tests/page_source.rs
+++ b/crates/vmux_editor/tests/page_source.rs
@@ -49,6 +49,11 @@ fn page_wires_shared_editor_diff_toggle() {
     assert!(s.contains("reveal_git_change(git_line_markers, cell_dims)"));
     assert!(s.contains("diff_marker_text_class(marker)"));
     assert!(s.contains("diff_marker_row_class(marker)"));
+    assert!(s.contains("text-ansi-3"));
+    assert!(s.contains("width:calc(var(--cw, 1ch) * {gw});"));
+    let line_number = s.find("\"{ln + 1}\"").unwrap();
+    let marker_sign = s.find("\"{diff_marker_sign(marker)}\"").unwrap();
+    assert!(line_number < marker_sign);
     assert!(s.contains("transition-transform duration-150"));
     assert!(s.contains("if git_path() != m.abs_path"));
 }

--- a/crates/vmux_editor/tests/page_source.rs
+++ b/crates/vmux_editor/tests/page_source.rs
@@ -46,6 +46,9 @@ fn page_wires_shared_editor_diff_toggle() {
     assert!(s.contains("schedule_git_refresh(git_refresh_generation, git_nonce)"));
     assert!(s.contains("GIT_CHANGED_EVENT"));
     assert!(s.contains("GitChangedEvent"));
+    assert!(s.contains("reveal_git_change(git_line_markers, cell_dims)"));
+    assert!(s.contains("diff_marker_text_class(marker)"));
+    assert!(s.contains("diff_marker_row_class(marker)"));
     assert!(s.contains("transition-transform duration-150"));
     assert!(s.contains("if git_path() != m.abs_path"));
 }

--- a/crates/vmux_editor/tests/page_source.rs
+++ b/crates/vmux_editor/tests/page_source.rs
@@ -42,7 +42,7 @@ fn page_wires_shared_editor_diff_toggle() {
     assert!(s.contains("if next == FileViewMode::Diff"));
     assert!(s.contains("visible: file_view_mode() == FileViewMode::Diff"));
     assert!(s.contains("markers: git_line_markers"));
-    assert!(s.contains("diff_marker_class(marker)"));
+    assert!(s.contains("diff_marker_sign(marker)"));
     assert!(s.contains("schedule_git_refresh(git_refresh_generation, git_nonce)"));
     assert!(s.contains("GIT_CHANGED_EVENT"));
     assert!(s.contains("GitChangedEvent"));

--- a/crates/vmux_editor/tests/page_source.rs
+++ b/crates/vmux_editor/tests/page_source.rs
@@ -44,6 +44,8 @@ fn page_wires_shared_editor_diff_toggle() {
     assert!(s.contains("markers: git_line_markers"));
     assert!(s.contains("diff_marker_class(marker)"));
     assert!(s.contains("schedule_git_refresh(git_refresh_generation, git_nonce)"));
+    assert!(s.contains("GIT_CHANGED_EVENT"));
+    assert!(s.contains("GitChangedEvent"));
     assert!(s.contains("transition-transform duration-150"));
     assert!(s.contains("if git_path() != m.abs_path"));
 }

--- a/crates/vmux_git/Cargo.toml
+++ b/crates/vmux_git/Cargo.toml
@@ -20,6 +20,7 @@ bevy = { workspace = true }
 bevy_ecs = { workspace = true }
 bevy_cef = { workspace = true }
 bevy_cef_core = { workspace = true }
+notify = { workspace = true }
 syntect = { workspace = true }
 similar = "2"
 two-face = { version = "0.5", default-features = false, features = ["syntect-fancy"] }

--- a/crates/vmux_git/src/event.rs
+++ b/crates/vmux_git/src/event.rs
@@ -3,6 +3,7 @@ pub const GIT_DIFF_META_EVENT: &str = "git-diff-meta";
 pub const GIT_DIFF_VIEWPORT_EVENT: &str = "git-diff-viewport";
 pub const GIT_RESULT_EVENT: &str = "git-result";
 pub const GIT_ERROR_EVENT: &str = "git-error";
+pub const GIT_CHANGED_EVENT: &str = "git-changed";
 
 macro_rules! wire {
     ($($item:item)*) => {
@@ -48,6 +49,7 @@ wire! {
     pub struct GitDiffViewportEvent { pub first_line: u32, pub total_lines: u32, pub lines: Vec<DiffLine> }
     pub struct GitResultEvent { pub action: String, pub ok: bool, pub message: String }
     pub struct GitErrorEvent { pub message: String }
+    pub struct GitChangedEvent {}
 }
 
 #[derive(

--- a/crates/vmux_git/src/plugin.rs
+++ b/crates/vmux_git/src/plugin.rs
@@ -1,10 +1,13 @@
-use std::sync::{Arc, Mutex};
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, mpsc};
 
 use bevy_cef::prelude::{BinEventEmitterPlugin, BinHostEmitEvent, BinReceive};
+use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 
 use crate::event::{
-    GitCommitRequest, GitDiffRequest, GitDiscardRequest, GitHunkRequest, GitPushRequest,
-    GitStageRequest, GitStatusRequest, GitUnstageRequest,
+    GIT_CHANGED_EVENT, GitChangedEvent, GitCommitRequest, GitDiffRequest, GitDiscardRequest,
+    GitHunkRequest, GitPushRequest, GitStageRequest, GitStatusRequest, GitUnstageRequest,
 };
 use crate::job::{Emit, JobKind, emit_event_name, run_job};
 
@@ -13,12 +16,162 @@ pub type OutboxQueue = Vec<(Entity, Vec<Emit>)>;
 #[derive(Resource, Clone, Default)]
 pub struct GitOutbox(pub Arc<Mutex<OutboxQueue>>);
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct GitWatchTarget {
+    path: PathBuf,
+    recursive: bool,
+}
+
+struct GitSubscription {
+    path: PathBuf,
+    targets: Vec<GitWatchTarget>,
+    complete: bool,
+}
+
+struct GitWatch {
+    watcher: RecommendedWatcher,
+    rx: mpsc::Receiver<notify::Result<notify::Event>>,
+    watched: HashSet<GitWatchTarget>,
+    subscriptions: HashMap<Entity, GitSubscription>,
+}
+
+fn canon(path: &Path) -> PathBuf {
+    path.canonicalize()
+        .unwrap_or_else(|_| match (path.parent(), path.file_name()) {
+            (Some(parent), Some(name)) => parent
+                .canonicalize()
+                .unwrap_or_else(|_| parent.to_path_buf())
+                .join(name),
+            _ => path.to_path_buf(),
+        })
+}
+
+fn resolve_git_path(root: &Path, value: &str) -> PathBuf {
+    let path = PathBuf::from(value.trim());
+    let path = if path.is_absolute() {
+        path
+    } else {
+        root.join(path)
+    };
+    canon(&path)
+}
+
+fn git_watch_targets(file: &Path) -> Result<Vec<GitWatchTarget>, crate::runner::GitError> {
+    let root = crate::runner::repo_root(file)?;
+    let (stdout, stderr, ok) = crate::runner::git(
+        &root,
+        &["rev-parse", "--absolute-git-dir", "--git-common-dir"],
+    )?;
+    if !ok {
+        return Err(crate::runner::git_err(&stdout, &stderr));
+    }
+    let mut lines = stdout.lines();
+    let git_dir = lines
+        .next()
+        .map(|line| resolve_git_path(&root, line))
+        .ok_or_else(|| crate::runner::GitError("missing git directory".into()))?;
+    let common_dir = lines
+        .next()
+        .map(|line| resolve_git_path(&root, line))
+        .ok_or_else(|| crate::runner::GitError("missing common git directory".into()))?;
+    let mut targets = vec![GitWatchTarget {
+        path: git_dir.clone(),
+        recursive: false,
+    }];
+    if common_dir != git_dir {
+        targets.push(GitWatchTarget {
+            path: common_dir.clone(),
+            recursive: false,
+        });
+    }
+    targets.push(GitWatchTarget {
+        path: common_dir.join("refs"),
+        recursive: true,
+    });
+    Ok(targets)
+}
+
+fn target_matches(target: &GitWatchTarget, changed: &Path) -> bool {
+    let changed = canon(changed);
+    changed == target.path
+        || if target.recursive {
+            changed.starts_with(&target.path)
+        } else {
+            changed.parent() == Some(target.path.as_path())
+        }
+}
+
+impl GitWatch {
+    fn subscribe(&mut self, entity: Entity, path: &Path) {
+        let path = canon(path);
+        if self
+            .subscriptions
+            .get(&entity)
+            .is_some_and(|subscription| subscription.path == path && subscription.complete)
+        {
+            return;
+        }
+        let Ok(targets) = git_watch_targets(&path) else {
+            self.subscriptions.remove(&entity);
+            return;
+        };
+        let mut complete = true;
+        for target in &targets {
+            if self.watched.contains(target) {
+                continue;
+            }
+            let mode = if target.recursive {
+                RecursiveMode::Recursive
+            } else {
+                RecursiveMode::NonRecursive
+            };
+            if self.watcher.watch(&target.path, mode).is_ok() {
+                self.watched.insert(target.clone());
+            } else {
+                complete = false;
+            }
+        }
+        self.subscriptions.insert(
+            entity,
+            GitSubscription {
+                path,
+                targets,
+                complete,
+            },
+        );
+    }
+}
+
 /// Wires the git bridge: runs each git request on a background thread and drains completed
 /// results back to the originating webview.
 pub struct GitPlugin;
 
 impl Plugin for GitPlugin {
     fn build(&self, app: &mut App) {
+        let (tx, rx) = mpsc::channel();
+        let proxy = app
+            .world()
+            .get_resource::<bevy::winit::EventLoopProxyWrapper>()
+            .map(|wrapper| (**wrapper).clone());
+        match notify::recommended_watcher(move |result: notify::Result<notify::Event>| {
+            let wake = result
+                .as_ref()
+                .is_ok_and(|event| !matches!(event.kind, EventKind::Access(_)));
+            let _ = tx.send(result);
+            if wake && let Some(proxy) = proxy.as_ref() {
+                let _ = proxy.send_event(bevy::winit::WinitUserEvent::WakeUp);
+            }
+        }) {
+            Ok(watcher) => {
+                app.insert_non_send(GitWatch {
+                    watcher,
+                    rx,
+                    watched: HashSet::new(),
+                    subscriptions: HashMap::new(),
+                });
+            }
+            Err(error) => bevy::log::warn!("git watcher init failed: {error}"),
+        }
         app.init_resource::<GitOutbox>()
             .add_plugins(BinEventEmitterPlugin::<(
                 GitStatusRequest,
@@ -38,7 +191,7 @@ impl Plugin for GitPlugin {
             .add_observer(on_commit_request)
             .add_observer(on_push_request)
             .add_observer(on_hunk_request)
-            .add_systems(Update, drain_git_outbox);
+            .add_systems(Update, (drain_git_watch, drain_git_outbox));
     }
 }
 
@@ -56,13 +209,57 @@ fn on_status_request(
     trigger: On<BinReceive<GitStatusRequest>>,
     sources: Query<&GitDiffSource>,
     outbox: Res<GitOutbox>,
+    watch: Option<NonSendMut<GitWatch>>,
 ) {
+    if let Some(mut watch) = watch {
+        watch.subscribe(
+            trigger.event().webview,
+            Path::new(&trigger.event().payload.path),
+        );
+    }
     spawn_job(&outbox, trigger.event().webview, JobKind::Status {
         path: trigger.event().payload.path.clone().into(),
         dirty: sources
             .get(trigger.event().webview)
             .is_ok_and(|source| source.dirty),
     });
+}
+
+fn drain_git_watch(watch: Option<NonSendMut<GitWatch>>, mut commands: Commands) {
+    let Some(watch) = watch else {
+        return;
+    };
+    let mut changed = HashSet::new();
+    while let Ok(result) = watch.rx.try_recv() {
+        let Ok(event) = result else {
+            continue;
+        };
+        if matches!(event.kind, EventKind::Access(_)) {
+            continue;
+        }
+        changed.extend(event.paths);
+    }
+    if changed.is_empty() {
+        return;
+    }
+    let affected: Vec<Entity> = watch
+        .subscriptions
+        .iter()
+        .filter(|(_, subscription)| {
+            subscription
+                .targets
+                .iter()
+                .any(|target| changed.iter().any(|path| target_matches(target, path)))
+        })
+        .map(|(entity, _)| *entity)
+        .collect();
+    for entity in affected {
+        commands.trigger(BinHostEmitEvent::from_rkyv(
+            entity,
+            GIT_CHANGED_EVENT,
+            &GitChangedEvent {},
+        ));
+    }
 }
 
 fn on_diff_request(
@@ -147,6 +344,7 @@ fn drain_git_outbox(outbox: Res<GitOutbox>, mut commands: Commands) {
 mod tests {
     use super::*;
     use crate::event::GitErrorEvent;
+    use crate::runner::test_repo;
 
     #[test]
     fn drain_empties_outbox() {
@@ -164,5 +362,77 @@ mod tests {
         app.update();
 
         assert!(app.world().resource::<GitOutbox>().0.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn git_watch_targets_cover_index_and_refs() {
+        let repo = test_repo::init();
+        let file = test_repo::write(repo.path(), "a.txt", "one\n");
+        let targets = git_watch_targets(&file).unwrap();
+        let git_dir = canon(&repo.path().join(".git"));
+
+        assert!(targets.contains(&GitWatchTarget {
+            path: git_dir.clone(),
+            recursive: false,
+        }));
+        assert!(targets.contains(&GitWatchTarget {
+            path: git_dir.join("refs"),
+            recursive: true,
+        }));
+    }
+
+    #[test]
+    fn linked_worktree_targets_cover_private_and_common_git_dirs() {
+        let repo = test_repo::init();
+        test_repo::write(repo.path(), "a.txt", "one\n");
+        test_repo::run(repo.path(), &["add", "a.txt"]);
+        test_repo::run(repo.path(), &["commit", "-qm", "init"]);
+        let parent = tempfile::tempdir().unwrap();
+        let worktree = parent.path().join("linked");
+        test_repo::run(
+            repo.path(),
+            &[
+                "worktree",
+                "add",
+                "-q",
+                "-b",
+                "linked",
+                worktree.to_str().unwrap(),
+            ],
+        );
+
+        let targets = git_watch_targets(&worktree.join("a.txt")).unwrap();
+        let common = canon(&repo.path().join(".git"));
+
+        assert!(targets.iter().any(|target| {
+            !target.recursive
+                && target.path != common
+                && target.path.starts_with(common.join("worktrees"))
+        }));
+        assert!(targets.contains(&GitWatchTarget {
+            path: common.clone(),
+            recursive: false,
+        }));
+        assert!(targets.contains(&GitWatchTarget {
+            path: common.join("refs"),
+            recursive: true,
+        }));
+    }
+
+    #[test]
+    fn watch_target_matching_respects_recursion() {
+        let root = canon(Path::new("/tmp/vmux-git-watch"));
+        let direct = GitWatchTarget {
+            path: root.clone(),
+            recursive: false,
+        };
+        let recursive = GitWatchTarget {
+            path: root.clone(),
+            recursive: true,
+        };
+
+        assert!(target_matches(&direct, &root.join("index")));
+        assert!(!target_matches(&direct, &root.join("refs/heads/main")));
+        assert!(target_matches(&recursive, &root.join("refs/heads/main")));
     }
 }

--- a/crates/vmux_git/src/ui.rs
+++ b/crates/vmux_git/src/ui.rs
@@ -302,6 +302,7 @@ pub fn DiffView(
     let mut expanded = use_signal(HashSet::<(usize, usize)>::new);
     let mut loading = use_signal(|| true);
     let mut error = use_signal(String::new);
+    let mut requested_path = use_signal(String::new);
 
     let _vp =
         use_bin_event_listener::<GitDiffViewportEvent, _>(GIT_DIFF_VIEWPORT_EVENT, move |p| {
@@ -320,10 +321,16 @@ pub fn DiffView(
         let p = path();
         let _ = nonce();
         if !p.is_empty() {
-            loading.set(true);
+            let path_changed = *requested_path.peek() != p;
+            requested_path.set(p.clone());
+            if path_changed || lines.peek().is_empty() {
+                loading.set(true);
+            }
             error.set(String::new());
-            lines.set(Vec::new());
-            expanded.set(HashSet::new());
+            if path_changed {
+                lines.set(Vec::new());
+                expanded.set(HashSet::new());
+            }
             let _ = try_cef_bin_emit_rkyv(&GitDiffRequest {
                 path: p,
                 top_line: 0,

--- a/crates/vmux_server/src/build.rs
+++ b/crates/vmux_server/src/build.rs
@@ -8,6 +8,11 @@ use std::time::SystemTime;
 use regex::Regex;
 
 pub const CEF_EMBEDDED_APP_INDEX_CSS: &str = "index.css";
+pub const SKIP_DX_BUILD_ENV: &str = "VMUX_SKIP_DX_BUILD";
+
+pub fn skip_dx_build() -> bool {
+    std::env::var_os(SKIP_DX_BUILD_ENV).is_some()
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CefMode {
@@ -86,6 +91,7 @@ impl PageBuilder {
             println!("cargo:rerun-if-changed={}", p.display());
         }
         println!("cargo:rerun-if-changed=build.rs");
+        println!("cargo:rerun-if-env-changed={SKIP_DX_BUILD_ENV}");
 
         if std::env::var("TARGET")
             .unwrap_or_default()
@@ -97,7 +103,7 @@ impl PageBuilder {
         let release = std::env::var("PROFILE").unwrap_or_default() == "release";
         let dist = self.manifest_dir.join(self.dist_subdir);
         let shell = self.manifest_dir.join("assets/index.html");
-        if self.needs_dist_rebuild(release, &workspace_root) {
+        if !skip_dx_build() && self.needs_dist_rebuild(release, &workspace_root) {
             run_dx_web_bundle(
                 &workspace_root,
                 self.dx_package,

--- a/crates/vmux_ui/build.rs
+++ b/crates/vmux_ui/build.rs
@@ -9,8 +9,8 @@ use std::path::{Path, PathBuf};
 mod page_build;
 
 use page_build::{
-    dx_web_public_dir, replace_dist_from_dx_public, run_dx_web_bundle,
-    workspace_root_from_manifest_dir,
+    SKIP_DX_BUILD_ENV, dx_web_public_dir, replace_dist_from_dx_public, run_dx_web_bundle,
+    skip_dx_build, workspace_root_from_manifest_dir,
 };
 
 fn main() {
@@ -19,6 +19,7 @@ fn main() {
 
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=../vmux_server/src/build.rs");
+    println!("cargo:rerun-if-env-changed={SKIP_DX_BUILD_ENV}");
 
     let target = std::env::var("TARGET").unwrap_or_default();
     let profile = std::env::var("PROFILE").unwrap_or_default();
@@ -31,6 +32,10 @@ fn main() {
     }
 
     if profile == "release" {
+        return;
+    }
+
+    if skip_dx_build() {
         return;
     }
 


### PR DESCRIPTION
## Context

Diff views remain stale when Git state changes outside the editor, such as committing from an embedded terminal. The editor should react to repository metadata changes without requiring navigation or another edit.

## Implementation

Watch each subscribed repository’s worktree Git directory, common Git directory, and refs, including linked-worktree layouts. Relevant filesystem events wake Bevy’s reactive event loop and emit a debounced refresh event to the editor page.

## Checks / QA

1. Open a modified file in Diff mode.
2. Commit the change from an embedded terminal.
3. Confirm the diff and Git status clear automatically without interacting with the editor.