### PR TITLE
fix(release): correct v0.0.25 cask checksum

### DIFF
--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,6 +1,6 @@
 cask "vmux" do
   version "0.0.25"
-  sha256 "38f43c3c085a595677a96431fe852f2c57266afd1c00b63dfdcc7a7cce4abf78"
+  sha256 "3c0fb73ff83260d9f9bea87adac1d365e14964d23d520ed7ea8deb4f9664cd30"
 
   url "https://github.com/vmux-ai/vmux/releases/download/v0.0.25/Vmux_0.0.25_aarch64.dmg"
   name "Vmux"


### PR DESCRIPTION
Corrects the Homebrew cask SHA-256 to match the complete published v0.0.25 DMG. The previous value was computed while the artifact download was still incomplete.\n\nPublished DMG SHA-256: 3c0fb73ff83260d9f9bea87adac1d365e14964d23d520ed7ea8deb4f9664cd30