### PR TITLE
perf(dev): reuse CEF build artifacts

### DIFF
--- a/.github/workflows/api-docs-freshness.yml
+++ b/.github/workflows/api-docs-freshness.yml
@@ -95,7 +95,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: api-docs
-          cache-all-crates: true
 
       - name: Cache CEF framework
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: lint
-          cache-all-crates: true
 
       - name: Cache cargo binaries
         uses: actions/cache@v4
@@ -130,11 +129,7 @@ jobs:
           fi
 
       - name: Install dioxus-cli
-        run: |
-          if ! dx --version 2>/dev/null | grep -q "${{ env.DIOXUS_CLI_VERSION }}"; then
-            cargo install dioxus-cli --locked --version "${{ env.DIOXUS_CLI_VERSION }}" --force
-          fi
-          dx --version
+        run: ./scripts/install-dioxus-cli.sh
 
       - name: Install tailwindcss
         run: TAILWINDCSS_INSTALL_DIR="$HOME/.local/bin" ./scripts/install-tailwindcss.sh
@@ -186,7 +181,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: test
-          cache-all-crates: true
 
       - name: Cache cargo binaries
         uses: actions/cache@v4
@@ -219,11 +213,7 @@ jobs:
           fi
 
       - name: Install dioxus-cli
-        run: |
-          if ! dx --version 2>/dev/null | grep -q "${{ env.DIOXUS_CLI_VERSION }}"; then
-            cargo install dioxus-cli --locked --version "${{ env.DIOXUS_CLI_VERSION }}" --force
-          fi
-          dx --version
+        run: ./scripts/install-dioxus-cli.sh
 
       - name: Install tailwindcss
         run: TAILWINDCSS_INSTALL_DIR="$HOME/.local/bin" ./scripts/install-tailwindcss.sh
@@ -347,13 +337,6 @@ jobs:
         with:
           workspaces: website
           shared-key: website
-          cache-all-crates: true
-
-      - name: Cache cargo binaries
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/bin
-          key: cargo-bin-${{ runner.os }}-dx${{ env.DIOXUS_CLI_VERSION }}-v3
 
       - name: Cache binaryen
         uses: actions/cache@v4
@@ -362,11 +345,7 @@ jobs:
           key: binaryen-${{ runner.os }}-${{ runner.arch }}-${{ env.BINARYEN_VERSION }}
 
       - name: Install dioxus-cli
-        run: |
-          if ! dx --version 2>/dev/null | grep -q "${{ env.DIOXUS_CLI_VERSION }}"; then
-            cargo install dioxus-cli --locked --version "${{ env.DIOXUS_CLI_VERSION }}" --force
-          fi
-          dx --version
+        run: ./scripts/install-dioxus-cli.sh
 
       - name: Install binaryen
         run: ./scripts/install-dioxus-binaryen.sh
@@ -434,7 +413,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: build-mac
-          cache-all-crates: true
 
       - name: Cache cargo binaries
         uses: actions/cache@v4
@@ -473,11 +451,7 @@ jobs:
           fi
 
       - name: Install dioxus-cli
-        run: |
-          if ! dx --version 2>/dev/null | grep -q "${{ env.DIOXUS_CLI_VERSION }}"; then
-            cargo install dioxus-cli --locked --version "${{ env.DIOXUS_CLI_VERSION }}" --force
-          fi
-          dx --version
+        run: ./scripts/install-dioxus-cli.sh
 
       - name: Install binaryen
         run: ./scripts/install-dioxus-binaryen.sh

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "website/**"
       - "scripts/install.sh"
+      - "scripts/install-dioxus-cli.sh"
       - ".github/workflows/deploy-website.yml"
   workflow_dispatch:
 
@@ -21,6 +22,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   TAILWINDCSS_VERSION: "4.2.4"
+  DIOXUS_CLI_VERSION: "0.7.4"
   BINARYEN_VERSION: "127"
   DX_HOME: ${{ github.workspace }}/.dx
 
