### PR TITLE
feat(agent): add ACP model selection

### DIFF
--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -134,22 +134,45 @@ fn approval_detail_label(path: &str) -> String {
 pub struct AgentChatPagePlugin;
 
 #[cfg(not(target_arch = "wasm32"))]
+#[derive(Message)]
+struct AcpSetModelRequest {
+    sid: String,
+    request_id: u64,
+    config_id: String,
+    model_id: String,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Resource, Default)]
+struct AcpModelRequestCounter(u64);
+
+#[cfg(not(target_arch = "wasm32"))]
+impl AcpModelRequestCounter {
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(1);
+        self.0
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 impl Plugin for AgentChatPagePlugin {
     fn build(&self, app: &mut App) {
         app.world_mut().spawn(PAGE_MANIFEST);
-        app.add_plugins(BinEventEmitterPlugin::<(
-            ChatSubmit,
-            ChatApproval,
-            ChatCancel,
-            ChatResume,
-            ChatClearQueue,
-            ChatCancelQueuedPrompt,
-            ChatEscape,
-            ResumeListRequest,
-            ResumeSession,
-            RuntimeSwitchRequest,
-            SelectModel,
-        )>::for_hosts(&["agent"]))
+        app.init_resource::<AcpModelRequestCounter>()
+            .add_message::<AcpSetModelRequest>()
+            .add_plugins(BinEventEmitterPlugin::<(
+                ChatSubmit,
+                ChatApproval,
+                ChatCancel,
+                ChatResume,
+                ChatClearQueue,
+                ChatCancelQueuedPrompt,
+                ChatEscape,
+                ResumeListRequest,
+                ResumeSession,
+                RuntimeSwitchRequest,
+                SelectModel,
+            )>::for_hosts(&["agent"]))
             .add_observer(on_chat_submit)
             .add_observer(on_chat_approval)
             .add_observer(on_chat_cancel)
@@ -169,6 +192,7 @@ impl Plugin for AgentChatPagePlugin {
                     sync_chat_to_ready_views,
                     push_acp_model_state_to_page,
                     push_removed_acp_model_state_to_page,
+                    send_acp_model_requests,
                     drain_resume_list_tasks,
                     drain_resume_handoff_tasks,
                 ),
@@ -298,7 +322,7 @@ fn model_state_of(state: Option<&AcpModelState>) -> ModelState {
         return ModelState::default();
     };
     ModelState {
-        current_model_id: state.current_model_id.clone(),
+        current_model_id: state.display_model_id().to_string(),
         current_model_name: state.current_name().to_string(),
         models: state
             .models
@@ -726,27 +750,51 @@ fn slash_commands_for(cross_runtime: bool, has_models: bool) -> Vec<SlashCommand
 fn on_select_model(
     trigger: On<BinReceive<SelectModel>>,
     child_of: Query<&ChildOf>,
-    sessions: Query<(&AcpSession, &AcpModelState)>,
+    mut sessions: Query<(&AcpSession, &mut AcpModelState)>,
+    mut counter: ResMut<AcpModelRequestCounter>,
+    mut requests: MessageWriter<AcpSetModelRequest>,
+) {
+    let Ok(parent) = child_of.get(trigger.event().webview) else {
+        return;
+    };
+    let Ok((session, mut model_state)) = sessions.get_mut(parent.parent()) else {
+        return;
+    };
+    let model_id = trigger.event().payload.model_id.clone();
+    if model_state.display_model_id() == model_id
+        || !model_state.models.iter().any(|model| model.id == model_id)
+    {
+        return;
+    }
+    let request_id = counter.next();
+    requests.write(AcpSetModelRequest {
+        sid: session.sid.clone(),
+        request_id,
+        config_id: model_state.config_id.clone(),
+        model_id: model_id.clone(),
+    });
+    model_state.pending = Some(crate::client::acp::PendingAcpModelSelection {
+        request_id,
+        model_id,
+    });
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn send_acp_model_requests(
+    mut requests: MessageReader<AcpSetModelRequest>,
     service: Option<Res<ServiceClient>>,
 ) {
     let Some(service) = service else {
         return;
     };
-    let Ok(parent) = child_of.get(trigger.event().webview) else {
-        return;
-    };
-    let Ok((session, model_state)) = sessions.get(parent.parent()) else {
-        return;
-    };
-    let model_id = trigger.event().payload.model_id.clone();
-    if !model_state.models.iter().any(|model| model.id == model_id) {
-        return;
+    for request in requests.read() {
+        service.0.send(ClientMessage::AcpSetModel {
+            sid: request.sid.clone(),
+            request_id: request.request_id,
+            config_id: request.config_id.clone(),
+            model_id: request.model_id.clone(),
+        });
     }
-    service.0.send(ClientMessage::AcpSetModel {
-        sid: session.sid.clone(),
-        config_id: model_state.config_id.clone(),
-        model_id,
-    });
 }
 
 /// The target url + cwd for an ACP↔CLI runtime handoff of the current session, or `None` when
@@ -1077,6 +1125,96 @@ mod native_tests {
         let with_cli = slash_commands_for(true, false);
         assert_eq!(with_cli.len(), 2);
         assert_eq!(with_cli[1].name, "cli");
+    }
+
+    #[test]
+    fn model_selection_updates_cached_state_before_response() {
+        let mut app = App::new();
+        app.init_resource::<AcpModelRequestCounter>()
+            .add_message::<AcpSetModelRequest>()
+            .add_observer(on_select_model);
+        let stack = app
+            .world_mut()
+            .spawn((
+                AcpSession {
+                    agent_id: "claude".into(),
+                    sid: "s1".into(),
+                    cwd: "/tmp".into(),
+                    anchor: vmux_core::ProcessId::new(),
+                    resume: None,
+                },
+                AcpModelState {
+                    config_id: "model".into(),
+                    current_model_id: "default".into(),
+                    pending: None,
+                    models: vec![
+                        vmux_service::protocol::AcpModelOption {
+                            id: "default".into(),
+                            name: "Default".into(),
+                            description: None,
+                        },
+                        vmux_service::protocol::AcpModelOption {
+                            id: "fable".into(),
+                            name: "Fable".into(),
+                            description: None,
+                        },
+                    ],
+                },
+            ))
+            .id();
+        let webview = app.world_mut().spawn(ChildOf(stack)).id();
+
+        app.world_mut().trigger(BinReceive {
+            webview,
+            payload: SelectModel {
+                model_id: "fable".into(),
+            },
+        });
+
+        let state = app.world().get::<AcpModelState>(stack).unwrap();
+        assert_eq!(state.current_model_id, "default");
+        assert_eq!(
+            state.pending.as_ref().map(|pending| pending.request_id),
+            Some(1)
+        );
+        assert_eq!(
+            state
+                .pending
+                .as_ref()
+                .map(|pending| pending.model_id.as_str()),
+            Some("fable")
+        );
+        assert_eq!(state.current_name(), "Fable");
+        let requests: Vec<_> = app
+            .world_mut()
+            .resource_mut::<Messages<AcpSetModelRequest>>()
+            .drain()
+            .collect();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].sid, "s1");
+        assert_eq!(requests[0].request_id, 1);
+        assert_eq!(requests[0].config_id, "model");
+        assert_eq!(requests[0].model_id, "fable");
+
+        app.world_mut().trigger(BinReceive {
+            webview,
+            payload: SelectModel {
+                model_id: "fable".into(),
+            },
+        });
+        app.world_mut().trigger(BinReceive {
+            webview,
+            payload: SelectModel {
+                model_id: "missing".into(),
+            },
+        });
+        assert_eq!(
+            app.world_mut()
+                .resource_mut::<Messages<AcpSetModelRequest>>()
+                .drain()
+                .count(),
+            0
+        );
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -22,14 +22,15 @@ use bevy_cef::prelude::{BinEventEmitterPlugin, BinHostEmitEvent, BinReceive, Bro
 #[cfg(not(target_arch = "wasm32"))]
 use crate::chat_page::event::{
     CHAT_SNAPSHOT_EVENT, ChatApproval, ChatCancel, ChatCancelQueuedPrompt, ChatClearQueue,
-    ChatEscape, ChatResume, ChatSnapshot, ChatSubmit, QueuedPromptSnapshot,
-    RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions, ResumeListRequest,
-    ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SlashCommandEntry, SlashCommands,
+    ChatEscape, ChatResume, ChatSnapshot, ChatSubmit, MODEL_STATE_EVENT, ModelOptionEntry,
+    ModelState, QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry,
+    ResumableSessions, ResumeListRequest, ResumeSession, RuntimeSwitchRequest,
+    SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry, SlashCommands,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use crate::chat_page::turns::group_turns;
 #[cfg(not(target_arch = "wasm32"))]
-use crate::client::acp::AcpSession;
+use crate::client::acp::{AcpModelState, AcpSession};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::components::{AgentMessages, AgentSession, PromptQueue};
 #[cfg(not(target_arch = "wasm32"))]
@@ -147,6 +148,7 @@ impl Plugin for AgentChatPagePlugin {
             ResumeListRequest,
             ResumeSession,
             RuntimeSwitchRequest,
+            SelectModel,
         )>::for_hosts(&["agent"]))
             .add_observer(on_chat_submit)
             .add_observer(on_chat_approval)
@@ -158,12 +160,15 @@ impl Plugin for AgentChatPagePlugin {
             .add_observer(on_resume_list_request)
             .add_observer(on_resume_session)
             .add_observer(on_runtime_switch_request)
+            .add_observer(on_select_model)
             .add_observer(reset_chat_synced_on_page_ready)
             .add_systems(
                 Update,
                 (
                     (track_turn_duration, push_chat_to_page).chain(),
                     sync_chat_to_ready_views,
+                    push_acp_model_state_to_page,
+                    push_removed_acp_model_state_to_page,
                     drain_resume_list_tasks,
                     drain_resume_handoff_tasks,
                 ),
@@ -249,7 +254,7 @@ fn sync_chat_to_ready_views(
         &PromptQueue,
         Option<&ImportedConversation>,
     )>,
-    acp_sessions: Query<&AcpSession>,
+    acp_sessions: Query<(&AcpSession, Option<&AcpModelState>)>,
     browsers: NonSend<Browsers>,
     mut commands: Commands,
 ) {
@@ -270,20 +275,115 @@ fn sync_chat_to_ready_views(
             CHAT_SNAPSHOT_EVENT,
             &snapshot_of(messages, state, turn_meta, profile, meta, queue, imported),
         ));
-        let cross = acp_sessions
+        let (cross, model_state) = acp_sessions
             .get(stack)
             .ok()
-            .and_then(|acp| acp_agent_kind(&acp.agent_id))
+            .map(|(acp, model)| {
+                (
+                    acp_agent_kind(&acp.agent_id)
+                        .map(kind_supports_cross_runtime)
+                        .unwrap_or(false),
+                    model,
+                )
+            })
+            .unwrap_or((false, None));
+        emit_model_state(webview, model_state, cross, &mut commands);
+        commands.entity(webview).insert(ChatSynced);
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn model_state_of(state: Option<&AcpModelState>) -> ModelState {
+    let Some(state) = state else {
+        return ModelState::default();
+    };
+    ModelState {
+        current_model_id: state.current_model_id.clone(),
+        current_model_name: state.current_name().to_string(),
+        models: state
+            .models
+            .iter()
+            .map(|model| ModelOptionEntry {
+                id: model.id.clone(),
+                name: model.name.clone(),
+                description: model.description.clone().unwrap_or_default(),
+            })
+            .collect(),
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn emit_model_state(
+    webview: Entity,
+    model_state: Option<&AcpModelState>,
+    cross_runtime: bool,
+    commands: &mut Commands,
+) {
+    commands.trigger(BinHostEmitEvent::from_rkyv(
+        webview,
+        MODEL_STATE_EVENT,
+        &model_state_of(model_state),
+    ));
+    commands.trigger(BinHostEmitEvent::from_rkyv(
+        webview,
+        SLASH_COMMANDS_EVENT,
+        &SlashCommands {
+            commands: slash_commands_for(cross_runtime, model_state.is_some()),
+        },
+    ));
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn push_acp_model_state_to_page(
+    sessions: Query<(Entity, &AcpSession, &AcpModelState), Changed<AcpModelState>>,
+    children: Query<&Children>,
+    is_browser: Query<(), With<vmux_layout::Browser>>,
+    browsers: NonSend<Browsers>,
+    mut commands: Commands,
+) {
+    for (stack, session, model_state) in &sessions {
+        let Ok(kids) = children.get(stack) else {
+            continue;
+        };
+        let Some(webview) = kids.iter().find(|&entity| is_browser.contains(entity)) else {
+            continue;
+        };
+        if !browsers.has_browser(webview) || !browsers.host_emit_ready(&webview) {
+            continue;
+        }
+        let cross = acp_agent_kind(&session.agent_id)
             .map(kind_supports_cross_runtime)
             .unwrap_or(false);
-        commands.trigger(BinHostEmitEvent::from_rkyv(
-            webview,
-            SLASH_COMMANDS_EVENT,
-            &SlashCommands {
-                commands: slash_commands_for(cross),
-            },
-        ));
-        commands.entity(webview).insert(ChatSynced);
+        emit_model_state(webview, Some(model_state), cross, &mut commands);
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn push_removed_acp_model_state_to_page(
+    mut removed: RemovedComponents<AcpModelState>,
+    sessions: Query<&AcpSession>,
+    children: Query<&Children>,
+    is_browser: Query<(), With<vmux_layout::Browser>>,
+    browsers: NonSend<Browsers>,
+    mut commands: Commands,
+) {
+    for stack in removed.read() {
+        let Ok(session) = sessions.get(stack) else {
+            continue;
+        };
+        let Ok(kids) = children.get(stack) else {
+            continue;
+        };
+        let Some(webview) = kids.iter().find(|&entity| is_browser.contains(entity)) else {
+            continue;
+        };
+        if !browsers.has_browser(webview) || !browsers.host_emit_ready(&webview) {
+            continue;
+        }
+        let cross = acp_agent_kind(&session.agent_id)
+            .map(kind_supports_cross_runtime)
+            .unwrap_or(false);
+        emit_model_state(webview, None, cross, &mut commands);
     }
 }
 
@@ -600,14 +700,19 @@ fn relative_time(mtime: std::time::SystemTime) -> String {
     }
 }
 
-/// The slash commands offered on an ACP pane: `/resume` always, `/cli` only when the agent's
-/// runtime shares session ids with its CLI (so the handoff actually continues the conversation).
+/// The slash commands offered on an ACP pane.
 #[cfg(not(target_arch = "wasm32"))]
-fn slash_commands_for(cross_runtime: bool) -> Vec<SlashCommandEntry> {
+fn slash_commands_for(cross_runtime: bool, has_models: bool) -> Vec<SlashCommandEntry> {
     let mut v = vec![SlashCommandEntry {
         name: "resume".into(),
         description: "Resume a past session".into(),
     }];
+    if has_models {
+        v.push(SlashCommandEntry {
+            name: "model".into(),
+            description: "Select model".into(),
+        });
+    }
     if cross_runtime {
         v.push(SlashCommandEntry {
             name: "cli".into(),
@@ -615,6 +720,33 @@ fn slash_commands_for(cross_runtime: bool) -> Vec<SlashCommandEntry> {
         });
     }
     v
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn on_select_model(
+    trigger: On<BinReceive<SelectModel>>,
+    child_of: Query<&ChildOf>,
+    sessions: Query<(&AcpSession, &AcpModelState)>,
+    service: Option<Res<ServiceClient>>,
+) {
+    let Some(service) = service else {
+        return;
+    };
+    let Ok(parent) = child_of.get(trigger.event().webview) else {
+        return;
+    };
+    let Ok((session, model_state)) = sessions.get(parent.parent()) else {
+        return;
+    };
+    let model_id = trigger.event().payload.model_id.clone();
+    if !model_state.models.iter().any(|model| model.id == model_id) {
+        return;
+    }
+    service.0.send(ClientMessage::AcpSetModel {
+        sid: session.sid.clone(),
+        config_id: model_state.config_id.clone(),
+        model_id,
+    });
 }
 
 /// The target url + cwd for an ACP↔CLI runtime handoff of the current session, or `None` when
@@ -938,8 +1070,11 @@ mod native_tests {
 
     #[test]
     fn slash_commands_include_cli_only_when_cross_runtime() {
-        assert_eq!(slash_commands_for(false).len(), 1);
-        let with_cli = slash_commands_for(true);
+        assert_eq!(slash_commands_for(false, false).len(), 1);
+        let with_model = slash_commands_for(false, true);
+        assert_eq!(with_model.len(), 2);
+        assert_eq!(with_model[1].name, "model");
+        let with_cli = slash_commands_for(true, false);
         assert_eq!(with_cli.len(), 2);
         assert_eq!(with_cli[1].name, "cli");
     }

--- a/crates/vmux_agent/src/chat_page/composer.rs
+++ b/crates/vmux_agent/src/chat_page/composer.rs
@@ -1,4 +1,6 @@
-use super::event::{ChatBlock, ChatItem, ResumableSessionEntry, SlashCommandEntry};
+use super::event::{
+    ChatBlock, ChatItem, ModelOptionEntry, ResumableSessionEntry, SlashCommandEntry,
+};
 use unicode_segmentation::UnicodeSegmentation;
 
 const CHAT_PAGE_TITLE_MAX_GRAPHEMES: usize = 64;
@@ -8,6 +10,7 @@ pub(crate) enum SelectorMode<'a> {
     None,
     Commands(&'a str),
     Resume(&'a str),
+    Models(&'a str),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -51,6 +54,11 @@ pub(crate) fn selector_mode(draft: &str) -> SelectorMode<'_> {
     {
         return SelectorMode::Resume(rest.trim_start_matches(char::is_whitespace));
     }
+    if let Some(rest) = token.strip_prefix("model")
+        && rest.chars().next().is_some_and(char::is_whitespace)
+    {
+        return SelectorMode::Models(rest.trim_start_matches(char::is_whitespace));
+    }
     if token.chars().any(char::is_whitespace) {
         SelectorMode::None
     } else {
@@ -72,7 +80,24 @@ pub(crate) fn should_fetch_resume(draft: &str, commands: &[SlashCommandEntry]) -
                 && matches.next().is_none()
         }
         SelectorMode::None => false,
+        SelectorMode::Models(_) => false,
     }
+}
+
+pub(crate) fn filter_models(models: &[ModelOptionEntry], query: &str) -> Vec<ModelOptionEntry> {
+    let query = query.trim().to_lowercase();
+    if query.is_empty() {
+        return models.to_vec();
+    }
+    models
+        .iter()
+        .filter(|model| {
+            model.id.to_lowercase().contains(&query)
+                || model.name.to_lowercase().contains(&query)
+                || model.description.to_lowercase().contains(&query)
+        })
+        .cloned()
+        .collect()
 }
 
 pub(crate) fn filter_sessions(
@@ -362,11 +387,32 @@ mod tests {
         assert_eq!(selector_mode("/res"), SelectorMode::Commands("res"));
         assert_eq!(selector_mode("/resume"), SelectorMode::Commands("resume"));
         assert_eq!(selector_mode("/resume "), SelectorMode::Resume(""));
+        assert_eq!(selector_mode("/model"), SelectorMode::Commands("model"));
+        assert_eq!(selector_mode("/model son"), SelectorMode::Models("son"));
         assert_eq!(
             selector_mode("/resume  SID-9"),
             SelectorMode::Resume("SID-9")
         );
         assert_eq!(selector_mode("/unknown arg"), SelectorMode::None);
+    }
+
+    #[test]
+    fn models_filter_by_name_id_and_description() {
+        let models = vec![
+            ModelOptionEntry {
+                id: "claude-sonnet".into(),
+                name: "Sonnet".into(),
+                description: "Balanced".into(),
+            },
+            ModelOptionEntry {
+                id: "claude-opus".into(),
+                name: "Opus".into(),
+                description: "Most capable".into(),
+            },
+        ];
+        assert_eq!(filter_models(&models, "son")[0].id, "claude-sonnet");
+        assert_eq!(filter_models(&models, "capable")[0].id, "claude-opus");
+        assert_eq!(filter_models(&models, "claude-opus")[0].name, "Opus");
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -161,6 +161,8 @@ pub struct ChatEscape;
 pub const RESUMABLE_SESSIONS_EVENT: &str = "resumable_sessions";
 /// Bin-event id: native → page, the slash commands available for this pane.
 pub const SLASH_COMMANDS_EVENT: &str = "slash_commands";
+/// Bin-event id: native → page, current ACP model and selectable models.
+pub const MODEL_STATE_EVENT: &str = "model_state";
 
 /// One row in the `/resume` picker. Strings only (the page is dumb — native does the work).
 #[derive(
@@ -231,6 +233,55 @@ pub struct SlashCommandEntry {
 )]
 pub struct SlashCommands {
     pub commands: Vec<SlashCommandEntry>,
+}
+
+/// One row in the `/model` picker.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ModelOptionEntry {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+}
+
+/// Native → page ACP model state.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ModelState {
+    pub current_model_id: String,
+    pub current_model_name: String,
+    pub models: Vec<ModelOptionEntry>,
+}
+
+/// Page → native selected ACP model.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct SelectModel {
+    pub model_id: String,
 }
 
 /// Page → native: open the `/resume` picker (native replies with [`ResumableSessions`]).

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -2,15 +2,17 @@
 
 use crate::chat_page::composer::{
     PromptEdit, ResumeMenuState, SelectorMode, ToolActivity, chat_page_title, edit_prompt,
-    filter_sessions, is_handoff_boundary, menu_direction, move_selection, resume_menu_state,
-    selector_mode, should_clear_draft_on_escape, should_fetch_resume, tool_activity,
+    filter_models, filter_sessions, is_handoff_boundary, menu_direction, move_selection,
+    resume_menu_state, selector_mode, should_clear_draft_on_escape, should_fetch_resume,
+    tool_activity,
 };
 use crate::chat_page::event::{
     CHAT_SNAPSHOT_EVENT, ChatApproval, ChatBlock, ChatCancel, ChatCancelQueuedPrompt,
     ChatClearQueue, ChatEscape, ChatItem, ChatResume, ChatSnapshot, ChatSubmit, ChatTurn,
-    QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions,
-    ResumeListRequest, ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT,
-    SlashCommandEntry, SlashCommands, WORKING_VERBS,
+    MODEL_STATE_EVENT, ModelOptionEntry, ModelState, QueuedPromptSnapshot,
+    RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions, ResumeListRequest,
+    ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry,
+    SlashCommands, WORKING_VERBS,
 };
 use dioxus::prelude::*;
 use std::borrow::Cow;
@@ -88,6 +90,7 @@ fn install_global_prompt_input(draft: Signal<String>, slash_cmds: Signal<Vec<Sla
 
         let selector_open = match selector_mode(&draft.peek()) {
             SelectorMode::Resume(_) => true,
+            SelectorMode::Models(_) => true,
             SelectorMode::Commands(query) => {
                 let query = query.to_lowercase();
                 slash_cmds
@@ -169,6 +172,9 @@ pub fn Page() -> Element {
     let mut paused = use_signal(|| false);
     let mut slash_cmds = use_signal(Vec::<SlashCommandEntry>::new);
     let mut sessions = use_signal(Vec::<ResumableSessionEntry>::new);
+    let mut models = use_signal(Vec::<ModelOptionEntry>::new);
+    let mut current_model_id = use_signal(String::new);
+    let mut current_model = use_signal(String::new);
     let mut menu_sel = use_signal(|| 0usize);
     let mut resume_requested = use_signal(|| false);
     let mut resume_loading = use_signal(|| false);
@@ -242,6 +248,12 @@ pub fn Page() -> Element {
     let _cmds = use_bin_event_listener::<SlashCommands, _>(SLASH_COMMANDS_EVENT, move |s| {
         slash_cmds.set(s.commands.clone());
     });
+    let _models = use_bin_event_listener::<ModelState, _>(MODEL_STATE_EVENT, move |state| {
+        models.set(state.models.clone());
+        current_model_id.set(state.current_model_id.clone());
+        current_model.set(state.current_model_name.clone());
+        menu_sel.set(0);
+    });
     let _sess =
         use_bin_event_listener::<ResumableSessions, _>(RESUMABLE_SESSIONS_EVENT, move |s| {
             sessions.set(s.sessions.clone());
@@ -301,6 +313,10 @@ pub fn Page() -> Element {
         SelectorMode::Resume(query) => Some(query),
         _ => None,
     };
+    let model_query = match selector {
+        SelectorMode::Models(query) => Some(query),
+        _ => None,
+    };
     let filtered_cmds: Vec<SlashCommandEntry> = command_query
         .map(|query| {
             let query = query.to_lowercase();
@@ -315,8 +331,12 @@ pub fn Page() -> Element {
     let filtered_sessions = resume_query
         .map(|query| filter_sessions(&sessions.read(), query))
         .unwrap_or_default();
+    let filtered_models = model_query
+        .map(|query| filter_models(&models.read(), query))
+        .unwrap_or_default();
     let cmd_menu_open = command_query.is_some() && !filtered_cmds.is_empty();
     let session_menu_open = resume_query.is_some();
+    let model_menu_open = model_query.is_some();
     let resume_state = resume_query.map(|_| {
         resume_menu_state(
             resume_requested(),
@@ -330,6 +350,7 @@ pub fn Page() -> Element {
         let selected = menu_sel();
         let _ = draft.read();
         let _ = sessions.read().len();
+        let _ = models.read().len();
         if let Some(element) = web_sys::window()
             .and_then(|window| window.document())
             .and_then(|document| {
@@ -363,6 +384,11 @@ pub fn Page() -> Element {
                     span { class: "h-2.5 w-2.5 rounded-full {status_dot_class(&status())}" }
                     span { class: "bg-gradient-to-b from-foreground to-foreground/60 bg-clip-text text-sm font-semibold capitalize text-transparent",
                         "{header_name}"
+                    }
+                    if !current_model().is_empty() {
+                        span { class: "min-w-0 truncate rounded-md bg-foreground/[0.06] px-2 py-0.5 font-mono text-[10px] text-muted-foreground ring-1 ring-inset ring-foreground/10",
+                            "{current_model}"
+                        }
                     }
                 }
             }
@@ -553,6 +579,37 @@ pub fn Page() -> Element {
                             }
                         }
                     }
+                    if model_menu_open {
+                        div { class: "absolute bottom-full left-0 z-20 mb-2 max-h-80 w-full overflow-y-auto rounded-xl border border-foreground/10 bg-background/95 shadow-xl backdrop-blur-xl",
+                            if filtered_models.is_empty() {
+                                div { class: "px-3.5 py-2 text-sm text-muted-foreground", "No matching models" }
+                            } else {
+                                for (i , model) in filtered_models.iter().enumerate() {
+                                    {
+                                        let model = model.clone();
+                                        let selected = model.id == current_model_id();
+                                        rsx! {
+                                            div {
+                                                key: "model{i}",
+                                                id: "agent-selector-item-{i}",
+                                                class: if i == menu_sel() { "flex cursor-pointer flex-col gap-0.5 px-3.5 py-2 bg-foreground/10" } else { "flex cursor-pointer flex-col gap-0.5 px-3.5 py-2" },
+                                                onclick: move |_| select_model(&model, draft),
+                                                div { class: "flex min-w-0 items-baseline gap-2",
+                                                    span { class: "min-w-0 flex-1 truncate text-sm text-foreground", "{model.name}" }
+                                                    if selected {
+                                                        span { class: "shrink-0 text-[10px] uppercase tracking-wide text-emerald-500", "current" }
+                                                    }
+                                                }
+                                                if !model.description.is_empty() {
+                                                    span { class: "truncate text-xs text-muted-foreground", "{model.description}" }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                     if !queued.read().is_empty() {
                         div { class: "flex flex-col items-end gap-1.5",
                             for queued_prompt in queued.read().iter().cloned() {
@@ -644,7 +701,7 @@ pub fn Page() -> Element {
                                 onkeydown: move |e| {
                                     let streaming = matches!(status().as_str(), "streaming" | "awaiting");
                                     let draft_now = draft.peek().clone();
-                                    let (cmd_items, sess_items, session_selector_open) = match selector_mode(&draft_now) {
+                                    let (cmd_items, sess_items, model_items, session_selector_open, model_selector_open) = match selector_mode(&draft_now) {
                                         SelectorMode::Commands(query) => {
                                             let query = query.to_lowercase();
                                             (
@@ -655,19 +712,34 @@ pub fn Page() -> Element {
                                                     .cloned()
                                                     .collect::<Vec<_>>(),
                                                 Vec::new(),
+                                                Vec::new(),
+                                                false,
                                                 false,
                                             )
                                         }
                                         SelectorMode::Resume(query) => (
                                             Vec::new(),
                                             filter_sessions(&sessions.peek(), query),
+                                            Vec::new(),
+                                            true,
+                                            false,
+                                        ),
+                                        SelectorMode::Models(query) => (
+                                            Vec::new(),
+                                            Vec::new(),
+                                            filter_models(&models.peek(), query),
+                                            false,
                                             true,
                                         ),
-                                        SelectorMode::None => (Vec::new(), Vec::new(), false),
+                                        SelectorMode::None => (Vec::new(), Vec::new(), Vec::new(), false, false),
                                     };
-                                    let selector_open = session_selector_open || !cmd_items.is_empty();
+                                    let selector_open = session_selector_open
+                                        || model_selector_open
+                                        || !cmd_items.is_empty();
                                     let selector_len = if session_selector_open {
                                         sess_items.len()
+                                    } else if model_selector_open {
+                                        model_items.len()
                                     } else {
                                         cmd_items.len()
                                     };
@@ -698,6 +770,10 @@ pub fn Page() -> Element {
                                             if let Some(session) = sess_items.get(selected) {
                                                 select_resume_session(session, draft);
                                             }
+                                        } else if model_selector_open {
+                                            if let Some(model) = model_items.get(selected) {
+                                                select_model(model, draft);
+                                            }
                                         } else if let Some(command) = cmd_items.get(selected) {
                                             run_slash_command(&command.name, draft, menu_sel);
                                         }
@@ -709,7 +785,7 @@ pub fn Page() -> Element {
                                         menu_sel.set(0);
                                         return;
                                     }
-                                    if session_selector_open
+                                    if (session_selector_open || model_selector_open)
                                         && matches!(e.key(), Key::Enter | Key::Escape)
                                     {
                                         return;
@@ -816,6 +892,10 @@ fn run_slash_command(name: &str, mut draft: Signal<String>, mut menu_sel: Signal
             menu_sel.set(0);
             draft.set("/resume ".to_string());
         }
+        "model" => {
+            menu_sel.set(0);
+            draft.set("/model ".to_string());
+        }
         "cli" => {
             let _ = try_cef_bin_emit_rkyv(&RuntimeSwitchRequest { to: "cli".into() });
             draft.set(String::new());
@@ -826,6 +906,13 @@ fn run_slash_command(name: &str, mut draft: Signal<String>, mut menu_sel: Signal
         }
         _ => {}
     }
+}
+
+fn select_model(model: &ModelOptionEntry, mut draft: Signal<String>) {
+    let _ = try_cef_bin_emit_rkyv(&SelectModel {
+        model_id: model.id.clone(),
+    });
+    draft.set(String::new());
 }
 
 fn select_resume_session(session: &ResumableSessionEntry, mut draft: Signal<String>) {

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -39,16 +39,30 @@ pub struct AcpSession {
 pub struct AcpModelState {
     pub config_id: String,
     pub current_model_id: String,
+    pub(crate) pending: Option<PendingAcpModelSelection>,
     pub models: Vec<vmux_service::protocol::AcpModelOption>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PendingAcpModelSelection {
+    pub request_id: u64,
+    pub model_id: String,
+}
+
 impl AcpModelState {
+    pub fn display_model_id(&self) -> &str {
+        self.pending
+            .as_ref()
+            .map(|pending| pending.model_id.as_str())
+            .unwrap_or(&self.current_model_id)
+    }
+
     pub fn current_name(&self) -> &str {
         self.models
             .iter()
-            .find(|model| model.id == self.current_model_id)
+            .find(|model| model.id == self.display_model_id())
             .map(|model| model.name.as_str())
-            .unwrap_or(&self.current_model_id)
+            .unwrap_or_else(|| self.display_model_id())
     }
 }
 
@@ -162,6 +176,7 @@ impl Plugin for AcpAgentPlugin {
             .init_resource::<AcpInstallGeneration>()
             .add_message::<vmux_service::agent_events::PageAgentInfo>()
             .add_message::<vmux_service::agent_events::PageAgentModelInfo>()
+            .add_message::<vmux_service::agent_events::PageAgentModelSelectionResult>()
             .add_message::<vmux_service::agent_events::PageAgentSessionCreated>()
             .add_message::<vmux_service::agent_events::PageAgentAcpTerminalCreated>()
             .add_systems(Startup, start_catalog_fetch)
@@ -173,7 +188,7 @@ impl Plugin for AcpAgentPlugin {
                     drain_acp_installs,
                     receive_catalog,
                     apply_acp_agent_info,
-                    apply_acp_model_info,
+                    (apply_acp_model_info, apply_acp_model_selection_result).chain(),
                     apply_acp_session_created,
                     apply_acp_terminal_created,
                 ),
@@ -202,11 +217,11 @@ fn apply_acp_agent_info(
 
 fn apply_acp_model_info(
     mut reader: MessageReader<vmux_service::agent_events::PageAgentModelInfo>,
-    sessions: Query<(Entity, &AcpSession, Option<&AcpModelState>)>,
+    mut sessions: Query<(Entity, &AcpSession, Option<&mut AcpModelState>)>,
     mut commands: Commands,
 ) {
     for event in reader.read() {
-        for (entity, session, current) in &sessions {
+        for (entity, session, current) in &mut sessions {
             if session.sid != event.sid {
                 continue;
             }
@@ -216,13 +231,41 @@ fn apply_acp_model_info(
                 }
                 continue;
             }
-            let next = AcpModelState {
-                config_id: event.config_id.clone(),
-                current_model_id: event.current_model_id.clone(),
-                models: event.models.clone(),
-            };
-            if current != Some(&next) {
-                commands.entity(entity).insert(next);
+            if let Some(mut current) = current {
+                let pending = current.pending.take();
+                *current = AcpModelState {
+                    config_id: event.config_id.clone(),
+                    current_model_id: event.current_model_id.clone(),
+                    pending,
+                    models: event.models.clone(),
+                };
+            } else {
+                commands.entity(entity).insert(AcpModelState {
+                    config_id: event.config_id.clone(),
+                    current_model_id: event.current_model_id.clone(),
+                    pending: None,
+                    models: event.models.clone(),
+                });
+            }
+        }
+    }
+}
+
+fn apply_acp_model_selection_result(
+    mut reader: MessageReader<vmux_service::agent_events::PageAgentModelSelectionResult>,
+    mut sessions: Query<(&AcpSession, &mut AcpModelState)>,
+) {
+    for event in reader.read() {
+        for (session, mut state) in &mut sessions {
+            if session.sid == event.sid
+                && state.pending.as_ref().is_some_and(|pending| {
+                    pending.request_id == event.request_id && pending.model_id == event.model_id
+                })
+            {
+                if event.succeeded {
+                    state.current_model_id.clone_from(&event.model_id);
+                }
+                state.pending = None;
             }
         }
     }
@@ -888,7 +931,125 @@ mod tests {
 
         let state = app.world().get::<AcpModelState>(matching).unwrap();
         assert_eq!(state.current_name(), "Claude Sonnet");
+        assert!(state.pending.is_none());
         assert!(app.world().get::<AcpModelState>(unrelated).is_none());
+    }
+
+    #[test]
+    fn model_results_preserve_latest_pending_selection() {
+        use vmux_service::agent_events::{PageAgentModelInfo, PageAgentModelSelectionResult};
+        use vmux_service::protocol::AcpModelOption;
+
+        let models = vec![
+            AcpModelOption {
+                id: "default".into(),
+                name: "Default".into(),
+                description: None,
+            },
+            AcpModelOption {
+                id: "opus".into(),
+                name: "Opus".into(),
+                description: None,
+            },
+            AcpModelOption {
+                id: "fable".into(),
+                name: "Fable".into(),
+                description: None,
+            },
+        ];
+        let mut app = App::new();
+        app.add_message::<PageAgentModelInfo>()
+            .add_message::<PageAgentModelSelectionResult>()
+            .add_systems(
+                Update,
+                (apply_acp_model_info, apply_acp_model_selection_result).chain(),
+            );
+        let entity = app
+            .world_mut()
+            .spawn((
+                AcpSession {
+                    agent_id: "claude".into(),
+                    sid: "s1".into(),
+                    cwd: "/tmp".into(),
+                    anchor: vmux_core::ProcessId::new(),
+                    resume: None,
+                },
+                AcpModelState {
+                    config_id: "model".into(),
+                    current_model_id: "default".into(),
+                    pending: Some(PendingAcpModelSelection {
+                        request_id: 2,
+                        model_id: "fable".into(),
+                    }),
+                    models: models.clone(),
+                },
+            ))
+            .id();
+
+        app.world_mut().write_message(PageAgentModelInfo {
+            sid: "s1".into(),
+            config_id: "model".into(),
+            current_model_id: "opus".into(),
+            models: models.clone(),
+        });
+        app.update();
+
+        let state = app.world().get::<AcpModelState>(entity).unwrap();
+        assert_eq!(state.current_model_id, "opus");
+        assert_eq!(
+            state.pending.as_ref().map(|pending| pending.request_id),
+            Some(2)
+        );
+        assert_eq!(state.current_name(), "Fable");
+
+        app.world_mut()
+            .write_message(PageAgentModelSelectionResult {
+                sid: "s1".into(),
+                request_id: 1,
+                model_id: "fable".into(),
+                succeeded: false,
+            });
+        app.update();
+        assert_eq!(
+            app.world()
+                .get::<AcpModelState>(entity)
+                .unwrap()
+                .pending
+                .as_ref()
+                .map(|pending| pending.request_id),
+            Some(2)
+        );
+
+        app.world_mut()
+            .write_message(PageAgentModelSelectionResult {
+                sid: "s1".into(),
+                request_id: 2,
+                model_id: "fable".into(),
+                succeeded: false,
+            });
+        app.update();
+        let state = app.world().get::<AcpModelState>(entity).unwrap();
+        assert!(state.pending.is_none());
+        assert_eq!(state.current_name(), "Opus");
+
+        {
+            let mut state = app.world_mut().get_mut::<AcpModelState>(entity).unwrap();
+            state.pending = Some(PendingAcpModelSelection {
+                request_id: 3,
+                model_id: "fable".into(),
+            });
+        }
+        app.world_mut()
+            .write_message(PageAgentModelSelectionResult {
+                sid: "s1".into(),
+                request_id: 3,
+                model_id: "fable".into(),
+                succeeded: true,
+            });
+        app.update();
+        let state = app.world().get::<AcpModelState>(entity).unwrap();
+        assert_eq!(state.current_model_id, "fable");
+        assert!(state.pending.is_none());
     }
 
     #[test]

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -35,6 +35,23 @@ pub struct AcpSession {
     pub resume: Option<String>,
 }
 
+#[derive(Component, Clone, Debug, PartialEq, Eq)]
+pub struct AcpModelState {
+    pub config_id: String,
+    pub current_model_id: String,
+    pub models: Vec<vmux_service::protocol::AcpModelOption>,
+}
+
+impl AcpModelState {
+    pub fn current_name(&self) -> &str {
+        self.models
+            .iter()
+            .find(|model| model.id == self.current_model_id)
+            .map(|model| model.name.as_str())
+            .unwrap_or(&self.current_model_id)
+    }
+}
+
 /// Progress, resolved launch spec, or terminal failure of a background agent install, keyed by
 /// session id. The resolved spec is turned into `SpawnAcpAgent` on the ECS side (which owns the
 /// non-clonable `ServiceClient`).
@@ -144,6 +161,7 @@ impl Plugin for AcpAgentPlugin {
             .init_resource::<AcpCatalog>()
             .init_resource::<AcpInstallGeneration>()
             .add_message::<vmux_service::agent_events::PageAgentInfo>()
+            .add_message::<vmux_service::agent_events::PageAgentModelInfo>()
             .add_message::<vmux_service::agent_events::PageAgentSessionCreated>()
             .add_message::<vmux_service::agent_events::PageAgentAcpTerminalCreated>()
             .add_systems(Startup, start_catalog_fetch)
@@ -155,6 +173,7 @@ impl Plugin for AcpAgentPlugin {
                     drain_acp_installs,
                     receive_catalog,
                     apply_acp_agent_info,
+                    apply_acp_model_info,
                     apply_acp_session_created,
                     apply_acp_terminal_created,
                 ),
@@ -176,6 +195,34 @@ fn apply_acp_agent_info(
         for (session, mut profile) in &mut sessions {
             if session.sid == event.sid && profile.name != name {
                 *profile = vmux_core::team::Profile::registry(name, &session.agent_id);
+            }
+        }
+    }
+}
+
+fn apply_acp_model_info(
+    mut reader: MessageReader<vmux_service::agent_events::PageAgentModelInfo>,
+    sessions: Query<(Entity, &AcpSession, Option<&AcpModelState>)>,
+    mut commands: Commands,
+) {
+    for event in reader.read() {
+        for (entity, session, current) in &sessions {
+            if session.sid != event.sid {
+                continue;
+            }
+            if event.config_id.is_empty() || event.models.is_empty() {
+                if current.is_some() {
+                    commands.entity(entity).remove::<AcpModelState>();
+                }
+                continue;
+            }
+            let next = AcpModelState {
+                config_id: event.config_id.clone(),
+                current_model_id: event.current_model_id.clone(),
+                models: event.models.clone(),
+            };
+            if current != Some(&next) {
+                commands.entity(entity).insert(next);
             }
         }
     }
@@ -794,6 +841,54 @@ mod tests {
             app.world().get::<Profile>(matching).unwrap().name,
             "Antigravity"
         );
+    }
+
+    #[test]
+    fn live_acp_model_info_updates_only_matching_session() {
+        use vmux_service::agent_events::PageAgentModelInfo;
+        use vmux_service::protocol::AcpModelOption;
+
+        let mut app = App::new();
+        app.add_plugins(bevy::app::TaskPoolPlugin::default())
+            .add_plugins(AcpAgentPlugin)
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>();
+        let matching = app
+            .world_mut()
+            .spawn(AcpSession {
+                agent_id: "claude".into(),
+                sid: "s1".into(),
+                cwd: "/tmp".into(),
+                anchor: vmux_core::ProcessId::new(),
+                resume: None,
+            })
+            .id();
+        let unrelated = app
+            .world_mut()
+            .spawn(AcpSession {
+                agent_id: "codex".into(),
+                sid: "s2".into(),
+                cwd: "/tmp".into(),
+                anchor: vmux_core::ProcessId::new(),
+                resume: None,
+            })
+            .id();
+
+        app.world_mut().write_message(PageAgentModelInfo {
+            sid: "s1".into(),
+            config_id: "model".into(),
+            current_model_id: "sonnet".into(),
+            models: vec![AcpModelOption {
+                id: "sonnet".into(),
+                name: "Claude Sonnet".into(),
+                description: None,
+            }],
+        });
+        app.update();
+
+        let state = app.world().get::<AcpModelState>(matching).unwrap();
+        assert_eq!(state.current_name(), "Claude Sonnet");
+        assert!(app.world().get::<AcpModelState>(unrelated).is_none());
     }
 
     #[test]

--- a/crates/vmux_service/src/acp.rs
+++ b/crates/vmux_service/src/acp.rs
@@ -97,6 +97,12 @@ impl AcpSessionManager {
             .and_then(|handle| handle.shared.agent_info_message())
     }
 
+    pub fn model_info(&self, sid: &str) -> Option<ServiceMessage> {
+        self.sessions
+            .get(sid)
+            .and_then(|handle| handle.shared.model_info_message())
+    }
+
     pub fn contains(&self, sid: &str) -> bool {
         self.sessions.contains_key(sid)
     }
@@ -129,5 +135,6 @@ mod tests {
         assert!(mgr.subscribe("nope").is_none());
         assert!(mgr.snapshot("nope").is_none());
         assert!(mgr.agent_info("nope").is_none());
+        assert!(mgr.model_info("nope").is_none());
     }
 }

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -47,6 +47,7 @@ pub enum AcpInput {
         decision: ApprovalDecision,
     },
     SetModel {
+        request_id: u64,
         config_id: String,
         model_id: String,
     },
@@ -685,6 +686,7 @@ pub async fn run(
                         }
                     }
                     AcpInput::SetModel {
+                        request_id,
                         config_id,
                         model_id,
                     } => {
@@ -709,8 +711,20 @@ pub async fn run(
                                     &model_id,
                                     &response.config_options,
                                 );
+                                publish_model_selection_result(
+                                    &main_shared,
+                                    request_id,
+                                    &model_id,
+                                    true,
+                                );
                             }
                             Err(err) => {
+                                publish_model_selection_result(
+                                    &main_shared,
+                                    request_id,
+                                    &model_id,
+                                    false,
+                                );
                                 main_shared.emit_status(AgentRunStatus::Errored(format!(
                                     "acp model selection failed: {err}"
                                 )));
@@ -757,6 +771,20 @@ fn acp_display_name(info: Option<&Implementation>) -> Option<String> {
             (!name.is_empty()).then_some(name)
         })
         .map(str::to_string)
+}
+
+fn publish_model_selection_result(
+    shared: &AcpShared,
+    request_id: u64,
+    model_id: &str,
+    succeeded: bool,
+) {
+    shared.emit(ServiceMessage::AcpModelSelectionResult {
+        sid: shared.sid.clone(),
+        request_id,
+        model_id: model_id.to_string(),
+        succeeded,
+    });
 }
 
 async fn load_requested_session<F, Fut, E>(
@@ -1279,6 +1307,35 @@ mod tests {
                 assert_eq!(models[0].name, "Claude Sonnet");
             }
             other => panic!("expected replayable ACP model info, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn model_selection_result_publishes_request_identity() {
+        let (stream_tx, mut stream_rx) = broadcast::channel(2);
+        let shared = AcpShared::new(
+            "s1".into(),
+            PathBuf::from("/tmp"),
+            ProcessId::new(),
+            stream_tx,
+            Arc::new(tokio::sync::Mutex::new(ProcessManager::default())),
+            Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        );
+        publish_model_selection_result(&shared, 7, "fable", false);
+
+        match stream_rx.try_recv().expect("selection result") {
+            ServiceMessage::AcpModelSelectionResult {
+                sid,
+                request_id,
+                model_id,
+                succeeded,
+            } => {
+                assert_eq!(sid, "s1");
+                assert_eq!(request_id, 7);
+                assert_eq!(model_id, "fable");
+                assert!(!succeeded);
+            }
+            other => panic!("expected ACP model selection result, got {other:?}"),
         }
     }
 

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -15,10 +15,11 @@ use agent_client_protocol::schema::v1::{
     LoadSessionRequest, McpServer, NewSessionRequest, PermissionOption, PermissionOptionId,
     PromptRequest, ReadTextFileRequest, ReadTextFileResponse, ReleaseTerminalRequest,
     ReleaseTerminalResponse, RequestPermissionOutcome, RequestPermissionRequest,
-    RequestPermissionResponse, SelectedPermissionOutcome, SessionId, SessionNotification,
-    SessionUpdate, TerminalExitStatus, TerminalId, TerminalOutputRequest, TerminalOutputResponse,
-    TextContent, WaitForTerminalExitRequest, WaitForTerminalExitResponse, WriteTextFileRequest,
-    WriteTextFileResponse,
+    RequestPermissionResponse, SelectedPermissionOutcome, SessionConfigKind, SessionConfigOption,
+    SessionConfigOptionCategory, SessionConfigSelectOptions, SessionId, SessionNotification,
+    SessionUpdate, SetSessionConfigOptionRequest, TerminalExitStatus, TerminalId,
+    TerminalOutputRequest, TerminalOutputResponse, TextContent, WaitForTerminalExitRequest,
+    WaitForTerminalExitResponse, WriteTextFileRequest, WriteTextFileResponse,
 };
 use agent_client_protocol::{Client, Responder};
 use tokio::process::Command;
@@ -44,6 +45,10 @@ pub enum AcpInput {
     Approve {
         call_id: String,
         decision: ApprovalDecision,
+    },
+    SetModel {
+        config_id: String,
+        model_id: String,
     },
     /// Interrupt the in-flight prompt (ACP `session/cancel`); keep the session alive.
     Cancel,
@@ -81,6 +86,7 @@ pub struct AcpShared {
     /// typing into its pane.
     pub input_writers: Arc<tokio::sync::Mutex<HashMap<ProcessId, PtyInputWriter>>>,
     agent_name: Mutex<Option<String>>,
+    model_info: Mutex<Option<AcpModelInfoState>>,
     history_replay: AtomicBool,
     history_replay_updates: AtomicUsize,
     /// Set by `AcpInput::Cancel`; read (and reset) when the in-flight prompt resolves so it
@@ -108,6 +114,7 @@ impl AcpShared {
             manager,
             input_writers,
             agent_name: Mutex::new(None),
+            model_info: Mutex::new(None),
             history_replay: AtomicBool::new(false),
             history_replay_updates: AtomicUsize::new(0),
             cancel_requested: AtomicBool::new(false),
@@ -135,12 +142,63 @@ impl AcpShared {
             })
     }
 
+    pub fn model_info_message(&self) -> Option<ServiceMessage> {
+        self.model_info
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|state| state.message(&self.sid))
+    }
+
     fn publish_agent_info(&self, name: String) {
         *self.agent_name.lock().unwrap() = Some(name.clone());
         self.emit(ServiceMessage::AcpAgentInfo {
             sid: self.sid.clone(),
             name,
         });
+    }
+
+    fn publish_model_info(&self, config_options: &[SessionConfigOption]) {
+        let next = model_info(config_options);
+        let mut current = self.model_info.lock().unwrap();
+        if *current == next {
+            return;
+        }
+        let removed = current.is_some() && next.is_none();
+        *current = next.clone();
+        drop(current);
+        if let Some(state) = next {
+            self.emit(state.message(&self.sid));
+        } else if removed {
+            self.emit(ServiceMessage::AcpModelInfo {
+                sid: self.sid.clone(),
+                config_id: String::new(),
+                current_model_id: String::new(),
+                models: Vec::new(),
+            });
+        }
+    }
+
+    fn publish_selected_model(
+        &self,
+        config_id: &str,
+        model_id: &str,
+        config_options: &[SessionConfigOption],
+    ) {
+        let response = model_info(config_options);
+        let mut current = self.model_info.lock().unwrap();
+        let Some(mut next) = response.or_else(|| current.clone()) else {
+            return;
+        };
+        if next.config_id == config_id && next.models.iter().any(|model| model.id == model_id) {
+            next.current_model_id = model_id.to_string();
+        }
+        if current.as_ref() == Some(&next) {
+            return;
+        }
+        *current = Some(next.clone());
+        drop(current);
+        self.emit(next.message(&self.sid));
     }
 
     fn begin_history_replay(&self) {
@@ -178,6 +236,9 @@ impl AcpShared {
 }
 
 fn project_session_update(shared: &AcpShared, update: SessionUpdate) {
+    if let SessionUpdate::ConfigOptionUpdate(config) = &update {
+        shared.publish_model_info(&config.config_options);
+    }
     let mut projector = shared.projector.lock().unwrap();
     let intents = projector.apply(update);
     if shared.history_replay.load(Ordering::SeqCst) {
@@ -228,6 +289,57 @@ fn project_session_update(shared: &AcpShared, update: SessionUpdate) {
             }
         }
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct AcpModelInfoState {
+    config_id: String,
+    current_model_id: String,
+    models: Vec<crate::protocol::AcpModelOption>,
+}
+
+impl AcpModelInfoState {
+    fn message(&self, sid: &str) -> ServiceMessage {
+        ServiceMessage::AcpModelInfo {
+            sid: sid.to_string(),
+            config_id: self.config_id.clone(),
+            current_model_id: self.current_model_id.clone(),
+            models: self.models.clone(),
+        }
+    }
+}
+
+fn model_info(config_options: &[SessionConfigOption]) -> Option<AcpModelInfoState> {
+    let config = config_options.iter().find(|config| {
+        matches!(
+            config.category.as_ref(),
+            Some(SessionConfigOptionCategory::Model)
+        ) || config.id.to_string().eq_ignore_ascii_case("model")
+            || config.name.trim().eq_ignore_ascii_case("model")
+    })?;
+    let SessionConfigKind::Select(select) = &config.kind else {
+        return None;
+    };
+    let options = match &select.options {
+        SessionConfigSelectOptions::Ungrouped(options) => options.iter().collect::<Vec<_>>(),
+        SessionConfigSelectOptions::Grouped(groups) => groups
+            .iter()
+            .flat_map(|group| group.options.iter())
+            .collect::<Vec<_>>(),
+        _ => return None,
+    };
+    Some(AcpModelInfoState {
+        config_id: config.id.to_string(),
+        current_model_id: select.current_value.to_string(),
+        models: options
+            .into_iter()
+            .map(|option| crate::protocol::AcpModelOption {
+                id: option.value.to_string(),
+                name: option.name.clone(),
+                description: option.description.clone(),
+            })
+            .collect(),
+    })
 }
 
 fn approval_details(
@@ -443,7 +555,15 @@ pub async fn run(
                     let mut load = LoadSessionRequest::new(sid, main_shared.cwd.clone());
                     load.mcp_servers = mcp_servers.clone();
                     load.meta = session_meta.clone();
-                    async { cx.send_request(load).block_task().await.map(|_| ()) }
+                    let shared = main_shared.clone();
+                    let cx = cx.clone();
+                    async move {
+                        cx.send_request(load).block_task().await.map(|response| {
+                            shared.publish_model_info(
+                                response.config_options.as_deref().unwrap_or_default(),
+                            );
+                        })
+                    }
                 })
                 .await;
             if resume_requested {
@@ -454,6 +574,42 @@ pub async fn run(
                     sid: main_shared.sid.clone(),
                     acp_session_id: sid.to_string(),
                 });
+            }
+            if session_id.is_none() {
+                let ensured = ensure_session(&mut session_id, || {
+                    let mut new_session = NewSessionRequest::new(main_shared.cwd.clone());
+                    new_session.mcp_servers = mcp_servers.clone();
+                    new_session.meta = session_meta.clone();
+                    let shared = main_shared.clone();
+                    let cx = cx.clone();
+                    async move {
+                        cx.send_request(new_session)
+                            .block_task()
+                            .await
+                            .map(|response| {
+                                shared.publish_model_info(
+                                    response.config_options.as_deref().unwrap_or_default(),
+                                );
+                                response.session_id
+                            })
+                    }
+                })
+                .await;
+                match ensured {
+                    Ok((sid, true)) => {
+                        main_shared.emit(ServiceMessage::AcpSessionCreated {
+                            sid: main_shared.sid.clone(),
+                            acp_session_id: sid.to_string(),
+                        });
+                    }
+                    Ok(_) => {}
+                    Err(err) => {
+                        main_shared.emit_status(AgentRunStatus::Errored(format!(
+                            "acp session/new failed: {err}"
+                        )));
+                        return Ok(());
+                    }
+                }
             }
             main_shared.emit_status(AgentRunStatus::Idle);
 
@@ -472,11 +628,18 @@ pub async fn run(
                             let mut new_session = NewSessionRequest::new(main_shared.cwd.clone());
                             new_session.mcp_servers = mcp_servers.clone();
                             new_session.meta = session_meta.clone();
-                            async {
+                            let shared = main_shared.clone();
+                            let cx = cx.clone();
+                            async move {
                                 cx.send_request(new_session)
                                     .block_task()
                                     .await
-                                    .map(|response| response.session_id)
+                                    .map(|response| {
+                                        shared.publish_model_info(
+                                            response.config_options.as_deref().unwrap_or_default(),
+                                        );
+                                        response.session_id
+                                    })
                             }
                         })
                         .await;
@@ -519,6 +682,39 @@ pub async fn run(
                         if let Some(tx) = main_shared.pending_perms.lock().unwrap().remove(&call_id)
                         {
                             let _ = tx.send(decision);
+                        }
+                    }
+                    AcpInput::SetModel {
+                        config_id,
+                        model_id,
+                    } => {
+                        let Some(sid) = session_id.clone() else {
+                            main_shared.emit_status(AgentRunStatus::Errored(
+                                "ACP session is not ready".to_string(),
+                            ));
+                            continue;
+                        };
+                        match cx
+                            .send_request(SetSessionConfigOptionRequest::new(
+                                sid,
+                                config_id.clone(),
+                                model_id.clone(),
+                            ))
+                            .block_task()
+                            .await
+                        {
+                            Ok(response) => {
+                                main_shared.publish_selected_model(
+                                    &config_id,
+                                    &model_id,
+                                    &response.config_options,
+                                );
+                            }
+                            Err(err) => {
+                                main_shared.emit_status(AgentRunStatus::Errored(format!(
+                                    "acp model selection failed: {err}"
+                                )));
+                            }
                         }
                     }
                     AcpInput::Cancel => {
@@ -947,7 +1143,8 @@ fn status_after_prompt(cancelled: bool, errored: Option<String>) -> AgentRunStat
 mod tests {
     use super::*;
     use agent_client_protocol::schema::v1::{
-        ContentChunk, Implementation, PermissionOptionKind, ToolCall, ToolCallUpdateFields,
+        ContentChunk, Implementation, PermissionOptionKind, SessionConfigSelectGroup,
+        SessionConfigSelectOption, ToolCall, ToolCallUpdateFields,
     };
 
     fn opt(id: &str, kind: PermissionOptionKind) -> PermissionOption {
@@ -1003,6 +1200,158 @@ mod tests {
                 assert_eq!(name, "Antigravity");
             }
             other => panic!("expected replayable ACP agent info, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn model_info_reads_categorized_grouped_selector() {
+        let config = SessionConfigOption::select(
+            "llm",
+            "Language model",
+            "opus",
+            vec![SessionConfigSelectGroup::new(
+                "anthropic",
+                "Anthropic",
+                vec![
+                    SessionConfigSelectOption::new("sonnet", "Claude Sonnet"),
+                    SessionConfigSelectOption::new("opus", "Claude Opus")
+                        .description("Most capable"),
+                ],
+            )],
+        )
+        .category(SessionConfigOptionCategory::Model);
+
+        let info = model_info(&[config]).expect("model selector");
+
+        assert_eq!(info.config_id, "llm");
+        assert_eq!(info.current_model_id, "opus");
+        assert_eq!(info.models.len(), 2);
+        assert_eq!(info.models[1].name, "Claude Opus");
+        assert_eq!(info.models[1].description.as_deref(), Some("Most capable"));
+    }
+
+    #[test]
+    fn model_info_falls_back_to_model_id_without_category() {
+        let config = SessionConfigOption::select(
+            "model",
+            "Runtime",
+            "gpt-5",
+            vec![SessionConfigSelectOption::new("gpt-5", "GPT-5")],
+        );
+
+        let info = model_info(&[config]).expect("model selector");
+
+        assert_eq!(info.config_id, "model");
+        assert_eq!(info.current_model_id, "gpt-5");
+    }
+
+    #[test]
+    fn acp_model_info_is_replayable_without_a_subscriber() {
+        let (stream_tx, stream_rx) = broadcast::channel(1);
+        drop(stream_rx);
+        let shared = AcpShared::new(
+            "s1".into(),
+            PathBuf::from("/tmp"),
+            ProcessId::new(),
+            stream_tx,
+            Arc::new(tokio::sync::Mutex::new(ProcessManager::default())),
+            Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        );
+        let config = SessionConfigOption::select(
+            "model",
+            "Model",
+            "sonnet",
+            vec![SessionConfigSelectOption::new("sonnet", "Claude Sonnet")],
+        )
+        .category(SessionConfigOptionCategory::Model);
+
+        shared.publish_model_info(&[config]);
+
+        match shared.model_info_message() {
+            Some(ServiceMessage::AcpModelInfo {
+                sid,
+                current_model_id,
+                models,
+                ..
+            }) => {
+                assert_eq!(sid, "s1");
+                assert_eq!(current_model_id, "sonnet");
+                assert_eq!(models[0].name, "Claude Sonnet");
+            }
+            other => panic!("expected replayable ACP model info, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn selected_model_wins_over_stale_set_response() {
+        let (stream_tx, mut stream_rx) = broadcast::channel(4);
+        let shared = AcpShared::new(
+            "s1".into(),
+            PathBuf::from("/tmp"),
+            ProcessId::new(),
+            stream_tx,
+            Arc::new(tokio::sync::Mutex::new(ProcessManager::default())),
+            Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        );
+        let stale = SessionConfigOption::select(
+            "model",
+            "Model",
+            "fable",
+            vec![
+                SessionConfigSelectOption::new("default", "Default"),
+                SessionConfigSelectOption::new("fable", "Fable"),
+            ],
+        )
+        .category(SessionConfigOptionCategory::Model);
+        shared.publish_model_info(std::slice::from_ref(&stale));
+        let _ = stream_rx.try_recv();
+
+        shared.publish_selected_model("model", "default", &[stale]);
+
+        match stream_rx.try_recv().expect("selected model update") {
+            ServiceMessage::AcpModelInfo {
+                current_model_id, ..
+            } => assert_eq!(current_model_id, "default"),
+            other => panic!("expected ACP model info, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn selected_model_uses_cached_options_when_set_response_is_empty() {
+        let (stream_tx, mut stream_rx) = broadcast::channel(4);
+        let shared = AcpShared::new(
+            "s1".into(),
+            PathBuf::from("/tmp"),
+            ProcessId::new(),
+            stream_tx,
+            Arc::new(tokio::sync::Mutex::new(ProcessManager::default())),
+            Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        );
+        let config = SessionConfigOption::select(
+            "model",
+            "Model",
+            "fable",
+            vec![
+                SessionConfigSelectOption::new("default", "Default"),
+                SessionConfigSelectOption::new("fable", "Fable"),
+            ],
+        )
+        .category(SessionConfigOptionCategory::Model);
+        shared.publish_model_info(&[config]);
+        let _ = stream_rx.try_recv();
+
+        shared.publish_selected_model("model", "default", &[]);
+
+        match stream_rx.try_recv().expect("selected model update") {
+            ServiceMessage::AcpModelInfo {
+                current_model_id,
+                models,
+                ..
+            } => {
+                assert_eq!(current_model_id, "default");
+                assert_eq!(models.len(), 2);
+            }
+            other => panic!("expected ACP model info, got {other:?}"),
         }
     }
 

--- a/crates/vmux_service/src/agent_events.rs
+++ b/crates/vmux_service/src/agent_events.rs
@@ -85,6 +85,15 @@ pub struct PageAgentInfo {
     pub name: String,
 }
 
+/// Current model and selectable models reported by a running ACP session.
+#[derive(Message)]
+pub struct PageAgentModelInfo {
+    pub sid: String,
+    pub config_id: String,
+    pub current_model_id: String,
+    pub models: Vec<crate::protocol::AcpModelOption>,
+}
+
 /// The ACP session was created/loaded; carries the agent-assigned session id so the GUI can
 /// redirect the pane url to `vmux://agent/<id>/<acp_session_id>` (the persisted resume handle).
 #[derive(Message)]

--- a/crates/vmux_service/src/agent_events.rs
+++ b/crates/vmux_service/src/agent_events.rs
@@ -94,6 +94,14 @@ pub struct PageAgentModelInfo {
     pub models: Vec<crate::protocol::AcpModelOption>,
 }
 
+#[derive(Message)]
+pub struct PageAgentModelSelectionResult {
+    pub sid: String,
+    pub request_id: u64,
+    pub model_id: String,
+    pub succeeded: bool,
+}
+
 /// The ACP session was created/loaded; carries the agent-assigned session id so the GUI can
 /// redirect the pane url to `vmux://agent/<id>/<acp_session_id>` (the persisted resume handle).
 #[derive(Message)]

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -465,6 +465,12 @@ pub enum ClientMessage {
         text: String,
         context: Option<String>,
     },
+    /// Select a model exposed by an ACP session's model configuration option.
+    AcpSetModel {
+        sid: String,
+        config_id: String,
+        model_id: String,
+    },
     /// Interrupt the session's in-flight turn without tearing the session down.
     AgentCancel {
         sid: String,
@@ -781,6 +787,21 @@ pub enum ServiceMessage {
         sid: String,
         name: String,
     },
+    /// Current model and selectable models reported by an ACP session.
+    AcpModelInfo {
+        sid: String,
+        config_id: String,
+        current_model_id: String,
+        models: Vec<AcpModelOption>,
+    },
+}
+
+/// One model exposed by an ACP session configuration selector.
+#[derive(Debug, Clone, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub struct AcpModelOption {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
 }
 
 /// Metadata about a process, returned in ProcessList.
@@ -1284,6 +1305,11 @@ mod tests {
                 text: "hi".into(),
                 context: Some("prior conversation".into()),
             },
+            ClientMessage::AcpSetModel {
+                sid: "s".into(),
+                config_id: "model".into(),
+                model_id: "sonnet".into(),
+            },
             ClientMessage::AgentApprove {
                 sid: "s".into(),
                 call_id: "c".into(),
@@ -1342,6 +1368,16 @@ mod tests {
             ServiceMessage::AcpAgentInfo {
                 sid: "s".into(),
                 name: "Antigravity".into(),
+            },
+            ServiceMessage::AcpModelInfo {
+                sid: "s".into(),
+                config_id: "model".into(),
+                current_model_id: "sonnet".into(),
+                models: vec![AcpModelOption {
+                    id: "sonnet".into(),
+                    name: "Claude Sonnet".into(),
+                    description: Some("Balanced".into()),
+                }],
             },
         ];
         for msg in services {

--- a/crates/vmux_service/src/protocol.rs
+++ b/crates/vmux_service/src/protocol.rs
@@ -468,6 +468,7 @@ pub enum ClientMessage {
     /// Select a model exposed by an ACP session's model configuration option.
     AcpSetModel {
         sid: String,
+        request_id: u64,
         config_id: String,
         model_id: String,
     },
@@ -793,6 +794,13 @@ pub enum ServiceMessage {
         config_id: String,
         current_model_id: String,
         models: Vec<AcpModelOption>,
+    },
+    /// Completion of a model selection request, correlated by `request_id`.
+    AcpModelSelectionResult {
+        sid: String,
+        request_id: u64,
+        model_id: String,
+        succeeded: bool,
     },
 }
 
@@ -1307,6 +1315,7 @@ mod tests {
             },
             ClientMessage::AcpSetModel {
                 sid: "s".into(),
+                request_id: 7,
                 config_id: "model".into(),
                 model_id: "sonnet".into(),
             },
@@ -1378,6 +1387,12 @@ mod tests {
                     name: "Claude Sonnet".into(),
                     description: Some("Balanced".into()),
                 }],
+            },
+            ServiceMessage::AcpModelSelectionResult {
+                sid: "s".into(),
+                request_id: 7,
+                model_id: "opus".into(),
+                succeeded: false,
             },
         ];
         for msg in services {

--- a/crates/vmux_service/src/server.rs
+++ b/crates/vmux_service/src/server.rs
@@ -790,6 +790,20 @@ async fn handle_client(
                 }
             }
 
+            ClientMessage::AcpSetModel {
+                sid,
+                config_id,
+                model_id,
+            } => {
+                acp_manager.lock().await.input(
+                    &sid,
+                    crate::acp::AcpInput::SetModel {
+                        config_id,
+                        model_id,
+                    },
+                );
+            }
+
             ClientMessage::AgentCancel { sid } => {
                 if acp_manager.lock().await.contains(&sid) {
                     acp_manager
@@ -887,6 +901,10 @@ async fn handle_client(
                     if let Some(agent_info) = acp_manager.lock().await.agent_info(&sid) {
                         let mut w = writer.lock().await;
                         write_message!(&mut *w, &agent_info)?;
+                    }
+                    if let Some(model_info) = acp_manager.lock().await.model_info(&sid) {
+                        let mut w = writer.lock().await;
+                        write_message!(&mut *w, &model_info)?;
                     }
                     if let Some(old) = page_agent_forwarders.remove(&sid) {
                         old.abort();

--- a/crates/vmux_service/src/server.rs
+++ b/crates/vmux_service/src/server.rs
@@ -792,12 +792,14 @@ async fn handle_client(
 
             ClientMessage::AcpSetModel {
                 sid,
+                request_id,
                 config_id,
                 model_id,
             } => {
                 acp_manager.lock().await.input(
                     &sid,
                     crate::acp::AcpInput::SetModel {
+                        request_id,
                         config_id,
                         model_id,
                     },

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -1187,6 +1187,8 @@ struct PollServiceWriters<'w> {
     page_agent_snapshot: MessageWriter<'w, vmux_service::agent_events::PageAgentSnapshot>,
     page_agent_info: MessageWriter<'w, vmux_service::agent_events::PageAgentInfo>,
     page_agent_model_info: MessageWriter<'w, vmux_service::agent_events::PageAgentModelInfo>,
+    page_agent_model_selection_result:
+        MessageWriter<'w, vmux_service::agent_events::PageAgentModelSelectionResult>,
     page_agent_session_created:
         MessageWriter<'w, vmux_service::agent_events::PageAgentSessionCreated>,
     page_agent_acp_terminal_created:
@@ -1700,6 +1702,21 @@ fn poll_service_messages(
                         config_id,
                         current_model_id,
                         models,
+                    },
+                );
+            }
+            ServiceMessage::AcpModelSelectionResult {
+                sid,
+                request_id,
+                model_id,
+                succeeded,
+            } => {
+                writers.page_agent_model_selection_result.write(
+                    vmux_service::agent_events::PageAgentModelSelectionResult {
+                        sid,
+                        request_id,
+                        model_id,
+                        succeeded,
                     },
                 );
             }

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -1186,6 +1186,7 @@ struct PollServiceWriters<'w> {
     page_agent_awaiting: MessageWriter<'w, vmux_service::agent_events::PageAgentAwaitingApproval>,
     page_agent_snapshot: MessageWriter<'w, vmux_service::agent_events::PageAgentSnapshot>,
     page_agent_info: MessageWriter<'w, vmux_service::agent_events::PageAgentInfo>,
+    page_agent_model_info: MessageWriter<'w, vmux_service::agent_events::PageAgentModelInfo>,
     page_agent_session_created:
         MessageWriter<'w, vmux_service::agent_events::PageAgentSessionCreated>,
     page_agent_acp_terminal_created:
@@ -1686,6 +1687,21 @@ fn poll_service_messages(
                 writers
                     .page_agent_info
                     .write(vmux_service::agent_events::PageAgentInfo { sid, name });
+            }
+            ServiceMessage::AcpModelInfo {
+                sid,
+                config_id,
+                current_model_id,
+                models,
+            } => {
+                writers.page_agent_model_info.write(
+                    vmux_service::agent_events::PageAgentModelInfo {
+                        sid,
+                        config_id,
+                        current_model_id,
+                        models,
+                    },
+                );
             }
             ServiceMessage::AgentCommandResult { request_id, result } => {
                 writers.agent_command_results.write(


### PR DESCRIPTION
## Context

ACP agents can expose multiple models, but vmux did not show the active model or provide a way to change it. This made authentication or availability failures difficult to recover from without leaving the session.

## Implementation

Read ACP model configuration options from session creation, loading, and live config updates. Surface the active model in the chat header and add a searchable `/model` picker that sends `session/set_config_option`. Use optimistic shared state plus request IDs so the header updates immediately while stale, failed, or out-of-order responses reconcile safely.

## Checks / QA

1. Open an ACP agent that exposes model options and confirm its active model appears in the header.
2. Run `/model`, filter the list, and select a different model.
3. Confirm the header and current marker update immediately.
4. Switch back to Default after selecting another model and confirm the header returns to Default.
5. Change models rapidly and confirm the last selection remains displayed.