### PR TITLE
perf(build): share caches across worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ When taking a Linear issue (e.g. "take VMX-XX"), immediately move it to **In Pro
 
 1. Check if a worktree already exists: `git worktree list`
 2. Create worktree if needed: `git worktree add .worktrees/vmx-<number> -b <branch-name>` — always name the worktree directory using the `vmx-<number>` convention matching the Linear issue (e.g., `.worktrees/vmx-88`).
-3. `cd` into the worktree directory and make all edits there.
+3. `cd` into the worktree directory and make all edits there. The first build through `make` automatically seeds its build cache from the main worktree.
 4. When done, merge to main, then remove: `git worktree remove .worktrees/<short-name>`
 5. Remember: if the worktree is deleted while your shell is inside it, `cd` back to the repo root — `../..` won't work.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,9 +90,11 @@ syntect = { version = "5", default-features = false, features = ["default-fancy"
 # Our crates stay at opt-level 1 for fast rebuilds; all deps compile at 3 (cached).
 [profile.dev]
 opt-level = 1
+debug = "line-tables-only"
 
 [profile.dev.package."*"]
 opt-level = 3
+debug = false
 
 # Hot CEF render/compositing path: optimize even in dev so the texture pipeline
 # isn't bottlenecked by an unoptimized build during development.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev test-app local release build-local build-release build setup-cef install-debug-render-process doctor ensure-mac-deps ensure-package-deps ensure-codesign-deps website build-website-release build-website-css api-docs lint lint-fix test setup-hooks cleanup
+.PHONY: dev test-app local release build-local build-release build setup-cef install-debug-render-process seed-target doctor ensure-mac-deps ensure-package-deps ensure-codesign-deps website build-website-release build-website-css api-docs lint lint-fix test setup-hooks cleanup
 
 .DEFAULT_GOAL := dev
 
@@ -6,6 +6,7 @@ VMUX_PROFILE ?= personal
 VMUX_TEST ?=
 
 CARGO_BIN := $(or $(shell command -v cargo 2>/dev/null),$(HOME)/.cargo/bin/cargo)
+CARGO_WITH_CEF_CACHE := CARGO_BIN="$(CARGO_BIN)" ./scripts/cargo-with-cef-cache.sh
 RUSTUP_BIN := $(or $(shell command -v rustup 2>/dev/null),$(HOME)/.cargo/bin/rustup)
 EXPORT_CEF_BIN := $(or $(shell command -v export-cef-dir 2>/dev/null),$(HOME)/.cargo/bin/export-cef-dir)
 DX_BIN := $(or $(shell command -v dx 2>/dev/null),$(HOME)/.cargo/bin/dx)
@@ -21,8 +22,8 @@ CEF_DEBUG_RENDER := $(CEF_FRAMEWORK_DIR)/Libraries/bevy_cef_debug_render_process
 # Header / history / UI library `dist/` folders are built by each crate’s `build.rs` via **`dx build`** when you compile `vmux_desktop` (needs `dioxus-cli` on PATH).
 
 dev: ensure-mac-deps ensure-codesign-deps install-debug-render-process
-	env -u CEF_PATH "$(CARGO_BIN)" build -p vmux_service -p vmux_cli
-	env -u CEF_PATH "$(CARGO_BIN)" build -p vmux_desktop --features dev
+	$(CARGO_WITH_CEF_CACHE) build -p vmux_service -p vmux_cli
+	$(CARGO_WITH_CEF_CACHE) build -p vmux_desktop --features dev
 	@identity="$$(./scripts/ensure-local-codesign-identity.sh)" && \
 	APPLE_SIGNING_IDENTITY="$$identity" \
 	APP_BINARY="target/debug/vmux_desktop" \
@@ -45,7 +46,7 @@ test-app:
 	$(MAKE) dev VMUX_PROFILE=gregor VMUX_TEST=1
 
 build: ensure-mac-deps
-	env -u CEF_PATH "$(CARGO_BIN)" build -p vmux_desktop -p vmux_cli -p vmux_service --release
+	$(CARGO_WITH_CEF_CACHE) build -p vmux_desktop -p vmux_cli -p vmux_service --release
 
 -include .env
 export
