### PR TITLE
feat(agent): modernize ACP chat loading and composer

### DIFF
--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -1587,6 +1587,7 @@ mod native_tests {
         ));
         assert!(source.contains("if show_capability_examples"));
         assert!(source.contains("Type / for quick access"));
+        assert!(!source.contains("agent-chat-caret relative top-px ml-px h-4 w-1.5 shrink-0"));
         assert!(source.contains("prompt_prefix_at_utf16"));
         assert!(source.contains("agent-chat-caret"));
         assert!(source.contains("caret-color:transparent"));

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -1576,10 +1576,11 @@ mod native_tests {
     fn composer_auto_grows_and_contains_action_button() {
         let source = include_str!("chat_page/page.rs");
         assert!(source.contains("fn resize_prompt_textarea()"));
-        assert!(source.contains("textarea.scroll_height().clamp(48, 160)"));
-        assert!(source.contains("max-h-40 min-h-12"));
+        assert!(source.contains("textarea.scroll_height().clamp(44, 160)"));
+        assert!(source.contains("max-h-40 min-h-11"));
         assert!(source.contains("rounded-[1.35rem]"));
-        assert!(source.contains("mb-0.5 mr-0.5 flex h-9 w-9"));
+        assert!(source.contains("backdrop-blur-3xl backdrop-saturate-150"));
+        assert!(source.contains("shrink-0 self-center items-center justify-center"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -1581,6 +1581,8 @@ mod native_tests {
         assert!(source.contains("rounded-[1.35rem]"));
         assert!(source.contains("backdrop-blur-3xl backdrop-saturate-150"));
         assert!(source.contains("shrink-0 self-center items-center justify-center"));
+        assert!(source.contains("if draft.read().is_empty()"));
+        assert!(source.contains("placeholder:text-transparent"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -1582,6 +1582,7 @@ mod native_tests {
         assert!(source.contains("backdrop-blur-3xl backdrop-saturate-150"));
         assert!(source.contains("shrink-0 self-center items-center justify-center"));
         assert!(source.contains("if draft.read().is_empty()"));
+        assert!(source.contains("caret-transparent"));
         assert!(source.contains("placeholder:text-transparent"));
     }
 

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -1582,6 +1582,11 @@ mod native_tests {
         assert!(source.contains("backdrop-blur-3xl backdrop-saturate-150"));
         assert!(source.contains("h-8 w-8 shrink-0 self-center items-center justify-center"));
         assert!(source.contains("if draft.read().is_empty()"));
+        assert!(source.contains(
+            "let show_capability_examples = items.read().is_empty() && queued.read().is_empty();"
+        ));
+        assert!(source.contains("if show_capability_examples"));
+        assert!(source.contains("Type / for quick access"));
         assert!(source.contains("prompt_prefix_at_utf16"));
         assert!(source.contains("agent-chat-caret"));
         assert!(source.contains("caret-color:transparent"));

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -1567,8 +1567,19 @@ mod native_tests {
         assert!(source.contains("MatrixRain {"));
         assert!(source.contains("PromptGhost {"));
         assert!(source.contains("terminal: false"));
-        assert!(source.contains("absolute inset-0 z-20 flex items-center justify-center"));
-        assert!(source.contains("type a prompt · runs when ready"));
+        assert!(source.contains("id: \"chat-scroll\""));
+        assert!(source.contains("bg-gradient-to-t from-background via-background/95"));
+        assert!(!source.contains("absolute inset-0 z-20 flex items-center justify-center"));
+    }
+
+    #[test]
+    fn composer_auto_grows_and_contains_action_button() {
+        let source = include_str!("chat_page/page.rs");
+        assert!(source.contains("fn resize_prompt_textarea()"));
+        assert!(source.contains("textarea.scroll_height().clamp(48, 160)"));
+        assert!(source.contains("max-h-40 min-h-12"));
+        assert!(source.contains("rounded-[1.35rem]"));
+        assert!(source.contains("mb-0.5 mr-0.5 flex h-9 w-9"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -1582,9 +1582,11 @@ mod native_tests {
         assert!(source.contains("backdrop-blur-3xl backdrop-saturate-150"));
         assert!(source.contains("shrink-0 self-center items-center justify-center"));
         assert!(source.contains("if draft.read().is_empty()"));
-        assert!(source.contains("caret-transparent"));
-        assert!(source.contains("caret-shape:block"));
-        assert!(source.contains("--agent-caret:rgb({agent_accent.rain_rgb})"));
+        assert!(source.contains("prompt_prefix_at_utf16"));
+        assert!(source.contains("agent-chat-caret"));
+        assert!(source.contains("caret-color:transparent"));
+        assert!(source.contains("onkeyup"));
+        assert!(source.contains("onscroll"));
         assert!(source.contains("placeholder:text-transparent"));
     }
 

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -1576,11 +1576,11 @@ mod native_tests {
     fn composer_auto_grows_and_contains_action_button() {
         let source = include_str!("chat_page/page.rs");
         assert!(source.contains("fn resize_prompt_textarea()"));
-        assert!(source.contains("textarea.scroll_height().clamp(44, 160)"));
-        assert!(source.contains("max-h-40 min-h-11"));
-        assert!(source.contains("rounded-[1.35rem]"));
+        assert!(source.contains("textarea.scroll_height().clamp(40, 160)"));
+        assert!(source.contains("max-h-40 min-h-10"));
+        assert!(source.contains("rounded-2xl"));
         assert!(source.contains("backdrop-blur-3xl backdrop-saturate-150"));
-        assert!(source.contains("shrink-0 self-center items-center justify-center"));
+        assert!(source.contains("h-8 w-8 shrink-0 self-center items-center justify-center"));
         assert!(source.contains("if draft.read().is_empty()"));
         assert!(source.contains("prompt_prefix_at_utf16"));
         assert!(source.contains("agent-chat-caret"));

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -1583,6 +1583,8 @@ mod native_tests {
         assert!(source.contains("shrink-0 self-center items-center justify-center"));
         assert!(source.contains("if draft.read().is_empty()"));
         assert!(source.contains("caret-transparent"));
+        assert!(source.contains("caret-shape:block"));
+        assert!(source.contains("--agent-caret:rgb({agent_accent.rain_rgb})"));
         assert!(source.contains("placeholder:text-transparent"));
     }
 

--- a/crates/vmux_agent/src/chat_page/composer.rs
+++ b/crates/vmux_agent/src/chat_page/composer.rs
@@ -356,6 +356,10 @@ pub(crate) fn edit_prompt(
     (updated, caret_utf16)
 }
 
+pub(crate) fn prompt_prefix_at_utf16(value: &str, offset: u32) -> &str {
+    &value[..utf16_to_byte(value, offset)]
+}
+
 fn utf16_to_byte(value: &str, offset: u32) -> usize {
     let mut units = 0u32;
     for (byte, character) in value.char_indices() {
@@ -637,5 +641,11 @@ mod tests {
         assert!(is_handoff_boundary(1, 2));
         assert!(!is_handoff_boundary(2, 2));
         assert!(!is_handoff_boundary(0, 0));
+    }
+
+    #[test]
+    fn prompt_prefix_uses_utf16_caret_offsets() {
+        assert_eq!(prompt_prefix_at_utf16("a🙂b", 3), "a🙂");
+        assert_eq!(prompt_prefix_at_utf16("a🙂b", 4), "a🙂b");
     }
 }

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -3,8 +3,8 @@
 use crate::chat_page::composer::{
     PromptEdit, ResumeMenuState, SelectorMode, ToolActivity, chat_page_title, edit_prompt,
     filter_models, filter_sessions, is_handoff_boundary, menu_direction, move_selection,
-    resume_menu_state, selector_mode, should_clear_draft_on_escape, should_fetch_resume,
-    tool_activity,
+    prompt_prefix_at_utf16, resume_menu_state, selector_mode, should_clear_draft_on_escape,
+    should_fetch_resume, tool_activity,
 };
 use crate::chat_page::event::{
     CHAT_SNAPSHOT_EVENT, ChatApproval, ChatBlock, ChatCancel, ChatCancelQueuedPrompt,
@@ -58,6 +58,16 @@ fn resize_prompt_textarea() {
     let height = textarea.scroll_height().clamp(44, 160);
     let overflow = if height == 160 { "auto" } else { "hidden" };
     let _ = textarea.set_attribute("style", &format!("height:{height}px;overflow-y:{overflow}"));
+}
+
+fn sync_prompt_caret(mut caret: Signal<Option<u32>>, mut scroll_top: Signal<i32>) {
+    let Some(textarea) = prompt_textarea() else {
+        return;
+    };
+    let start = textarea.selection_start().ok().flatten().unwrap_or(0);
+    let end = textarea.selection_end().ok().flatten().unwrap_or(start);
+    caret.set((start == end).then_some(start));
+    scroll_top.set(textarea.scroll_top());
 }
 
 fn dispatch_input_event(textarea: &web_sys::HtmlTextAreaElement) {
@@ -175,6 +185,8 @@ pub fn Page() -> Element {
     let mut handoff_truncated = use_signal(|| false);
     let mut handoff_message_count = use_signal(|| 0u32);
     let mut draft = use_signal(String::new);
+    let mut prompt_caret = use_signal(|| None::<u32>);
+    let prompt_scroll_top = use_signal(|| 0i32);
     let mut elapsed = use_signal(|| 0u32);
     let mut at_bottom = use_signal(|| true);
     let mut last_top = use_signal(|| 0i32);
@@ -318,6 +330,10 @@ pub fn Page() -> Element {
         }
     };
     let draft_val = draft();
+    let prompt_caret_prefix = prompt_caret()
+        .filter(|_| !draft_val.is_empty())
+        .map(|offset| prompt_prefix_at_utf16(&draft_val, offset).to_string());
+    let prompt_scroll_offset = prompt_scroll_top();
     let selector = selector_mode(&draft_val);
     let command_query = match selector {
         SelectorMode::Commands(query) => Some(query),
@@ -380,7 +396,7 @@ pub fn Page() -> Element {
     rsx! {
         main {
             class: "relative isolate flex h-screen flex-col overflow-hidden bg-background text-foreground",
-            style: "background-image:radial-gradient(120% 80% at 50% -10%, rgba(129,140,248,0.05), transparent 55%);--agent-caret:rgb({agent_accent.rain_rgb});",
+            style: "background-image:radial-gradient(120% 80% at 50% -10%, rgba(129,140,248,0.05), transparent 55%);",
             style { dangerous_inner_html: MD_CSS }
             if installing_splash {
                 div { class: "pointer-events-none absolute inset-0 z-0 overflow-hidden bg-background opacity-75",
@@ -695,23 +711,39 @@ pub fn Page() -> Element {
                         div { class: "pointer-events-none absolute -left-12 -top-12 h-24 w-72 rotate-[-5deg] rounded-full bg-white/[0.09] blur-2xl" }
                         div { class: "relative z-10 min-w-0 flex-1 overflow-hidden",
                             if draft.read().is_empty() {
-                                div { class: "pointer-events-none absolute inset-0 flex items-center overflow-hidden px-3.5",
+                                div { class: "pointer-events-none absolute inset-0 flex -translate-y-px items-center overflow-hidden px-3.5",
                                     PromptGhost {
                                         accent_bg: agent_accent.accent_bg.to_string(),
                                         terminal: false,
                                     }
                                 }
                             }
+                            if let Some(prefix) = prompt_caret_prefix.as_ref() {
+                                div { class: "pointer-events-none absolute inset-0 z-20 overflow-hidden",
+                                    div {
+                                        class: "min-h-11 w-full whitespace-pre-wrap break-words px-3.5 py-2.5 text-[15px] leading-6 text-transparent",
+                                        style: "transform:translateY(-{prompt_scroll_offset}px);",
+                                        span { "{prefix}" }
+                                        span { class: "agent-chat-caret relative top-px ml-px inline-block h-4 w-1.5 align-middle {agent_accent.accent_bg}" }
+                                    }
+                                }
+                            }
                             textarea {
                                 id: PROMPT_ID,
-                                class: if draft.read().is_empty() { "agent-chat-prompt relative z-10 max-h-40 min-h-11 w-full resize-none bg-transparent px-3.5 py-2.5 text-[15px] leading-6 caret-transparent placeholder:text-transparent focus:outline-none" } else { "agent-chat-prompt relative z-10 max-h-40 min-h-11 w-full resize-none bg-transparent px-3.5 py-2.5 text-[15px] leading-6 placeholder:text-transparent focus:outline-none" },
+                                class: "agent-chat-prompt relative z-10 max-h-40 min-h-11 w-full resize-none bg-transparent px-3.5 py-2.5 text-[15px] leading-6 placeholder:text-transparent focus:outline-none",
                                 rows: "1",
                                 placeholder: "Message the agent…",
                                 value: "{draft}",
                                 oninput: move |e| {
                                     draft.set(e.value());
                                     menu_sel.set(0);
+                                    sync_prompt_caret(prompt_caret, prompt_scroll_top);
                                 },
+                                onfocus: move |_| sync_prompt_caret(prompt_caret, prompt_scroll_top),
+                                onblur: move |_| prompt_caret.set(None),
+                                onkeyup: move |_| sync_prompt_caret(prompt_caret, prompt_scroll_top),
+                                onmouseup: move |_| sync_prompt_caret(prompt_caret, prompt_scroll_top),
+                                onscroll: move |_| sync_prompt_caret(prompt_caret, prompt_scroll_top),
                                 onkeydown: move |e| {
                                     let streaming = matches!(status().as_str(), "streaming" | "awaiting");
                                     let draft_now = draft.peek().clone();
@@ -1360,8 +1392,9 @@ fn md_to_html(src: &str) -> String {
 /// HTML, and its preflight strips heading/list defaults). Theme-neutral rgba so it works in both
 /// light and dark.
 const MD_CSS: &str = r#"
-.agent-chat-prompt{caret-shape:block;caret-color:var(--agent-caret)}
-.agent-chat-prompt.caret-transparent{caret-color:transparent}
+.agent-chat-prompt{caret-color:transparent}
+.agent-chat-caret{animation:agent-chat-caret-blink 1s step-end infinite}
+@keyframes agent-chat-caret-blink{0%,49%{opacity:1}50%,100%{opacity:0}}
 .chat-md{line-height:1.6;word-break:break-word}
 .chat-md>*:first-child{margin-top:0}
 .chat-md>*:last-child{margin-bottom:0}

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -719,10 +719,7 @@ pub fn Page() -> Element {
                                             terminal: false,
                                         }
                                     } else {
-                                        div { class: "flex max-w-full items-center whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50",
-                                            span { class: "min-w-0 truncate", "Type / for quick access" }
-                                            span { class: "agent-chat-caret relative top-px ml-px h-4 w-1.5 shrink-0 {agent_accent.accent_bg}" }
-                                        }
+                                        div { class: "max-w-full truncate whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50", "Type / for quick access" }
                                     }
                                 }
                             }

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -50,6 +50,16 @@ fn prompt_textarea() -> Option<web_sys::HtmlTextAreaElement> {
         .ok()
 }
 
+fn resize_prompt_textarea() {
+    let Some(textarea) = prompt_textarea() else {
+        return;
+    };
+    let _ = textarea.set_attribute("style", "height:auto;overflow-y:hidden");
+    let height = textarea.scroll_height().clamp(48, 160);
+    let overflow = if height == 160 { "auto" } else { "hidden" };
+    let _ = textarea.set_attribute("style", &format!("height:{height}px;overflow-y:{overflow}"));
+}
+
 fn dispatch_input_event(textarea: &web_sys::HtmlTextAreaElement) {
     let init = web_sys::EventInit::new();
     init.set_bubbles(true);
@@ -181,6 +191,10 @@ pub fn Page() -> Element {
     let mut verb = use_signal(|| "Working".to_string());
 
     use_effect(move || install_global_prompt_input(draft, slash_cmds));
+    use_effect(move || {
+        let _ = draft.read();
+        resize_prompt_textarea();
+    });
 
     use_future(move || async move {
         loop {
@@ -369,7 +383,7 @@ pub fn Page() -> Element {
             style: "background-image:radial-gradient(120% 80% at 50% -10%, rgba(129,140,248,0.05), transparent 55%);",
             style { dangerous_inner_html: MD_CSS }
             if installing_splash {
-                div { class: "pointer-events-none absolute inset-0 z-0 overflow-hidden bg-background",
+                div { class: "pointer-events-none absolute inset-0 z-0 overflow-hidden bg-background opacity-75",
                     MatrixRain {
                         accent_rgb: agent_accent.rain_rgb.to_string(),
                         words: vec![header_name.to_uppercase()],
@@ -379,78 +393,87 @@ pub fn Page() -> Element {
                 div { class: "pointer-events-none absolute inset-0 -z-10 overflow-hidden",
                     div { class: "absolute left-1/2 top-[-10%] h-[30rem] w-[30rem] -translate-x-1/2 rounded-full blur-[150px] dark:bg-indigo-500/10" }
                 }
-                header { class: "relative z-10 flex items-center gap-2.5 border-b border-foreground/10 bg-background/50 px-5 py-3 backdrop-blur-xl",
-                    {avatar_node(&agent_icon(), &accent(), &agent, &header_name, "h-6 w-6 text-[11px]")}
-                    span { class: "h-2.5 w-2.5 rounded-full {status_dot_class(&status())}" }
-                    span { class: "bg-gradient-to-b from-foreground to-foreground/60 bg-clip-text text-sm font-semibold capitalize text-transparent",
-                        "{header_name}"
-                    }
-                    if !current_model().is_empty() {
-                        span { class: "min-w-0 truncate rounded-md bg-foreground/[0.06] px-2 py-0.5 font-mono text-[10px] text-muted-foreground ring-1 ring-inset ring-foreground/10",
-                            "{current_model}"
-                        }
+            }
+            header { class: "relative z-10 flex items-center gap-2.5 border-b border-foreground/10 bg-background/50 px-5 py-3 backdrop-blur-xl",
+                {avatar_node(&agent_icon(), &accent(), &agent, &header_name, "h-6 w-6 text-[11px]")}
+                span { class: "h-2.5 w-2.5 rounded-full {status_dot_class(&status())}" }
+                span { class: "bg-gradient-to-b from-foreground to-foreground/60 bg-clip-text text-sm font-semibold capitalize text-transparent",
+                    "{header_name}"
+                }
+                if !current_model().is_empty() {
+                    span { class: "min-w-0 truncate rounded-md bg-foreground/[0.06] px-2 py-0.5 font-mono text-[10px] text-muted-foreground ring-1 ring-inset ring-foreground/10",
+                        "{current_model}"
                     }
                 }
             }
-            if !installing_splash {
-                div {
-                    id: "chat-scroll",
-                    class: "relative z-10 flex-1 overflow-y-auto px-4 py-6",
-                    onscroll: move |_| {
-                        if let Some(el) = web_sys::window()
-                            .and_then(|w| w.document())
-                            .and_then(|d| d.get_element_by_id("chat-scroll"))
+            div {
+                id: "chat-scroll",
+                class: "relative z-10 flex-1 overflow-y-auto px-4 py-6",
+                onscroll: move |_| {
+                    if let Some(el) = web_sys::window()
+                        .and_then(|w| w.document())
+                        .and_then(|d| d.get_element_by_id("chat-scroll"))
+                    {
+                        let top = el.scroll_top();
+                        let dist = el.scroll_height() - top - el.client_height();
+                        // Re-pin once the user reaches the bottom; unpin only when they scroll UP
+                        // (scroll_top decreases). Never unpin from our own programmatic
+                        // scroll-to-bottom, which only moves down and would otherwise poison
+                        // `at_bottom` with a stale, mid-stream scroll height.
+                        if dist <= 48 {
+                            at_bottom.set(true);
+                        } else if top < *last_top.peek() - 4 {
+                            at_bottom.set(false);
+                        }
+                        last_top.set(top);
+                    }
+                },
+                div { class: "mx-auto flex min-h-full max-w-3xl flex-col gap-4",
+                    if installing_splash {
+                        div { class: "my-auto flex flex-col items-center gap-3 py-16 text-center",
+                            {avatar_node(&agent_icon(), &accent(), &agent, &header_name, "h-14 w-14 text-xl")}
+                            h2 { class: "bg-gradient-to-b from-foreground to-foreground/50 bg-clip-text text-3xl font-semibold capitalize tracking-tight text-transparent",
+                                "{header_name}"
+                            }
+                            div { class: "flex max-w-sm items-center gap-2 rounded-full bg-background/70 px-3 py-1.5 text-xs text-muted-foreground ring-1 ring-inset ring-foreground/10 backdrop-blur-xl",
+                                span { class: "h-1.5 w-1.5 shrink-0 animate-pulse rounded-full {agent_accent.accent_bg}" }
+                                span { class: "truncate", "{install_detail}" }
+                            }
+                        }
+                    } else if items.read().is_empty() && status() == "idle" {
+                        div { class: "flex flex-col items-center gap-3 py-24 text-center",
+                            {avatar_node(&agent_icon(), &accent(), &agent, &header_name, "h-14 w-14 text-xl")}
+                            h2 { class: "bg-gradient-to-b from-foreground to-foreground/50 bg-clip-text text-3xl font-semibold capitalize tracking-tight text-transparent",
+                                "{header_name}"
+                            }
+                            p { class: "text-sm text-muted-foreground", "Ready when you are." }
+                        }
+                    }
+                    for (i , item) in items.read().iter().enumerate() {
+                        {render_item(i, item, &verb(), elapsed())}
+                        if !handoff_source().is_empty()
+                            && is_handoff_boundary(i, handoff_message_count())
                         {
-                            let top = el.scroll_top();
-                            let dist = el.scroll_height() - top - el.client_height();
-                            // Re-pin once the user reaches the bottom; unpin only when they scroll UP
-                            // (scroll_top decreases). Never unpin from our own programmatic
-                            // scroll-to-bottom, which only moves down and would otherwise poison
-                            // `at_bottom` with a stale, mid-stream scroll height.
-                            if dist <= 48 {
-                                at_bottom.set(true);
-                            } else if top < *last_top.peek() - 4 {
-                                at_bottom.set(false);
-                            }
-                            last_top.set(top);
-                        }
-                    },
-                    div { class: "mx-auto flex max-w-3xl flex-col gap-4",
-                        if items.read().is_empty() && status() == "idle" {
-                            div { class: "flex flex-col items-center gap-3 py-24 text-center",
-                                {avatar_node(&agent_icon(), &accent(), &agent, &header_name, "h-14 w-14 text-xl")}
-                                h2 { class: "bg-gradient-to-b from-foreground to-foreground/50 bg-clip-text text-3xl font-semibold capitalize tracking-tight text-transparent",
-                                    "{header_name}"
-                                }
-                                p { class: "text-sm text-muted-foreground", "Ready when you are." }
-                            }
-                        }
-                        for (i , item) in items.read().iter().enumerate() {
-                            {render_item(i, item, &verb(), elapsed())}
-                            if !handoff_source().is_empty()
-                                && is_handoff_boundary(i, handoff_message_count())
-                            {
-                                div { class: "flex items-center gap-2 py-1 text-xs text-muted-foreground",
-                                    span { class: "h-px flex-1 bg-foreground/10" }
-                                    span { "Continued from {handoff_source}" }
-                                    if handoff_truncated() {
-                                        span { class: "text-amber-500/80", "· older context omitted" }
-                                    }
-                                    span { class: "h-px flex-1 bg-foreground/10" }
-                                }
-                            }
-                        }
-                        if status() == "errored" {
-                            div { class: "rounded-xl bg-red-500/10 px-4 py-3 text-sm text-red-600 ring-1 ring-inset ring-red-500/20 dark:text-red-300",
-                                "{error}"
-                            }
-                        }
-                        if paused() {
-                            div { class: "flex items-center gap-3 py-1 text-xs text-muted-foreground",
+                            div { class: "flex items-center gap-2 py-1 text-xs text-muted-foreground",
                                 span { class: "h-px flex-1 bg-foreground/10" }
-                                span { class: "shrink-0", "interrupted" }
+                                span { "Continued from {handoff_source}" }
+                                if handoff_truncated() {
+                                    span { class: "text-amber-500/80", "· older context omitted" }
+                                }
                                 span { class: "h-px flex-1 bg-foreground/10" }
                             }
+                        }
+                    }
+                    if status() == "errored" {
+                        div { class: "rounded-xl bg-red-500/10 px-4 py-3 text-sm text-red-600 ring-1 ring-inset ring-red-500/20 dark:text-red-300",
+                            "{error}"
+                        }
+                    }
+                    if paused() {
+                        div { class: "flex items-center gap-3 py-1 text-xs text-muted-foreground",
+                            span { class: "h-px flex-1 bg-foreground/10" }
+                            span { class: "shrink-0", "interrupted" }
+                            span { class: "h-px flex-1 bg-foreground/10" }
                         }
                     }
                 }
@@ -514,20 +537,9 @@ pub fn Page() -> Element {
             }
 
             div {
-                class: if installing_splash { "absolute inset-0 z-20 flex items-center justify-center px-4" } else { "relative z-10 border-t border-foreground/10 bg-background/50 px-4 py-3 backdrop-blur-xl" },
+                class: "relative z-10 bg-gradient-to-t from-background via-background/95 to-transparent px-4 pb-4 pt-8",
                 div {
-                    class: if installing_splash { "relative flex w-full max-w-md flex-col gap-2 rounded-2xl bg-white/70 p-4 ring-1 ring-inset ring-black/10 backdrop-blur-md dark:bg-black/40 dark:ring-white/10" } else { "relative mx-auto flex max-w-3xl flex-col gap-2" },
-                    if installing {
-                        div { class: "mb-1 flex items-center gap-3",
-                            div { class: "flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-foreground/[0.06] ring-1 ring-inset ring-foreground/10",
-                                {avatar_node(&agent_icon(), &accent(), &agent, &header_name, "h-5 w-5 text-[10px]")}
-                            }
-                            div { class: "min-w-0 flex-1",
-                                div { class: "truncate text-sm font-semibold {agent_accent.accent_text}", "{header_name}" }
-                                div { class: "truncate text-xs text-muted-foreground", "{install_detail}" }
-                            }
-                        }
-                    }
+                    class: "relative mx-auto flex max-w-3xl flex-col gap-2",
                     if cmd_menu_open {
                         div { class: "absolute bottom-full left-0 z-20 mb-2 w-full overflow-hidden rounded-xl border border-foreground/10 bg-background/95 shadow-xl backdrop-blur-xl",
                             for (i , command) in filtered_cmds.iter().enumerate() {
@@ -678,10 +690,10 @@ pub fn Page() -> Element {
                             }
                         }
                     }
-                    div { class: if installing { "flex items-end gap-2 rounded-xl bg-foreground/[0.04] px-3 py-2 ring-1 ring-inset ring-foreground/10" } else { "flex items-end gap-2" },
+                    div { class: "relative flex items-end rounded-[1.35rem] bg-background/90 p-1.5 shadow-[0_18px_55px_-28px_rgba(0,0,0,0.65)] ring-1 ring-inset ring-foreground/15 backdrop-blur-2xl transition-all duration-200 focus-within:bg-background focus-within:ring-foreground/30 focus-within:shadow-[0_22px_65px_-28px_rgba(0,0,0,0.75)]",
                         div { class: "relative min-w-0 flex-1 overflow-hidden",
                             if installing && draft.read().is_empty() {
-                                div { class: "pointer-events-none absolute inset-0 flex items-center overflow-hidden px-1",
+                                div { class: "pointer-events-none absolute inset-0 flex items-center overflow-hidden px-3",
                                     PromptGhost {
                                         accent_bg: agent_accent.accent_bg.to_string(),
                                         terminal: false,
@@ -690,7 +702,7 @@ pub fn Page() -> Element {
                             }
                             textarea {
                                 id: PROMPT_ID,
-                                class: if installing { "relative z-10 max-h-40 min-h-9 w-full resize-none bg-transparent px-1 py-2 font-mono text-sm placeholder:text-transparent focus:outline-none" } else { "max-h-40 w-full resize-none rounded-xl bg-foreground/[0.06] px-3.5 py-2.5 text-sm ring-1 ring-inset ring-foreground/10 transition focus:bg-foreground/[0.09] focus:outline-none focus:ring-foreground/25" },
+                                class: if installing { "relative z-10 max-h-40 min-h-12 w-full resize-none bg-transparent px-3 py-3 text-[15px] leading-6 placeholder:text-transparent focus:outline-none" } else { "max-h-40 min-h-12 w-full resize-none bg-transparent px-3 py-3 text-[15px] leading-6 placeholder:text-muted-foreground/55 focus:outline-none" },
                                 rows: "1",
                                 placeholder: "Message the agent…",
                                 value: "{draft}",
@@ -817,7 +829,7 @@ pub fn Page() -> Element {
                         if matches!(status().as_str(), "streaming" | "awaiting") {
                             if queued.read().is_empty() {
                                 button {
-                                    class: "flex items-center justify-center rounded-xl p-2.5 text-muted-foreground transition hover:bg-foreground/10 hover:text-foreground active:scale-[0.98]",
+                                    class: "mb-0.5 mr-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-foreground/[0.08] text-foreground/70 ring-1 ring-inset ring-foreground/10 transition hover:bg-foreground/[0.14] hover:text-foreground active:scale-95",
                                     title: "Stop",
                                     onclick: move |_| {
                                         let _ = try_cef_bin_emit_rkyv(&ChatCancel);
@@ -831,7 +843,7 @@ pub fn Page() -> Element {
                                 }
                             } else {
                                 button {
-                                    class: "flex items-center justify-center rounded-xl p-2.5 text-muted-foreground transition hover:bg-foreground/10 hover:text-foreground active:scale-[0.98]",
+                                    class: "mb-0.5 mr-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br text-white shadow-lg transition hover:brightness-110 active:scale-95 {agent_accent.grad}",
                                     title: "Send all queued prompts now (Esc)",
                                     onclick: move |_| {
                                         let _ = try_cef_bin_emit_rkyv(&ChatEscape);
@@ -851,7 +863,8 @@ pub fn Page() -> Element {
                             }
                         } else {
                             button {
-                                class: "flex items-center justify-center rounded-xl p-2.5 text-muted-foreground transition hover:bg-foreground/10 hover:text-foreground active:scale-[0.98]",
+                                class: if draft.read().trim().is_empty() { "mb-0.5 mr-0.5 flex h-9 w-9 shrink-0 cursor-default items-center justify-center rounded-xl bg-foreground/[0.06] text-muted-foreground/35 ring-1 ring-inset ring-foreground/[0.06]" } else { "mb-0.5 mr-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br text-white shadow-lg transition hover:brightness-110 active:scale-95 {agent_accent.grad}" },
+                                disabled: draft.read().trim().is_empty(),
                                 title: "Send (Enter)",
                                 onclick: move |_| do_submit(draft, at_bottom),
                                 svg {
@@ -865,15 +878,6 @@ pub fn Page() -> Element {
                                     path { d: "M12 19V5" }
                                     path { d: "M5 12l7-7 7 7" }
                                 }
-                            }
-                        }
-                    }
-                    if installing {
-                        div { class: "px-1 text-[10px] text-muted-foreground/70",
-                            if draft.read().is_empty() {
-                                "type a prompt · runs when ready"
-                            } else {
-                                "runs when ready · Enter sends"
                             }
                         }
                     }

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -694,8 +694,8 @@ pub fn Page() -> Element {
                         div { class: "pointer-events-none absolute inset-px rounded-[1.25rem] bg-gradient-to-b from-white/[0.12] via-white/[0.025] to-transparent dark:from-white/[0.10]" }
                         div { class: "pointer-events-none absolute -left-12 -top-12 h-24 w-72 rotate-[-5deg] rounded-full bg-white/[0.09] blur-2xl" }
                         div { class: "relative z-10 min-w-0 flex-1 overflow-hidden",
-                            if installing && draft.read().is_empty() {
-                                div { class: "pointer-events-none absolute inset-0 flex items-center overflow-hidden px-3",
+                            if draft.read().is_empty() {
+                                div { class: "pointer-events-none absolute inset-0 flex items-center overflow-hidden px-3.5",
                                     PromptGhost {
                                         accent_bg: agent_accent.accent_bg.to_string(),
                                         terminal: false,
@@ -704,7 +704,7 @@ pub fn Page() -> Element {
                             }
                             textarea {
                                 id: PROMPT_ID,
-                                class: if installing { "relative z-10 max-h-40 min-h-11 w-full resize-none bg-transparent px-3.5 py-2.5 text-[15px] leading-6 placeholder:text-transparent focus:outline-none" } else { "max-h-40 min-h-11 w-full resize-none bg-transparent px-3.5 py-2.5 text-[15px] leading-6 placeholder:text-muted-foreground/55 focus:outline-none" },
+                                class: "relative z-10 max-h-40 min-h-11 w-full resize-none bg-transparent px-3.5 py-2.5 text-[15px] leading-6 placeholder:text-transparent focus:outline-none",
                                 rows: "1",
                                 placeholder: "Message the agent…",
                                 value: "{draft}",

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -380,7 +380,7 @@ pub fn Page() -> Element {
     rsx! {
         main {
             class: "relative isolate flex h-screen flex-col overflow-hidden bg-background text-foreground",
-            style: "background-image:radial-gradient(120% 80% at 50% -10%, rgba(129,140,248,0.05), transparent 55%);",
+            style: "background-image:radial-gradient(120% 80% at 50% -10%, rgba(129,140,248,0.05), transparent 55%);--agent-caret:rgb({agent_accent.rain_rgb});",
             style { dangerous_inner_html: MD_CSS }
             if installing_splash {
                 div { class: "pointer-events-none absolute inset-0 z-0 overflow-hidden bg-background opacity-75",
@@ -704,7 +704,7 @@ pub fn Page() -> Element {
                             }
                             textarea {
                                 id: PROMPT_ID,
-                                class: if draft.read().is_empty() { "relative z-10 max-h-40 min-h-11 w-full resize-none bg-transparent px-3.5 py-2.5 text-[15px] leading-6 caret-transparent placeholder:text-transparent focus:outline-none" } else { "relative z-10 max-h-40 min-h-11 w-full resize-none bg-transparent px-3.5 py-2.5 text-[15px] leading-6 placeholder:text-transparent focus:outline-none" },
+                                class: if draft.read().is_empty() { "agent-chat-prompt relative z-10 max-h-40 min-h-11 w-full resize-none bg-transparent px-3.5 py-2.5 text-[15px] leading-6 caret-transparent placeholder:text-transparent focus:outline-none" } else { "agent-chat-prompt relative z-10 max-h-40 min-h-11 w-full resize-none bg-transparent px-3.5 py-2.5 text-[15px] leading-6 placeholder:text-transparent focus:outline-none" },
                                 rows: "1",
                                 placeholder: "Message the agent…",
                                 value: "{draft}",
@@ -1360,6 +1360,8 @@ fn md_to_html(src: &str) -> String {
 /// HTML, and its preflight strips heading/list defaults). Theme-neutral rgba so it works in both
 /// light and dark.
 const MD_CSS: &str = r#"
+.agent-chat-prompt{caret-shape:block;caret-color:var(--agent-caret)}
+.agent-chat-prompt.caret-transparent{caret-color:transparent}
 .chat-md{line-height:1.6;word-break:break-word}
 .chat-md>*:first-child{margin-top:0}
 .chat-md>*:last-child{margin-bottom:0}

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -55,7 +55,7 @@ fn resize_prompt_textarea() {
         return;
     };
     let _ = textarea.set_attribute("style", "height:auto;overflow-y:hidden");
-    let height = textarea.scroll_height().clamp(44, 160);
+    let height = textarea.scroll_height().clamp(40, 160);
     let overflow = if height == 160 { "auto" } else { "hidden" };
     let _ = textarea.set_attribute("style", &format!("height:{height}px;overflow-y:{overflow}"));
 }
@@ -706,8 +706,8 @@ pub fn Page() -> Element {
                             }
                         }
                     }
-                    div { class: "relative flex items-center overflow-hidden rounded-[1.35rem] bg-white/45 p-1.5 shadow-[0_18px_55px_-24px_rgba(0,0,0,0.65),inset_0_1px_0_rgba(255,255,255,0.18),inset_0_-1px_0_rgba(255,255,255,0.04)] ring-1 ring-inset ring-black/10 backdrop-blur-3xl backdrop-saturate-150 transition-all duration-200 focus-within:bg-white/55 focus-within:ring-black/20 focus-within:shadow-[0_22px_65px_-24px_rgba(0,0,0,0.72),inset_0_1px_0_rgba(255,255,255,0.22)] dark:bg-white/[0.045] dark:ring-white/[0.16] dark:focus-within:bg-white/[0.065] dark:focus-within:ring-white/25",
-                        div { class: "pointer-events-none absolute inset-px rounded-[1.25rem] bg-gradient-to-b from-white/[0.12] via-white/[0.025] to-transparent dark:from-white/[0.10]" }
+                    div { class: "relative flex items-center overflow-hidden rounded-2xl bg-white/45 p-1 shadow-[0_18px_55px_-24px_rgba(0,0,0,0.65),inset_0_1px_0_rgba(255,255,255,0.18),inset_0_-1px_0_rgba(255,255,255,0.04)] ring-1 ring-inset ring-black/10 backdrop-blur-3xl backdrop-saturate-150 transition-all duration-200 focus-within:bg-white/55 focus-within:ring-black/20 focus-within:shadow-[0_22px_65px_-24px_rgba(0,0,0,0.72),inset_0_1px_0_rgba(255,255,255,0.22)] dark:bg-white/[0.045] dark:ring-white/[0.16] dark:focus-within:bg-white/[0.065] dark:focus-within:ring-white/25",
+                        div { class: "pointer-events-none absolute inset-px rounded-[0.9rem] bg-gradient-to-b from-white/[0.12] via-white/[0.025] to-transparent dark:from-white/[0.10]" }
                         div { class: "pointer-events-none absolute -left-12 -top-12 h-24 w-72 rotate-[-5deg] rounded-full bg-white/[0.09] blur-2xl" }
                         div { class: "relative z-10 min-w-0 flex-1 overflow-hidden",
                             if draft.read().is_empty() {
@@ -721,7 +721,7 @@ pub fn Page() -> Element {
                             if let Some(prefix) = prompt_caret_prefix.as_ref() {
                                 div { class: "pointer-events-none absolute inset-0 z-20 overflow-hidden",
                                     div {
-                                        class: "min-h-11 w-full whitespace-pre-wrap break-words px-3.5 py-2.5 text-[15px] leading-6 text-transparent",
+                                        class: "min-h-10 w-full whitespace-pre-wrap break-words px-3.5 py-2 text-[15px] leading-6 text-transparent",
                                         style: "transform:translateY(-{prompt_scroll_offset}px);",
                                         span { "{prefix}" }
                                         span { class: "agent-chat-caret relative top-px ml-px inline-block h-4 w-1.5 align-middle {agent_accent.accent_bg}" }
@@ -730,7 +730,7 @@ pub fn Page() -> Element {
                             }
                             textarea {
                                 id: PROMPT_ID,
-                                class: "agent-chat-prompt relative z-10 max-h-40 min-h-11 w-full resize-none bg-transparent px-3.5 py-2.5 text-[15px] leading-6 placeholder:text-transparent focus:outline-none",
+                                class: "agent-chat-prompt relative z-10 max-h-40 min-h-10 w-full resize-none bg-transparent px-3.5 py-2 text-[15px] leading-6 placeholder:text-transparent focus:outline-none",
                                 rows: "1",
                                 placeholder: "Message the agent…",
                                 value: "{draft}",
@@ -863,7 +863,7 @@ pub fn Page() -> Element {
                         if matches!(status().as_str(), "streaming" | "awaiting") {
                             if queued.read().is_empty() {
                                 button {
-                                    class: "relative z-10 mr-0.5 flex h-9 w-9 shrink-0 self-center items-center justify-center rounded-xl bg-white/40 text-foreground/70 shadow-sm ring-1 ring-inset ring-black/10 transition hover:bg-white/60 hover:text-foreground active:scale-95 dark:bg-white/[0.08] dark:ring-white/10 dark:hover:bg-white/[0.14]",
+                                    class: "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg bg-white/40 text-foreground/70 shadow-sm ring-1 ring-inset ring-black/10 transition hover:bg-white/60 hover:text-foreground active:scale-95 dark:bg-white/[0.08] dark:ring-white/10 dark:hover:bg-white/[0.14]",
                                     title: "Stop",
                                     onclick: move |_| {
                                         let _ = try_cef_bin_emit_rkyv(&ChatCancel);
@@ -877,7 +877,7 @@ pub fn Page() -> Element {
                                 }
                             } else {
                                 button {
-                                    class: "relative z-10 mr-0.5 flex h-9 w-9 shrink-0 self-center items-center justify-center rounded-xl bg-gradient-to-br text-white shadow-lg transition hover:brightness-110 active:scale-95 {agent_accent.grad}",
+                                    class: "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg bg-gradient-to-br text-white shadow-lg transition hover:brightness-110 active:scale-95 {agent_accent.grad}",
                                     title: "Send all queued prompts now (Esc)",
                                     onclick: move |_| {
                                         let _ = try_cef_bin_emit_rkyv(&ChatEscape);
@@ -897,7 +897,7 @@ pub fn Page() -> Element {
                             }
                         } else {
                             button {
-                                class: if draft.read().trim().is_empty() { "relative z-10 mr-0.5 flex h-9 w-9 shrink-0 cursor-default self-center items-center justify-center rounded-xl bg-white/25 text-muted-foreground/35 shadow-sm ring-1 ring-inset ring-black/[0.06] dark:bg-white/[0.055] dark:ring-white/[0.08]" } else { "relative z-10 mr-0.5 flex h-9 w-9 shrink-0 self-center items-center justify-center rounded-xl bg-gradient-to-br text-white shadow-lg transition hover:brightness-110 active:scale-95 {agent_accent.grad}" },
+                                class: if draft.read().trim().is_empty() { "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 cursor-default self-center items-center justify-center rounded-lg bg-white/25 text-muted-foreground/35 shadow-sm ring-1 ring-inset ring-black/[0.06] dark:bg-white/[0.055] dark:ring-white/[0.08]" } else { "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg bg-gradient-to-br text-white shadow-lg transition hover:brightness-110 active:scale-95 {agent_accent.grad}" },
                                 disabled: draft.read().trim().is_empty(),
                                 title: "Send (Enter)",
                                 onclick: move |_| do_submit(draft, at_bottom),

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -704,7 +704,7 @@ pub fn Page() -> Element {
                             }
                             textarea {
                                 id: PROMPT_ID,
-                                class: "relative z-10 max-h-40 min-h-11 w-full resize-none bg-transparent px-3.5 py-2.5 text-[15px] leading-6 placeholder:text-transparent focus:outline-none",
+                                class: if draft.read().is_empty() { "relative z-10 max-h-40 min-h-11 w-full resize-none bg-transparent px-3.5 py-2.5 text-[15px] leading-6 caret-transparent placeholder:text-transparent focus:outline-none" } else { "relative z-10 max-h-40 min-h-11 w-full resize-none bg-transparent px-3.5 py-2.5 text-[15px] leading-6 placeholder:text-transparent focus:outline-none" },
                                 rows: "1",
                                 placeholder: "Message the agent…",
                                 value: "{draft}",

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -55,7 +55,7 @@ fn resize_prompt_textarea() {
         return;
     };
     let _ = textarea.set_attribute("style", "height:auto;overflow-y:hidden");
-    let height = textarea.scroll_height().clamp(48, 160);
+    let height = textarea.scroll_height().clamp(44, 160);
     let overflow = if height == 160 { "auto" } else { "hidden" };
     let _ = textarea.set_attribute("style", &format!("height:{height}px;overflow-y:{overflow}"));
 }
@@ -690,8 +690,10 @@ pub fn Page() -> Element {
                             }
                         }
                     }
-                    div { class: "relative flex items-end rounded-[1.35rem] bg-background/90 p-1.5 shadow-[0_18px_55px_-28px_rgba(0,0,0,0.65)] ring-1 ring-inset ring-foreground/15 backdrop-blur-2xl transition-all duration-200 focus-within:bg-background focus-within:ring-foreground/30 focus-within:shadow-[0_22px_65px_-28px_rgba(0,0,0,0.75)]",
-                        div { class: "relative min-w-0 flex-1 overflow-hidden",
+                    div { class: "relative flex items-center overflow-hidden rounded-[1.35rem] bg-white/45 p-1.5 shadow-[0_18px_55px_-24px_rgba(0,0,0,0.65),inset_0_1px_0_rgba(255,255,255,0.18),inset_0_-1px_0_rgba(255,255,255,0.04)] ring-1 ring-inset ring-black/10 backdrop-blur-3xl backdrop-saturate-150 transition-all duration-200 focus-within:bg-white/55 focus-within:ring-black/20 focus-within:shadow-[0_22px_65px_-24px_rgba(0,0,0,0.72),inset_0_1px_0_rgba(255,255,255,0.22)] dark:bg-white/[0.045] dark:ring-white/[0.16] dark:focus-within:bg-white/[0.065] dark:focus-within:ring-white/25",
+                        div { class: "pointer-events-none absolute inset-px rounded-[1.25rem] bg-gradient-to-b from-white/[0.12] via-white/[0.025] to-transparent dark:from-white/[0.10]" }
+                        div { class: "pointer-events-none absolute -left-12 -top-12 h-24 w-72 rotate-[-5deg] rounded-full bg-white/[0.09] blur-2xl" }
+                        div { class: "relative z-10 min-w-0 flex-1 overflow-hidden",
                             if installing && draft.read().is_empty() {
                                 div { class: "pointer-events-none absolute inset-0 flex items-center overflow-hidden px-3",
                                     PromptGhost {
@@ -702,7 +704,7 @@ pub fn Page() -> Element {
                             }
                             textarea {
                                 id: PROMPT_ID,
-                                class: if installing { "relative z-10 max-h-40 min-h-12 w-full resize-none bg-transparent px-3 py-3 text-[15px] leading-6 placeholder:text-transparent focus:outline-none" } else { "max-h-40 min-h-12 w-full resize-none bg-transparent px-3 py-3 text-[15px] leading-6 placeholder:text-muted-foreground/55 focus:outline-none" },
+                                class: if installing { "relative z-10 max-h-40 min-h-11 w-full resize-none bg-transparent px-3.5 py-2.5 text-[15px] leading-6 placeholder:text-transparent focus:outline-none" } else { "max-h-40 min-h-11 w-full resize-none bg-transparent px-3.5 py-2.5 text-[15px] leading-6 placeholder:text-muted-foreground/55 focus:outline-none" },
                                 rows: "1",
                                 placeholder: "Message the agent…",
                                 value: "{draft}",
@@ -829,7 +831,7 @@ pub fn Page() -> Element {
                         if matches!(status().as_str(), "streaming" | "awaiting") {
                             if queued.read().is_empty() {
                                 button {
-                                    class: "mb-0.5 mr-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-foreground/[0.08] text-foreground/70 ring-1 ring-inset ring-foreground/10 transition hover:bg-foreground/[0.14] hover:text-foreground active:scale-95",
+                                    class: "relative z-10 mr-0.5 flex h-9 w-9 shrink-0 self-center items-center justify-center rounded-xl bg-white/40 text-foreground/70 shadow-sm ring-1 ring-inset ring-black/10 transition hover:bg-white/60 hover:text-foreground active:scale-95 dark:bg-white/[0.08] dark:ring-white/10 dark:hover:bg-white/[0.14]",
                                     title: "Stop",
                                     onclick: move |_| {
                                         let _ = try_cef_bin_emit_rkyv(&ChatCancel);
@@ -843,7 +845,7 @@ pub fn Page() -> Element {
                                 }
                             } else {
                                 button {
-                                    class: "mb-0.5 mr-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br text-white shadow-lg transition hover:brightness-110 active:scale-95 {agent_accent.grad}",
+                                    class: "relative z-10 mr-0.5 flex h-9 w-9 shrink-0 self-center items-center justify-center rounded-xl bg-gradient-to-br text-white shadow-lg transition hover:brightness-110 active:scale-95 {agent_accent.grad}",
                                     title: "Send all queued prompts now (Esc)",
                                     onclick: move |_| {
                                         let _ = try_cef_bin_emit_rkyv(&ChatEscape);
@@ -863,7 +865,7 @@ pub fn Page() -> Element {
                             }
                         } else {
                             button {
-                                class: if draft.read().trim().is_empty() { "mb-0.5 mr-0.5 flex h-9 w-9 shrink-0 cursor-default items-center justify-center rounded-xl bg-foreground/[0.06] text-muted-foreground/35 ring-1 ring-inset ring-foreground/[0.06]" } else { "mb-0.5 mr-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br text-white shadow-lg transition hover:brightness-110 active:scale-95 {agent_accent.grad}" },
+                                class: if draft.read().trim().is_empty() { "relative z-10 mr-0.5 flex h-9 w-9 shrink-0 cursor-default self-center items-center justify-center rounded-xl bg-white/25 text-muted-foreground/35 shadow-sm ring-1 ring-inset ring-black/[0.06] dark:bg-white/[0.055] dark:ring-white/[0.08]" } else { "relative z-10 mr-0.5 flex h-9 w-9 shrink-0 self-center items-center justify-center rounded-xl bg-gradient-to-br text-white shadow-lg transition hover:brightness-110 active:scale-95 {agent_accent.grad}" },
                                 disabled: draft.read().trim().is_empty(),
                                 title: "Send (Enter)",
                                 onclick: move |_| do_submit(draft, at_bottom),

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -321,6 +321,7 @@ pub fn Page() -> Element {
     let agent_accent = agent_accent(&agent);
     let installing = status() == "installing";
     let installing_splash = installing && items.read().is_empty();
+    let show_capability_examples = items.read().is_empty() && queued.read().is_empty();
     let install_detail = {
         let detail = error();
         if detail.is_empty() {
@@ -712,9 +713,16 @@ pub fn Page() -> Element {
                         div { class: "relative z-10 min-w-0 flex-1 overflow-hidden",
                             if draft.read().is_empty() {
                                 div { class: "pointer-events-none absolute inset-0 flex -translate-y-px items-center overflow-hidden px-3.5",
-                                    PromptGhost {
-                                        accent_bg: agent_accent.accent_bg.to_string(),
-                                        terminal: false,
+                                    if show_capability_examples {
+                                        PromptGhost {
+                                            accent_bg: agent_accent.accent_bg.to_string(),
+                                            terminal: false,
+                                        }
+                                    } else {
+                                        div { class: "flex max-w-full items-center whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50",
+                                            span { class: "min-w-0 truncate", "Type / for quick access" }
+                                            span { class: "agent-chat-caret relative top-px ml-px h-4 w-1.5 shrink-0 {agent_accent.accent_bg}" }
+                                        }
                                     }
                                 }
                             }

--- a/crates/vmux_terminal/src/page.rs
+++ b/crates/vmux_terminal/src/page.rs
@@ -1055,6 +1055,8 @@ const TERMINAL_PROMPT_EXAMPLES: &[&str] = &[
     "git log --oneline -10",
 ];
 
+const PROMPT_CARET_CSS: &str = ".vmux-prompt-caret{animation:vmux-prompt-caret-blink 1s step-end infinite}@keyframes vmux-prompt-caret-blink{0%,49%{opacity:1}50%,100%{opacity:0}}";
+
 /// Placeholder that types example prompts one character at a time with a blinking caret.
 #[component]
 pub fn PromptGhost(accent_bg: String, terminal: bool) -> Element {
@@ -1092,11 +1094,17 @@ pub fn PromptGhost(accent_bg: String, terminal: bool) -> Element {
     } else {
         "max-w-full whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50"
     };
+    let caret_class = if terminal {
+        format!("vmux-prompt-caret ml-px inline-block h-3.5 w-1.5 align-middle {accent_bg}")
+    } else {
+        "vmux-prompt-caret ml-px inline-block h-5 w-px align-middle bg-foreground/80".to_string()
+    };
     rsx! {
+        style { dangerous_inner_html: PROMPT_CARET_CSS }
         div {
             class: "{ghost_class}",
             "{shown}"
-            span { class: "ml-px inline-block h-3.5 w-1.5 align-middle animate-pulse {accent_bg}" }
+            span { class: "{caret_class}" }
         }
     }
 }

--- a/crates/vmux_terminal/src/page.rs
+++ b/crates/vmux_terminal/src/page.rs
@@ -1092,18 +1092,18 @@ pub fn PromptGhost(accent_bg: String, terminal: bool) -> Element {
     let ghost_class = if terminal {
         "w-80 whitespace-pre-wrap break-words font-mono text-sm text-muted-foreground/50"
     } else {
-        "max-w-full whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50"
+        "flex max-w-full items-center whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50"
     };
     let caret_class = if terminal {
         format!("vmux-prompt-caret ml-px inline-block h-3.5 w-1.5 align-middle {accent_bg}")
     } else {
-        "vmux-prompt-caret ml-px inline-block h-5 w-px align-middle bg-foreground/80".to_string()
+        format!("vmux-prompt-caret relative top-px ml-px h-4 w-1.5 shrink-0 {accent_bg}")
     };
     rsx! {
         style { dangerous_inner_html: PROMPT_CARET_CSS }
         div {
             class: "{ghost_class}",
-            "{shown}"
+            span { class: if terminal { "" } else { "min-w-0 truncate" }, "{shown}" }
             span { class: "{caret_class}" }
         }
     }

--- a/crates/vmux_terminal/src/page.rs
+++ b/crates/vmux_terminal/src/page.rs
@@ -998,10 +998,54 @@ fn row_selection_cols(
 }
 
 const AGENT_PROMPT_EXAMPLES: &[&str] = &[
-    "Find me a hotel with AC near Paris for this weekend",
-    "Find the best flight from Paris to Tokyo next month",
+    "Find me the best flight from Paris to Tokyo next month",
+    "Find a quiet hotel with AC near central Paris for this weekend",
+    "Plan a five-day food and culture trip through Kyoto",
+    "Build me a relaxed weekend itinerary for Lisbon",
+    "Compare rail passes for a two-week trip around Europe",
+    "Find highly rated restaurants nearby with vegetarian options",
+    "Research the visa requirements for my next international trip",
+    "Create a lightweight packing list for a ten-day winter trip",
+    "Plan a scenic road trip from San Francisco to Portland",
+    "Compare the best neighborhoods for a month-long stay in Tokyo",
+    "Find quiet coworking spaces with day passes and fast Wi-Fi",
+    "Plan a memorable surprise birthday weekend on a sensible budget",
+    "Build a healthy weekly meal plan and shopping list for two",
+    "Turn this grocery budget into affordable meals for the week",
+    "Create a beginner workout plan I can do at home in 30 minutes",
+    "Make a six-week study plan for conversational Japanese",
+    "Compare the best noise-canceling headphones under $300",
+    "Find an ergonomic standing desk setup for a small apartment",
+    "Research the best compact camera for travel and street photography",
+    "Compare lightweight laptops for coding, travel, and battery life",
+    "Summarize these PDFs and extract the decisions and action items",
+    "Turn my meeting notes into a clear project plan with owners",
+    "Draft a concise follow-up email from these scattered notes",
+    "Organize my Downloads folder into a clean, useful structure",
+    "Find duplicate photos and help me safely clean them up",
+    "Analyze this CSV and explain the most important trends",
+    "Turn these receipts into a categorized expense report",
     "Build a landing site for my new restaurant — make it themeable",
+    "Prototype a clean dashboard from this product brief",
+    "Debug the failing tests and explain the root cause",
+    "Explain how this codebase works and where I should start",
+    "Refactor this module without changing its behavior",
+    "Add the requested feature and verify the important edge cases",
+    "Review my staged changes for bugs, security, and maintainability",
     "Open a PR for my staged changes",
+    "Generate release notes from the changes since the last version",
+    "Investigate these application logs and find the likely failure",
+    "Find the performance bottleneck and propose the smallest fix",
+    "Update outdated dependencies and resolve compatibility issues",
+    "Set up this project locally and verify the development workflow",
+    "Automate this repetitive workflow with a reliable script",
+    "Research my competitors and summarize their positioning",
+    "Create a launch plan for this product with milestones and risks",
+    "Turn this rough brief into a prioritized execution checklist",
+    "Find the latest reliable information and summarize the sources",
+    "Compare my subscriptions and identify easy ways to save money",
+    "Design a comfortable home office setup for a tight space",
+    "Create a realistic monthly budget from these transactions",
 ];
 
 const TERMINAL_PROMPT_EXAMPLES: &[&str] = &[
@@ -1019,7 +1063,7 @@ pub fn PromptGhost(accent_bg: String, terminal: bool) -> Element {
     } else {
         AGENT_PROMPT_EXAMPLES
     };
-    let ex_idx = use_signal(|| 0usize);
+    let ex_idx = use_signal(|| random_prompt_example_index(examples.len(), None));
     let typed = use_signal(|| 0usize);
     let cb: Rc<RefCell<Option<Closure<dyn FnMut()>>>> = use_hook(|| Rc::new(RefCell::new(None)));
     let timer: Rc<RefCell<Option<i32>>> = use_hook(|| Rc::new(RefCell::new(None)));
@@ -1043,12 +1087,29 @@ pub fn PromptGhost(accent_bg: String, terminal: bool) -> Element {
     let example = examples[ex_idx() % examples.len()];
     let full = example.chars().count();
     let shown: String = example.chars().take(typed().min(full)).collect();
+    let ghost_class = if terminal {
+        "w-80 whitespace-pre-wrap break-words font-mono text-sm text-muted-foreground/50"
+    } else {
+        "max-w-full whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50"
+    };
     rsx! {
         div {
-            class: "w-80 whitespace-pre-wrap break-words font-mono text-sm text-muted-foreground/50",
+            class: "{ghost_class}",
             "{shown}"
             span { class: "ml-px inline-block h-3.5 w-1.5 align-middle animate-pulse {accent_bg}" }
         }
+    }
+}
+
+fn random_prompt_example_index(len: usize, current: Option<usize>) -> usize {
+    if len <= 1 {
+        return 0;
+    }
+    let next = ((js_sys::Math::random() * len as f64) as usize).min(len - 1);
+    if current == Some(next) {
+        (next + 1) % len
+    } else {
+        next
     }
 }
 
@@ -1059,21 +1120,21 @@ fn start_prompt_typewriter(
     cb_cell: Rc<RefCell<Option<Closure<dyn FnMut()>>>>,
     timer_cell: Rc<RefCell<Option<i32>>>,
 ) {
-    const PAUSE_TICKS: usize = 28;
+    const PAUSE_TICKS: usize = 40;
     let cb = Closure::wrap(Box::new(move || {
         let idx = *ex_idx.peek();
         let full = examples[idx % examples.len()].chars().count();
         let t = *typed.peek();
         if t >= full + PAUSE_TICKS {
             typed.set(0);
-            ex_idx.set((idx + 1) % examples.len());
+            ex_idx.set(random_prompt_example_index(examples.len(), Some(idx)));
         } else {
             typed.set(t + 1);
         }
     }) as Box<dyn FnMut()>);
     if let Some(win) = web_sys::window()
         && let Ok(id) = win
-            .set_interval_with_callback_and_timeout_and_arguments_0(cb.as_ref().unchecked_ref(), 60)
+            .set_interval_with_callback_and_timeout_and_arguments_0(cb.as_ref().unchecked_ref(), 50)
     {
         *timer_cell.borrow_mut() = Some(id);
     }

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -4625,6 +4625,25 @@ mod tests {
     }
 
     #[test]
+    fn prompt_ghost_rotates_many_random_agent_examples() {
+        let source = include_str!("page.rs");
+        let examples = source
+            .split("const AGENT_PROMPT_EXAMPLES")
+            .nth(1)
+            .and_then(|tail| tail.split("];").next())
+            .unwrap_or_default();
+        assert!(
+            examples
+                .lines()
+                .filter(|line| line.trim_start().starts_with('"'))
+                .count()
+                >= 40
+        );
+        assert!(source.contains("random_prompt_example_index"));
+        assert!(source.contains("js_sys::Math::random()"));
+    }
+
+    #[test]
     fn terminal_web_shortcut_wakes_next_command_frame() {
         let source = include_str!("plugin.rs");
         let on_term_key = source

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -4641,7 +4641,7 @@ mod tests {
         );
         assert!(source.contains("random_prompt_example_index"));
         assert!(source.contains("js_sys::Math::random()"));
-        assert!(source.contains("h-5 w-px align-middle bg-foreground/80"));
+        assert!(source.contains("relative top-px ml-px h-4 w-1.5 shrink-0"));
         assert!(source.contains("vmux-prompt-caret-blink 1s step-end infinite"));
     }
 

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -4641,6 +4641,8 @@ mod tests {
         );
         assert!(source.contains("random_prompt_example_index"));
         assert!(source.contains("js_sys::Math::random()"));
+        assert!(source.contains("h-5 w-px align-middle bg-foreground/80"));
+        assert!(source.contains("vmux-prompt-caret-blink 1s step-end infinite"));
     }
 
     #[test]


### PR DESCRIPTION
## Context

ACP startup looked disconnected from the chat surface, while the composer used a fixed-height input with controls outside its visual container. The result felt less cohesive and made longer prompts awkward to edit.

## Implementation

Keep the normal chat header, transcript area, and composer visible during startup while Matrix Rain runs behind them. Replace the footer divider with a soft gradient and use a glass composer that contains its send, stop, and queued-send actions. The textarea grows with its content up to 160 px and scrolls beyond that limit.

## Checks / QA

- Open a fresh ACP agent and confirm startup uses the chat layout over Matrix Rain.
- Type a multiline prompt and confirm the composer grows while the action stays aligned at the lower right.
- Start a response, stop it, and queue prompts to verify each action state remains inside the composer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic prompt textarea auto-resizing as you type.
  * Enhanced the prompt ghost experience with more rotating example prompts, randomized selection, and a dedicated blinking caret effect.
* **Improvements**
  * Refreshed chat page layout to better unify splash/idle content with the scroll area and updated background/overlay styling.
  * Updated composer controls and button visuals, including disabling “Send (Enter)” when the draft is empty.
* **Bug Fixes**
  * Refined textarea height behavior using clamping and improved draft/empty-state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->