### PR TITLE
perf(build): reuse compatible worktree targets

### DIFF
--- a/scripts/cargo-with-cef-cache.sh
+++ b/scripts/cargo-with-cef-cache.sh
@@ -4,17 +4,11 @@ set -euo pipefail
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cargo_bin="${CARGO_BIN:-cargo}"
 cef_cache="${VMUX_CEF_SDK_CACHE:-}"
-linked_worktree=0
+target_seed_key=""
+cargo_pid=""
+cargo_status=0
 
-if git_dir="$(git -C "$root" rev-parse --path-format=absolute --git-dir 2>/dev/null)" \
-    && common_dir="$(git -C "$root" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" \
-    && [[ "$git_dir" != "$common_dir" ]]; then
-    linked_worktree=1
-fi
-
-if [[ "${CI:-}" != "true" ]]; then
-    "$root/scripts/seed-worktree-target.sh" --if-needed "$root"
-fi
+source "$root/scripts/target-cache-common.sh"
 
 if [[ -z "$cef_cache" && "${CI:-}" != "true" ]]; then
     case "$(uname -s)" in
@@ -26,7 +20,7 @@ fi
 if sccache_bin="$(command -v sccache 2>/dev/null)"; then
     export CMAKE_C_COMPILER_LAUNCHER="${CMAKE_C_COMPILER_LAUNCHER:-$sccache_bin}"
     export CMAKE_CXX_COMPILER_LAUNCHER="${CMAKE_CXX_COMPILER_LAUNCHER:-$sccache_bin}"
-    if [[ "${CI:-}" != "true" && "$linked_worktree" == "1" ]]; then
+    if [[ "${CI:-}" != "true" ]]; then
         export RUSTC_WRAPPER="${RUSTC_WRAPPER:-$sccache_bin}"
         if [[ "$RUSTC_WRAPPER" == "$sccache_bin" ]]; then
             export CARGO_INCREMENTAL="${CARGO_INCREMENTAL:-0}"
@@ -34,9 +28,76 @@ if sccache_bin="$(command -v sccache 2>/dev/null)"; then
     fi
 fi
 
