### PR TITLE
feat(updater): add manual update check

### DIFF
--- a/crates/vmux_desktop/src/updater.rs
+++ b/crates/vmux_desktop/src/updater.rs
@@ -5,7 +5,10 @@ use std::sync::{Mutex, mpsc};
 use std::time::Duration;
 
 use vmux_layout::event::RestartRequestEvent;
-use vmux_setting::AppSettings;
+use vmux_setting::{
+    AppSettings,
+    event::{CheckForUpdatesRequest, CurrentUpdateCheckStatus, UpdateCheckStatus},
+};
 
 const DEFAULT_ENDPOINT: &str = "https://vmux.ai/updates.json";
 
@@ -198,7 +201,6 @@ struct UpdateChecker {
     rx: Mutex<mpsc::Receiver<UpdateResult>>,
     tx: mpsc::Sender<UpdateResult>,
     timer: Timer,
-    started: bool,
     done: bool,
     in_flight: bool,
 }
@@ -226,7 +228,6 @@ fn init_update_checker(mut commands: Commands, config: Res<UpdateConfig>) {
         rx: Mutex::new(rx),
         tx,
         timer: Timer::from_seconds(config.initial_delay.as_secs_f32(), TimerMode::Once),
-        started: false,
         done: false,
         in_flight: false,
     });
