### PR TITLE
feat(editor): animate and extend file explorer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ If any check fails, fix the issue before committing. Do not push broken code.
 
 ## Debugging
 
+**Never launch or run vmux yourself.** Do not execute `make dev`, `vmux_desktop`, `Vmux.app`, or automate input against the app. Build it when needed, then ask the user to run the normal build. After the user runs it, inspect the app logs directly.
+
 When adding temporary diagnostics to investigate a bug, make logging unconditional (default-on) — never gate it behind an env var or flag the user must set. The user runs the normal build; logs must appear without extra setup. Strip every temporary diagnostic before committing the fix.
 
 **Always read the app's own logs in Application Support first** — do not ask the user to capture stderr. After the user runs the app, read these files yourself directly; never ask them to paste, relay, or summarize log contents. vmux writes them to:

--- a/crates/vmux_core/src/event.rs
+++ b/crates/vmux_core/src/event.rs
@@ -76,6 +76,7 @@ pub const EXPLORER_FS_RESULT_EVENT: &str = "explorer_fs_result";
 pub const EXPLORER_TREE_TOGGLE_EVENT: &str = "explorer_tree_toggle";
 pub const EXPLORER_TREE_PREFETCH_EVENT: &str = "explorer_tree_prefetch";
 pub const EXPLORER_TREE_REFRESH_EVENT: &str = "explorer_tree_refresh";
+pub const EXPLORER_REVEAL_CURRENT_EVENT: &str = "explorer_reveal_current";
 pub const EXPLORER_CREATE_EVENT: &str = "explorer_create";
 pub const EXPLORER_RENAME_EVENT: &str = "explorer_rename";
 pub const EXPLORER_DELETE_EVENT: &str = "explorer_delete";