-if [[ -n "$cef_cache" ]]; then
-    mkdir -p "$cef_cache"
-    exec env CEF_PATH="$cef_cache" "$cargo_bin" "$@"
+cleanup() {
+    vmux_target_lock_release 8
+}
+
+forward_signal() {
+    local signal="$1"
+    if [[ -n "$cargo_pid" ]] && kill -0 "$cargo_pid" 2>/dev/null; then
+        kill -s "$signal" "$cargo_pid" 2>/dev/null || true
+    fi
+}
+
+if [[ "${CI:-}" != "true" ]]; then
+    target_seed_key="$(CARGO_BIN="$cargo_bin" "$root/scripts/target-seed-key.sh")"
+    export VMUX_TARGET_SEED_KEY="$target_seed_key"
+    if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
+        case "$CARGO_TARGET_DIR" in
+            /*) target_dir="$CARGO_TARGET_DIR" ;;
+            *) target_dir="$PWD/$CARGO_TARGET_DIR" ;;
+        esac
+    else
+        target_dir="$root/target"
+    fi
+    target_parent="$(dirname "$target_dir")"
+    mkdir -p "$target_parent"
+    target_parent="$(cd "$target_parent" && pwd)"
+    target_dir="$target_parent/$(basename "$target_dir")"
+    export VMUX_TARGET_DESTINATION="$target_dir"
+    "$root/scripts/seed-worktree-target.sh" --if-needed "$root"
+    vmux_target_lock_acquire "$target_dir" "$root" 8
+    trap cleanup EXIT
 fi
 
-exec env -u CEF_PATH "$cargo_bin" "$@"
+trap 'forward_signal HUP' HUP
+trap 'forward_signal INT' INT
+trap 'forward_signal TERM' TERM
+
+set +e
+if [[ -n "$cef_cache" ]]; then
+    mkdir -p "$cef_cache"
+    env CEF_PATH="$cef_cache" "$cargo_bin" "$@" &
+else
+    env -u CEF_PATH "$cargo_bin" "$@" &
+fi
+cargo_pid=$!
+while true; do
+    wait "$cargo_pid"
+    cargo_status=$?
+    if [[ "$cargo_status" -gt 128 ]] && kill -0 "$cargo_pid" 2>/dev/null; then
+        continue
+    fi
+    break
+done
+cargo_pid=""
+set -e
+
+if [[ "$cargo_status" != "0" ]]; then
+    exit "$cargo_status"
+fi
+
+case "${1:-}" in
+    bench | build | check | clippy | doc | rustc | test)
+        artifact_command=1
+        ;;
+    *)
+        artifact_command=0
+        ;;
+esac
+
+if [[ -n "$target_seed_key" && "$artifact_command" == "1" ]]; then
+    rm -rf -- "$target_dir/.vmux-seed"
+    mkdir -p "$target_dir/.vmux-seed"
+    touch "$target_dir/.vmux-seed/$target_seed_key"
+fi

--- a/scripts/seed-worktree-target.sh
+++ b/scripts/seed-worktree-target.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$root/scripts/target-cache-common.sh"
+
 if_needed=0
 if [[ "${1:-}" == "--if-needed" ]]; then
     if_needed=1
@@ -27,41 +30,107 @@ fi
 main_root="$(dirname "$common_dir")"
 destination_root="${1:-$(git rev-parse --show-toplevel)}"
 destination_root="$(cd "$destination_root" && pwd)"
-source_target="${VMUX_TARGET_SEED:-$main_root/target}"
-destination_target="$destination_root/target"
-
-if [[ ! -d "$source_target" ]]; then
-    skip_or_fail "target seed not found: $source_target"
+target_dir_setting="${CARGO_TARGET_DIR:-target}"
+if [[ -n "${VMUX_TARGET_DESTINATION:-}" ]]; then
+    destination_target="$VMUX_TARGET_DESTINATION"
+elif [[ "$target_dir_setting" == /* ]]; then
+    destination_target="$target_dir_setting"
+else
+    destination_target="$destination_root/$target_dir_setting"
 fi
+destination_parent="$(dirname "$destination_target")"
+mkdir -p "$destination_parent"
+destination_parent="$(cd "$destination_parent" && pwd)"
+destination_target="$destination_parent/$(basename "$destination_target")"
+target_seed_key="${VMUX_TARGET_SEED_KEY:-}"
+source_target="${VMUX_TARGET_SEED:-}"
+staging_target=""
+
+cleanup() {
+    vmux_target_lock_release 9
+    vmux_target_lock_release 8
+    if [[ -n "$staging_target" && -e "$staging_target" ]]; then
+        rm -rf -- "$staging_target"
+    fi
+}
+trap cleanup EXIT
+
+vmux_target_lock_acquire "$destination_target" "$root" 8
+
+if [[ -e "$destination_target" || -L "$destination_target" ]]; then
+    skip_or_fail "target destination already exists: $destination_target"
+fi
+
+if [[ -z "$source_target" && -n "$target_seed_key" ]]; then
+    newest_marker_mtime=0
+    while IFS= read -r line; do
+        if [[ "$line" != worktree\ * ]]; then
+            continue
+        fi
+        candidate_root="${line#worktree }"
+        if [[ "$target_dir_setting" == /* ]]; then
+            candidate_target="$target_dir_setting"
+        else
+            candidate_target="$candidate_root/$target_dir_setting"
+        fi
+        marker="$candidate_target/.vmux-seed/$target_seed_key"
+        if [[ "$candidate_target" == "$destination_target" || -L "$candidate_target" || ! -f "$marker" ]]; then
+            continue
+        fi
+        case "$(uname -s)" in
+            Darwin) marker_mtime="$(stat -f '%m' "$marker")" ;;
+            *) marker_mtime="$(stat -c '%Y' "$marker")" ;;
+        esac
+        if [[ "$marker_mtime" -gt "$newest_marker_mtime" ]]; then
+            source_target="$candidate_target"
+            newest_marker_mtime="$marker_mtime"
+        fi
+    done < <(git worktree list --porcelain)
+    if [[ -z "$source_target" ]]; then
+        skip_or_fail "compatible target seed not found"
+    fi
+fi
+
+source_target="${source_target:-$main_root/target}"
+if [[ ! -d "$source_target" || -L "$source_target" ]]; then
+    skip_or_fail "target seed not found or unsafe: $source_target"
+fi
+source_target="$(cd "$source_target" && pwd)"
 
 if [[ "$source_target" == "$destination_target" ]]; then
     skip_or_fail "target seed and destination are identical: $source_target"
 fi
 
-if [[ -e "$destination_target" ]]; then
-    skip_or_fail "target destination already exists: $destination_target"
+if [[ -n "${VMUX_TARGET_SEED:-}" ]]; then
+    source_lock_mode="wait"
+else
+    source_lock_mode="try"
+fi
+if ! vmux_target_lock_acquire "$source_target" "$root" 9 "$source_lock_mode"; then
+    skip_or_fail "compatible target seed busy: $source_target"
 fi
 
-complete=0
-cleanup() {
-    if [[ "$complete" != "1" && -e "$destination_target" ]]; then
-        rm -rf "$destination_target"
-    fi
-}
-trap cleanup EXIT
+if [[ -n "$target_seed_key" && ! -f "$source_target/.vmux-seed/$target_seed_key" ]]; then
+    skip_or_fail "target seed became incompatible: $source_target"
+fi
+
+staging_target="$destination_parent/.vmux-target-seed.$$.$RANDOM"
+if [[ -e "$staging_target" || -L "$staging_target" ]]; then
+    skip_or_fail "target staging path already exists: $staging_target"
+fi
 
 case "$(uname -s)" in
     Darwin)
         source_device="$(df "$source_target" | awk 'END { print $1 }')"
-        destination_device="$(df "$destination_root" | awk 'END { print $1 }')"
+        destination_device="$(df "$destination_parent" | awk 'END { print $1 }')"
         if [[ "$source_device" != "$destination_device" ]] || ! mount | awk -v device="$source_device" '$1 == device && $0 ~ /\(apfs,/ { found = 1 } END { exit !found }'; then
             echo "target seed requires source and destination on the same APFS filesystem" >&2
             exit 1
         fi
-        cp -cR "$source_target" "$destination_target"
+        cp -cR "$source_target" "$staging_target"
         ;;
     Linux)
-        cp --reflink=always -a "$source_target" "$destination_target"
+        cp --reflink=always -a "$source_target" "$staging_target"
         ;;
     *)
         echo "target seed unsupported on $(uname -s)" >&2
@@ -69,11 +138,15 @@ case "$(uname -s)" in
         ;;
 esac
 
-while IFS= read -r path; do
-    rm -rf "$path"
-done < <(find "$destination_target" -type d \( -name incremental -o -path '*/build/cef-dll-sys-*' -o -path '*/.fingerprint/cef-dll-sys-*' \) -prune -print)
+vmux_target_lock_release 9
 
