### PR TITLE
perf(macos): accelerate transparent layout overlay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9747,6 +9747,8 @@ dependencies = [
  "objc2-core-media",
  "objc2-core-video",
  "objc2-foundation 0.3.2",
+ "objc2-io-surface",
+ "objc2-metal 0.3.2",
  "objc2-quartz-core 0.3.2",
  "objc2-screen-capture-kit",
  "objc2-user-notifications 0.3.2",

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -992,8 +992,7 @@ fn sync_windowed_content_mesh_materials(
 ///
 /// This drives the material's alpha rather than `Visibility`: the OSR focus pipeline treats a
 /// `Visibility::Hidden` webview as hidden and tells CEF to stop rendering it. Keeping the entity
-/// visible leaves OSR running. Alpha mode stays `Blend` so pages show through the layout's
-/// transparent areas.
+/// visible leaves OSR running. Premultiplied alpha preserves CEF's accelerated transparent pixels.
 fn sync_layout_mesh_visibility(
     layout_q: Query<&WebviewMaterialHandle<WebviewExtendStandardMaterial>, With<LayoutCef>>,
     mut materials: ResMut<Assets<WebviewExtendStandardMaterial>>,
@@ -1003,8 +1002,8 @@ fn sync_layout_mesh_visibility(
         let Some(mut material) = materials.get_mut(mat_handle.id()) else {
             continue;
         };
-        if material.base.alpha_mode != AlphaMode::Blend {
-            material.base.alpha_mode = AlphaMode::Blend;
+        if material.base.alpha_mode != AlphaMode::Premultiplied {
+            material.base.alpha_mode = AlphaMode::Premultiplied;
         }
         if material.base.base_color.alpha() != want_alpha {
             material.base.base_color.set_alpha(want_alpha);
@@ -4254,9 +4253,9 @@ mod tests {
         assert_eq!(
             mat.base.base_color.alpha(),
             1.0,
-            "User mode renders the layout via the mesh (CPU OSR) so it tracks live resize"
+            "User mode renders the layout via the accelerated OSR mesh so it tracks live resize"
         );
-        assert_eq!(mat.base.alpha_mode, AlphaMode::Blend);
+        assert_eq!(mat.base.alpha_mode, AlphaMode::Premultiplied);
     }
 
     #[test]
@@ -4269,8 +4268,8 @@ mod tests {
         );
         assert_eq!(
             mat.base.alpha_mode,
-            AlphaMode::Blend,
-            "Player keeps Blend so pages show through the layout's transparent areas"
+            AlphaMode::Premultiplied,
+            "Player uses premultiplied alpha so pages show through the layout's transparent areas"
         );
     }
 
@@ -4752,7 +4751,7 @@ mod tests {
     }
 
     #[test]
-    fn layout_cef_shell_keeps_blend_material() {
+    fn layout_cef_shell_keeps_premultiplied_material() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .insert_resource(test_app_settings_with_radius(12.0))
@@ -4762,7 +4761,7 @@ mod tests {
             .add_systems(Update, sync_webview_pane_corner_clip);
 
         let mut material = WebviewExtendStandardMaterial::default();
-        material.base.alpha_mode = AlphaMode::Blend;
+        material.base.alpha_mode = AlphaMode::Premultiplied;
         let handle = app
             .world_mut()
             .resource_mut::<Assets<WebviewExtendStandardMaterial>>()
@@ -4783,7 +4782,7 @@ mod tests {
             .expect("webview material");
 
         assert_eq!(material.extension.pane_corner_clip, Vec4::ZERO);
-        assert_eq!(material.base.alpha_mode, AlphaMode::Blend);
+        assert_eq!(material.base.alpha_mode, AlphaMode::Premultiplied);
     }
 
     #[test]

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -22,8 +22,10 @@ use bevy::{
 };
 use bevy_cef::prelude::*;
 use bevy_cef_core::prelude::{
-    CefEmbeddedHosts, CommandLineConfig, RenderTextureMessage, webview_debug_log,
+    CefEmbeddedHosts, CommandLineConfig, NativeMouseButtons, NativeMouseMovePresenter,
+    RenderTextureMessage, webview_debug_log,
 };
+use std::cell::RefCell;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{LazyLock, Mutex};
 use vmux_command::{
@@ -322,10 +324,29 @@ struct CefPointerHitRect {
 struct NativeLayoutPointerState {
     regions: Vec<CefPointerHitRect>,
     pointer_inside: bool,
+    position_px: Option<Vec2>,
 }
 
 static NATIVE_LAYOUT_POINTER_STATE: LazyLock<Mutex<NativeLayoutPointerState>> =
     LazyLock::new(|| Mutex::new(NativeLayoutPointerState::default()));
+
+#[derive(Default)]
+struct NativeLayoutMousePresenterState {
+    scale: f32,
+    presenter: Option<NativeMouseMovePresenter>,
+}
+
+thread_local! {
+    static NATIVE_LAYOUT_MOUSE_PRESENTER: RefCell<NativeLayoutMousePresenterState> =
+        RefCell::new(NativeLayoutMousePresenterState::default());
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct NativeLayoutPointerMoveResult {
+    pub owns_pointer: bool,
+    pub forwarded: bool,
+    pub changed: bool,
+}
 
 fn cef_pointer_hit_rect_contains(rect: CefPointerHitRect, point: Vec2) -> bool {
     if !rect.interactive {
@@ -357,6 +378,28 @@ fn clear_native_layout_pointer_regions() {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     state.regions.clear();
     state.pointer_inside = false;
+    state.position_px = None;
+    NATIVE_LAYOUT_MOUSE_PRESENTER.with_borrow_mut(|state| {
+        state.presenter = None;
+    });
+}
+
+fn set_native_layout_mouse_presenter(scale: f32, presenter: Option<NativeMouseMovePresenter>) {
+    NATIVE_LAYOUT_MOUSE_PRESENTER.with_borrow_mut(|state| {
+        state.scale = scale;
+        let same_browser = state
+            .presenter
+            .as_ref()
+            .map(NativeMouseMovePresenter::browser_id)
+            == presenter.as_ref().map(NativeMouseMovePresenter::browser_id);
+        if !same_browser {
+            state.presenter = presenter;
+        }
+    });
+}
+
+fn native_layout_mouse_presenter_active() -> bool {
+    NATIVE_LAYOUT_MOUSE_PRESENTER.with_borrow(|state| state.presenter.is_some())
 }
 
 fn layout_pointer_move_should_wake(was_inside: bool, inside: bool) -> bool {
@@ -379,6 +422,60 @@ pub fn native_layout_pointer_move_should_wake(x_px: f32, y_px: f32) -> bool {
     let should_wake = layout_pointer_move_should_wake(state.pointer_inside, inside);
     state.pointer_inside = inside;
     should_wake
+}
+
+pub fn forward_native_layout_pointer_move(
+    x_px: f32,
+    y_px: f32,
+    buttons: NativeMouseButtons,
+) -> NativeLayoutPointerMoveResult {
+    if !x_px.is_finite() || !y_px.is_finite() {
+        return NativeLayoutPointerMoveResult::default();
+    }
+    let (was_inside, inside) = {
+        let mut state = NATIVE_LAYOUT_POINTER_STATE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let inside = state
+            .regions
+            .iter()
+            .copied()
+            .any(|rect| cef_pointer_hit_rect_contains(rect, Vec2::new(x_px, y_px)));
+        let was_inside = state.pointer_inside;
+        state.pointer_inside = inside;
+        state.position_px = Some(Vec2::new(x_px, y_px));
+        (was_inside, inside)
+    };
+    let owns_pointer = was_inside || inside;
+    let forwarded = NATIVE_LAYOUT_MOUSE_PRESENTER.with_borrow(|state| {
+        let Some(presenter) = state.presenter.as_ref() else {
+            return false;
+        };
+        if !owns_pointer || !state.scale.is_finite() || state.scale <= 0.0 {
+            return false;
+        }
+        presenter.send(Vec2::new(x_px, y_px) / state.scale, buttons, !inside);
+        true
+    });
+    NativeLayoutPointerMoveResult {
+        owns_pointer,
+        forwarded,
+        changed: was_inside != inside,
+    }
+}
+
+pub fn native_layout_pointer_is_inside() -> bool {
+    NATIVE_LAYOUT_POINTER_STATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .pointer_inside
+}
+
+pub fn native_layout_pointer_position_px() -> Option<Vec2> {
+    NATIVE_LAYOUT_POINTER_STATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .position_px
 }
 
 fn cef_pointer_hit_rect(
@@ -429,6 +526,12 @@ fn sync_layout_cef_pointer_target(
     let Ok((layout, has_target)) = layout_q.single() else {
         return;
     };
+    #[cfg(target_os = "macos")]
+    let should_target = {
+        let _ = (&windows, &cef_regions);
+        modal_pointer_targets.is_empty() && native_layout_pointer_is_inside()
+    };
+    #[cfg(not(target_os = "macos"))]
     let should_target = modal_pointer_targets.is_empty()
         && windows
             .single()
@@ -442,6 +545,12 @@ fn sync_layout_cef_pointer_target(
     }
 }
 
+#[cfg(target_os = "macos")]
+fn forward_layout_cef_cursor_move(mut events: MessageReader<CursorMoved>) {
+    for _ in events.read() {}
+}
+
+#[cfg(not(target_os = "macos"))]
 fn forward_layout_cef_cursor_move(
     mut events: MessageReader<CursorMoved>,
     buttons: Res<ButtonInput<MouseButton>>,
@@ -500,7 +609,13 @@ fn forward_layout_cef_mouse_button(
         let Ok(window) = windows.get(event.window) else {
             continue;
         };
-        let Some(position) = window.cursor_position() else {
+        #[cfg(target_os = "macos")]
+        let position = native_layout_pointer_position_px()
+            .map(|position| position / window.resolution.scale_factor())
+            .or_else(|| window.cursor_position());
+        #[cfg(not(target_os = "macos"))]
+        let position = window.cursor_position();
+        let Some(position) = position else {
             continue;
         };
         let inside = cef_pointer_regions_contains(position, &cef_regions);
@@ -994,10 +1109,15 @@ fn sync_windowed_content_mesh_materials(
 /// `Visibility::Hidden` webview as hidden and tells CEF to stop rendering it. Keeping the entity
 /// visible leaves OSR running. Premultiplied alpha preserves CEF's accelerated transparent pixels.
 fn sync_layout_mesh_visibility(
+    mode: Res<vmux_layout::scene::InteractionMode>,
     layout_q: Query<&WebviewMaterialHandle<WebviewExtendStandardMaterial>, With<LayoutCef>>,
     mut materials: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
-    let want_alpha = 1.0;
+    let want_alpha = if *mode == vmux_layout::scene::InteractionMode::User {
+        0.0
+    } else {
+        1.0
+    };
     for mat_handle in &layout_q {
         let Some(mut material) = materials.get_mut(mat_handle.id()) else {
             continue;
@@ -1017,23 +1137,29 @@ fn sync_cef_backend_for_interaction_mode(world: &mut World) {
         .copied()
         .unwrap_or_default();
     let base_windowed = windowed_backend_should_use_windowed(world, mode);
-    let mut query = world.query_filtered::<(Entity, Has<LayoutCef>, Has<WebviewNativeOverlay>), (
-        With<Browser>,
-        With<WebviewSource>,
-    )>();
-    let entities: Vec<(Entity, bool, bool)> = query.iter(world).collect();
+    let mut query = world.query_filtered::<(
+        Entity,
+        Has<LayoutCef>,
+        Has<WebviewNativeOverlay>,
+        Has<WebviewNativeDirectOverlay>,
+    ), (With<Browser>, With<WebviewSource>)>();
+    let entities: Vec<(Entity, bool, bool, bool)> = query.iter(world).collect();
     let target_windowed = |_entity: Entity, is_layout: bool| base_windowed && !is_layout;
-    let target_native_overlay = |_is_layout: bool| false;
+    let target_native_overlay = |is_layout: bool| {
+        cfg!(target_os = "macos") && mode == vmux_layout::scene::InteractionMode::User && is_layout
+    };
     let mut recreate = Vec::new();
     {
         let browsers = world.non_send::<Browsers>();
-        for &(entity, is_layout, actual_native_overlay) in &entities {
+        for &(entity, is_layout, actual_native_overlay, actual_direct_overlay) in &entities {
             let has_browser = browsers.has_browser(entity);
             let actual_windowed = browsers.is_windowed(&entity);
             let want_windowed = target_windowed(entity, is_layout);
             let want_native_overlay = target_native_overlay(is_layout);
             let needs_recreate = actual_windowed.is_some_and(|actual| actual != want_windowed)
-                || has_browser && actual_native_overlay != want_native_overlay;
+                || has_browser
+                    && (actual_native_overlay != want_native_overlay
+                        || actual_direct_overlay != want_native_overlay);
             if needs_recreate {
                 recreate.push(entity);
             }
@@ -1045,14 +1171,16 @@ fn sync_cef_backend_for_interaction_mode(world: &mut World) {
             browsers.close(entity);
         }
     }
-    for (entity, is_layout, _) in entities {
+    for (entity, is_layout, _, _) in entities {
         let want_windowed = target_windowed(entity, is_layout);
         let want_native_overlay = target_native_overlay(is_layout);
         let marker_matches = world.get::<WebviewWindowed>(entity).is_some() == want_windowed;
         let overlay_matches =
             world.get::<WebviewNativeOverlay>(entity).is_some() == want_native_overlay;
+        let direct_overlay_matches =
+            world.get::<WebviewNativeDirectOverlay>(entity).is_some() == want_native_overlay;
         let needs_recreate = recreate.contains(&entity);
-        if marker_matches && overlay_matches && !needs_recreate {
+        if marker_matches && overlay_matches && direct_overlay_matches && !needs_recreate {
             continue;
         }
         let Ok(mut entity_mut) = world.get_entity_mut(entity) else {
@@ -1064,9 +1192,11 @@ fn sync_cef_backend_for_interaction_mode(world: &mut World) {
             entity_mut.remove::<WebviewWindowed>();
         }
         if want_native_overlay {
-            entity_mut.insert(WebviewNativeOverlay);
+            entity_mut.insert((WebviewNativeOverlay, WebviewNativeDirectOverlay));
         } else {
-            entity_mut.remove::<WebviewNativeOverlay>();
+            entity_mut
+                .remove::<WebviewNativeOverlay>()
+                .remove::<WebviewNativeDirectOverlay>();
         }
         if needs_recreate {
             entity_mut
@@ -1607,6 +1737,14 @@ fn refresh_layout_cef_hover(
             .filter(|rect| rect.interactive)
             .map(|rect| physical_cef_pointer_hit_rect(rect, scale)),
     );
+    #[cfg(target_os = "macos")]
+    {
+        set_native_layout_mouse_presenter(scale, browsers.native_mouse_move_presenter(&layout));
+        if native_layout_mouse_presenter_active() {
+            *state = LayoutHoverRefreshState::default();
+            return;
+        }
+    }
     let Some(cursor_px) = vmux_layout::pane::pane_hover_cursor_position(window_entity, window)
     else {
         reset_layout_cef_hover(&browsers, &buttons, layout, &mut state);
@@ -4248,12 +4386,12 @@ mod tests {
     }
 
     #[test]
-    fn user_mode_makes_layout_mesh_visible() {
-        let mat = layout_material_after_mode(vmux_layout::scene::InteractionMode::User, 0.0);
+    fn user_mode_hides_layout_mesh_behind_native_overlay() {
+        let mat = layout_material_after_mode(vmux_layout::scene::InteractionMode::User, 1.0);
         assert_eq!(
             mat.base.base_color.alpha(),
-            1.0,
-            "User mode renders the layout via the accelerated OSR mesh so it tracks live resize"
+            0.0,
+            "User mode presents layout chrome through the native accelerated overlay"
         );
         assert_eq!(mat.base.alpha_mode, AlphaMode::Premultiplied);
     }
@@ -5086,7 +5224,21 @@ mod tests {
         sync_cef_backend_for_interaction_mode(app.world_mut());
 
         assert!(app.world().get::<WebviewWindowed>(layout).is_none());
-        assert!(app.world().get::<WebviewNativeOverlay>(layout).is_none());
+        assert_eq!(
+            app.world().get::<WebviewNativeOverlay>(layout).is_some(),
+            cfg!(target_os = "macos")
+        );
+        assert_eq!(
+            app.world()
+                .get::<WebviewNativeDirectOverlay>(layout)
+                .is_some(),
+            cfg!(target_os = "macos")
+        );
+        assert!(
+            app.world()
+                .get::<WebviewNativeDirectOverlay>(modal)
+                .is_none()
+        );
         assert_eq!(
             app.world().get::<WebviewWindowed>(terminal).is_some(),
             cfg!(target_os = "macos")
@@ -5135,6 +5287,16 @@ mod tests {
         sync_cef_backend_for_interaction_mode(app.world_mut());
 
         assert!(app.world().get::<WebviewWindowed>(layout).is_none());
+        assert_eq!(
+            app.world().get::<WebviewNativeOverlay>(layout).is_some(),
+            cfg!(target_os = "macos")
+        );
+        assert_eq!(
+            app.world()
+                .get::<WebviewNativeDirectOverlay>(layout)
+                .is_some(),
+            cfg!(target_os = "macos")
+        );
         assert_eq!(
             app.world().get::<WebviewWindowed>(modal).is_some(),
             cfg!(target_os = "macos")
@@ -5442,8 +5604,44 @@ mod tests {
         assert!(refresh_fn.contains("cef_pointer_regions_contains"));
         assert!(refresh_fn.contains("window.resolution.scale_factor()"));
         assert!(refresh_fn.contains("set_native_layout_pointer_regions"));
+        assert!(refresh_fn.contains("browsers.native_mouse_move_presenter"));
+        assert!(refresh_fn.contains("native_layout_mouse_presenter_active"));
         assert!(refresh_fn.contains("browsers.send_mouse_move"));
         assert!(refresh_fn.matches("reset_layout_cef_hover").count() >= 5);
+    }
+
+    #[test]
+    fn macos_layout_mouse_move_has_one_forwarding_path() {
+        let source = include_str!("lib.rs");
+        let raw_forward = source
+            .split("#[cfg(target_os = \"macos\")]\nfn forward_layout_cef_cursor_move")
+            .nth(1)
+            .and_then(|tail| tail.split("#[cfg(not(target_os = \"macos\"))]").next())
+            .unwrap_or_default();
+
+        assert!(!raw_forward.contains("browsers.send_mouse_move"));
+        assert!(raw_forward.contains("events.read()"));
+    }
+
+    #[test]
+    fn macos_layout_click_uses_native_pointer_position() {
+        let source = include_str!("lib.rs");
+        let click_forward = source
+            .split("fn forward_layout_cef_mouse_button")
+            .nth(1)
+            .and_then(|tail| {
+                tail.split("fn dismiss_windowed_command_bar_on_outside_click")
+                    .next()
+            })
+            .unwrap_or_default();
+        let target_sync = source
+            .split("fn sync_layout_cef_pointer_target")
+            .nth(1)
+            .and_then(|tail| tail.split("fn forward_layout_cef_cursor_move").next())
+            .unwrap_or_default();
+
+        assert!(click_forward.contains("native_layout_pointer_position_px"));
+        assert!(target_sync.contains("native_layout_pointer_is_inside"));
     }
 
     #[test]

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -384,6 +384,7 @@ fn clear_native_layout_pointer_regions() {
     });
 }
 
+#[cfg(target_os = "macos")]
 fn set_native_layout_mouse_presenter(scale: f32, presenter: Option<NativeMouseMovePresenter>) {
     NATIVE_LAYOUT_MOUSE_PRESENTER.with_borrow_mut(|state| {
         state.scale = scale;
@@ -398,6 +399,7 @@ fn set_native_layout_mouse_presenter(scale: f32, presenter: Option<NativeMouseMo
     });
 }
 
+#[cfg(target_os = "macos")]
 fn native_layout_mouse_presenter_active() -> bool {
     NATIVE_LAYOUT_MOUSE_PRESENTER.with_borrow(|state| state.presenter.is_some())
 }

--- a/crates/vmux_desktop/Cargo.toml
+++ b/crates/vmux_desktop/Cargo.toml
@@ -109,9 +109,14 @@ objc2-core-graphics = { version = "0.3", features = [
 ] }
 objc2-core-foundation = { version = "0.3", features = [
     "CFBase",
+    "CFDictionary",
     "CFRunLoop",
     "CFMachPort",
+    "CFNumber",
+    "CFString",
 ] }
+objc2-io-surface = "0.3"
+objc2-metal = { version = "0.3", features = ["objc2-io-surface"] }
 objc2-screen-capture-kit = { version = "0.3", features = [
     "SCStream",
     "SCShareableContent",

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -275,7 +275,10 @@ fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) 
         }
         if matches!(
             event_type,
-            NSEventType::MouseMoved | NSEventType::LeftMouseDown
+            NSEventType::MouseMoved
+                | NSEventType::LeftMouseDragged
+                | NSEventType::RightMouseDragged
+                | NSEventType::OtherMouseDragged
         ) {
             let location = event_location_in_window_physical_px(ev);
             if let Some((x, y)) = location
@@ -285,17 +288,31 @@ fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) 
             }
             let should_wake = location
                 .map(|(x, y)| {
+                    let result = vmux_browser::forward_native_layout_pointer_move(
+                        x,
+                        y,
+                        native_mouse_buttons(),
+                    );
                     let layout_should_wake =
-                        vmux_browser::native_layout_pointer_move_should_wake(x, y);
+                        result.owns_pointer && (!result.forwarded || result.changed);
                     let pane_should_wake =
-                        !layout_should_wake && vmux_layout::pane::wake_on_move(x, y);
+                        !result.owns_pointer && vmux_layout::pane::wake_on_move(x, y);
                     native_mouse_move_should_wake(layout_should_wake, pane_should_wake)
                 })
                 .unwrap_or(false);
             if should_wake {
-                local_wake(NATIVE_MOUSE_MOVE_WAKE_INTERVAL);
+                let interval = if event_type == NSEventType::MouseMoved {
+                    NATIVE_MOUSE_MOVE_WAKE_INTERVAL
+                } else {
+                    NATIVE_MOUSE_DRAG_WAKE_INTERVAL
+                };
+                local_wake(interval);
             }
         } else {
+            if let Some((x, y)) = event_location_in_window_physical_px(ev) {
+                let _ =
+                    vmux_browser::forward_native_layout_pointer_move(x, y, native_mouse_buttons());
+            }
             local_wake(NATIVE_MOUSE_DRAG_WAKE_INTERVAL);
         }
         event.as_ptr()
@@ -310,7 +327,7 @@ fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) 
         }
         global_wake(NATIVE_MOUSE_MOVE_WAKE_INTERVAL);
     });
-    let mask = NSEventMask::MouseMoved
+    let mouse_mask = NSEventMask::MouseMoved
         | NSEventMask::LeftMouseDown
         | NSEventMask::LeftMouseUp
         | NSEventMask::LeftMouseDragged
@@ -320,9 +337,17 @@ fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) 
         | NSEventMask::OtherMouseDown
         | NSEventMask::OtherMouseUp
         | NSEventMask::OtherMouseDragged;
+    let local_mask = mouse_mask | NSEventMask::ScrollWheel;
+    let global_mask = NSEventMask::LeftMouseDown
+        | NSEventMask::LeftMouseUp
+        | NSEventMask::RightMouseDown
+        | NSEventMask::RightMouseUp
+        | NSEventMask::OtherMouseDown
+        | NSEventMask::OtherMouseUp;
     let local_token =
-        unsafe { NSEvent::addLocalMonitorForEventsMatchingMask_handler(mask, &local_block) };
-    let global_token = NSEvent::addGlobalMonitorForEventsMatchingMask_handler(mask, &global_block);
+        unsafe { NSEvent::addLocalMonitorForEventsMatchingMask_handler(local_mask, &local_block) };
+    let global_token =
+        NSEvent::addGlobalMonitorForEventsMatchingMask_handler(global_mask, &global_block);
     if local_token.is_some() || global_token.is_some() {
         NATIVE_MOUSE_WAKE_MONITOR_INSTALLED.store(true, Ordering::Relaxed);
         if let Some(token) = local_token {
@@ -405,15 +430,27 @@ fn event_location_in_window_physical_px(event: &objc2_app_kit::NSEvent) -> Optio
     }
 }
 
+#[cfg(target_os = "macos")]
+fn native_mouse_buttons() -> bevy_cef_core::prelude::NativeMouseButtons {
+    let pressed = objc2_app_kit::NSEvent::pressedMouseButtons();
+    bevy_cef_core::prelude::NativeMouseButtons {
+        left: pressed & 1 != 0,
+        right: pressed & (1 << 1) != 0,
+        middle: pressed & (1 << 2) != 0,
+    }
+}
+
 /// `react_to_device_events` is off in browse (User) mode: native CEF views own scroll/input, so only
 /// Player mode's free camera consumes `AccumulatedMouseMotion`.
 ///
-/// At rest `react_to_window_events` is on so the layout mesh + camera respond to window events
-/// (sizing, focus). During a live resize it flips off and `wait` drops to ~16ms: the loop is paced by
-/// the timer at ~60Hz instead of rendering on every 120Hz `Resized`, capping the resize CPU spike.
-/// `Resized` still updates the `Window` on delivery, so the timer reads the latest size each tick and
-/// the layout tracks the drag. `live_resize` is driven by [`install_live_resize_monitor`].
-pub(crate) fn foreground_winit_settings(player: bool, live_resize: bool) -> WinitSettings {
+/// At rest window events wake rendering except while native layout chrome owns the pointer. Layout
+/// hover and scroll then use the explicit 30Hz native monitor wake instead of rendering once per
+/// raw macOS pointer event. During live resize the 16ms timer caps rendering near 60Hz.
+pub(crate) fn foreground_winit_settings(
+    player: bool,
+    live_resize: bool,
+    layout_pointer_inside: bool,
+) -> WinitSettings {
     let focused_mode = if live_resize {
         UpdateMode::Reactive {
             wait: Duration::from_millis(16),
@@ -426,7 +463,7 @@ pub(crate) fn foreground_winit_settings(player: bool, live_resize: bool) -> Wini
             wait: FOCUSED_FRAME_INTERVAL,
             react_to_device_events: player,
             react_to_user_events: true,
-            react_to_window_events: true,
+            react_to_window_events: player || !layout_pointer_inside,
         }
     };
     WinitSettings {
@@ -456,10 +493,18 @@ fn sync_winit_power_mode(
     let live_resize = IN_LIVE_RESIZE.load(Ordering::Relaxed);
     #[cfg(not(target_os = "macos"))]
     let live_resize = false;
+    #[cfg(target_os = "macos")]
+    let layout_pointer_inside = vmux_browser::native_layout_pointer_is_inside();
+    #[cfg(not(target_os = "macos"))]
+    let layout_pointer_inside = false;
     let next = if all_hidden {
         hidden_winit_settings()
     } else {
-        foreground_winit_settings(*mode == InteractionMode::Player, live_resize)
+        foreground_winit_settings(
+            *mode == InteractionMode::Player,
+            live_resize,
+            layout_pointer_inside,
+        )
     };
     if settings.focused_mode != next.focused_mode || settings.unfocused_mode != next.unfocused_mode
     {
@@ -739,7 +784,7 @@ mod tests {
 
     #[test]
     fn foreground_power_mode_is_reactive_when_focused() {
-        let settings = foreground_winit_settings(false, false);
+        let settings = foreground_winit_settings(false, false, false);
 
         let UpdateMode::Reactive {
             wait,
@@ -770,14 +815,14 @@ mod tests {
             wait: resize_wait,
             react_to_window_events: resize_window,
             ..
-        } = foreground_winit_settings(false, true).focused_mode
+        } = foreground_winit_settings(false, true, false).focused_mode
         else {
             panic!("focused mode must be Reactive");
         };
         assert_eq!(resize_wait, Duration::from_millis(16));
         assert!(!resize_window);
 
-        let player = foreground_winit_settings(true, false);
+        let player = foreground_winit_settings(true, false, false);
         let UpdateMode::Reactive {
             react_to_device_events: player_device,
             react_to_window_events: player_window,
@@ -788,10 +833,20 @@ mod tests {
         };
         assert!(player_device);
         assert!(player_window);
+
+        let layout_hover = foreground_winit_settings(false, false, true);
+        let UpdateMode::Reactive {
+            react_to_window_events: layout_window,
+            ..
+        } = layout_hover.focused_mode
+        else {
+            panic!("focused mode must be Reactive");
+        };
+        assert!(!layout_window);
     }
 
     #[test]
-    fn native_mouse_motion_wakes_reactive_loop() {
+    fn native_mouse_motion_forwards_directly_before_waking() {
         let source = include_str!("background_lifecycle.rs");
         let monitor = source
             .split("fn install_native_mouse_wake_monitor")
@@ -802,8 +857,10 @@ mod tests {
         assert!(monitor.contains("NSEventMask::MouseMoved"));
         assert!(monitor.contains("NSEventMask::LeftMouseDown"));
         assert!(monitor.contains("WinitUserEvent::WakeUp"));
-        assert!(monitor.contains("vmux_browser::native_layout_pointer_move_should_wake"));
+        assert!(monitor.contains("vmux_browser::forward_native_layout_pointer_move"));
+        assert!(monitor.contains("!result.forwarded || result.changed"));
         assert!(monitor.contains("vmux_layout::pane::wake_on_move"));
+        assert!(monitor.contains("let global_mask = NSEventMask::LeftMouseDown"));
     }
 
     #[test]
@@ -840,7 +897,7 @@ mod tests {
     }
 
     #[test]
-    fn native_mouse_scroll_does_not_wake_reactive_loop() {
+    fn native_layout_scroll_wakes_reactive_loop() {
         let source = include_str!("background_lifecycle.rs");
         let monitor = source
             .split("fn install_native_mouse_wake_monitor")
@@ -848,7 +905,7 @@ mod tests {
             .and_then(|tail| tail.split("fn foreground_winit_settings").next())
             .unwrap_or_default();
 
-        assert!(!monitor.contains("NSEventMask::ScrollWheel"));
+        assert!(monitor.contains("NSEventMask::ScrollWheel"));
     }
 
     #[test]

--- a/crates/vmux_desktop/src/glass.rs
+++ b/crates/vmux_desktop/src/glass.rs
@@ -1,6 +1,11 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
 use bevy::prelude::*;
+use bevy_cef_core::prelude::WebviewDirtyRect;
 use vmux_layout::cef::LayoutCef;
 use vmux_layout::scene::InteractionMode;
 
@@ -12,32 +17,35 @@ pub(crate) struct GlassPlugin;
 
 impl Plugin for GlassPlugin {
     fn build(&self, app: &mut App) {
-        app.init_non_send::<GlassState>()
-            .init_non_send::<LayoutOverlay>()
-            .init_non_send::<CommandBarOverlay>()
-            .add_systems(PreUpdate, install_window_glass)
-            .add_systems(
-                Update,
-                (
-                    sync_window_glass_visibility,
-                    keep_window_surface_layer_transparent,
-                ),
+        app.insert_resource(bevy_cef::prelude::NativeOverlayPresenter(Some(
+            native_overlay_presenter(),
+        )))
+        .init_non_send::<GlassState>()
+        .init_non_send::<LayoutOverlay>()
+        .init_non_send::<CommandBarOverlay>()
+        .add_systems(PreUpdate, install_window_glass)
+        .add_systems(
+            Update,
+            (
+                sync_window_glass_visibility,
+                keep_window_surface_layer_transparent,
+            ),
+        )
+        .add_systems(
+            Update,
+            handle_toggle_fullscreen_command.in_set(vmux_command::ReadAppCommands),
+        )
+        .add_systems(
+            Last,
+            (
+                reveal_window_after_layout_ready,
+                restore_fullscreen_after_reveal,
+                ensure_window_active_after_reveal,
+                sync_layout_overlay,
+                sync_command_bar_overlay,
             )
-            .add_systems(
-                Update,
-                handle_toggle_fullscreen_command.in_set(vmux_command::ReadAppCommands),
-            )
-            .add_systems(
-                Last,
-                (
-                    reveal_window_after_layout_ready,
-                    restore_fullscreen_after_reveal,
-                    ensure_window_active_after_reveal,
-                    sync_layout_overlay,
-                    sync_command_bar_overlay,
-                )
-                    .chain(),
-            );
+                .chain(),
+        );
     }
 }
 
@@ -346,6 +354,729 @@ struct CommandBarOverlay {
     held: Option<bevy_cef_core::prelude::AcceleratedFrame>,
 }
 
+#[derive(Clone)]
+struct SendLayer(objc2::rc::Retained<objc2_quartz_core::CALayer>);
+
+unsafe impl Send for SendLayer {}
+unsafe impl Sync for SendLayer {}
+
+#[derive(Clone)]
+struct MetalOverlayContext {
+    device: objc2::rc::Retained<objc2::runtime::ProtocolObject<dyn objc2_metal::MTLDevice>>,
+    queue: objc2::rc::Retained<objc2::runtime::ProtocolObject<dyn objc2_metal::MTLCommandQueue>>,
+}
+
+unsafe impl Send for MetalOverlayContext {}
+unsafe impl Sync for MetalOverlayContext {}
+
+#[derive(Clone)]
+struct MetalOverlaySurface {
+    io_surface: objc2_core_foundation::CFRetained<objc2_io_surface::IOSurfaceRef>,
+    texture: objc2::rc::Retained<objc2::runtime::ProtocolObject<dyn objc2_metal::MTLTexture>>,
+}
+
+unsafe impl Send for MetalOverlaySurface {}
+unsafe impl Sync for MetalOverlaySurface {}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+enum OverlayDamage {
+    #[default]
+    None,
+    Full,
+    Rects(Vec<WebviewDirtyRect>),
+}
+
+impl OverlayDamage {
+    fn from_frame(width: u32, height: u32, dirty: &[WebviewDirtyRect]) -> Self {
+        if dirty.is_empty() {
+            Self::Full
+        } else {
+            overlay_damage_from_rects(width, height, dirty.iter().copied())
+        }
+    }
+
+    fn union(self, other: Self, width: u32, height: u32) -> Self {
+        match (self, other) {
+            (Self::Full, _) | (_, Self::Full) => Self::Full,
+            (Self::None, damage) | (damage, Self::None) => damage,
+            (Self::Rects(mut left), Self::Rects(right)) => {
+                left.extend(right);
+                overlay_damage_from_rects(width, height, left)
+            }
+        }
+    }
+
+    fn into_frame_dirty(self) -> Vec<WebviewDirtyRect> {
+        match self {
+            Self::None | Self::Full => Vec::new(),
+            Self::Rects(rects) => rects,
+        }
+    }
+}
+
+struct MetalOverlaySlot {
+    surface: MetalOverlaySurface,
+    initialized: bool,
+    stale: OverlayDamage,
+}
+
+struct MetalOverlaySwapchain {
+    generation: u64,
+    width: u32,
+    height: u32,
+    format: bevy_cef_core::prelude::AcceleratedPixelFormat,
+    slots: [MetalOverlaySlot; 2],
+    front: Option<usize>,
+}
+
+struct MetalSourceTexture {
+    io_surface: usize,
+    width: u32,
+    height: u32,
+    format: bevy_cef_core::prelude::AcceleratedPixelFormat,
+    texture: objc2::rc::Retained<objc2::runtime::ProtocolObject<dyn objc2_metal::MTLTexture>>,
+    last_used: u64,
+}
+
+unsafe impl Send for MetalSourceTexture {}
+unsafe impl Sync for MetalSourceTexture {}
+
+#[derive(Clone)]
+struct MetalOverlayInFlight {
+    generation: u64,
+    target: usize,
+    damage: OverlayDamage,
+}
+
+#[derive(Default)]
+struct NativeOverlayPresentState {
+    layers: HashMap<Entity, SendLayer>,
+    pending: HashMap<Entity, bevy_cef_core::prelude::AcceleratedFrame>,
+    held: HashMap<Entity, bevy_cef_core::prelude::AcceleratedFrame>,
+    metal: Option<MetalOverlayContext>,
+    swapchains: HashMap<Entity, MetalOverlaySwapchain>,
+    source_textures: HashMap<Entity, Vec<MetalSourceTexture>>,
+    in_flight: HashMap<Entity, MetalOverlayInFlight>,
+    next_generation: u64,
+    source_texture_clock: u64,
+}
+
+static NATIVE_OVERLAY_PRESENT_STATE: LazyLock<Mutex<NativeOverlayPresentState>> =
+    LazyLock::new(|| Mutex::new(NativeOverlayPresentState::default()));
+static NATIVE_OVERLAY_PRESENT_SCHEDULED: AtomicBool = AtomicBool::new(false);
+
+fn overlay_rect_union(left: WebviewDirtyRect, right: WebviewDirtyRect) -> Option<WebviewDirtyRect> {
+    let left_right = left.x.saturating_add(left.width);
+    let left_bottom = left.y.saturating_add(left.height);
+    let right_right = right.x.saturating_add(right.width);
+    let right_bottom = right.y.saturating_add(right.height);
+    if left_right < right.x
+        || right_right < left.x
+        || left_bottom < right.y
+        || right_bottom < left.y
+    {
+        return None;
+    }
+    let x = left.x.min(right.x);
+    let y = left.y.min(right.y);
+    Some(WebviewDirtyRect {
+        x,
+        y,
+        width: left_right.max(right_right).saturating_sub(x),
+        height: left_bottom.max(right_bottom).saturating_sub(y),
+    })
+}
+
+fn overlay_damage_from_rects(
+    width: u32,
+    height: u32,
+    rects: impl IntoIterator<Item = WebviewDirtyRect>,
+) -> OverlayDamage {
+    let mut merged = Vec::<WebviewDirtyRect>::new();
+    for rect in rects {
+        let right = rect.x.saturating_add(rect.width).min(width);
+        let bottom = rect.y.saturating_add(rect.height).min(height);
+        if right <= rect.x || bottom <= rect.y || rect.x >= width || rect.y >= height {
+            continue;
+        }
+        let mut rect = WebviewDirtyRect {
+            x: rect.x,
+            y: rect.y,
+            width: right - rect.x,
+            height: bottom - rect.y,
+        };
+        let mut index = 0;
+        while index < merged.len() {
+            if let Some(union) = overlay_rect_union(merged[index], rect) {
+                rect = union;
+                merged.swap_remove(index);
+                index = 0;
+            } else {
+                index += 1;
+            }
+        }
+        merged.push(rect);
+    }
+    if merged.is_empty() {
+        return OverlayDamage::None;
+    }
+    let area = merged.iter().fold(0_u64, |total, rect| {
+        total.saturating_add(rect.width as u64 * rect.height as u64)
+    });
+    let full_area = width as u64 * height as u64;
+    if merged.len() > 16 || area.saturating_mul(2) >= full_area {
+        OverlayDamage::Full
+    } else {
+        OverlayDamage::Rects(merged)
+    }
+}
+
+fn coalesced_overlay_dirty(
+    width: u32,
+    height: u32,
+    previous: &[WebviewDirtyRect],
+    latest: &[WebviewDirtyRect],
+    same_surface: bool,
+) -> Vec<WebviewDirtyRect> {
+    if !same_surface {
+        return Vec::new();
+    }
+    OverlayDamage::from_frame(width, height, previous)
+        .union(
+            OverlayDamage::from_frame(width, height, latest),
+            width,
+            height,
+        )
+        .into_frame_dirty()
+}
+
+fn native_overlay_blit_regions<'a>(
+    width: u32,
+    height: u32,
+    damage: &'a OverlayDamage,
+    initialized: bool,
+) -> Cow<'a, [WebviewDirtyRect]> {
+    if !initialized || matches!(damage, OverlayDamage::Full) {
+        return Cow::Owned(vec![WebviewDirtyRect {
+            x: 0,
+            y: 0,
+            width,
+            height,
+        }]);
+    }
+    match damage {
+        OverlayDamage::None => Cow::Borrowed(&[]),
+        OverlayDamage::Full => unreachable!(),
+        OverlayDamage::Rects(rects) => Cow::Borrowed(rects),
+    }
+}
+
+fn native_overlay_presenter() -> bevy_cef_core::prelude::AcceleratedFramePresenter {
+    Arc::new(|frame| {
+        let mut state = NATIVE_OVERLAY_PRESENT_STATE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let webview = frame.webview;
+        if let Some(previous) = state.pending.insert(webview, frame)
+            && let Some(latest) = state.pending.get_mut(&webview)
+        {
+            latest.dirty = coalesced_overlay_dirty(
+                latest.width,
+                latest.height,
+                &previous.dirty,
+                &latest.dirty,
+                previous.width == latest.width
+                    && previous.height == latest.height
+                    && previous.format == latest.format,
+            );
+        }
+        let should_schedule = !state.in_flight.contains_key(&webview);
+        drop(state);
+        if should_schedule {
+            schedule_native_overlay_present();
+        }
+    })
+}
+
+fn schedule_native_overlay_present() {
+    if NATIVE_OVERLAY_PRESENT_SCHEDULED.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    dispatch2::DispatchQueue::main().exec_async(drain_native_overlay_present);
+}
+
+fn drain_native_overlay_present() {
+    use objc2::runtime::AnyObject;
+
+    let ready = {
+        let mut state = NATIVE_OVERLAY_PRESENT_STATE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let entities: Vec<_> = state
+            .pending
+            .keys()
+            .copied()
+            .filter(|entity| {
+                state.layers.contains_key(entity) && !state.in_flight.contains_key(entity)
+            })
+            .collect();
+        entities
+            .into_iter()
+            .filter_map(|entity| {
+                Some((
+                    entity,
+                    state.layers.get(&entity)?.clone(),
+                    state.pending.remove(&entity)?,
+                ))
+            })
+            .collect::<Vec<_>>()
+    };
+
+    for (entity, layer, frame) in ready {
+        if present_native_overlay_dirty(entity, &frame) {
+            continue;
+        }
+        let io_surface = frame.io_surface as *mut AnyObject;
+        if io_surface.is_null() {
+            continue;
+        }
+        unsafe { layer.0.setContents(Some(&*io_surface)) };
+        NATIVE_OVERLAY_PRESENT_STATE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .held
+            .insert(entity, frame);
+    }
+
+    NATIVE_OVERLAY_PRESENT_SCHEDULED.store(false, Ordering::Release);
+    let has_ready = {
+        let state = NATIVE_OVERLAY_PRESENT_STATE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.pending.keys().any(|entity| {
+            state.layers.contains_key(entity) && !state.in_flight.contains_key(entity)
+        })
+    };
+    if has_ready {
+        schedule_native_overlay_present();
+    }
+}
+
+fn register_native_overlay_layer(
+    entity: Entity,
+    layer: &objc2::rc::Retained<objc2_quartz_core::CALayer>,
+) {
+    let mut state = NATIVE_OVERLAY_PRESENT_STATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    state
+        .layers
+        .entry(entity)
+        .or_insert_with(|| SendLayer(layer.clone()));
+    let should_schedule = state.pending.contains_key(&entity);
+    drop(state);
+    if should_schedule {
+        schedule_native_overlay_present();
+    }
+}
+
+fn unregister_native_overlay_layer(entity: Entity) {
+    let mut state = NATIVE_OVERLAY_PRESENT_STATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    state.layers.remove(&entity);
+    state.pending.remove(&entity);
+    state.held.remove(&entity);
+    state.swapchains.remove(&entity);
+    state.source_textures.remove(&entity);
+    state.in_flight.remove(&entity);
+}
+
+fn create_metal_overlay_context() -> Option<MetalOverlayContext> {
+    use objc2_metal::MTLDevice;
+
+    let device = objc2_metal::MTLCreateSystemDefaultDevice()?;
+    let queue = device.newCommandQueue()?;
+    Some(MetalOverlayContext { device, queue })
+}
+
+fn overlay_metal_format(
+    format: bevy_cef_core::prelude::AcceleratedPixelFormat,
+) -> (objc2_metal::MTLPixelFormat, i32) {
+    match format {
+        bevy_cef_core::prelude::AcceleratedPixelFormat::Rgba8 => {
+            (objc2_metal::MTLPixelFormat::RGBA8Unorm_sRGB, 0x5247_4241)
+        }
+        bevy_cef_core::prelude::AcceleratedPixelFormat::Bgra8 => {
+            (objc2_metal::MTLPixelFormat::BGRA8Unorm_sRGB, 0x4247_5241)
+        }
+    }
+}
+
+fn overlay_texture_descriptor(
+    width: u32,
+    height: u32,
+    pixel_format: objc2_metal::MTLPixelFormat,
+) -> objc2::rc::Retained<objc2_metal::MTLTextureDescriptor> {
+    let descriptor = unsafe {
+        objc2_metal::MTLTextureDescriptor::texture2DDescriptorWithPixelFormat_width_height_mipmapped(
+            pixel_format,
+            width as usize,
+            height as usize,
+            false,
+        )
+    };
+    descriptor.setStorageMode(objc2_metal::MTLStorageMode::Shared);
+    descriptor
+}
+
+fn create_overlay_io_surface(
+    width: u32,
+    height: u32,
+    pixel_fourcc: i32,
+) -> Option<objc2_core_foundation::CFRetained<objc2_io_surface::IOSurfaceRef>> {
+    use objc2_core_foundation::{CFDictionary, CFNumber, CFType};
+    use objc2_io_surface::{
+        IOSurfaceRef, kIOSurfaceAllocSize, kIOSurfaceBytesPerElement, kIOSurfaceBytesPerRow,
+        kIOSurfaceHeight, kIOSurfacePixelFormat, kIOSurfaceWidth,
+    };
+
+    let bytes_per_row = (width as usize * 4).div_ceil(256) * 256;
+    let width_value = CFNumber::new_i64(width as i64);
+    let height_value = CFNumber::new_i64(height as i64);
+    let bytes_per_row_value = CFNumber::new_i64(bytes_per_row as i64);
+    let bytes_per_element_value = CFNumber::new_i64(4);
+    let alloc_size_value = CFNumber::new_i64((bytes_per_row * height as usize) as i64);
+    let pixel_format_value = CFNumber::new_i32(pixel_fourcc);
+    let keys: [&CFType; 6] = unsafe {
+        [
+            kIOSurfaceWidth.as_ref(),
+            kIOSurfaceHeight.as_ref(),
+            kIOSurfaceBytesPerRow.as_ref(),
+            kIOSurfaceBytesPerElement.as_ref(),
+            kIOSurfaceAllocSize.as_ref(),
+            kIOSurfacePixelFormat.as_ref(),
+        ]
+    };
+    let values: [&CFType; 6] = [
+        width_value.as_ref(),
+        height_value.as_ref(),
+        bytes_per_row_value.as_ref(),
+        bytes_per_element_value.as_ref(),
+        alloc_size_value.as_ref(),
+        pixel_format_value.as_ref(),
+    ];
+    let properties = CFDictionary::<CFType, CFType>::from_slices(&keys, &values);
+    unsafe { IOSurfaceRef::new(properties.as_opaque()) }
+}
+
+fn create_metal_overlay_surface(
+    context: &MetalOverlayContext,
+    width: u32,
+    height: u32,
+    format: bevy_cef_core::prelude::AcceleratedPixelFormat,
+) -> Option<MetalOverlaySurface> {
+    use objc2_metal::MTLDevice;
+
+    let (pixel_format, pixel_fourcc) = overlay_metal_format(format);
+    let io_surface = create_overlay_io_surface(width, height, pixel_fourcc)?;
+    let descriptor = overlay_texture_descriptor(width, height, pixel_format);
+    let texture =
+        context
+            .device
+            .newTextureWithDescriptor_iosurface_plane(&descriptor, &io_surface, 0)?;
+    Some(MetalOverlaySurface {
+        io_surface,
+        texture,
+    })
+}
+
+fn create_metal_overlay_swapchain(
+    context: &MetalOverlayContext,
+    generation: u64,
+    width: u32,
+    height: u32,
+    format: bevy_cef_core::prelude::AcceleratedPixelFormat,
+) -> Option<MetalOverlaySwapchain> {
+    let create_slot = || {
+        Some(MetalOverlaySlot {
+            surface: create_metal_overlay_surface(context, width, height, format)?,
+            initialized: false,
+            stale: OverlayDamage::None,
+        })
+    };
+    Some(MetalOverlaySwapchain {
+        generation,
+        width,
+        height,
+        format,
+        slots: [create_slot()?, create_slot()?],
+        front: None,
+    })
+}
+
+fn cached_source_texture(
+    state: &mut NativeOverlayPresentState,
+    context: &MetalOverlayContext,
+    entity: Entity,
+    frame: &bevy_cef_core::prelude::AcceleratedFrame,
+) -> Option<objc2::rc::Retained<objc2::runtime::ProtocolObject<dyn objc2_metal::MTLTexture>>> {
+    use objc2_metal::MTLDevice;
+
+    state.source_texture_clock = state.source_texture_clock.wrapping_add(1);
+    let last_used = state.source_texture_clock;
+    let cache = state.source_textures.entry(entity).or_default();
+    if let Some(cached) = cache.iter_mut().find(|cached| {
+        cached.io_surface == frame.io_surface
+            && cached.width == frame.width
+            && cached.height == frame.height
+            && cached.format == frame.format
+    }) {
+        cached.last_used = last_used;
+        return Some(cached.texture.clone());
+    }
+    let source_surface = unsafe { &*(frame.io_surface as *const objc2_io_surface::IOSurfaceRef) };
+    let (pixel_format, _) = overlay_metal_format(frame.format);
+    let descriptor = overlay_texture_descriptor(frame.width, frame.height, pixel_format);
+    let texture =
+        context
+            .device
+            .newTextureWithDescriptor_iosurface_plane(&descriptor, source_surface, 0)?;
+    if cache.len() >= 4
+        && let Some((oldest, _)) = cache
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, cached)| cached.last_used)
+    {
+        cache.swap_remove(oldest);
+    }
+    cache.push(MetalSourceTexture {
+        io_surface: frame.io_surface,
+        width: frame.width,
+        height: frame.height,
+        format: frame.format,
+        texture: texture.clone(),
+        last_used,
+    });
+    Some(texture)
+}
+
+fn complete_native_overlay_present(
+    entity: Entity,
+    generation: u64,
+    target: usize,
+    succeeded: bool,
+) {
+    use objc2::runtime::AnyObject;
+
+    let (layer, surface, should_schedule) = {
+        let mut state = NATIVE_OVERLAY_PRESENT_STATE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let Some(in_flight) = state.in_flight.remove(&entity) else {
+            return;
+        };
+        if in_flight.generation != generation || in_flight.target != target {
+            return;
+        }
+        let surface = if succeeded {
+            let Some(swapchain) = state.swapchains.get_mut(&entity) else {
+                return;
+            };
+            if swapchain.generation != generation {
+                return;
+            }
+            for (index, slot) in swapchain.slots.iter_mut().enumerate() {
+                if index == target {
+                    slot.initialized = true;
+                    slot.stale = OverlayDamage::None;
+                } else if slot.initialized {
+                    slot.stale = std::mem::take(&mut slot.stale).union(
+                        in_flight.damage.clone(),
+                        swapchain.width,
+                        swapchain.height,
+                    );
+                }
+            }
+            swapchain.front = Some(target);
+            Some(swapchain.slots[target].surface.clone())
+        } else {
+            None
+        };
+        let layer = surface
+            .as_ref()
+            .and_then(|_| state.layers.get(&entity).cloned());
+        if surface.is_some() {
+            state.held.remove(&entity);
+        }
+        let should_schedule = state.pending.contains_key(&entity)
+            && state.layers.contains_key(&entity)
+            && !state.in_flight.contains_key(&entity);
+        (layer, surface, should_schedule)
+    };
+    if let (Some(layer), Some(surface)) = (layer, surface) {
+        let io_surface =
+            (&*surface.io_surface as *const objc2_io_surface::IOSurfaceRef).cast::<AnyObject>();
+        unsafe { layer.0.setContents(Some(&*io_surface)) };
+    }
+    if should_schedule {
+        schedule_native_overlay_present();
+    }
+}
+
+fn present_native_overlay_dirty(
+    entity: Entity,
+    frame: &bevy_cef_core::prelude::AcceleratedFrame,
+) -> bool {
+    use objc2_metal::{
+        MTLBlitCommandEncoder, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandEncoder,
+        MTLCommandQueue, MTLOrigin, MTLSize,
+    };
+
+    if frame.io_surface == 0 || frame.width == 0 || frame.height == 0 {
+        return false;
+    }
+    let (
+        context,
+        surface,
+        source_texture,
+        generation,
+        target,
+        frame_damage,
+        copy_damage,
+        initialized,
+    ) = {
+        let mut state = NATIVE_OVERLAY_PRESENT_STATE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.in_flight.contains_key(&entity) {
+            return false;
+        }
+        if state.metal.is_none() {
+            state.metal = create_metal_overlay_context();
+        }
+        let Some(context) = state.metal.clone() else {
+            return false;
+        };
+        let recreate = state.swapchains.get(&entity).is_none_or(|swapchain| {
+            swapchain.width != frame.width
+                || swapchain.height != frame.height
+                || swapchain.format != frame.format
+        });
+        if recreate {
+            state.next_generation = state.next_generation.wrapping_add(1);
+            let generation = state.next_generation;
+            let Some(swapchain) = create_metal_overlay_swapchain(
+                &context,
+                generation,
+                frame.width,
+                frame.height,
+                frame.format,
+            ) else {
+                return false;
+            };
+            state.swapchains.insert(entity, swapchain);
+            state.source_textures.remove(&entity);
+        }
+        let Some(source_texture) = cached_source_texture(&mut state, &context, entity, frame)
+        else {
+            return false;
+        };
+        let frame_damage = OverlayDamage::from_frame(frame.width, frame.height, &frame.dirty);
+        let swapchain = state.swapchains.get(&entity).unwrap();
+        let target = swapchain.front.map_or(0, |front| 1 - front);
+        let slot = &swapchain.slots[target];
+        let copy_damage = if slot.initialized {
+            slot.stale
+                .clone()
+                .union(frame_damage.clone(), frame.width, frame.height)
+        } else {
+            OverlayDamage::Full
+        };
+        (
+            context,
+            slot.surface.clone(),
+            source_texture,
+            swapchain.generation,
+            target,
+            frame_damage,
+            copy_damage,
+            slot.initialized,
+        )
+    };
+    let Some(command_buffer) = context.queue.commandBuffer() else {
+        return false;
+    };
+    let Some(blit) = command_buffer.blitCommandEncoder() else {
+        return false;
+    };
+    let copy = |x: u32, y: u32, width: u32, height: u32| {
+        if width == 0 || height == 0 {
+            return;
+        }
+        unsafe {
+            blit.copyFromTexture_sourceSlice_sourceLevel_sourceOrigin_sourceSize_toTexture_destinationSlice_destinationLevel_destinationOrigin(
+                &source_texture,
+                0,
+                0,
+                MTLOrigin {
+                    x: x as usize,
+                    y: y as usize,
+                    z: 0,
+                },
+                MTLSize {
+                    width: width as usize,
+                    height: height as usize,
+                    depth: 1,
+                },
+                &surface.texture,
+                0,
+                0,
+                MTLOrigin {
+                    x: x as usize,
+                    y: y as usize,
+                    z: 0,
+                },
+            );
+        }
+    };
+    for rect in
+        native_overlay_blit_regions(frame.width, frame.height, &copy_damage, initialized).iter()
+    {
+        copy(rect.x, rect.y, rect.width, rect.height);
+    }
+    blit.endEncoding();
+    NATIVE_OVERLAY_PRESENT_STATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .in_flight
+        .insert(
+            entity,
+            MetalOverlayInFlight {
+                generation,
+                target,
+                damage: frame_damage,
+            },
+        );
+    let keepalive = frame.keepalive.clone();
+    let completed = block2::RcBlock::new(
+        move |buffer: std::ptr::NonNull<
+            objc2::runtime::ProtocolObject<dyn objc2_metal::MTLCommandBuffer>,
+        >| {
+            let succeeded =
+                unsafe { buffer.as_ref() }.status() == MTLCommandBufferStatus::Completed;
+            let keepalive = keepalive.clone();
+            dispatch2::DispatchQueue::main().exec_async(move || {
+                complete_native_overlay_present(entity, generation, target, succeeded);
+                drop(keepalive);
+            });
+        },
+    );
+    unsafe { command_buffer.addCompletedHandler(block2::RcBlock::as_ptr(&completed)) };
+    command_buffer.commit();
+    true
+}
+
 fn primary_content_view_ptr(entity: Entity) -> Option<*mut core::ffi::c_void> {
     use bevy::winit::WINIT_WINDOWS;
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
@@ -393,9 +1124,12 @@ fn sync_layout_overlay(
 ) {
     use objc2::{MainThreadMarker, rc::Retained, runtime::AnyObject};
     use objc2_app_kit::{NSColor, NSView};
-    use objc2_quartz_core::CALayer;
+    use objc2_quartz_core::{CAAutoresizingMask, CALayer};
 
     if *mode != InteractionMode::User {
+        for layout_e in &layout_e_q {
+            unregister_native_overlay_layer(layout_e);
+        }
         if state.shown {
             if let Some(layer) = &state.layer {
                 layer.setHidden(true);
@@ -415,9 +1149,6 @@ fn sync_layout_overlay(
         .lock()
         .ok()
         .and_then(|mut map| map.remove(&layout_e));
-    if next.is_none() && state.held.is_none() {
-        return;
-    }
     let Some(ns_view) = primary_content_view_ptr(window_e) else {
         return;
     };
@@ -436,12 +1167,16 @@ fn sync_layout_overlay(
         layer.setOpaque(false);
         layer.setBackgroundColor(Some(&clear_color.CGColor()));
         layer.setZPosition(100.0);
+        layer.setAutoresizingMask(
+            CAAutoresizingMask::LayerWidthSizable | CAAutoresizingMask::LayerHeightSizable,
+        );
         host_layer.addSublayer(&layer);
         state.layer = Some(layer);
     }
     let Some(layer) = state.layer.clone() else {
         return;
     };
+    register_native_overlay_layer(layout_e, &layer);
     layer.setOpaque(false);
     layer.setBackgroundColor(Some(&clear_color.CGColor()));
     layer.setFrame(bounds);
@@ -662,6 +1397,147 @@ mod tests {
         assert!(overlay.contains("host_layer.setOpaque(false)"));
         assert!(overlay.contains("host_layer.setBackgroundColor(Some(&clear_color.CGColor()))"));
         assert!(overlay.contains("layer.setBackgroundColor(Some(&clear_color.CGColor()))"));
+    }
+
+    #[test]
+    fn native_overlay_blits_only_dirty_regions() {
+        let dirty = vec![
+            WebviewDirtyRect {
+                x: 10,
+                y: 20,
+                width: 30,
+                height: 40,
+            },
+            WebviewDirtyRect {
+                x: 50,
+                y: 60,
+                width: 70,
+                height: 80,
+            },
+        ];
+
+        let damage = OverlayDamage::from_frame(200, 100, &dirty);
+
+        assert_eq!(
+            native_overlay_blit_regions(200, 100, &damage, true).as_ref(),
+            [
+                dirty[0],
+                WebviewDirtyRect {
+                    height: 40,
+                    ..dirty[1]
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn native_overlay_resize_forces_full_blit() {
+        let dirty = vec![WebviewDirtyRect {
+            x: 10,
+            y: 20,
+            width: 30,
+            height: 40,
+        }];
+
+        let damage = OverlayDamage::from_frame(200, 100, &dirty);
+
+        assert_eq!(
+            native_overlay_blit_regions(200, 100, &damage, false).as_ref(),
+            [WebviewDirtyRect {
+                x: 0,
+                y: 0,
+                width: 200,
+                height: 100,
+            }]
+        );
+    }
+
+    #[test]
+    fn native_overlay_coalescing_unions_dirty_regions() {
+        let previous = vec![WebviewDirtyRect {
+            x: 10,
+            y: 20,
+            width: 30,
+            height: 40,
+        }];
+        let latest = vec![WebviewDirtyRect {
+            x: 100,
+            y: 20,
+            width: 30,
+            height: 40,
+        }];
+
+        let dirty = coalesced_overlay_dirty(200, 100, &previous, &latest, true);
+
+        assert_eq!(
+            dirty,
+            [
+                WebviewDirtyRect {
+                    x: 10,
+                    y: 20,
+                    width: 30,
+                    height: 40,
+                },
+                WebviewDirtyRect {
+                    x: 100,
+                    y: 20,
+                    width: 30,
+                    height: 40,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn native_overlay_coalescing_merges_overlapping_regions() {
+        let previous = vec![WebviewDirtyRect {
+            x: 10,
+            y: 20,
+            width: 30,
+            height: 40,
+        }];
+        let latest = vec![WebviewDirtyRect {
+            x: 20,
+            y: 30,
+            width: 40,
+            height: 50,
+        }];
+
+        assert_eq!(
+            coalesced_overlay_dirty(200, 100, &previous, &latest, true),
+            [WebviewDirtyRect {
+                x: 10,
+                y: 20,
+                width: 50,
+                height: 60,
+            }]
+        );
+    }
+
+    #[test]
+    fn native_overlay_full_damage_survives_coalescing() {
+        let latest = vec![WebviewDirtyRect {
+            x: 20,
+            y: 30,
+            width: 40,
+            height: 50,
+        }];
+
+        assert!(coalesced_overlay_dirty(200, 100, &[], &latest, true).is_empty());
+        assert!(coalesced_overlay_dirty(200, 100, &latest, &latest, false).is_empty());
+    }
+
+    #[test]
+    fn native_overlay_metal_completion_is_asynchronous() {
+        let source = include_str!("glass.rs");
+        let presenter = source
+            .split("fn present_native_overlay_dirty")
+            .nth(1)
+            .and_then(|tail| tail.split("fn primary_content_view_ptr").next())
+            .unwrap_or_default();
+
+        assert!(presenter.contains("addCompletedHandler"));
+        assert!(!presenter.contains("waitUntilCompleted"));
     }
 
     fn reveal_test_app(reveal_ready: bool) -> App {

--- a/crates/vmux_desktop/src/lib.rs
+++ b/crates/vmux_desktop/src/lib.rs
@@ -104,7 +104,7 @@ impl Plugin for VmuxPlugin {
             ..default()
         };
 
-        let winit_settings = background_lifecycle::foreground_winit_settings(false, false);
+        let winit_settings = background_lifecycle::foreground_winit_settings(false, false, false);
         app.insert_resource(winit_settings)
             .add_plugins((
                 vmux_core::CorePlugin,

--- a/crates/vmux_layout/src/cef.rs
+++ b/crates/vmux_layout/src/cef.rs
@@ -4,6 +4,8 @@ use bevy_cef::prelude::*;
 
 use crate::event::LAYOUT_PAGE_URL;
 
+const LAYOUT_OSR_MAX_FRAME_RATE: i32 = 30;
+
 #[derive(Component)]
 pub struct Browser;
 
@@ -215,11 +217,14 @@ pub fn layout_cef_bundle(
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) -> impl Bundle {
     (
-        LayoutCef,
-        Browser,
-        HostWindow(host_window),
-        WebviewTransparent,
-        bevy_cef::prelude::CefIgnorePinchZoom,
+        (
+            LayoutCef,
+            Browser,
+            HostWindow(host_window),
+            WebviewTransparent,
+            WebviewMaxFrameRate(LAYOUT_OSR_MAX_FRAME_RATE),
+            bevy_cef::prelude::CefIgnorePinchZoom,
+        ),
         Node {
             width: Val::Percent(100.0),
             height: Val::Percent(100.0),

--- a/crates/vmux_layout/src/window.rs
+++ b/crates/vmux_layout/src/window.rs
@@ -1080,6 +1080,7 @@ mod tests {
         assert_eq!(material.base.cull_mode, None);
     }
 
+    #[cfg(feature = "player-mode")]
     #[test]
     fn transparent_webview_material_uses_premultiplied_alpha() {
         let mut app = App::new();
@@ -1093,7 +1094,7 @@ mod tests {
         app.world_mut().spawn((
             WebviewSource::new("https://example.com/"),
             WebviewTransparent,
-            MeshMaterial3d(handle.clone()),
+            WebviewMaterialHandle(handle.clone()),
         ));
         app.update();
 
@@ -1204,7 +1205,7 @@ mod tests {
     }
 
     #[test]
-    fn layout_uses_transparent_osr_native_overlay() {
+    fn layout_uses_transparent_osr_surface() {
         let mut app = setup_window_app();
         app.update();
 
@@ -1235,10 +1236,11 @@ mod tests {
                 .get::<WebviewNativeOverlay>(layout_shell)
                 .is_none()
         );
-        assert!(
+        assert_eq!(
             app.world()
                 .get::<WebviewMaxFrameRate>(layout_shell)
-                .is_none()
+                .map(|rate| rate.0),
+            Some(30)
         );
         assert!(
             app.world()

--- a/crates/vmux_layout/src/window.rs
+++ b/crates/vmux_layout/src/window.rs
@@ -680,17 +680,24 @@ fn sync_window_surface_alpha(
 fn apply_webview_material_defaults(
     mut materials: ResMut<Assets<WebviewExtendStandardMaterial>>,
     q: Query<
-        &WebviewMaterialHandle<WebviewExtendStandardMaterial>,
+        (
+            &WebviewMaterialHandle<WebviewExtendStandardMaterial>,
+            Has<WebviewTransparent>,
+        ),
         Or<(
             Added<WebviewSource>,
             Changed<WebviewMaterialHandle<WebviewExtendStandardMaterial>>,
         )>,
     >,
 ) {
-    for handle in &q {
+    for (handle, transparent) in &q {
         if let Some(mut material) = materials.get_mut(handle) {
             material.base.unlit = true;
-            material.base.alpha_mode = AlphaMode::Blend;
+            material.base.alpha_mode = if transparent {
+                AlphaMode::Premultiplied
+            } else {
+                AlphaMode::Blend
+            };
             material.base.depth_bias = WEBVIEW_MESH_DEPTH_BIAS;
             material.base.cull_mode = None;
         }
@@ -1071,6 +1078,32 @@ mod tests {
         assert_eq!(material.base.alpha_mode, AlphaMode::Blend);
         assert_eq!(material.base.depth_bias, WEBVIEW_MESH_DEPTH_BIAS);
         assert_eq!(material.base.cull_mode, None);
+    }
+
+    #[test]
+    fn transparent_webview_material_uses_premultiplied_alpha() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+            .add_systems(Update, apply_webview_material_defaults);
+        let handle = app
+            .world_mut()
+            .resource_mut::<Assets<WebviewExtendStandardMaterial>>()
+            .add(WebviewExtendStandardMaterial::default());
+        app.world_mut().spawn((
+            WebviewSource::new("https://example.com/"),
+            WebviewTransparent,
+            MeshMaterial3d(handle.clone()),
+        ));
+        app.update();
+
+        let material = app
+            .world()
+            .resource::<Assets<WebviewExtendStandardMaterial>>()
+            .get(&handle)
+            .expect("webview material");
+
+        assert_eq!(material.base.alpha_mode, AlphaMode::Premultiplied);
     }
 
     fn test_settings(gap: f32) -> LayoutSettings {

--- a/patches/bevy_cef-0.5.2/src/common/components.rs
+++ b/patches/bevy_cef-0.5.2/src/common/components.rs
@@ -18,6 +18,7 @@ impl Plugin for WebviewCoreComponentsPlugin {
             .register_type::<WebviewWindowedNativeFocus>()
             .register_type::<WebviewMaxFrameRate>()
             .register_type::<WebviewNativeOverlay>()
+            .register_type::<WebviewNativeDirectOverlay>()
             .register_type::<HistorySwipeVisualOffset>()
             .register_type::<HostWindow>()
             .register_type::<ZoomLevel>()
@@ -93,6 +94,11 @@ pub struct WebviewMaxFrameRate(pub i32);
 #[derive(Component, Debug, Clone, Copy, Default, Reflect)]
 #[reflect(Component, Default)]
 pub struct WebviewNativeOverlay;
+
+/// Marker: present accelerated frames through the host's native presenter without waking Bevy.
+#[derive(Component, Debug, Clone, Copy, Default, Reflect)]
+#[reflect(Component, Default)]
+pub struct WebviewNativeDirectOverlay;
 
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Debug)]

--- a/patches/bevy_cef-0.5.2/src/webview.rs
+++ b/patches/bevy_cef-0.5.2/src/webview.rs
@@ -2,8 +2,9 @@ use crate::cef_state::{MediaPermissionSender, WebviewCefStateSender};
 use crate::common::localhost::responser::{InlineHtmlId, InlineHtmlStore};
 use crate::common::{
     BinIpcEventRawSender, HostWindow, IpcEventRawSender, ResolvedWebviewUri, SnapshotResultSender,
-    WebviewMaxFrameRate, WebviewNativeLiquidGlass, WebviewOpaqueWindowedBackground, WebviewSize,
-    WebviewSource, WebviewTransparent, WebviewWindowed, WebviewWindowedNativeFocus,
+    WebviewMaxFrameRate, WebviewNativeDirectOverlay, WebviewNativeLiquidGlass,
+    WebviewOpaqueWindowedBackground, WebviewSize, WebviewSource, WebviewTransparent,
+    WebviewWindowed, WebviewWindowedNativeFocus,
 };
 use crate::cursor_icon::SystemCursorIconSender;
 use crate::loading_state::{WebviewCommittedNavigationSender, WebviewLoadingStateSender};
@@ -34,6 +35,9 @@ mod webview_sprite;
 #[derive(Resource, Clone)]
 struct TextureWakeCallback(Option<TextureWake>);
 
+#[derive(Resource, Clone, Default)]
+pub struct NativeOverlayPresenter(pub Option<AcceleratedFramePresenter>);
+
 #[derive(Resource, Clone)]
 struct TextureWakeMinInterval(Arc<AtomicU64>);
 
@@ -61,7 +65,7 @@ fn duration_nanos(duration: Duration) -> u64 {
 
 pub mod prelude {
     pub use crate::webview::{
-        CefSystems, RequestCloseDevtool, RequestShowDevTool, WebviewPlugin,
+        CefSystems, NativeOverlayPresenter, RequestCloseDevtool, RequestShowDevTool, WebviewPlugin,
         accelerated_upload::NativeOverlayFrames, mesh::*, texture_upload::WebviewTextureUploads,
     };
 }
@@ -132,6 +136,7 @@ impl Plugin for WebviewPlugin {
         app.register_type::<RequestShowDevTool>()
             .init_resource::<CefDiskProfileRoot>()
             .init_non_send::<Browsers>()
+            .init_resource::<NativeOverlayPresenter>()
             .insert_resource(TextureWakeCallback(texture_wake))
             .insert_resource(texture_wake_policy)
             .add_plugins((MeshWebviewPlugin,))
@@ -142,6 +147,7 @@ impl Plugin for WebviewPlugin {
                     create_webview,
                     navigate_on_source_change,
                 )
+                    .run_if(not(on_message::<AppExit>))
                     .in_set(CefSystems::CreateAndResize),
             )
             .add_systems(
@@ -269,19 +275,21 @@ fn create_webview(
     committed_nav_sender: Res<WebviewCommittedNavigationSender>,
     cef_senders: (Res<WebviewCefStateSender>, Res<MediaPermissionSender>),
     popup_sender: Res<WebviewPopupSender>,
-    texture_wake: Res<TextureWakeCallback>,
+    render_callbacks: (Res<TextureWakeCallback>, Res<NativeOverlayPresenter>),
     webviews: Query<
         (
             Entity,
             &ResolvedWebviewUri,
             &WebviewSize,
             &PreloadScripts,
+            Option<&WebviewMaxFrameRate>,
             Option<&HostWindow>,
             Has<WebviewTransparent>,
             Has<WebviewWindowed>,
             Has<WebviewNativeLiquidGlass>,
             Has<WebviewOpaqueWindowedBackground>,
             Has<WebviewWindowedNativeFocus>,
+            Has<WebviewNativeDirectOverlay>,
         ),
         With<ResolvedWebviewUri>,
     >,
@@ -295,12 +303,14 @@ fn create_webview(
             uri,
             size,
             initialize_scripts,
+            max_frame_rate,
             host_window,
             transparent,
             windowed,
             native_liquid_glass,
             opaque_windowed_background,
             windowed_native_focus,
+            native_direct_overlay,
         ) in
             webviews.iter()
         {
@@ -320,8 +330,11 @@ fn create_webview(
             let refresh_rate_millihertz = winit_window
                 .and_then(|window| window.current_monitor())
                 .and_then(|monitor| monitor.refresh_rate_millihertz());
-            let windowless_frame_rate =
+            let mut windowless_frame_rate =
                 windowless_frame_rate_from_refresh_millihertz(refresh_rate_millihertz);
+            if let Some(cap) = max_frame_rate {
+                windowless_frame_rate = windowless_frame_rate.min(cap.0.max(1));
+            }
             let host_window = winit_window
                 .and_then(|w| {
                     #[allow(deprecated)]
@@ -352,7 +365,10 @@ fn create_webview(
                 cef_senders.0.0.clone(),
                 cef_senders.1.0.clone(),
                 popup_sender.0.clone(),
-                texture_wake.0.clone(),
+                render_callbacks.0.0.clone(),
+                native_direct_overlay
+                    .then(|| render_callbacks.1.0.clone())
+                    .flatten(),
                 &initialize_scripts.0,
                 host_window,
                 disk_profile.0.as_deref(),
@@ -494,5 +510,17 @@ mod tests {
     fn windowless_webviews_use_shared_textures() {
         assert!(shared_texture_enabled(false));
         assert!(!shared_texture_enabled(true));
+    }
+
+    #[test]
+    fn webview_creation_stops_during_app_exit() {
+        let source = include_str!("webview.rs");
+        let plugin = source
+            .split("impl Plugin for WebviewPlugin")
+            .nth(1)
+            .and_then(|tail| tail.split("fn duration_nanos").next())
+            .unwrap_or_default();
+
+        assert!(plugin.contains("run_if(not(on_message::<AppExit>))"));
     }
 }

--- a/patches/bevy_cef-0.5.2/src/webview.rs
+++ b/patches/bevy_cef-0.5.2/src/webview.rs
@@ -2,9 +2,8 @@ use crate::cef_state::{MediaPermissionSender, WebviewCefStateSender};
 use crate::common::localhost::responser::{InlineHtmlId, InlineHtmlStore};
 use crate::common::{
     BinIpcEventRawSender, HostWindow, IpcEventRawSender, ResolvedWebviewUri, SnapshotResultSender,
-    WebviewMaxFrameRate, WebviewNativeLiquidGlass, WebviewNativeOverlay,
-    WebviewOpaqueWindowedBackground, WebviewSize, WebviewSource, WebviewTransparent,
-    WebviewWindowed, WebviewWindowedNativeFocus,
+    WebviewMaxFrameRate, WebviewNativeLiquidGlass, WebviewOpaqueWindowedBackground, WebviewSize,
+    WebviewSource, WebviewTransparent, WebviewWindowed, WebviewWindowedNativeFocus,
 };
 use crate::cursor_icon::SystemCursorIconSender;
 use crate::loading_state::{WebviewCommittedNavigationSender, WebviewLoadingStateSender};
@@ -252,6 +251,10 @@ fn spawn_texture_wake_throttler(
     }) as TextureWake
 }
 
+fn shared_texture_enabled(windowed: bool) -> bool {
+    !windowed
+}
+
 #[allow(clippy::too_many_arguments)]
 fn create_webview(
     mut browsers: NonSendMut<Browsers>,
@@ -279,7 +282,6 @@ fn create_webview(
             Has<WebviewNativeLiquidGlass>,
             Has<WebviewOpaqueWindowedBackground>,
             Has<WebviewWindowedNativeFocus>,
-            Has<WebviewNativeOverlay>,
         ),
         With<ResolvedWebviewUri>,
     >,
@@ -299,7 +301,6 @@ fn create_webview(
             native_liquid_glass,
             opaque_windowed_background,
             windowed_native_focus,
-            native_overlay,
         ) in
             webviews.iter()
         {
@@ -364,11 +365,7 @@ fn create_webview(
                 },
                 windowless_frame_rate,
                 windowed,
-                // Transparent OSR webviews that render to a Bevy mesh (not a native overlay) must use
-                // CPU paint: the accelerated shared-texture path blits transparent surfaces to black
-                // on the mesh. The layout is the only such case (transparent + mesh in player mode);
-                // it routes through the native overlay (accelerated) in user mode.
-                !transparent || native_overlay,
+                shared_texture_enabled(windowed),
                 native_liquid_glass,
                 windowed && windowed_native_focus,
             );
@@ -491,5 +488,11 @@ mod tests {
         assert!(implementation.contains("Has<WebviewWindowedNativeFocus>"));
         assert!(implementation.contains("windowed_native_focus"));
         assert!(implementation.contains("windowed && windowed_native_focus"));
+    }
+
+    #[test]
+    fn windowless_webviews_use_shared_textures() {
+        assert!(shared_texture_enabled(false));
+        assert!(!shared_texture_enabled(true));
     }
 }

--- a/patches/bevy_cef-0.5.2/src/webview/accelerated_upload.rs
+++ b/patches/bevy_cef-0.5.2/src/webview/accelerated_upload.rs
@@ -1,3 +1,4 @@
+use super::TextureWakeCallback;
 use crate::common::WebviewNativeOverlay;
 use crate::prelude::WebviewSurface;
 use bevy::asset::RenderAssetUsages;
@@ -58,6 +59,7 @@ fn queue_accelerated_uploads(
     overlay_frames: Res<NativeOverlayFrames>,
     mut images: ResMut<Assets<Image>>,
     queue: Res<WebviewAcceleratedQueue>,
+    texture_wake: Option<Res<TextureWakeCallback>>,
 ) {
     let Ok(mut pending) = queue.0.lock() else {
         return;
@@ -67,6 +69,7 @@ fn queue_accelerated_uploads(
     // the last upload, blit the whole surface (drop dirty rects) so no superseded region is missed.
     let mut latest: HashMap<Entity, AcceleratedFrame> = HashMap::new();
     let mut coalesced: HashSet<Entity> = HashSet::new();
+    let mut resized = false;
     while let Ok(frame) = browsers.try_receive_accelerated() {
         let webview = frame.webview;
         if latest.insert(webview, frame).is_some() {
@@ -88,13 +91,27 @@ fn queue_accelerated_uploads(
             frame.dirty.clear();
         }
         let id = surface.0.id();
-        let mismatched = images
-            .get(id)
-            .is_none_or(|image| image.width() != frame.width || image.height() != frame.height);
-        if mismatched && let Some(mut image) = images.get_mut(id) {
-            *image = resized_surface_image(frame.width, frame.height);
+        if let Some(mut image) = images.get_mut(id) {
+            resized |= resize_surface_image_if_needed(&mut image, frame.width, frame.height);
         }
         pending.push(PendingAcceleratedUpload { image: id, frame });
+    }
+    if resized {
+        request_followup_frame(texture_wake.as_deref());
+    }
+}
+
+fn resize_surface_image_if_needed(image: &mut Image, width: u32, height: u32) -> bool {
+    if image.width() == width && image.height() == height {
+        return false;
+    }
+    *image = resized_surface_image(width, height);
+    true
+}
+
+fn request_followup_frame(texture_wake: Option<&TextureWakeCallback>) {
+    if let Some(wake) = texture_wake.and_then(|wake| wake.0.as_ref()) {
+        wake();
     }
 }
 
@@ -214,6 +231,10 @@ fn upload_accelerated_textures(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     #[test]
     fn accelerated_uploads_survive_gpu_asset_resize_lag() {
         let source = include_str!("accelerated_upload.rs");
@@ -235,5 +256,23 @@ mod tests {
             upload.contains("retry.push(upload);"),
             "GPU-size misses must retry instead of dropping one-shot frames"
         );
+    }
+
+    #[test]
+    fn surface_resize_requests_followup_frame() {
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let wakes_for_callback = Arc::clone(&wakes);
+        let wake = TextureWakeCallback(Some(Arc::new(move || {
+            wakes_for_callback.fetch_add(1, Ordering::Relaxed);
+        })));
+        let mut image = resized_surface_image(1, 1);
+
+        assert!(resize_surface_image_if_needed(&mut image, 100, 50));
+        request_followup_frame(Some(&wake));
+
+        assert_eq!(image.width(), 100);
+        assert_eq!(image.height(), 50);
+        assert_eq!(wakes.load(Ordering::Relaxed), 1);
+        assert!(!resize_surface_image_if_needed(&mut image, 100, 50));
     }
 }

--- a/patches/bevy_cef-0.5.2/src/webview/accelerated_upload.rs
+++ b/patches/bevy_cef-0.5.2/src/webview/accelerated_upload.rs
@@ -11,7 +11,7 @@ use bevy::render::render_resource::{
 use bevy::render::renderer::{RenderDevice, RenderQueue};
 use bevy::render::texture::GpuImage;
 use bevy::render::{Extract, ExtractSchedule, Render, RenderApp, RenderSystems};
-use bevy_cef_core::prelude::{AcceleratedFrame, Browsers};
+use bevy_cef_core::prelude::{AcceleratedFrame, AcceleratedPixelFormat, Browsers};
 use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 
@@ -92,7 +92,12 @@ fn queue_accelerated_uploads(
         }
         let id = surface.0.id();
         if let Some(mut image) = images.get_mut(id) {
-            resized |= resize_surface_image_if_needed(&mut image, frame.width, frame.height);
+            resized |= resize_surface_image_if_needed(
+                &mut image,
+                frame.width,
+                frame.height,
+                accelerated_surface_format(frame.format),
+            );
         }
         pending.push(PendingAcceleratedUpload { image: id, frame });
     }
@@ -101,11 +106,19 @@ fn queue_accelerated_uploads(
     }
 }
 
-fn resize_surface_image_if_needed(image: &mut Image, width: u32, height: u32) -> bool {
-    if image.width() == width && image.height() == height {
+fn resize_surface_image_if_needed(
+    image: &mut Image,
+    width: u32,
+    height: u32,
+    format: TextureFormat,
+) -> bool {
+    if image.width() == width
+        && image.height() == height
+        && image.texture_descriptor.format == format
+    {
         return false;
     }
-    *image = resized_surface_image(width, height);
+    *image = resized_surface_image(width, height, format);
     true
 }
 
@@ -115,7 +128,14 @@ fn request_followup_frame(texture_wake: Option<&TextureWakeCallback>) {
     }
 }
 
-fn resized_surface_image(width: u32, height: u32) -> Image {
+fn accelerated_surface_format(format: AcceleratedPixelFormat) -> TextureFormat {
+    match format {
+        AcceleratedPixelFormat::Rgba8 => TextureFormat::Rgba8UnormSrgb,
+        AcceleratedPixelFormat::Bgra8 => TextureFormat::Bgra8UnormSrgb,
+    }
+}
+
+fn resized_surface_image(width: u32, height: u32, format: TextureFormat) -> Image {
     Image::new_fill(
         Extent3d {
             width,
@@ -124,7 +144,7 @@ fn resized_surface_image(width: u32, height: u32) -> Image {
         },
         TextureDimension::D2,
         &[0, 0, 0, 0],
-        TextureFormat::Bgra8UnormSrgb,
+        format,
         RenderAssetUsages::all(),
     )
 }
@@ -265,14 +285,48 @@ mod tests {
         let wake = TextureWakeCallback(Some(Arc::new(move || {
             wakes_for_callback.fetch_add(1, Ordering::Relaxed);
         })));
-        let mut image = resized_surface_image(1, 1);
+        let mut image = resized_surface_image(1, 1, TextureFormat::Bgra8UnormSrgb);
 
-        assert!(resize_surface_image_if_needed(&mut image, 100, 50));
+        assert!(resize_surface_image_if_needed(
+            &mut image,
+            100,
+            50,
+            TextureFormat::Bgra8UnormSrgb,
+        ));
         request_followup_frame(Some(&wake));
 
         assert_eq!(image.width(), 100);
         assert_eq!(image.height(), 50);
         assert_eq!(wakes.load(Ordering::Relaxed), 1);
-        assert!(!resize_surface_image_if_needed(&mut image, 100, 50));
+        assert!(!resize_surface_image_if_needed(
+            &mut image,
+            100,
+            50,
+            TextureFormat::Bgra8UnormSrgb,
+        ));
+    }
+
+    #[test]
+    fn accelerated_surface_matches_cef_pixel_format() {
+        assert_eq!(
+            accelerated_surface_format(AcceleratedPixelFormat::Rgba8),
+            TextureFormat::Rgba8UnormSrgb
+        );
+        assert_eq!(
+            accelerated_surface_format(AcceleratedPixelFormat::Bgra8),
+            TextureFormat::Bgra8UnormSrgb
+        );
+
+        let mut image = resized_surface_image(100, 50, TextureFormat::Bgra8UnormSrgb);
+        assert!(resize_surface_image_if_needed(
+            &mut image,
+            100,
+            50,
+            TextureFormat::Rgba8UnormSrgb,
+        ));
+        assert_eq!(
+            image.texture_descriptor.format,
+            TextureFormat::Rgba8UnormSrgb
+        );
     }
 }

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
@@ -63,6 +63,35 @@ pub const BACKGROUND_WINDOWLESS_FRAME_RATE: i32 = 30;
 /// Frame rate for a hidden host window. CEF still needs a nonzero rate to keep timers alive.
 pub const HIDDEN_WINDOWLESS_FRAME_RATE: i32 = 1;
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct NativeMouseButtons {
+    pub left: bool,
+    pub right: bool,
+    pub middle: bool,
+}
+
+#[derive(Clone)]
+pub struct NativeMouseMovePresenter {
+    browser_id: i32,
+    host: BrowserHost,
+}
+
+impl NativeMouseMovePresenter {
+    pub fn browser_id(&self) -> i32 {
+        self.browser_id
+    }
+
+    pub fn send(&self, position: Vec2, buttons: NativeMouseButtons, mouse_leave: bool) {
+        let mouse_event = cef::MouseEvent {
+            x: position.x as i32,
+            y: position.y as i32,
+            modifiers: modifiers_from_native_mouse_buttons(buttons),
+        };
+        self.host
+            .send_mouse_move_event(Some(&mouse_event), mouse_leave as _);
+    }
+}
+
 static REGISTER_GLOBAL_SCHEME_HANDLER_FACTORIES: Once = Once::new();
 
 /// Whether a webview at `uri` must use an extension-free request context.
@@ -198,6 +227,7 @@ impl Browsers {
         media_permission_sender: MediaPermissionSenderInner,
         webview_popup_sender: WebviewPopupSenderInner,
         texture_wake: Option<TextureWake>,
+        accelerated_presenter: Option<AcceleratedFramePresenter>,
         initialize_scripts: &[String],
         _window_handle: Option<RawWindowHandle>,
         disk_profile_root: Option<&str>,
@@ -237,6 +267,7 @@ impl Browsers {
             media_permission_sender,
             webview_popup_sender,
             texture_wake,
+            accelerated_presenter,
             !allow_native_focus,
         );
 
@@ -534,6 +565,17 @@ impl Browsers {
                 .host
                 .send_mouse_move_event(Some(&mouse_event), mouse_leave as _);
         }
+    }
+
+    pub fn native_mouse_move_presenter(
+        &self,
+        webview: &Entity,
+    ) -> Option<NativeMouseMovePresenter> {
+        let browser = self.browsers.get(webview)?;
+        (!browser.windowed).then(|| NativeMouseMovePresenter {
+            browser_id: browser.client.identifier(),
+            host: browser.host.clone(),
+        })
     }
 
     pub fn send_mouse_click(
@@ -1970,6 +2012,7 @@ impl Browsers {
         media_permission_sender: MediaPermissionSenderInner,
         webview_popup_sender: WebviewPopupSenderInner,
         texture_wake: Option<TextureWake>,
+        accelerated_presenter: Option<AcceleratedFramePresenter>,
         cancel_native_focus: bool,
     ) -> Client {
         let client = ClientHandlerBuilder::new(RenderHandlerBuilder::build(
@@ -1977,6 +2020,7 @@ impl Browsers {
             self.sender.clone(),
             self.accel_sender.clone(),
             texture_wake.clone(),
+            accelerated_presenter,
             size.clone(),
             device_scale.clone(),
         ))
@@ -2052,6 +2096,21 @@ pub fn modifiers_from_mouse_buttons<'a>(buttons: impl IntoIterator<Item = &'a Mo
             }
             _ => {}
         }
+    }
+    modifiers
+}
+
+#[allow(clippy::unnecessary_cast)]
+pub fn modifiers_from_native_mouse_buttons(buttons: NativeMouseButtons) -> u32 {
+    let mut modifiers = cef_event_flags_t::EVENTFLAG_NONE.0 as u32;
+    if buttons.left {
+        modifiers |= cef_event_flags_t::EVENTFLAG_LEFT_MOUSE_BUTTON.0 as u32;
+    }
+    if buttons.right {
+        modifiers |= cef_event_flags_t::EVENTFLAG_RIGHT_MOUSE_BUTTON.0 as u32;
+    }
+    if buttons.middle {
+        modifiers |= cef_event_flags_t::EVENTFLAG_MIDDLE_MOUSE_BUTTON.0 as u32;
     }
     modifiers
 }
@@ -2143,7 +2202,9 @@ mod tests {
         windowless_frame_interval_from_refresh_millihertz,
         windowless_frame_rate_from_refresh_millihertz,
     };
-    use crate::prelude::modifiers_from_mouse_buttons;
+    use crate::prelude::{
+        NativeMouseButtons, modifiers_from_mouse_buttons, modifiers_from_native_mouse_buttons,
+    };
     use bevy::prelude::*;
     use std::time::Duration;
 
@@ -2215,6 +2276,21 @@ mod tests {
             modifiers,
             cef_dll_sys::cef_event_flags_t::EVENTFLAG_LEFT_MOUSE_BUTTON.0 as u32
                 | cef_dll_sys::cef_event_flags_t::EVENTFLAG_RIGHT_MOUSE_BUTTON.0 as u32
+        );
+    }
+
+    #[test]
+    #[allow(clippy::unnecessary_cast)]
+    fn native_mouse_buttons_map_to_cef_modifiers() {
+        let modifiers = modifiers_from_native_mouse_buttons(NativeMouseButtons {
+            left: true,
+            right: false,
+            middle: true,
+        });
+        assert_eq!(
+            modifiers,
+            cef_dll_sys::cef_event_flags_t::EVENTFLAG_LEFT_MOUSE_BUTTON.0 as u32
+                | cef_dll_sys::cef_event_flags_t::EVENTFLAG_MIDDLE_MOUSE_BUTTON.0 as u32
         );
     }
 

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/renderer_handler.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/renderer_handler.rs
@@ -16,6 +16,7 @@ pub type TextureSender = Sender<RenderTextureMessage>;
 pub type TextureReceiver = Receiver<RenderTextureMessage>;
 
 pub type TextureWake = Arc<dyn Fn() + Send + Sync + 'static>;
+pub type AcceleratedFramePresenter = Arc<dyn Fn(AcceleratedFrame) + Send + Sync + 'static>;
 
 /// The texture structure passed from [`CefRenderHandler::OnPaint`](https://cef-builds.spotifycdn.com/docs/106.1/classCefRenderHandler.html#a6547d5c9dd472e6b84706dc81d3f1741).
 #[derive(Debug, Clone, PartialEq, Message)]
@@ -89,11 +90,18 @@ pub struct SendSharedTextureHandle(pub SharedTextureHandle);
 unsafe impl Send for SendSharedTextureHandle {}
 unsafe impl Sync for SendSharedTextureHandle {}
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AcceleratedPixelFormat {
+    Rgba8,
+    Bgra8,
+}
+
 pub struct AcceleratedFrame {
     pub webview: Entity,
     pub ty: RenderPaintElementType,
     pub width: u32,
     pub height: u32,
+    pub format: AcceleratedPixelFormat,
     pub handle: SendSharedTextureHandle,
     /// Raw `IOSurfaceRef` (as `usize`) backing this frame, kept alive by `keepalive`. Lets a native
     /// overlay set it directly as a `CALayer`'s `contents` instead of importing into a GPU texture.
@@ -119,6 +127,7 @@ pub struct RenderHandlerBuilder {
     texture_sender: TextureSender,
     accel_sender: AcceleratedSender,
     texture_wake: Option<TextureWake>,
+    accelerated_presenter: Option<AcceleratedFramePresenter>,
     size: SharedViewSize,
     device_scale: SharedDeviceScaleFactor,
 }
@@ -129,6 +138,7 @@ impl RenderHandlerBuilder {
         texture_sender: TextureSender,
         accel_sender: AcceleratedSender,
         texture_wake: Option<TextureWake>,
+        accelerated_presenter: Option<AcceleratedFramePresenter>,
         size: SharedViewSize,
         device_scale: SharedDeviceScaleFactor,
     ) -> RenderHandler {
@@ -138,6 +148,7 @@ impl RenderHandlerBuilder {
             texture_sender,
             accel_sender,
             texture_wake,
+            accelerated_presenter,
             size,
             device_scale,
         })
@@ -172,6 +183,7 @@ impl Clone for RenderHandlerBuilder {
             texture_sender: self.texture_sender.clone(),
             accel_sender: self.accel_sender.clone(),
             texture_wake: self.texture_wake.clone(),
+            accelerated_presenter: self.accelerated_presenter.clone(),
             size: self.size.clone(),
             device_scale: self.device_scale.clone(),
         }
@@ -261,14 +273,23 @@ impl ImplRenderHandler for RenderHandlerBuilder {
                 ty,
                 width,
                 height,
+                format: if info.format == ColorType::RGBA_8888 {
+                    AcceleratedPixelFormat::Rgba8
+                } else {
+                    AcceleratedPixelFormat::Bgra8
+                },
                 handle: SendSharedTextureHandle(SharedTextureHandle::new(info)),
                 io_surface,
                 keepalive,
                 dirty: webview_dirty_rects(dirty_rects, width, height),
             };
-            let _ = self.accel_sender.send_blocking(frame);
-            if let Some(wake) = self.texture_wake.as_ref() {
-                wake();
+            if let Some(presenter) = self.accelerated_presenter.as_ref() {
+                presenter(frame);
+            } else {
+                let _ = self.accel_sender.send_blocking(frame);
+                if let Some(wake) = self.texture_wake.as_ref() {
+                    wake();
+                }
             }
         }
         #[cfg(not(target_os = "macos"))]
@@ -323,6 +344,21 @@ mod tests {
 
         assert!(rx.try_recv().is_ok());
         assert_eq!(wakes.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn accelerated_native_presenter_bypasses_bevy_wake() {
+        let source = include_str!("renderer_handler.rs");
+        let callback = source
+            .split("fn on_accelerated_paint")
+            .nth(1)
+            .and_then(|tail| tail.split("fn get_raw").next())
+            .unwrap_or_default();
+
+        assert!(callback.contains("presenter(frame)"));
+        assert!(callback.contains("else {"));
+        assert!(callback.contains("self.accel_sender.send_blocking(frame)"));
+        assert!(callback.contains("wake()"));
     }
 
     #[test]


### PR DESCRIPTION
## Context

Transparent CEF off-screen rendering copied every layout frame through CPU memory, causing high CPU usage during pointer movement. Keep the sidebar and header composited above Liquid Glass without CPU readback.

## Implementation

Consume accelerated CEF IOSurface frames directly in Metal, cache texture wrappers, double-buffer destination surfaces, merge dirty regions, and submit asynchronous blits at a 30 FPS layout cap. Route native pointer movement directly to CEF and guard resize and shutdown transitions.

## Checks / QA

- Launch the macOS dev app and confirm the sidebar and header render above Liquid Glass.
- Move, click, and double-click across the layout; verify hover and controls remain responsive.
- Resize the window and verify the overlay updates without disappearing or tearing.
- Quit the app and verify CEF browsers are not recreated during shutdown.