### PR TITLE
perf(cef): coalesce input and paint pipelines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,6 +962,7 @@ dependencies = [
  "raw-window-handle",
  "serde",
  "serde_json",
+ "smallvec",
  "uuid",
  "winit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ notify = "6"
 dioxus = { version = "=0.7.4", features = ["web"] }
 wasm-bindgen = "0.2"
 regex = "1"
+smallvec = "1"
 
 alacritty_terminal = "0.26"
 portable-pty = "0.9"

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -11,7 +11,7 @@ use bevy::{
     ecs::{message::Messages, relationship::Relationship},
     input::{
         ButtonState, InputSystems,
-        mouse::{MouseButton, MouseButtonInput},
+        mouse::{MouseButton, MouseButtonInput, MouseWheel},
     },
     material::AlphaMode,
     picking::pointer::PointerButton,
@@ -22,10 +22,8 @@ use bevy::{
 };
 use bevy_cef::prelude::*;
 use bevy_cef_core::prelude::{
-    CefEmbeddedHosts, CommandLineConfig, NativeMouseButtons, NativeMouseMovePresenter,
-    RenderTextureMessage, webview_debug_log,
+    CefEmbeddedHosts, CommandLineConfig, RenderTextureMessage, webview_debug_log,
 };
-use std::cell::RefCell;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{LazyLock, Mutex};
 use vmux_command::{
@@ -232,7 +230,12 @@ impl Plugin for BrowserPlugin {
             )
             .add_systems(
                 Last,
-                (refresh_layout_cef_hover, refresh_active_windowed_hover),
+                (
+                    refresh_layout_cef_hover,
+                    refresh_active_windowed_hover,
+                    sync_layout_cef_frame_rate,
+                )
+                    .chain(),
             )
             .init_resource::<HostFocusIntent>()
             .init_resource::<PendingNavSnapshots>()
@@ -320,33 +323,7 @@ struct CefPointerHitRect {
     interactive: bool,
 }
 
-#[derive(Default)]
-struct NativeLayoutPointerState {
-    regions: Vec<CefPointerHitRect>,
-    pointer_inside: bool,
-    position_px: Option<Vec2>,
-}
-
-static NATIVE_LAYOUT_POINTER_STATE: LazyLock<Mutex<NativeLayoutPointerState>> =
-    LazyLock::new(|| Mutex::new(NativeLayoutPointerState::default()));
-
-#[derive(Default)]
-struct NativeLayoutMousePresenterState {
-    scale: f32,
-    presenter: Option<NativeMouseMovePresenter>,
-}
-
-thread_local! {
-    static NATIVE_LAYOUT_MOUSE_PRESENTER: RefCell<NativeLayoutMousePresenterState> =
-        RefCell::new(NativeLayoutMousePresenterState::default());
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct NativeLayoutPointerMoveResult {
-    pub owns_pointer: bool,
-    pub forwarded: bool,
-    pub changed: bool,
-}
+static NATIVE_LAYOUT_POINTER_INSIDE: AtomicBool = AtomicBool::new(false);
 
 fn cef_pointer_hit_rect_contains(rect: CefPointerHitRect, point: Vec2) -> bool {
     if !rect.interactive {
@@ -358,126 +335,8 @@ fn cef_pointer_hit_rect_contains(rect: CefPointerHitRect, point: Vec2) -> bool {
     point.x >= min.x && point.x <= max.x && point.y >= min.y && point.y <= max.y
 }
 
-fn physical_cef_pointer_hit_rect(mut rect: CefPointerHitRect, scale: f32) -> CefPointerHitRect {
-    rect.center *= scale;
-    rect.size *= scale;
-    rect
-}
-
-fn set_native_layout_pointer_regions(regions: impl IntoIterator<Item = CefPointerHitRect>) {
-    let mut state = NATIVE_LAYOUT_POINTER_STATE
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    state.regions.clear();
-    state.regions.extend(regions);
-}
-
-fn clear_native_layout_pointer_regions() {
-    let mut state = NATIVE_LAYOUT_POINTER_STATE
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    state.regions.clear();
-    state.pointer_inside = false;
-    state.position_px = None;
-    NATIVE_LAYOUT_MOUSE_PRESENTER.with_borrow_mut(|state| {
-        state.presenter = None;
-    });
-}
-
-#[cfg(target_os = "macos")]
-fn set_native_layout_mouse_presenter(scale: f32, presenter: Option<NativeMouseMovePresenter>) {
-    NATIVE_LAYOUT_MOUSE_PRESENTER.with_borrow_mut(|state| {
-        state.scale = scale;
-        let same_browser = state
-            .presenter
-            .as_ref()
-            .map(NativeMouseMovePresenter::browser_id)
-            == presenter.as_ref().map(NativeMouseMovePresenter::browser_id);
-        if !same_browser {
-            state.presenter = presenter;
-        }
-    });
-}
-
-#[cfg(target_os = "macos")]
-fn native_layout_mouse_presenter_active() -> bool {
-    NATIVE_LAYOUT_MOUSE_PRESENTER.with_borrow(|state| state.presenter.is_some())
-}
-
-fn layout_pointer_move_should_wake(was_inside: bool, inside: bool) -> bool {
-    was_inside || inside
-}
-
-/// Returns whether native pointer motion needs a layout hover update.
-pub fn native_layout_pointer_move_should_wake(x_px: f32, y_px: f32) -> bool {
-    if !x_px.is_finite() || !y_px.is_finite() {
-        return false;
-    }
-    let mut state = NATIVE_LAYOUT_POINTER_STATE
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let inside = state
-        .regions
-        .iter()
-        .copied()
-        .any(|rect| cef_pointer_hit_rect_contains(rect, Vec2::new(x_px, y_px)));
-    let should_wake = layout_pointer_move_should_wake(state.pointer_inside, inside);
-    state.pointer_inside = inside;
-    should_wake
-}
-
-pub fn forward_native_layout_pointer_move(
-    x_px: f32,
-    y_px: f32,
-    buttons: NativeMouseButtons,
-) -> NativeLayoutPointerMoveResult {
-    if !x_px.is_finite() || !y_px.is_finite() {
-        return NativeLayoutPointerMoveResult::default();
-    }
-    let (was_inside, inside) = {
-        let mut state = NATIVE_LAYOUT_POINTER_STATE
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let inside = state
-            .regions
-            .iter()
-            .copied()
-            .any(|rect| cef_pointer_hit_rect_contains(rect, Vec2::new(x_px, y_px)));
-        let was_inside = state.pointer_inside;
-        state.pointer_inside = inside;
-        state.position_px = Some(Vec2::new(x_px, y_px));
-        (was_inside, inside)
-    };
-    let owns_pointer = was_inside || inside;
-    let forwarded = NATIVE_LAYOUT_MOUSE_PRESENTER.with_borrow(|state| {
-        let Some(presenter) = state.presenter.as_ref() else {
-            return false;
-        };
-        if !owns_pointer || !state.scale.is_finite() || state.scale <= 0.0 {
-            return false;
-        }
-        presenter.send(Vec2::new(x_px, y_px) / state.scale, buttons, !inside);
-        true
-    });
-    NativeLayoutPointerMoveResult {
-        owns_pointer,
-        forwarded,
-        changed: was_inside != inside,
-    }
-}
-
 pub fn native_layout_pointer_is_inside() -> bool {
-    NATIVE_LAYOUT_POINTER_STATE
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .pointer_inside
-}
-
-pub fn native_layout_pointer_position_px() -> Option<Vec2> {
-    NATIVE_LAYOUT_POINTER_STATE
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .position_px
+    NATIVE_LAYOUT_POINTER_INSIDE.load(Ordering::Relaxed)
 }
 
 fn cef_pointer_hit_rect(
@@ -526,12 +385,23 @@ fn sync_layout_cef_pointer_target(
     mut commands: Commands,
 ) {
     let Ok((layout, has_target)) = layout_q.single() else {
+        NATIVE_LAYOUT_POINTER_INSIDE.store(false, Ordering::Relaxed);
         return;
     };
     #[cfg(target_os = "macos")]
     let should_target = {
-        let _ = (&windows, &cef_regions);
-        modal_pointer_targets.is_empty() && native_layout_pointer_is_inside()
+        let inside = windows
+            .single()
+            .ok()
+            .and_then(|window| {
+                let scale = window.resolution.scale_factor();
+                (scale.is_finite() && scale > 0.0).then_some(scale)
+            })
+            .and_then(|scale| {
+                vmux_layout::native_pointer::snapshot().map(|pointer| pointer.position_px / scale)
+            })
+            .is_some_and(|position| cef_pointer_regions_contains(position, &cef_regions));
+        modal_pointer_targets.is_empty() && inside
     };
     #[cfg(not(target_os = "macos"))]
     let should_target = modal_pointer_targets.is_empty()
@@ -540,6 +410,7 @@ fn sync_layout_cef_pointer_target(
             .ok()
             .and_then(Window::cursor_position)
             .is_some_and(|pos| cef_pointer_regions_contains(pos, &cef_regions));
+    NATIVE_LAYOUT_POINTER_INSIDE.store(should_target, Ordering::Relaxed);
     if should_target && !has_target {
         commands.entity(layout).insert(CefPointerTarget);
     } else if !should_target && has_target {
@@ -612,8 +483,10 @@ fn forward_layout_cef_mouse_button(
             continue;
         };
         #[cfg(target_os = "macos")]
-        let position = native_layout_pointer_position_px()
-            .map(|position| position / window.resolution.scale_factor())
+        let native_pointer = vmux_layout::native_pointer::snapshot();
+        #[cfg(target_os = "macos")]
+        let position = native_pointer
+            .map(|pointer| pointer.position_px / window.resolution.scale_factor())
             .or_else(|| window.cursor_position());
         #[cfg(not(target_os = "macos"))]
         let position = window.cursor_position();
@@ -625,6 +498,10 @@ fn forward_layout_cef_mouse_button(
             *captured = true;
         }
         if inside || *captured {
+            #[cfg(target_os = "macos")]
+            if let Some(pointer) = native_pointer {
+                browsers.send_native_mouse_move(&layout, pointer.buttons, position, !inside);
+            }
             browsers.send_mouse_click(
                 &layout,
                 position,
@@ -1668,6 +1545,7 @@ fn windowed_hover_refresh_position(
 
 #[derive(Default)]
 struct LayoutHoverRefreshState {
+    sequence: u64,
     position: Option<Vec2>,
     in_region: bool,
 }
@@ -1678,7 +1556,19 @@ fn reset_layout_cef_hover(
     layout: Entity,
     state: &mut LayoutHoverRefreshState,
 ) {
+    #[cfg(target_os = "macos")]
+    let _ = buttons;
     if state.in_region {
+        #[cfg(target_os = "macos")]
+        if let Some(pointer) = vmux_layout::native_pointer::snapshot() {
+            browsers.send_native_mouse_move(
+                &layout,
+                pointer.buttons,
+                state.position.unwrap_or_default(),
+                true,
+            );
+        }
+        #[cfg(not(target_os = "macos"))]
         browsers.send_mouse_move(
             &layout,
             buttons.get_pressed(),
@@ -1701,69 +1591,78 @@ fn refresh_layout_cef_hover(
     mut state: Local<LayoutHoverRefreshState>,
 ) {
     let Ok(layout) = layout_q.single() else {
-        clear_native_layout_pointer_regions();
+        NATIVE_LAYOUT_POINTER_INSIDE.store(false, Ordering::Relaxed);
         *state = LayoutHoverRefreshState::default();
         return;
     };
     if suppress.0 || !modal_pointer_targets.is_empty() {
-        clear_native_layout_pointer_regions();
+        NATIVE_LAYOUT_POINTER_INSIDE.store(false, Ordering::Relaxed);
         reset_layout_cef_hover(&browsers, &buttons, layout, &mut state);
         return;
     }
     let Some(window_entity) = primary_window.single().ok() else {
-        clear_native_layout_pointer_regions();
+        NATIVE_LAYOUT_POINTER_INSIDE.store(false, Ordering::Relaxed);
         reset_layout_cef_hover(&browsers, &buttons, layout, &mut state);
         return;
     };
     let Ok(window) = windows.get(window_entity) else {
-        clear_native_layout_pointer_regions();
+        NATIVE_LAYOUT_POINTER_INSIDE.store(false, Ordering::Relaxed);
         reset_layout_cef_hover(&browsers, &buttons, layout, &mut state);
         return;
     };
     let scale = window.resolution.scale_factor();
     if !scale.is_finite() || scale <= 0.0 {
-        clear_native_layout_pointer_regions();
+        NATIVE_LAYOUT_POINTER_INSIDE.store(false, Ordering::Relaxed);
         reset_layout_cef_hover(&browsers, &buttons, layout, &mut state);
         return;
     }
-    set_native_layout_pointer_regions(
-        cef_regions
-            .iter()
-            .map(
-                |(header, side_sheet, node, computed, transform, visibility, open)| {
-                    cef_pointer_hit_rect(
-                        header, side_sheet, node, computed, transform, visibility, open,
-                    )
-                },
-            )
-            .filter(|rect| rect.interactive)
-            .map(|rect| physical_cef_pointer_hit_rect(rect, scale)),
-    );
     #[cfg(target_os = "macos")]
-    {
-        set_native_layout_mouse_presenter(scale, browsers.native_mouse_move_presenter(&layout));
-        if native_layout_mouse_presenter_active() {
-            *state = LayoutHoverRefreshState::default();
-            return;
-        }
-    }
+    let Some(pointer) = vmux_layout::native_pointer::snapshot() else {
+        NATIVE_LAYOUT_POINTER_INSIDE.store(false, Ordering::Relaxed);
+        reset_layout_cef_hover(&browsers, &buttons, layout, &mut state);
+        return;
+    };
+    #[cfg(target_os = "macos")]
+    let cursor_px = pointer.position_px;
+    #[cfg(not(target_os = "macos"))]
     let Some(cursor_px) = vmux_layout::pane::pane_hover_cursor_position(window_entity, window)
     else {
         reset_layout_cef_hover(&browsers, &buttons, layout, &mut state);
         return;
     };
+    #[cfg(target_os = "macos")]
+    let sequence = pointer.sequence;
+    #[cfg(not(target_os = "macos"))]
+    let sequence = 0;
     let position = cursor_px / scale;
     let in_region = cef_pointer_regions_contains(position, &cef_regions);
-    if state.position == Some(position) && state.in_region == in_region {
+    NATIVE_LAYOUT_POINTER_INSIDE.store(in_region, Ordering::Relaxed);
+    if state.sequence == sequence
+        && state.position == Some(position)
+        && state.in_region == in_region
+    {
         return;
     }
     if in_region {
+        #[cfg(target_os = "macos")]
+        browsers.send_native_mouse_move(&layout, pointer.buttons, position, false);
+        #[cfg(not(target_os = "macos"))]
         browsers.send_mouse_move(&layout, buttons.get_pressed(), position, false);
     } else if state.in_region {
+        #[cfg(target_os = "macos")]
+        browsers.send_native_mouse_move(&layout, pointer.buttons, position, true);
+        #[cfg(not(target_os = "macos"))]
         browsers.send_mouse_move(&layout, buttons.get_pressed(), position, true);
     }
+    state.sequence = sequence;
     state.position = Some(position);
     state.in_region = in_region;
+}
+
+#[derive(Default)]
+struct WindowedHoverRefreshState {
+    entity: Option<Entity>,
+    position: Option<Vec2>,
 }
 
 fn refresh_active_windowed_hover(
@@ -1790,39 +1689,126 @@ fn refresh_active_windowed_hover(
             Without<SideSheet>,
         ),
     >,
+    mut state: Local<WindowedHoverRefreshState>,
 ) {
     if vmux_layout::command_bar::handler::is_command_bar_open(&modal_q) {
+        *state = WindowedHoverRefreshState::default();
         return;
     }
     if native_left_mouse_down() {
+        *state = WindowedHoverRefreshState::default();
         return;
     }
     let Some((entity, transform, computed, ui_gt, host_window)) = active_q.iter().next() else {
+        *state = WindowedHoverRefreshState::default();
         return;
     };
     if transform.scale.x <= 1.0e-3 {
+        *state = WindowedHoverRefreshState::default();
         return;
     }
     let Some(window_entity) = host_window
         .map(|host| host.0)
         .or_else(|| primary_window.single().ok())
     else {
+        *state = WindowedHoverRefreshState::default();
         return;
     };
     let Ok(window) = windows.get(window_entity) else {
+        *state = WindowedHoverRefreshState::default();
         return;
     };
     let Some(cursor_px) = vmux_layout::pane::pane_hover_cursor_position(window_entity, window)
     else {
+        *state = WindowedHoverRefreshState::default();
         return;
     };
     let Some(frame) = windowed_hover_refresh_frame(computed, ui_gt) else {
+        *state = WindowedHoverRefreshState::default();
         return;
     };
     let Some(position) = windowed_hover_refresh_position(cursor_px, frame) else {
+        *state = WindowedHoverRefreshState::default();
         return;
     };
+    if state.entity == Some(entity) && state.position == Some(position) {
+        return;
+    }
     browsers.send_mouse_move(&entity, buttons.get_pressed(), position, false);
+    state.entity = Some(entity);
+    state.position = Some(position);
+}
+
+const LAYOUT_IDLE_FRAME_RATE: i32 = 10;
+const LAYOUT_HOVER_FRAME_RATE: i32 = 30;
+const LAYOUT_ACTIVE_FRAME_RATE: i32 = 60;
+const LAYOUT_INPUT_BURST: std::time::Duration = std::time::Duration::from_millis(250);
+
+#[derive(Default)]
+struct LayoutFrameRateState {
+    native_sequence: u64,
+    last_input: Option<std::time::Instant>,
+    dragging_layout: bool,
+}
+
+fn layout_frame_rate(
+    now: std::time::Instant,
+    last_input: Option<std::time::Instant>,
+    hovered: bool,
+    dragging: bool,
+) -> i32 {
+    if dragging
+        || last_input.is_some_and(|last| now.saturating_duration_since(last) < LAYOUT_INPUT_BURST)
+    {
+        LAYOUT_ACTIVE_FRAME_RATE
+    } else if hovered {
+        LAYOUT_HOVER_FRAME_RATE
+    } else {
+        LAYOUT_IDLE_FRAME_RATE
+    }
+}
+
+fn sync_layout_cef_frame_rate(
+    mut cursor_events: MessageReader<CursorMoved>,
+    mut button_events: MessageReader<MouseButtonInput>,
+    mut wheel_events: MessageReader<MouseWheel>,
+    buttons: Res<ButtonInput<MouseButton>>,
+    mut layout_q: Query<&mut WebviewMaxFrameRate, With<LayoutCef>>,
+    mut state: Local<LayoutFrameRateState>,
+) {
+    let inside = native_layout_pointer_is_inside();
+    let pointer = vmux_layout::native_pointer::snapshot();
+    let native_changed = pointer.is_some_and(|pointer| {
+        if pointer.sequence == state.native_sequence {
+            return false;
+        }
+        state.native_sequence = pointer.sequence;
+        true
+    });
+    let pointer_moved = native_changed || cursor_events.read().count() > 0;
+    let button_changed = button_events.read().count() > 0;
+    let wheel_changed = wheel_events.read().count() > 0;
+    let input_changed = pointer_moved || button_changed || wheel_changed;
+    let now = std::time::Instant::now();
+    if (inside || state.dragging_layout) && (button_changed || wheel_changed) {
+        state.last_input = Some(now);
+    }
+    let native_dragging = pointer.is_some_and(|pointer| {
+        pointer.buttons.left || pointer.buttons.right || pointer.buttons.middle
+    });
+    let any_pressed = native_dragging || buttons.get_pressed().next().is_some();
+    if !any_pressed {
+        state.dragging_layout = false;
+    } else if inside && input_changed {
+        state.dragging_layout = true;
+    }
+    let desired = layout_frame_rate(now, state.last_input, inside, state.dragging_layout);
+    let Ok(mut cap) = layout_q.single_mut() else {
+        return;
+    };
+    if cap.0 != desired {
+        cap.0 = desired;
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -2570,7 +2556,7 @@ fn flush_pending_osr_textures(
     mut ew: MessageWriter<RenderTextureMessage>,
     browsers: NonSend<Browsers>,
 ) {
-    while let Ok(texture) = browsers.try_receive_texture() {
+    for texture in browsers.drain_render_textures() {
         ew.write(texture);
     }
 }
@@ -5591,6 +5577,7 @@ mod tests {
         assert!(refresh_fn.contains("With<WebviewWindowed>"));
         assert!(refresh_fn.contains("vmux_layout::pane::pane_hover_cursor_position"));
         assert!(refresh_fn.contains("browsers.send_mouse_move"));
+        assert!(refresh_fn.contains("state.position == Some(position)"));
     }
 
     #[test]
@@ -5602,13 +5589,10 @@ mod tests {
             .and_then(|tail| tail.split("fn refresh_active_windowed_hover").next())
             .unwrap_or_default();
 
-        assert!(refresh_fn.contains("pane_hover_cursor_position"));
+        assert!(refresh_fn.contains("vmux_layout::native_pointer::snapshot()"));
         assert!(refresh_fn.contains("cef_pointer_regions_contains"));
         assert!(refresh_fn.contains("window.resolution.scale_factor()"));
-        assert!(refresh_fn.contains("set_native_layout_pointer_regions"));
-        assert!(refresh_fn.contains("browsers.native_mouse_move_presenter"));
-        assert!(refresh_fn.contains("native_layout_mouse_presenter_active"));
-        assert!(refresh_fn.contains("browsers.send_mouse_move"));
+        assert!(refresh_fn.contains("browsers.send_native_mouse_move"));
         assert!(refresh_fn.matches("reset_layout_cef_hover").count() >= 5);
     }
 
@@ -5642,31 +5626,41 @@ mod tests {
             .and_then(|tail| tail.split("fn forward_layout_cef_cursor_move").next())
             .unwrap_or_default();
 
-        assert!(click_forward.contains("native_layout_pointer_position_px"));
-        assert!(target_sync.contains("native_layout_pointer_is_inside"));
+        assert!(click_forward.contains("vmux_layout::native_pointer::snapshot()"));
+        assert!(target_sync.contains("vmux_layout::native_pointer::snapshot()"));
     }
 
     #[test]
-    fn native_layout_pointer_regions_use_physical_coordinates() {
-        let rect = physical_cef_pointer_hit_rect(
-            CefPointerHitRect {
-                center: Vec2::new(50.0, 25.0),
-                size: Vec2::new(20.0, 10.0),
-                interactive: true,
-            },
-            2.0,
+    fn layout_pointer_regions_match_layout_coordinates() {
+        let rect = CefPointerHitRect {
+            center: Vec2::new(50.0, 25.0),
+            size: Vec2::new(20.0, 10.0),
+            interactive: true,
+        };
+
+        assert!(cef_pointer_hit_rect_contains(rect, Vec2::new(50.0, 25.0)));
+        assert!(!cef_pointer_hit_rect_contains(rect, Vec2::new(39.0, 25.0)));
+    }
+
+    #[test]
+    fn layout_frame_rate_bursts_after_input() {
+        let now = std::time::Instant::now();
+        assert_eq!(
+            layout_frame_rate(now, None, false, false),
+            LAYOUT_IDLE_FRAME_RATE
         );
-
-        assert!(cef_pointer_hit_rect_contains(rect, Vec2::new(100.0, 50.0)));
-        assert!(!cef_pointer_hit_rect_contains(rect, Vec2::new(79.0, 50.0)));
-    }
-
-    #[test]
-    fn native_layout_pointer_wakes_inside_and_once_on_exit() {
-        assert!(!layout_pointer_move_should_wake(false, false));
-        assert!(layout_pointer_move_should_wake(false, true));
-        assert!(layout_pointer_move_should_wake(true, true));
-        assert!(layout_pointer_move_should_wake(true, false));
+        assert_eq!(
+            layout_frame_rate(now, None, true, false),
+            LAYOUT_HOVER_FRAME_RATE
+        );
+        assert_eq!(
+            layout_frame_rate(now, Some(now), false, false),
+            LAYOUT_ACTIVE_FRAME_RATE
+        );
+        assert_eq!(
+            layout_frame_rate(now, None, true, true),
+            LAYOUT_ACTIVE_FRAME_RATE
+        );
     }
 
     #[test]

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -1640,15 +1640,12 @@ fn refresh_layout_cef_hover(
     let unchanged = state.sequence == sequence
         && state.position == Some(position)
         && state.in_region == in_region;
-    #[cfg(not(target_os = "macos"))]
     if unchanged {
         return;
     }
-    #[cfg(target_os = "macos")]
-    let _ = unchanged;
     if in_region {
         #[cfg(target_os = "macos")]
-        browsers.send_native_mouse_move_force(&layout, pointer.buttons, position, false);
+        browsers.send_native_mouse_move(&layout, pointer.buttons, position, false);
         #[cfg(not(target_os = "macos"))]
         browsers.send_mouse_move(&layout, buttons.get_pressed(), position, false);
     } else if state.in_region {
@@ -5595,7 +5592,7 @@ mod tests {
         assert!(refresh_fn.contains("vmux_layout::native_pointer::snapshot()"));
         assert!(refresh_fn.contains("cef_pointer_regions_contains"));
         assert!(refresh_fn.contains("window.resolution.scale_factor()"));
-        assert!(refresh_fn.contains("browsers.send_native_mouse_move_force"));
+        assert!(refresh_fn.contains("browsers.send_native_mouse_move"));
         assert!(refresh_fn.matches("reset_layout_cef_hover").count() >= 5);
     }
 

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -1637,15 +1637,18 @@ fn refresh_layout_cef_hover(
     let position = cursor_px / scale;
     let in_region = cef_pointer_regions_contains(position, &cef_regions);
     NATIVE_LAYOUT_POINTER_INSIDE.store(in_region, Ordering::Relaxed);
-    if state.sequence == sequence
+    let unchanged = state.sequence == sequence
         && state.position == Some(position)
-        && state.in_region == in_region
-    {
+        && state.in_region == in_region;
+    #[cfg(not(target_os = "macos"))]
+    if unchanged {
         return;
     }
+    #[cfg(target_os = "macos")]
+    let _ = unchanged;
     if in_region {
         #[cfg(target_os = "macos")]
-        browsers.send_native_mouse_move(&layout, pointer.buttons, position, false);
+        browsers.send_native_mouse_move_force(&layout, pointer.buttons, position, false);
         #[cfg(not(target_os = "macos"))]
         browsers.send_mouse_move(&layout, buttons.get_pressed(), position, false);
     } else if state.in_region {
@@ -1740,7 +1743,7 @@ fn refresh_active_windowed_hover(
 }
 
 const LAYOUT_IDLE_FRAME_RATE: i32 = 10;
-const LAYOUT_HOVER_FRAME_RATE: i32 = 60;
+const LAYOUT_HOVER_FRAME_RATE: i32 = 30;
 const LAYOUT_ACTIVE_FRAME_RATE: i32 = 60;
 const LAYOUT_INPUT_BURST: std::time::Duration = std::time::Duration::from_millis(250);
 
@@ -5592,7 +5595,7 @@ mod tests {
         assert!(refresh_fn.contains("vmux_layout::native_pointer::snapshot()"));
         assert!(refresh_fn.contains("cef_pointer_regions_contains"));
         assert!(refresh_fn.contains("window.resolution.scale_factor()"));
-        assert!(refresh_fn.contains("browsers.send_native_mouse_move"));
+        assert!(refresh_fn.contains("browsers.send_native_mouse_move_force"));
         assert!(refresh_fn.matches("reset_layout_cef_hover").count() >= 5);
     }
 

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -1740,7 +1740,7 @@ fn refresh_active_windowed_hover(
 }
 
 const LAYOUT_IDLE_FRAME_RATE: i32 = 10;
-const LAYOUT_HOVER_FRAME_RATE: i32 = 30;
+const LAYOUT_HOVER_FRAME_RATE: i32 = 60;
 const LAYOUT_ACTIVE_FRAME_RATE: i32 = 60;
 const LAYOUT_INPUT_BURST: std::time::Duration = std::time::Duration::from_millis(250);
 

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -24,6 +24,10 @@ use bevy_cef::prelude::*;
 use bevy_cef_core::prelude::{
     CefEmbeddedHosts, CommandLineConfig, RenderTextureMessage, webview_debug_log,
 };
+#[cfg(target_os = "macos")]
+use bevy_cef_core::prelude::{NativeMouseButtons, NativeMouseMovePresenter};
+#[cfg(target_os = "macos")]
+use std::cell::RefCell;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{LazyLock, Mutex};
 use vmux_command::{
@@ -323,7 +327,42 @@ struct CefPointerHitRect {
     interactive: bool,
 }
 
+#[cfg(target_os = "macos")]
+#[derive(Default)]
+struct NativeLayoutPointerState {
+    regions: Vec<CefPointerHitRect>,
+    pointer_inside: bool,
+    position_px: Option<Vec2>,
+    buttons: NativeMouseButtons,
+    pending: bool,
+}
+
+#[cfg(target_os = "macos")]
+static NATIVE_LAYOUT_POINTER_STATE: LazyLock<Mutex<NativeLayoutPointerState>> =
+    LazyLock::new(|| Mutex::new(NativeLayoutPointerState::default()));
 static NATIVE_LAYOUT_POINTER_INSIDE: AtomicBool = AtomicBool::new(false);
+
+#[cfg(target_os = "macos")]
+#[derive(Default)]
+struct NativeLayoutMousePresenterState {
+    scale: f32,
+    presenter: Option<NativeMouseMovePresenter>,
+}
+
+#[cfg(target_os = "macos")]
+thread_local! {
+    static NATIVE_LAYOUT_MOUSE_PRESENTER: RefCell<NativeLayoutMousePresenterState> =
+        RefCell::new(NativeLayoutMousePresenterState::default());
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct NativeLayoutPointerMoveResult {
+    pub owns_pointer: bool,
+    pub presenter_active: bool,
+    pub region_changed: bool,
+    pub pending: bool,
+}
 
 fn cef_pointer_hit_rect_contains(rect: CefPointerHitRect, point: Vec2) -> bool {
     if !rect.interactive {
@@ -333,6 +372,147 @@ fn cef_pointer_hit_rect_contains(rect: CefPointerHitRect, point: Vec2) -> bool {
     let min = rect.center - half;
     let max = rect.center + half;
     point.x >= min.x && point.x <= max.x && point.y >= min.y && point.y <= max.y
+}
+
+#[cfg(target_os = "macos")]
+fn physical_cef_pointer_hit_rect(mut rect: CefPointerHitRect, scale: f32) -> CefPointerHitRect {
+    rect.center *= scale;
+    rect.size *= scale;
+    rect
+}
+
+#[cfg(target_os = "macos")]
+fn set_native_layout_pointer_regions(regions: impl IntoIterator<Item = CefPointerHitRect>) {
+    let mut state = NATIVE_LAYOUT_POINTER_STATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    state.regions.clear();
+    state.regions.extend(regions);
+}
+
+#[cfg(target_os = "macos")]
+fn set_native_layout_mouse_presenter(scale: f32, presenter: Option<NativeMouseMovePresenter>) {
+    NATIVE_LAYOUT_MOUSE_PRESENTER.with_borrow_mut(|state| {
+        state.scale = scale;
+        let same_browser = state
+            .presenter
+            .as_ref()
+            .map(NativeMouseMovePresenter::browser_id)
+            == presenter.as_ref().map(NativeMouseMovePresenter::browser_id);
+        if !same_browser {
+            state.presenter = presenter;
+        }
+    });
+}
+
+#[cfg(target_os = "macos")]
+fn native_layout_mouse_presenter_active() -> bool {
+    NATIVE_LAYOUT_MOUSE_PRESENTER.with_borrow(|state| state.presenter.is_some())
+}
+
+#[cfg(target_os = "macos")]
+fn clear_native_layout_pointer_state() {
+    let should_flush = {
+        let mut state = NATIVE_LAYOUT_POINTER_STATE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.regions.clear();
+        let should_flush = state.pointer_inside && state.position_px.is_some();
+        state.pointer_inside = false;
+        state.pending |= should_flush;
+        should_flush
+    };
+    NATIVE_LAYOUT_POINTER_INSIDE.store(false, Ordering::Relaxed);
+    if should_flush {
+        flush_native_layout_pointer_move();
+    }
+    set_native_layout_mouse_presenter(1.0, None);
+}
+
+#[cfg(target_os = "macos")]
+fn queue_native_layout_pointer_sample(
+    state: &mut NativeLayoutPointerState,
+    position: Vec2,
+    buttons: NativeMouseButtons,
+) -> NativeLayoutPointerMoveResult {
+    let inside = state
+        .regions
+        .iter()
+        .copied()
+        .any(|rect| cef_pointer_hit_rect_contains(rect, position));
+    let was_inside = state.pointer_inside;
+    let sample_changed =
+        state.position_px != Some(position) || state.buttons != buttons || was_inside != inside;
+    state.pointer_inside = inside;
+    state.position_px = Some(position);
+    state.buttons = buttons;
+    if (was_inside || inside) && sample_changed {
+        state.pending = true;
+    }
+    NativeLayoutPointerMoveResult {
+        owns_pointer: was_inside || inside,
+        presenter_active: false,
+        region_changed: was_inside != inside,
+        pending: state.pending,
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub fn queue_native_layout_pointer_move(
+    x_px: f32,
+    y_px: f32,
+    buttons: NativeMouseButtons,
+) -> NativeLayoutPointerMoveResult {
+    if !x_px.is_finite() || !y_px.is_finite() {
+        return NativeLayoutPointerMoveResult::default();
+    }
+    let (mut result, inside) = {
+        let mut state = NATIVE_LAYOUT_POINTER_STATE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let position = Vec2::new(x_px, y_px);
+        let result = queue_native_layout_pointer_sample(&mut state, position, buttons);
+        (result, state.pointer_inside)
+    };
+    NATIVE_LAYOUT_POINTER_INSIDE.store(inside, Ordering::Relaxed);
+    result.presenter_active = native_layout_mouse_presenter_active();
+    result
+}
+
+#[cfg(target_os = "macos")]
+pub fn flush_native_layout_pointer_move() -> bool {
+    let Some((position_px, buttons, inside)) = ({
+        let mut state = NATIVE_LAYOUT_POINTER_STATE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !state.pending {
+            None
+        } else {
+            state.pending = false;
+            state
+                .position_px
+                .map(|position| (position, state.buttons, state.pointer_inside))
+        }
+    }) else {
+        return false;
+    };
+    let forwarded = NATIVE_LAYOUT_MOUSE_PRESENTER.with_borrow(|state| {
+        let Some(presenter) = state.presenter.as_ref() else {
+            return false;
+        };
+        if !state.scale.is_finite() || state.scale <= 0.0 {
+            return false;
+        }
+        presenter.send(position_px / state.scale, buttons, !inside);
+        true
+    });
+    if !forwarded {
+        NATIVE_LAYOUT_POINTER_STATE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .pending = true;
+    }
+    forwarded
 }
 
 pub fn native_layout_pointer_is_inside() -> bool {
@@ -1545,8 +1725,11 @@ fn windowed_hover_refresh_position(
 
 #[derive(Default)]
 struct LayoutHoverRefreshState {
+    #[cfg(not(target_os = "macos"))]
     sequence: u64,
+    #[cfg(not(target_os = "macos"))]
     position: Option<Vec2>,
+    #[cfg(not(target_os = "macos"))]
     in_region: bool,
 }
 
@@ -1557,26 +1740,23 @@ fn reset_layout_cef_hover(
     state: &mut LayoutHoverRefreshState,
 ) {
     #[cfg(target_os = "macos")]
-    let _ = buttons;
-    if state.in_region {
-        #[cfg(target_os = "macos")]
-        if let Some(pointer) = vmux_layout::native_pointer::snapshot() {
-            browsers.send_native_mouse_move(
+    {
+        let _ = (browsers, buttons, layout);
+        clear_native_layout_pointer_state();
+        *state = LayoutHoverRefreshState::default();
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        if state.in_region {
+            browsers.send_mouse_move(
                 &layout,
-                pointer.buttons,
+                buttons.get_pressed(),
                 state.position.unwrap_or_default(),
                 true,
             );
         }
-        #[cfg(not(target_os = "macos"))]
-        browsers.send_mouse_move(
-            &layout,
-            buttons.get_pressed(),
-            state.position.unwrap_or_default(),
-            true,
-        );
+        *state = LayoutHoverRefreshState::default();
     }
-    *state = LayoutHoverRefreshState::default();
 }
 
 fn refresh_layout_cef_hover(
@@ -1591,6 +1771,9 @@ fn refresh_layout_cef_hover(
     mut state: Local<LayoutHoverRefreshState>,
 ) {
     let Ok(layout) = layout_q.single() else {
+        #[cfg(target_os = "macos")]
+        clear_native_layout_pointer_state();
+        #[cfg(not(target_os = "macos"))]
         NATIVE_LAYOUT_POINTER_INSIDE.store(false, Ordering::Relaxed);
         *state = LayoutHoverRefreshState::default();
         return;
@@ -1617,46 +1800,59 @@ fn refresh_layout_cef_hover(
         return;
     }
     #[cfg(target_os = "macos")]
-    let Some(pointer) = vmux_layout::native_pointer::snapshot() else {
-        NATIVE_LAYOUT_POINTER_INSIDE.store(false, Ordering::Relaxed);
-        reset_layout_cef_hover(&browsers, &buttons, layout, &mut state);
-        return;
-    };
-    #[cfg(target_os = "macos")]
-    let cursor_px = pointer.position_px;
-    #[cfg(not(target_os = "macos"))]
-    let Some(cursor_px) = vmux_layout::pane::pane_hover_cursor_position(window_entity, window)
-    else {
-        reset_layout_cef_hover(&browsers, &buttons, layout, &mut state);
-        return;
-    };
-    #[cfg(target_os = "macos")]
-    let sequence = pointer.sequence;
-    #[cfg(not(target_os = "macos"))]
-    let sequence = 0;
-    let position = cursor_px / scale;
-    let in_region = cef_pointer_regions_contains(position, &cef_regions);
-    NATIVE_LAYOUT_POINTER_INSIDE.store(in_region, Ordering::Relaxed);
-    let unchanged = state.sequence == sequence
-        && state.position == Some(position)
-        && state.in_region == in_region;
-    if unchanged {
-        return;
+    {
+        set_native_layout_pointer_regions(
+            cef_regions
+                .iter()
+                .map(
+                    |(header, side_sheet, node, computed, transform, visibility, open)| {
+                        cef_pointer_hit_rect(
+                            header, side_sheet, node, computed, transform, visibility, open,
+                        )
+                    },
+                )
+                .filter(|rect| rect.interactive)
+                .map(|rect| physical_cef_pointer_hit_rect(rect, scale)),
+        );
+        set_native_layout_mouse_presenter(scale, browsers.native_mouse_move_presenter(&layout));
+        if let Some(pointer) = vmux_layout::native_pointer::snapshot() {
+            let result = queue_native_layout_pointer_move(
+                pointer.position_px.x,
+                pointer.position_px.y,
+                pointer.buttons,
+            );
+            if result.owns_pointer {
+                flush_native_layout_pointer_move();
+            }
+        }
+        *state = LayoutHoverRefreshState::default();
     }
-    if in_region {
-        #[cfg(target_os = "macos")]
-        browsers.send_native_mouse_move(&layout, pointer.buttons, position, false);
-        #[cfg(not(target_os = "macos"))]
-        browsers.send_mouse_move(&layout, buttons.get_pressed(), position, false);
-    } else if state.in_region {
-        #[cfg(target_os = "macos")]
-        browsers.send_native_mouse_move(&layout, pointer.buttons, position, true);
-        #[cfg(not(target_os = "macos"))]
-        browsers.send_mouse_move(&layout, buttons.get_pressed(), position, true);
+    #[cfg(not(target_os = "macos"))]
+    {
+        let Some(cursor_px) = vmux_layout::pane::pane_hover_cursor_position(window_entity, window)
+        else {
+            reset_layout_cef_hover(&browsers, &buttons, layout, &mut state);
+            return;
+        };
+        let sequence = 0;
+        let position = cursor_px / scale;
+        let in_region = cef_pointer_regions_contains(position, &cef_regions);
+        NATIVE_LAYOUT_POINTER_INSIDE.store(in_region, Ordering::Relaxed);
+        let unchanged = state.sequence == sequence
+            && state.position == Some(position)
+            && state.in_region == in_region;
+        if unchanged {
+            return;
+        }
+        if in_region {
+            browsers.send_mouse_move(&layout, buttons.get_pressed(), position, false);
+        } else if state.in_region {
+            browsers.send_mouse_move(&layout, buttons.get_pressed(), position, true);
+        }
+        state.sequence = sequence;
+        state.position = Some(position);
+        state.in_region = in_region;
     }
-    state.sequence = sequence;
-    state.position = Some(position);
-    state.in_region = in_region;
 }
 
 #[derive(Default)]
@@ -5590,10 +5786,72 @@ mod tests {
             .unwrap_or_default();
 
         assert!(refresh_fn.contains("vmux_layout::native_pointer::snapshot()"));
-        assert!(refresh_fn.contains("cef_pointer_regions_contains"));
+        assert!(refresh_fn.contains("set_native_layout_pointer_regions"));
+        assert!(refresh_fn.contains("physical_cef_pointer_hit_rect"));
+        assert!(refresh_fn.contains("browsers.native_mouse_move_presenter"));
+        assert!(refresh_fn.contains("queue_native_layout_pointer_move"));
+        assert!(refresh_fn.contains("flush_native_layout_pointer_move"));
         assert!(refresh_fn.contains("window.resolution.scale_factor()"));
-        assert!(refresh_fn.contains("browsers.send_native_mouse_move"));
         assert!(refresh_fn.matches("reset_layout_cef_hover").count() >= 5);
+    }
+
+    #[test]
+    fn native_layout_pointer_queue_retains_only_latest_sample() {
+        let source = include_str!("lib.rs");
+        let sample = source
+            .split("fn queue_native_layout_pointer_sample")
+            .nth(1)
+            .and_then(|tail| tail.split("pub fn queue_native_layout_pointer_move").next())
+            .unwrap_or_default();
+        let queue = source
+            .split("pub fn queue_native_layout_pointer_move")
+            .nth(1)
+            .and_then(|tail| tail.split("pub fn flush_native_layout_pointer_move").next())
+            .unwrap_or_default();
+        let flush = source
+            .split("pub fn flush_native_layout_pointer_move")
+            .nth(1)
+            .and_then(|tail| tail.split("pub fn native_layout_pointer_is_inside").next())
+            .unwrap_or_default();
+
+        assert!(sample.contains("state.position_px = Some(position)"));
+        assert!(sample.contains("state.buttons = buttons"));
+        assert!(source.contains("fn queue_native_layout_pointer_sample"));
+        assert!(sample.contains("sample_changed"));
+        assert!(sample.contains("state.pending = true"));
+        assert!(queue.contains("queue_native_layout_pointer_sample"));
+        assert!(flush.contains("state.pending = false"));
+        assert!(flush.contains("presenter.send(position_px / state.scale"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn native_layout_pointer_queue_skips_identical_sample() {
+        let mut state = NativeLayoutPointerState {
+            regions: vec![CefPointerHitRect {
+                center: Vec2::new(50.0, 25.0),
+                size: Vec2::new(20.0, 10.0),
+                interactive: true,
+            }],
+            ..Default::default()
+        };
+        let buttons = NativeMouseButtons::default();
+
+        let entered =
+            queue_native_layout_pointer_sample(&mut state, Vec2::new(50.0, 25.0), buttons);
+        assert!(entered.owns_pointer);
+        assert!(entered.region_changed);
+        assert!(entered.pending);
+        state.pending = false;
+        let duplicate =
+            queue_native_layout_pointer_sample(&mut state, Vec2::new(50.0, 25.0), buttons);
+        assert!(duplicate.owns_pointer);
+        assert!(!duplicate.region_changed);
+        assert!(!duplicate.pending);
+        let moved = queue_native_layout_pointer_sample(&mut state, Vec2::new(51.0, 25.0), buttons);
+        assert!(moved.owns_pointer);
+        assert!(!moved.region_changed);
+        assert!(moved.pending);
     }
 
     #[test]

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -24,7 +24,7 @@ const UNFOCUSED_FRAME_INTERVAL: Duration = Duration::from_secs(1);
 const HIDDEN_FRAME_INTERVAL: Duration = Duration::from_secs(60);
 const BACKGROUND_CEF_WAKE_INTERVAL: Duration = Duration::from_secs(1);
 #[cfg(target_os = "macos")]
-const NATIVE_MOUSE_MOVE_WAKE_INTERVAL: Duration = Duration::from_millis(16);
+const NATIVE_MOUSE_MOVE_WAKE_INTERVAL: Duration = Duration::from_millis(33);
 #[cfg(target_os = "macos")]
 const NATIVE_MOUSE_DRAG_WAKE_INTERVAL: Duration = Duration::from_millis(16);
 

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -246,25 +246,18 @@ fn activate_app_during_boot(
 fn activate_app_during_boot() {}
 
 #[cfg(target_os = "macos")]
-fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) {
-    use objc2_app_kit::{NSEvent, NSEventMask, NSEventType};
+type NativeThrottle = Arc<dyn Fn(Duration) + Send + Sync>;
 
-    let Some(proxy) = proxy else {
-        return;
-    };
-    if NATIVE_MOUSE_WAKE_MONITOR_INSTALLED.load(Ordering::Relaxed) {
-        return;
-    }
-    let proxy = (**proxy).clone();
-    let thread_proxy = proxy.clone();
+#[cfg(target_os = "macos")]
+fn native_throttle(name: &'static str, action: impl Fn() + Send + 'static) -> NativeThrottle {
     let pending_interval_ns = Arc::new(AtomicU64::new(u64::MAX));
     let thread_pending_interval_ns = Arc::clone(&pending_interval_ns);
-    let (wake_tx, wake_rx) = std::sync::mpsc::sync_channel::<()>(1);
+    let (tx, rx) = std::sync::mpsc::sync_channel::<()>(1);
     std::thread::Builder::new()
-        .name("native-mouse-wake-throttle".into())
+        .name(name.into())
         .spawn(move || {
             let mut last_fire: Option<Instant> = None;
-            while wake_rx.recv().is_ok() {
+            while rx.recv().is_ok() {
                 let mut interval_ns = thread_pending_interval_ns.swap(u64::MAX, Ordering::AcqRel);
                 if interval_ns == u64::MAX {
                     continue;
@@ -274,7 +267,7 @@ fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) 
                     if let Some(last) = last_fire {
                         let elapsed = Instant::now().saturating_duration_since(last);
                         if elapsed < interval {
-                            match wake_rx.recv_timeout(interval - elapsed) {
+                            match rx.recv_timeout(interval - elapsed) {
                                 Ok(()) => {
                                     interval_ns = interval_ns.min(
                                         thread_pending_interval_ns.swap(u64::MAX, Ordering::AcqRel),
@@ -286,7 +279,7 @@ fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) 
                             }
                         }
                     }
-                    let _ = thread_proxy.send_event(WinitUserEvent::WakeUp);
+                    action();
                     last_fire = Some(Instant::now());
                     interval_ns = thread_pending_interval_ns.swap(u64::MAX, Ordering::AcqRel);
                     if interval_ns == u64::MAX {
@@ -295,11 +288,32 @@ fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) 
                 }
             }
         })
-        .expect("failed to spawn native mouse wake throttler");
-    let wake = Arc::new(move |min_interval: Duration| {
+        .unwrap_or_else(|error| panic!("failed to spawn {name}: {error}"));
+    Arc::new(move |min_interval: Duration| {
         let min_interval = min_interval.as_nanos().min(u64::MAX as u128) as u64;
         pending_interval_ns.fetch_min(min_interval, Ordering::Relaxed);
-        let _ = wake_tx.try_send(());
+        let _ = tx.try_send(());
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) {
+    use objc2_app_kit::{NSEvent, NSEventMask, NSEventType};
+
+    let Some(proxy) = proxy else {
+        return;
+    };
+    if NATIVE_MOUSE_WAKE_MONITOR_INSTALLED.load(Ordering::Relaxed) {
+        return;
+    }
+    let proxy = (**proxy).clone();
+    let wake = native_throttle("native-mouse-wake-throttle", move || {
+        let _ = proxy.send_event(WinitUserEvent::WakeUp);
+    });
+    let flush_layout = native_throttle("native-layout-pointer-throttle", || {
+        dispatch2::DispatchQueue::main().exec_async(|| {
+            vmux_browser::flush_native_layout_pointer_move();
+        });
     });
     let local_wake = wake.clone();
     let local_block = block2::RcBlock::new(move |event: NonNull<NSEvent>| -> *mut NSEvent {
@@ -317,24 +331,56 @@ fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) 
                 | NSEventType::RightMouseDragged
                 | NSEventType::OtherMouseDragged
         );
+        let button_event = matches!(
+            event_type,
+            NSEventType::LeftMouseDown
+                | NSEventType::LeftMouseUp
+                | NSEventType::RightMouseDown
+                | NSEventType::RightMouseUp
+                | NSEventType::OtherMouseDown
+                | NSEventType::OtherMouseUp
+        );
         let location = event_location_in_window_physical_px(ev);
+        let buttons = native_mouse_buttons();
         if let Some((x, y)) = location {
-            vmux_layout::native_pointer::publish(Vec2::new(x, y), native_mouse_buttons(), motion);
+            vmux_layout::native_pointer::publish(Vec2::new(x, y), buttons, motion);
         }
+        let layout_pointer = (motion || button_event)
+            .then(|| {
+                location.map(|(x, y)| vmux_browser::queue_native_layout_pointer_move(x, y, buttons))
+            })
+            .flatten();
         if event_type == NSEventType::LeftMouseDown
             && let Some((x_px, y_px)) = location
         {
             vmux_browser::request_native_command_bar_dismiss_for_mouse_down(x_px, y_px);
         }
         if motion {
-            HOVER_OVER_PANE.store(true, Ordering::Relaxed);
             let interval = if event_type == NSEventType::MouseMoved {
                 NATIVE_MOUSE_MOVE_WAKE_INTERVAL
             } else {
                 NATIVE_MOUSE_DRAG_WAKE_INTERVAL
             };
-            local_wake(interval);
+            if let Some(result) = layout_pointer
+                && result.owns_pointer
+                && result.presenter_active
+            {
+                if result.region_changed {
+                    vmux_browser::flush_native_layout_pointer_move();
+                    local_wake(interval);
+                } else if result.pending {
+                    flush_layout(interval);
+                }
+            } else {
+                HOVER_OVER_PANE.store(true, Ordering::Relaxed);
+                local_wake(interval);
+            }
         } else {
+            if layout_pointer.is_some_and(|result| {
+                result.owns_pointer && result.presenter_active && result.pending
+            }) {
+                vmux_browser::flush_native_layout_pointer_move();
+            }
             local_wake(NATIVE_MOUSE_DRAG_WAKE_INTERVAL);
         }
         event.as_ptr()
@@ -881,6 +927,10 @@ mod tests {
         assert!(monitor.contains("NSEventMask::LeftMouseDown"));
         assert!(monitor.contains("WinitUserEvent::WakeUp"));
         assert!(monitor.contains("vmux_layout::native_pointer::publish"));
+        assert!(monitor.contains("vmux_browser::queue_native_layout_pointer_move"));
+        assert!(monitor.contains("flush_layout(interval)"));
+        assert!(monitor.contains("if result.region_changed"));
+        assert!(monitor.contains("vmux_browser::flush_native_layout_pointer_move()"));
         assert!(!monitor.contains("forward_native_layout_pointer_move"));
         assert!(!monitor.contains("vmux_layout::pane::wake_on_move"));
         assert!(monitor.contains("let global_mask = NSEventMask::LeftMouseDown"));
@@ -889,18 +939,35 @@ mod tests {
     #[test]
     fn native_mouse_wake_throttle_has_a_trailing_wake() {
         let source = include_str!("background_lifecycle.rs");
+        let throttle = source
+            .split("fn native_throttle")
+            .nth(1)
+            .and_then(|tail| tail.split("fn install_native_mouse_wake_monitor").next())
+            .unwrap_or_default();
+
+        assert!(throttle.contains("sync_channel::<()>(1)"));
+        assert!(throttle.contains("recv_timeout"));
+        assert!(throttle.contains("pending_interval_ns.fetch_min"));
+        assert!(!throttle.contains("while wake_rx.try_recv().is_ok()"));
+        assert!(!throttle.contains("thread_pending_interval_ns.store"));
+        assert!(!throttle.contains("LAST_NATIVE_MOUSE_WAKE.lock()"));
+    }
+
+    #[test]
+    fn native_layout_motion_skips_bevy_wake_after_entry() {
+        let source = include_str!("background_lifecycle.rs");
         let monitor = source
             .split("fn install_native_mouse_wake_monitor")
             .nth(1)
             .and_then(|tail| tail.split("fn foreground_winit_settings").next())
             .unwrap_or_default();
 
-        assert!(monitor.contains("sync_channel::<()>(1)"));
-        assert!(monitor.contains("recv_timeout"));
-        assert!(monitor.contains("pending_interval_ns.fetch_min"));
-        assert!(!monitor.contains("while wake_rx.try_recv().is_ok()"));
-        assert!(!monitor.contains("thread_pending_interval_ns.store"));
-        assert!(!monitor.contains("LAST_NATIVE_MOUSE_WAKE.lock()"));
+        assert!(monitor.contains("result.owns_pointer"));
+        assert!(monitor.contains("result.presenter_active"));
+        assert!(monitor.contains(
+            "if result.region_changed {\n                    vmux_browser::flush_native_layout_pointer_move();\n                    local_wake(interval);\n                } else if result.pending {\n                    flush_layout(interval);\n                }"
+        ));
+        assert!(monitor.contains("layout_pointer.is_some_and"));
     }
 
     #[test]

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -246,10 +246,7 @@ fn activate_app_during_boot(
 fn activate_app_during_boot() {}
 
 #[cfg(target_os = "macos")]
-fn install_native_mouse_wake_monitor(
-    proxy: Option<Res<EventLoopProxyWrapper>>,
-    primary_window: Query<Entity, With<bevy::window::PrimaryWindow>>,
-) {
+fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) {
     use objc2_app_kit::{NSEvent, NSEventMask, NSEventType};
 
     let Some(proxy) = proxy else {
@@ -258,9 +255,6 @@ fn install_native_mouse_wake_monitor(
     if NATIVE_MOUSE_WAKE_MONITOR_INSTALLED.load(Ordering::Relaxed) {
         return;
     }
-    let Some(primary_window) = primary_window.single().ok().and_then(appkit_window_ptr) else {
-        return;
-    };
     let proxy = (**proxy).clone();
     let thread_proxy = proxy.clone();
     let pending_interval_ns = Arc::new(AtomicU64::new(u64::MAX));
@@ -323,7 +317,7 @@ fn install_native_mouse_wake_monitor(
                 | NSEventType::RightMouseDragged
                 | NSEventType::OtherMouseDragged
         );
-        let location = event_location_in_window_physical_px(ev, primary_window);
+        let location = event_location_in_window_physical_px(ev);
         if let Some((x, y)) = location {
             vmux_layout::native_pointer::publish(Vec2::new(x, y), native_mouse_buttons(), motion);
         }
@@ -444,34 +438,9 @@ fn install_live_resize_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) {
 fn install_live_resize_monitor() {}
 
 #[cfg(target_os = "macos")]
-fn appkit_window_ptr(entity: Entity) -> Option<usize> {
-    use bevy::winit::WINIT_WINDOWS;
-    use objc2_app_kit::{NSView, NSWindow};
-    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
-
-    WINIT_WINDOWS.with_borrow(|windows| {
-        let window = windows.get_window(entity)?;
-        let handle = window.window_handle().ok()?;
-        let RawWindowHandle::AppKit(appkit) = handle.as_raw() else {
-            return None;
-        };
-        let view = unsafe { &*appkit.ns_view.as_ptr().cast::<NSView>() };
-        let window = view.window()?;
-        Some((&*window as *const NSWindow) as usize)
-    })
-}
-
-#[cfg(target_os = "macos")]
-fn event_location_in_window_physical_px(
-    event: &objc2_app_kit::NSEvent,
-    expected_window: usize,
-) -> Option<(f32, f32)> {
+fn event_location_in_window_physical_px(event: &objc2_app_kit::NSEvent) -> Option<(f32, f32)> {
     let mtm = objc2::MainThreadMarker::new()?;
     let window = event.window(mtm)?;
-    let window_ptr = (&*window as *const objc2_app_kit::NSWindow) as usize;
-    if window_ptr != expected_window {
-        return None;
-    }
     let content = window.contentView()?;
     let point = content.convertPoint_fromView(event.locationInWindow(), None);
     let scale = window.backingScaleFactor();
@@ -988,6 +957,20 @@ mod tests {
         assert!(plugin_build.contains("activate_primary_window_on_startup"));
         assert!(source.contains("activateIgnoringOtherApps"));
         assert!(source.contains("makeKeyAndOrderFront"));
+    }
+
+    #[test]
+    fn native_mouse_monitor_does_not_wait_for_window_creation() {
+        let source = include_str!("background_lifecycle.rs");
+        let monitor = source
+            .split("fn install_native_mouse_wake_monitor")
+            .nth(1)
+            .and_then(|tail| tail.split("fn foreground_winit_settings").next())
+            .unwrap_or_default();
+
+        assert!(monitor.contains("proxy: Option<Res<EventLoopProxyWrapper>>"));
+        assert!(!monitor.contains("PrimaryWindow"));
+        assert!(!monitor.contains("appkit_window_ptr"));
     }
 
     #[test]

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -24,7 +24,7 @@ const UNFOCUSED_FRAME_INTERVAL: Duration = Duration::from_secs(1);
 const HIDDEN_FRAME_INTERVAL: Duration = Duration::from_secs(60);
 const BACKGROUND_CEF_WAKE_INTERVAL: Duration = Duration::from_secs(1);
 #[cfg(target_os = "macos")]
-const NATIVE_MOUSE_MOVE_WAKE_INTERVAL: Duration = Duration::from_millis(33);
+const NATIVE_MOUSE_MOVE_WAKE_INTERVAL: Duration = Duration::from_millis(16);
 #[cfg(target_os = "macos")]
 const NATIVE_MOUSE_DRAG_WAKE_INTERVAL: Duration = Duration::from_millis(16);
 

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -292,11 +292,12 @@ fn install_native_mouse_wake_monitor(
                             }
                         }
                     }
-                    while wake_rx.try_recv().is_ok() {}
-                    thread_pending_interval_ns.store(u64::MAX, Ordering::Release);
                     let _ = thread_proxy.send_event(WinitUserEvent::WakeUp);
                     last_fire = Some(Instant::now());
-                    break;
+                    interval_ns = thread_pending_interval_ns.swap(u64::MAX, Ordering::AcqRel);
+                    if interval_ns == u64::MAX {
+                        break;
+                    }
                 }
             }
         })
@@ -928,6 +929,8 @@ mod tests {
         assert!(monitor.contains("sync_channel::<()>(1)"));
         assert!(monitor.contains("recv_timeout"));
         assert!(monitor.contains("pending_interval_ns.fetch_min"));
+        assert!(!monitor.contains("while wake_rx.try_recv().is_ok()"));
+        assert!(!monitor.contains("thread_pending_interval_ns.store"));
         assert!(!monitor.contains("LAST_NATIVE_MOUSE_WAKE.lock()"));
     }
 

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -6,13 +6,11 @@ use bevy_cef_core::prelude::{
     Browsers, MessageLoopWakePolicy, windowless_frame_interval_from_refresh_millihertz,
 };
 #[cfg(target_os = "macos")]
-use parking_lot::Mutex;
-#[cfg(target_os = "macos")]
 use std::ptr::NonNull;
 #[cfg(target_os = "macos")]
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 #[cfg(target_os = "macos")]
-use std::sync::{Arc, LazyLock};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 #[cfg(target_os = "macos")]
 use std::time::Instant;
@@ -66,19 +64,11 @@ impl Plugin for BackgroundLifecyclePlugin {
 #[cfg(target_os = "macos")]
 static NATIVE_MOUSE_WAKE_MONITOR_INSTALLED: AtomicBool = AtomicBool::new(false);
 #[cfg(target_os = "macos")]
-static LAST_NATIVE_MOUSE_WAKE: LazyLock<Mutex<Option<Instant>>> =
-    LazyLock::new(|| Mutex::new(None));
-#[cfg(target_os = "macos")]
 static IN_LIVE_RESIZE: AtomicBool = AtomicBool::new(false);
 #[cfg(target_os = "macos")]
 static LIVE_RESIZE_MONITOR_INSTALLED: AtomicBool = AtomicBool::new(false);
 #[cfg(target_os = "macos")]
 static HOVER_OVER_PANE: AtomicBool = AtomicBool::new(false);
-
-#[cfg(any(target_os = "macos", test))]
-fn native_mouse_move_should_wake(layout_should_wake: bool, pane_should_wake: bool) -> bool {
-    layout_should_wake || pane_should_wake
-}
 
 #[cfg(target_os = "macos")]
 fn activate_primary_window_on_startup(
@@ -100,8 +90,31 @@ fn activate_primary_window_on_startup() {}
 fn grab_key_window_on_pane_hover(
     intent: Res<vmux_browser::HostFocusIntent>,
     primary_window: Query<Entity, With<bevy::window::PrimaryWindow>>,
+    panes: Query<
+        (&ComputedNode, &bevy::ui::UiGlobalTransform),
+        (
+            With<vmux_layout::pane::Pane>,
+            Without<vmux_layout::pane::PaneSplit>,
+        ),
+    >,
 ) {
     if !HOVER_OVER_PANE.swap(false, Ordering::Relaxed) {
+        return;
+    }
+    let Some(pointer) = vmux_layout::native_pointer::snapshot() else {
+        return;
+    };
+    let over_pane = panes.iter().any(|(node, transform)| {
+        let center = transform.transform_point2(Vec2::ZERO);
+        let half = node.size * 0.5;
+        let min = center - half;
+        let max = center + half;
+        pointer.position_px.x >= min.x
+            && pointer.position_px.x <= max.x
+            && pointer.position_px.y >= min.y
+            && pointer.position_px.y <= max.y
+    });
+    if !over_pane {
         return;
     }
     if *intent == vmux_browser::HostFocusIntent::Unmanaged {
@@ -233,7 +246,10 @@ fn activate_app_during_boot(
 fn activate_app_during_boot() {}
 
 #[cfg(target_os = "macos")]
-fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) {
+fn install_native_mouse_wake_monitor(
+    proxy: Option<Res<EventLoopProxyWrapper>>,
+    primary_window: Query<Entity, With<bevy::window::PrimaryWindow>>,
+) {
     use objc2_app_kit::{NSEvent, NSEventMask, NSEventType};
 
     let Some(proxy) = proxy else {
@@ -242,22 +258,53 @@ fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) 
     if NATIVE_MOUSE_WAKE_MONITOR_INSTALLED.load(Ordering::Relaxed) {
         return;
     }
+    let Some(primary_window) = primary_window.single().ok().and_then(appkit_window_ptr) else {
+        return;
+    };
     let proxy = (**proxy).clone();
-    let wake = Arc::new(move |min_interval: Duration| {
-        let should_wake = {
-            let mut last = LAST_NATIVE_MOUSE_WAKE.lock();
-            let now = Instant::now();
-            match *last {
-                Some(prev) if now.duration_since(prev) < min_interval => false,
-                _ => {
-                    *last = Some(now);
-                    true
+    let thread_proxy = proxy.clone();
+    let pending_interval_ns = Arc::new(AtomicU64::new(u64::MAX));
+    let thread_pending_interval_ns = Arc::clone(&pending_interval_ns);
+    let (wake_tx, wake_rx) = std::sync::mpsc::sync_channel::<()>(1);
+    std::thread::Builder::new()
+        .name("native-mouse-wake-throttle".into())
+        .spawn(move || {
+            let mut last_fire: Option<Instant> = None;
+            while wake_rx.recv().is_ok() {
+                let mut interval_ns = thread_pending_interval_ns.swap(u64::MAX, Ordering::AcqRel);
+                if interval_ns == u64::MAX {
+                    continue;
+                }
+                loop {
+                    let interval = Duration::from_nanos(interval_ns);
+                    if let Some(last) = last_fire {
+                        let elapsed = Instant::now().saturating_duration_since(last);
+                        if elapsed < interval {
+                            match wake_rx.recv_timeout(interval - elapsed) {
+                                Ok(()) => {
+                                    interval_ns = interval_ns.min(
+                                        thread_pending_interval_ns.swap(u64::MAX, Ordering::AcqRel),
+                                    );
+                                    continue;
+                                }
+                                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+                                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => return,
+                            }
+                        }
+                    }
+                    while wake_rx.try_recv().is_ok() {}
+                    thread_pending_interval_ns.store(u64::MAX, Ordering::Release);
+                    let _ = thread_proxy.send_event(WinitUserEvent::WakeUp);
+                    last_fire = Some(Instant::now());
+                    break;
                 }
             }
-        };
-        if should_wake {
-            let _ = proxy.send_event(WinitUserEvent::WakeUp);
-        }
+        })
+        .expect("failed to spawn native mouse wake throttler");
+    let wake = Arc::new(move |min_interval: Duration| {
+        let min_interval = min_interval.as_nanos().min(u64::MAX as u128) as u64;
+        pending_interval_ns.fetch_min(min_interval, Ordering::Relaxed);
+        let _ = wake_tx.try_send(());
     });
     let local_wake = wake.clone();
     let local_block = block2::RcBlock::new(move |event: NonNull<NSEvent>| -> *mut NSEvent {
@@ -268,51 +315,31 @@ fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) 
         } else if event_type == NSEventType::LeftMouseUp {
             vmux_browser::set_native_left_mouse_down(false);
         }
-        if event_type == NSEventType::LeftMouseDown
-            && let Some((x_px, y_px)) = event_location_in_window_physical_px(ev)
-        {
-            vmux_browser::request_native_command_bar_dismiss_for_mouse_down(x_px, y_px);
-        }
-        if matches!(
+        let motion = matches!(
             event_type,
             NSEventType::MouseMoved
                 | NSEventType::LeftMouseDragged
                 | NSEventType::RightMouseDragged
                 | NSEventType::OtherMouseDragged
-        ) {
-            let location = event_location_in_window_physical_px(ev);
-            if let Some((x, y)) = location
-                && vmux_layout::pane::cursor_over_pane(x, y)
-            {
-                HOVER_OVER_PANE.store(true, Ordering::Relaxed);
-            }
-            let should_wake = location
-                .map(|(x, y)| {
-                    let result = vmux_browser::forward_native_layout_pointer_move(
-                        x,
-                        y,
-                        native_mouse_buttons(),
-                    );
-                    let layout_should_wake =
-                        result.owns_pointer && (!result.forwarded || result.changed);
-                    let pane_should_wake =
-                        !result.owns_pointer && vmux_layout::pane::wake_on_move(x, y);
-                    native_mouse_move_should_wake(layout_should_wake, pane_should_wake)
-                })
-                .unwrap_or(false);
-            if should_wake {
-                let interval = if event_type == NSEventType::MouseMoved {
-                    NATIVE_MOUSE_MOVE_WAKE_INTERVAL
-                } else {
-                    NATIVE_MOUSE_DRAG_WAKE_INTERVAL
-                };
-                local_wake(interval);
-            }
+        );
+        let location = event_location_in_window_physical_px(ev, primary_window);
+        if let Some((x, y)) = location {
+            vmux_layout::native_pointer::publish(Vec2::new(x, y), native_mouse_buttons(), motion);
+        }
+        if event_type == NSEventType::LeftMouseDown
+            && let Some((x_px, y_px)) = location
+        {
+            vmux_browser::request_native_command_bar_dismiss_for_mouse_down(x_px, y_px);
+        }
+        if motion {
+            HOVER_OVER_PANE.store(true, Ordering::Relaxed);
+            let interval = if event_type == NSEventType::MouseMoved {
+                NATIVE_MOUSE_MOVE_WAKE_INTERVAL
+            } else {
+                NATIVE_MOUSE_DRAG_WAKE_INTERVAL
+            };
+            local_wake(interval);
         } else {
-            if let Some((x, y)) = event_location_in_window_physical_px(ev) {
-                let _ =
-                    vmux_browser::forward_native_layout_pointer_move(x, y, native_mouse_buttons());
-            }
             local_wake(NATIVE_MOUSE_DRAG_WAKE_INTERVAL);
         }
         event.as_ptr()
@@ -325,6 +352,7 @@ fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) 
         } else if event_type == NSEventType::LeftMouseUp {
             vmux_browser::set_native_left_mouse_down(false);
         }
+        vmux_layout::native_pointer::publish_buttons(native_mouse_buttons());
         global_wake(NATIVE_MOUSE_MOVE_WAKE_INTERVAL);
     });
     let mouse_mask = NSEventMask::MouseMoved
@@ -415,9 +443,34 @@ fn install_live_resize_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) {
 fn install_live_resize_monitor() {}
 
 #[cfg(target_os = "macos")]
-fn event_location_in_window_physical_px(event: &objc2_app_kit::NSEvent) -> Option<(f32, f32)> {
+fn appkit_window_ptr(entity: Entity) -> Option<usize> {
+    use bevy::winit::WINIT_WINDOWS;
+    use objc2_app_kit::{NSView, NSWindow};
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+
+    WINIT_WINDOWS.with_borrow(|windows| {
+        let window = windows.get_window(entity)?;
+        let handle = window.window_handle().ok()?;
+        let RawWindowHandle::AppKit(appkit) = handle.as_raw() else {
+            return None;
+        };
+        let view = unsafe { &*appkit.ns_view.as_ptr().cast::<NSView>() };
+        let window = view.window()?;
+        Some((&*window as *const NSWindow) as usize)
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn event_location_in_window_physical_px(
+    event: &objc2_app_kit::NSEvent,
+    expected_window: usize,
+) -> Option<(f32, f32)> {
     let mtm = objc2::MainThreadMarker::new()?;
     let window = event.window(mtm)?;
+    let window_ptr = (&*window as *const objc2_app_kit::NSWindow) as usize;
+    if window_ptr != expected_window {
+        return None;
+    }
     let content = window.contentView()?;
     let point = content.convertPoint_fromView(event.locationInWindow(), None);
     let scale = window.backingScaleFactor();
@@ -846,7 +899,7 @@ mod tests {
     }
 
     #[test]
-    fn native_mouse_motion_forwards_directly_before_waking() {
+    fn native_mouse_motion_publishes_latest_sample_before_waking() {
         let source = include_str!("background_lifecycle.rs");
         let monitor = source
             .split("fn install_native_mouse_wake_monitor")
@@ -857,17 +910,25 @@ mod tests {
         assert!(monitor.contains("NSEventMask::MouseMoved"));
         assert!(monitor.contains("NSEventMask::LeftMouseDown"));
         assert!(monitor.contains("WinitUserEvent::WakeUp"));
-        assert!(monitor.contains("vmux_browser::forward_native_layout_pointer_move"));
-        assert!(monitor.contains("!result.forwarded || result.changed"));
-        assert!(monitor.contains("vmux_layout::pane::wake_on_move"));
+        assert!(monitor.contains("vmux_layout::native_pointer::publish"));
+        assert!(!monitor.contains("forward_native_layout_pointer_move"));
+        assert!(!monitor.contains("vmux_layout::pane::wake_on_move"));
         assert!(monitor.contains("let global_mask = NSEventMask::LeftMouseDown"));
     }
 
     #[test]
-    fn native_mouse_motion_skips_active_page_without_layout() {
-        assert!(native_mouse_move_should_wake(true, false));
-        assert!(native_mouse_move_should_wake(false, true));
-        assert!(!native_mouse_move_should_wake(false, false));
+    fn native_mouse_wake_throttle_has_a_trailing_wake() {
+        let source = include_str!("background_lifecycle.rs");
+        let monitor = source
+            .split("fn install_native_mouse_wake_monitor")
+            .nth(1)
+            .and_then(|tail| tail.split("fn foreground_winit_settings").next())
+            .unwrap_or_default();
+
+        assert!(monitor.contains("sync_channel::<()>(1)"));
+        assert!(monitor.contains("recv_timeout"));
+        assert!(monitor.contains("pending_interval_ns.fetch_min"));
+        assert!(!monitor.contains("LAST_NATIVE_MOUSE_WAKE.lock()"));
     }
 
     #[test]

--- a/crates/vmux_desktop/src/glass.rs
+++ b/crates/vmux_desktop/src/glass.rs
@@ -451,7 +451,6 @@ struct MetalOverlayInFlight {
 #[derive(Default)]
 struct NativeOverlayPresentState {
     layers: HashMap<Entity, SendLayer>,
-    pending: HashMap<Entity, bevy_cef_core::prelude::AcceleratedFrame>,
     held: HashMap<Entity, bevy_cef_core::prelude::AcceleratedFrame>,
     metal: Option<MetalOverlayContext>,
     swapchains: HashMap<Entity, MetalOverlaySwapchain>,
@@ -463,6 +462,9 @@ struct NativeOverlayPresentState {
 
 static NATIVE_OVERLAY_PRESENT_STATE: LazyLock<Mutex<NativeOverlayPresentState>> =
     LazyLock::new(|| Mutex::new(NativeOverlayPresentState::default()));
+static NATIVE_OVERLAY_MAILBOX: LazyLock<
+    Mutex<HashMap<Entity, Option<bevy_cef_core::prelude::AcceleratedFrame>>>,
+> = LazyLock::new(|| Mutex::new(HashMap::new()));
 static NATIVE_OVERLAY_PRESENT_SCHEDULED: AtomicBool = AtomicBool::new(false);
 
 fn overlay_rect_union(left: WebviewDirtyRect, right: WebviewDirtyRect) -> Option<WebviewDirtyRect> {
@@ -537,9 +539,9 @@ fn coalesced_overlay_dirty(
     previous: &[WebviewDirtyRect],
     latest: &[WebviewDirtyRect],
     same_surface: bool,
-) -> Vec<WebviewDirtyRect> {
+) -> bevy_cef_core::prelude::WebviewDirtyRects {
     if !same_surface {
-        return Vec::new();
+        return Default::default();
     }
     OverlayDamage::from_frame(width, height, previous)
         .union(
@@ -548,6 +550,8 @@ fn coalesced_overlay_dirty(
             height,
         )
         .into_frame_dirty()
+        .into_iter()
+        .collect()
 }
 
 fn native_overlay_blit_regions<'a>(
@@ -573,25 +577,33 @@ fn native_overlay_blit_regions<'a>(
 
 fn native_overlay_presenter() -> bevy_cef_core::prelude::AcceleratedFramePresenter {
     Arc::new(|frame| {
-        let mut state = NATIVE_OVERLAY_PRESENT_STATE
+        let mut pending = NATIVE_OVERLAY_MAILBOX
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let webview = frame.webview;
-        if let Some(previous) = state.pending.insert(webview, frame)
-            && let Some(latest) = state.pending.get_mut(&webview)
-        {
-            latest.dirty = coalesced_overlay_dirty(
-                latest.width,
-                latest.height,
-                &previous.dirty,
-                &latest.dirty,
-                previous.width == latest.width
-                    && previous.height == latest.height
-                    && previous.format == latest.format,
-            );
-        }
-        let should_schedule = !state.in_flight.contains_key(&webview);
-        drop(state);
+        let should_schedule = match pending.entry(webview) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(Some(frame));
+                true
+            }
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                if let Some(previous) = entry.get_mut().replace(frame)
+                    && let Some(latest) = entry.get_mut().as_mut()
+                {
+                    latest.dirty = coalesced_overlay_dirty(
+                        latest.width,
+                        latest.height,
+                        &previous.dirty,
+                        &latest.dirty,
+                        previous.width == latest.width
+                            && previous.height == latest.height
+                            && previous.format == latest.format,
+                    );
+                }
+                false
+            }
+        };
+        drop(pending);
         if should_schedule {
             schedule_native_overlay_present();
         }
@@ -608,27 +620,24 @@ fn schedule_native_overlay_present() {
 fn drain_native_overlay_present() {
     use objc2::runtime::AnyObject;
 
-    let ready = {
-        let mut state = NATIVE_OVERLAY_PRESENT_STATE
+    let ready_layers = {
+        let state = NATIVE_OVERLAY_PRESENT_STATE
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let entities: Vec<_> = state
-            .pending
-            .keys()
-            .copied()
-            .filter(|entity| {
-                state.layers.contains_key(entity) && !state.in_flight.contains_key(entity)
-            })
-            .collect();
-        entities
+        state
+            .layers
+            .iter()
+            .filter(|(entity, _)| !state.in_flight.contains_key(entity))
+            .map(|(entity, layer)| (*entity, layer.clone()))
+            .collect::<Vec<_>>()
+    };
+    let ready = {
+        let mut pending = NATIVE_OVERLAY_MAILBOX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        ready_layers
             .into_iter()
-            .filter_map(|entity| {
-                Some((
-                    entity,
-                    state.layers.get(&entity)?.clone(),
-                    state.pending.remove(&entity)?,
-                ))
-            })
+            .filter_map(|(entity, layer)| Some((entity, layer, pending.get_mut(&entity)?.take()?)))
             .collect::<Vec<_>>()
     };
 
@@ -653,8 +662,14 @@ fn drain_native_overlay_present() {
         let state = NATIVE_OVERLAY_PRESENT_STATE
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        state.pending.keys().any(|entity| {
-            state.layers.contains_key(entity) && !state.in_flight.contains_key(entity)
+        let mut pending = NATIVE_OVERLAY_MAILBOX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        pending.retain(|entity, frame| frame.is_some() || state.in_flight.contains_key(entity));
+        pending.iter().any(|(entity, frame)| {
+            frame.is_some()
+                && state.layers.contains_key(entity)
+                && !state.in_flight.contains_key(entity)
         })
     };
     if has_ready {
@@ -673,8 +688,12 @@ fn register_native_overlay_layer(
         .layers
         .entry(entity)
         .or_insert_with(|| SendLayer(layer.clone()));
-    let should_schedule = state.pending.contains_key(&entity);
     drop(state);
+    let should_schedule = NATIVE_OVERLAY_MAILBOX
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&entity)
+        .is_some_and(Option::is_some);
     if should_schedule {
         schedule_native_overlay_present();
     }
@@ -685,11 +704,15 @@ fn unregister_native_overlay_layer(entity: Entity) {
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     state.layers.remove(&entity);
-    state.pending.remove(&entity);
     state.held.remove(&entity);
     state.swapchains.remove(&entity);
     state.source_textures.remove(&entity);
     state.in_flight.remove(&entity);
+    drop(state);
+    NATIVE_OVERLAY_MAILBOX
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(&entity);
 }
 
 fn create_metal_overlay_context() -> Option<MetalOverlayContext> {
@@ -869,7 +892,7 @@ fn complete_native_overlay_present(
 ) {
     use objc2::runtime::AnyObject;
 
-    let (layer, surface, should_schedule) = {
+    let (layer, surface, can_schedule) = {
         let mut state = NATIVE_OVERLAY_PRESENT_STATE
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -909,16 +932,30 @@ fn complete_native_overlay_present(
         if surface.is_some() {
             state.held.remove(&entity);
         }
-        let should_schedule = state.pending.contains_key(&entity)
-            && state.layers.contains_key(&entity)
-            && !state.in_flight.contains_key(&entity);
-        (layer, surface, should_schedule)
+        let can_schedule =
+            state.layers.contains_key(&entity) && !state.in_flight.contains_key(&entity);
+        (layer, surface, can_schedule)
     };
     if let (Some(layer), Some(surface)) = (layer, surface) {
         let io_surface =
             (&*surface.io_surface as *const objc2_io_surface::IOSurfaceRef).cast::<AnyObject>();
         unsafe { layer.0.setContents(Some(&*io_surface)) };
     }
+    let should_schedule = if can_schedule {
+        let mut pending = NATIVE_OVERLAY_MAILBOX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match pending.get(&entity) {
+            Some(Some(_)) => true,
+            Some(None) => {
+                pending.remove(&entity);
+                false
+            }
+            None => false,
+        }
+    } else {
+        false
+    };
     if should_schedule {
         schedule_native_overlay_present();
     }
@@ -1120,7 +1157,7 @@ fn sync_layout_overlay(
     window_q: Query<Entity, With<bevy::window::PrimaryWindow>>,
     windows: Query<&bevy::window::Window>,
     mode: Res<InteractionMode>,
-    overlay_frames: Res<bevy_cef::prelude::NativeOverlayFrames>,
+    mut overlay_frames: ResMut<bevy_cef::prelude::NativeOverlayFrames>,
 ) {
     use objc2::{MainThreadMarker, rc::Retained, runtime::AnyObject};
     use objc2_app_kit::{NSColor, NSView};
@@ -1144,11 +1181,7 @@ fn sync_layout_overlay(
     let (Ok(window_e), Ok(layout_e)) = (window_q.single(), layout_e_q.single()) else {
         return;
     };
-    let next = overlay_frames
-        .0
-        .lock()
-        .ok()
-        .and_then(|mut map| map.remove(&layout_e));
+    let next = overlay_frames.0.remove(&layout_e);
     let Some(ns_view) = primary_content_view_ptr(window_e) else {
         return;
     };
@@ -1210,7 +1243,7 @@ fn sync_command_bar_overlay(
     modal_e_q: Query<Entity, With<vmux_layout::window::Modal>>,
     window_q: Query<Entity, With<bevy::window::PrimaryWindow>>,
     windows: Query<&bevy::window::Window>,
-    overlay_frames: Res<bevy_cef::prelude::NativeOverlayFrames>,
+    mut overlay_frames: ResMut<bevy_cef::prelude::NativeOverlayFrames>,
 ) {
     use objc2::{MainThreadMarker, MainThreadOnly, runtime::AnyObject};
     use objc2_app_kit::NSView;
@@ -1234,11 +1267,7 @@ fn sync_command_bar_overlay(
     };
     // Pull the latest OSR frame for the modal. A *windowed* command bar produces none, so leave the
     // overlay dormant rather than covering the native command bar with an empty input-stealing layer.
-    let next = overlay_frames
-        .0
-        .lock()
-        .ok()
-        .and_then(|mut map| map.remove(&modal_e));
+    let next = overlay_frames.0.remove(&modal_e);
     if next.is_none() && state.held.is_none() {
         return;
     }
@@ -1470,8 +1499,8 @@ mod tests {
         let dirty = coalesced_overlay_dirty(200, 100, &previous, &latest, true);
 
         assert_eq!(
-            dirty,
-            [
+            dirty.as_slice(),
+            &[
                 WebviewDirtyRect {
                     x: 10,
                     y: 20,
@@ -1504,8 +1533,8 @@ mod tests {
         }];
 
         assert_eq!(
-            coalesced_overlay_dirty(200, 100, &previous, &latest, true),
-            [WebviewDirtyRect {
+            coalesced_overlay_dirty(200, 100, &previous, &latest, true).as_slice(),
+            &[WebviewDirtyRect {
                 x: 10,
                 y: 20,
                 width: 50,

--- a/crates/vmux_layout/src/command_bar/handler.rs
+++ b/crates/vmux_layout/src/command_bar/handler.rs
@@ -2337,8 +2337,20 @@ mod tests {
                 ty: bevy_cef_core::prelude::RenderPaintElementType::View,
                 width: 1,
                 height: 1,
-                buffer: std::sync::Arc::new(vec![0, 0, 0, 255]),
-                dirty: Vec::new(),
+                patches: std::sync::Arc::new(
+                    [bevy_cef_core::prelude::WebviewPaintPatch {
+                        rect: bevy_cef_core::prelude::WebviewDirtyRect {
+                            x: 0,
+                            y: 0,
+                            width: 1,
+                            height: 1,
+                        },
+                        buffer: std::sync::Arc::new(vec![0, 0, 0, 255]),
+                    }]
+                    .into_iter()
+                    .collect(),
+                ),
+                dirty: Default::default(),
             });
 
         app.update();

--- a/crates/vmux_layout/src/lib.rs
+++ b/crates/vmux_layout/src/lib.rs
@@ -55,6 +55,8 @@ pub mod active;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod archive;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod native_pointer;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod pane;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod placement;

--- a/crates/vmux_layout/src/native_pointer.rs
+++ b/crates/vmux_layout/src/native_pointer.rs
@@ -1,0 +1,142 @@
+use bevy::prelude::Vec2;
+use bevy_cef_core::prelude::NativeMouseButtons;
+use std::hint::spin_loop;
+use std::sync::atomic::{AtomicU8, AtomicU32, AtomicU64, Ordering, fence};
+
+static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+static X_BITS: AtomicU32 = AtomicU32::new(0);
+static Y_BITS: AtomicU32 = AtomicU32::new(0);
+static BUTTONS: AtomicU8 = AtomicU8::new(0);
+static MOTION_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct NativePointerSnapshot {
+    pub sequence: u64,
+    pub motion_sequence: u64,
+    pub position_px: Vec2,
+    pub buttons: NativeMouseButtons,
+}
+
+pub fn publish(position_px: Vec2, buttons: NativeMouseButtons, motion: bool) {
+    let writing = loop {
+        let current = SEQUENCE.load(Ordering::Acquire);
+        if current & 1 != 0 {
+            spin_loop();
+            continue;
+        }
+        if SEQUENCE
+            .compare_exchange_weak(
+                current,
+                current.wrapping_add(1),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+        {
+            break current.wrapping_add(1);
+        }
+    };
+    X_BITS.store(position_px.x.to_bits(), Ordering::Relaxed);
+    Y_BITS.store(position_px.y.to_bits(), Ordering::Relaxed);
+    BUTTONS.store(button_bits(buttons), Ordering::Relaxed);
+    let completed = writing.wrapping_add(1);
+    if motion {
+        MOTION_SEQUENCE.store(completed, Ordering::Relaxed);
+    }
+    SEQUENCE.store(completed, Ordering::Release);
+}
+
+pub fn publish_buttons(buttons: NativeMouseButtons) {
+    if let Some(pointer) = snapshot() {
+        publish(pointer.position_px, buttons, false);
+    }
+}
+
+pub fn snapshot() -> Option<NativePointerSnapshot> {
+    loop {
+        let before = SEQUENCE.load(Ordering::Acquire);
+        if before == 0 {
+            return None;
+        }
+        if before & 1 != 0 {
+            spin_loop();
+            continue;
+        }
+        let position_px = Vec2::new(
+            f32::from_bits(X_BITS.load(Ordering::Relaxed)),
+            f32::from_bits(Y_BITS.load(Ordering::Relaxed)),
+        );
+        let buttons = buttons_from_bits(BUTTONS.load(Ordering::Relaxed));
+        let motion_sequence = MOTION_SEQUENCE.load(Ordering::Relaxed);
+        fence(Ordering::Acquire);
+        let after = SEQUENCE.load(Ordering::Relaxed);
+        if before == after {
+            return Some(NativePointerSnapshot {
+                sequence: after,
+                motion_sequence,
+                position_px,
+                buttons,
+            });
+        }
+    }
+}
+
+fn button_bits(buttons: NativeMouseButtons) -> u8 {
+    u8::from(buttons.left) | (u8::from(buttons.right) << 1) | (u8::from(buttons.middle) << 2)
+}
+
+fn buttons_from_bits(bits: u8) -> NativeMouseButtons {
+    NativeMouseButtons {
+        left: bits & 1 != 0,
+        right: bits & (1 << 1) != 0,
+        middle: bits & (1 << 2) != 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_is_coherent() {
+        publish(
+            Vec2::new(123.5, 456.25),
+            NativeMouseButtons {
+                left: true,
+                right: false,
+                middle: true,
+            },
+            true,
+        );
+
+        let snapshot = snapshot().expect("snapshot");
+        assert_eq!(snapshot.position_px, Vec2::new(123.5, 456.25));
+        assert_eq!(
+            snapshot.buttons,
+            NativeMouseButtons {
+                left: true,
+                right: false,
+                middle: true,
+            }
+        );
+        assert_eq!(snapshot.sequence & 1, 0);
+        assert_eq!(snapshot.motion_sequence, snapshot.sequence);
+    }
+
+    #[test]
+    fn button_update_preserves_position_and_motion_sequence() {
+        publish(Vec2::new(10.0, 20.0), NativeMouseButtons::default(), true);
+        let before = snapshot().expect("snapshot");
+
+        publish_buttons(NativeMouseButtons {
+            left: true,
+            right: false,
+            middle: false,
+        });
+
+        let after = snapshot().expect("snapshot");
+        assert_eq!(after.position_px, before.position_px);
+        assert_eq!(after.motion_sequence, before.motion_sequence);
+        assert!(after.buttons.left);
+    }
+}

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -102,10 +102,7 @@ impl Plugin for PanePlugin {
         #[cfg(target_os = "macos")]
         app.add_systems(
             Update,
-            (
-                publish_pane_hover_regions,
-                apply_pending_hover.before(crate::stack::ComputeFocusSet),
-            ),
+            apply_pending_hover.before(crate::stack::ComputeFocusSet),
         );
         #[cfg(not(target_os = "macos"))]
         app.add_systems(
@@ -2166,127 +2163,47 @@ fn native_window_cursor_position(window_entity: Entity, window: &Window) -> Opti
 }
 
 #[cfg(target_os = "macos")]
-mod hover_wake {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    use std::sync::{LazyLock, Mutex};
-
-    #[derive(Default)]
-    struct Regions {
-        panes: Vec<(u64, f32, f32, f32, f32)>,
-        active: Option<u64>,
-    }
-
-    static REGIONS: LazyLock<Mutex<Regions>> = LazyLock::new(|| Mutex::new(Regions::default()));
-    static PENDING: AtomicU64 = AtomicU64::new(0);
-
-    pub fn publish(panes: Vec<(u64, f32, f32, f32, f32)>, active: Option<u64>) {
-        if let Ok(mut regions) = REGIONS.lock() {
-            regions.panes = panes;
-            regions.active = active;
-        }
-    }
-
-    fn region_contains(region: &(u64, f32, f32, f32, f32), x: f32, y: f32) -> bool {
-        let (_, min_x, min_y, max_x, max_y) = *region;
-        x >= min_x && x <= max_x && y >= min_y && y <= max_y
-    }
-
-    pub fn wake_on_move(x: f32, y: f32) -> bool {
-        let Ok(regions) = REGIONS.lock() else {
-            return false;
-        };
-        let hit = regions
-            .panes
-            .iter()
-            .find(|region| region_contains(region, x, y))
-            .map(|(entity, ..)| *entity);
-        match hit {
-            Some(entity) if Some(entity) == regions.active => false,
-            Some(entity) => {
-                PENDING.store(entity, Ordering::Relaxed);
-                true
-            }
-            None => true,
-        }
-    }
-
-    pub fn cursor_over_pane(x: f32, y: f32) -> bool {
-        let Ok(regions) = REGIONS.lock() else {
-            return false;
-        };
-        regions
-            .panes
-            .iter()
-            .any(|region| region_contains(region, x, y))
-    }
-
-    pub fn take_pending_target() -> Option<u64> {
-        match PENDING.swap(0, Ordering::Relaxed) {
-            0 => None,
-            bits => Some(bits),
-        }
-    }
-}
-
-#[cfg(target_os = "macos")]
-pub use hover_wake::{cursor_over_pane, wake_on_move};
-
-#[cfg(target_os = "macos")]
-fn publish_pane_hover_regions(
+fn apply_pending_hover(
     mode: Res<crate::scene::InteractionMode>,
     leaf_panes: Query<
         (Entity, &ComputedNode, &UiGlobalTransform),
         (With<Pane>, Without<PaneSplit>),
     >,
     pane_ts: Query<(Entity, &LastActivatedAt), With<Pane>>,
-) {
-    if *mode != crate::scene::InteractionMode::User {
-        hover_wake::publish(Vec::new(), None);
-        return;
-    }
-    let mut panes = Vec::new();
-    for (entity, node, ui_gt) in &leaf_panes {
-        let center = ui_gt.transform_point2(Vec2::ZERO);
-        let half = node.size * 0.5;
-        panes.push((
-            entity.to_bits(),
-            center.x - half.x,
-            center.y - half.y,
-            center.x + half.x,
-            center.y + half.y,
-        ));
-    }
-    let active = active_among(
-        leaf_panes
-            .iter()
-            .filter_map(|(entity, _, _)| pane_ts.get(entity).ok()),
-    )
-    .map(|entity| entity.to_bits());
-    hover_wake::publish(panes, active);
-}
-
-#[cfg(target_os = "macos")]
-fn apply_pending_hover(
-    mode: Res<crate::scene::InteractionMode>,
-    leaf_panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
-    pane_ts: Query<(Entity, &LastActivatedAt), With<Pane>>,
     pane_children: Query<&Children, With<Pane>>,
     stack_ts: Query<(Entity, &LastActivatedAt), With<Stack>>,
     mut commands: Commands,
+    mut last_motion_sequence: Local<u64>,
 ) {
-    let Some(bits) = hover_wake::take_pending_target() else {
+    let Some(pointer) = crate::native_pointer::snapshot() else {
         return;
     };
+    if pointer.motion_sequence == 0 || pointer.motion_sequence == *last_motion_sequence {
+        return;
+    }
+    *last_motion_sequence = pointer.motion_sequence;
     if *mode != crate::scene::InteractionMode::User {
         return;
     }
-    let Some(target) = Entity::try_from_bits(bits) else {
+    let target = leaf_panes.iter().find_map(|(entity, node, ui_gt)| {
+        let center = ui_gt.transform_point2(Vec2::ZERO);
+        let half = node.size * 0.5;
+        let min = center - half;
+        let max = center + half;
+        (pointer.position_px.x >= min.x
+            && pointer.position_px.x <= max.x
+            && pointer.position_px.y >= min.y
+            && pointer.position_px.y <= max.y)
+            .then_some(entity)
+    });
+    let Some(target) = target else {
         return;
     };
-    if !leaf_panes.contains(target) {
-        return;
-    }
-    let current = active_among(leaf_panes.iter().filter_map(|e| pane_ts.get(e).ok()));
+    let current = active_among(
+        leaf_panes
+            .iter()
+            .filter_map(|(entity, _, _)| pane_ts.get(entity).ok()),
+    );
     if current == Some(target) {
         return;
     }
@@ -5477,17 +5394,16 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn wake_on_move_suppresses_active_pane() {
-        super::hover_wake::publish(
-            vec![(1, 0.0, 0.0, 100.0, 100.0), (2, 200.0, 0.0, 300.0, 100.0)],
-            Some(1),
-        );
-        assert!(!super::wake_on_move(50.0, 50.0));
-        assert_eq!(super::hover_wake::take_pending_target(), None);
-        assert!(super::wake_on_move(250.0, 50.0));
-        assert_eq!(super::hover_wake::take_pending_target(), Some(2));
-        assert!(super::wake_on_move(150.0, 50.0));
-        assert_eq!(super::hover_wake::take_pending_target(), None);
+    fn native_pane_hover_reads_latest_pointer_in_update() {
+        let source = include_str!("pane.rs");
+        let apply = source
+            .split("fn apply_pending_hover")
+            .nth(1)
+            .and_then(|tail| tail.split("fn click_pane_in_player_mode").next())
+            .unwrap_or_default();
+
+        assert!(apply.contains("crate::native_pointer::snapshot()"));
+        assert!(apply.contains("pointer.motion_sequence"));
     }
 
     #[test]

--- a/patches/bevy_cef-0.5.2/src/webview/accelerated_upload.rs
+++ b/patches/bevy_cef-0.5.2/src/webview/accelerated_upload.rs
@@ -11,8 +11,10 @@ use bevy::render::render_resource::{
 use bevy::render::renderer::{RenderDevice, RenderQueue};
 use bevy::render::texture::GpuImage;
 use bevy::render::{Extract, ExtractSchedule, Render, RenderApp, RenderSystems};
-use bevy_cef_core::prelude::{AcceleratedFrame, AcceleratedPixelFormat, Browsers};
-use std::collections::{HashMap, HashSet};
+use bevy_cef_core::prelude::{
+    AcceleratedFrame, AcceleratedPixelFormat, Browsers, coalesce_webview_dirty_rects,
+};
+use std::collections::HashMap;
 use std::sync::Mutex;
 
 struct PendingAcceleratedUpload {
@@ -27,7 +29,7 @@ pub struct WebviewAcceleratedQueue(Mutex<Vec<PendingAcceleratedUpload>>);
 /// display (instead of a Bevy texture). Take the frame and keep it alive while its IOSurface is set
 /// as a `CALayer`'s contents.
 #[derive(Resource, Default)]
-pub struct NativeOverlayFrames(pub Mutex<HashMap<Entity, AcceleratedFrame>>);
+pub struct NativeOverlayFrames(pub HashMap<Entity, AcceleratedFrame>);
 
 #[derive(Resource, Default)]
 struct ExtractedAcceleratedUploads(Vec<PendingAcceleratedUpload>);
@@ -56,7 +58,7 @@ fn queue_accelerated_uploads(
     browsers: NonSend<Browsers>,
     surfaces: Query<&WebviewSurface>,
     overlay_webviews: Query<Entity, With<WebviewNativeOverlay>>,
-    overlay_frames: Res<NativeOverlayFrames>,
+    mut overlay_frames: ResMut<NativeOverlayFrames>,
     mut images: ResMut<Assets<Image>>,
     queue: Res<WebviewAcceleratedQueue>,
     texture_wake: Option<Res<TextureWakeCallback>>,
@@ -64,32 +66,17 @@ fn queue_accelerated_uploads(
     let Ok(mut pending) = queue.0.lock() else {
         return;
     };
-    // Coalesce to the newest frame per webview. Each accelerated frame carries the full current
-    // surface, so older queued frames are redundant. When more than one arrived for a webview since
-    // the last upload, blit the whole surface (drop dirty rects) so no superseded region is missed.
-    let mut latest: HashMap<Entity, AcceleratedFrame> = HashMap::new();
-    let mut coalesced: HashSet<Entity> = HashSet::new();
     let mut resized = false;
-    while let Ok(frame) = browsers.try_receive_accelerated() {
+    for frame in browsers.drain_accelerated_frames() {
         let webview = frame.webview;
-        if latest.insert(webview, frame).is_some() {
-            coalesced.insert(webview);
-        }
-    }
-    for (webview, mut frame) in latest {
         let overlay = overlay_webviews.contains(webview);
         if overlay {
-            if let Ok(mut overlay) = overlay_frames.0.lock() {
-                overlay.insert(webview, frame);
-            }
+            overlay_frames.0.insert(webview, frame);
             continue;
         }
         let Ok(surface) = surfaces.get(webview) else {
             continue;
         };
-        if coalesced.contains(&webview) {
-            frame.dirty.clear();
-        }
         let id = surface.0.id();
         if let Some(mut image) = images.get_mut(id) {
             resized |= resize_surface_image_if_needed(
@@ -163,11 +150,28 @@ fn coalesce_pending_accelerated_uploads(uploads: &mut Vec<PendingAcceleratedUplo
     if uploads.len() < 2 {
         return;
     }
-    let mut latest = HashMap::new();
+    let mut latest = Vec::<PendingAcceleratedUpload>::new();
     for upload in uploads.drain(..) {
-        latest.insert(upload.frame.webview, upload);
+        let key = (upload.frame.webview, upload.frame.ty);
+        let mut upload = upload;
+        if let Some(index) = latest
+            .iter()
+            .position(|pending| (pending.frame.webview, pending.frame.ty) == key)
+        {
+            let previous = latest.remove(index);
+            upload.frame.dirty = coalesce_webview_dirty_rects(
+                upload.frame.width,
+                upload.frame.height,
+                &previous.frame.dirty,
+                &upload.frame.dirty,
+                previous.frame.width == upload.frame.width
+                    && previous.frame.height == upload.frame.height
+                    && previous.frame.format == upload.frame.format,
+            );
+        }
+        latest.push(upload);
     }
-    uploads.extend(latest.into_values());
+    uploads.extend(latest);
 }
 
 fn upload_accelerated_textures(

--- a/patches/bevy_cef-0.5.2/src/webview/mesh.rs
+++ b/patches/bevy_cef-0.5.2/src/webview/mesh.rs
@@ -21,6 +21,8 @@ use bevy::input::gestures::PinchGesture;
 use bevy::input::mouse::{MouseScrollUnit, MouseWheel};
 #[cfg(feature = "pbr")]
 use bevy::picking::Pickable;
+#[cfg(feature = "pbr")]
+use bevy::platform::collections::HashMap;
 #[cfg(not(feature = "pbr"))]
 use bevy::prelude::Deref;
 #[cfg(feature = "pbr")]
@@ -215,6 +217,7 @@ fn on_mouse_wheel(
         for _ in er.read() {}
         return;
     }
+    let mut pending = HashMap::<Entity, (Vec2, Vec2)>::default();
     let use_targets = webviews_targeted.iter().next().is_some();
     for event in er.read() {
         let Ok(window) = windows.get(event.window) else {
@@ -246,7 +249,13 @@ fn on_mouse_wheel(
                     commands
                         .entity(webview)
                         .insert(HistorySwipeVisualOffset::default());
-                    browsers.send_mouse_wheel(&webview, pos, delta);
+                    pending
+                        .entry(webview)
+                        .and_modify(|(position, accumulated)| {
+                            *position = pos;
+                            *accumulated += delta;
+                        })
+                        .or_insert((pos, delta));
                 }
                 HistorySwipeOutcome::Consumed { visual } => {
                     commands
@@ -264,6 +273,9 @@ fn on_mouse_wheel(
                 }
             }
         }
+    }
+    for (webview, (position, delta)) in pending {
+        browsers.send_mouse_wheel(&webview, position, delta);
     }
 }
 

--- a/patches/bevy_cef-0.5.2/src/webview/mesh/webview_extend_material.rs
+++ b/patches/bevy_cef-0.5.2/src/webview/mesh/webview_extend_material.rs
@@ -59,6 +59,7 @@ where
 fn render<E: MaterialExtension>(
     mut commands: Commands,
     mut er: MessageReader<RenderTextureMessage>,
+    browsers: NonSend<Browsers>,
     mut images: ResMut<Assets<Image>>,
     mut materials: ResMut<Assets<WebviewExtendedMaterial<E>>>,
     mut uploads: ResMut<WebviewTextureUploads>,
@@ -79,6 +80,6 @@ fn render<E: MaterialExtension>(
         commands
             .entity(texture.webview)
             .insert(WebviewSurface(handle.clone()));
-        apply_webview_texture(texture, &mut images, &handle, &mut uploads);
+        apply_webview_texture(texture, &browsers, &mut images, &handle, &mut uploads);
     }
 }

--- a/patches/bevy_cef-0.5.2/src/webview/mesh/webview_extend_standard_material.rs
+++ b/patches/bevy_cef-0.5.2/src/webview/mesh/webview_extend_standard_material.rs
@@ -107,6 +107,7 @@ fn ensure_mesh_webview_placeholder(
 pub fn render_standard_materials(
     mut commands: Commands,
     mut er: MessageReader<RenderTextureMessage>,
+    browsers: NonSend<Browsers>,
     mut images: ResMut<Assets<Image>>,
     mut materials: ResMut<Assets<WebviewExtendStandardMaterial>>,
     mut uploads: ResMut<WebviewTextureUploads>,
@@ -128,14 +129,16 @@ pub fn render_standard_materials(
         commands
             .entity(texture.webview)
             .insert(WebviewSurface(handle.clone()));
-        apply_webview_texture(texture, &mut images, &handle, &mut uploads);
+        apply_webview_texture(texture, &browsers, &mut images, &handle, &mut uploads);
         if logged.insert(texture.webview) {
+            let bytes = texture
+                .patches
+                .iter()
+                .map(|patch| patch.buffer.len())
+                .sum::<usize>();
             webview_debug_log(format!(
                 "texture applied entity={:?} size={}x{} bytes={}",
-                texture.webview,
-                texture.width,
-                texture.height,
-                texture.buffer.len()
+                texture.webview, texture.width, texture.height, bytes
             ));
         }
     }

--- a/patches/bevy_cef-0.5.2/src/webview/mesh/webview_material.rs
+++ b/patches/bevy_cef-0.5.2/src/webview/mesh/webview_material.rs
@@ -72,7 +72,7 @@ pub(crate) fn webview_placeholder_image() -> Image {
 }
 
 fn send_render_textures(mut ew: MessageWriter<RenderTextureMessage>, browsers: NonSend<Browsers>) {
-    while let Ok(texture) = browsers.try_receive_texture() {
+    for texture in browsers.drain_render_textures() {
         ew.write(texture);
     }
 }
@@ -84,6 +84,18 @@ fn send_render_textures(mut ew: MessageWriter<RenderTextureMessage>, browsers: N
 /// Keeps [`RenderAssetUsages::all`]: the main-world copy must persist so the upload path can read
 /// the current surface size and so the prepared `GpuImage` is never unloaded between resizes.
 pub(crate) fn update_webview_image(texture: &RenderTextureMessage, image: &mut Image) {
+    let stride = texture.width as usize * 4;
+    let mut buffer = vec![0_u8; stride * texture.height as usize];
+    for patch in texture.patches.iter() {
+        let row_bytes = patch.rect.width as usize * 4;
+        for row in 0..patch.rect.height as usize {
+            let source_start = row * row_bytes;
+            let destination_start =
+                (patch.rect.y as usize + row) * stride + patch.rect.x as usize * 4;
+            buffer[destination_start..destination_start + row_bytes]
+                .copy_from_slice(&patch.buffer[source_start..source_start + row_bytes]);
+        }
+    }
     *image = Image::new(
         Extent3d {
             width: texture.width,
@@ -91,7 +103,7 @@ pub(crate) fn update_webview_image(texture: &RenderTextureMessage, image: &mut I
             depth_or_array_layers: 1,
         },
         TextureDimension::D2,
-        (*texture.buffer).clone(),
+        buffer,
         TextureFormat::Bgra8UnormSrgb,
         RenderAssetUsages::all(),
     );

--- a/patches/bevy_cef-0.5.2/src/webview/texture_upload.rs
+++ b/patches/bevy_cef-0.5.2/src/webview/texture_upload.rs
@@ -7,7 +7,7 @@ use bevy::render::render_resource::{
 use bevy::render::renderer::RenderQueue;
 use bevy::render::texture::GpuImage;
 use bevy::render::{Extract, ExtractSchedule, Render, RenderApp, RenderSystems};
-use bevy_cef_core::prelude::{RenderTextureMessage, WebviewDirtyRect};
+use bevy_cef_core::prelude::{Browsers, RenderTextureMessage, WebviewPaintPatches};
 use std::sync::Arc;
 
 /// A CEF paint streamed into an already-prepared GPU texture via `write_texture`, so the texture
@@ -15,10 +15,9 @@ use std::sync::Arc;
 #[derive(Clone)]
 struct PendingTextureUpload {
     image: AssetId<Image>,
-    buffer: Arc<Vec<u8>>,
+    patches: Arc<WebviewPaintPatches>,
     width: u32,
     height: u32,
-    dirty: Vec<WebviewDirtyRect>,
 }
 
 /// Render-world queue of pending webview pixel uploads. Public only because the public
@@ -56,6 +55,7 @@ impl Plugin for WebviewTextureUploadPlugin {
 /// leaving the asset (and its bind group) untouched.
 pub(crate) fn apply_webview_texture(
     texture: &RenderTextureMessage,
+    browsers: &Browsers,
     images: &mut Assets<Image>,
     handle: &Handle<Image>,
     uploads: &mut WebviewTextureUploads,
@@ -67,11 +67,12 @@ pub(crate) fn apply_webview_texture(
     if same_size {
         uploads.0.push(PendingTextureUpload {
             image: handle.id(),
-            buffer: texture.buffer.clone(),
+            patches: texture.patches.clone(),
             width: texture.width,
             height: texture.height,
-            dirty: texture.dirty.clone(),
         });
+    } else if !texture.dirty.is_empty() {
+        browsers.request_full_cpu_paint(texture.webview, texture.ty);
     } else if let Some(mut image) = images.get_mut(handle.id()) {
         update_webview_image(texture, &mut image);
     }
@@ -103,31 +104,16 @@ fn upload_webview_textures(
         {
             continue;
         }
-        let stride = upload.width * 4;
-        if upload.dirty.is_empty() {
+        for patch in upload.patches.iter() {
             write_region(
                 &queue,
                 gpu,
-                &upload.buffer,
-                stride,
-                0,
-                0,
-                upload.width,
-                upload.height,
+                &patch.buffer,
+                patch.rect.x,
+                patch.rect.y,
+                patch.rect.width,
+                patch.rect.height,
             );
-        } else {
-            for rect in &upload.dirty {
-                write_region(
-                    &queue,
-                    gpu,
-                    &upload.buffer,
-                    stride,
-                    rect.x,
-                    rect.y,
-                    rect.width,
-                    rect.height,
-                );
-            }
         }
     }
 }
@@ -137,7 +123,6 @@ fn write_region(
     queue: &RenderQueue,
     gpu: &GpuImage,
     buffer: &[u8],
-    stride: u32,
     x: u32,
     y: u32,
     width: u32,
@@ -146,7 +131,6 @@ fn write_region(
     if width == 0 || height == 0 {
         return;
     }
-    let offset = y as u64 * stride as u64 + x as u64 * 4;
     queue.write_texture(
         TexelCopyTextureInfo {
             texture: &gpu.texture,
@@ -157,8 +141,8 @@ fn write_region(
         },
         buffer,
         TexelCopyBufferLayout {
-            offset,
-            bytes_per_row: Some(stride),
+            offset: 0,
+            bytes_per_row: Some(width * 4),
             rows_per_image: None,
         },
         Extent3d {
@@ -174,7 +158,7 @@ mod tests {
     use super::*;
     use bevy::asset::RenderAssetUsages;
     use bevy::render::render_resource::{TextureDimension, TextureFormat};
-    use bevy_cef_core::prelude::RenderPaintElementType;
+    use bevy_cef_core::prelude::{RenderPaintElementType, WebviewDirtyRect, WebviewPaintPatch};
 
     fn paint(width: u32, height: u32) -> RenderTextureMessage {
         RenderTextureMessage {
@@ -182,8 +166,20 @@ mod tests {
             ty: RenderPaintElementType::View,
             width,
             height,
-            buffer: Arc::new(vec![0u8; (width * height * 4) as usize]),
-            dirty: Vec::new(),
+            patches: Arc::new(
+                [WebviewPaintPatch {
+                    rect: WebviewDirtyRect {
+                        x: 0,
+                        y: 0,
+                        width,
+                        height,
+                    },
+                    buffer: Arc::new(vec![0u8; (width * height * 4) as usize]),
+                }]
+                .into_iter()
+                .collect(),
+            ),
+            dirty: Default::default(),
         }
     }
 
@@ -206,8 +202,9 @@ mod tests {
         let mut images = Assets::<Image>::default();
         let handle = images.add(surface(4, 4));
         let mut uploads = WebviewTextureUploads::default();
+        let browsers = Browsers::default();
 
-        apply_webview_texture(&paint(4, 4), &mut images, &handle, &mut uploads);
+        apply_webview_texture(&paint(4, 4), &browsers, &mut images, &handle, &mut uploads);
 
         assert_eq!(uploads.0.len(), 1);
         assert_eq!(
@@ -221,8 +218,9 @@ mod tests {
         let mut images = Assets::<Image>::default();
         let handle = images.add(surface(4, 4));
         let mut uploads = WebviewTextureUploads::default();
+        let browsers = Browsers::default();
 
-        apply_webview_texture(&paint(8, 6), &mut images, &handle, &mut uploads);
+        apply_webview_texture(&paint(8, 6), &browsers, &mut images, &handle, &mut uploads);
 
         assert!(uploads.0.is_empty());
         assert_eq!(

--- a/patches/bevy_cef-0.5.2/src/webview/webview_sprite.rs
+++ b/patches/bevy_cef-0.5.2/src/webview/webview_sprite.rs
@@ -12,6 +12,7 @@ use crate::webview::pinch_zoom::zoom_level_after_pinch;
 use crate::webview::texture_upload::{WebviewTextureUploads, apply_webview_texture};
 use bevy::input::gestures::PinchGesture;
 use bevy::input::mouse::{MouseScrollUnit, MouseWheel};
+use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
 use bevy_cef_core::prelude::{Browsers, RenderTextureMessage};
 use std::fmt::Debug;
@@ -99,6 +100,7 @@ fn sync_sprite_material_alpha(
 fn render(
     mut commands: Commands,
     mut er: MessageReader<RenderTextureMessage>,
+    browsers: NonSend<Browsers>,
     mut images: ResMut<Assets<bevy::prelude::Image>>,
     mut uploads: ResMut<WebviewTextureUploads>,
     mut webviews: Query<&mut Sprite, With<WebviewSource>>,
@@ -110,7 +112,7 @@ fn render(
         if sprite.image == Handle::default() {
             sprite.image = images.add(webview_placeholder_image());
         }
-        apply_webview_texture(texture, &mut images, &sprite.image, &mut uploads);
+        apply_webview_texture(texture, &browsers, &mut images, &sprite.image, &mut uploads);
         commands
             .entity(texture.webview)
             .insert(WebviewSurface(sprite.image.clone()));
@@ -193,6 +195,7 @@ fn on_mouse_wheel(
         for _ in er.read() {}
         return;
     }
+    let mut pending = HashMap::<Entity, (Vec2, Vec2)>::default();
     for event in er.read() {
         let Ok(window) = windows.get(event.window) else {
             continue;
@@ -218,7 +221,13 @@ fn on_mouse_wheel(
                     commands
                         .entity(webview)
                         .insert(HistorySwipeVisualOffset::default());
-                    browsers.send_mouse_wheel(&webview, pos, delta);
+                    pending
+                        .entry(webview)
+                        .and_modify(|(position, accumulated)| {
+                            *position = pos;
+                            *accumulated += delta;
+                        })
+                        .or_insert((pos, delta));
                 }
                 HistorySwipeOutcome::Consumed { visual } => {
                     commands
@@ -236,6 +245,9 @@ fn on_mouse_wheel(
                 }
             }
         }
+    }
+    for (webview, (position, delta)) in pending {
+        browsers.send_mouse_wheel(&webview, position, delta);
     }
 }
 

--- a/patches/bevy_cef_core-0.5.2/Cargo.toml
+++ b/patches/bevy_cef_core-0.5.2/Cargo.toml
@@ -113,6 +113,9 @@ features = ["sandbox"]
 version = "0.6"
 optional = true
 
+[dependencies.smallvec]
+version = "1"
+
 [dependencies.serde]
 version = "1"
 features = [

--- a/patches/bevy_cef_core-0.5.2/Cargo.toml.orig
+++ b/patches/bevy_cef_core-0.5.2/Cargo.toml.orig
@@ -21,6 +21,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 async-channel = { workspace = true }
 raw-window-handle = { workspace = true }
+smallvec = { workspace = true }
 winit = "0.30"
 
 [features]

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
@@ -6,7 +6,7 @@ use crate::browser_process::client_handler::{
     SnapshotResultRaw,
 };
 use crate::prelude::*;
-use async_channel::{Sender, TryRecvError};
+use async_channel::Sender;
 use bevy::input::ButtonState;
 use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
@@ -130,6 +130,7 @@ pub struct WebviewBrowser {
     pub device_scale: SharedDeviceScaleFactor,
     windowless_frame_rate: Cell<i32>,
     hidden: Cell<bool>,
+    last_mouse_move: Cell<Option<(i32, i32, u32, bool)>>,
     /// Last applied windowed (native) frame in points `(x, y, w, h)`. Used to skip redundant
     /// `setFrame`/`was_resized` calls — re-resizing CEF to the same size every frame clears its
     /// surface and leaves it blank until the next real paint.
@@ -193,8 +194,8 @@ pub struct Browsers {
 
 impl Default for Browsers {
     fn default() -> Self {
-        let (sender, receiver) = async_channel::unbounded::<RenderTextureMessage>();
-        let (accel_sender, accel_receiver) = async_channel::unbounded::<AcceleratedFrame>();
+        let (sender, receiver) = TextureMailbox::channel();
+        let (accel_sender, accel_receiver) = AcceleratedMailbox::channel();
         Browsers {
             browsers: HashMap::default(),
             sender,
@@ -421,6 +422,7 @@ impl Browsers {
             device_scale,
             windowless_frame_rate: Cell::new(windowless_frame_rate),
             hidden: Cell::new(false),
+            last_mouse_move: Cell::new(None),
             last_frame: Cell::new(None),
             last_corner_radius: Cell::new(None),
             last_corner_radius_all_corners: Cell::new(None),
@@ -556,11 +558,40 @@ impl Browsers {
         // Route by webview entity. Requiring `focused_frame()` drops all input until CEF already
         // has focus — so the first click never reaches `set_focus`.
         if let Some(browser) = self.browsers.get(webview) {
+            let modifiers = modifiers_from_mouse_buttons(buttons);
             let mouse_event = cef::MouseEvent {
                 x: position.x as i32,
                 y: position.y as i32,
-                modifiers: modifiers_from_mouse_buttons(buttons),
+                modifiers,
             };
+            let signature = (mouse_event.x, mouse_event.y, modifiers, mouse_leave);
+            if browser.last_mouse_move.replace(Some(signature)) == Some(signature) {
+                return;
+            }
+            browser
+                .host
+                .send_mouse_move_event(Some(&mouse_event), mouse_leave as _);
+        }
+    }
+
+    pub fn send_native_mouse_move(
+        &self,
+        webview: &Entity,
+        buttons: NativeMouseButtons,
+        position: Vec2,
+        mouse_leave: bool,
+    ) {
+        if let Some(browser) = self.browsers.get(webview) {
+            let modifiers = modifiers_from_native_mouse_buttons(buttons);
+            let mouse_event = cef::MouseEvent {
+                x: position.x as i32,
+                y: position.y as i32,
+                modifiers,
+            };
+            let signature = (mouse_event.x, mouse_event.y, modifiers, mouse_leave);
+            if browser.last_mouse_move.replace(Some(signature)) == Some(signature) {
+                return;
+            }
             browser
                 .host
                 .send_mouse_move_event(Some(&mouse_event), mouse_leave as _);
@@ -1631,6 +1662,8 @@ impl Browsers {
     ///
     /// The browser will be removed from the hash map after closing.
     pub fn close(&mut self, webview: &Entity) {
+        self.sender.discard(*webview);
+        self.accel_sender.discard(*webview);
         if let Some(browser) = self.browsers.remove(webview) {
             info!(
                 "cef_close_browser webview={webview:?} windowed={}",
@@ -1657,13 +1690,24 @@ impl Browsers {
     }
 
     #[inline]
-    pub fn try_receive_texture(&self) -> core::result::Result<RenderTextureMessage, TryRecvError> {
-        self.receiver.try_recv()
+    pub fn drain_render_textures(&self) -> Vec<RenderTextureMessage> {
+        self.receiver.drain()
+    }
+
+    pub fn request_full_cpu_paint(&self, webview: Entity, ty: RenderPaintElementType) {
+        self.sender.request_full(webview, ty);
+        if let Some(browser) = self.browsers.get(&webview) {
+            let ty = match ty {
+                RenderPaintElementType::View => cef::PaintElementType::VIEW,
+                RenderPaintElementType::Popup => cef::PaintElementType::POPUP,
+            };
+            browser.host.invalidate(ty);
+        }
     }
 
     #[inline]
-    pub fn try_receive_accelerated(&self) -> core::result::Result<AcceleratedFrame, TryRecvError> {
-        self.accel_receiver.try_recv()
+    pub fn drain_accelerated_frames(&self) -> Vec<AcceleratedFrame> {
+        self.accel_receiver.drain()
     }
 
     /// Shows the DevTools for the specified webview.
@@ -2615,7 +2659,7 @@ mod tests {
         let close_fn = implementation
             .split("pub fn close")
             .nth(1)
-            .and_then(|tail| tail.split("pub fn try_receive_texture").next())
+            .and_then(|tail| tail.split("pub fn drain_render_textures").next())
             .unwrap_or_default();
 
         assert!(close_fn.contains("window_handle"));

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
@@ -581,6 +581,27 @@ impl Browsers {
         position: Vec2,
         mouse_leave: bool,
     ) {
+        self.send_native_mouse_move_inner(webview, buttons, position, mouse_leave, true);
+    }
+
+    pub fn send_native_mouse_move_force(
+        &self,
+        webview: &Entity,
+        buttons: NativeMouseButtons,
+        position: Vec2,
+        mouse_leave: bool,
+    ) {
+        self.send_native_mouse_move_inner(webview, buttons, position, mouse_leave, false);
+    }
+
+    fn send_native_mouse_move_inner(
+        &self,
+        webview: &Entity,
+        buttons: NativeMouseButtons,
+        position: Vec2,
+        mouse_leave: bool,
+        deduplicate: bool,
+    ) {
         if let Some(browser) = self.browsers.get(webview) {
             let modifiers = modifiers_from_native_mouse_buttons(buttons);
             let mouse_event = cef::MouseEvent {
@@ -589,7 +610,7 @@ impl Browsers {
                 modifiers,
             };
             let signature = (mouse_event.x, mouse_event.y, modifiers, mouse_leave);
-            if browser.last_mouse_move.replace(Some(signature)) == Some(signature) {
+            if browser.last_mouse_move.replace(Some(signature)) == Some(signature) && deduplicate {
                 return;
             }
             browser

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/browsers.rs
@@ -581,27 +581,6 @@ impl Browsers {
         position: Vec2,
         mouse_leave: bool,
     ) {
-        self.send_native_mouse_move_inner(webview, buttons, position, mouse_leave, true);
-    }
-
-    pub fn send_native_mouse_move_force(
-        &self,
-        webview: &Entity,
-        buttons: NativeMouseButtons,
-        position: Vec2,
-        mouse_leave: bool,
-    ) {
-        self.send_native_mouse_move_inner(webview, buttons, position, mouse_leave, false);
-    }
-
-    fn send_native_mouse_move_inner(
-        &self,
-        webview: &Entity,
-        buttons: NativeMouseButtons,
-        position: Vec2,
-        mouse_leave: bool,
-        deduplicate: bool,
-    ) {
         if let Some(browser) = self.browsers.get(webview) {
             let modifiers = modifiers_from_native_mouse_buttons(buttons);
             let mouse_event = cef::MouseEvent {
@@ -610,7 +589,7 @@ impl Browsers {
                 modifiers,
             };
             let signature = (mouse_event.x, mouse_event.y, modifiers, mouse_leave);
-            if browser.last_mouse_move.replace(Some(signature)) == Some(signature) && deduplicate {
+            if browser.last_mouse_move.replace(Some(signature)) == Some(signature) {
                 return;
             }
             browser

--- a/patches/bevy_cef_core-0.5.2/src/browser_process/renderer_handler.rs
+++ b/patches/bevy_cef_core-0.5.2/src/browser_process/renderer_handler.rs
@@ -1,19 +1,21 @@
 #[cfg(target_os = "macos")]
 use super::keepalive::{IoSurfaceKeepAlive, RealIoSurfaceOps};
-use async_channel::{Receiver, Sender};
 use bevy::prelude::*;
 use cef::osr_texture_import::SharedTextureHandle;
 use cef::rc::{Rc, RcImpl};
 use cef::*;
 use cef_dll_sys::cef_paint_element_type_t;
+use smallvec::SmallVec;
 use std::any::Any;
 use std::cell::Cell;
+use std::collections::{HashMap, HashSet};
 use std::os::raw::c_int;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
-pub type TextureSender = Sender<RenderTextureMessage>;
-
-pub type TextureReceiver = Receiver<RenderTextureMessage>;
+/// Inline dirty-rectangle storage for CEF paints.
+pub type WebviewDirtyRects = SmallVec<[WebviewDirtyRect; 8]>;
+/// Inline pixel-patch storage for CPU CEF paints.
+pub type WebviewPaintPatches = SmallVec<[WebviewPaintPatch; 4]>;
 
 pub type TextureWake = Arc<dyn Fn() + Send + Sync + 'static>;
 pub type AcceleratedFramePresenter = Arc<dyn Fn(AcceleratedFrame) + Send + Sync + 'static>;
@@ -29,14 +31,20 @@ pub struct RenderTextureMessage {
     pub width: u32,
     /// The height of the texture.
     pub height: u32,
-    /// This buffer will be `width` *`height` * 4 bytes in size and represents a BGRA image with an upper-left origin.
-    ///
-    /// Wrapped in `Arc` so the message survives Bevy's per-reader clone (3 consumers — mesh,
-    /// extend-material, sprite) without copying the full BGRA buffer each time.
-    pub buffer: Arc<Vec<u8>>,
-    /// Sub-regions of `buffer` that changed this paint, in pixels with an upper-left origin.
+    /// Packed BGRA pixel patches for the changed regions.
+    pub patches: Arc<WebviewPaintPatches>,
+    /// Changed regions in pixels with an upper-left origin.
     /// Empty means treat the whole frame as dirty (full upload).
-    pub dirty: Vec<WebviewDirtyRect>,
+    pub dirty: WebviewDirtyRects,
+}
+
+/// Packed BGRA pixels for one changed surface region.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WebviewPaintPatch {
+    /// Destination region in the webview surface.
+    pub rect: WebviewDirtyRect,
+    /// Tightly packed rows with `rect.width * 4` bytes per row.
+    pub buffer: Arc<Vec<u8>>,
 }
 
 /// A changed sub-region of a webview paint, in pixels with an upper-left origin.
@@ -48,19 +56,14 @@ pub struct WebviewDirtyRect {
     pub height: u32,
 }
 
-fn webview_dirty_rects(
-    rects: Option<&[cef::Rect]>,
-    width: u32,
-    height: u32,
-) -> Vec<WebviewDirtyRect> {
+fn webview_dirty_rects(rects: Option<&[cef::Rect]>, width: u32, height: u32) -> WebviewDirtyRects {
     let Some(rects) = rects else {
-        return Vec::new();
+        return WebviewDirtyRects::new();
     };
     let surface_w = width as i32;
     let surface_h = height as i32;
-    rects
-        .iter()
-        .filter_map(|r| {
+    optimize_webview_dirty_rects(
+        rects.iter().filter_map(|r| {
             let left = r.x.max(0);
             let top = r.y.max(0);
             let right = r.x.saturating_add(r.width).min(surface_w);
@@ -74,8 +77,87 @@ fn webview_dirty_rects(
                 width: (right - left) as u32,
                 height: (bottom - top) as u32,
             })
-        })
-        .collect()
+        }),
+        width,
+        height,
+    )
+}
+
+fn dirty_rect_union(left: WebviewDirtyRect, right: WebviewDirtyRect) -> Option<WebviewDirtyRect> {
+    let left_right = left.x.saturating_add(left.width);
+    let left_bottom = left.y.saturating_add(left.height);
+    let right_right = right.x.saturating_add(right.width);
+    let right_bottom = right.y.saturating_add(right.height);
+    if left_right < right.x
+        || right_right < left.x
+        || left_bottom < right.y
+        || right_bottom < left.y
+    {
+        return None;
+    }
+    let x = left.x.min(right.x);
+    let y = left.y.min(right.y);
+    Some(WebviewDirtyRect {
+        x,
+        y,
+        width: left_right.max(right_right).saturating_sub(x),
+        height: left_bottom.max(right_bottom).saturating_sub(y),
+    })
+}
+
+/// Clamp and merge dirty rectangles, using an empty result for a full-frame update.
+pub fn optimize_webview_dirty_rects(
+    rects: impl IntoIterator<Item = WebviewDirtyRect>,
+    width: u32,
+    height: u32,
+) -> WebviewDirtyRects {
+    let mut merged = WebviewDirtyRects::new();
+    for rect in rects {
+        let right = rect.x.saturating_add(rect.width).min(width);
+        let bottom = rect.y.saturating_add(rect.height).min(height);
+        if rect.x >= width || rect.y >= height || right <= rect.x || bottom <= rect.y {
+            continue;
+        }
+        let mut rect = WebviewDirtyRect {
+            x: rect.x,
+            y: rect.y,
+            width: right - rect.x,
+            height: bottom - rect.y,
+        };
+        let mut index = 0;
+        while index < merged.len() {
+            if let Some(union) = dirty_rect_union(merged[index], rect) {
+                rect = union;
+                merged.swap_remove(index);
+                index = 0;
+            } else {
+                index += 1;
+            }
+        }
+        merged.push(rect);
+    }
+    let area = merged.iter().fold(0_u64, |total, rect| {
+        total.saturating_add(rect.width as u64 * rect.height as u64)
+    });
+    let full_area = width as u64 * height as u64;
+    if merged.len() > 16 || area.saturating_mul(2) >= full_area {
+        merged.clear();
+    }
+    merged
+}
+
+/// Combine damage from dropped frames, using an empty result for a full-frame update.
+pub fn coalesce_webview_dirty_rects(
+    width: u32,
+    height: u32,
+    previous: &[WebviewDirtyRect],
+    latest: &[WebviewDirtyRect],
+    same_surface: bool,
+) -> WebviewDirtyRects {
+    if !same_surface || previous.is_empty() || latest.is_empty() {
+        return WebviewDirtyRects::new();
+    }
+    optimize_webview_dirty_rects(previous.iter().chain(latest).copied(), width, height)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -84,6 +166,201 @@ pub enum RenderPaintElementType {
     View,
     /// The popup frame of the browser.
     Popup,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct PaintFrameKey {
+    webview: Entity,
+    ty: RenderPaintElementType,
+}
+
+#[derive(Default)]
+struct TextureMailboxState {
+    pending: HashMap<PaintFrameKey, PendingTexturePaint>,
+    sizes: HashMap<PaintFrameKey, (u32, u32)>,
+    force_full: HashSet<PaintFrameKey>,
+    next_generation: u64,
+    next_sequence: u64,
+}
+
+struct PendingTexturePaint {
+    generation: u64,
+    sequence: u64,
+    width: u32,
+    height: u32,
+    dirty: WebviewDirtyRects,
+    message: Option<RenderTextureMessage>,
+}
+
+/// Latest CPU paint per webview and paint element.
+#[derive(Clone, Default)]
+pub struct TextureMailbox(Arc<Mutex<TextureMailboxState>>);
+
+pub type TextureSender = TextureMailbox;
+pub type TextureReceiver = TextureMailbox;
+
+impl TextureMailbox {
+    /// Create producer and consumer handles for one mailbox.
+    pub fn channel() -> (TextureSender, TextureReceiver) {
+        let mailbox = Self::default();
+        (mailbox.clone(), mailbox)
+    }
+
+    fn publish_paint(
+        &self,
+        webview: Entity,
+        ty: RenderPaintElementType,
+        width: u32,
+        height: u32,
+        dirty: WebviewDirtyRects,
+        buffer: *const u8,
+    ) -> bool {
+        let key = PaintFrameKey { webview, ty };
+        let (generation, sequence, dirty) = {
+            let mut state = self
+                .0
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let same_surface = state.sizes.get(&key) == Some(&(width, height));
+            state.sizes.insert(key, (width, height));
+            let dirty = if state.force_full.remove(&key) {
+                WebviewDirtyRects::new()
+            } else if let Some(previous) = state.pending.get(&key) {
+                coalesce_webview_dirty_rects(
+                    width,
+                    height,
+                    &previous.dirty,
+                    &dirty,
+                    previous.width == width && previous.height == height,
+                )
+            } else if same_surface {
+                dirty
+            } else {
+                WebviewDirtyRects::new()
+            };
+            state.next_generation = state.next_generation.wrapping_add(1);
+            state.next_sequence = state.next_sequence.wrapping_add(1);
+            let generation = state.next_generation;
+            let sequence = state.next_sequence;
+            state.pending.insert(
+                key,
+                PendingTexturePaint {
+                    generation,
+                    sequence,
+                    width,
+                    height,
+                    dirty: dirty.clone(),
+                    message: None,
+                },
+            );
+            (generation, sequence, dirty)
+        };
+        let patches = Arc::new(copy_paint_patches(buffer, width, height, &dirty));
+        let message = RenderTextureMessage {
+            webview,
+            ty,
+            width,
+            height,
+            patches,
+            dirty,
+        };
+        let mut state = self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let Some(pending) = state
+            .pending
+            .get_mut(&key)
+            .filter(|pending| pending.generation == generation && pending.sequence == sequence)
+        else {
+            return false;
+        };
+        pending.message = Some(message);
+        true
+    }
+
+    /// Drain all latest pending paints.
+    pub fn drain(&self) -> Vec<RenderTextureMessage> {
+        let mut state = self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut ready = Vec::new();
+        state.pending.retain(|_, pending| {
+            let Some(message) = pending.message.take() else {
+                return true;
+            };
+            ready.push((pending.sequence, message));
+            false
+        });
+        ready.sort_unstable_by_key(|(sequence, _)| *sequence);
+        ready.into_iter().map(|(_, message)| message).collect()
+    }
+
+    /// Force the next CPU paint for one surface to carry the complete frame.
+    pub fn request_full(&self, webview: Entity, ty: RenderPaintElementType) {
+        let key = PaintFrameKey { webview, ty };
+        let mut state = self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.pending.remove(&key);
+        state.force_full.insert(key);
+    }
+
+    /// Remove pending state for a closed webview.
+    pub fn discard(&self, webview: Entity) {
+        let mut state = self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.pending.retain(|key, _| key.webview != webview);
+        state.sizes.retain(|key, _| key.webview != webview);
+        state.force_full.retain(|key| key.webview != webview);
+    }
+}
+
+fn copy_paint_patches(
+    buffer: *const u8,
+    width: u32,
+    height: u32,
+    dirty: &[WebviewDirtyRect],
+) -> WebviewPaintPatches {
+    let full = WebviewDirtyRect {
+        x: 0,
+        y: 0,
+        width,
+        height,
+    };
+    let rects = if dirty.is_empty() {
+        std::slice::from_ref(&full)
+    } else {
+        dirty
+    };
+    let source_stride = width as usize * 4;
+    rects
+        .iter()
+        .filter(|rect| rect.width > 0 && rect.height > 0)
+        .map(|rect| {
+            let row_bytes = rect.width as usize * 4;
+            let mut bytes = vec![0_u8; row_bytes * rect.height as usize];
+            for row in 0..rect.height as usize {
+                let source_offset = (rect.y as usize + row) * source_stride + rect.x as usize * 4;
+                let destination_offset = row * row_bytes;
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        buffer.add(source_offset),
+                        bytes.as_mut_ptr().add(destination_offset),
+                        row_bytes,
+                    );
+                }
+            }
+            WebviewPaintPatch {
+                rect: *rect,
+                buffer: Arc::new(bytes),
+            }
+        })
+        .collect()
 }
 
 pub struct SendSharedTextureHandle(pub SharedTextureHandle);
@@ -107,11 +384,79 @@ pub struct AcceleratedFrame {
     /// overlay set it directly as a `CALayer`'s `contents` instead of importing into a GPU texture.
     pub io_surface: usize,
     pub keepalive: Arc<dyn Any + Send + Sync>,
-    pub dirty: Vec<WebviewDirtyRect>,
+    pub dirty: WebviewDirtyRects,
 }
 
-pub type AcceleratedSender = Sender<AcceleratedFrame>;
-pub type AcceleratedReceiver = Receiver<AcceleratedFrame>;
+#[derive(Default)]
+struct AcceleratedMailboxState {
+    pending: HashMap<PaintFrameKey, (u64, AcceleratedFrame)>,
+    next_sequence: u64,
+}
+
+/// Latest accelerated paint per webview and paint element.
+#[derive(Clone, Default)]
+pub struct AcceleratedMailbox(Arc<Mutex<AcceleratedMailboxState>>);
+
+pub type AcceleratedSender = AcceleratedMailbox;
+pub type AcceleratedReceiver = AcceleratedMailbox;
+
+impl AcceleratedMailbox {
+    /// Create producer and consumer handles for one mailbox.
+    pub fn channel() -> (AcceleratedSender, AcceleratedReceiver) {
+        let mailbox = Self::default();
+        (mailbox.clone(), mailbox)
+    }
+
+    /// Replace the pending frame and return whether the mailbox became non-empty for its key.
+    pub fn publish(&self, mut frame: AcceleratedFrame) -> bool {
+        let key = PaintFrameKey {
+            webview: frame.webview,
+            ty: frame.ty,
+        };
+        let mut state = self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some((_, previous)) = state.pending.get(&key) {
+            frame.dirty = coalesce_webview_dirty_rects(
+                frame.width,
+                frame.height,
+                &previous.dirty,
+                &frame.dirty,
+                previous.width == frame.width
+                    && previous.height == frame.height
+                    && previous.format == frame.format,
+            );
+        }
+        state.next_sequence = state.next_sequence.wrapping_add(1);
+        let sequence = state.next_sequence;
+        state.pending.insert(key, (sequence, frame)).is_none()
+    }
+
+    /// Drain all latest pending frames.
+    pub fn drain(&self) -> Vec<AcceleratedFrame> {
+        let mut state = self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut frames = state
+            .pending
+            .drain()
+            .map(|(_, frame)| frame)
+            .collect::<Vec<_>>();
+        frames.sort_unstable_by_key(|(sequence, _)| *sequence);
+        frames.into_iter().map(|(_, frame)| frame).collect()
+    }
+
+    /// Remove pending state for a closed webview.
+    pub fn discard(&self, webview: Entity) {
+        self.0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .pending
+            .retain(|key, _| key.webview != webview);
+    }
+}
 
 pub type SharedViewSize = std::rc::Rc<Cell<Vec2>>;
 
@@ -231,17 +576,16 @@ impl ImplRenderHandler for RenderHandlerBuilder {
             cef_paint_element_type_t::PET_POPUP => RenderPaintElementType::Popup,
             _ => RenderPaintElementType::View,
         };
-        let texture = RenderTextureMessage {
-            webview: self.webview,
-            ty,
-            width: width as u32,
-            height: height as u32,
-            buffer: Arc::new(unsafe {
-                std::slice::from_raw_parts(buffer, (width * height * 4) as usize).to_vec()
-            }),
-            dirty: webview_dirty_rects(dirty_rects, width as u32, height as u32),
-        };
-        send_render_texture(&self.texture_sender, self.texture_wake.as_ref(), texture);
+        let width = width as u32;
+        let height = height as u32;
+        let dirty = webview_dirty_rects(dirty_rects, width, height);
+        if self
+            .texture_sender
+            .publish_paint(self.webview, ty, width, height, dirty, buffer)
+            && let Some(wake) = self.texture_wake.as_ref()
+        {
+            wake();
+        }
     }
 
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -286,8 +630,9 @@ impl ImplRenderHandler for RenderHandlerBuilder {
             if let Some(presenter) = self.accelerated_presenter.as_ref() {
                 presenter(frame);
             } else {
-                let _ = self.accel_sender.send_blocking(frame);
-                if let Some(wake) = self.texture_wake.as_ref() {
+                if self.accel_sender.publish(frame)
+                    && let Some(wake) = self.texture_wake.as_ref()
+                {
                     wake();
                 }
             }
@@ -304,46 +649,110 @@ impl ImplRenderHandler for RenderHandlerBuilder {
     }
 }
 
-fn send_render_texture(
-    texture_sender: &TextureSender,
-    texture_wake: Option<&TextureWake>,
-    texture: RenderTextureMessage,
-) {
-    let _ = texture_sender.send_blocking(texture);
-    if let Some(wake) = texture_wake {
-        wake();
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
-    fn render_texture_delivery_wakes_consumer() {
-        let (tx, rx) = async_channel::unbounded();
-        let wakes = Arc::new(AtomicUsize::new(0));
-        let wakes_for_callback = Arc::clone(&wakes);
-        let wake: TextureWake = Arc::new(move || {
-            wakes_for_callback.fetch_add(1, Ordering::Relaxed);
-        });
-
-        send_render_texture(
-            &tx,
-            Some(&wake),
-            RenderTextureMessage {
-                webview: Entity::from_bits(1),
-                ty: RenderPaintElementType::View,
+    fn texture_mailbox_keeps_latest_frame() {
+        let (tx, rx) = TextureMailbox::channel();
+        let first = vec![1_u8; 4 * 4 * 4];
+        let latest = vec![2_u8; 4 * 4 * 4];
+        assert!(tx.publish_paint(
+            Entity::from_bits(1),
+            RenderPaintElementType::View,
+            4,
+            4,
+            WebviewDirtyRects::new(),
+            first.as_ptr(),
+        ));
+        assert!(tx.publish_paint(
+            Entity::from_bits(1),
+            RenderPaintElementType::View,
+            4,
+            4,
+            smallvec::smallvec![WebviewDirtyRect {
+                x: 1,
+                y: 1,
                 width: 1,
                 height: 1,
-                buffer: Arc::new(vec![0, 0, 0, 0]),
-                dirty: Vec::new(),
-            },
+            }],
+            latest.as_ptr(),
+        ));
+
+        let frames = rx.drain();
+        assert_eq!(frames.len(), 1);
+        assert!(frames[0].dirty.is_empty());
+        assert_eq!(frames[0].patches[0].buffer.as_slice(), latest.as_slice());
+    }
+
+    #[test]
+    fn texture_mailbox_copies_only_dirty_pixels_after_initial_frame() {
+        let (tx, rx) = TextureMailbox::channel();
+        let first = vec![1_u8; 4 * 4 * 4];
+        tx.publish_paint(
+            Entity::from_bits(1),
+            RenderPaintElementType::View,
+            4,
+            4,
+            WebviewDirtyRects::new(),
+            first.as_ptr(),
+        );
+        rx.drain();
+        let latest = vec![2_u8; 4 * 4 * 4];
+        tx.publish_paint(
+            Entity::from_bits(1),
+            RenderPaintElementType::View,
+            4,
+            4,
+            smallvec::smallvec![WebviewDirtyRect {
+                x: 1,
+                y: 1,
+                width: 2,
+                height: 1,
+            }],
+            latest.as_ptr(),
         );
 
-        assert!(rx.try_recv().is_ok());
-        assert_eq!(wakes.load(Ordering::Relaxed), 1);
+        let frames = rx.drain();
+        assert_eq!(frames[0].patches.len(), 1);
+        assert_eq!(frames[0].patches[0].buffer.len(), 8);
+        assert!(frames[0].patches[0].buffer.iter().all(|byte| *byte == 2));
+    }
+
+    #[test]
+    fn requested_full_paint_repairs_consumer_reinitialization() {
+        let (tx, rx) = TextureMailbox::channel();
+        let first = vec![1_u8; 4 * 4 * 4];
+        tx.publish_paint(
+            Entity::from_bits(1),
+            RenderPaintElementType::View,
+            4,
+            4,
+            WebviewDirtyRects::new(),
+            first.as_ptr(),
+        );
+        rx.drain();
+        tx.request_full(Entity::from_bits(1), RenderPaintElementType::View);
+
+        let latest = vec![2_u8; 4 * 4 * 4];
+        tx.publish_paint(
+            Entity::from_bits(1),
+            RenderPaintElementType::View,
+            4,
+            4,
+            smallvec::smallvec![WebviewDirtyRect {
+                x: 1,
+                y: 1,
+                width: 1,
+                height: 1,
+            }],
+            latest.as_ptr(),
+        );
+
+        let frames = rx.drain();
+        assert!(frames[0].dirty.is_empty());
+        assert_eq!(frames[0].patches[0].buffer.len(), latest.len());
     }
 
     #[test]
@@ -357,7 +766,7 @@ mod tests {
 
         assert!(callback.contains("presenter(frame)"));
         assert!(callback.contains("else {"));
-        assert!(callback.contains("self.accel_sender.send_blocking(frame)"));
+        assert!(callback.contains("self.accel_sender.publish(frame)"));
         assert!(callback.contains("wake()"));
     }
 
@@ -367,25 +776,25 @@ mod tests {
             cef::Rect {
                 x: -5,
                 y: 0,
-                width: 100,
-                height: 100,
+                width: 10,
+                height: 10,
             },
             cef::Rect {
                 x: 90,
                 y: 90,
-                width: 100,
-                height: 100,
+                width: 20,
+                height: 20,
             },
         ];
         let dirty = webview_dirty_rects(Some(&rects), 100, 100);
         assert_eq!(
-            dirty,
-            vec![
+            dirty.as_slice(),
+            &[
                 WebviewDirtyRect {
                     x: 0,
                     y: 0,
-                    width: 95,
-                    height: 100,
+                    width: 5,
+                    height: 10,
                 },
                 WebviewDirtyRect {
                     x: 90,
@@ -400,5 +809,36 @@ mod tests {
     #[test]
     fn missing_dirty_rects_mean_full_frame() {
         assert!(webview_dirty_rects(None, 100, 100).is_empty());
+    }
+
+    #[test]
+    fn overlapping_dirty_rects_are_merged() {
+        let dirty = optimize_webview_dirty_rects(
+            [
+                WebviewDirtyRect {
+                    x: 10,
+                    y: 10,
+                    width: 10,
+                    height: 10,
+                },
+                WebviewDirtyRect {
+                    x: 15,
+                    y: 15,
+                    width: 10,
+                    height: 10,
+                },
+            ],
+            100,
+            100,
+        );
+        assert_eq!(
+            dirty.as_slice(),
+            &[WebviewDirtyRect {
+                x: 10,
+                y: 10,
+                width: 15,
+                height: 15,
+            }]
+        );
     }
 }


### PR DESCRIPTION
## Context\n\nHigh-frequency AppKit pointer events and unbounded CEF paint queues did work far above the visible render rate. This reduces input, copy, wake, and presentation overhead while preserving exact click and damage behavior.\n\n## Implementation\n\nUses a lock-free latest-pointer snapshot with 30 Hz hover and 60 Hz drag wakes, exact pre-click forwarding, wheel accumulation, and 10/30/60 FPS layout pacing. CPU and accelerated paints now use latest-frame mailboxes, ordered damage coalescing, packed dirty patches, bounded rectangle storage, and full-frame recovery when a consumer is reinitialized. Native overlay presentation keeps one pending frame per entity and avoids redundant drains while Metal work is in flight; the existing copied IOSurface swapchain remains to avoid reuse-pool tearing.\n\n## Checks / QA\n\n- Move, click, drag, and scroll across layout regions; verify hover transitions and exact click targets.\n- Release a drag outside the app; verify input and frame rate return to idle.\n- Resize the window and exercise overlays/popups; verify no stale pixels, black regions, or tearing.\n- Compare idle, hover, and drag CPU usage and visual responsiveness.