-find "$destination_target" -type f \( -name 'cef_dll_sys-*' -o -name 'libcef_dll_sys-*' \) -delete
+find "$staging_target" -type d \( -name incremental -o -path '*/build/cef-dll-sys-*' -o -path '*/.fingerprint/cef-dll-sys-*' \) -prune -exec rm -rf -- {} \;
+find "$staging_target" -type f \( -name 'cef_dll_sys-*' -o -name 'libcef_dll_sys-*' \) -delete
 
-complete=1
+mv -n "$staging_target" "$destination_target"
+if [[ -e "$staging_target" ]]; then
+    skip_or_fail "target destination appeared during seed: $destination_target"
+fi
+staging_target=""
+
 echo "seeded target: $source_target -> $destination_target"

--- a/scripts/target-cache-common.sh
+++ b/scripts/target-cache-common.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+vmux_target_lock_file() {
+    local target_dir="$1"
+    local repo_root="$2"
+    local lock_key
+    local lock_root
+
+    lock_key="$(printf '%s\n' "$target_dir" | git -C "$repo_root" hash-object --stdin)"
+    lock_root="${VMUX_TARGET_LOCK_ROOT:-${TMPDIR:-/tmp}/vmux-target-locks-${UID:-$(id -u)}}"
+    if [[ -L "$lock_root" ]]; then
+        echo "unsafe target lock root: $lock_root" >&2
+        return 1
+    fi
+    mkdir -p "$lock_root"
+    chmod 700 "$lock_root"
+    printf '%s/%s.lock\n' "$lock_root" "$lock_key"
+}
+
+vmux_target_lock_acquire() {
+    local target_dir="$1"
+    local repo_root="$2"
+    local slot="$3"
+    local mode="${4:-wait}"
+    local lock_file
+    local lock_var="VMUX_TARGET_LOCK_FILE_$slot"
+    local waiting=0
+
+    lock_file="$(vmux_target_lock_file "$target_dir" "$repo_root")"
+    case "$(uname -s)" in
+        Darwin)
+            while ! shlock -f "$lock_file" -p "$$"; do
+                if [[ "$mode" == "try" ]]; then
+                    return 1
+                fi
+                if [[ "$waiting" == "0" ]]; then
+                    echo "waiting for target cache lock: $target_dir"
+                    waiting=1
+                fi
+                sleep 1
+            done
+            ;;
+        Linux)
+            case "$slot" in
+                8) exec 8>"$lock_file" ;;
+                9) exec 9>"$lock_file" ;;
+                *) echo "unsupported target lock slot: $slot" >&2; return 1 ;;
+            esac
+            if [[ "$mode" == "try" ]]; then
+                flock -n "$slot" || return 1
+            else
+                flock "$slot"
+            fi
+            ;;
+        *)
+            echo "target cache locking unsupported on $(uname -s)" >&2
+            return 1
+            ;;
+    esac
+    printf -v "$lock_var" '%s' "$lock_file"
+}
+
+vmux_target_lock_release() {
+    local slot="$1"
+    local lock_var="VMUX_TARGET_LOCK_FILE_$slot"
+    local lock_file="${!lock_var:-}"
+
+    if [[ -z "$lock_file" ]]; then
+        return 0
+    fi
+    case "$(uname -s)" in
+        Darwin)
+            if [[ -r "$lock_file" ]] && [[ "$(<"$lock_file")" == "$$" ]]; then
+                rm -f -- "$lock_file"
+            fi
+            ;;
+        Linux)
+            flock -u "$slot"
+            case "$slot" in
+                8) exec 8>&- ;;
+                9) exec 9>&- ;;
+            esac
+            ;;
+    esac
+    printf -v "$lock_var" '%s' ""
+}