@@ -43,7 +45,6 @@ jobs:
         with:
           workspaces: website
           shared-key: deploy-website
-          cache-all-crates: true
 
       - name: Cache tailwindcss
         uses: actions/cache@v4
@@ -63,7 +64,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install dioxus-cli
-        run: command -v dx >/dev/null 2>&1 || cargo install dioxus-cli --locked --version 0.7.4
+        run: ./scripts/install-dioxus-cli.sh
 
       - name: Install Binaryen
         run: ./scripts/install-dioxus-binaryen.sh

--- a/Makefile
+++ b/Makefile
@@ -77,9 +77,8 @@ setup-cef:
 # Build from vmux-patched bevy_cef_core (required when adding CEF schemes such as vmux://).
 # Installs into the same path `bevy_cef` debug mode loads on macOS.
 install-debug-render-process:
-	$(CARGO_WITH_CEF_CACHE) build -p bevy_cef_debug_render_process --features debug
-	cp "$(CURDIR)/target/debug/bevy_cef_debug_render_process" \
-	  "$(CEF_FRAMEWORK_DIR)/Libraries/bevy_cef_debug_render_process"
+	CARGO_BIN="$(CARGO_BIN)" CEF_FRAMEWORK_DIR="$(CEF_FRAMEWORK_DIR)" \
+	  ./scripts/install-debug-render-process.sh
 
 seed-target:
 	./scripts/seed-worktree-target.sh

--- a/crates/vmux_desktop/tests/release_invariants.rs
+++ b/crates/vmux_desktop/tests/release_invariants.rs
@@ -67,7 +67,7 @@ fn local_cargo_builds_share_cef_sdk_and_sccache() {
 }
 
 #[test]