@@ -767,6 +768,8 @@ pub struct OutlineRow {
 pub struct ExplorerTreeEvent {
     pub root_name: String,
     pub root_path: String,
+    pub current_path: String,
+    pub focus_path: String,
     pub loading: bool,
     pub rows: Vec<TreeRow>,
 }
@@ -879,6 +882,21 @@ pub struct ExplorerTreePrefetch {
 pub struct ExplorerTreeRefresh {
     pub path: String,
 }
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ExplorerRevealCurrent;
 
 #[derive(
     Debug,
@@ -999,6 +1017,8 @@ mod file_event_tests {
         let e = ExplorerTreeEvent {
             root_name: "VMUX".into(),
             root_path: "/r".into(),
+            current_path: "/r/src/lib.rs".into(),
+            focus_path: "/r/src/lib.rs".into(),
             loading: false,
             rows: vec![TreeRow {
                 name: "src".into(),

--- a/crates/vmux_core/src/event.rs
+++ b/crates/vmux_core/src/event.rs
@@ -72,7 +72,13 @@ pub const EXPLORER_TREE_EVENT: &str = "explorer_tree";
 pub const EXPLORER_OPEN_EDITORS_EVENT: &str = "explorer_open_editors";
 pub const EXPLORER_OUTLINE_EVENT: &str = "explorer_outline";
 pub const EXPLORER_CHROME_EVENT: &str = "explorer_chrome";
+pub const EXPLORER_FS_RESULT_EVENT: &str = "explorer_fs_result";
 pub const EXPLORER_TREE_TOGGLE_EVENT: &str = "explorer_tree_toggle";
+pub const EXPLORER_TREE_PREFETCH_EVENT: &str = "explorer_tree_prefetch";
+pub const EXPLORER_TREE_REFRESH_EVENT: &str = "explorer_tree_refresh";
+pub const EXPLORER_CREATE_EVENT: &str = "explorer_create";
+pub const EXPLORER_RENAME_EVENT: &str = "explorer_rename";
+pub const EXPLORER_DELETE_EVENT: &str = "explorer_delete";
 pub const EXPLORER_CLOSE_EDITOR_EVENT: &str = "explorer_close_editor";
 pub const EXPLORER_PANEL_TOGGLE_EVENT: &str = "explorer_panel_toggle";
 pub const EXPLORER_PANEL_WIDTH_EVENT: &str = "explorer_panel_width";
@@ -708,6 +714,7 @@ pub struct TreeRow {
     pub depth: u16,
     pub is_dir: bool,
     pub expanded: bool,
+    pub loading: bool,
 }
 
 #[derive(
@@ -759,7 +766,26 @@ pub struct OutlineRow {
 )]
 pub struct ExplorerTreeEvent {
     pub root_name: String,
+    pub root_path: String,
+    pub loading: bool,
     pub rows: Vec<TreeRow>,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ExplorerFsResult {
+    pub ok: bool,
+    pub message: String,
+    pub open_path: String,
 }
 
 #[derive(
@@ -835,6 +861,84 @@ pub struct ExplorerTreeToggle {
     rkyv::Serialize,
     rkyv::Deserialize,
 )]
+pub struct ExplorerTreePrefetch {
+    pub path: String,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ExplorerTreeRefresh {
+    pub path: String,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ExplorerCreate {
+    pub parent: String,
+    pub name: String,
+    pub is_dir: bool,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ExplorerRename {
+    pub path: String,
+    pub name: String,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ExplorerDelete {
+    pub path: String,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
 pub struct ExplorerCloseEditor {
     pub path: String,
 }
@@ -894,12 +998,15 @@ mod file_event_tests {
     fn explorer_tree_event_rkyv_roundtrip() {
         let e = ExplorerTreeEvent {
             root_name: "VMUX".into(),
+            root_path: "/r".into(),
+            loading: false,
             rows: vec![TreeRow {
                 name: "src".into(),
                 path: "/r/src".into(),
                 depth: 0,
                 is_dir: true,
                 expanded: true,
+                loading: false,
             }],
         };
         let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&e).expect("ser");

--- a/crates/vmux_core/src/event.rs
+++ b/crates/vmux_core/src/event.rs
@@ -836,6 +836,8 @@ pub struct OutlineEvent {
 pub struct ExplorerChromeEvent {
     pub visible: bool,
     pub width: u32,
+    pub client_id: u64,
+    pub request_id: u64,
 }
 
 #[derive(
@@ -974,7 +976,11 @@ pub struct ExplorerCloseEditor {
     rkyv::Serialize,
     rkyv::Deserialize,
 )]
-pub struct ExplorerPanelToggle;
+pub struct ExplorerPanelSetVisible {
+    pub visible: bool,
+    pub client_id: u64,
+    pub request_id: u64,
+}
 
 #[derive(
     Debug,

--- a/crates/vmux_core/src/event.rs
+++ b/crates/vmux_core/src/event.rs
@@ -69,6 +69,7 @@ pub const LSP_UPDATE_REQUEST: &str = "lsp_update_request";
 pub const LSP_INSTALL_PROGRESS_EVENT: &str = "lsp_install_progress";
 pub const LSP_PKG_STATUS_EVENT: &str = "lsp_pkg_status";
 pub const EXPLORER_TREE_EVENT: &str = "explorer_tree";
+pub const EXPLORER_FOCUS_EVENT: &str = "explorer_focus";
 pub const EXPLORER_OPEN_EDITORS_EVENT: &str = "explorer_open_editors";
 pub const EXPLORER_OUTLINE_EVENT: &str = "explorer_outline";
 pub const EXPLORER_CHROME_EVENT: &str = "explorer_chrome";
@@ -772,6 +773,21 @@ pub struct ExplorerTreeEvent {
     pub focus_path: String,
     pub loading: bool,
     pub rows: Vec<TreeRow>,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ExplorerFocusEvent {
+    pub path: String,
 }
 
 #[derive(

--- a/crates/vmux_editor/src/dir.rs
+++ b/crates/vmux_editor/src/dir.rs
@@ -10,8 +10,15 @@ pub fn list_dir(path: &Path) -> Vec<FileDirEntry> {
         .flatten()
         .map(|e| {
             let path = e.path();
-            let is_dir = std::fs::metadata(&path)
-                .map(|m| m.is_dir())
+            let is_dir = e
+                .file_type()
+                .map(|kind| {
+                    kind.is_dir()
+                        || kind.is_symlink()
+                            && std::fs::metadata(&path)
+                                .map(|metadata| metadata.is_dir())
+                                .unwrap_or(false)
+                })
                 .unwrap_or(false);
             FileDirEntry {
                 name: e.file_name().to_string_lossy().to_string(),

--- a/crates/vmux_editor/src/explorer.rs
+++ b/crates/vmux_editor/src/explorer.rs
@@ -124,11 +124,16 @@ fn tree_row_id(path: &str) -> String {
     format!("explorer-row-{hash:016x}")
 }
 
-fn schedule_tree_focus(path: String) {
+fn schedule_tree_focus(path: String, mut generation: Signal<u32>) {
+    let id = generation().wrapping_add(1);
+    generation.set(id);
     let Some(window) = web_sys::window() else {
         return;
     };
     let focus = Closure::once(move || {
+        if generation() != id {
+            return;
+        }
         let Some(element) = web_sys::window()
             .and_then(|window| window.document())
             .and_then(|document| document.get_element_by_id(&tree_row_id(&path)))
@@ -147,6 +152,11 @@ fn schedule_tree_focus(path: String) {
         TREE_MOTION_MS + 20,
     );
     focus.forget();
+}
+
+fn cancel_tree_focus(mut generation: Signal<u32>) {
+    let id = generation.peek().wrapping_add(1);
+    generation.set(id);
 }
 
 fn reconcile_rows(
@@ -285,13 +295,14 @@ fn prompt_title(kind: PromptKind) -> &'static str {
 }
 
 #[component]
-pub fn ExplorerPanel() -> Element {
+pub fn ExplorerPanel(visible: Signal<bool>) -> Element {
     let mut root_name = use_signal(|| "Explorer".to_string());
     let mut root_path = use_signal(String::new);
     let mut current_path = use_signal(String::new);
     let mut root_loading = use_signal(|| false);
     let rows = use_signal(Vec::<MotionRow>::new);
     let row_generation = use_signal(|| 0u32);
+    let focus_generation = use_signal(|| 0u32);
     let mut open_editors = use_signal(Vec::<OpenEditorItem>::new);
     let mut outline = use_signal(Vec::<OutlineRow>::new);
     let mut show_open = use_signal(|| true);
@@ -303,14 +314,28 @@ pub fn ExplorerPanel() -> Element {
     let mut notice = use_signal(|| None::<ExplorerNotice>);
     let notice_generation = use_signal(|| 0u32);
 
+    use_effect(move || {
+        if !visible() {
+            cancel_tree_focus(focus_generation);
+        }
+    });
+
     let _tree = use_bin_event_listener::<ExplorerTreeEvent, _>(EXPLORER_TREE_EVENT, move |e| {
         root_name.set(e.root_name);
         root_path.set(e.root_path);
         current_path.set(e.current_path);
         root_loading.set(e.loading);
         reconcile_rows(rows, row_generation, e.rows);
-        if !e.focus_path.is_empty() {
-            schedule_tree_focus(e.focus_path);
+        if visible() && !e.focus_path.is_empty() {
+            schedule_tree_focus(e.focus_path, focus_generation);
+        }
+    });
+    let _focus = use_bin_event_listener::<ExplorerFocusEvent, _>(EXPLORER_FOCUS_EVENT, move |e| {
+        if current_path() != e.path {
+            current_path.set(e.path.clone());
+        }
+        if visible() {
+            schedule_tree_focus(e.path, focus_generation);
         }
     });
     let _open =

--- a/crates/vmux_editor/src/explorer.rs
+++ b/crates/vmux_editor/src/explorer.rs
@@ -1,13 +1,54 @@
 #![allow(non_snake_case)]
 
-//! Dumb Explorer panel for the file editor page: renders the backend-pushed
-//! tree, open-editors, and outline view-models and emits user intents. All
-//! state lives in the native plugin; this module only renders and forwards.
+//! Explorer panel rendering, motion, context menus, and user intents.
+
+use std::collections::{HashMap, HashSet};
 
 use dioxus::prelude::*;
 use vmux_core::event::*;
 use vmux_ui::file_icon::type_icon;
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener};
+use wasm_bindgen::{JsCast, closure::Closure};
+
+const TREE_MOTION_MS: i32 = 170;
+const NOTICE_MS: i32 = 2400;
+
+#[derive(Clone, PartialEq)]
+struct MotionRow {
+    row: TreeRow,
+    visible: bool,
+}
+
+#[derive(Clone, PartialEq)]
+struct TreeMenu {
+    path: String,
+    name: String,
+    is_dir: bool,
+    is_root: bool,
+    x: f64,
+    y: f64,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PromptKind {
+    CreateFile,
+    CreateDir,
+    Rename,
+    Delete,
+}
+
+#[derive(Clone, PartialEq)]
+struct TreePrompt {
+    kind: PromptKind,
+    path: String,
+    name: String,
+}
+
+#[derive(Clone, PartialEq)]
+struct ExplorerNotice {
+    ok: bool,
+    message: String,
+}
 
 fn open_file(path: String) {
     let _ = try_cef_bin_emit_rkyv(&FileOpenEvent { path });
@@ -15,6 +56,14 @@ fn open_file(path: String) {
 
 fn toggle_dir(path: String) {
     let _ = try_cef_bin_emit_rkyv(&ExplorerTreeToggle { path });
+}
+
+fn prefetch_dir(path: String) {
+    let _ = try_cef_bin_emit_rkyv(&ExplorerTreePrefetch { path });
+}
+
+fn refresh_dir(path: String) {
+    let _ = try_cef_bin_emit_rkyv(&ExplorerTreeRefresh { path });
 }
 
 fn close_editor(path: String) {
@@ -28,39 +77,232 @@ fn goto_line(line: u32) {
     });
 }
 
-fn chevron(expanded: bool) -> Element {
-    rsx! {
-        span {
-            class: "inline-block w-4 shrink-0 text-center text-sm leading-none text-foreground/60",
-            {if expanded { "\u{25BE}" } else { "\u{25B8}" }}
+fn create_entry(parent: String, name: String, is_dir: bool) {
+    let _ = try_cef_bin_emit_rkyv(&ExplorerCreate {
+        parent,
+        name,
+        is_dir,
+    });
+}
+
+fn rename_entry(path: String, name: String) {
+    let _ = try_cef_bin_emit_rkyv(&ExplorerRename { path, name });
+}
+
+fn delete_entry(path: String) {
+    let _ = try_cef_bin_emit_rkyv(&ExplorerDelete { path });
+}
+
+fn menu_position(x: f64, y: f64) -> (f64, f64) {
+    let Some(window) = web_sys::window() else {
+        return (x, y);
+    };
+    let width = window
+        .inner_width()
+        .ok()
+        .and_then(|value| value.as_f64())
+        .unwrap_or(x + 200.0);
+    let height = window
+        .inner_height()
+        .ok()
+        .and_then(|value| value.as_f64())
+        .unwrap_or(y + 240.0);
+    (
+        x.min((width - 190.0).max(8.0)),
+        y.min((height - 220.0).max(8.0)),
+    )
+}
+
+fn reconcile_rows(
+    mut rows: Signal<Vec<MotionRow>>,
+    mut generation: Signal<u32>,
+    next: Vec<TreeRow>,
+) {
+    let id = generation().wrapping_add(1);
+    generation.set(id);
+    let next_by_path: HashMap<String, TreeRow> = next
+        .iter()
+        .cloned()
+        .map(|row| (row.path.clone(), row))
+        .collect();
+    let next_paths: HashSet<String> = next_by_path.keys().cloned().collect();
+    let mut merged: Vec<MotionRow> = rows
+        .read()
+        .iter()
+        .map(|old| match next_by_path.get(&old.row.path) {
+            Some(row) => MotionRow {
+                row: row.clone(),
+                visible: true,
+            },
+            None => MotionRow {
+                row: old.row.clone(),
+                visible: false,
+            },
+        })
+        .collect();
+    for (index, row) in next.iter().enumerate() {
+        if merged.iter().any(|item| item.row.path == row.path) {
+            continue;
         }
+        let insert_at = next[..index]
+            .iter()
+            .rev()
+            .find_map(|previous| {
+                merged
+                    .iter()
+                    .position(|item| item.row.path == previous.path)
+                    .map(|position| position + 1)
+            })
+            .unwrap_or(0);
+        merged.insert(
+            insert_at,
+            MotionRow {
+                row: row.clone(),
+                visible: false,
+            },
+        );
+    }
+    rows.set(merged);
+    if let Some(window) = web_sys::window() {
+        let enter_paths = next_paths;
+        let enter = Closure::once(move || {
+            if generation() != id {
+                return;
+            }
+            let mut current = rows.read().clone();
+            for item in &mut current {
+                if enter_paths.contains(&item.row.path) {
+                    item.visible = true;
+                }
+            }
+            rows.set(current);
+        });
+        let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(
+            enter.as_ref().unchecked_ref(),
+            0,
+        );
+        enter.forget();
+
+        let settle = Closure::once(move || {
+            if generation() == id {
+                rows.set(
+                    next.into_iter()
+                        .map(|row| MotionRow { row, visible: true })
+                        .collect(),
+                );
+            }
+        });
+        let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(
+            settle.as_ref().unchecked_ref(),
+            TREE_MOTION_MS,
+        );
+        settle.forget();
+    } else {
+        rows.set(
+            next.into_iter()
+                .map(|row| MotionRow { row, visible: true })
+                .collect(),
+        );
+    }
+}
+
+fn show_notice(
+    mut notice: Signal<Option<ExplorerNotice>>,
+    mut generation: Signal<u32>,
+    value: ExplorerNotice,
+) {
+    let id = generation().wrapping_add(1);
+    generation.set(id);
+    notice.set(Some(value));
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let clear = Closure::once(move || {
+        if generation() == id {
+            notice.set(None);
+        }
+    });
+    let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(
+        clear.as_ref().unchecked_ref(),
+        NOTICE_MS,
+    );
+    clear.forget();
+}
+
+fn submit_prompt(mut prompt: Signal<Option<TreePrompt>>, draft: Signal<String>) {
+    let Some(current) = prompt() else {
+        return;
+    };
+    let name = draft().trim().to_string();
+    match current.kind {
+        PromptKind::CreateFile if !name.is_empty() => create_entry(current.path, name, false),
+        PromptKind::CreateDir if !name.is_empty() => create_entry(current.path, name, true),
+        PromptKind::Rename if !name.is_empty() => rename_entry(current.path, name),
+        PromptKind::Delete => delete_entry(current.path),
+        _ => return,
+    }
+    prompt.set(None);
+}
+
+fn chevron(expanded: bool, loading: bool) -> Element {
+    if loading {
+        return rsx! {
+            span { class: "inline-block h-3 w-3 shrink-0 animate-spin rounded-full border border-foreground/25 border-t-foreground/70" }
+        };
+    }
+    let class = if expanded {
+        "inline-block w-4 shrink-0 rotate-90 text-center text-base leading-none text-foreground/60 transition-transform duration-150 ease-out"
+    } else {
+        "inline-block w-4 shrink-0 rotate-0 text-center text-base leading-none text-foreground/60 transition-transform duration-150 ease-out"
+    };
+    rsx! {
+        span { class: "{class}", "\u{203A}" }
     }
 }
 
 fn section_header(title: String, open: Signal<bool>, on_toggle: EventHandler<()>) -> Element {
     rsx! {
         div {
-            class: "flex items-center gap-1 px-2 py-1 cursor-default text-[11px] font-bold uppercase tracking-wide text-foreground/70 hover:text-foreground",
+            class: "flex items-center gap-1 px-2 py-1 cursor-default text-[11px] font-bold uppercase tracking-wide text-foreground/70 transition-colors hover:text-foreground",
             onclick: move |_| on_toggle.call(()),
-            {chevron(open())}
+            {chevron(open(), false)}
             span { class: "truncate", "{title}" }
         }
+    }
+}
+
+fn prompt_title(kind: PromptKind) -> &'static str {
+    match kind {
+        PromptKind::CreateFile => "New File",
+        PromptKind::CreateDir => "New Folder",
+        PromptKind::Rename => "Rename",
+        PromptKind::Delete => "Delete",
     }
 }
 
 #[component]
 pub fn ExplorerPanel() -> Element {
     let mut root_name = use_signal(|| "Explorer".to_string());
-    let mut rows = use_signal(Vec::<TreeRow>::new);
+    let mut root_path = use_signal(String::new);
+    let mut root_loading = use_signal(|| false);
+    let rows = use_signal(Vec::<MotionRow>::new);
+    let row_generation = use_signal(|| 0u32);
     let mut open_editors = use_signal(Vec::<OpenEditorItem>::new);
     let mut outline = use_signal(Vec::<OutlineRow>::new);
     let mut show_open = use_signal(|| true);
     let mut show_files = use_signal(|| true);
     let mut show_outline = use_signal(|| true);
+    let mut menu = use_signal(|| None::<TreeMenu>);
+    let mut prompt = use_signal(|| None::<TreePrompt>);
+    let mut draft = use_signal(String::new);
+    let mut notice = use_signal(|| None::<ExplorerNotice>);
+    let notice_generation = use_signal(|| 0u32);
 
     let _tree = use_bin_event_listener::<ExplorerTreeEvent, _>(EXPLORER_TREE_EVENT, move |e| {
         root_name.set(e.root_name);
-        rows.set(e.rows);
+        root_path.set(e.root_path);
+        root_loading.set(e.loading);
+        reconcile_rows(rows, row_generation, e.rows);
     });
     let _open =
         use_bin_event_listener::<OpenEditorsEvent, _>(EXPLORER_OPEN_EDITORS_EVENT, move |e| {
@@ -69,44 +311,75 @@ pub fn ExplorerPanel() -> Element {
     let _outline = use_bin_event_listener::<OutlineEvent, _>(EXPLORER_OUTLINE_EVENT, move |e| {
         outline.set(e.items);
     });
+    let _fs_result =
+        use_bin_event_listener::<ExplorerFsResult, _>(EXPLORER_FS_RESULT_EVENT, move |e| {
+            if e.ok && !e.open_path.is_empty() {
+                open_file(e.open_path);
+            }
+            show_notice(
+                notice,
+                notice_generation,
+                ExplorerNotice {
+                    ok: e.ok,
+                    message: e.message,
+                },
+            );
+        });
+
+    let open_body = if show_open() {
+        "grid grid-rows-[1fr] opacity-100 transition-[grid-template-rows,opacity] duration-200 ease-out"
+    } else {
+        "grid grid-rows-[0fr] opacity-0 transition-[grid-template-rows,opacity] duration-200 ease-out"
+    };
+    let files_body = if show_files() {
+        "grid grid-rows-[1fr] opacity-100 transition-[grid-template-rows,opacity] duration-200 ease-out"
+    } else {
+        "grid grid-rows-[0fr] opacity-0 transition-[grid-template-rows,opacity] duration-200 ease-out"
+    };
+    let outline_body = if show_outline() {
+        "grid grid-rows-[1fr] opacity-100 transition-[grid-template-rows,opacity] duration-200 ease-out"
+    } else {
+        "grid grid-rows-[0fr] opacity-0 transition-[grid-template-rows,opacity] duration-200 ease-out"
+    };
 
     rsx! {
-        div { class: "flex h-full w-full flex-col overflow-hidden bg-foreground/[0.04] font-sans text-xs text-foreground select-none",
+        div { class: "relative flex h-full w-full flex-col overflow-hidden bg-foreground/[0.04] font-sans text-xs text-foreground select-none",
             div { class: "flex h-9 shrink-0 items-center px-4 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground",
                 "Explorer"
             }
             div { class: "min-h-0 flex-1 overflow-y-auto pb-4",
-
                 {section_header("Open Editors".to_string(), show_open, EventHandler::new(move |_| show_open.set(!show_open())))}
-                if show_open() {
-                    for it in open_editors() {
-                        {
-                            let p_open = it.path.clone();
-                            let p_close = it.path.clone();
-                            let active = it.active;
-                            let dirty = it.dirty;
-                            rsx! {
-                                div {
-                                    key: "{it.path}",
-                                    class: if active {
-                                        "group flex items-center gap-1 px-2 py-0.5 cursor-default bg-cyan-400/12 text-foreground"
-                                    } else {
-                                        "group flex items-center gap-1 px-2 py-0.5 cursor-default text-foreground/75 hover:bg-foreground/[0.08]"
-                                    },
-                                    style: "padding-left:20px;",
-                                    onclick: move |_| open_file(p_open.clone()),
-                                    span {
-                                        class: "inline-block w-3 shrink-0 cursor-default text-center text-foreground/50 opacity-0 group-hover:opacity-100 hover:text-foreground",
-                                        onclick: move |e: Event<MouseData>| {
-                                            e.stop_propagation();
-                                            close_editor(p_close.clone());
+                div { class: "{open_body}",
+                    div { class: "min-h-0 overflow-hidden",
+                        for it in open_editors() {
+                            {
+                                let p_open = it.path.clone();
+                                let p_close = it.path.clone();
+                                let active = it.active;
+                                let dirty = it.dirty;
+                                rsx! {
+                                    div {
+                                        key: "{it.path}",
+                                        class: if active {
+                                            "group flex items-center gap-1 px-2 py-0.5 cursor-default bg-cyan-400/12 text-foreground transition-[background-color,opacity,transform] duration-150"
+                                        } else {
+                                            "group flex items-center gap-1 px-2 py-0.5 cursor-default text-foreground/75 transition-[background-color,opacity,transform] duration-150 hover:bg-foreground/[0.08]"
                                         },
-                                        "\u{00D7}"
-                                    }
-                                    {type_icon(&it.path, false, "h-4 w-4 shrink-0 opacity-80")}
-                                    span { class: "truncate", "{it.name}" }
-                                    if dirty {
-                                        span { class: "ml-auto h-1.5 w-1.5 shrink-0 rounded-full bg-cyan-300" }
+                                        style: "padding-left:20px;",
+                                        onclick: move |_| open_file(p_open.clone()),
+                                        span {
+                                            class: "inline-block w-3 shrink-0 cursor-default text-center text-foreground/50 opacity-0 transition-opacity group-hover:opacity-100 hover:text-foreground",
+                                            onclick: move |e: Event<MouseData>| {
+                                                e.stop_propagation();
+                                                close_editor(p_close.clone());
+                                            },
+                                            "\u{00D7}"
+                                        }
+                                        {type_icon(&it.path, false, "h-4 w-4 shrink-0 opacity-80")}
+                                        span { class: "truncate", "{it.name}" }
+                                        if dirty {
+                                            span { class: "ml-auto h-1.5 w-1.5 shrink-0 rounded-full bg-cyan-300" }
+                                        }
                                     }
                                 }
                             }
@@ -114,33 +387,87 @@ pub fn ExplorerPanel() -> Element {
                     }
                 }
 
-                {section_header(root_name(), show_files, EventHandler::new(move |_| show_files.set(!show_files())))}
-                if show_files() {
-                    for r in rows() {
-                        {
-                            let path_t = r.path.clone();
-                            let is_dir = r.is_dir;
-                            let pad = (r.depth as u32) * 12 + 8;
-                            rsx! {
-                                div {
-                                    key: "{r.path}",
-                                    class: "flex items-center gap-1 px-1 py-0.5 cursor-default text-foreground/80 hover:bg-foreground/[0.08]",
-                                    style: "padding-left:{pad}px;",
-                                    title: "{r.path}",
-                                    onclick: move |_| {
-                                        if is_dir {
-                                            toggle_dir(path_t.clone());
-                                        } else {
-                                            open_file(path_t.clone());
+                div {
+                    oncontextmenu: move |e: Event<MouseData>| {
+                        e.prevent_default();
+                        let coordinates = e.client_coordinates();
+                        let (x, y) = menu_position(coordinates.x, coordinates.y);
+                        menu.set(Some(TreeMenu {
+                            path: root_path(),
+                            name: root_name(),
+                            is_dir: true,
+                            is_root: true,
+                            x,
+                            y,
+                        }));
+                    },
+                    {section_header(root_name(), show_files, EventHandler::new(move |_| show_files.set(!show_files())))}
+                }
+                div { class: "{files_body}",
+                    div { class: "min-h-0 overflow-hidden",
+                        if root_loading() && rows.read().is_empty() {
+                            div { class: "flex h-6 items-center gap-2 px-3 text-foreground/45",
+                                span { class: "h-3 w-3 animate-spin rounded-full border border-foreground/20 border-t-foreground/60" }
+                                "Loading"
+                            }
+                        }
+                        for motion in rows() {
+                            {
+                                let row = motion.row.clone();
+                                let path_click = row.path.clone();
+                                let path_prefetch = row.path.clone();
+                                let path_menu = row.path.clone();
+                                let name_menu = row.name.clone();
+                                let is_dir = row.is_dir;
+                                let pad = (row.depth as u32) * 12 + 8;
+                                let motion_class = if motion.visible {
+                                    "grid grid-rows-[1fr] opacity-100 translate-y-0 transition-[grid-template-rows,opacity,transform] duration-150 ease-out"
+                                } else {
+                                    "grid grid-rows-[0fr] opacity-0 -translate-y-1 transition-[grid-template-rows,opacity,transform] duration-150 ease-out"
+                                };
+                                rsx! {
+                                    div { key: "{row.path}", class: "{motion_class}",
+                                        div { class: "min-h-0 overflow-hidden",
+                                            div {
+                                                class: "flex h-[22px] items-center gap-1 px-1 cursor-default text-foreground/80 transition-colors duration-100 hover:bg-foreground/[0.08]",
+                                                style: "padding-left:{pad}px;",
+                                                title: "{row.path}",
+                                                onmouseenter: move |_| {
+                                                    if is_dir {
+                                                        prefetch_dir(path_prefetch.clone());
+                                                    }
+                                                },
+                                                oncontextmenu: move |e: Event<MouseData>| {
+                                                    e.prevent_default();
+                                                    e.stop_propagation();
+                                                    let coordinates = e.client_coordinates();
+                                                    let (x, y) = menu_position(coordinates.x, coordinates.y);
+                                                    menu.set(Some(TreeMenu {
+                                                        path: path_menu.clone(),
+                                                        name: name_menu.clone(),
+                                                        is_dir,
+                                                        is_root: false,
+                                                        x,
+                                                        y,
+                                                    }));
+                                                },
+                                                onclick: move |_| {
+                                                    if is_dir {
+                                                        toggle_dir(path_click.clone());
+                                                    } else {
+                                                        open_file(path_click.clone());
+                                                    }
+                                                },
+                                                if is_dir {
+                                                    {chevron(row.expanded, row.loading)}
+                                                } else {
+                                                    span { class: "inline-block w-4 shrink-0" }
+                                                }
+                                                {type_icon(&row.path, is_dir, "h-4 w-4 shrink-0 opacity-80")}
+                                                span { class: "truncate", "{row.name}" }
+                                            }
                                         }
-                                    },
-                                    if is_dir {
-                                        {chevron(r.expanded)}
-                                    } else {
-                                        span { class: "inline-block w-3 shrink-0" }
                                     }
-                                    {type_icon(&r.path, is_dir, "h-4 w-4 shrink-0 opacity-80")}
-                                    span { class: "truncate", "{r.name}" }
                                 }
                             }
                         }
@@ -148,23 +475,170 @@ pub fn ExplorerPanel() -> Element {
                 }
 
                 {section_header("Outline".to_string(), show_outline, EventHandler::new(move |_| show_outline.set(!show_outline())))}
-                if show_outline() {
-                    for s in outline() {
-                        {
-                            let line = s.line;
-                            let pad = (s.depth as u32) * 12 + 20;
-                            rsx! {
-                                div {
-                                    key: "{s.line}-{s.name}",
-                                    class: "flex items-center gap-1 px-1 py-0.5 cursor-default text-foreground/75 hover:bg-foreground/[0.08]",
-                                    style: "padding-left:{pad}px;",
-                                    onclick: move |_| goto_line(line),
-                                    {outline_glyph(s.kind)}
-                                    span { class: "truncate", "{s.name}" }
+                div { class: "{outline_body}",
+                    div { class: "min-h-0 overflow-hidden",
+                        for s in outline() {
+                            {
+                                let line = s.line;
+                                let pad = (s.depth as u32) * 12 + 20;
+                                rsx! {
+                                    div {
+                                        key: "{s.line}-{s.name}",
+                                        class: "flex items-center gap-1 px-1 py-0.5 cursor-default text-foreground/75 transition-colors duration-100 hover:bg-foreground/[0.08]",
+                                        style: "padding-left:{pad}px;",
+                                        onclick: move |_| goto_line(line),
+                                        {outline_glyph(s.kind)}
+                                        span { class: "truncate", "{s.name}" }
+                                    }
                                 }
                             }
                         }
                     }
+                }
+            }
+
+            if let Some(current) = menu() {
+                div {
+                    class: "fixed inset-0 z-[998]",
+                    onclick: move |_| menu.set(None),
+                    oncontextmenu: move |e| {
+                        e.prevent_default();
+                        menu.set(None);
+                    },
+                }
+                div {
+                    class: "fixed z-[999] min-w-[180px] origin-top-left animate-[dx-fade-zoom-in_120ms_ease-out_forwards] rounded-lg bg-background p-1 text-xs text-foreground shadow-[0_12px_40px_rgba(0,0,0,0.28),inset_0_0_0_1px_var(--border)]",
+                    style: "left:{current.x}px;top:{current.y}px;",
+                    onclick: move |e| e.stop_propagation(),
+                    if current.is_dir {
+                        button {
+                            class: "flex w-full items-center rounded-md px-3 py-2 text-left transition-colors hover:bg-foreground/[0.08]",
+                            onclick: {
+                                let path = current.path.clone();
+                                move |_| {
+                                    draft.set(String::new());
+                                    prompt.set(Some(TreePrompt { kind: PromptKind::CreateFile, path: path.clone(), name: String::new() }));
+                                    menu.set(None);
+                                }
+                            },
+                            "New File"
+                        }
+                        button {
+                            class: "flex w-full items-center rounded-md px-3 py-2 text-left transition-colors hover:bg-foreground/[0.08]",
+                            onclick: {
+                                let path = current.path.clone();
+                                move |_| {
+                                    draft.set(String::new());
+                                    prompt.set(Some(TreePrompt { kind: PromptKind::CreateDir, path: path.clone(), name: String::new() }));
+                                    menu.set(None);
+                                }
+                            },
+                            "New Folder"
+                        }
+                        div { class: "mx-2 my-1 h-px bg-border" }
+                        button {
+                            class: "flex w-full items-center rounded-md px-3 py-2 text-left transition-colors hover:bg-foreground/[0.08]",
+                            onclick: {
+                                let path = current.path.clone();
+                                move |_| {
+                                    refresh_dir(path.clone());
+                                    menu.set(None);
+                                }
+                            },
+                            "Refresh"
+                        }
+                    }
+                    if !current.is_root {
+                        if current.is_dir {
+                            div { class: "mx-2 my-1 h-px bg-border" }
+                        }
+                        button {
+                            class: "flex w-full items-center rounded-md px-3 py-2 text-left transition-colors hover:bg-foreground/[0.08]",
+                            onclick: {
+                                let path = current.path.clone();
+                                let name = current.name.clone();
+                                move |_| {
+                                    draft.set(name.clone());
+                                    prompt.set(Some(TreePrompt { kind: PromptKind::Rename, path: path.clone(), name: name.clone() }));
+                                    menu.set(None);
+                                }
+                            },
+                            "Rename"
+                        }
+                        button {
+                            class: "flex w-full items-center rounded-md px-3 py-2 text-left text-red-600 transition-colors hover:bg-red-500/10 dark:text-red-300",
+                            onclick: {
+                                let path = current.path.clone();
+                                let name = current.name.clone();
+                                move |_| {
+                                    prompt.set(Some(TreePrompt { kind: PromptKind::Delete, path: path.clone(), name: name.clone() }));
+                                    menu.set(None);
+                                }
+                            },
+                            "Delete"
+                        }
+                    }
+                }
+            }
+
+            if let Some(current) = prompt() {
+                div {
+                    class: "fixed inset-0 z-[1000] flex items-center justify-center bg-black/25 animate-[dx-fade-in_120ms_ease-out_forwards]",
+                    onclick: move |_| prompt.set(None),
+                    div {
+                        class: "w-[min(360px,calc(100vw-32px))] animate-[dx-fade-zoom-in_150ms_ease-out_forwards] rounded-xl bg-background p-4 shadow-[0_18px_60px_rgba(0,0,0,0.35),inset_0_0_0_1px_var(--border)]",
+                        onclick: move |e| e.stop_propagation(),
+                        div { class: "text-sm font-semibold text-foreground", "{prompt_title(current.kind)}" }
+                        if current.kind == PromptKind::Delete {
+                            div { class: "mt-2 text-xs leading-relaxed text-muted-foreground",
+                                "Delete “{current.name}”? This cannot be undone."
+                            }
+                        } else {
+                            input {
+                                class: "mt-3 w-full rounded-md border border-border bg-foreground/[0.04] px-3 py-2 text-sm text-foreground outline-none transition-colors focus:border-cyan-400/50",
+                                autofocus: true,
+                                value: "{draft}",
+                                oninput: move |e| draft.set(e.value()),
+                                onkeydown: move |e| {
+                                    e.stop_propagation();
+                                    if e.key() == Key::Enter {
+                                        e.prevent_default();
+                                        submit_prompt(prompt, draft);
+                                    } else if e.key() == Key::Escape {
+                                        prompt.set(None);
+                                    }
+                                },
+                            }
+                        }
+                        div { class: "mt-4 flex justify-end gap-2",
+                            button {
+                                class: "rounded-md px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-foreground/[0.08] hover:text-foreground",
+                                onclick: move |_| prompt.set(None),
+                                "Cancel"
+                            }
+                            button {
+                                class: if current.kind == PromptKind::Delete {
+                                    "rounded-md bg-red-500 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-red-600"
+                                } else {
+                                    "rounded-md bg-cyan-500 px-3 py-1.5 text-xs font-medium text-slate-950 transition-colors hover:bg-cyan-400"
+                                },
+                                onclick: move |_| submit_prompt(prompt, draft),
+                                {if current.kind == PromptKind::Delete { "Delete" } else { "Save" }}
+                            }
+                        }
+                    }
+                }
+            }
+
+            if let Some(current) = notice() {
+                button {
+                    class: if current.ok {
+                        "absolute bottom-3 left-3 right-3 z-[997] animate-[dx-fade-zoom-in_150ms_ease-out_forwards] rounded-lg bg-emerald-500/90 px-3 py-2 text-left text-xs text-white shadow-lg"
+                    } else {
+                        "absolute bottom-3 left-3 right-3 z-[997] animate-[dx-fade-zoom-in_150ms_ease-out_forwards] rounded-lg bg-red-500/90 px-3 py-2 text-left text-xs text-white shadow-lg"
+                    },
+                    onclick: move |_| notice.set(None),
+                    "{current.message}"
                 }
             }
         }

--- a/crates/vmux_editor/src/explorer.rs
+++ b/crates/vmux_editor/src/explorer.rs
@@ -2,8 +2,9 @@
 
 //! Explorer panel rendering, motion, context menus, and user intents.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
+use crate::page_model::merge_tree_motion_rows;
 use dioxus::prelude::*;
 use vmux_core::event::*;
 use vmux_ui::file_icon::type_icon;
@@ -155,48 +156,16 @@ fn reconcile_rows(
 ) {
     let id = generation().wrapping_add(1);
     generation.set(id);
-    let next_by_path: HashMap<String, TreeRow> = next
-        .iter()
-        .cloned()
-        .map(|row| (row.path.clone(), row))
-        .collect();
-    let next_paths: HashSet<String> = next_by_path.keys().cloned().collect();
-    let mut merged: Vec<MotionRow> = rows
+    let next_paths: HashSet<String> = next.iter().map(|row| row.path.clone()).collect();
+    let current = rows
         .read()
         .iter()
-        .map(|old| match next_by_path.get(&old.row.path) {
-            Some(row) => MotionRow {
-                row: row.clone(),
-                visible: true,
-            },
-            None => MotionRow {
-                row: old.row.clone(),
-                visible: false,
-            },
-        })
+        .map(|motion| motion.row.clone())
+        .collect::<Vec<_>>();
+    let merged = merge_tree_motion_rows(&current, &next)
+        .into_iter()
+        .map(|(row, visible)| MotionRow { row, visible })
         .collect();
-    for (index, row) in next.iter().enumerate() {
-        if merged.iter().any(|item| item.row.path == row.path) {
-            continue;
-        }
-        let insert_at = next[..index]
-            .iter()
-            .rev()
-            .find_map(|previous| {
-                merged
-                    .iter()
-                    .position(|item| item.row.path == previous.path)
-                    .map(|position| position + 1)
-            })
-            .unwrap_or(0);
-        merged.insert(
-            insert_at,
-            MotionRow {
-                row: row.clone(),
-                visible: false,
-            },
-        );
-    }
     rows.set(merged);
     if let Some(window) = web_sys::window() {
         let enter_paths = next_paths;
@@ -465,9 +434,9 @@ pub fn ExplorerPanel() -> Element {
                                 let active = row.path == current_path();
                                 let pad = (row.depth as u32) * 12 + 8;
                                 let motion_class = if motion.visible {
-                                    "grid grid-rows-[1fr] opacity-100 translate-y-0 transition-[grid-template-rows,opacity,translate] duration-150 ease-out"
+                                    "opacity-100 translate-y-0 transition-[opacity,translate] duration-150 ease-out"
                                 } else {
-                                    "grid grid-rows-[0fr] opacity-0 -translate-y-1 transition-[grid-template-rows,opacity,translate] duration-150 ease-out"
+                                    "pointer-events-none opacity-0 -translate-y-1 transition-[opacity,translate] duration-150 ease-out"
                                 };
                                 rsx! {
                                     div { key: "{row.path}", class: "{motion_class}",

--- a/crates/vmux_editor/src/explorer.rs
+++ b/crates/vmux_editor/src/explorer.rs
@@ -286,9 +286,9 @@ fn chevron(expanded: bool, loading: bool) -> Element {
         };
     }
     let class = if expanded {
-        "inline-block w-4 shrink-0 rotate-90 text-center text-base leading-none text-foreground/60 transition-transform duration-150 ease-out"
+        "inline-block w-4 shrink-0 rotate-90 text-center text-base leading-none text-foreground/60 transition-[rotate] duration-150 ease-out"
     } else {
-        "inline-block w-4 shrink-0 rotate-0 text-center text-base leading-none text-foreground/60 transition-transform duration-150 ease-out"
+        "inline-block w-4 shrink-0 rotate-0 text-center text-base leading-none text-foreground/60 transition-[rotate] duration-150 ease-out"
     };
     rsx! {
         span { class: "{class}", "\u{203A}" }
@@ -465,9 +465,9 @@ pub fn ExplorerPanel() -> Element {
                                 let active = row.path == current_path();
                                 let pad = (row.depth as u32) * 12 + 8;
                                 let motion_class = if motion.visible {
-                                    "grid grid-rows-[1fr] opacity-100 translate-y-0 transition-[grid-template-rows,opacity,transform] duration-150 ease-out"
+                                    "grid grid-rows-[1fr] opacity-100 translate-y-0 transition-[grid-template-rows,opacity,translate] duration-150 ease-out"
                                 } else {
-                                    "grid grid-rows-[0fr] opacity-0 -translate-y-1 transition-[grid-template-rows,opacity,transform] duration-150 ease-out"
+                                    "grid grid-rows-[0fr] opacity-0 -translate-y-1 transition-[grid-template-rows,opacity,translate] duration-150 ease-out"
                                 };
                                 rsx! {
                                     div { key: "{row.path}", class: "{motion_class}",

--- a/crates/vmux_editor/src/explorer.rs
+++ b/crates/vmux_editor/src/explorer.rs
@@ -113,6 +113,41 @@ fn menu_position(x: f64, y: f64) -> (f64, f64) {
     )
 }
 
+fn tree_row_id(path: &str) -> String {
+    let hash = path
+        .as_bytes()
+        .iter()
+        .fold(0xcbf29ce484222325u64, |hash, byte| {
+            (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
+        });
+    format!("explorer-row-{hash:016x}")
+}
+
+fn schedule_tree_focus(path: String) {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let focus = Closure::once(move || {
+        let Some(element) = web_sys::window()
+            .and_then(|window| window.document())
+            .and_then(|document| document.get_element_by_id(&tree_row_id(&path)))
+        else {
+            return;
+        };
+        let options = web_sys::ScrollIntoViewOptions::new();
+        options.set_block(web_sys::ScrollLogicalPosition::Nearest);
+        element.scroll_into_view_with_scroll_into_view_options(&options);
+        if let Ok(element) = element.dyn_into::<web_sys::HtmlElement>() {
+            let _ = element.focus();
+        }
+    });
+    let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(
+        focus.as_ref().unchecked_ref(),
+        TREE_MOTION_MS + 20,
+    );
+    focus.forget();
+}
+
 fn reconcile_rows(
     mut rows: Signal<Vec<MotionRow>>,
     mut generation: Signal<u32>,
@@ -284,6 +319,7 @@ fn prompt_title(kind: PromptKind) -> &'static str {
 pub fn ExplorerPanel() -> Element {
     let mut root_name = use_signal(|| "Explorer".to_string());
     let mut root_path = use_signal(String::new);
+    let mut current_path = use_signal(String::new);
     let mut root_loading = use_signal(|| false);
     let rows = use_signal(Vec::<MotionRow>::new);
     let row_generation = use_signal(|| 0u32);
@@ -301,8 +337,12 @@ pub fn ExplorerPanel() -> Element {
     let _tree = use_bin_event_listener::<ExplorerTreeEvent, _>(EXPLORER_TREE_EVENT, move |e| {
         root_name.set(e.root_name);
         root_path.set(e.root_path);
+        current_path.set(e.current_path);
         root_loading.set(e.loading);
         reconcile_rows(rows, row_generation, e.rows);
+        if !e.focus_path.is_empty() {
+            schedule_tree_focus(e.focus_path);
+        }
     });
     let _open =
         use_bin_event_listener::<OpenEditorsEvent, _>(EXPLORER_OPEN_EDITORS_EVENT, move |e| {
@@ -388,6 +428,9 @@ pub fn ExplorerPanel() -> Element {
                 }
 
                 div {
+                    id: "{tree_row_id(&root_path())}",
+                    tabindex: "-1",
+                    class: if current_path() == root_path() { "bg-cyan-400/10 outline-none" } else { "outline-none" },
                     oncontextmenu: move |e: Event<MouseData>| {
                         e.prevent_default();
                         let coordinates = e.client_coordinates();
@@ -419,6 +462,7 @@ pub fn ExplorerPanel() -> Element {
                                 let path_menu = row.path.clone();
                                 let name_menu = row.name.clone();
                                 let is_dir = row.is_dir;
+                                let active = row.path == current_path();
                                 let pad = (row.depth as u32) * 12 + 8;
                                 let motion_class = if motion.visible {
                                     "grid grid-rows-[1fr] opacity-100 translate-y-0 transition-[grid-template-rows,opacity,transform] duration-150 ease-out"
@@ -429,7 +473,13 @@ pub fn ExplorerPanel() -> Element {
                                     div { key: "{row.path}", class: "{motion_class}",
                                         div { class: "min-h-0 overflow-hidden",
                                             div {
-                                                class: "flex h-[22px] items-center gap-1 px-1 cursor-default text-foreground/80 transition-colors duration-100 hover:bg-foreground/[0.08]",
+                                                id: "{tree_row_id(&row.path)}",
+                                                tabindex: "-1",
+                                                class: if active {
+                                                    "flex h-[22px] items-center gap-1 px-1 cursor-default bg-cyan-400/12 text-foreground outline-none transition-colors duration-100"
+                                                } else {
+                                                    "flex h-[22px] items-center gap-1 px-1 cursor-default text-foreground/80 outline-none transition-colors duration-100 hover:bg-foreground/[0.08]"
+                                                },
                                                 style: "padding-left:{pad}px;",
                                                 title: "{row.path}",
                                                 onmouseenter: move |_| {

--- a/crates/vmux_editor/src/explorer_fs.rs
+++ b/crates/vmux_editor/src/explorer_fs.rs
@@ -1,0 +1,144 @@
+//! Filesystem mutations used by Explorer context-menu actions.
+
+use std::path::{Component, Path, PathBuf};
+
+fn checked_name(name: &str) -> Result<&str, String> {
+    let name = name.trim();
+    let mut components = Path::new(name).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(_)), None) => Ok(name),
+        _ => Err("Name must be one file or folder name".to_string()),
+    }
+}
+
+fn checked_parent(root: &Path, parent: &Path) -> Result<PathBuf, String> {
+    let root = root
+        .canonicalize()
+        .map_err(|e| format!("Cannot access {}: {e}", root.display()))?;
+    let parent = parent
+        .canonicalize()
+        .map_err(|e| format!("Cannot access {}: {e}", parent.display()))?;
+    if !parent.starts_with(&root) {
+        return Err("Path is outside the Explorer root".to_string());
+    }
+    Ok(parent)
+}
+
+fn checked_source(root: &Path, path: &Path) -> Result<PathBuf, String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "Explorer root cannot be changed".to_string())?;
+    let parent = checked_parent(root, parent)?;
+    let name = path
+        .file_name()
+        .ok_or_else(|| "Explorer root cannot be changed".to_string())?;
+    let source = parent.join(name);
+    std::fs::symlink_metadata(&source)
+        .map_err(|e| format!("Cannot access {}: {e}", source.display()))?;
+    Ok(source)
+}
+
+pub fn create_entry(
+    root: &Path,
+    parent: &Path,
+    name: &str,
+    is_dir: bool,
+) -> Result<PathBuf, String> {
+    let name = checked_name(name)?;
+    let parent = checked_parent(root, parent)?;
+    let target = parent.join(name);
+    if target.exists() {
+        return Err(format!("{} already exists", target.display()));
+    }
+    if is_dir {
+        std::fs::create_dir(&target)
+    } else {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&target)
+            .map(|_| ())
+    }
+    .map_err(|e| format!("Cannot create {}: {e}", target.display()))?;
+    Ok(target)
+}
+
+pub fn rename_entry(root: &Path, path: &Path, name: &str) -> Result<(PathBuf, bool), String> {
+    let name = checked_name(name)?;
+    let source = checked_source(root, path)?;
+    let metadata = std::fs::symlink_metadata(&source)
+        .map_err(|e| format!("Cannot access {}: {e}", source.display()))?;
+    let target = source
+        .parent()
+        .ok_or_else(|| "Explorer root cannot be changed".to_string())?
+        .join(name);
+    if target == source {
+        return Ok((target, metadata.is_dir()));
+    }
+    if target.exists() {
+        return Err(format!("{} already exists", target.display()));
+    }
+    std::fs::rename(&source, &target)
+        .map_err(|e| format!("Cannot rename {}: {e}", source.display()))?;
+    Ok((target, metadata.is_dir()))
+}
+
+pub fn delete_entry(root: &Path, path: &Path) -> Result<(PathBuf, bool), String> {
+    let source = checked_source(root, path)?;
+    let metadata = std::fs::symlink_metadata(&source)
+        .map_err(|e| format!("Cannot access {}: {e}", source.display()))?;
+    let is_dir = metadata.is_dir() && !metadata.file_type().is_symlink();
+    if is_dir {
+        std::fs::remove_dir_all(&source)
+    } else {
+        std::fs::remove_file(&source)
+    }
+    .map_err(|e| format!("Cannot delete {}: {e}", source.display()))?;
+    Ok((
+        source
+            .parent()
+            .ok_or_else(|| "Explorer root cannot be changed".to_string())?
+            .to_path_buf(),
+        is_dir,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn creates_renames_and_deletes_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let file = create_entry(root, root, "a.txt", false).unwrap();
+        assert!(file.is_file());
+        let (renamed, is_dir) = rename_entry(root, &file, "b.txt").unwrap();
+        assert!(!is_dir);
+        assert!(renamed.is_file());
+        delete_entry(root, &renamed).unwrap();
+        assert!(!renamed.exists());
+
+        let dir = create_entry(root, root, "src", true).unwrap();
+        std::fs::write(dir.join("lib.rs"), "").unwrap();
+        let (renamed, is_dir) = rename_entry(root, &dir, "source").unwrap();
+        assert!(is_dir);
+        delete_entry(root, &renamed).unwrap();
+        assert!(!renamed.exists());
+    }
+
+    #[test]
+    fn rejects_nested_names_and_outside_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        assert!(create_entry(tmp.path(), tmp.path(), "a/b", false).is_err());
+        assert!(create_entry(tmp.path(), outside.path(), "x", false).is_err());
+    }
+
+    #[test]
+    fn rejects_root_mutation() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(rename_entry(tmp.path(), tmp.path(), "other").is_err());
+        assert!(delete_entry(tmp.path(), tmp.path()).is_err());
+    }
+}

--- a/crates/vmux_editor/src/explorer_model.rs
+++ b/crates/vmux_editor/src/explorer_model.rs
@@ -13,10 +13,11 @@ use vmux_core::event::{FileDirEntry, OutlineRow, TreeRow};
 pub fn flatten_tree(
     root: &Path,
     expanded: &HashSet<PathBuf>,
+    loading: &HashSet<PathBuf>,
     children: &HashMap<PathBuf, Vec<FileDirEntry>>,
 ) -> Vec<TreeRow> {
     let mut out = Vec::new();
-    walk(root, 0, expanded, children, &mut out);
+    walk(root, 0, expanded, loading, children, &mut out);
     out
 }
 
@@ -24,6 +25,7 @@ fn walk(
     dir: &Path,
     depth: u16,
     expanded: &HashSet<PathBuf>,
+    loading: &HashSet<PathBuf>,
     children: &HashMap<PathBuf, Vec<FileDirEntry>>,
     out: &mut Vec<TreeRow>,
 ) {
@@ -39,9 +41,10 @@ fn walk(
             depth,
             is_dir: e.is_dir,
             expanded: is_open,
+            loading: loading.contains(&p),
         });
         if is_open {
-            walk(&p, depth + 1, expanded, children, out);
+            walk(&p, depth + 1, expanded, loading, children, out);
         }
     }
 }
@@ -173,7 +176,7 @@ mod tests {
             vec![entry("b.rs", "/r/src/b.rs", false)],
         );
         let expanded = HashSet::from([PathBuf::from("/r/src")]);
-        let rows = flatten_tree(&root, &expanded, &children);
+        let rows = flatten_tree(&root, &expanded, &HashSet::new(), &children);
         let got: Vec<_> = rows.iter().map(|r| (r.name.as_str(), r.depth)).collect();
         assert_eq!(got, vec![("src", 0), ("b.rs", 1), ("a.rs", 0)]);
         assert!(rows[0].expanded);
@@ -188,15 +191,35 @@ mod tests {
             PathBuf::from("/r/src"),
             vec![entry("b.rs", "/r/src/b.rs", false)],
         );
-        let rows = flatten_tree(&root, &HashSet::new(), &children);
+        let rows = flatten_tree(&root, &HashSet::new(), &HashSet::new(), &children);
         assert_eq!(rows.len(), 1);
         assert!(!rows[0].expanded);
     }
 
     #[test]
     fn missing_cache_yields_no_rows() {
-        let rows = flatten_tree(&PathBuf::from("/r"), &HashSet::new(), &HashMap::new());
+        let rows = flatten_tree(
+            &PathBuf::from("/r"),
+            &HashSet::new(),
+            &HashSet::new(),
+            &HashMap::new(),
+        );
         assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn loading_dir_is_marked() {
+        let root = PathBuf::from("/r");
+        let src = PathBuf::from("/r/src");
+        let children = HashMap::from([(root.clone(), vec![entry("src", "/r/src", true)])]);
+        let rows = flatten_tree(
+            &root,
+            &HashSet::from([src.clone()]),
+            &HashSet::from([src]),
+            &children,
+        );
+        assert!(rows[0].expanded);
+        assert!(rows[0].loading);
     }
 
     #[test]

--- a/crates/vmux_editor/src/lib.rs
+++ b/crates/vmux_editor/src/lib.rs
@@ -18,6 +18,8 @@ pub mod keymap;
 #[cfg(not(target_arch = "wasm32"))]
 mod dir;
 #[cfg(not(target_arch = "wasm32"))]
+mod explorer_fs;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod explorer_model;
 #[cfg(not(target_arch = "wasm32"))]
 mod preview;

--- a/crates/vmux_editor/src/page.rs
+++ b/crates/vmux_editor/src/page.rs
@@ -319,6 +319,79 @@ fn render_preview(preview: &Preview) -> Element {
     }
 }
 
+fn toggle_explorer(mut visible: Signal<bool>) {
+    visible.set(!visible());
+    let _ = try_cef_bin_emit_rkyv(&ExplorerPanelToggle);
+}
+
+fn reveal_current_in_explorer(mut visible: Signal<bool>) {
+    if visible() {
+        let _ = try_cef_bin_emit_rkyv(&ExplorerRevealCurrent);
+    } else {
+        visible.set(true);
+        let _ = try_cef_bin_emit_rkyv(&ExplorerPanelToggle);
+    }
+}
+
+#[component]
+fn ExplorerSidebar(
+    visible: Signal<bool>,
+    width: Signal<u32>,
+    mut resizing: Signal<bool>,
+) -> Element {
+    let open = visible();
+    let panel_width = width();
+    let wrapper_style = if open {
+        format!("width:{panel_width}px;")
+    } else {
+        "width:0px;".to_string()
+    };
+    let panel_style = format!("width:{panel_width}px;");
+    let panel_class = if open {
+        "absolute inset-y-0 left-0 h-full translate-x-0 opacity-100 transition-[transform,opacity] duration-200 ease-out will-change-transform"
+    } else {
+        "pointer-events-none absolute inset-y-0 left-0 h-full -translate-x-full opacity-0 transition-[transform,opacity] duration-200 ease-out will-change-transform"
+    };
+    rsx! {
+        div { class: "relative z-[2] h-full shrink-0", style: "{wrapper_style}",
+            div { class: "{panel_class}", style: "{panel_style}", ExplorerPanel {} }
+        }
+        div {
+            class: if open {
+                "relative z-[2] h-full w-1 shrink-0 cursor-col-resize bg-foreground/[0.06] opacity-100 transition-opacity duration-150 hover:bg-cyan-400/40"
+            } else {
+                "pointer-events-none h-full w-0 shrink-0 opacity-0"
+            },
+            onmousedown: move |e: Event<MouseData>| {
+                e.prevent_default();
+                resizing.set(true);
+            },
+        }
+    }
+}
+
+#[component]
+fn ExplorerToggleButton(mut visible: Signal<bool>) -> Element {
+    rsx! {
+        button {
+            class: "shrink-0 cursor-default rounded p-0.5 text-foreground/60 hover:bg-foreground/[0.08] hover:text-foreground",
+            title: "Toggle Explorer (Cmd+B)",
+            onclick: move |_| toggle_explorer(visible),
+            svg {
+                class: "h-4 w-4",
+                view_box: "0 0 24 24",
+                fill: "none",
+                stroke: "currentColor",
+                stroke_width: "2",
+                stroke_linecap: "round",
+                stroke_linejoin: "round",
+                rect { x: "3", y: "3", width: "18", height: "18", rx: "2" }
+                line { x1: "9", y1: "3", x2: "9", y2: "21" }
+            }
+        }
+    }
+}
+
 #[component]
 pub fn Page() -> Element {
     use_theme();
@@ -640,12 +713,6 @@ pub fn Page() -> Element {
     let comp_sel_clamped = comp_sel().min(comp_filtered.len().saturating_sub(1));
     let comp_keys = comp_filtered.clone();
 
-    let explorer_panel_style = if explorer_visible() {
-        format!("width:{}px;", explorer_width())
-    } else {
-        "width:0px;".to_string()
-    };
-
     rsx! {
         div {
             class: "flex h-full w-full flex-row overflow-hidden bg-background",
@@ -662,21 +729,10 @@ pub fn Page() -> Element {
                 }
             },
 
-            div {
-                class: "h-full shrink-0 overflow-hidden transition-[width] duration-200 ease-out will-change-[width]",
-                style: "{explorer_panel_style}",
-                ExplorerPanel {}
-            }
-            div {
-                class: if explorer_visible() {
-                    "h-full w-1 shrink-0 cursor-col-resize bg-foreground/[0.06] opacity-100 transition-[width,opacity,background-color] duration-200 hover:bg-cyan-400/40"
-                } else {
-                    "pointer-events-none h-full w-0 shrink-0 bg-transparent opacity-0 transition-[width,opacity,background-color] duration-200"
-                },
-                onmousedown: move |e: Event<MouseData>| {
-                    e.prevent_default();
-                    explorer_resizing.set(true);
-                },
+            ExplorerSidebar {
+                visible: explorer_visible,
+                width: explorer_width,
+                resizing: explorer_resizing,
             }
 
         div {
@@ -705,10 +761,17 @@ pub fn Page() -> Element {
                     return;
                 };
                 let key = raw.key();
+                if (raw.meta_key() || raw.ctrl_key())
+                    && raw.shift_key()
+                    && key.eq_ignore_ascii_case("e")
+                {
+                    e.prevent_default();
+                    reveal_current_in_explorer(explorer_visible);
+                    return;
+                }
                 if (raw.meta_key() || raw.ctrl_key()) && key.eq_ignore_ascii_case("b") {
                     e.prevent_default();
-                    explorer_visible.set(!explorer_visible());
-                    let _ = try_cef_bin_emit_rkyv(&ExplorerPanelToggle);
+                    toggle_explorer(explorer_visible);
                     return;
                 }
                 match mode() {
@@ -826,25 +889,7 @@ pub fn Page() -> Element {
 
             div {
                 class: "flex h-9 shrink-0 items-center gap-2 border-b border-foreground/[0.07] bg-foreground/[0.06] px-4 font-sans text-xs text-muted-foreground",
-                button {
-                    class: "shrink-0 cursor-default rounded p-0.5 text-foreground/60 hover:bg-foreground/[0.08] hover:text-foreground",
-                    title: "Toggle Explorer",
-                    onclick: move |_| {
-                        explorer_visible.set(!explorer_visible());
-                        let _ = try_cef_bin_emit_rkyv(&ExplorerPanelToggle);
-                    },
-                    svg {
-                        class: "h-4 w-4",
-                        view_box: "0 0 24 24",
-                        fill: "none",
-                        stroke: "currentColor",
-                        stroke_width: "2",
-                        stroke_linecap: "round",
-                        stroke_linejoin: "round",
-                        rect { x: "3", y: "3", width: "18", height: "18", rx: "2" }
-                        line { x1: "9", y1: "3", x2: "9", y2: "21" }
-                    }
-                }
+                ExplorerToggleButton { visible: explorer_visible }
                 {type_icon(&header_path, mode() == Mode::Dir, "h-4 w-4 shrink-0 text-foreground/80")}
                 span { class: "truncate text-foreground/90", "{header_path}" }
                 if dirty() {

--- a/crates/vmux_editor/src/page.rs
+++ b/crates/vmux_editor/src/page.rs
@@ -404,12 +404,9 @@ fn ExplorerSidebar(
 ) -> Element {
     let open = visible();
     let panel_width = width();
-    let wrapper_style = if open {
-        format!("width:{panel_width}px;")
-    } else {
-        "width:0px;".to_string()
-    };
+    let wrapper_style = format!("width:{panel_width}px;");
     let panel_style = format!("width:{panel_width}px;");
+    let resizer_style = format!("left:{panel_width}px;");
     let panel_class = if open {
         "absolute inset-y-0 left-0 h-full translate-x-0 opacity-100 transition-[translate,opacity] duration-200 ease-out will-change-[translate]"
     } else {
@@ -417,19 +414,24 @@ fn ExplorerSidebar(
     };
     rsx! {
         div {
-            class: "relative z-[2] h-full shrink-0",
+            class: if open {
+                "absolute inset-y-0 left-0 z-[3] h-full pointer-events-auto"
+            } else {
+                "pointer-events-none absolute inset-y-0 left-0 z-[3] h-full"
+            },
             style: "{wrapper_style}",
             onkeydown: move |event| {
                 handle_explorer_shortcut(&event, visible, client_id, request_id, mode);
             },
-            div { class: "{panel_class}", style: "{panel_style}", ExplorerPanel {} }
+            div { class: "{panel_class}", style: "{panel_style}", ExplorerPanel { visible } }
         }
         div {
             class: if open {
-                "relative z-[2] h-full w-1 shrink-0 cursor-col-resize bg-foreground/[0.06] opacity-100 transition-opacity duration-150 hover:bg-cyan-400/40"
+                "absolute inset-y-0 z-[4] w-1 -translate-x-1/2 cursor-col-resize bg-foreground/[0.06] opacity-100 transition-opacity duration-150 hover:bg-cyan-400/40"
             } else {
-                "pointer-events-none h-full w-0 shrink-0 opacity-0"
+                "pointer-events-none absolute inset-y-0 z-[4] w-1 -translate-x-1/2 opacity-0 transition-opacity duration-150"
             },
+            style: "{resizer_style}",
             onmousedown: move |e: Event<MouseData>| {
                 e.prevent_default();
                 resizing.set(true);
@@ -534,10 +536,13 @@ pub fn Page() -> Element {
                 explorer_request_id(),
                 c.client_id,
                 c.request_id,
-            ) {
+            ) && explorer_visible() != c.visible
+            {
                 explorer_visible.set(c.visible);
             }
-            explorer_width.set(c.width);
+            if explorer_width() != c.width {
+                explorer_width.set(c.width);
+            }
         });
 
     let _tidy =
@@ -797,7 +802,7 @@ pub fn Page() -> Element {
 
     rsx! {
         div {
-            class: "flex h-full w-full flex-row overflow-hidden bg-background",
+            class: "relative flex h-full w-full flex-row overflow-hidden bg-background",
             onmousemove: move |e: Event<MouseData>| {
                 if explorer_resizing() {
                     let x = e.client_coordinates().x as i32;

--- a/crates/vmux_editor/src/page.rs
+++ b/crates/vmux_editor/src/page.rs
@@ -404,9 +404,12 @@ fn ExplorerSidebar(
 ) -> Element {
     let open = visible();
     let panel_width = width();
-    let wrapper_style = format!("width:{panel_width}px;");
+    let wrapper_style = if open {
+        format!("width:{panel_width}px;contain:layout style;")
+    } else {
+        "width:0px;contain:layout style;".to_string()
+    };
     let panel_style = format!("width:{panel_width}px;");
-    let resizer_style = format!("left:{panel_width}px;");
     let panel_class = if open {
         "absolute inset-y-0 left-0 h-full translate-x-0 opacity-100 transition-[translate,opacity] duration-200 ease-out will-change-[translate]"
     } else {
@@ -414,11 +417,7 @@ fn ExplorerSidebar(
     };
     rsx! {
         div {
-            class: if open {
-                "absolute inset-y-0 left-0 z-[3] h-full pointer-events-auto"
-            } else {
-                "pointer-events-none absolute inset-y-0 left-0 z-[3] h-full"
-            },
+            class: "relative z-[2] h-full shrink-0",
             style: "{wrapper_style}",
             onkeydown: move |event| {
                 handle_explorer_shortcut(&event, visible, client_id, request_id, mode);
@@ -427,11 +426,10 @@ fn ExplorerSidebar(
         }
         div {
             class: if open {
-                "absolute inset-y-0 z-[4] w-1 -translate-x-1/2 cursor-col-resize bg-foreground/[0.06] opacity-100 transition-opacity duration-150 hover:bg-cyan-400/40"
+                "relative z-[2] h-full w-1 shrink-0 cursor-col-resize bg-foreground/[0.06] opacity-100 transition-opacity duration-150 hover:bg-cyan-400/40"
             } else {
-                "pointer-events-none absolute inset-y-0 z-[4] w-1 -translate-x-1/2 opacity-0 transition-opacity duration-150"
+                "pointer-events-none h-full w-0 shrink-0 opacity-0"
             },
-            style: "{resizer_style}",
             onmousedown: move |e: Event<MouseData>| {
                 e.prevent_default();
                 resizing.set(true);
@@ -802,7 +800,7 @@ pub fn Page() -> Element {
 
     rsx! {
         div {
-            class: "relative flex h-full w-full flex-row overflow-hidden bg-background",
+            class: "flex h-full w-full flex-row overflow-hidden bg-background",
             onmousemove: move |e: Event<MouseData>| {
                 if explorer_resizing() {
                     let x = e.client_coordinates().x as i32;

--- a/crates/vmux_editor/src/page.rs
+++ b/crates/vmux_editor/src/page.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use crate::explorer::ExplorerPanel;
 use crate::page_model::{
     clamp_selection, dir_select_index, gutter_width, image_mime, line_severity,
-    severity_color_class, span_style, squiggle_style,
+    severity_color_class, should_apply_explorer_chrome, span_style, squiggle_style,
 };
 use dioxus::prelude::*;
 use vmux_core::event::*;
@@ -319,17 +319,39 @@ fn render_preview(preview: &Preview) -> Element {
     }
 }
 
-fn toggle_explorer(mut visible: Signal<bool>) {
-    visible.set(!visible());
-    let _ = try_cef_bin_emit_rkyv(&ExplorerPanelToggle);
+fn explorer_client_id() -> u64 {
+    ((js_sys::Date::now() as u64) << 12) ^ (js_sys::Math::random() * 4096.0) as u64
 }
 
-fn reveal_current_in_explorer(mut visible: Signal<bool>) {
+fn set_explorer_visible(
+    next: bool,
+    mut visible: Signal<bool>,
+    client_id: Signal<u64>,
+    mut request_id: Signal<u64>,
+) {
+    let next_request_id = request_id().wrapping_add(1);
+    request_id.set(next_request_id);
+    visible.set(next);
+    let _ = try_cef_bin_emit_rkyv(&ExplorerPanelSetVisible {
+        visible: next,
+        client_id: client_id(),
+        request_id: next_request_id,
+    });
+}
+
+fn toggle_explorer(visible: Signal<bool>, client_id: Signal<u64>, request_id: Signal<u64>) {
+    set_explorer_visible(!visible(), visible, client_id, request_id);
+}
+
+fn reveal_current_in_explorer(
+    visible: Signal<bool>,
+    client_id: Signal<u64>,
+    request_id: Signal<u64>,
+) {
     if visible() {
         let _ = try_cef_bin_emit_rkyv(&ExplorerRevealCurrent);
     } else {
-        visible.set(true);
-        let _ = try_cef_bin_emit_rkyv(&ExplorerPanelToggle);
+        set_explorer_visible(true, visible, client_id, request_id);
     }
 }
 
@@ -348,9 +370,9 @@ fn ExplorerSidebar(
     };
     let panel_style = format!("width:{panel_width}px;");
     let panel_class = if open {
-        "absolute inset-y-0 left-0 h-full translate-x-0 opacity-100 transition-[transform,opacity] duration-200 ease-out will-change-transform"
+        "absolute inset-y-0 left-0 h-full translate-x-0 opacity-100 transition-[translate,opacity] duration-200 ease-out will-change-[translate]"
     } else {
-        "pointer-events-none absolute inset-y-0 left-0 h-full -translate-x-full opacity-0 transition-[transform,opacity] duration-200 ease-out will-change-transform"
+        "pointer-events-none absolute inset-y-0 left-0 h-full -translate-x-full opacity-0 transition-[translate,opacity] duration-200 ease-out will-change-[translate]"
     };
     rsx! {
         div { class: "relative z-[2] h-full shrink-0", style: "{wrapper_style}",
@@ -371,12 +393,16 @@ fn ExplorerSidebar(
 }
 
 #[component]
-fn ExplorerToggleButton(mut visible: Signal<bool>) -> Element {
+fn ExplorerToggleButton(
+    visible: Signal<bool>,
+    client_id: Signal<u64>,
+    request_id: Signal<u64>,
+) -> Element {
     rsx! {
         button {
             class: "shrink-0 cursor-default rounded p-0.5 text-foreground/60 hover:bg-foreground/[0.08] hover:text-foreground",
             title: "Toggle Explorer (Cmd+B)",
-            onclick: move |_| toggle_explorer(visible),
+            onclick: move |_| toggle_explorer(visible, client_id, request_id),
             svg {
                 class: "h-4 w-4",
                 view_box: "0 0 24 24",
@@ -450,11 +476,20 @@ pub fn Page() -> Element {
     let mut explorer_visible = use_signal(|| false);
     let mut explorer_width = use_signal(|| 240u32);
     let mut explorer_resizing = use_signal(|| false);
+    let explorer_client_id = use_signal(explorer_client_id);
+    let explorer_request_id = use_signal(|| 0u64);
     let mut tidy_prompt = use_signal(|| Option::<u32>::None);
 
     let _chrome =
         use_bin_event_listener::<ExplorerChromeEvent, _>(EXPLORER_CHROME_EVENT, move |c| {
-            explorer_visible.set(c.visible);
+            if should_apply_explorer_chrome(
+                explorer_client_id(),
+                explorer_request_id(),
+                c.client_id,
+                c.request_id,
+            ) {
+                explorer_visible.set(c.visible);
+            }
             explorer_width.set(c.width);
         });
 
@@ -766,12 +801,16 @@ pub fn Page() -> Element {
                     && key.eq_ignore_ascii_case("e")
                 {
                     e.prevent_default();
-                    reveal_current_in_explorer(explorer_visible);
+                    reveal_current_in_explorer(
+                        explorer_visible,
+                        explorer_client_id,
+                        explorer_request_id,
+                    );
                     return;
                 }
                 if (raw.meta_key() || raw.ctrl_key()) && key.eq_ignore_ascii_case("b") {
                     e.prevent_default();
-                    toggle_explorer(explorer_visible);
+                    toggle_explorer(explorer_visible, explorer_client_id, explorer_request_id);
                     return;
                 }
                 match mode() {
@@ -889,7 +928,11 @@ pub fn Page() -> Element {
 
             div {
                 class: "flex h-9 shrink-0 items-center gap-2 border-b border-foreground/[0.07] bg-foreground/[0.06] px-4 font-sans text-xs text-muted-foreground",
-                ExplorerToggleButton { visible: explorer_visible }
+                ExplorerToggleButton {
+                    visible: explorer_visible,
+                    client_id: explorer_client_id,
+                    request_id: explorer_request_id,
+                }
                 {type_icon(&header_path, mode() == Mode::Dir, "h-4 w-4 shrink-0 text-foreground/80")}
                 span { class: "truncate text-foreground/90", "{header_path}" }
                 if dirty() {

--- a/crates/vmux_editor/src/page.rs
+++ b/crates/vmux_editor/src/page.rs
@@ -663,18 +663,20 @@ pub fn Page() -> Element {
             },
 
             div {
-                class: "h-full shrink-0 overflow-hidden",
+                class: "h-full shrink-0 overflow-hidden transition-[width] duration-200 ease-out will-change-[width]",
                 style: "{explorer_panel_style}",
                 ExplorerPanel {}
             }
-            if explorer_visible() {
-                div {
-                    class: "h-full w-1 shrink-0 cursor-col-resize bg-foreground/[0.06] hover:bg-cyan-400/40",
-                    onmousedown: move |e: Event<MouseData>| {
-                        e.prevent_default();
-                        explorer_resizing.set(true);
-                    },
-                }
+            div {
+                class: if explorer_visible() {
+                    "h-full w-1 shrink-0 cursor-col-resize bg-foreground/[0.06] opacity-100 transition-[width,opacity,background-color] duration-200 hover:bg-cyan-400/40"
+                } else {
+                    "pointer-events-none h-full w-0 shrink-0 bg-transparent opacity-0 transition-[width,opacity,background-color] duration-200"
+                },
+                onmousedown: move |e: Event<MouseData>| {
+                    e.prevent_default();
+                    explorer_resizing.set(true);
+                },
             }
 
         div {

--- a/crates/vmux_editor/src/page.rs
+++ b/crates/vmux_editor/src/page.rs
@@ -328,6 +328,7 @@ fn set_explorer_visible(
     mut visible: Signal<bool>,
     client_id: Signal<u64>,
     mut request_id: Signal<u64>,
+    mode: Signal<Mode>,
 ) {
     let next_request_id = request_id().wrapping_add(1);
     request_id.set(next_request_id);
@@ -337,22 +338,59 @@ fn set_explorer_visible(
         client_id: client_id(),
         request_id: next_request_id,
     });
+    if !next {
+        match mode() {
+            Mode::Text => focus_file_input(),
+            Mode::Dir | Mode::Media(_) => focus_container(),
+        }
+    }
 }
 
-fn toggle_explorer(visible: Signal<bool>, client_id: Signal<u64>, request_id: Signal<u64>) {
-    set_explorer_visible(!visible(), visible, client_id, request_id);
+fn toggle_explorer(
+    visible: Signal<bool>,
+    client_id: Signal<u64>,
+    request_id: Signal<u64>,
+    mode: Signal<Mode>,
+) {
+    set_explorer_visible(!visible(), visible, client_id, request_id, mode);
 }
 
 fn reveal_current_in_explorer(
     visible: Signal<bool>,
     client_id: Signal<u64>,
     request_id: Signal<u64>,
+    mode: Signal<Mode>,
 ) {
     if visible() {
         let _ = try_cef_bin_emit_rkyv(&ExplorerRevealCurrent);
     } else {
-        set_explorer_visible(true, visible, client_id, request_id);
+        set_explorer_visible(true, visible, client_id, request_id, mode);
     }
+}
+
+fn handle_explorer_shortcut(
+    event: &Event<KeyboardData>,
+    visible: Signal<bool>,
+    client_id: Signal<u64>,
+    request_id: Signal<u64>,
+    mode: Signal<Mode>,
+) -> bool {
+    let data = event.data();
+    let Some(raw) = data.downcast::<web_sys::KeyboardEvent>() else {
+        return false;
+    };
+    let key = raw.key();
+    if (raw.meta_key() || raw.ctrl_key()) && raw.shift_key() && key.eq_ignore_ascii_case("e") {
+        event.prevent_default();
+        reveal_current_in_explorer(visible, client_id, request_id, mode);
+        return true;
+    }
+    if (raw.meta_key() || raw.ctrl_key()) && key.eq_ignore_ascii_case("b") {
+        event.prevent_default();
+        toggle_explorer(visible, client_id, request_id, mode);
+        return true;
+    }
+    false
 }
 
 #[component]
@@ -360,6 +398,9 @@ fn ExplorerSidebar(
     visible: Signal<bool>,
     width: Signal<u32>,
     mut resizing: Signal<bool>,
+    client_id: Signal<u64>,
+    request_id: Signal<u64>,
+    mode: Signal<Mode>,
 ) -> Element {
     let open = visible();
     let panel_width = width();
@@ -375,7 +416,12 @@ fn ExplorerSidebar(
         "pointer-events-none absolute inset-y-0 left-0 h-full -translate-x-full opacity-0 transition-[translate,opacity] duration-200 ease-out will-change-[translate]"
     };
     rsx! {
-        div { class: "relative z-[2] h-full shrink-0", style: "{wrapper_style}",
+        div {
+            class: "relative z-[2] h-full shrink-0",
+            style: "{wrapper_style}",
+            onkeydown: move |event| {
+                handle_explorer_shortcut(&event, visible, client_id, request_id, mode);
+            },
             div { class: "{panel_class}", style: "{panel_style}", ExplorerPanel {} }
         }
         div {
@@ -397,12 +443,13 @@ fn ExplorerToggleButton(
     visible: Signal<bool>,
     client_id: Signal<u64>,
     request_id: Signal<u64>,
+    mode: Signal<Mode>,
 ) -> Element {
     rsx! {
         button {
             class: "shrink-0 cursor-default rounded p-0.5 text-foreground/60 hover:bg-foreground/[0.08] hover:text-foreground",
             title: "Toggle Explorer (Cmd+B)",
-            onclick: move |_| toggle_explorer(visible, client_id, request_id),
+            onclick: move |_| toggle_explorer(visible, client_id, request_id, mode),
             svg {
                 class: "h-4 w-4",
                 view_box: "0 0 24 24",
@@ -768,6 +815,9 @@ pub fn Page() -> Element {
                 visible: explorer_visible,
                 width: explorer_width,
                 resizing: explorer_resizing,
+                client_id: explorer_client_id,
+                request_id: explorer_request_id,
+                mode,
             }
 
         div {
@@ -791,28 +841,20 @@ pub fn Page() -> Element {
             },
 
             onkeydown: move |e: Event<KeyboardData>| {
+                if handle_explorer_shortcut(
+                    &e,
+                    explorer_visible,
+                    explorer_client_id,
+                    explorer_request_id,
+                    mode,
+                ) {
+                    return;
+                }
                 let data = e.data();
                 let Some(raw) = data.downcast::<web_sys::KeyboardEvent>() else {
                     return;
                 };
                 let key = raw.key();
-                if (raw.meta_key() || raw.ctrl_key())
-                    && raw.shift_key()
-                    && key.eq_ignore_ascii_case("e")
-                {
-                    e.prevent_default();
-                    reveal_current_in_explorer(
-                        explorer_visible,
-                        explorer_client_id,
-                        explorer_request_id,
-                    );
-                    return;
-                }
-                if (raw.meta_key() || raw.ctrl_key()) && key.eq_ignore_ascii_case("b") {
-                    e.prevent_default();
-                    toggle_explorer(explorer_visible, explorer_client_id, explorer_request_id);
-                    return;
-                }
                 match mode() {
                     Mode::Dir => {
                         let vis = visible_entries(&dir_entries.read(), show_hidden());
@@ -932,6 +974,7 @@ pub fn Page() -> Element {
                     visible: explorer_visible,
                     client_id: explorer_client_id,
                     request_id: explorer_request_id,
+                    mode,
                 }
                 {type_icon(&header_path, mode() == Mode::Dir, "h-4 w-4 shrink-0 text-foreground/80")}
                 span { class: "truncate text-foreground/90", "{header_path}" }

--- a/crates/vmux_editor/src/page_model.rs
+++ b/crates/vmux_editor/src/page_model.rs
@@ -1,4 +1,8 @@
-use vmux_core::event::{DiagSeverity, FileDiagnostic, FileDirEntry, LspPkgStatus, StyledSpan};
+use std::collections::{HashMap, HashSet};
+
+use vmux_core::event::{
+    DiagSeverity, FileDiagnostic, FileDirEntry, LspPkgStatus, StyledSpan, TreeRow,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PkgAction {
@@ -15,6 +19,33 @@ pub fn should_apply_explorer_chrome(
     event_request_id: u64,
 ) -> bool {
     event_client_id != local_client_id || event_request_id >= latest_request_id
+}
+
+pub fn merge_tree_motion_rows(current: &[TreeRow], next: &[TreeRow]) -> Vec<(TreeRow, bool)> {
+    let current_paths: HashSet<&str> = current.iter().map(|row| row.path.as_str()).collect();
+    let next_indices: HashMap<&str, usize> = next
+        .iter()
+        .enumerate()
+        .map(|(index, row)| (row.path.as_str(), index))
+        .collect();
+    let mut exiting_after = vec![Vec::new(); next.len() + 1];
+    let mut anchor = 0usize;
+    for row in current {
+        if let Some(index) = next_indices.get(row.path.as_str()) {
+            anchor = index + 1;
+        } else {
+            exiting_after[anchor].push(row.clone());
+        }
+    }
+    let exiting_count = exiting_after.iter().map(Vec::len).sum::<usize>();
+    let mut merged = Vec::with_capacity(next.len() + exiting_count);
+    merged.extend(exiting_after[0].drain(..).map(|row| (row, false)));
+    for (index, row) in next.iter().cloned().enumerate() {
+        let visible = current_paths.contains(row.path.as_str());
+        merged.push((row, visible));
+        merged.extend(exiting_after[index + 1].drain(..).map(|row| (row, false)));
+    }
+    merged
 }
 
 pub fn pkg_status_label(status: LspPkgStatus) -> &'static str {
@@ -227,6 +258,34 @@ mod tests {
         assert!(!should_apply_explorer_chrome(7, 3, 7, 2));
         assert!(should_apply_explorer_chrome(7, 3, 7, 3));
         assert!(should_apply_explorer_chrome(7, 3, 9, 1));
+    }
+
+    #[test]
+    fn tree_motion_merge_is_linear_ordered_and_marks_entries() {
+        let row = |path: &str| TreeRow {
+            name: path.to_string(),
+            path: path.to_string(),
+            depth: 0,
+            is_dir: false,
+            expanded: false,
+            loading: false,
+        };
+        let current = vec![row("a"), row("b"), row("c"), row("d")];
+        let next = vec![row("a"), row("x"), row("d")];
+        let merged = merge_tree_motion_rows(&current, &next);
+        assert_eq!(
+            merged
+                .iter()
+                .map(|(row, visible)| (row.path.as_str(), *visible))
+                .collect::<Vec<_>>(),
+            vec![
+                ("a", true),
+                ("b", false),
+                ("c", false),
+                ("x", false),
+                ("d", true)
+            ]
+        );
     }
 }
 

--- a/crates/vmux_editor/src/page_model.rs
+++ b/crates/vmux_editor/src/page_model.rs
@@ -8,6 +8,15 @@ pub enum PkgAction {
     None,
 }
 
+pub fn should_apply_explorer_chrome(
+    local_client_id: u64,
+    latest_request_id: u64,
+    event_client_id: u64,
+    event_request_id: u64,
+) -> bool {
+    event_client_id != local_client_id || event_request_id >= latest_request_id
+}
+
 pub fn pkg_status_label(status: LspPkgStatus) -> &'static str {
     match status {
         LspPkgStatus::Available => "Available",
@@ -210,6 +219,14 @@ mod tests {
         assert_eq!(pkg_status_label(LspPkgStatus::OnPath), "On PATH");
         assert_eq!(pkg_status_label(LspPkgStatus::Installed), "Installed");
         assert_eq!(pkg_status_label(LspPkgStatus::Available), "Available");
+    }
+
+    #[test]
+    fn rapid_explorer_toggle_ignores_stale_echoes() {
+        assert!(!should_apply_explorer_chrome(7, 3, 7, 1));
+        assert!(!should_apply_explorer_chrome(7, 3, 7, 2));
+        assert!(should_apply_explorer_chrome(7, 3, 7, 3));
+        assert!(should_apply_explorer_chrome(7, 3, 9, 1));
     }
 }
 

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -94,6 +94,7 @@ pub(crate) struct ExplorerState {
     pub loading: HashSet<PathBuf>,
     pub children: HashMap<PathBuf, Vec<FileDirEntry>>,
     pub open_editors: Vec<PathBuf>,
+    pub focus_path: Option<PathBuf>,
 }
 
 #[derive(Component)]
@@ -2014,6 +2015,40 @@ fn explorer_path_allowed(st: &ExplorerState, path: &Path) -> bool {
     path == st.root || path.starts_with(&st.root)
 }
 
+fn reveal_current_in_tree(
+    entity: Entity,
+    current: &Path,
+    st: &mut ExplorerState,
+    commands: &mut Commands,
+) {
+    let root = project_root(current);
+    if st.root != root {
+        st.root = root;
+        st.expanded.clear();
+        st.loading.clear();
+        st.children.clear();
+        st.focus_path = None;
+    }
+    let current_dir = if current.is_dir() {
+        current
+    } else {
+        current.parent().unwrap_or(current)
+    };
+    let Ok(relative) = current_dir.strip_prefix(&st.root) else {
+        return;
+    };
+    let mut dir = st.root.clone();
+    st.expanded.insert(dir.clone());
+    start_explorer_dir_load(entity, dir.clone(), st, commands, false);
+    for component in relative.components() {
+        dir.push(component);
+        st.expanded.insert(dir.clone());
+        start_explorer_dir_load(entity, dir.clone(), st, commands, false);
+    }
+    st.focus_path = Some(current.to_path_buf());
+    commands.entity(entity).insert(ExplorerTreeDirty);
+}
+
 fn init_explorer_state(
     mut q: Query<(Entity, &FileView, &mut ExplorerState)>,
     mut commands: Commands,
@@ -2052,21 +2087,34 @@ fn drain_explorer_dir_loads(
 }
 
 fn emit_explorer_tree(
-    q: Query<(Entity, &ExplorerState), TreeDirtyReady>,
+    mut q: Query<(Entity, &FileView, &mut ExplorerState), TreeDirtyReady>,
     browsers: NonSend<Browsers>,
     mut commands: Commands,
 ) {
-    for (entity, st) in &q {
+    for (entity, fv, mut st) in &mut q {
         if !browsers.has_browser(entity) || !browsers.host_emit_ready(&entity) {
             continue;
         }
         let rows = flatten_tree(&st.root, &st.expanded, &st.loading, &st.children);
+        let focus_ready = st.focus_path.as_ref().is_some_and(|path| {
+            path == &st.root || rows.iter().any(|row| Path::new(&row.path) == path)
+        });
+        let focus_path = if focus_ready {
+            st.focus_path
+                .take()
+                .map(|path| path.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
         commands.trigger(BinHostEmitEvent::from_rkyv(
             entity,
             EXPLORER_TREE_EVENT,
             &ExplorerTreeEvent {
                 root_name: explorer_root_name(&st.root),
                 root_path: st.root.to_string_lossy().into_owned(),
+                current_path: fv.path.to_string_lossy().into_owned(),
+                focus_path,
                 loading: st.loading.contains(&st.root),
                 rows,
             },
@@ -2125,6 +2173,18 @@ fn on_explorer_tree_refresh(
     if explorer_path_allowed(&st, &path) {
         start_explorer_dir_load(entity, path, &mut st, &mut commands, true);
     }
+}
+
+fn on_explorer_reveal_current(
+    trigger: On<BinReceive<ExplorerRevealCurrent>>,
+    mut q: Query<(&FileView, &mut ExplorerState)>,
+    mut commands: Commands,
+) {
+    let entity = trigger.event().webview;
+    let Ok((fv, mut st)) = q.get_mut(entity) else {
+        return;
+    };
+    reveal_current_in_tree(entity, &fv.path, &mut st, &mut commands);
 }
 
 fn run_explorer_mutation(
@@ -2464,16 +2524,23 @@ fn mark_chrome_unsent(views: &Query<Entity, With<FileView>>, commands: &mut Comm
 }
 
 fn on_explorer_panel_toggle(
-    _trigger: On<BinReceive<ExplorerPanelToggle>>,
+    trigger: On<BinReceive<ExplorerPanelToggle>>,
     mut chrome: ResMut<ExplorerChrome>,
     settings: Option<ResMut<vmux_setting::AppSettings>>,
     saves: Option<ResMut<bevy::ecs::message::Messages<vmux_setting::SettingsSaveRequest>>>,
+    mut editors: Query<(&FileView, &mut ExplorerState)>,
     views: Query<Entity, With<FileView>>,
     mut commands: Commands,
 ) {
     chrome.visible = !chrome.visible;
     persist_chrome(*chrome, settings, saves);
     mark_chrome_unsent(&views, &mut commands);
+    if chrome.visible {
+        let entity = trigger.event().webview;
+        if let Ok((fv, mut st)) = editors.get_mut(entity) {
+            reveal_current_in_tree(entity, &fv.path, &mut st, &mut commands);
+        }
+    }
 }
 
 fn on_explorer_panel_width(
@@ -2680,6 +2747,7 @@ impl Plugin for EditorPlugin {
                 ExplorerTreeToggle,
                 ExplorerTreePrefetch,
                 ExplorerTreeRefresh,
+                ExplorerRevealCurrent,
                 ExplorerCreate,
                 ExplorerRename,
                 ExplorerDelete,
@@ -2752,6 +2820,7 @@ impl Plugin for EditorPlugin {
             .add_observer(on_explorer_tree_toggle)
             .add_observer(on_explorer_tree_prefetch)
             .add_observer(on_explorer_tree_refresh)
+            .add_observer(on_explorer_reveal_current)
             .add_observer(on_explorer_create)
             .add_observer(on_explorer_rename)
             .add_observer(on_explorer_delete)
@@ -3131,6 +3200,31 @@ mod explorer_tests {
     }
 
     #[test]
+    fn reveal_current_expands_ancestors_and_focuses_file() {
+        let tmp = git_repo();
+        let file = tmp.path().join("src").join("lib.rs");
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_systems(Update, (init_explorer_state, drain_explorer_dir_loads))
+            .add_observer(on_explorer_reveal_current);
+        let e = app
+            .world_mut()
+            .spawn((FileView { path: file.clone() }, ExplorerState::default()))
+            .id();
+        wait_for_children(&mut app, e, tmp.path());
+        app.world_mut().trigger(BinReceive {
+            webview: e,
+            payload: ExplorerRevealCurrent,
+        });
+        let src = tmp.path().join("src");
+        wait_for_children(&mut app, e, &src);
+        let st = app.world().get::<ExplorerState>(e).unwrap();
+        assert!(st.expanded.contains(tmp.path()));
+        assert!(st.expanded.contains(&src));
+        assert_eq!(st.focus_path.as_deref(), Some(file.as_path()));
+    }
+
+    #[test]
     fn panel_toggle_flips_chrome() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
@@ -3150,6 +3244,33 @@ mod explorer_tests {
             payload: ExplorerPanelToggle,
         });
         assert!(!app.world().resource::<ExplorerChrome>().visible);
+    }
+
+    #[test]
+    fn panel_open_reveals_current_file() {
+        let tmp = git_repo();
+        let file = tmp.path().join("src").join("lib.rs");
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .insert_resource(ExplorerChrome {
+                visible: false,
+                width: 240,
+            })
+            .add_systems(Update, (init_explorer_state, drain_explorer_dir_loads))
+            .add_observer(on_explorer_panel_toggle);
+        let e = app
+            .world_mut()
+            .spawn((FileView { path: file.clone() }, ExplorerState::default()))
+            .id();
+        wait_for_children(&mut app, e, tmp.path());
+        app.world_mut().trigger(BinReceive {
+            webview: e,
+            payload: ExplorerPanelToggle,
+        });
+        wait_for_children(&mut app, e, &tmp.path().join("src"));
+        assert!(app.world().resource::<ExplorerChrome>().visible);
+        let st = app.world().get::<ExplorerState>(e).unwrap();
+        assert_eq!(st.focus_path.as_deref(), Some(file.as_path()));
     }
 
     #[test]

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -91,8 +91,46 @@ pub struct FileThemeSent;
 pub(crate) struct ExplorerState {
     pub root: PathBuf,
     pub expanded: HashSet<PathBuf>,
+    pub loading: HashSet<PathBuf>,
     pub children: HashMap<PathBuf, Vec<FileDirEntry>>,
     pub open_editors: Vec<PathBuf>,
+}
+
+#[derive(Component)]
+struct ExplorerDirLoadTask {
+    webview: Entity,
+    task: Task<(PathBuf, Vec<FileDirEntry>)>,
+}
+
+#[derive(Clone)]
+enum ExplorerMutation {
+    Create {
+        parent: PathBuf,
+        name: String,
+        is_dir: bool,
+    },
+    Rename {
+        path: PathBuf,
+        name: String,
+    },
+    Delete {
+        path: PathBuf,
+    },
+}
+
+struct ExplorerMutationOutcome {
+    changed_path: PathBuf,
+    refresh_dir: PathBuf,
+    old_path: Option<PathBuf>,
+    was_dir: bool,
+    open_created: bool,
+}
+
+#[derive(Component)]
+struct ExplorerMutationTask {
+    webview: Entity,
+    operation: ExplorerMutation,
+    task: Task<Result<ExplorerMutationOutcome, String>>,
 }
 
 #[derive(Component)]
@@ -1178,20 +1216,14 @@ fn drain_file_changes(
             commands.entity(entity).insert(FileReloadRequested);
         }
         let cached: Vec<PathBuf> = st.children.keys().cloned().collect();
-        let mut tree_changed = false;
         for d in cached {
             let dc = canon(&d);
             if changed
                 .iter()
                 .any(|c| c.parent().map(|p| canon(p) == dc).unwrap_or(false))
             {
-                let kids = list_dir(&d);
-                st.children.insert(d, kids);
-                tree_changed = true;
+                start_explorer_dir_load(entity, d, &mut st, &mut commands, true);
             }
-        }
-        if tree_changed {
-            commands.entity(entity).insert(ExplorerTreeDirty);
         }
     }
 }
@@ -1955,6 +1987,33 @@ fn explorer_root_name(root: &Path) -> String {
         .unwrap_or_else(|| root.to_string_lossy().to_uppercase())
 }
 
+fn start_explorer_dir_load(
+    entity: Entity,
+    path: PathBuf,
+    st: &mut ExplorerState,
+    commands: &mut Commands,
+    force: bool,
+) {
+    if st.loading.contains(&path) || !force && st.children.contains_key(&path) {
+        return;
+    }
+    st.loading.insert(path.clone());
+    let task_path = path.clone();
+    let task = IoTaskPool::get().spawn(async move {
+        let entries = list_dir(&task_path);
+        (task_path, entries)
+    });
+    commands.spawn(ExplorerDirLoadTask {
+        webview: entity,
+        task,
+    });
+    commands.entity(entity).insert(ExplorerTreeDirty);
+}
+
+fn explorer_path_allowed(st: &ExplorerState, path: &Path) -> bool {
+    path == st.root || path.starts_with(&st.root)
+}
+
 fn init_explorer_state(
     mut q: Query<(Entity, &FileView, &mut ExplorerState)>,
     mut commands: Commands,
@@ -1964,10 +2023,31 @@ fn init_explorer_state(
             continue;
         }
         let root = project_root(&fv.path);
-        st.children.insert(root.clone(), list_dir(&root));
         st.expanded.insert(root.clone());
-        st.root = root;
-        commands.entity(entity).insert(ExplorerTreeDirty);
+        st.root = root.clone();
+        start_explorer_dir_load(entity, root, &mut st, &mut commands, false);
+    }
+}
+
+fn drain_explorer_dir_loads(
+    mut tasks: Query<(Entity, &mut ExplorerDirLoadTask)>,
+    mut states: Query<&mut ExplorerState>,
+    mut commands: Commands,
+) {
+    for (task_entity, mut pending) in &mut tasks {
+        let Some((path, entries)) = future::block_on(future::poll_once(&mut pending.task)) else {
+            continue;
+        };
+        let webview = pending.webview;
+        commands.entity(task_entity).despawn();
+        let Ok(mut st) = states.get_mut(webview) else {
+            continue;
+        };
+        if !st.loading.remove(&path) {
+            continue;
+        }
+        st.children.insert(path, entries);
+        commands.entity(webview).insert(ExplorerTreeDirty);
     }
 }
 
@@ -1980,12 +2060,14 @@ fn emit_explorer_tree(
         if !browsers.has_browser(entity) || !browsers.host_emit_ready(&entity) {
             continue;
         }
-        let rows = flatten_tree(&st.root, &st.expanded, &st.children);
+        let rows = flatten_tree(&st.root, &st.expanded, &st.loading, &st.children);
         commands.trigger(BinHostEmitEvent::from_rkyv(
             entity,
             EXPLORER_TREE_EVENT,
             &ExplorerTreeEvent {
                 root_name: explorer_root_name(&st.root),
+                root_path: st.root.to_string_lossy().into_owned(),
+                loading: st.loading.contains(&st.root),
                 rows,
             },
         ));
@@ -2006,13 +2088,315 @@ fn on_explorer_tree_toggle(
     if st.expanded.contains(&path) {
         st.expanded.remove(&path);
     } else {
-        if !st.children.contains_key(&path) {
-            let kids = list_dir(&path);
-            st.children.insert(path.clone(), kids);
+        if !explorer_path_allowed(&st, &path) {
+            return;
         }
-        st.expanded.insert(path);
+        st.expanded.insert(path.clone());
+        start_explorer_dir_load(entity, path, &mut st, &mut commands, false);
     }
     commands.entity(entity).insert(ExplorerTreeDirty);
+}
+
+fn on_explorer_tree_prefetch(
+    trigger: On<BinReceive<ExplorerTreePrefetch>>,
+    mut q: Query<&mut ExplorerState>,
+    mut commands: Commands,
+) {
+    let entity = trigger.event().webview;
+    let path = PathBuf::from(&trigger.event().payload.path);
+    let Ok(mut st) = q.get_mut(entity) else {
+        return;
+    };
+    if explorer_path_allowed(&st, &path) {
+        start_explorer_dir_load(entity, path, &mut st, &mut commands, false);
+    }
+}
+
+fn on_explorer_tree_refresh(
+    trigger: On<BinReceive<ExplorerTreeRefresh>>,
+    mut q: Query<&mut ExplorerState>,
+    mut commands: Commands,
+) {
+    let entity = trigger.event().webview;
+    let path = PathBuf::from(&trigger.event().payload.path);
+    let Ok(mut st) = q.get_mut(entity) else {
+        return;
+    };
+    if explorer_path_allowed(&st, &path) {
+        start_explorer_dir_load(entity, path, &mut st, &mut commands, true);
+    }
+}
+
+fn run_explorer_mutation(
+    root: PathBuf,
+    operation: ExplorerMutation,
+) -> Result<ExplorerMutationOutcome, String> {
+    match operation {
+        ExplorerMutation::Create {
+            parent,
+            name,
+            is_dir,
+        } => {
+            let changed_path = crate::explorer_fs::create_entry(&root, &parent, &name, is_dir)?;
+            Ok(ExplorerMutationOutcome {
+                changed_path,
+                refresh_dir: parent,
+                old_path: None,
+                was_dir: is_dir,
+                open_created: !is_dir,
+            })
+        }
+        ExplorerMutation::Rename { path, name } => {
+            let refresh_dir = path
+                .parent()
+                .ok_or_else(|| "Explorer root cannot be changed".to_string())?
+                .to_path_buf();
+            let (changed_path, was_dir) = crate::explorer_fs::rename_entry(&root, &path, &name)?;
+            Ok(ExplorerMutationOutcome {
+                changed_path,
+                refresh_dir,
+                old_path: Some(path),
+                was_dir,
+                open_created: false,
+            })
+        }
+        ExplorerMutation::Delete { path } => {
+            let (refresh_dir, was_dir) = crate::explorer_fs::delete_entry(&root, &path)?;
+            Ok(ExplorerMutationOutcome {
+                changed_path: path.clone(),
+                refresh_dir,
+                old_path: Some(path),
+                was_dir,
+                open_created: false,
+            })
+        }
+    }
+}
+
+fn start_explorer_mutation(
+    entity: Entity,
+    root: PathBuf,
+    operation: ExplorerMutation,
+    commands: &mut Commands,
+) {
+    let task_operation = operation.clone();
+    let task = IoTaskPool::get().spawn(async move { run_explorer_mutation(root, task_operation) });
+    commands.spawn(ExplorerMutationTask {
+        webview: entity,
+        operation,
+        task,
+    });
+}
+
+fn on_explorer_create(
+    trigger: On<BinReceive<ExplorerCreate>>,
+    q: Query<&ExplorerState>,
+    mut commands: Commands,
+) {
+    let entity = trigger.event().webview;
+    let Ok(st) = q.get(entity) else {
+        return;
+    };
+    let payload = &trigger.event().payload;
+    start_explorer_mutation(
+        entity,
+        st.root.clone(),
+        ExplorerMutation::Create {
+            parent: PathBuf::from(&payload.parent),
+            name: payload.name.clone(),
+            is_dir: payload.is_dir,
+        },
+        &mut commands,
+    );
+}
+
+fn on_explorer_rename(
+    trigger: On<BinReceive<ExplorerRename>>,
+    q: Query<&ExplorerState>,
+    mut commands: Commands,
+) {
+    let entity = trigger.event().webview;
+    let Ok(st) = q.get(entity) else {
+        return;
+    };
+    let payload = &trigger.event().payload;
+    start_explorer_mutation(
+        entity,
+        st.root.clone(),
+        ExplorerMutation::Rename {
+            path: PathBuf::from(&payload.path),
+            name: payload.name.clone(),
+        },
+        &mut commands,
+    );
+}
+
+fn on_explorer_delete(
+    trigger: On<BinReceive<ExplorerDelete>>,
+    q: Query<&ExplorerState>,
+    mut commands: Commands,
+) {
+    let entity = trigger.event().webview;
+    let Ok(st) = q.get(entity) else {
+        return;
+    };
+    start_explorer_mutation(
+        entity,
+        st.root.clone(),
+        ExplorerMutation::Delete {
+            path: PathBuf::from(&trigger.event().payload.path),
+        },
+        &mut commands,
+    );
+}
+
+fn remap_path(path: &Path, old: &Path, new: &Path) -> Option<PathBuf> {
+    path.strip_prefix(old).ok().map(|suffix| new.join(suffix))
+}
+
+fn evict_explorer_subtree(st: &mut ExplorerState, path: &Path) {
+    st.expanded.retain(|entry| !entry.starts_with(path));
+    st.loading.retain(|entry| !entry.starts_with(path));
+    st.children.retain(|entry, _| !entry.starts_with(path));
+}
+
+fn explorer_mutation_message(
+    operation: &ExplorerMutation,
+    outcome: &ExplorerMutationOutcome,
+) -> String {
+    match operation {
+        ExplorerMutation::Create { is_dir: true, .. } => format!(
+            "Created folder {}",
+            outcome
+                .changed_path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+        ),
+        ExplorerMutation::Create { is_dir: false, .. } => format!(
+            "Created file {}",
+            outcome
+                .changed_path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+        ),
+        ExplorerMutation::Rename { .. } => format!(
+            "Renamed to {}",
+            outcome
+                .changed_path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+        ),
+        ExplorerMutation::Delete { path } => format!(
+            "Deleted {}",
+            path.file_name().unwrap_or_default().to_string_lossy()
+        ),
+    }
+}
+
+fn emit_explorer_fs_result(
+    webview: Entity,
+    ok: bool,
+    message: String,
+    open_path: String,
+    browsers: &Browsers,
+    commands: &mut Commands,
+) {
+    if browsers.has_browser(webview) && browsers.host_emit_ready(&webview) {
+        commands.trigger(BinHostEmitEvent::from_rkyv(
+            webview,
+            EXPLORER_FS_RESULT_EVENT,
+            &ExplorerFsResult {
+                ok,
+                message,
+                open_path,
+            },
+        ));
+    }
+}
+
+fn drain_explorer_mutations(
+    mut tasks: Query<(Entity, &mut ExplorerMutationTask)>,
+    mut views: Query<(&FileView, &mut ExplorerState)>,
+    browsers: NonSend<Browsers>,
+    mut commands: Commands,
+) {
+    for (task_entity, mut pending) in &mut tasks {
+        let Some(result) = future::block_on(future::poll_once(&mut pending.task)) else {
+            continue;
+        };
+        let webview = pending.webview;
+        let operation = pending.operation.clone();
+        commands.entity(task_entity).despawn();
+        let Ok((fv, mut st)) = views.get_mut(webview) else {
+            continue;
+        };
+        let outcome = match result {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                emit_explorer_fs_result(
+                    webview,
+                    false,
+                    error,
+                    String::new(),
+                    &browsers,
+                    &mut commands,
+                );
+                continue;
+            }
+        };
+        let mut open_path = if outcome.open_created {
+            Some(outcome.changed_path.clone())
+        } else {
+            None
+        };
+        if let Some(old_path) = outcome.old_path.as_ref() {
+            match &operation {
+                ExplorerMutation::Rename { .. } => {
+                    for open in &mut st.open_editors {
+                        if let Some(remapped) = remap_path(open, old_path, &outcome.changed_path) {
+                            *open = remapped;
+                        }
+                    }
+                    if let Some(remapped) = remap_path(&fv.path, old_path, &outcome.changed_path) {
+                        open_path = Some(remapped);
+                    }
+                }
+                ExplorerMutation::Delete { .. } => {
+                    st.open_editors.retain(|open| !open.starts_with(old_path));
+                    if fv.path.starts_with(old_path) {
+                        open_path = Some(outcome.refresh_dir.clone());
+                    }
+                }
+                ExplorerMutation::Create { .. } => {}
+            }
+            if outcome.was_dir {
+                evict_explorer_subtree(&mut st, old_path);
+            }
+        }
+        start_explorer_dir_load(
+            webview,
+            outcome.refresh_dir.clone(),
+            &mut st,
+            &mut commands,
+            true,
+        );
+        commands
+            .entity(webview)
+            .insert((ExplorerTreeDirty, OpenEditorsDirty));
+        emit_explorer_fs_result(
+            webview,
+            true,
+            explorer_mutation_message(&operation, &outcome),
+            open_path
+                .map(|path| path.to_string_lossy().into_owned())
+                .unwrap_or_default(),
+            &browsers,
+            &mut commands,
+        );
+    }
 }
 
 fn sync_explorer_chrome(
@@ -2294,6 +2678,11 @@ impl Plugin for EditorPlugin {
             )>::default())
             .add_plugins(BinEventEmitterPlugin::<(
                 ExplorerTreeToggle,
+                ExplorerTreePrefetch,
+                ExplorerTreeRefresh,
+                ExplorerCreate,
+                ExplorerRename,
+                ExplorerDelete,
                 ExplorerCloseEditor,
                 ExplorerPanelToggle,
                 ExplorerPanelWidth,
@@ -2327,6 +2716,7 @@ impl Plugin for EditorPlugin {
                     (drain_file_changes, reload_changed_files).chain(),
                 ),
             )
+            .add_systems(Update, (drain_explorer_dir_loads, drain_explorer_mutations))
             .add_systems(
                 Update,
                 (
@@ -2360,6 +2750,11 @@ impl Plugin for EditorPlugin {
             .add_observer(on_file_fold_toggle)
             .add_observer(on_file_view_mode_set)
             .add_observer(on_explorer_tree_toggle)
+            .add_observer(on_explorer_tree_prefetch)
+            .add_observer(on_explorer_tree_refresh)
+            .add_observer(on_explorer_create)
+            .add_observer(on_explorer_rename)
+            .add_observer(on_explorer_delete)
             .add_observer(on_explorer_panel_toggle)
             .add_observer(on_explorer_panel_width)
             .add_observer(on_explorer_close_editor)
@@ -2665,18 +3060,33 @@ mod explorer_tests {
         });
     }
 
+    fn wait_for_children(app: &mut App, e: Entity, path: &Path) {
+        for _ in 0..1000 {
+            app.update();
+            if app
+                .world()
+                .get::<ExplorerState>(e)
+                .is_some_and(|st| st.children.contains_key(path))
+            {
+                return;
+            }
+            std::thread::yield_now();
+        }
+        panic!("directory load did not finish: {}", path.display());
+    }
+
     #[test]
     fn init_builds_root_listing_and_marks_dirty() {
         let tmp = git_repo();
         let file = tmp.path().join("src").join("lib.rs");
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .add_systems(Update, init_explorer_state);
+            .add_systems(Update, (init_explorer_state, drain_explorer_dir_loads));
         let e = app
             .world_mut()
             .spawn((FileView { path: file }, ExplorerState::default()))
             .id();
-        app.update();
+        wait_for_children(&mut app, e, tmp.path());
         let st = app.world().get::<ExplorerState>(e).unwrap();
         assert_eq!(st.root.as_path(), tmp.path());
         assert!(st.expanded.contains(&tmp.path().to_path_buf()));
@@ -2696,15 +3106,16 @@ mod explorer_tests {
         let file = tmp.path().join("README.md");
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .add_systems(Update, init_explorer_state)
+            .add_systems(Update, (init_explorer_state, drain_explorer_dir_loads))
             .add_observer(on_explorer_tree_toggle);
         let e = app
             .world_mut()
             .spawn((FileView { path: file }, ExplorerState::default()))
             .id();
-        app.update();
+        wait_for_children(&mut app, e, tmp.path());
         let src = tmp.path().join("src");
         toggle(&mut app, e, &src);
+        wait_for_children(&mut app, e, &src);
         let st = app.world().get::<ExplorerState>(e).unwrap();
         assert!(st.expanded.contains(&src));
         assert!(

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -150,6 +150,8 @@ struct ExplorerChromeSent;
 struct ExplorerChrome {
     visible: bool,
     width: u32,
+    client_id: u64,
+    request_id: u64,
 }
 
 #[derive(Resource, Default)]
@@ -2496,6 +2498,8 @@ fn emit_explorer_chrome(
             &ExplorerChromeEvent {
                 visible: chrome.visible,
                 width: chrome.width,
+                client_id: chrome.client_id,
+                request_id: chrome.request_id,
             },
         ));
         commands.entity(entity).insert(ExplorerChromeSent);
@@ -2523,8 +2527,8 @@ fn mark_chrome_unsent(views: &Query<Entity, With<FileView>>, commands: &mut Comm
     }
 }
 
-fn on_explorer_panel_toggle(
-    trigger: On<BinReceive<ExplorerPanelToggle>>,
+fn on_explorer_panel_set_visible(
+    trigger: On<BinReceive<ExplorerPanelSetVisible>>,
     mut chrome: ResMut<ExplorerChrome>,
     settings: Option<ResMut<vmux_setting::AppSettings>>,
     saves: Option<ResMut<bevy::ecs::message::Messages<vmux_setting::SettingsSaveRequest>>>,
@@ -2532,7 +2536,9 @@ fn on_explorer_panel_toggle(
     views: Query<Entity, With<FileView>>,
     mut commands: Commands,
 ) {
-    chrome.visible = !chrome.visible;
+    chrome.visible = trigger.event().payload.visible;
+    chrome.client_id = trigger.event().payload.client_id;
+    chrome.request_id = trigger.event().payload.request_id;
     persist_chrome(*chrome, settings, saves);
     mark_chrome_unsent(&views, &mut commands);
     if chrome.visible {
@@ -2717,6 +2723,8 @@ impl Plugin for EditorPlugin {
             .insert_resource(ExplorerChrome {
                 visible: false,
                 width: vmux_setting::EXPLORER_DEFAULT_WIDTH,
+                client_id: 0,
+                request_id: 0,
             })
             .init_resource::<ExplorerChromeSynced>()
             .init_resource::<SharedFileViewMode>()
@@ -2752,7 +2760,7 @@ impl Plugin for EditorPlugin {
                 ExplorerRename,
                 ExplorerDelete,
                 ExplorerCloseEditor,
-                ExplorerPanelToggle,
+                ExplorerPanelSetVisible,
                 ExplorerPanelWidth,
                 ExplorerGoto,
             )>::default())
@@ -2824,7 +2832,7 @@ impl Plugin for EditorPlugin {
             .add_observer(on_explorer_create)
             .add_observer(on_explorer_rename)
             .add_observer(on_explorer_delete)
-            .add_observer(on_explorer_panel_toggle)
+            .add_observer(on_explorer_panel_set_visible)
             .add_observer(on_explorer_panel_width)
             .add_observer(on_explorer_close_editor)
             .add_observer(on_explorer_goto);
@@ -3225,14 +3233,16 @@ mod explorer_tests {
     }
 
     #[test]
-    fn panel_toggle_flips_chrome() {
+    fn panel_visibility_is_idempotent() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .insert_resource(ExplorerChrome {
                 visible: true,
                 width: 240,
+                client_id: 0,
+                request_id: 0,
             })
-            .add_observer(on_explorer_panel_toggle);
+            .add_observer(on_explorer_panel_set_visible);
         let e = app
             .world_mut()
             .spawn(FileView {
@@ -3241,9 +3251,25 @@ mod explorer_tests {
             .id();
         app.world_mut().trigger(BinReceive {
             webview: e,
-            payload: ExplorerPanelToggle,
+            payload: ExplorerPanelSetVisible {
+                visible: false,
+                client_id: 7,
+                request_id: 1,
+            },
         });
         assert!(!app.world().resource::<ExplorerChrome>().visible);
+        app.world_mut().trigger(BinReceive {
+            webview: e,
+            payload: ExplorerPanelSetVisible {
+                visible: false,
+                client_id: 7,
+                request_id: 2,
+            },
+        });
+        let chrome = app.world().resource::<ExplorerChrome>();
+        assert!(!chrome.visible);
+        assert_eq!(chrome.client_id, 7);
+        assert_eq!(chrome.request_id, 2);
     }
 
     #[test]
@@ -3255,9 +3281,11 @@ mod explorer_tests {
             .insert_resource(ExplorerChrome {
                 visible: false,
                 width: 240,
+                client_id: 0,
+                request_id: 0,
             })
             .add_systems(Update, (init_explorer_state, drain_explorer_dir_loads))
-            .add_observer(on_explorer_panel_toggle);
+            .add_observer(on_explorer_panel_set_visible);
         let e = app
             .world_mut()
             .spawn((FileView { path: file.clone() }, ExplorerState::default()))
@@ -3265,7 +3293,11 @@ mod explorer_tests {
         wait_for_children(&mut app, e, tmp.path());
         app.world_mut().trigger(BinReceive {
             webview: e,
-            payload: ExplorerPanelToggle,
+            payload: ExplorerPanelSetVisible {
+                visible: true,
+                client_id: 9,
+                request_id: 1,
+            },
         });
         wait_for_children(&mut app, e, &tmp.path().join("src"));
         assert!(app.world().resource::<ExplorerChrome>().visible);
@@ -3280,6 +3312,8 @@ mod explorer_tests {
             .insert_resource(ExplorerChrome {
                 visible: true,
                 width: 240,
+                client_id: 0,
+                request_id: 0,
             })
             .add_observer(on_explorer_panel_width);
         let e = app

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -1225,7 +1225,7 @@ fn drain_file_changes(
                 .iter()
                 .any(|c| c.parent().map(|p| canon(p) == dc).unwrap_or(false))
             {
-                start_explorer_dir_load(entity, d, &mut st, &mut commands, true);
+                let _ = start_explorer_dir_load(entity, d, &mut st, &mut commands, true);
             }
         }
     }
@@ -1996,9 +1996,9 @@ fn start_explorer_dir_load(
     st: &mut ExplorerState,
     commands: &mut Commands,
     force: bool,
-) {
+) -> bool {
     if st.loading.contains(&path) || !force && st.children.contains_key(&path) {
-        return;
+        return false;
     }
     st.loading.insert(path.clone());
     let task_path = path.clone();
@@ -2011,6 +2011,7 @@ fn start_explorer_dir_load(
         task,
     });
     commands.entity(entity).insert(ExplorerTreeDirty);
+    true
 }
 
 fn explorer_path_allowed(st: &ExplorerState, path: &Path) -> bool {
@@ -2023,6 +2024,7 @@ fn reveal_current_in_tree(
     st: &mut ExplorerState,
     commands: &mut Commands,
 ) {
+    let mut tree_changed = false;
     let root = project_root(current);
     if st.root != root {
         st.root = root;
@@ -2030,6 +2032,7 @@ fn reveal_current_in_tree(
         st.loading.clear();
         st.children.clear();
         st.focus_path = None;
+        tree_changed = true;
     }
     let current_dir = if current.is_dir() {
         current
@@ -2040,15 +2043,34 @@ fn reveal_current_in_tree(
         return;
     };
     let mut dir = st.root.clone();
-    st.expanded.insert(dir.clone());
-    start_explorer_dir_load(entity, dir.clone(), st, commands, false);
+    tree_changed |= st.expanded.insert(dir.clone());
+    tree_changed |= start_explorer_dir_load(entity, dir.clone(), st, commands, false);
     for component in relative.components() {
         dir.push(component);
-        st.expanded.insert(dir.clone());
-        start_explorer_dir_load(entity, dir.clone(), st, commands, false);
+        tree_changed |= st.expanded.insert(dir.clone());
+        tree_changed |= start_explorer_dir_load(entity, dir.clone(), st, commands, false);
     }
-    st.focus_path = Some(current.to_path_buf());
-    commands.entity(entity).insert(ExplorerTreeDirty);
+    if tree_changed {
+        st.focus_path = Some(current.to_path_buf());
+        commands.entity(entity).insert(ExplorerTreeDirty);
+    }
+}
+
+fn emit_explorer_focus(
+    entity: Entity,
+    current: &Path,
+    browsers: &Browsers,
+    commands: &mut Commands,
+) {
+    if browsers.has_browser(entity) && browsers.host_emit_ready(&entity) {
+        commands.trigger(BinHostEmitEvent::from_rkyv(
+            entity,
+            EXPLORER_FOCUS_EVENT,
+            &ExplorerFocusEvent {
+                path: current.to_string_lossy().into_owned(),
+            },
+        ));
+    }
 }
 
 fn init_explorer_state(
@@ -2062,7 +2084,7 @@ fn init_explorer_state(
         let root = project_root(&fv.path);
         st.expanded.insert(root.clone());
         st.root = root.clone();
-        start_explorer_dir_load(entity, root, &mut st, &mut commands, false);
+        let _ = start_explorer_dir_load(entity, root, &mut st, &mut commands, false);
     }
 }
 
@@ -2142,7 +2164,7 @@ fn on_explorer_tree_toggle(
             return;
         }
         st.expanded.insert(path.clone());
-        start_explorer_dir_load(entity, path, &mut st, &mut commands, false);
+        let _ = start_explorer_dir_load(entity, path, &mut st, &mut commands, false);
     }
     commands.entity(entity).insert(ExplorerTreeDirty);
 }
@@ -2158,7 +2180,7 @@ fn on_explorer_tree_prefetch(
         return;
     };
     if explorer_path_allowed(&st, &path) {
-        start_explorer_dir_load(entity, path, &mut st, &mut commands, false);
+        let _ = start_explorer_dir_load(entity, path, &mut st, &mut commands, false);
     }
 }
 
@@ -2173,13 +2195,14 @@ fn on_explorer_tree_refresh(
         return;
     };
     if explorer_path_allowed(&st, &path) {
-        start_explorer_dir_load(entity, path, &mut st, &mut commands, true);
+        let _ = start_explorer_dir_load(entity, path, &mut st, &mut commands, true);
     }
 }
 
 fn on_explorer_reveal_current(
     trigger: On<BinReceive<ExplorerRevealCurrent>>,
     mut q: Query<(&FileView, &mut ExplorerState)>,
+    browsers: Option<NonSend<Browsers>>,
     mut commands: Commands,
 ) {
     let entity = trigger.event().webview;
@@ -2187,6 +2210,9 @@ fn on_explorer_reveal_current(
         return;
     };
     reveal_current_in_tree(entity, &fv.path, &mut st, &mut commands);
+    if let Some(browsers) = browsers {
+        emit_explorer_focus(entity, &fv.path, &browsers, &mut commands);
+    }
 }
 
 fn run_explorer_mutation(
@@ -2438,7 +2464,7 @@ fn drain_explorer_mutations(
                 evict_explorer_subtree(&mut st, old_path);
             }
         }
-        start_explorer_dir_load(
+        let _ = start_explorer_dir_load(
             webview,
             outcome.refresh_dir.clone(),
             &mut st,
@@ -2532,19 +2558,28 @@ fn on_explorer_panel_set_visible(
     mut chrome: ResMut<ExplorerChrome>,
     settings: Option<ResMut<vmux_setting::AppSettings>>,
     saves: Option<ResMut<bevy::ecs::message::Messages<vmux_setting::SettingsSaveRequest>>>,
-    mut editors: Query<(&FileView, &mut ExplorerState)>,
-    views: Query<Entity, With<FileView>>,
+    mut editors: Query<(Entity, &FileView, &mut ExplorerState)>,
+    browsers: Option<NonSend<Browsers>>,
     mut commands: Commands,
 ) {
     chrome.visible = trigger.event().payload.visible;
     chrome.client_id = trigger.event().payload.client_id;
     chrome.request_id = trigger.event().payload.request_id;
     persist_chrome(*chrome, settings, saves);
-    mark_chrome_unsent(&views, &mut commands);
-    if chrome.visible {
-        let entity = trigger.event().webview;
-        if let Ok((fv, mut st)) = editors.get_mut(entity) {
-            reveal_current_in_tree(entity, &fv.path, &mut st, &mut commands);
+    let entity = trigger.event().webview;
+    for (view, _, _) in &mut editors {
+        if view == entity {
+            commands.entity(view).insert(ExplorerChromeSent);
+        } else {
+            commands.entity(view).remove::<ExplorerChromeSent>();
+        }
+    }
+    if chrome.visible
+        && let Ok((_, fv, mut st)) = editors.get_mut(entity)
+    {
+        reveal_current_in_tree(entity, &fv.path, &mut st, &mut commands);
+        if let Some(browsers) = browsers {
+            emit_explorer_focus(entity, &fv.path, &browsers, &mut commands);
         }
     }
 }
@@ -3230,6 +3265,43 @@ mod explorer_tests {
         assert!(st.expanded.contains(tmp.path()));
         assert!(st.expanded.contains(&src));
         assert_eq!(st.focus_path.as_deref(), Some(file.as_path()));
+    }
+
+    #[test]
+    fn repeated_reveal_skips_unchanged_tree_rebuild() {
+        let tmp = git_repo();
+        let file = tmp.path().join("src").join("lib.rs");
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_systems(Update, (init_explorer_state, drain_explorer_dir_loads))
+            .add_observer(on_explorer_reveal_current);
+        let e = app
+            .world_mut()
+            .spawn((FileView { path: file }, ExplorerState::default()))
+            .id();
+        wait_for_children(&mut app, e, tmp.path());
+        app.world_mut().trigger(BinReceive {
+            webview: e,
+            payload: ExplorerRevealCurrent,
+        });
+        wait_for_children(&mut app, e, &tmp.path().join("src"));
+        app.world_mut().entity_mut(e).remove::<ExplorerTreeDirty>();
+        app.world_mut()
+            .get_mut::<ExplorerState>(e)
+            .unwrap()
+            .focus_path = None;
+        app.world_mut().trigger(BinReceive {
+            webview: e,
+            payload: ExplorerRevealCurrent,
+        });
+        assert!(app.world().get::<ExplorerTreeDirty>(e).is_none());
+        assert!(
+            app.world()
+                .get::<ExplorerState>(e)
+                .unwrap()
+                .focus_path
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/vmux_editor/tests/page_source.rs
+++ b/crates/vmux_editor/tests/page_source.rs
@@ -37,6 +37,8 @@ fn explorer_animates_tree_and_sections() {
     assert!(s.contains("grid-rows-[1fr]"));
     assert!(s.contains("transition-[grid-template-rows,opacity,transform]"));
     assert!(s.contains("transition-transform duration-150"));
+    assert!(s.contains("schedule_tree_focus"));
+    assert!(s.contains("current_path"));
 }
 
 #[test]
@@ -46,7 +48,12 @@ fn page_mounts_panel_and_wires_toggle() {
     assert!(s.contains("ExplorerPanelToggle"));
     assert!(s.contains("ExplorerChromeEvent"));
     assert!(s.contains("ExplorerPanelWidth"));
-    assert!(s.contains("transition-[width] duration-200"));
+    assert!(s.contains("ExplorerSidebar"));
+    assert!(s.contains("-translate-x-full"));
+    assert!(!s.contains("transition-[width] duration-200"));
+    assert!(s.contains("ExplorerRevealCurrent"));
+    assert!(s.contains("raw.shift_key()"));
+    assert!(s.contains("key.eq_ignore_ascii_case(\"e\")"));
 }
 
 #[test]

--- a/crates/vmux_editor/tests/page_source.rs
+++ b/crates/vmux_editor/tests/page_source.rs
@@ -46,14 +46,17 @@ fn explorer_animates_tree_and_sections() {
 #[test]
 fn page_mounts_panel_and_wires_toggle() {
     let s = page_source();
-    assert!(s.contains("ExplorerPanel {}"));
+    assert!(s.contains("ExplorerPanel { visible }"));
     assert!(s.contains("ExplorerPanelSetVisible"));
     assert!(s.contains("ExplorerChromeEvent"));
+    assert!(explorer_source().contains("ExplorerFocusEvent"));
     assert!(s.contains("ExplorerPanelWidth"));
     assert!(s.contains("ExplorerSidebar"));
     assert!(s.contains("-translate-x-full"));
     assert!(s.contains("transition-[translate,opacity]"));
     assert!(!s.contains("transition-[width] duration-200"));
+    assert!(!s.contains("width:0px"));
+    assert!(s.contains("absolute inset-y-0 left-0 z-[3]"));
     assert!(s.contains("ExplorerRevealCurrent"));
     assert!(s.contains("handle_explorer_shortcut"));
     assert!(s.contains("Mode::Text => focus_file_input()"));

--- a/crates/vmux_editor/tests/page_source.rs
+++ b/crates/vmux_editor/tests/page_source.rs
@@ -33,9 +33,11 @@ fn explorer_rows_emit_intents() {
 fn explorer_animates_tree_and_sections() {
     let s = explorer_source();
     assert!(s.contains("reconcile_rows"));
+    assert!(s.contains("merge_tree_motion_rows"));
     assert!(s.contains("grid-rows-[0fr]"));
     assert!(s.contains("grid-rows-[1fr]"));
-    assert!(s.contains("transition-[grid-template-rows,opacity,translate]"));
+    assert!(s.contains("transition-[opacity,translate]"));
+    assert!(!s.contains("transition-[grid-template-rows,opacity,translate]"));
     assert!(s.contains("transition-[rotate] duration-150"));
     assert!(s.contains("schedule_tree_focus"));
     assert!(s.contains("current_path"));
@@ -53,6 +55,8 @@ fn page_mounts_panel_and_wires_toggle() {
     assert!(s.contains("transition-[translate,opacity]"));
     assert!(!s.contains("transition-[width] duration-200"));
     assert!(s.contains("ExplorerRevealCurrent"));
+    assert!(s.contains("handle_explorer_shortcut"));
+    assert!(s.contains("Mode::Text => focus_file_input()"));
     assert!(s.contains("raw.shift_key()"));
     assert!(s.contains("key.eq_ignore_ascii_case(\"e\")"));
 }

--- a/crates/vmux_editor/tests/page_source.rs
+++ b/crates/vmux_editor/tests/page_source.rs
@@ -21,6 +21,22 @@ fn explorer_rows_emit_intents() {
     assert!(s.contains("FileOpenEvent"));
     assert!(s.contains("ExplorerCloseEditor"));
     assert!(s.contains("ExplorerGoto"));
+    assert!(s.contains("ExplorerTreePrefetch"));
+    assert!(s.contains("ExplorerTreeRefresh"));
+    assert!(s.contains("ExplorerCreate"));
+    assert!(s.contains("ExplorerRename"));
+    assert!(s.contains("ExplorerDelete"));
+    assert!(s.contains("EXPLORER_FS_RESULT_EVENT"));
+}
+
+#[test]
+fn explorer_animates_tree_and_sections() {
+    let s = explorer_source();
+    assert!(s.contains("reconcile_rows"));
+    assert!(s.contains("grid-rows-[0fr]"));
+    assert!(s.contains("grid-rows-[1fr]"));
+    assert!(s.contains("transition-[grid-template-rows,opacity,transform]"));
+    assert!(s.contains("transition-transform duration-150"));
 }
 
 #[test]
@@ -30,6 +46,7 @@ fn page_mounts_panel_and_wires_toggle() {
     assert!(s.contains("ExplorerPanelToggle"));
     assert!(s.contains("ExplorerChromeEvent"));
     assert!(s.contains("ExplorerPanelWidth"));
+    assert!(s.contains("transition-[width] duration-200"));
 }
 
 #[test]

--- a/crates/vmux_editor/tests/page_source.rs
+++ b/crates/vmux_editor/tests/page_source.rs
@@ -35,8 +35,8 @@ fn explorer_animates_tree_and_sections() {
     assert!(s.contains("reconcile_rows"));
     assert!(s.contains("grid-rows-[0fr]"));
     assert!(s.contains("grid-rows-[1fr]"));
-    assert!(s.contains("transition-[grid-template-rows,opacity,transform]"));
-    assert!(s.contains("transition-transform duration-150"));
+    assert!(s.contains("transition-[grid-template-rows,opacity,translate]"));
+    assert!(s.contains("transition-[rotate] duration-150"));
     assert!(s.contains("schedule_tree_focus"));
     assert!(s.contains("current_path"));
 }
@@ -45,11 +45,12 @@ fn explorer_animates_tree_and_sections() {
 fn page_mounts_panel_and_wires_toggle() {
     let s = page_source();
     assert!(s.contains("ExplorerPanel {}"));
-    assert!(s.contains("ExplorerPanelToggle"));
+    assert!(s.contains("ExplorerPanelSetVisible"));
     assert!(s.contains("ExplorerChromeEvent"));
     assert!(s.contains("ExplorerPanelWidth"));
     assert!(s.contains("ExplorerSidebar"));
     assert!(s.contains("-translate-x-full"));
+    assert!(s.contains("transition-[translate,opacity]"));
     assert!(!s.contains("transition-[width] duration-200"));
     assert!(s.contains("ExplorerRevealCurrent"));
     assert!(s.contains("raw.shift_key()"));

--- a/crates/vmux_editor/tests/page_source.rs
+++ b/crates/vmux_editor/tests/page_source.rs
@@ -55,8 +55,8 @@ fn page_mounts_panel_and_wires_toggle() {
     assert!(s.contains("-translate-x-full"));
     assert!(s.contains("transition-[translate,opacity]"));
     assert!(!s.contains("transition-[width] duration-200"));
-    assert!(!s.contains("width:0px"));
-    assert!(s.contains("absolute inset-y-0 left-0 z-[3]"));
+    assert!(s.contains("width:0px;contain:layout style;"));
+    assert!(s.contains("relative z-[2] h-full shrink-0"));
     assert!(s.contains("ExplorerRevealCurrent"));
     assert!(s.contains("handle_explorer_shortcut"));
     assert!(s.contains("Mode::Text => focus_file_input()"));


### PR DESCRIPTION
## Context

Opening Explorer folders blocked the editor while directory enumeration ran on the main thread, and tree changes snapped into place. The Explorer also lacked common file-management actions.

## Implementation

Directory reads and filesystem mutations now run on the I/O task pool, with hover prefetching, cache-aware loading state, and safe root-bound path validation. A keyed motion layer animates row insertion/removal, folder and section expansion, panel visibility, menus, dialogs, and operation feedback. Context menus support new files, new folders, refresh, rename, and confirmed deletion while keeping active paths and open-editor state synchronized.

## Checks / QA

- Expand and collapse nested folders repeatedly; confirm the editor remains responsive and rows move smoothly.
- Toggle the Explorer and each section; confirm width, chevrons, and content animate.
- Right-click the root, folders, and files; create, rename, refresh, and delete entries.
- Rename or delete the currently open file or containing folder; confirm navigation and Open Editors remain consistent.