--- a/scripts/target-seed-key.sh
+++ b/scripts/target-seed-key.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cargo_bin="${CARGO_BIN:-cargo}"
+rustc_bin="${RUSTC:-rustc}"
+manifest_paths=()
+
+while IFS= read -r path; do
+    manifest_paths+=("$path")
+done < <(
+    find "$root" \
+        \( -path "$root/.git" -o -path "$root/.worktrees" -o -path "$root/target" \) -prune \
+        -o -type f \
+        \( -name Cargo.toml -o -name Cargo.lock -o -name rust-toolchain -o -name rust-toolchain.toml -o -path '*/.cargo/config' -o -path '*/.cargo/config.toml' \) \
+        -print \
+        | LC_ALL=C sort
+)
+
+{
+    printf 'cargo=%s\n' "$("$cargo_bin" -V)"
+    printf 'rustc=%s\n' "$("$rustc_bin" -vV)"
+    printf 'rustc-wrapper=%s\n' "${RUSTC_WRAPPER:-}"
+    printf 'rustc-workspace-wrapper=%s\n' "${RUSTC_WORKSPACE_WRAPPER:-}"
+    printf 'cargo-incremental=%s\n' "${CARGO_INCREMENTAL:-}"
+    printf 'rustflags=%s\n' "${RUSTFLAGS:-}"
+    printf 'cargo-encoded-rustflags=%s\n' "${CARGO_ENCODED_RUSTFLAGS:-}"
+    printf 'cargo-build-target=%s\n' "${CARGO_BUILD_TARGET:-}"
+    printf 'macosx-deployment-target=%s\n' "${MACOSX_DEPLOYMENT_TARGET:-}"
+    for path in "${manifest_paths[@]}"; do
+        printf 'file=%s\n' "${path#"$root/"}"
+    done
+    git -C "$root" hash-object "${manifest_paths[@]}"
+} | git -C "$root" hash-object --stdin


### PR DESCRIPTION
## Context

Fresh worktrees could clone stale or incompatible target directories, causing Cargo to discard most artifacts and rebuild the desktop dependency graph. Concurrent agents also needed safe coordination when reading and creating target caches.

## Implementation

Targets now advertise a compatibility key derived from the Rust/Cargo toolchain, compiler configuration, and workspace manifests. New worktrees select the newest compatible completed target, clone it through a staging path, and atomically install it. External cross-process locks protect builds and seeds on macOS and Linux, while signal forwarding and custom target-directory handling keep cleanup safe.

## Checks / QA

- Create a fresh worktree without a target directory and run the normal desktop build; verify a compatible target is seeded automatically.
- Start two seed/build commands for the same worktree and verify one waits without corrupting the target.
- Seeded static desktop build measured about 3m 37s including cloning, compared with 10m 38s for the incompatible cold build.