-fn worktree_target_seed_uses_copy_on_write_and_drops_cef_cmake_state() {
+fn worktree_target_seed_uses_copy_on_write_and_relocates_cef_cmake_state() {
     let makefile = include_str!("../../../Makefile");
     let script = include_str!("../../../scripts/seed-worktree-target.sh");
 
@@ -76,8 +76,77 @@ fn worktree_target_seed_uses_copy_on_write_and_drops_cef_cmake_state() {
     assert!(script.contains("--if-needed"));
     assert!(script.contains("cp -cR"));
     assert!(script.contains("cp --reflink=always -a"));
-    assert!(script.contains("cef-dll-sys-*"));
-    assert!(script.contains("libcef_dll_sys-*"));
+    assert!(script.contains("relocate-cef-target.sh"));
+    assert!(!script.contains("-path '*/build/cef-dll-sys-*' -o"));
+}
+
+#[test]
+fn cef_target_relocator_rewrites_only_cef_build_state() {
+    use std::{fs, process::Command};
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let staging = temp.path().join("target");
+    let source = temp.path().join("source-target");
+    let original = temp.path().join("original-target");
+    let destination = temp.path().join("destination-target");
+    let cmake = staging.join("debug/build/cef-dll-sys-test/out/build/CMakeCache.txt");
+    let fingerprint = staging
+        .join("debug/.fingerprint/cef-dll-sys-test/run-build-script-build-script-build.json");
+    let dep = staging.join("debug/deps/cef_dll_sys-test.d");
+    let unrelated = staging.join("debug/build/other/output");
+
+    for path in [&cmake, &fingerprint, &dep] {
+        fs::create_dir_all(path.parent().expect("parent")).expect("create parent");
+        fs::write(path, format!("{}\n", original.display())).expect("write fixture");
+    }
+    fs::write(
+        &cmake,
+        format!(
+            "CMAKE_CACHEFILE_DIR:INTERNAL={}/debug/build/cef-dll-sys-test/out/build\n",
+            original.display()
+        ),
+    )
+    .expect("write CMake cache fixture");
+    fs::create_dir_all(unrelated.parent().expect("parent")).expect("create unrelated parent");
+    fs::write(&unrelated, format!("{}\n", source.display())).expect("write unrelated fixture");
+
+    let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../scripts/relocate-cef-target.sh");
+    let status = Command::new("bash")
+        .arg(script)
+        .arg(&staging)
+        .arg(&source)
+        .arg(&destination)
+        .status()
+        .expect("run CEF target relocator");
+    assert!(status.success());
+
+    for path in [&cmake, &fingerprint, &dep] {
+        assert!(
+            fs::read_to_string(path)
+                .expect("read relocated fixture")
+                .contains(&destination.display().to_string())
+        );
+    }
+    assert_eq!(
+        fs::read_to_string(unrelated).expect("read unrelated fixture"),
+        format!("{}\n", source.display())
+    );
+}
+
+#[test]
+fn debug_render_process_install_uses_fingerprint_cache() {
+    let makefile = include_str!("../../../Makefile");
+    let script = include_str!("../../../scripts/install-debug-render-process.sh");
+
+    assert!(makefile.contains("./scripts/install-debug-render-process.sh"));
+    assert!(!makefile.contains(
+        "$(CARGO_WITH_CEF_CACHE) build -p bevy_cef_debug_render_process --features debug"
+    ));
+    assert!(script.contains("VMUX_CEF_HELPER_CACHE"));
+    assert!(script.contains("hash-object --stdin"));
+    assert!(script.contains("CEF debug render process up to date"));
+    assert!(script.contains("Installed cached CEF debug render process"));
 }
 
 #[test]

--- a/scripts/install-debug-render-process.sh
+++ b/scripts/install-debug-render-process.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cargo_bin="${CARGO_BIN:-cargo}"
+rustc_bin="${RUSTC:-rustc}"
+cef_framework_dir="${CEF_FRAMEWORK_DIR:-$HOME/.local/share/Chromium Embedded Framework.framework}"
+installed_dir="$cef_framework_dir/Libraries"
+helper_name="bevy_cef_debug_render_process"
+installed_helper="$installed_dir/$helper_name"
+stamp="$installed_dir/.vmux-$helper_name.fingerprint"
+target_setting="${CARGO_TARGET_DIR:-target}"
+tmp_install=""
+tmp_stamp=""
+tmp_cache=""
+
+source "$root/scripts/target-cache-common.sh"
+
+case "$(uname -s)" in
+    Darwin) helper_cache="${VMUX_CEF_HELPER_CACHE:-$HOME/Library/Caches/Vmux/cef-debug-render-process}" ;;
+    Linux) helper_cache="${VMUX_CEF_HELPER_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/vmux/cef-debug-render-process}" ;;
+    *) echo "CEF debug render process install unsupported on $(uname -s)" >&2; exit 1 ;;
+esac
+
+if [[ ! -d "$installed_dir" ]]; then
+    echo "CEF framework libraries not found: $installed_dir" >&2
+    exit 1
+fi
+
+cleanup() {
+    vmux_target_lock_release 9
+    [[ -z "$tmp_install" ]] || rm -f -- "$tmp_install"
+    [[ -z "$tmp_stamp" ]] || rm -f -- "$tmp_stamp"
+    [[ -z "$tmp_cache" ]] || rm -f -- "$tmp_cache"
+}
+trap cleanup EXIT
+
+mkdir -p "$helper_cache"
+vmux_target_lock_acquire "$helper_cache" "$root" 9
+
+input_paths=(
+    "$root/Cargo.lock"
+    "$root/Cargo.toml"
+    "$root/scripts/cargo-with-cef-cache.sh"
+    "$root/scripts/install-debug-render-process.sh"
+)
+if [[ -f "$root/rust-toolchain.toml" ]]; then
+    input_paths+=("$root/rust-toolchain.toml")
+fi
+for directory in \
+    "$root/patches/bevy_cef_core-0.5.2" \
+    "$root/patches/bevy_cef_debug_render_process-0.5.2" \
+    "$root/patches/bevy_remote-0.19.0" \
+    "$root/patches/bevy_window-0.19.0"
+do
+    while IFS= read -r path; do
+        input_paths+=("$path")
+    done < <(
+        find "$directory" -path "$directory/target" -prune -o -type f -print \
+            | LC_ALL=C sort
+    )
+done
+
+fingerprint="$({
+    printf 'cargo=%s\n' "$("$cargo_bin" -V)"
+    printf 'rustc=%s\n' "$("$rustc_bin" -vV)"
+    printf 'rustc-wrapper=%s\n' "${RUSTC_WRAPPER:-}"
+    printf 'rustflags=%s\n' "${RUSTFLAGS:-}"
+    printf 'cargo-encoded-rustflags=%s\n' "${CARGO_ENCODED_RUSTFLAGS:-}"
+    printf 'cargo-build-target=%s\n' "${CARGO_BUILD_TARGET:-}"
+    printf 'macosx-deployment-target=%s\n' "${MACOSX_DEPLOYMENT_TARGET:-}"
+    printf 'vmux-cef-sdk-cache=%s\n' "${VMUX_CEF_SDK_CACHE:-}"
+    env | LC_ALL=C sort | sed -n '/^CARGO_PROFILE_DEV_/p'
+    for path in "${input_paths[@]}"; do
+        printf 'file=%s\n' "${path#"$root/"}"
+    done
+    git -C "$root" hash-object "${input_paths[@]}"
+} | git -C "$root" hash-object --stdin)"
+
+if [[ -x "$installed_helper" && -f "$stamp" && "$(<"$stamp")" == "$fingerprint" ]]; then
+    echo "CEF debug render process up to date"
+    exit 0
+fi
+
+cache_entry="$helper_cache/$fingerprint"
+cached_helper="$cache_entry/$helper_name"
+
+install_helper() {
+    local source="$1"
+    tmp_install="$(mktemp "$installed_dir/.vmux-$helper_name.XXXXXX")"
+    cp "$source" "$tmp_install"
+    chmod 755 "$tmp_install"
+    mv -f "$tmp_install" "$installed_helper"
+    tmp_install=""
+    tmp_stamp="$(mktemp "$installed_dir/.vmux-$helper_name-stamp.XXXXXX")"
+    printf '%s\n' "$fingerprint" > "$tmp_stamp"
+    mv -f "$tmp_stamp" "$stamp"
+    tmp_stamp=""
+}
+
+if [[ -x "$cached_helper" ]]; then
+    install_helper "$cached_helper"
+    echo "Installed cached CEF debug render process"
+    exit 0
+fi
+
+cd "$root"
+CARGO_BIN="$cargo_bin" "$root/scripts/cargo-with-cef-cache.sh" \
+    build -p bevy_cef_debug_render_process --features debug
+
+if [[ "$target_setting" == /* ]]; then
+    target_dir="$target_setting"
+else
+    target_dir="$root/$target_setting"
+fi
+if [[ -n "${CARGO_BUILD_TARGET:-}" ]]; then
+    target_dir="$target_dir/$CARGO_BUILD_TARGET"
+fi
+built_helper="$target_dir/debug/$helper_name"
+if [[ ! -x "$built_helper" ]]; then
+    echo "CEF debug render process build output not found: $built_helper" >&2
+    exit 1
+fi
+
+mkdir -p "$cache_entry"
+tmp_cache="$(mktemp "$cache_entry/.$helper_name.XXXXXX")"
+cp "$built_helper" "$tmp_cache"
+chmod 755 "$tmp_cache"
+mv -f "$tmp_cache" "$cached_helper"
+tmp_cache=""
+install_helper "$cached_helper"
+echo "Built and cached CEF debug render process"

--- a/scripts/install-dioxus-cli.sh
+++ b/scripts/install-dioxus-cli.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${DIOXUS_CLI_VERSION:-0.7.4}"
+INSTALL_DIR="${DIOXUS_CLI_INSTALL_DIR:-$HOME/.local/bin}"
+
+if command -v dx >/dev/null 2>&1; then
+    VERSION_OUTPUT="$(dx --version 2>&1 || true)"
+    if [[ "$VERSION_OUTPUT" == "dioxus $VERSION"* ]]; then
+        exit 0
+    fi
+fi
+
+case "$(uname -s)-$(uname -m)" in
+    Linux-x86_64)
+        ASSET="dx-x86_64-unknown-linux-gnu.tar.gz"
+        ;;
+    Linux-aarch64 | Linux-arm64)
+        ASSET="dx-aarch64-unknown-linux-gnu.tar.gz"
+        ;;
+    Darwin-x86_64)
+        ASSET="dx-x86_64-apple-darwin.tar.gz"
+        ;;
+    Darwin-arm64)
+        ASSET="dx-aarch64-apple-darwin.tar.gz"
+        ;;
+    *)
+        echo "unsupported platform for dioxus-cli: $(uname -s)-$(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+TMP_DIR="$(mktemp -d -t dioxus-cli.XXXXXX)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+BASE_URL="https://github.com/DioxusLabs/dioxus/releases/download/v${VERSION}"
+curl --retry 5 --retry-delay 2 --retry-max-time 120 -fsSL -o "$TMP_DIR/$ASSET" "$BASE_URL/$ASSET"
+curl --retry 5 --retry-delay 2 --retry-max-time 120 -fsSL -o "$TMP_DIR/checksums.sha256" "$BASE_URL/${ASSET%.tar.gz}.sha256"
+
+if command -v sha256sum >/dev/null 2>&1; then
+    CHECKSUM=(sha256sum -c -)
+elif command -v shasum >/dev/null 2>&1; then
+    CHECKSUM=(shasum -a 256 -c -)
+else
+    echo "sha256sum or shasum is required" >&2
+    exit 1
+fi
+
+(
+    cd "$TMP_DIR"
+    grep "  $ASSET$" checksums.sha256 | "${CHECKSUM[@]}"
+)
+
+tar -xzf "$TMP_DIR/$ASSET" -C "$TMP_DIR"
+mkdir -p "$INSTALL_DIR"
+install -m 0755 "$TMP_DIR/dx" "$INSTALL_DIR/dx"
+
+if command -v xattr >/dev/null 2>&1; then
+    xattr -d com.apple.quarantine "$INSTALL_DIR/dx" >/dev/null 2>&1 || true
+fi
+
+"$INSTALL_DIR/dx" --version

--- a/scripts/relocate-cef-target.sh
+++ b/scripts/relocate-cef-target.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" != "3" ]]; then
+    echo "usage: $0 <staging-target> <source-target> <destination-target>" >&2
+    exit 1
+fi
+
+staging_target="$1"
+source_target="$2"
+destination_target="$3"
+source_targets=("$source_target")
+cef_build_directories=()
+cef_fingerprint_directories=()
+shopt -s nullglob
+
+if [[ "$source_target" == "$destination_target" ]]; then
+    exit 0
+fi
+
+append_source_target() {
+    local candidate="$1"
+    local existing
+    if [[ -z "$candidate" || "$candidate" == "$destination_target" ]]; then
+        return
+    fi
+    for existing in "${source_targets[@]}"; do
+        if [[ "$existing" == "$candidate" ]]; then
+            return
+        fi
+    done
+    source_targets+=("$candidate")
+}
+
+for directory in \
+    "$staging_target"/*/build/cef-dll-sys-* \
+    "$staging_target"/*/*/build/cef-dll-sys-*
+do
+    [[ ! -d "$directory" ]] || cef_build_directories+=("$directory")
+done
+
+for directory in \
+    "$staging_target"/*/.fingerprint/cef-dll-sys-* \
+    "$staging_target"/*/*/.fingerprint/cef-dll-sys-*
+do
+    [[ ! -d "$directory" ]] || cef_fingerprint_directories+=("$directory")
+done
+
+for directory in "${cef_build_directories[@]}"; do
+    cache="$directory/out/build/CMakeCache.txt"
+    if [[ ! -f "$cache" ]]; then
+        continue
+    fi
+    cache_directory="$(sed -n 's/^CMAKE_CACHEFILE_DIR:INTERNAL=//p' "$cache" | tail -1)"
+    relative_cache="${cache#"$staging_target/"}"
+    relative_build_directory="${relative_cache%/CMakeCache.txt}"
+    suffix="/$relative_build_directory"
+    if [[ -n "$cache_directory" && "$cache_directory" == *"$suffix" ]]; then
+        append_source_target "${cache_directory%"$suffix"}"
+    fi
+done
+
+rewrite_file() {
+    local path="$1"
+    local candidate
+    for candidate in "${source_targets[@]}"; do
+        if LC_ALL=C grep -Fq "$candidate" "$path"; then
+            SOURCE_TARGET="$candidate" DESTINATION_TARGET="$destination_target" \
+                perl -0pi -e 's/\Q$ENV{SOURCE_TARGET}\E/$ENV{DESTINATION_TARGET}/g' "$path"
+        fi
+    done
+}
+
+for directory in "${cef_fingerprint_directories[@]}"; do
+    while IFS= read -r -d '' path; do
+        rewrite_file "$path"
+    done < <(find "$directory" -type f -name '*.json' -print0)
+done
+
+for directory in "${cef_build_directories[@]}"; do
+    while IFS= read -r -d '' path; do
+        rewrite_file "$path"
+    done < <(
+        find "$directory" -maxdepth 1 -type f \
+            \( -name '*.d' -o -name 'output' -o -name 'root-output' -o -name 'stderr' \) \
+            -print0
+        if [[ -d "$directory/out/build" ]]; then
+            find "$directory/out/build" -type f \
+            \( -name '*.cmake' -o -name '*.d' -o -name '*.json' -o -name '*.ninja' \
+                -o -name '*.txt' -o -name '*.yaml' \) -print0
+        fi
+    )
+done
+
+for path in \
+    "$staging_target"/*/deps/cef_dll_sys-*.d \
+    "$staging_target"/*/deps/libcef_dll_sys-*.d \
+    "$staging_target"/*/*/deps/cef_dll_sys-*.d \
+    "$staging_target"/*/*/deps/libcef_dll_sys-*.d
+do
+    [[ ! -f "$path" ]] || rewrite_file "$path"
+done

--- a/scripts/seed-worktree-target.sh
+++ b/scripts/seed-worktree-target.sh
@@ -140,8 +140,8 @@ esac
 
 vmux_target_lock_release 9
 
-find "$staging_target" -type d \( -name incremental -o -path '*/build/cef-dll-sys-*' -o -path '*/.fingerprint/cef-dll-sys-*' \) -prune -exec rm -rf -- {} \;
-find "$staging_target" -type f \( -name 'cef_dll_sys-*' -o -name 'libcef_dll_sys-*' \) -delete
+find "$staging_target" -type d -name incremental -prune -exec rm -rf -- {} \;
+"$root/scripts/relocate-cef-target.sh" "$staging_target" "$source_target" "$destination_target"
 
 mv -n "$staging_target" "$destination_target"
 if [[ -e "$staging_target" ]]; then


### PR DESCRIPTION
## Context

Normal development runs repeatedly check or rebuild the CEF render-process helper, while new worktrees discard reusable CEF CMake artifacts. This adds avoidable latency and can trigger stale absolute-path failures.

## Implementation

Caches the debug render-process helper by source, toolchain, and build configuration, with atomic installation and shared locking. Worktree target seeding now relocates CMake and Cargo metadata paths, including nested seed origins, so compiled CEF wrapper artifacts remain reusable.

## Checks / QA

- Run `make` twice and confirm the second run reports the CEF debug render process as up to date.
- Create a new worktree, seed its target, and verify CEF builds without a stale `CMakeCache.txt` path error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build & Installation**
  - Improved installation of the debug rendering helper for CEF-based builds.
  - Added fingerprint-based caching to avoid unnecessary rebuilds when the toolchain and project inputs are unchanged.
  - Added shared cache support to speed up repeated installations.

- **Reliability**
  - Improved handling of build artifacts when workspaces or target directories move.
  - Ensured only CEF-related build state is relocated, preserving unrelated build outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->