### PR TITLE
chore(release): v0.0.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9602,7 +9602,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9647,7 +9647,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_browser"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "base64 0.22.1",
  "bevy",
@@ -9673,7 +9673,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -9686,7 +9686,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9701,7 +9701,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command_mcp"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "serde_json",
  "vmux_command",
@@ -9710,7 +9710,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9731,7 +9731,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9799,7 +9799,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_editor"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "arboard",
  "bevy",
@@ -9842,7 +9842,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_git"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9861,7 +9861,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9882,7 +9882,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -9919,7 +9919,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "muda",
  "proc-macro2",
@@ -9929,7 +9929,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -9942,14 +9942,14 @@ dependencies = [
 
 [[package]]
 name = "vmux_profile"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "vmux_server"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "dioxus",
  "regex",
@@ -9970,7 +9970,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "agent-client-protocol",
  "alacritty_terminal",
@@ -10010,7 +10010,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service_client"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "chrono",
  "libc",
@@ -10023,7 +10023,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10046,7 +10046,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10071,7 +10071,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_team"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10092,7 +10092,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10126,7 +10126,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "dioxus",
  "dioxus-primitives",
@@ -10144,7 +10144,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_wire"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "bevy_ecs",
  "bevy_reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.24"
+version = "0.0.25"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "GPL-3.0-or-later"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.24"
-  sha256 "991edceaddea936a8a64921d512c97842400fab75a312cf15b0448ff60a2cc8f"
+  version "0.0.25"
+  sha256 "38f43c3c085a595677a96431fe852f2c57266afd1c00b63dfdcc7a7cce4abf78"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.24/Vmux_0.0.24_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.25/Vmux_0.0.25_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai/"

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.24",
-  "pub_date": "2026-07-15T06:42:47Z",
+  "version": "v0.0.25",
+  "pub_date": "2026-07-17T10:50:13Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.24/Vmux-v0.0.24-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzgvWkdnQ0c4YldZWXF3elFwWjhKUFphZU5LOWhLUXl1V21oVjBoakNudlFFNHBEQnZqZXVXQ3lXRWhVbXhzN0JwZUZjR05nNUVEamdKVnhQRDl1a1FJPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg0MDk3MDEzCWZpbGU6Vm11eC12MC4wLjI0LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKNTIybk0reGpXeG9iUWdMMlhlY2dkL1pNWlVPV2xqSTAyWitXakh0QWcwUkphN3l3V0tlSW5FUWdQeWRlT1A1WVRzeDFYTzlFOGJCcUthRDh1U2VtQUE9PQo=",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.25/Vmux-v0.0.25-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTyttaFZSM2R5Q0o2RkQzRFpGV08ycXV4L0dwYmtCcGdueVRrUHdRR2VIWUJBQ3BKajRzQ2d5dGt3d1N4VFVYNFJpV1M1bnVtb2F0NDQrWElPaTJCZ0FNPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg0Mjg1MzE0CWZpbGU6Vm11eC12MC4wLjI1LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKc1cvYXg2T2FWbVA4NHp1NGQ5M0czZTdlcWpvWnRnSFJxWDZkQytyb0Z1K3llUzlKTU1SUUhISTJqUEs3K1VMcUZNazd1V0RQZ21LcUFKOWh6NVU3QUE9PQo=",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.24/Vmux_0.0.24_aarch64.dmg",
-      "filename": "Vmux_0.0.24_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.25/Vmux_0.0.25_aarch64.dmg",
+      "filename": "Vmux_0.0.25_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
Patch release. Bumps workspace version 0.0.24 -> 0.0.25. Releases on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Incremented the workspace package version to 0.0.25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->