### PR TITLE
chore(ci): update actions for Node.js 24

### DIFF
--- a/.github/workflows/api-docs-freshness.yml
+++ b/.github/workflows/api-docs-freshness.yml
@@ -31,7 +31,7 @@ jobs:
     outputs:
       version: ${{ steps.resolve.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Resolve cef crate version from Cargo.lock
@@ -52,7 +52,7 @@ jobs:
     env:
       CEF_VERSION: ${{ needs.cef-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -97,7 +97,7 @@ jobs:
           shared-key: api-docs
 
       - name: Cache CEF framework
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/Chromium Embedded Framework.framework
           key: cef-${{ runner.os }}-${{ env.CEF_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       version: ${{ steps.resolve.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Resolve cef crate version from Cargo.lock
         id: resolve
@@ -49,7 +49,7 @@ jobs:
     env:
       CEF_VERSION: ${{ needs.cef-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Free disk space
         run: |
@@ -88,19 +88,19 @@ jobs:
           shared-key: lint
 
       - name: Cache cargo binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/bin
           key: cargo-bin-${{ runner.os }}-dx${{ env.DIOXUS_CLI_VERSION }}-cef${{ env.CEF_VERSION }}-v3
 
       - name: Cache CEF framework
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/Chromium Embedded Framework.framework
           key: cef-${{ runner.os }}-${{ env.CEF_VERSION }}
 
       - name: Cache tailwindcss
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/bin/tailwindcss
           key: tailwindcss-${{ runner.os }}-${{ env.TAILWINDCSS_VERSION }}
@@ -145,7 +145,7 @@ jobs:
     env:
       CEF_VERSION: ${{ needs.cef-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Free disk space
         run: |
@@ -183,19 +183,19 @@ jobs:
           shared-key: test
 
       - name: Cache cargo binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/bin
           key: cargo-bin-${{ runner.os }}-dx${{ env.DIOXUS_CLI_VERSION }}-cef${{ env.CEF_VERSION }}-v3
 
       - name: Cache CEF framework
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/Chromium Embedded Framework.framework
           key: cef-${{ runner.os }}-${{ env.CEF_VERSION }}
 
       - name: Cache tailwindcss
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/bin/tailwindcss
           key: tailwindcss-${{ runner.os }}-${{ env.TAILWINDCSS_VERSION }}
@@ -229,8 +229,8 @@ jobs:
       packaging: ${{ steps.filter.outputs.packaging }}
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -327,7 +327,7 @@ jobs:
     if: needs.changes.outputs.website == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@1.95.0
         with:
@@ -339,7 +339,7 @@ jobs:
           shared-key: website
 
       - name: Cache binaryen
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .dx/tools/binaryen-${{ env.BINARYEN_VERSION }}
           key: binaryen-${{ runner.os }}-${{ runner.arch }}-${{ env.BINARYEN_VERSION }}
@@ -364,7 +364,7 @@ jobs:
     env:
       CEF_VERSION: ${{ needs.cef-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -415,25 +415,25 @@ jobs:
           shared-key: build-mac
 
       - name: Cache cargo binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/bin
           key: cargo-bin-${{ runner.os }}-dx${{ env.DIOXUS_CLI_VERSION }}-cp0.11.9-cef${{ env.CEF_VERSION }}-v3
 
       - name: Cache binaryen
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .dx/tools/binaryen-${{ env.BINARYEN_VERSION }}
           key: binaryen-${{ runner.os }}-${{ runner.arch }}-${{ env.BINARYEN_VERSION }}
 
       - name: Cache CEF framework
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/Chromium Embedded Framework.framework
           key: cef-${{ runner.os }}-${{ env.CEF_VERSION }}
 
       - name: Cache tailwindcss
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/bin/tailwindcss
           key: tailwindcss-${{ runner.os }}-${{ env.TAILWINDCSS_VERSION }}
@@ -528,7 +528,7 @@ jobs:
 
       - name: Upload .dmg artifact
         if: env.PREP_DONE != '1' && env.IS_RELEASE_PR != '1'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Vmux-${{ github.sha }}.dmg
           path: target/release/Vmux_*.dmg

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -34,7 +34,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.95.0
@@ -47,13 +47,13 @@ jobs:
           shared-key: deploy-website
 
       - name: Cache tailwindcss
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/bin/tailwindcss
           key: tailwindcss-${{ runner.os }}-${{ env.TAILWINDCSS_VERSION }}
 
       - name: Cache binaryen
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .dx/tools/binaryen-${{ env.BINARYEN_VERSION }}
           key: binaryen-${{ runner.os }}-${{ runner.arch }}-${{ env.BINARYEN_VERSION }}
@@ -95,10 +95,10 @@ jobs:
         run: install -m 0644 scripts/install.sh website/target/dx/vmux_website/release/web/public/install
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: website/target/dx/vmux_website/release/web/public
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       version: ${{ steps.detect.outputs.version }}
       tag: ${{ steps.detect.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -63,7 +63,7 @@ jobs:
     env:
       TAG: ${{ needs.detect-version.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Verify draft release exists with all assets
         env:


### PR DESCRIPTION
## Context
GitHub Actions reports Node.js 20 deprecation warnings for several workflow actions. Upgrade them before Node.js 20 action support is removed.

## Implementation
Use the first Node.js 24-compatible major for checkout, cache, path filtering, artifact upload, and Pages deployment while preserving existing workflow inputs and behavior.

## Checks / QA
Confirm CI jobs run without Node.js 20 deprecation annotations. Confirm the website deployment uploads and deploys the Pages artifact successfully.