@@ -238,8 +239,11 @@ fn poll_update_result(
     settings: Res<AppSettings>,
     time: Res<Time>,
     mut state: ResMut<vmux_layout::UpdateState>,
+    mut status: ResMut<CurrentUpdateCheckStatus>,
+    mut manual_requests: MessageReader<CheckForUpdatesRequest>,
     proxy: Option<Res<EventLoopProxyWrapper>>,
 ) {
+    let manual_requested = manual_requests.read().count() > 0 && !checker.in_flight;
     let mut results = Vec::new();
     if let Ok(rx) = checker.rx.lock() {
         while let Ok(result) = rx.try_recv() {
@@ -250,6 +254,7 @@ fn poll_update_result(
         match result {
             UpdateResult::NoUpdate => {
                 checker.in_flight = false;
+                status.0 = UpdateCheckStatus::UpToDate;
                 bevy::log::debug!("no update available");
             }
             UpdateResult::Downloading {
@@ -257,6 +262,9 @@ fn poll_update_result(
                 downloaded,
                 total,
             } => {
+                status.0 = UpdateCheckStatus::Downloading {
+                    version: version.clone(),
+                };
                 *state = vmux_layout::UpdateState::Downloading {
                     version,
                     downloaded,
@@ -264,16 +272,23 @@ fn poll_update_result(
                 };
             }
             UpdateResult::Installing { version } => {
+                status.0 = UpdateCheckStatus::Installing {
+                    version: version.clone(),
+                };
                 *state = vmux_layout::UpdateState::Installing { version };
             }
             UpdateResult::Installed { version } => {
                 checker.in_flight = false;
                 bevy::log::info!("update v{version} installed, will take effect on next launch");
+                status.0 = UpdateCheckStatus::Ready {
+                    version: version.clone(),
+                };
                 *state = vmux_layout::UpdateState::Ready { version };
                 checker.done = true;
             }
             UpdateResult::Failed(e) => {
                 checker.in_flight = false;
+                status.0 = UpdateCheckStatus::Failed;
                 bevy::log::debug!("update check failed: {e}");
                 if !matches!(
                     *state,
@@ -289,36 +304,43 @@ fn poll_update_result(
         return;
     }
 
-    if !settings.auto_update {
-        return;
-    }
-
     if checker.in_flight {
         return;
     }
 
-    checker.timer.tick(time.delta());
+    let automatic_due = if settings.auto_update {
+        checker.timer.tick(time.delta());
+        checker.timer.just_finished()
+    } else {
+        false
+    };
 
-    if !checker.timer.just_finished() {
+    if !should_start_update_check(manual_requested, settings.auto_update, automatic_due) {
         return;
     }
 
-    if !checker.started {
-        checker.started = true;
-        checker.timer.set_duration(config.poll_interval);
-        checker.timer.set_mode(TimerMode::Repeating);
-        checker.timer.reset();
-    }
+    checker.timer.set_duration(config.poll_interval);
+    checker.timer.set_mode(TimerMode::Repeating);
+    checker.timer.reset();
 
     let tx = checker.tx.clone();
     let endpoint = config.endpoint.clone();
     let pubkey = config.pubkey.clone();
     let wake = make_wake(proxy.as_deref());
     checker.in_flight = true;
+    status.0 = UpdateCheckStatus::Checking;
 
     std::thread::spawn(move || {
         run_update_check(&endpoint, &pubkey, &tx, &*wake);
     });
+}
+
+fn should_start_update_check(
+    manual_requested: bool,
+    auto_update: bool,
+    automatic_due: bool,
+) -> bool {
+    manual_requested || (auto_update && automatic_due)
 }
 
 fn make_wake(proxy: Option<&EventLoopProxyWrapper>) -> Box<dyn Fn() + Send> {
@@ -506,6 +528,26 @@ mod tests {
     #[test]
     fn default_endpoint_is_vmux_ai_updates_json() {
         assert_eq!(DEFAULT_ENDPOINT, "https://vmux.ai/updates.json");
+    }
+
+    #[test]
+    fn default_updater_checks_after_launch_and_hourly() {
+        let updater = VmuxUpdaterBuilder::default();
+
+        assert_eq!(updater.initial_delay, Duration::from_secs(5));
+        assert_eq!(updater.poll_interval, Duration::from_secs(3600));
+    }
+
+    #[test]
+    fn manual_update_check_bypasses_auto_update_setting() {
+        assert!(should_start_update_check(true, false, false));
+    }
+
+    #[test]
+    fn automatic_update_check_requires_enabled_setting_and_due_timer() {
+        assert!(should_start_update_check(false, true, true));
+        assert!(!should_start_update_check(false, false, true));
+        assert!(!should_start_update_check(false, true, false));
     }
 
     #[test]

--- a/crates/vmux_setting/src/event.rs
+++ b/crates/vmux_setting/src/event.rs
@@ -1,6 +1,80 @@
 pub const SETTINGS_PAGE_URL: &str = "vmux://settings/";
 pub const SETTINGS_LIST_EVENT: &str = "settings_list";
 pub const SETTINGS_SCHEMA_EVENT: &str = "settings_schema";
+pub const UPDATE_CHECK_STATUS_EVENT: &str = "update_check_status";
+
+/// Requests an immediate update check.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct CheckForUpdatesEvent;
+
+/// Current updater activity shown in Settings.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub enum UpdateCheckStatus {
+    #[default]
+    Idle,
+    Checking,
+    UpToDate,
+    Downloading {
+        version: String,
+    },
+    Installing {
+        version: String,
+    },
+    Ready {
+        version: String,
+    },
+    Failed,
+}
+
+/// Carries updater activity to the Settings page.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct UpdateCheckStatusEvent {
+    pub status: UpdateCheckStatus,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+/// Native request consumed by the desktop updater.
+#[derive(bevy::prelude::Message, Clone, Copy, Debug, Default)]
+pub struct CheckForUpdatesRequest;
+
+/// Updater activity shared by the desktop updater and Settings host.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(bevy::prelude::Resource, Clone, Debug, Default, PartialEq, Eq)]
+pub struct CurrentUpdateCheckStatus(pub UpdateCheckStatus);
 
 #[derive(
     Clone,
@@ -86,6 +160,28 @@ mod tests {
         let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&original).expect("ser");
         let decoded =
             rkyv::from_bytes::<SettingsSchemaEvent, rkyv::rancor::Error>(&bytes).expect("de");
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn check_for_updates_event_rkyv_roundtrip() {
+        let original = CheckForUpdatesEvent;
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&original).expect("ser");
+        let decoded =
+            rkyv::from_bytes::<CheckForUpdatesEvent, rkyv::rancor::Error>(&bytes).expect("de");
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn update_check_status_event_rkyv_roundtrip() {
+        let original = UpdateCheckStatusEvent {
+            status: UpdateCheckStatus::Downloading {
+                version: "1.2.3".to_string(),
+            },
+        };
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&original).expect("ser");
+        let decoded =
+            rkyv::from_bytes::<UpdateCheckStatusEvent, rkyv::rancor::Error>(&bytes).expect("de");
         assert_eq!(decoded, original);
     }
 }

--- a/crates/vmux_setting/src/page.rs
+++ b/crates/vmux_setting/src/page.rs
@@ -1,12 +1,14 @@
 #![allow(non_snake_case)]
 
 use crate::event::{
-    SETTINGS_LIST_EVENT, SETTINGS_SCHEMA_EVENT, SettingsCommandEvent, SettingsListEvent,
-    SettingsSchemaEvent,
+    CheckForUpdatesEvent, SETTINGS_LIST_EVENT, SETTINGS_SCHEMA_EVENT, SettingsCommandEvent,
+    SettingsListEvent, SettingsSchemaEvent, UPDATE_CHECK_STATUS_EVENT, UpdateCheckStatus,
+    UpdateCheckStatusEvent,
 };
 use crate::schema::{SettingsSchema, WidgetKind};
 use dioxus::prelude::*;
 use serde_json::{Map, Value};
+use vmux_ui::components::button::{Button, ButtonVariant};
 use vmux_ui::components::card::{Card, CardContent, CardDescription, CardHeader, CardTitle};
 use vmux_ui::components::input::Input;
 use vmux_ui::components::select::{
@@ -192,6 +194,7 @@ fn SectionView(
     value: Value,
     schema: SettingsSchema,
 ) -> Element {
+    let show_update_check = id == "general";
     rsx! {
         section { id: "{id}", class: "scroll-mt-6",
             Card {
@@ -204,10 +207,71 @@ fn SectionView(
                 CardContent {
                     div { class: "flex flex-col divide-y divide-border",
                         ObjectBody { value, parent_path: root_path, depth: 0, schema }
+                        if show_update_check {
+                            UpdateCheckRow {}
+                        }
                     }
                 }
             }
         }
+    }
+}
+
+#[component]
+fn UpdateCheckRow() -> Element {
+    let mut status = use_signal(UpdateCheckStatus::default);
+    let _status_listener = use_bin_event_listener::<UpdateCheckStatusEvent, _>(
+        UPDATE_CHECK_STATUS_EVENT,
+        move |event| status.set(event.status),
+    );
+    let current = status();
+    let (button_label, hint, disabled) = update_check_presentation(&current);
+
+    rsx! {
+        Row {
+            label: "Software Update".to_string(),
+            hint: Some(hint),
+            control: rsx! {
+                Button {
+                    variant: ButtonVariant::Outline,
+                    disabled,
+                    onclick: move |_| {
+                        status.set(UpdateCheckStatus::Checking);
+                        let _ = try_cef_bin_emit_rkyv(&CheckForUpdatesEvent);
+                    },
+                    "{button_label}"
+                }
+            },
+        }
+    }
+}
+
+fn update_check_presentation(status: &UpdateCheckStatus) -> (&'static str, String, bool) {
+    match status {
+        UpdateCheckStatus::Idle => (
+            "Check for Updates",
+            "Checks automatically on launch and every hour when Auto-update is enabled."
+                .to_string(),
+            false,
+        ),
+        UpdateCheckStatus::Checking => ("Checking…", "Checking for updates…".to_string(), true),
+        UpdateCheckStatus::UpToDate => ("Check Again", "Vmux is up to date.".to_string(), false),
+        UpdateCheckStatus::Downloading { version } => {
+            ("Downloading…", format!("Downloading Vmux {version}…"), true)
+        }
+        UpdateCheckStatus::Installing { version } => {
+            ("Installing…", format!("Installing Vmux {version}…"), true)
+        }
+        UpdateCheckStatus::Ready { version } => (
+            "Update Ready",
+            format!("Vmux {version} is ready. Restart to apply it."),
+            true,
+        ),
+        UpdateCheckStatus::Failed => (
+            "Try Again",
+            "Unable to check for updates.".to_string(),
+            false,
+        ),
     }
 }
 

--- a/crates/vmux_setting/src/plugin.rs
+++ b/crates/vmux_setting/src/plugin.rs
@@ -5,15 +5,18 @@ use bevy::{ecs::message::MessageReader, prelude::*};
 use bevy_cef::prelude::{BinEventEmitterPlugin, WebviewExtendStandardMaterial};
 use vmux_command::{ReadAppCommands, WriteAppCommands};
 
-use crate::event::SettingsCommandEvent;
+use crate::event::{
+    CheckForUpdatesEvent, CheckForUpdatesRequest, CurrentUpdateCheckStatus, SettingsCommandEvent,
+};
 use runtime::{
     LastSelfWriteHash, SettingsLoadSet, SettingsSaveDebounce, SettingsSaveRequest,
     SettingsWriteRequest, flush_settings_save, load_settings, persist_settings_to_disk,
     reload_settings_on_change, request_settings_save,
 };
 use view::{
-    broadcast_schema_to_views, broadcast_settings_to_views, handle_open_settings_command,
-    handle_settings_page_open, on_settings_command, reset_sent_markers_on_page_ready,
+    broadcast_schema_to_views, broadcast_settings_to_views, broadcast_update_status_to_views,
+    handle_open_settings_command, handle_settings_page_open, on_check_for_updates,
+    on_settings_command, reset_sent_markers_on_page_ready,
 };
 
 /// Wires settings: RON load/save with debounce, schema and settings broadcasts, and the
@@ -26,8 +29,10 @@ impl Plugin for SettingsPlugin {
         vmux_core::register_host_spawn(app, "settings");
         app.init_resource::<LastSelfWriteHash>()
             .init_resource::<SettingsSaveDebounce>()
+            .init_resource::<CurrentUpdateCheckStatus>()
             .add_message::<SettingsWriteRequest>()
             .add_message::<SettingsSaveRequest>()
+            .add_message::<CheckForUpdatesRequest>()
             .configure_sets(
                 Startup,
                 SettingsLoadSet.before(vmux_layout::LayoutStartupSet::Window),
@@ -61,14 +66,20 @@ impl Plugin for SettingsPlugin {
                 Update,
                 handle_settings_page_open.in_set(vmux_core::PageOpenSet::HandleKnownPages),
             )
-            .add_plugins(BinEventEmitterPlugin::<(SettingsCommandEvent,)>::for_hosts(
-                &["settings"],
-            ))
+            .add_plugins(BinEventEmitterPlugin::<(
+                SettingsCommandEvent,
+                CheckForUpdatesEvent,
+            )>::for_hosts(&["settings"]))
             .add_observer(on_settings_command)
+            .add_observer(on_check_for_updates)
             .add_observer(reset_sent_markers_on_page_ready)
             .add_systems(
                 Update,
-                (broadcast_schema_to_views, broadcast_settings_to_views),
+                (
+                    broadcast_schema_to_views,
+                    broadcast_settings_to_views,
+                    broadcast_update_status_to_views,
+                ),
             )
             .add_systems(
                 Update,

--- a/crates/vmux_setting/src/plugin/view.rs
+++ b/crates/vmux_setting/src/plugin/view.rs
@@ -11,8 +11,9 @@ use vmux_layout::{
 };
 
 use crate::event::{
-    SETTINGS_LIST_EVENT, SETTINGS_PAGE_URL, SETTINGS_SCHEMA_EVENT, SettingsCommandEvent,
-    SettingsListEvent, SettingsSchemaEvent,
+    CheckForUpdatesEvent, CheckForUpdatesRequest, CurrentUpdateCheckStatus, SETTINGS_LIST_EVENT,
+    SETTINGS_PAGE_URL, SETTINGS_SCHEMA_EVENT, SettingsCommandEvent, SettingsListEvent,
+    SettingsSchemaEvent, UPDATE_CHECK_STATUS_EVENT, UpdateCheckStatusEvent,
 };
 use crate::schema::{FieldSpec, SectionSpec, SelectOption, SettingsSchema, WidgetKind};
 use crate::{AppSettings, SettingsWriteRequest, apply_settings_update, serialize_settings_to_json};
@@ -111,7 +112,8 @@ pub(crate) fn reset_sent_markers_on_page_ready(
     commands
         .entity(entity)
         .remove::<SettingsListSent>()
-        .remove::<SettingsSchemaSent>();
+        .remove::<SettingsSchemaSent>()
+        .remove::<UpdateCheckStatusSent>();
 }
 
 #[derive(Component)]
@@ -119,6 +121,9 @@ pub(crate) struct SettingsListSent;
 
 #[derive(Component)]
 pub(crate) struct SettingsSchemaSent;
+
+#[derive(Component)]
+pub(crate) struct UpdateCheckStatusSent;
 
 pub(crate) fn broadcast_settings_to_views(
     settings: Res<AppSettings>,
@@ -179,6 +184,48 @@ pub(crate) fn broadcast_schema_to_views(
     }
 }
 
+pub(crate) fn broadcast_update_status_to_views(
+    status: Res<CurrentUpdateCheckStatus>,
+    pending: Query<
+        Entity,
+        (
+            With<Settings>,
+            With<PageReady>,
+            Without<UpdateCheckStatusSent>,
+        ),
+    >,
+    sent: Query<Entity, (With<Settings>, With<PageReady>, With<UpdateCheckStatusSent>)>,
+    browsers: NonSend<Browsers>,
+    mut commands: Commands,
+) {
+    let payload = UpdateCheckStatusEvent {
+        status: status.0.clone(),
+    };
+    for entity in &pending {
+        if !browsers.has_browser(entity) || !browsers.host_emit_ready(&entity) {
+            continue;
+        }
+        commands.trigger(BinHostEmitEvent::from_rkyv(
+            entity,
+            UPDATE_CHECK_STATUS_EVENT,
+            &payload,
+        ));
+        commands.entity(entity).insert(UpdateCheckStatusSent);
+    }
+    if status.is_changed() {
+        for entity in &sent {
+            if !browsers.has_browser(entity) || !browsers.host_emit_ready(&entity) {
+                continue;
+            }
+            commands.trigger(BinHostEmitEvent::from_rkyv(
+                entity,
+                UPDATE_CHECK_STATUS_EVENT,
+                &payload,
+            ));
+        }
+    }
+}
+
 pub(crate) fn on_settings_command(
     trigger: On<BinReceive<SettingsCommandEvent>>,
     mut settings: ResMut<AppSettings>,
@@ -198,6 +245,13 @@ pub(crate) fn on_settings_command(
         }
         Err(e) => bevy::log::warn!("settings: update {} rejected: {}", evt.path, e),
     }
+}
+
+pub(crate) fn on_check_for_updates(
+    _trigger: On<BinReceive<CheckForUpdatesEvent>>,
+    mut requests: MessageWriter<CheckForUpdatesRequest>,
+) {
+    requests.write(CheckForUpdatesRequest);
 }
 
 pub(crate) fn handle_open_settings_command(
@@ -321,7 +375,7 @@ fn build_settings_schema() -> SettingsSchema {
                 "auto_update",
                 FieldSpec {
                     label: Some("Auto-update".into()),
-                    hint: Some("Check for new releases on launch.".into()),
+                    hint: Some("Check for and install updates on launch and every hour.".into()),
                     ..Default::default()
                 },
             ),


### PR DESCRIPTION
## Context
Users can only wait for the automatic updater and cannot trigger a check on demand. Add a macOS-style manual check while retaining launch and hourly automatic checks.

## Implementation
Adds a Software Update row to General settings and bridges typed request/status events between the settings webview and desktop updater. Manual checks run even when Auto-update is disabled, reset the hourly cadence, and report checking, download, install, ready, up-to-date, and failure states.

## Checks / QA
- Open Settings → General and verify Software Update appears below Auto-update.
- Click Check for Updates and verify the button and status update while checking.
- Disable Auto-update and verify the manual check still starts.
- With an available update, verify download, installation, ready, and restart states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Check for updates” control to the General settings.
  * Displays update progress, including checking, downloading, installing, ready, up-to-date, and failed states.
  * Added support for manually starting update checks.
  * Automatic update checks now run hourly when enabled.
* **Bug Fixes**
  * Improved update status handling and prevented redundant update checks.
* **Documentation**
  * Updated the automatic update setting hint to reflect hourly checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->