### PR TITLE
perf(ci): streamline CEF package builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,6 +363,7 @@ jobs:
       contents: write
     env:
       CEF_VERSION: ${{ needs.cef-version.outputs.version }}
+      VMUX_CEF_SDK_CACHE: ${{ github.workspace }}/.cache/cef-sdk
     steps:
       - uses: actions/checkout@v5
         with:
@@ -456,10 +457,8 @@ jobs:
       - name: Install binaryen
         run: ./scripts/install-dioxus-binaryen.sh
 
-      - name: Install bevy_cef tools
-        run: |
-          command -v bevy_cef_render_process >/dev/null 2>&1 || cargo install bevy_cef_render_process
-          command -v bevy_cef_bundle_app >/dev/null 2>&1 || cargo install bevy_cef_bundle_app
+      - name: Install bevy_cef bundle tool
+        run: command -v bevy_cef_bundle_app >/dev/null 2>&1 || cargo install bevy_cef_bundle_app
 
       - name: Install cargo-packager (patched for macOS Tahoe)
         run: |

--- a/crates/vmux_desktop/tests/packaging_metadata.rs
+++ b/crates/vmux_desktop/tests/packaging_metadata.rs
@@ -36,11 +36,95 @@ fn before_packaging_command_prepares_named_binaries() {
     let script = include_str!("../../../scripts/build-package-binaries.sh");
     assert!(script.contains("-p vmux_desktop"));
     assert!(script.contains("-p vmux_cli"));
-    assert!(script.contains(r#"target/release/Vmux Service"#));
+    assert!(script.contains(r#"$release_dir/Vmux Service"#));
     assert!(
         !script.contains("target/release/vmux_desktop target/release/Vmux"),
         "must not copy the GUI binary over the vmux name (case-insensitive clash)"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn package_binary_paths_honor_target_dir_and_triple() {
+    use std::{fs, os::unix::fs::PermissionsExt, process::Command};
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let cargo = temp.path().join("cargo");
+    let target = temp.path().join("custom target");
+    let cache = temp.path().join("cef sdk");
+    let log = temp.path().join("cargo.log");
+    fs::write(
+        &cargo,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+profile=release
+while [[ "$#" -gt 0 ]]; do
+    if [[ "$1" == "--profile" ]]; then
+        profile="$2"
+        shift 2
+    else
+        shift
+    fi
+done
+out="$CARGO_TARGET_DIR/${CARGO_BUILD_TARGET:-}/$profile"
+mkdir -p "$out"
+if [[ "$profile" == "cef-helper" ]]; then
+    : > "$out/bevy_cef_debug_render_process"
+else
+    : > "$out/vmux_service"
+fi
+printf '%s\n' "${CEF_PATH:-}" >> "$FAKE_CARGO_LOG"
+"#,
+    )
+    .expect("write fake cargo");
+    let mut permissions = fs::metadata(&cargo)
+        .expect("fake cargo metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&cargo, permissions).expect("make fake cargo executable");
+
+    let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../scripts/build-package-binaries.sh");
+    let status = Command::new("bash")
+        .arg(script)
+        .env("CI", "true")
+        .env("CARGO_BIN", &cargo)
+        .env("CARGO_TARGET_DIR", &target)
+        .env("CARGO_BUILD_TARGET", "aarch64-apple-darwin")
+        .env("VMUX_CEF_SDK_CACHE", &cache)
+        .env("FAKE_CARGO_LOG", &log)
+        .status()
+        .expect("run package binary build");
+    assert!(status.success());
+
+    let release = target.join("aarch64-apple-darwin/release");
+    assert!(release.join("bevy_cef_debug_render_process").is_file());
+    assert!(release.join("Vmux Service").is_file());
+    let cargo_log = fs::read_to_string(log).expect("read cargo log");
+    let cef_paths = cargo_log.lines().collect::<Vec<_>>();
+    let expected = cache.display().to_string();
+    assert!(cef_paths.len() >= 2);
+    assert!(cef_paths.iter().all(|path| *path == expected));
+}
+
+#[test]
+fn packaging_scripts_share_resolved_release_dir() {
+    let paths = include_str!("../../../scripts/cargo-target-paths.sh");
+    let build = include_str!("../../../scripts/build-package-binaries.sh");
+    let package = include_str!("../../../scripts/package.sh");
+    let inject = include_str!("../../../scripts/inject-cef.sh");
+    let before_each = include_str!("../../../scripts/before-each-package.sh");
+    let signing = include_str!("../../../scripts/sign-and-notarize.sh");
+
+    assert!(paths.contains("CARGO_TARGET_DIR"));
+    assert!(paths.contains("CARGO_BUILD_TARGET"));
+    assert!(build.contains("vmux_cargo_profile_dir \"$ROOT\" release"));
+    assert!(package.contains("VMUX_CARGO_RELEASE_DIR"));
+    assert!(package.contains("packager_args+=(--target \"$CARGO_BUILD_TARGET\")"));
+    assert!(inject.contains("VMUX_CARGO_RELEASE_DIR"));
+    assert!(inject.contains("$RELEASE_DIR/bevy_cef_debug_render_process"));
+    assert!(before_each.contains("$release_dir/Vmux.app"));
+    assert!(signing.contains("$(dirname \"$APP_BUNDLE\")"));
 }
 
 #[test]

--- a/crates/vmux_desktop/tests/release_invariants.rs
+++ b/crates/vmux_desktop/tests/release_invariants.rs
@@ -165,9 +165,9 @@ fn package_builds_cef_helper_separately_without_lto() {
     assert!(script.contains("build -p vmux_desktop -p vmux_service --release"));
     assert!(!script.contains("build -p vmux_desktop -p vmux_cli -p vmux_service --release"));
     assert!(script.contains("build -p bevy_cef_debug_render_process --profile cef-helper"));
-    assert!(script.contains(
-        "cp -f target/cef-helper/bevy_cef_debug_render_process target/release/bevy_cef_debug_render_process"
-    ));
+    assert!(script.contains("$helper_dir/bevy_cef_debug_render_process"));
+    assert!(script.contains("$release_dir/bevy_cef_debug_render_process"));
+    assert!(!script.contains("target/cef-helper"));
     assert!(!script.contains("-p vmux_service -p bevy_cef_debug_render_process --release"));
     assert!(manifest.contains("[profile.cef-helper]\ninherits = \"release\"\nlto = \"off\""));
     assert!(core_manifest.contains("default = [\"browser-process\"]"));
@@ -187,6 +187,23 @@ fn package_builds_cef_helper_separately_without_lto() {
     assert!(helper_manifest.contains("cef = { version = \"148.2.0\", default-features = false }"));
     assert!(!handler.contains("use bevy::"));
     assert!(!handler.contains("use bevy_remote::"));
+}
+
+#[test]
+fn macos_ci_shares_cef_sdk_without_installing_unused_render_process() {
+    let workflow = include_str!("../../../.github/workflows/ci.yml");
+
+    assert!(workflow.contains("VMUX_CEF_SDK_CACHE: ${{ github.workspace }}/.cache/cef-sdk"));
+    assert!(!workflow.contains("- name: Cache CEF SDK"));
+    assert!(!workflow.contains("cargo install bevy_cef_render_process"));
+}
+
+#[test]
+fn cef_debug_loader_requires_debug_feature() {
+    let core_source = include_str!("../../../patches/bevy_cef_core-0.5.2/src/lib.rs");
+    let feature_gate = "#[cfg(all(target_os = \"macos\", feature = \"debug\"))]";
+
+    assert_eq!(core_source.matches(feature_gate).count(), 2);
 }
 
 #[test]
@@ -225,7 +242,8 @@ fn build_git_env_uses_github_style_short_hash() {
 fn local_package_only_builds_app_bundle() {
     let package_script = include_str!("../../../scripts/package.sh");
 
-    assert!(package_script.contains("cargo-with-cef-cache.sh\" packager --release --formats app"));
+    assert!(package_script.contains("packager_args=(packager --release)"));
+    assert!(package_script.contains("packager_args+=(--formats app)"));
     assert!(package_script.contains("if [[ \"$PROFILE\" == \"local\" ]]"));
 }
 

--- a/patches/bevy_cef_core-0.5.2/src/lib.rs
+++ b/patches/bevy_cef_core-0.5.2/src/lib.rs
@@ -2,7 +2,7 @@
 
 #[cfg(feature = "browser-process")]
 mod browser_process;
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "debug"))]
 mod debug;
 
 mod dom_snapshot;
@@ -12,7 +12,7 @@ mod util;
 pub mod prelude {
     #[cfg(feature = "browser-process")]
     pub use crate::browser_process::*;
-    #[cfg(target_os = "macos")]
+    #[cfg(all(target_os = "macos", feature = "debug"))]
     pub use crate::debug::*;
     pub use crate::dom_snapshot::*;
     pub use crate::render_process::app::*;

--- a/scripts/before-each-package.sh
+++ b/scripts/before-each-package.sh
@@ -10,12 +10,13 @@ set -euo pipefail
 #   DMG bundles a release-ready .app.
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT/scripts/cargo-target-paths.sh"
+release_dir="${VMUX_CARGO_RELEASE_DIR:-$(vmux_cargo_profile_dir "$ROOT" release)}"
+app_bundle="${VMUX_APP_BUNDLE:-$release_dir/Vmux.app}"
 
 "$ROOT/scripts/inject-cef.sh"
 
 if [[ "${CARGO_PACKAGER_FORMAT:-}" == "dmg" ]]; then
-    VMUX_APP_BUNDLE="${VMUX_APP_BUNDLE:-$ROOT/target/release/Vmux.app}" \
-        "$ROOT/scripts/embed-launch-agent-plist.sh"
-    APP_BUNDLE="${VMUX_APP_BUNDLE:-$ROOT/target/release/Vmux.app}" \
-        "$ROOT/scripts/sign-and-notarize.sh"
+    VMUX_APP_BUNDLE="$app_bundle" "$ROOT/scripts/embed-launch-agent-plist.sh"
+    APP_BUNDLE="$app_bundle" "$ROOT/scripts/sign-and-notarize.sh"
 fi

--- a/scripts/build-package-binaries.sh
+++ b/scripts/build-package-binaries.sh
@@ -2,10 +2,14 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT/scripts/cargo-target-paths.sh"
+
+release_dir="$(vmux_cargo_profile_dir "$ROOT" release)"
+helper_dir="$(vmux_cargo_profile_dir "$ROOT" cef-helper)"
 
 cd "$ROOT"
 "$ROOT/scripts/cargo-with-cef-cache.sh" build -p vmux_cli --release
 "$ROOT/scripts/cargo-with-cef-cache.sh" build -p vmux_desktop -p vmux_service --release
 "$ROOT/scripts/cargo-with-cef-cache.sh" build -p bevy_cef_debug_render_process --profile cef-helper
-cp -f target/cef-helper/bevy_cef_debug_render_process target/release/bevy_cef_debug_render_process
-cp -f target/release/vmux_service "target/release/Vmux Service"
+cp -f "$helper_dir/bevy_cef_debug_render_process" "$release_dir/bevy_cef_debug_render_process"
+cp -f "$release_dir/vmux_service" "$release_dir/Vmux Service"

--- a/scripts/cargo-target-paths.sh
+++ b/scripts/cargo-target-paths.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+vmux_cargo_target_dir() {
+    local root="$1"
+    local target_dir="${CARGO_TARGET_DIR:-target}"
+
+    if [[ "$target_dir" != /* ]]; then
+        target_dir="$root/$target_dir"
+    fi
+    printf '%s\n' "$target_dir"
+}
+
+vmux_cargo_profile_dir() {
+    local root="$1"
+    local profile="$2"
+    local target_dir
+
+    target_dir="$(vmux_cargo_target_dir "$root")"
+    if [[ -n "${CARGO_BUILD_TARGET:-}" ]]; then
+        target_dir="$target_dir/$CARGO_BUILD_TARGET"
+    fi
+    printf '%s/%s\n' "$target_dir" "$profile"
+}

--- a/scripts/inject-cef.sh
+++ b/scripts/inject-cef.sh
@@ -11,14 +11,16 @@ if [[ "${CARGO_PACKAGER_FORMAT:-}" != "dmg" ]]; then
 fi
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT/scripts/cargo-target-paths.sh"
 export PATH="${HOME}/.cargo/bin:${PATH}"
 # Wrong CEF_PATH breaks cef-dll-sys; default macOS layout is ~/.local/share.
 unset CEF_PATH
 
-APP_BUNDLE="${VMUX_APP_BUNDLE:-${ROOT}/target/release/Vmux.app}"
+RELEASE_DIR="${VMUX_CARGO_RELEASE_DIR:-$(vmux_cargo_profile_dir "$ROOT" release)}"
+APP_BUNDLE="${VMUX_APP_BUNDLE:-$RELEASE_DIR/Vmux.app}"
 BUNDLE_ID_BASE="${VMUX_BUNDLE_ID:-ai.vmux.desktop}"
 CEF_FRAMEWORK="${CEF_FRAMEWORK:-${HOME}/.local/share/Chromium Embedded Framework.framework}"
-HELPER_BIN="${ROOT}/target/release/bevy_cef_debug_render_process"
+HELPER_BIN="${VMUX_CEF_HELPER_BIN:-$RELEASE_DIR/bevy_cef_debug_render_process}"
 
 if [[ ! -d "$APP_BUNDLE" ]]; then
     echo "inject-cef: .app not found at $APP_BUNDLE, skipping"

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PROFILE="${1:-local}"
 export PATH="${HOME}/.cargo/bin:${PATH}"
+source "$ROOT/scripts/cargo-target-paths.sh"
 
 CARGO_TOML="$ROOT/crates/vmux_desktop/Cargo.toml"
 INFO_PLIST="$ROOT/packaging/macos/Info.plist"
@@ -68,23 +69,20 @@ sed -i '' "/<key>CFBundleName<\/key>/{n;s|<string>.*</string>|<string>$PRODUCT_N
 export VMUX_BUNDLE_ID="$BUNDLE_ID"
 export VMUX_BUILD_PROFILE="$PROFILE"
 
-# The app bundle path uses the product name from packager metadata.
-# cargo-packager always outputs to target/release/<product-name>.app
 APP_NAME="$PRODUCT_NAME"
-export VMUX_APP_BUNDLE="$ROOT/target/release/$APP_NAME.app"
+export VMUX_CARGO_RELEASE_DIR="$(vmux_cargo_profile_dir "$ROOT" release)"
+export VMUX_APP_BUNDLE="$VMUX_CARGO_RELEASE_DIR/$APP_NAME.app"
 
 echo "==> Running cargo packager"
 cd "$ROOT"
-if [[ "$PROFILE" == "local" ]]; then
-    # Local skips the dmg pass; `make build-local` ad-hoc-signs the
-    # .app separately via sign-and-notarize.sh + SKIP_NOTARIZE=1.
-    VMUX_BUILD_PROFILE="$PROFILE" "$ROOT/scripts/cargo-with-cef-cache.sh" packager --release --formats app
-else
-    # Release: single invocation builds the .app, then the dmg pass'
-    # before-each hook injects CEF + signs + notarizes before
-    # dmg::package wraps it. Uses formats=["app","dmg"] from Cargo.toml.
-    VMUX_BUILD_PROFILE="$PROFILE" "$ROOT/scripts/cargo-with-cef-cache.sh" packager --release
+packager_args=(packager --release)
+if [[ -n "${CARGO_BUILD_TARGET:-}" ]]; then
+    packager_args+=(--target "$CARGO_BUILD_TARGET")
 fi
+if [[ "$PROFILE" == "local" ]]; then
+    packager_args+=(--formats app)
+fi
+VMUX_BUILD_PROFILE="$PROFILE" "$ROOT/scripts/cargo-with-cef-cache.sh" "${packager_args[@]}"
 
 # inject-cef only meaningfully runs in the dmg-format pass (the .app
 # doesn't exist during the app-format pass). For local app-only builds,

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -156,7 +156,7 @@ fi
 
 echo "==> Creating zip for notarization"
 APP_BASENAME="$(basename "$APP_BUNDLE" .app)"
-NOTARIZE_ZIP="$ROOT/target/release/${APP_BASENAME// /_}-notarize.zip"
+NOTARIZE_ZIP="$(dirname "$APP_BUNDLE")/${APP_BASENAME// /_}-notarize.zip"
 rm -f "$NOTARIZE_ZIP"
 ditto -c -k --keepParent "$APP_BUNDLE" "$NOTARIZE_ZIP"
 ls -lh "$NOTARIZE_ZIP"


### PR DESCRIPTION
## Context

PR #276 isolates the CEF render helper from release Thin LTO, but package builds still repeated CEF SDK setup and assumed Cargo's default output directory. CI also installed an unused render-process binary, while release helpers compiled macOS debug-loader code they never use.

## Implementation

Use one job-local CEF SDK path for both Cargo profiles without persisting PR-writable SDK contents. Resolve package artifacts through a shared Cargo target-path helper, forward configured target triples to cargo-packager, and compile the macOS debug loader only for the debug feature.

## Checks / QA

- Run macOS packaging with custom `CARGO_TARGET_DIR` and `CARGO_BUILD_TARGET` values and confirm the app contains the render helper and Vmux Service.
- Inspect package build output and confirm release and helper profiles use the same CEF SDK path.
- Package a normal release and verify CEF pages launch successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS packaging support for custom Cargo target directories and build targets.
  * Corrected application, helper binary, and notarization artifact paths during packaging.
  * Restricted macOS debug tooling to builds with the debug feature enabled.

* **Tests**
  * Expanded coverage for packaging paths, target triples, release directories, and CI configuration consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->