@@ -72,9 +73,12 @@ setup-cef:
 # Build from vmux-patched bevy_cef_core (required when adding CEF schemes such as vmux://).
 # Installs into the same path `bevy_cef` debug mode loads on macOS.
 install-debug-render-process:
-	env -u CEF_PATH "$(CARGO_BIN)" build -p bevy_cef_debug_render_process --features debug
+	$(CARGO_WITH_CEF_CACHE) build -p bevy_cef_debug_render_process --features debug
 	cp "$(CURDIR)/target/debug/bevy_cef_debug_render_process" \
 	  "$(CEF_FRAMEWORK_DIR)/Libraries/bevy_cef_debug_render_process"
+
+seed-target:
+	./scripts/seed-worktree-target.sh
 
 # Get workspace packages excluding vendored patches
 PKGS = $(shell "$(CARGO_BIN)" metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.manifest_path | test("patches") | not) | .name')
@@ -84,7 +88,7 @@ lint:
 		"$(CARGO_BIN)" fmt -p "$$pkg" -- --check || exit 1; \
 	done
 	@for pkg in $(PKGS); do \
-		env -u CEF_PATH "$(CARGO_BIN)" clippy -p "$$pkg" --all-targets -- -D warnings || exit 1; \
+		$(CARGO_WITH_CEF_CACHE) clippy -p "$$pkg" --all-targets -- -D warnings || exit 1; \
 	done
 
 lint-fix:
@@ -92,11 +96,11 @@ lint-fix:
 		"$(CARGO_BIN)" fmt -p "$$pkg" || exit 1; \
 	done
 	@for pkg in $(PKGS); do \
-		env -u CEF_PATH "$(CARGO_BIN)" clippy -p "$$pkg" --all-targets --fix --allow-dirty --allow-staged -- -D warnings || exit 1; \
+		$(CARGO_WITH_CEF_CACHE) clippy -p "$$pkg" --all-targets --fix --allow-dirty --allow-staged -- -D warnings || exit 1; \
 	done
 
 test:
