### PR TITLE
fix(tabs): activate new tabs in same update

### DIFF
--- a/crates/vmux_layout/src/space.rs
+++ b/crates/vmux_layout/src/space.rs
@@ -26,7 +26,8 @@ impl Plugin for SpacePlugin {
                     crate::active::ensure_active_stack,
                     crate::active::ensure_active_branch,
                 )
-                    .after(ReadAppCommands),
+                    .after(ReadAppCommands)
+                    .after(crate::window::spawn_requested_tab_layouts),
             )
             .add_systems(
                 PostUpdate,

--- a/crates/vmux_layout/src/stack.rs
+++ b/crates/vmux_layout/src/stack.rs
@@ -72,7 +72,10 @@ impl Plugin for StackPlugin {
                 Update,
                 compute_focused_stack
                     .in_set(ComputeFocusSet)
-                    .after(ReadAppCommands),
+                    .after(ReadAppCommands)
+                    .after(crate::active::ensure_active_tab)
+                    .after(crate::active::ensure_active_stack)
+                    .after(crate::active::ensure_active_branch),
             )
             .add_systems(PostUpdate, sync_stack_picking);
     }

--- a/crates/vmux_layout/src/tab.rs
+++ b/crates/vmux_layout/src/tab.rs
@@ -733,6 +733,33 @@ mod tests {
     }
 
     #[test]
+    fn new_tab_becomes_active_in_single_update() {
+        let mut app = build_app();
+        app.add_plugins(crate::space::SpacePlugin);
+        build_main_and_tab(&mut app);
+        let old_tab = app
+            .world_mut()
+            .query_filtered::<Entity, With<Tab>>()
+            .single(app.world())
+            .expect("initial tab");
+
+        app.world_mut()
+            .resource_mut::<Messages<AppCommand>>()
+            .write(AppCommand::Browser(BrowserCommand::Open(
+                OpenCommand::InNewTab { url: None },
+            )));
+
+        app.update();
+
+        let new_tab = app
+            .world_mut()
+            .query_filtered::<Entity, (With<Tab>, With<vmux_core::Active>)>()
+            .single(app.world())
+            .expect("one active tab");
+        assert_ne!(new_tab, old_tab);
+    }
+
+    #[test]
     fn new_tab_parents_under_active_space_container() {
         let mut app = build_app();
         let window = app.world_mut().spawn(PrimaryWindow).id();

--- a/crates/vmux_layout/src/tab.rs
+++ b/crates/vmux_layout/src/tab.rs
@@ -735,13 +735,29 @@ mod tests {
     #[test]
     fn new_tab_becomes_active_in_single_update() {
         let mut app = build_app();
-        app.add_plugins(crate::space::SpacePlugin);
+        app.init_resource::<crate::pane::PendingCursorWarp>()
+            .add_plugins((crate::space::SpacePlugin, crate::stack::StackPlugin));
         build_main_and_tab(&mut app);
         let old_tab = app
             .world_mut()
             .query_filtered::<Entity, With<Tab>>()
             .single(app.world())
             .expect("initial tab");
+        app.world_mut()
+            .entity_mut(old_tab)
+            .insert(vmux_core::Active);
+        let old_pane = app
+            .world_mut()
+            .spawn((crate::pane::Pane, LastActivatedAt(1), ChildOf(old_tab)))
+            .id();
+        let old_stack = app
+            .world_mut()
+            .spawn((
+                crate::stack::stack_bundle(),
+                LastActivatedAt(1),
+                ChildOf(old_pane),
+            ))
+            .id();
 
         app.world_mut()
             .resource_mut::<Messages<AppCommand>>()
@@ -757,6 +773,10 @@ mod tests {
             .single(app.world())
             .expect("one active tab");
         assert_ne!(new_tab, old_tab);
+        let focused = app.world().resource::<crate::stack::FocusedStack>();
+        assert_eq!(focused.tab, Some(new_tab));
+        assert!(focused.pane.is_some_and(|pane| pane != old_pane));
+        assert!(focused.stack.is_some_and(|stack| stack != old_stack));
     }
 
     #[test]


### PR DESCRIPTION
## Context
The first new tab opened after an idle period remained visually on the previous tab for roughly 350–414 ms. The tab scaffold was created in the command frame, but active-tab reconciliation could run before that spawn and leave the previous tab active until the next reactive update.

## Implementation
Run active tab, stack, and branch reconciliation after requested tab layouts spawn. Recompute focused stack only after that hierarchy is active, so layout state and tab chrome observe the new tab in the same update. Add a regression test that fails under the old ordering and passes with the new schedule.

## Checks / QA
- From an idle app, open a tab using the leader shortcut; verify it becomes active immediately.
- Repeat after waiting several seconds, then open several tabs quickly.