### PR TITLE
feat(agent): allow canceling queued prompts

### DIFF
--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -21,10 +21,10 @@ use bevy_cef::prelude::{BinEventEmitterPlugin, BinHostEmitEvent, BinReceive, Bro
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::chat_page::event::{
-    CHAT_SNAPSHOT_EVENT, ChatApproval, ChatCancel, ChatClearQueue, ChatEscape, ChatResume,
-    ChatSnapshot, ChatSubmit, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions,
-    ResumeListRequest, ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT,
-    SlashCommandEntry, SlashCommands,
+    CHAT_SNAPSHOT_EVENT, ChatApproval, ChatCancel, ChatCancelQueuedPrompt, ChatClearQueue,
+    ChatEscape, ChatResume, ChatSnapshot, ChatSubmit, QueuedPromptSnapshot,
+    RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions, ResumeListRequest,
+    ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SlashCommandEntry, SlashCommands,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use crate::chat_page::turns::group_turns;
@@ -147,6 +147,7 @@ impl Plugin for AgentChatPagePlugin {
             ChatCancel,
             ChatResume,
             ChatClearQueue,
+            ChatCancelQueuedPrompt,
             ChatEscape,
             ResumeListRequest,
             ResumeSession,
@@ -157,6 +158,7 @@ impl Plugin for AgentChatPagePlugin {
             .add_observer(on_chat_cancel)
             .add_observer(on_chat_resume)
             .add_observer(on_chat_clear_queue)
+            .add_observer(on_chat_cancel_queued_prompt)
             .add_observer(on_chat_escape)
             .add_observer(on_resume_list_request)
             .add_observer(on_resume_session)
@@ -365,7 +367,14 @@ fn snapshot_of(
                 u32::try_from(group_turns(&imported.messages, &[], false).len()).unwrap_or(u32::MAX)
             })
             .unwrap_or_default(),
-        queued: queue.items.iter().cloned().collect(),
+        queued: queue
+            .items
+            .iter()
+            .map(|item| QueuedPromptSnapshot {
+                id: item.id,
+                text: item.text.clone(),
+            })
+            .collect(),
         paused: queue.paused,
     }
 }
@@ -503,6 +512,20 @@ fn on_chat_clear_queue(
     };
     if let Ok(mut queue) = queues.get_mut(parent.parent()) {
         queue.clear();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn on_chat_cancel_queued_prompt(
+    trigger: On<BinReceive<ChatCancelQueuedPrompt>>,
+    child_of: Query<&ChildOf>,
+    mut queues: Query<&mut PromptQueue>,
+) {
+    let Ok(parent) = child_of.get(trigger.event().webview) else {
+        return;
+    };
+    if let Ok(mut queue) = queues.get_mut(parent.parent()) {
+        queue.remove(trigger.event().payload.id);
     }
 }
 
@@ -1087,7 +1110,10 @@ mod native_tests {
         enqueue_prompt(&mut queue, &mut state, "retry".into());
 
         assert!(matches!(state, AgentRunState::Idle));
-        assert_eq!(queue.items.front().map(String::as_str), Some("retry"));
+        assert_eq!(
+            queue.items.front().map(|item| item.text.as_str()),
+            Some("retry")
+        );
         assert!(!queue.paused);
     }
 
@@ -1098,7 +1124,7 @@ mod native_tests {
         let mut app = App::new();
         app.add_observer(on_chat_cancel);
         let mut queue = PromptQueue::default();
-        queue.items.push_back("queued".into());
+        queue.enqueue("queued".into());
         assert!(queue.request_flush());
         let stack = app.world_mut().spawn(queue).id();
         let webview = app.world_mut().spawn(ChildOf(stack)).id();
@@ -1124,7 +1150,7 @@ mod native_tests {
         let mut app = App::new();
         app.add_observer(on_chat_escape);
         let mut queue = PromptQueue::default();
-        queue.items.push_back("retry".into());
+        queue.enqueue("retry".into());
         queue.paused = true;
         let stack = app
             .world_mut()
@@ -1154,7 +1180,7 @@ mod native_tests {
         let mut app = App::new();
         app.add_observer(on_chat_escape);
         let mut queue = PromptQueue::default();
-        queue.items.push_back("queued".into());
+        queue.enqueue("queued".into());
         assert!(queue.request_flush());
         queue.items.clear();
         let stack = app
@@ -1175,6 +1201,31 @@ mod native_tests {
                 .unwrap()
                 .flush_pending()
         );
+    }
+
+    #[test]
+    fn cancel_queued_prompt_removes_only_target() {
+        use bevy_cef::prelude::BinReceive;
+
+        let mut app = App::new();
+        app.add_observer(on_chat_cancel_queued_prompt);
+        let mut queue = PromptQueue::default();
+        queue.enqueue("first".into());
+        queue.enqueue("second".into());
+        let second_id = queue.items[1].id;
+        let stack = app.world_mut().spawn(queue).id();
+        let webview = app.world_mut().spawn(ChildOf(stack)).id();
+
+        app.world_mut()
+            .trigger(BinReceive::<ChatCancelQueuedPrompt> {
+                webview,
+                payload: ChatCancelQueuedPrompt { id: second_id },
+            });
+        app.world_mut().flush();
+
+        let queue = app.world().get::<PromptQueue>(stack).unwrap();
+        assert_eq!(queue.items.len(), 1);
+        assert_eq!(queue.items[0].text, "first");
     }
 
     #[test]
@@ -1272,6 +1323,8 @@ mod native_tests {
         let source = include_str!("chat_page/page.rs");
         assert!(source.contains("kbd {"));
         assert!(source.contains("if queued.read().is_empty()"));
+        assert!(source.contains("ChatCancelQueuedPrompt"));
+        assert!(source.contains("title: \"Cancel queued prompt\""));
         assert!(source.contains("title: \"Stop\""));
         assert!(source.contains("rect { x: \"6\", y: \"6\""));
         assert!(source.contains("\"Send all queued prompts now (Esc)\""));

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -5,6 +5,21 @@
 /// Bin-event id: native → page conversation/run-state snapshot.
 pub const CHAT_SNAPSHOT_EVENT: &str = "chat_snapshot";
 
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct QueuedPromptSnapshot {
+    pub id: u64,
+    pub text: String,
+}
+
 /// Native → page: the full conversation plus run-state, pushed on every change.
 #[derive(
     Clone,
@@ -27,8 +42,8 @@ pub struct ChatSnapshot {
     pub approval_call_id: String,
     pub approval_name: String,
     pub approval_args_json: String,
-    /// Prompts queued behind the running turn (FIFO), oldest first. View-only on the page.
-    pub queued: Vec<String>,
+    /// Prompts queued behind the running turn (FIFO), oldest first.
+    pub queued: Vec<QueuedPromptSnapshot>,
     /// True after an interrupt: the queue is held (not auto-advancing) until resume/clear/submit.
     pub paused: bool,
     /// Agent display name (from the session `Profile`), for the header/hero.
@@ -113,6 +128,21 @@ pub struct ChatResume;
     rkyv::Deserialize,
 )]
 pub struct ChatClearQueue;
+
+/// Page → native: drop one queued prompt.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatCancelQueuedPrompt {
+    pub id: u64,
+}
 
 /// Page → native: apply Escape to the authoritative native queue and run state.
 #[derive(
@@ -341,14 +371,27 @@ mod tests {
             handoff_source: "Codex".to_string(),
             handoff_truncated: true,
             handoff_message_count: 2,
-            queued: vec!["a".into(), "b".into()],
+            queued: vec![
+                QueuedPromptSnapshot {
+                    id: 4,
+                    text: "a".into(),
+                },
+                QueuedPromptSnapshot {
+                    id: 9,
+                    text: "b".into(),
+                },
+            ],
             paused: true,
             ..Default::default()
         };
         let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&v).unwrap();
         let back = rkyv::from_bytes::<ChatSnapshot, rkyv::rancor::Error>(&bytes).unwrap();
         assert_eq!(back.status, "streaming");
-        assert_eq!(back.queued, vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(back.queued.len(), 2);
+        assert_eq!(back.queued[0].id, 4);
+        assert_eq!(back.queued[0].text, "a");
+        assert_eq!(back.queued[1].id, 9);
+        assert_eq!(back.queued[1].text, "b");
         assert!(back.paused);
         assert_eq!(back.handoff_source, "Codex");
         assert!(back.handoff_truncated);

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -6,10 +6,11 @@ use crate::chat_page::composer::{
     should_fetch_resume,
 };
 use crate::chat_page::event::{
-    CHAT_SNAPSHOT_EVENT, ChatApproval, ChatBlock, ChatCancel, ChatClearQueue, ChatEscape, ChatItem,
-    ChatResume, ChatSnapshot, ChatSubmit, ChatTurn, RESUMABLE_SESSIONS_EVENT,
-    ResumableSessionEntry, ResumableSessions, ResumeListRequest, ResumeSession,
-    RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SlashCommandEntry, SlashCommands, WORKING_VERBS,
+    CHAT_SNAPSHOT_EVENT, ChatApproval, ChatBlock, ChatCancel, ChatCancelQueuedPrompt,
+    ChatClearQueue, ChatEscape, ChatItem, ChatResume, ChatSnapshot, ChatSubmit, ChatTurn,
+    QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions,
+    ResumeListRequest, ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT,
+    SlashCommandEntry, SlashCommands, WORKING_VERBS,
 };
 use dioxus::prelude::*;
 use vmux_terminal::matrix_rain::MatrixRain;
@@ -163,7 +164,7 @@ pub fn Page() -> Element {
     let mut elapsed = use_signal(|| 0u32);
     let mut at_bottom = use_signal(|| true);
     let mut last_top = use_signal(|| 0i32);
-    let mut queued = use_signal(Vec::<String>::new);
+    let mut queued = use_signal(Vec::<QueuedPromptSnapshot>::new);
     let mut paused = use_signal(|| false);
     let mut slash_cmds = use_signal(Vec::<SlashCommandEntry>::new);
     let mut sessions = use_signal(Vec::<ResumableSessionEntry>::new);
@@ -558,12 +559,30 @@ pub fn Page() -> Element {
                     }
                     if !queued.read().is_empty() {
                         div { class: "flex flex-col items-end gap-1.5",
-                            for (qi , qtext) in queued.read().iter().enumerate() {
+                            for queued_prompt in queued.read().iter().cloned() {
                                 div {
-                                    key: "q{qi}",
-                                    class: "flex max-w-[80%] items-baseline gap-2 rounded-2xl border border-dashed border-foreground/20 bg-foreground/[0.03] px-3.5 py-2 text-sm text-muted-foreground",
+                                    key: "q{queued_prompt.id}",
+                                    class: "group flex max-w-[80%] items-center gap-2 rounded-2xl border border-dashed border-foreground/20 bg-foreground/[0.03] py-2 pl-3.5 pr-2 text-sm text-muted-foreground",
                                     span { class: "shrink-0 text-[10px] uppercase tracking-wide text-foreground/40", "queued" }
-                                    span { class: "whitespace-pre-wrap break-words", "{qtext}" }
+                                    span { class: "min-w-0 flex-1 whitespace-pre-wrap break-words", "{queued_prompt.text}" }
+                                    button {
+                                        class: "flex shrink-0 items-center rounded-lg p-1 text-foreground/35 opacity-70 transition hover:bg-foreground/10 hover:text-foreground hover:opacity-100 focus:opacity-100",
+                                        title: "Cancel queued prompt",
+                                        onclick: move |_| {
+                                            let _ = try_cef_bin_emit_rkyv(&ChatCancelQueuedPrompt {
+                                                id: queued_prompt.id,
+                                            });
+                                        },
+                                        svg {
+                                            class: "h-3.5 w-3.5",
+                                            view_box: "0 0 24 24",
+                                            fill: "none",
+                                            stroke: "currentColor",
+                                            stroke_width: "2",
+                                            stroke_linecap: "round",
+                                            path { d: "M6 6l12 12M18 6L6 18" }
+                                        }
+                                    }
                                 }
                             }
                             if paused() {

--- a/crates/vmux_agent/src/client/page/plugin.rs
+++ b/crates/vmux_agent/src/client/page/plugin.rs
@@ -322,7 +322,7 @@ mod tests {
             .add_systems(Update, consume_page_agent_stream);
 
         let mut queue = PromptQueue::default();
-        queue.items.push_back("next".into());
+        queue.enqueue("next".into());
         let e = app
             .world_mut()
             .spawn((
@@ -373,8 +373,8 @@ mod tests {
             .add_systems(Update, consume_page_agent_stream);
 
         let mut queue = PromptQueue::default();
-        queue.items.push_back("a".into());
-        queue.items.push_back("b".into());
+        queue.enqueue("a".into());
+        queue.enqueue("b".into());
         assert!(queue.request_flush());
         let e = app
             .world_mut()
@@ -433,7 +433,7 @@ mod tests {
             .add_systems(Update, consume_page_agent_stream);
 
         let mut queue = PromptQueue::default();
-        queue.items.push_back("retry".into());
+        queue.enqueue("retry".into());
         assert!(queue.request_flush());
         let entity = app
             .world_mut()
@@ -463,7 +463,10 @@ mod tests {
         let queue = app.world().get::<PromptQueue>(entity).unwrap();
         assert!(queue.flush_pending());
         assert!(!queue.paused);
-        assert_eq!(queue.items.front().map(String::as_str), Some("retry"));
+        assert_eq!(
+            queue.items.front().map(|item| item.text.as_str()),
+            Some("retry")
+        );
     }
 
     #[test]

--- a/crates/vmux_agent/src/components.rs
+++ b/crates/vmux_agent/src/components.rs
@@ -30,9 +30,17 @@ pub struct AgentApprovalPolicy {
 /// clears, or submits again; `flush_pending` combines all queued prompts for an Esc flush.
 #[derive(Component, Clone, Debug, Default)]
 pub struct PromptQueue {
-    pub items: VecDeque<String>,
+    pub items: VecDeque<QueuedPrompt>,
     pub paused: bool,
     flush_pending: bool,
+    next_id: u64,
+}
+
+/// One prompt waiting in a [`PromptQueue`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QueuedPrompt {
+    pub id: u64,
+    pub text: String,
 }
 
 impl PromptQueue {
@@ -48,8 +56,23 @@ impl PromptQueue {
 
     /// Append one prompt and allow dispatch to continue.
     pub fn enqueue(&mut self, text: String) {
-        self.items.push_back(text);
+        let id = self.next_id;
+        self.next_id = self.next_id.wrapping_add(1);
+        self.items.push_back(QueuedPrompt { id, text });
         self.paused = false;
+    }
+
+    /// Remove one queued prompt by its stable id.
+    pub fn remove(&mut self, id: u64) -> bool {
+        let Some(index) = self.items.iter().position(|item| item.id == id) else {
+            return false;
+        };
+        self.items.remove(index);
+        if self.items.is_empty() {
+            self.paused = false;
+            self.flush_pending = false;
+        }
+        true
     }
 
     /// Mark all currently queued prompts for one combined dispatch.
@@ -83,14 +106,14 @@ impl PromptQueue {
     /// Take one FIFO prompt, or all prompts joined by blank lines for a pending flush.
     pub fn take_next(&mut self) -> Option<String> {
         if !self.flush_pending {
-            return self.items.pop_front();
+            return self.items.pop_front().map(|item| item.text);
         }
         self.flush_pending = false;
-        let mut text = self.items.pop_front()?;
-        text.reserve(self.items.iter().map(|item| item.len() + 2).sum());
+        let mut text = self.items.pop_front()?.text;
+        text.reserve(self.items.iter().map(|item| item.text.len() + 2).sum());
         for item in self.items.drain(..) {
             text.push_str("\n\n");
-            text.push_str(&item);
+            text.push_str(&item.text);
         }
         Some(text)
     }
@@ -111,7 +134,7 @@ mod tests {
     fn prompt_queue_ready_gate() {
         let mut q = PromptQueue::default();
         assert!(!q.ready(true));
-        q.items.push_back("a".into());
+        q.enqueue("a".into());
         assert!(q.ready(true));
         assert!(!q.ready(false));
         q.paused = true;
@@ -121,17 +144,20 @@ mod tests {
     #[test]
     fn take_next_preserves_fifo_without_flush() {
         let mut q = PromptQueue::default();
-        q.items.push_back("first".into());
-        q.items.push_back("second".into());
+        q.enqueue("first".into());
+        q.enqueue("second".into());
         assert_eq!(q.take_next(), Some("first".to_string()));
-        assert_eq!(q.items.front().map(String::as_str), Some("second"));
+        assert_eq!(
+            q.items.front().map(|item| item.text.as_str()),
+            Some("second")
+        );
     }
 
     #[test]
     fn take_next_merges_all_items_for_flush() {
         let mut q = PromptQueue::default();
-        q.items.push_back("first".into());
-        q.items.push_back("second".into());
+        q.enqueue("first".into());
+        q.enqueue("second".into());
 
         assert!(q.request_flush());
         assert_eq!(q.take_next(), Some("first\n\nsecond".to_string()));
@@ -142,7 +168,7 @@ mod tests {
     #[test]
     fn enqueue_preserves_pending_flush() {
         let mut q = PromptQueue::default();
-        q.items.push_back("first".into());
+        q.enqueue("first".into());
         assert!(q.request_flush());
 
         q.enqueue("second".into());
@@ -154,7 +180,7 @@ mod tests {
     #[test]
     fn cancel_flush_clears_pending_flush() {
         let mut q = PromptQueue::default();
-        q.items.push_back("first".into());
+        q.enqueue("first".into());
         assert!(q.request_flush());
 
         q.cancel_flush();
@@ -165,7 +191,7 @@ mod tests {
     #[test]
     fn clear_resets_queue_state() {
         let mut q = PromptQueue::default();
-        q.items.push_back("first".into());
+        q.enqueue("first".into());
         assert!(q.request_flush());
         q.paused = true;
 
@@ -179,12 +205,39 @@ mod tests {
     #[test]
     fn resume_resets_pause_and_flush() {
         let mut q = PromptQueue::default();
-        q.items.push_back("first".into());
+        q.enqueue("first".into());
         assert!(q.request_flush());
         q.paused = true;
 
         q.resume();
 
+        assert!(!q.paused);
+        assert!(!q.flush_pending);
+    }
+
+    #[test]
+    fn remove_targets_stable_id() {
+        let mut q = PromptQueue::default();
+        q.enqueue("first".into());
+        q.enqueue("second".into());
+        let second_id = q.items[1].id;
+
+        assert!(q.remove(second_id));
+        assert_eq!(q.items.len(), 1);
+        assert_eq!(q.items[0].text, "first");
+        assert!(!q.remove(second_id));
+    }
+
+    #[test]
+    fn removing_last_item_resets_queue_state() {
+        let mut q = PromptQueue::default();
+        q.enqueue("first".into());
+        let id = q.items[0].id;
+        assert!(q.request_flush());
+        q.paused = true;
+
+        assert!(q.remove(id));
+        assert!(q.items.is_empty());
         assert!(!q.paused);
         assert!(!q.flush_pending);
     }

--- a/crates/vmux_agent/src/lib.rs
+++ b/crates/vmux_agent/src/lib.rs
@@ -73,7 +73,7 @@ pub use client::cli::strategy::CliAgentStrategy;
 #[cfg(not(target_arch = "wasm32"))]
 pub use client::page::plugin::PageAgentPlugin;
 #[cfg(not(target_arch = "wasm32"))]
-pub use components::{AgentApprovalPolicy, AgentMessages, AgentSession, PromptQueue};
+pub use components::{AgentApprovalPolicy, AgentMessages, AgentSession, PromptQueue, QueuedPrompt};
 #[cfg(not(target_arch = "wasm32"))]
 pub use events::{
     BrowserScrollRequest, BrowserSnapshotRequest, BrowserSnapshotResponse, NavAwaitingSnapshot,


### PR DESCRIPTION
## Context
Queued agent prompts could only be cleared as a group. Users need to remove an outdated follow-up without discarding the rest of the queue.

## Implementation
Queued prompts now carry stable per-session IDs through the native-to-page snapshot. Each queued prompt exposes a cancel control that sends a typed event back to the authoritative native queue, preserving the remaining FIFO order and resetting queue control state when the last item is removed.

## Checks / QA
1. Start a long-running agent turn and queue multiple prompts.
2. Cancel the middle prompt and verify the other prompts remain in order.
3. Cancel the final queued prompt while paused or flush-pending and verify queue controls disappear.
4. Verify Escape still sends all remaining queued prompts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to cancel individual queued prompts without affecting other queued items.
  * Queued prompts now display stable entries and support targeted cancellation.
  * Improved queued prompt handling while preserving FIFO order and combined submission behavior.

* **Bug Fixes**
  * Clearing the final queued prompt now correctly resets queue state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->