-	env -u CEF_PATH "$(CARGO_BIN)" test --workspace --exclude bevy_cef_core
+	$(CARGO_WITH_CEF_CACHE) test --workspace --exclude bevy_cef_core
 
 # Reset vmux *dev* storage for a clean test. Removes the layout store, session,
 # logs, the saved profile display name, and stale dev service sockets (all

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ make doctor
 make
 ```
 
+The first build through `make` in a linked worktree automatically seeds its build cache from the main worktree.
+
 See [Makefile](Makefile) for all targets.
 
 ## License

--- a/crates/vmux_desktop/tests/release_invariants.rs
+++ b/crates/vmux_desktop/tests/release_invariants.rs
@@ -42,13 +42,38 @@ fn test_app_marks_test_session() {
 fn dev_target_keeps_service_out_of_desktop_dynamic_linking_build() {
     let makefile = include_str!("../../../Makefile");
 
-    assert!(
-        makefile.contains("env -u CEF_PATH \"$(CARGO_BIN)\" build -p vmux_service -p vmux_cli")
-    );
-    assert!(
-        makefile.contains("env -u CEF_PATH \"$(CARGO_BIN)\" build -p vmux_desktop --features dev")
-    );
+    assert!(makefile.contains("$(CARGO_WITH_CEF_CACHE) build -p vmux_service -p vmux_cli"));
+    assert!(makefile.contains("$(CARGO_WITH_CEF_CACHE) build -p vmux_desktop --features dev"));
     assert!(!makefile.contains("build -p vmux_desktop -p vmux_cli -p vmux_service --features dev"));
+}
+
+#[test]
+fn local_cargo_builds_share_cef_sdk_and_sccache() {
+    let makefile = include_str!("../../../Makefile");
+    let wrapper = include_str!("../../../scripts/cargo-with-cef-cache.sh");
+
+    assert!(makefile.contains("./scripts/cargo-with-cef-cache.sh"));
+    assert!(wrapper.contains("seed-worktree-target.sh\" --if-needed"));
+    assert!(wrapper.contains("VMUX_CEF_SDK_CACHE"));
+    assert!(wrapper.contains("Library/Caches/Vmux/cef-sdk"));
+    assert!(wrapper.contains("CEF_PATH=\"$cef_cache\""));
+    assert!(wrapper.contains("command -v sccache"));
+    assert!(wrapper.contains("CMAKE_C_COMPILER_LAUNCHER"));
+    assert!(wrapper.contains("CMAKE_CXX_COMPILER_LAUNCHER"));
+}
+
+#[test]
+fn worktree_target_seed_uses_copy_on_write_and_drops_cef_cmake_state() {
+    let makefile = include_str!("../../../Makefile");
+    let script = include_str!("../../../scripts/seed-worktree-target.sh");
+
+    assert!(makefile.contains("seed-target:"));
+    assert!(script.contains("git rev-parse --path-format=absolute --git-common-dir"));
+    assert!(script.contains("--if-needed"));
+    assert!(script.contains("cp -cR"));
+    assert!(script.contains("cp --reflink=always -a"));
+    assert!(script.contains("cef-dll-sys-*"));
+    assert!(script.contains("libcef_dll_sys-*"));
 }
 
 #[test]
@@ -58,7 +83,7 @@ fn dev_target_stops_existing_debug_desktop_before_cef_initialize() {
         .find("target/debug/vmux_desktop")
         .expect("debug desktop stop");
     let run_idx = makefile
-        .find("exec env -u CEF_PATH")
+        .find("exec env -u CEF_PATH DYLD_LIBRARY_PATH")
         .expect("debug desktop run");
 
     assert!(makefile.contains("pgrep -f \"target/debug/vmux_desktop\""));
@@ -87,7 +112,7 @@ fn build_git_env_uses_github_style_short_hash() {
 fn local_package_only_builds_app_bundle() {
     let package_script = include_str!("../../../scripts/package.sh");
 
-    assert!(package_script.contains("cargo packager --release --formats app"));
+    assert!(package_script.contains("cargo-with-cef-cache.sh\" packager --release --formats app"));
     assert!(package_script.contains("if [[ \"$PROFILE\" == \"local\" ]]"));
 }
 

--- a/scripts/build-package-binaries.sh
+++ b/scripts/build-package-binaries.sh
@@ -4,5 +4,5 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 cd "$ROOT"
-env -u CEF_PATH cargo build -p vmux_desktop -p vmux_cli -p vmux_service -p bevy_cef_debug_render_process --release
+"$ROOT/scripts/cargo-with-cef-cache.sh" build -p vmux_desktop -p vmux_cli -p vmux_service -p bevy_cef_debug_render_process --release
 cp -f target/release/vmux_service "target/release/Vmux Service"

--- a/scripts/cargo-with-cef-cache.sh
+++ b/scripts/cargo-with-cef-cache.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cargo_bin="${CARGO_BIN:-cargo}"
+cef_cache="${VMUX_CEF_SDK_CACHE:-}"
+
+if [[ "${CI:-}" != "true" ]]; then
+    "$root/scripts/seed-worktree-target.sh" --if-needed "$root"
+fi
+
+if [[ -z "$cef_cache" && "${CI:-}" != "true" ]]; then
+    case "$(uname -s)" in
+        Darwin) cef_cache="$HOME/Library/Caches/Vmux/cef-sdk" ;;
+        *) cef_cache="${XDG_CACHE_HOME:-$HOME/.cache}/vmux/cef-sdk" ;;
+    esac
+fi
+
+if sccache_bin="$(command -v sccache 2>/dev/null)"; then
+    export CMAKE_C_COMPILER_LAUNCHER="${CMAKE_C_COMPILER_LAUNCHER:-$sccache_bin}"
+    export CMAKE_CXX_COMPILER_LAUNCHER="${CMAKE_CXX_COMPILER_LAUNCHER:-$sccache_bin}"
+fi
+
+if [[ -n "$cef_cache" ]]; then
+    mkdir -p "$cef_cache"
+    exec env CEF_PATH="$cef_cache" "$cargo_bin" "$@"
+fi
+
+exec env -u CEF_PATH "$cargo_bin" "$@"

--- a/scripts/cargo-with-cef-cache.sh
+++ b/scripts/cargo-with-cef-cache.sh
@@ -4,6 +4,13 @@ set -euo pipefail
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cargo_bin="${CARGO_BIN:-cargo}"
 cef_cache="${VMUX_CEF_SDK_CACHE:-}"
+linked_worktree=0
+
+if git_dir="$(git -C "$root" rev-parse --path-format=absolute --git-dir 2>/dev/null)" \
+    && common_dir="$(git -C "$root" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" \
+    && [[ "$git_dir" != "$common_dir" ]]; then
+    linked_worktree=1
+fi
 
 if [[ "${CI:-}" != "true" ]]; then
     "$root/scripts/seed-worktree-target.sh" --if-needed "$root"
@@ -19,6 +26,12 @@ fi
 if sccache_bin="$(command -v sccache 2>/dev/null)"; then
     export CMAKE_C_COMPILER_LAUNCHER="${CMAKE_C_COMPILER_LAUNCHER:-$sccache_bin}"
     export CMAKE_CXX_COMPILER_LAUNCHER="${CMAKE_CXX_COMPILER_LAUNCHER:-$sccache_bin}"
+    if [[ "${CI:-}" != "true" && "$linked_worktree" == "1" ]]; then
+        export RUSTC_WRAPPER="${RUSTC_WRAPPER:-$sccache_bin}"
+        if [[ "$RUSTC_WRAPPER" == "$sccache_bin" ]]; then
+            export CARGO_INCREMENTAL="${CARGO_INCREMENTAL:-0}"
+        fi
+    fi
 fi
 
 if [[ -n "$cef_cache" ]]; then

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PKG_ARGS=$(cargo metadata --no-deps --format-version 1 \
-  | jq -r '.packages[] | select(.manifest_path | test("patches") | not) | "-p " + .name' \
-  | tr '\n' ' ')
+PKG_ARGS=()
+while IFS= read -r package; do
+  PKG_ARGS+=("-p" "$package")
+done < <(cargo metadata --no-deps --format-version 1 \
+  | jq -r '.packages[] | select(.manifest_path | test("patches") | not) | .name')
 
-cargo fmt $PKG_ARGS -- --check
-env -u CEF_PATH cargo clippy $PKG_ARGS --all-targets -- -D warnings
-env -u CEF_PATH cargo test --workspace --exclude bevy_cef_core --exclude bevy_cef
+cargo fmt "${PKG_ARGS[@]}" -- --check
+./scripts/cargo-with-cef-cache.sh clippy "${PKG_ARGS[@]}" --all-targets -- -D warnings
+./scripts/cargo-with-cef-cache.sh test --workspace --exclude bevy_cef_core --exclude bevy_cef

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -78,12 +78,12 @@ cd "$ROOT"
 if [[ "$PROFILE" == "local" ]]; then
     # Local skips the dmg pass; `make build-local` ad-hoc-signs the
     # .app separately via sign-and-notarize.sh + SKIP_NOTARIZE=1.
-    env -u CEF_PATH VMUX_BUILD_PROFILE="$PROFILE" cargo packager --release --formats app
+    VMUX_BUILD_PROFILE="$PROFILE" "$ROOT/scripts/cargo-with-cef-cache.sh" packager --release --formats app
 else
     # Release: single invocation builds the .app, then the dmg pass'
     # before-each hook injects CEF + signs + notarizes before
     # dmg::package wraps it. Uses formats=["app","dmg"] from Cargo.toml.
-    env -u CEF_PATH VMUX_BUILD_PROFILE="$PROFILE" cargo packager --release
+    VMUX_BUILD_PROFILE="$PROFILE" "$ROOT/scripts/cargo-with-cef-cache.sh" packager --release
 fi
 
 # inject-cef only meaningfully runs in the dmg-format pass (the .app

--- a/scripts/seed-worktree-target.sh
+++ b/scripts/seed-worktree-target.sh
@@ -71,7 +71,7 @@ esac
 
 while IFS= read -r path; do
     rm -rf "$path"
-done < <(find "$destination_target" -type d \( -path '*/build/cef-dll-sys-*' -o -path '*/.fingerprint/cef-dll-sys-*' \) -prune -print)
+done < <(find "$destination_target" -type d \( -name incremental -o -path '*/build/cef-dll-sys-*' -o -path '*/.fingerprint/cef-dll-sys-*' \) -prune -print)
 
 find "$destination_target" -type f \( -name 'cef_dll_sys-*' -o -name 'libcef_dll_sys-*' \) -delete
 

--- a/scripts/seed-worktree-target.sh
+++ b/scripts/seed-worktree-target.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if_needed=0
+if [[ "${1:-}" == "--if-needed" ]]; then
+    if_needed=1
+    shift
+fi
+
+if [[ "$#" -gt 1 ]]; then
+    echo "usage: $0 [--if-needed] [worktree-path]" >&2
+    exit 1
+fi
+
+skip_or_fail() {
+    if [[ "$if_needed" == "1" ]]; then
+        exit 0
+    fi
+    echo "$1" >&2
+    exit 1
+}
+
+if ! common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"; then
+    skip_or_fail "not inside a git worktree"
+fi
+
+main_root="$(dirname "$common_dir")"
+destination_root="${1:-$(git rev-parse --show-toplevel)}"
+destination_root="$(cd "$destination_root" && pwd)"
+source_target="${VMUX_TARGET_SEED:-$main_root/target}"
+destination_target="$destination_root/target"
+
+if [[ ! -d "$source_target" ]]; then
+    skip_or_fail "target seed not found: $source_target"
+fi
+
+if [[ "$source_target" == "$destination_target" ]]; then
+    skip_or_fail "target seed and destination are identical: $source_target"
+fi
+
+if [[ -e "$destination_target" ]]; then
+    skip_or_fail "target destination already exists: $destination_target"
+fi
+
+complete=0
+cleanup() {
+    if [[ "$complete" != "1" && -e "$destination_target" ]]; then
+        rm -rf "$destination_target"
+    fi
+}
+trap cleanup EXIT
+
+case "$(uname -s)" in
+    Darwin)
+        source_device="$(df "$source_target" | awk 'END { print $1 }')"
+        destination_device="$(df "$destination_root" | awk 'END { print $1 }')"
+        if [[ "$source_device" != "$destination_device" ]] || ! mount | awk -v device="$source_device" '$1 == device && $0 ~ /\(apfs,/ { found = 1 } END { exit !found }'; then
+            echo "target seed requires source and destination on the same APFS filesystem" >&2
+            exit 1
+        fi
+        cp -cR "$source_target" "$destination_target"
+        ;;
+    Linux)
+        cp --reflink=always -a "$source_target" "$destination_target"
+        ;;
+    *)
+        echo "target seed unsupported on $(uname -s)" >&2
+        exit 1
+        ;;
+esac
+
+while IFS= read -r path; do
+    rm -rf "$path"
+done < <(find "$destination_target" -type d \( -path '*/build/cef-dll-sys-*' -o -path '*/.fingerprint/cef-dll-sys-*' \) -prune -print)
+
+find "$destination_target" -type f \( -name 'cef_dll_sys-*' -o -name 'libcef_dll_sys-*' \) -delete
+
+complete=1
+echo "seeded target: $source_target -> $destination_target"


### PR DESCRIPTION
## Context

Each linked worktree currently recompiles the CEF SDK and most Rust dependencies into an isolated target directory. This makes first builds slow and has consumed hundreds of gigabytes across active worktrees.

## Implementation

- Seed a linked worktree's target directory from the main target using filesystem copy-on-write on first build.
- Remove path-pinned CEF CMake state and incremental artifacts from the seed.
- Share a versioned CEF SDK cache across worktrees.
- Use sccache for CEF C/C++ and Rust compilation when available; Rust incremental compilation is disabled only in linked worktrees.
- Keep line-table debug information for workspace crates and remove dependency debug information.
- Preserve existing CI cache behavior.

## Checks / QA

- Shell syntax, Cargo metadata, worktree environment, and CI environment checks passed.
- Fresh linked-worktree `make` built, signed, and launched the app.
- Under concurrent multi-agent load, warm sccache reduced the service/CLI graph from 11m30s to 5m39s.
- Pre-push formatting, clippy, full tests, and doctests passed.
