### PR TITLE
fix(agent): tune Vibe CLI and ACP integration

### DIFF
--- a/crates/vmux_agent/src/chat_page/composer.rs
+++ b/crates/vmux_agent/src/chat_page/composer.rs
@@ -46,6 +46,10 @@ pub(crate) enum ToolActivity {
     Other,
 }
 
+pub(crate) fn should_expand_thinking(block_index: usize, block_count: usize) -> bool {
+    block_index + 1 == block_count
+}
+
 pub(crate) fn selector_mode(draft: &str) -> SelectorMode<'_> {
     let Some(token) = draft.strip_prefix('/') else {
         return SelectorMode::None;
@@ -393,6 +397,12 @@ mod tests {
             SelectorMode::Resume("SID-9")
         );
         assert_eq!(selector_mode("/unknown arg"), SelectorMode::None);
+    }
+
+    #[test]
+    fn thinking_expands_only_until_the_next_block() {
+        assert!(should_expand_thinking(0, 1));
+        assert!(!should_expand_thinking(0, 2));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -1000,6 +1000,10 @@ fn render_item(key: usize, item: &ChatItem, verb: &str, elapsed: u32) -> Element
 
 fn render_turn(key: usize, turn: &ChatTurn, verb: &str, elapsed: u32) -> Element {
     let reconnecting = matches!(turn.blocks.last(), Some(ChatBlock::Reconnect { .. }));
+    let latest_thinking = turn
+        .blocks
+        .iter()
+        .rposition(|block| matches!(block, ChatBlock::Thinking(_)));
     let blocks = turn
         .blocks
         .iter()
@@ -1020,7 +1024,7 @@ fn render_turn(key: usize, turn: &ChatTurn, verb: &str, elapsed: u32) -> Element
     rsx! {
         div { key: "{key}", class: "flex max-w-[90%] flex-col gap-2.5 self-start",
             for (j , block , children) in blocks {
-                {render_block(j, block, &children)}
+                {render_block(j, block, &children, latest_thinking == Some(j))}
             }
             if turn.running && !reconnecting {
                 {render_working(verb, elapsed)}
@@ -1088,7 +1092,8 @@ enum ActivityIcon {
 fn render_activity_icon(kind: ActivityIcon) -> Element {
     let paths: &[&str] = match kind {
         ActivityIcon::Thinking => &[
-            "m12 3-1.9 5.8a2 2 0 0 1-1.3 1.3L3 12l5.8 1.9a2 2 0 0 1 1.3 1.3L12 21l1.9-5.8a2 2 0 0 1 1.3-1.3L21 12l-5.8-1.9a2 2 0 0 1-1.3-1.3Z",
+            "M9.5 4A2.5 2.5 0 0 1 12 6.5v11a2.5 2.5 0 0 1-4.96.44A2.5 2.5 0 0 1 4.5 15.5a3 3 0 0 1 .34-5.14A2.5 2.5 0 0 1 6.5 6a3 3 0 0 1 3-2Z",
+            "M14.5 4A2.5 2.5 0 0 0 12 6.5v11a2.5 2.5 0 0 0 4.96.44A2.5 2.5 0 0 0 19.5 15.5a3 3 0 0 0-.34-5.14A2.5 2.5 0 0 0 17.5 6a3 3 0 0 0-3-2Z",
         ],
         ActivityIcon::ReadFile => &[
             "M12 7v14",
@@ -1183,7 +1188,12 @@ fn tool_presentation(name: &str) -> (ActivityIcon, Cow<'static, str>) {
     }
 }
 
-fn render_block(key: usize, block: &ChatBlock, children: &[(usize, &ChatBlock)]) -> Element {
+fn render_block(
+    key: usize,
+    block: &ChatBlock,
+    children: &[(usize, &ChatBlock)],
+    latest: bool,
+) -> Element {
     match block {
         ChatBlock::Text(text) => rsx! {
             div {
@@ -1195,7 +1205,7 @@ fn render_block(key: usize, block: &ChatBlock, children: &[(usize, &ChatBlock)])
         ChatBlock::Thinking(text) => rsx! {
             div { key: "{key}", class: "grid grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-2.5 py-1",
                 {render_activity_icon(ActivityIcon::Thinking)}
-                details { class: "disclosure min-w-0 text-sm text-muted-foreground",
+                details { open: latest, class: "disclosure min-w-0 text-sm text-muted-foreground",
                     summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
                         span { class: "font-medium", "Thinking" }
                         {render_disclosure_icon()}

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -4,7 +4,7 @@ use crate::chat_page::composer::{
     PromptEdit, ResumeMenuState, SelectorMode, ToolActivity, chat_page_title, edit_prompt,
     filter_models, filter_sessions, is_handoff_boundary, menu_direction, move_selection,
     prompt_prefix_at_utf16, resume_menu_state, selector_mode, should_clear_draft_on_escape,
-    should_fetch_resume, tool_activity,
+    should_expand_thinking, should_fetch_resume, tool_activity,
 };
 use crate::chat_page::event::{
     CHAT_SNAPSHOT_EVENT, ChatApproval, ChatBlock, ChatCancel, ChatCancelQueuedPrompt,
@@ -1000,10 +1000,7 @@ fn render_item(key: usize, item: &ChatItem, verb: &str, elapsed: u32) -> Element
 
 fn render_turn(key: usize, turn: &ChatTurn, verb: &str, elapsed: u32) -> Element {
     let reconnecting = matches!(turn.blocks.last(), Some(ChatBlock::Reconnect { .. }));
-    let latest_thinking = turn
-        .blocks
-        .iter()
-        .rposition(|block| matches!(block, ChatBlock::Thinking(_)));
+    let block_count = turn.blocks.len();
     let blocks = turn
         .blocks
         .iter()
@@ -1024,7 +1021,7 @@ fn render_turn(key: usize, turn: &ChatTurn, verb: &str, elapsed: u32) -> Element
     rsx! {
         div { key: "{key}", class: "flex max-w-[90%] flex-col gap-2.5 self-start",
             for (j , block , children) in blocks {
-                {render_block(j, block, &children, latest_thinking == Some(j))}
+                {render_block(j, block, &children, should_expand_thinking(j, block_count))}
             }
             if turn.running && !reconnecting {
                 {render_working(verb, elapsed)}

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -446,12 +446,7 @@ fn apply_agent_compatibility_env(
 }
 
 fn apply_vibe_compatibility_env(mut env: Vec<(String, String)>) -> Vec<(String, String)> {
-    let config = read_vibe_config(&env);
-    let mut disabled = config
-        .as_ref()
-        .and_then(|table| table.get("disabled_tools").cloned())
-        .and_then(|value| value.try_into::<Vec<String>>().ok())
-        .unwrap_or_default();
+    let mut disabled = Vec::new();
     if let Some(value) = env
         .iter()
         .rev()
@@ -471,14 +466,7 @@ fn apply_vibe_compatibility_env(mut env: Vec<(String, String)>) -> Vec<(String, 
         "VIBE_DISABLED_TOOLS".to_string(),
         serde_json::to_string(&disabled).unwrap(),
     ));
-    let mut mcp_servers = config
-        .as_ref()
-        .and_then(|table| table.get("mcp_servers"))
-        .and_then(|value| value.as_array())
-        .into_iter()
-        .flatten()
-        .filter_map(|server| serde_json::to_value(server).ok())
-        .collect::<Vec<_>>();
+    let mut mcp_servers: Vec<serde_json::Value> = Vec::new();
     if let Some(value) = env
         .iter()
         .rev()
@@ -501,31 +489,14 @@ fn apply_vibe_compatibility_env(mut env: Vec<(String, String)>) -> Vec<(String, 
             ),
         }
     }
+    env.retain(|(key, _)| key != "VIBE_MCP_SERVERS");
     if !mcp_servers.is_empty() {
-        env.retain(|(key, _)| key != "VIBE_MCP_SERVERS");
         env.push((
             "VIBE_MCP_SERVERS".to_string(),
             serde_json::to_string(&mcp_servers).unwrap(),
         ));
     }
     env
-}
-
-fn read_vibe_config(env: &[(String, String)]) -> Option<toml::Table> {
-    let value = |key: &str| {
-        env.iter()
-            .rev()
-            .find(|(candidate, _)| candidate == key)
-            .map(|(_, value)| value.as_str())
-    };
-    let root = value("VIBE_HOME")
-        .map(std::path::PathBuf::from)
-        .or_else(|| value("HOME").map(|home| std::path::PathBuf::from(home).join(".vibe")));
-    let path = root.map(|root| root.join("config.toml"))?;
-    let Ok(text) = std::fs::read_to_string(path) else {
-        return None;
-    };
-    text.parse::<toml::Table>().ok()
 }
 
 fn extend_unique(out: &mut Vec<String>, values: impl IntoIterator<Item = String>) {
@@ -1246,29 +1217,9 @@ mod tests {
 
     #[test]
     fn vibe_acp_routes_shell_commands_through_vmux_run() {
-        let tmp = std::env::temp_dir().join(format!(
-            "vmux-vibe-acp-env-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        let vibe_home = tmp.join(".vibe");
-        std::fs::create_dir_all(&vibe_home).unwrap();
-        std::fs::write(
-            vibe_home.join("config.toml"),
-            "disabled_tools = [\"from-config\"]\n\
-             [[mcp_servers]]\n\
-             name = \"from-config\"\n\
-             transport = \"stdio\"\n\
-             command = \"config-command\"\n",
-        )
-        .unwrap();
         let env = apply_agent_compatibility_env(
             "mistral-vibe",
             vec![
-                s("HOME", tmp.to_str().unwrap()),
                 s("VIBE_DISABLED_TOOLS", r#"["from-env"]"#),
                 s(
                     "VIBE_MCP_SERVERS",
@@ -1282,15 +1233,21 @@ mod tests {
             .map(|(_, value)| serde_json::from_str::<Vec<String>>(value).unwrap())
             .expect("Vibe ACP disabled tools");
 
-        assert_eq!(disabled, vec!["from-config", "from-env", "bash"]);
+        assert_eq!(disabled, vec!["from-env", "bash"]);
         let mcp_servers = env
             .iter()
             .find(|(key, _)| key == "VIBE_MCP_SERVERS")
             .map(|(_, value)| serde_json::from_str::<serde_json::Value>(value).unwrap())
             .expect("Vibe ACP MCP servers");
-        assert_eq!(mcp_servers[0]["name"], "from-config");
-        assert_eq!(mcp_servers[1]["name"], "from-env");
-        let _ = std::fs::remove_dir_all(tmp);
+        assert_eq!(mcp_servers[0]["name"], "from-env");
+    }
+
+    #[test]
+    fn vibe_acp_discards_invalid_mcp_environment() {
+        let env =
+            apply_agent_compatibility_env("mistral-vibe", vec![s("VIBE_MCP_SERVERS", "not-json")]);
+
+        assert!(env.iter().all(|(key, _)| key != "VIBE_MCP_SERVERS"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -436,12 +436,71 @@ fn build_agent_env(
 
 fn apply_agent_compatibility_env(
     agent_id: &str,
-    mut env: Vec<(String, String)>,
+    env: Vec<(String, String)>,
 ) -> Vec<(String, String)> {
-    if agent_id != "codex" {
-        return env;
+    match agent_id {
+        "mistral-vibe" | "vibe" => apply_vibe_compatibility_env(env),
+        "codex" => apply_codex_compatibility_env(env),
+        _ => env,
     }
+}
 
+fn apply_vibe_compatibility_env(mut env: Vec<(String, String)>) -> Vec<(String, String)> {
+    let mut disabled = read_vibe_disabled_tools(&env);
+    if let Some(value) = env
+        .iter()
+        .rev()
+        .find(|(key, _)| key == "VIBE_DISABLED_TOOLS")
+        .map(|(_, value)| value)
+    {
+        match serde_json::from_str::<Vec<String>>(value) {
+            Ok(existing) => extend_unique(&mut disabled, existing),
+            Err(err) => bevy::log::warn!(
+                "acp: existing VIBE_DISABLED_TOOLS is invalid JSON ({err}); discarding it"
+            ),
+        }
+    }
+    extend_unique(&mut disabled, ["bash".to_string()]);
+    env.retain(|(key, _)| key != "VIBE_DISABLED_TOOLS");
+    env.push((
+        "VIBE_DISABLED_TOOLS".to_string(),
+        serde_json::to_string(&disabled).unwrap(),
+    ));
+    env
+}
+
+fn read_vibe_disabled_tools(env: &[(String, String)]) -> Vec<String> {
+    let value = |key: &str| {
+        env.iter()
+            .rev()
+            .find(|(candidate, _)| candidate == key)
+            .map(|(_, value)| value.as_str())
+    };
+    let root = value("VIBE_HOME")
+        .map(std::path::PathBuf::from)
+        .or_else(|| value("HOME").map(|home| std::path::PathBuf::from(home).join(".vibe")));
+    let Some(path) = root.map(|root| root.join("config.toml")) else {
+        return Vec::new();
+    };
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    text.parse::<toml::Table>()
+        .ok()
+        .and_then(|table| table.get("disabled_tools").cloned())
+        .and_then(|value| value.try_into::<Vec<String>>().ok())
+        .unwrap_or_default()
+}
+
+fn extend_unique(out: &mut Vec<String>, values: impl IntoIterator<Item = String>) {
+    for value in values {
+        if !out.contains(&value) {
+            out.push(value);
+        }
+    }
+}
+
+fn apply_codex_compatibility_env(mut env: Vec<(String, String)>) -> Vec<(String, String)> {
     let existing = env
         .iter()
         .rev()
@@ -1147,6 +1206,40 @@ mod tests {
                 .unwrap()
                 .contains("mcp__vmux__run")
         );
+    }
+
+    #[test]
+    fn vibe_acp_routes_shell_commands_through_vmux_run() {
+        let tmp = std::env::temp_dir().join(format!(
+            "vmux-vibe-acp-env-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let vibe_home = tmp.join(".vibe");
+        std::fs::create_dir_all(&vibe_home).unwrap();
+        std::fs::write(
+            vibe_home.join("config.toml"),
+            "disabled_tools = [\"from-config\"]\n",
+        )
+        .unwrap();
+        let env = apply_agent_compatibility_env(
+            "mistral-vibe",
+            vec![
+                s("HOME", tmp.to_str().unwrap()),
+                s("VIBE_DISABLED_TOOLS", r#"["from-env"]"#),
+            ],
+        );
+        let disabled = env
+            .iter()
+            .find(|(key, _)| key == "VIBE_DISABLED_TOOLS")
+            .map(|(_, value)| serde_json::from_str::<Vec<String>>(value).unwrap())
+            .expect("Vibe ACP disabled tools");
+
+        assert_eq!(disabled, vec!["from-config", "from-env", "bash"]);
+        let _ = std::fs::remove_dir_all(tmp);
     }
 
     #[test]

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -446,7 +446,12 @@ fn apply_agent_compatibility_env(
 }
 
 fn apply_vibe_compatibility_env(mut env: Vec<(String, String)>) -> Vec<(String, String)> {
-    let mut disabled = read_vibe_disabled_tools(&env);
+    let config = read_vibe_config(&env);
+    let mut disabled = config
+        .as_ref()
+        .and_then(|table| table.get("disabled_tools").cloned())
+        .and_then(|value| value.try_into::<Vec<String>>().ok())
+        .unwrap_or_default();
     if let Some(value) = env
         .iter()
         .rev()
@@ -466,10 +471,47 @@ fn apply_vibe_compatibility_env(mut env: Vec<(String, String)>) -> Vec<(String, 
         "VIBE_DISABLED_TOOLS".to_string(),
         serde_json::to_string(&disabled).unwrap(),
     ));
+    let mut mcp_servers = config
+        .as_ref()
+        .and_then(|table| table.get("mcp_servers"))
+        .and_then(|value| value.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|server| serde_json::to_value(server).ok())
+        .collect::<Vec<_>>();
+    if let Some(value) = env
+        .iter()
+        .rev()
+        .find(|(key, _)| key == "VIBE_MCP_SERVERS")
+        .map(|(_, value)| value)
+    {
+        match serde_json::from_str::<Vec<serde_json::Value>>(value) {
+            Ok(existing) => {
+                for server in existing {
+                    if let Some(name) = server.get("name").and_then(serde_json::Value::as_str) {
+                        mcp_servers.retain(|candidate| {
+                            candidate.get("name").and_then(serde_json::Value::as_str) != Some(name)
+                        });
+                    }
+                    mcp_servers.push(server);
+                }
+            }
+            Err(err) => bevy::log::warn!(
+                "acp: existing VIBE_MCP_SERVERS is invalid JSON ({err}); discarding it"
+            ),
+        }
+    }
+    if !mcp_servers.is_empty() {
+        env.retain(|(key, _)| key != "VIBE_MCP_SERVERS");
+        env.push((
+            "VIBE_MCP_SERVERS".to_string(),
+            serde_json::to_string(&mcp_servers).unwrap(),
+        ));
+    }
     env
 }
 
-fn read_vibe_disabled_tools(env: &[(String, String)]) -> Vec<String> {
+fn read_vibe_config(env: &[(String, String)]) -> Option<toml::Table> {
     let value = |key: &str| {
         env.iter()
             .rev()
@@ -479,17 +521,11 @@ fn read_vibe_disabled_tools(env: &[(String, String)]) -> Vec<String> {
     let root = value("VIBE_HOME")
         .map(std::path::PathBuf::from)
         .or_else(|| value("HOME").map(|home| std::path::PathBuf::from(home).join(".vibe")));
-    let Some(path) = root.map(|root| root.join("config.toml")) else {
-        return Vec::new();
-    };
+    let path = root.map(|root| root.join("config.toml"))?;
     let Ok(text) = std::fs::read_to_string(path) else {
-        return Vec::new();
+        return None;
     };
-    text.parse::<toml::Table>()
-        .ok()
-        .and_then(|table| table.get("disabled_tools").cloned())
-        .and_then(|value| value.try_into::<Vec<String>>().ok())
-        .unwrap_or_default()
+    text.parse::<toml::Table>().ok()
 }
 
 fn extend_unique(out: &mut Vec<String>, values: impl IntoIterator<Item = String>) {
@@ -1222,7 +1258,11 @@ mod tests {
         std::fs::create_dir_all(&vibe_home).unwrap();
         std::fs::write(
             vibe_home.join("config.toml"),
-            "disabled_tools = [\"from-config\"]\n",
+            "disabled_tools = [\"from-config\"]\n\
+             [[mcp_servers]]\n\
+             name = \"from-config\"\n\
+             transport = \"stdio\"\n\
+             command = \"config-command\"\n",
         )
         .unwrap();
         let env = apply_agent_compatibility_env(
@@ -1230,6 +1270,10 @@ mod tests {
             vec![
                 s("HOME", tmp.to_str().unwrap()),
                 s("VIBE_DISABLED_TOOLS", r#"["from-env"]"#),
+                s(
+                    "VIBE_MCP_SERVERS",
+                    r#"[{"name":"from-env","transport":"stdio","command":"env-command"}]"#,
+                ),
             ],
         );
         let disabled = env
@@ -1239,6 +1283,13 @@ mod tests {
             .expect("Vibe ACP disabled tools");
 
         assert_eq!(disabled, vec!["from-config", "from-env", "bash"]);
+        let mcp_servers = env
+            .iter()
+            .find(|(key, _)| key == "VIBE_MCP_SERVERS")
+            .map(|(_, value)| serde_json::from_str::<serde_json::Value>(value).unwrap())
+            .expect("Vibe ACP MCP servers");
+        assert_eq!(mcp_servers[0]["name"], "from-config");
+        assert_eq!(mcp_servers[1]["name"], "from-env");
         let _ = std::fs::remove_dir_all(tmp);
     }
 

--- a/crates/vmux_agent/src/client/cli/vibe.rs
+++ b/crates/vmux_agent/src/client/cli/vibe.rs
@@ -40,6 +40,10 @@ impl CliAgentStrategy for VibeStrategy {
         // config (falling back to default models). `--trust` trusts the working
         // directory for this invocation (vibe's documented automation flag).
         let mut args = vec!["--trust".to_string()];
+        for tool in VIBE_WEB_TOOLS {
+            args.push("--disabled-tools".to_string());
+            args.push(tool.to_string());
+        }
         if vmux_core::profile::is_test_session() {
             args.push("--auto-approve".to_string());
         }
@@ -52,11 +56,8 @@ impl CliAgentStrategy for VibeStrategy {
 
     fn build_env(&self, mcp: &McpServerConfig) -> Vec<(String, String)> {
         let mcp_json = serialize_vibe_mcp_env(mcp);
-        let disabled = vibe_disabled_tools(read_user_disabled_tools());
-        let disabled_json = serde_json::to_string(&disabled).unwrap_or_else(|_| "[]".to_string());
         vec![
             ("VIBE_MCP_SERVERS".to_string(), mcp_json),
-            ("VIBE_DISABLED_TOOLS".to_string(), disabled_json),
             (
                 "VIBE_ENABLE_EXPERIMENTAL_HOOKS".to_string(),
                 "true".to_string(),
@@ -133,16 +134,6 @@ fn serialize_vibe_mcp_env(mcp: &McpServerConfig) -> String {
 }
 
 const VIBE_WEB_TOOLS: [&str; 2] = ["web_search", "web_fetch"];
-
-fn vibe_config_path() -> PathBuf {
-    std::env::var("VIBE_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            let home = std::env::var("HOME").unwrap_or_default();
-            PathBuf::from(home).join(".vibe")
-        })
-        .join("config.toml")
-}
 
 const VMUX_HOOK_NAME: &str = "vmux-file-follow";
 const VMUX_TURN_END_HOOK_NAME: &str = "vmux-turn-end";
@@ -237,30 +228,6 @@ fn upsert_vmux_hook(
             table.remove("strict");
         }
     }
-}
-
-fn parse_disabled_tools_toml(text: &str) -> Vec<String> {
-    text.parse::<toml::Table>()
-        .ok()
-        .and_then(|t| t.get("disabled_tools").cloned())
-        .and_then(|v| v.try_into::<Vec<String>>().ok())
-        .unwrap_or_default()
-}
-
-fn read_user_disabled_tools() -> Vec<String> {
-    std::fs::read_to_string(vibe_config_path())
-        .map(|t| parse_disabled_tools_toml(&t))
-        .unwrap_or_default()
-}
-
-fn vibe_disabled_tools(existing: Vec<String>) -> Vec<String> {
-    let mut out = existing;
-    for tool in VIBE_WEB_TOOLS {
-        if !out.iter().any(|t| t == tool) {
-            out.push(tool.to_string());
-        }
-    }
-    out
 }
 
 #[derive(serde::Deserialize)]
@@ -446,10 +413,27 @@ mod tests {
         };
         let prev = std::env::var("VMUX_TEST").ok();
         unsafe { std::env::remove_var("VMUX_TEST") };
-        assert_eq!(VibeStrategy.build_args(&mcp, None), vec!["--trust"]);
+        assert_eq!(
+            VibeStrategy.build_args(&mcp, None),
+            vec![
+                "--trust",
+                "--disabled-tools",
+                "web_search",
+                "--disabled-tools",
+                "web_fetch"
+            ]
+        );
         assert_eq!(
             VibeStrategy.build_args(&mcp, Some("sid-1")),
-            vec!["--trust", "--resume", "sid-1"]
+            vec![
+                "--trust",
+                "--disabled-tools",
+                "web_search",
+                "--disabled-tools",
+                "web_fetch",
+                "--resume",
+                "sid-1"
+            ]
         );
         unsafe { std::env::set_var("VMUX_TEST", "1") };
         assert!(
@@ -465,50 +449,14 @@ mod tests {
     }
 
     #[test]
-    fn disabled_tools_unions_web_tools_with_existing() {
-        let out = vibe_disabled_tools(vec!["bash".to_string()]);
-        assert!(out.contains(&"bash".to_string()));
-        assert!(out.contains(&"web_search".to_string()));
-        assert!(out.contains(&"web_fetch".to_string()));
-    }
-
-    #[test]
-    fn disabled_tools_dedups_when_web_tool_already_present() {
-        let out = vibe_disabled_tools(vec!["web_search".to_string()]);
-        assert_eq!(out.iter().filter(|t| *t == "web_search").count(), 1);
-    }
-
-    #[test]
-    fn parse_disabled_from_toml_reads_array() {
-        let toml = "disabled_tools = [\"bash\", \"foo\"]\nother = 1\n";
-        assert_eq!(
-            parse_disabled_tools_toml(toml),
-            vec!["bash".to_string(), "foo".to_string()]
-        );
-    }
-
-    #[test]
-    fn parse_disabled_from_toml_defaults_empty_when_absent_or_bad() {
-        assert!(parse_disabled_tools_toml("x = 1").is_empty());
-        assert!(parse_disabled_tools_toml("not = [valid").is_empty());
-    }
-
-    #[test]
-    fn build_env_sets_disabled_tools_json_array() {
+    fn build_env_does_not_override_disabled_tools() {
         let mcp = McpServerConfig {
             command: "vmux".to_string(),
             args: vec![],
             cwd: None,
         };
         let env = VibeStrategy.build_env(&mcp);
-        let val = env
-            .iter()
-            .find(|(k, _)| k == "VIBE_DISABLED_TOOLS")
-            .map(|(_, v)| v.clone())
-            .expect("VIBE_DISABLED_TOOLS present");
-        let parsed: Vec<String> = serde_json::from_str(&val).unwrap();
-        assert!(parsed.contains(&"web_search".to_string()));
-        assert!(parsed.contains(&"web_fetch".to_string()));
+        assert!(env.iter().all(|(key, _)| key != "VIBE_DISABLED_TOOLS"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/mcp.rs
+++ b/crates/vmux_agent/src/mcp.rs
@@ -20,7 +20,7 @@ pub fn resolve_acp(
 }
 
 fn acp_uses_native_terminals(agent_id: &str) -> bool {
-    !matches!(agent_id, "claude" | "codex")
+    !matches!(agent_id, "claude" | "codex" | "mistral-vibe" | "vibe")
 }
 
 fn resolve_inner(
@@ -123,6 +123,8 @@ mod tests {
     fn compatibility_acp_agents_keep_vmux_terminal_tools() {
         assert!(!acp_uses_native_terminals("codex"));
         assert!(!acp_uses_native_terminals("claude"));
+        assert!(!acp_uses_native_terminals("mistral-vibe"));
+        assert!(!acp_uses_native_terminals("vibe"));
         assert!(acp_uses_native_terminals("vibe-acp"));
     }
 

--- a/crates/vmux_service/Cargo.toml
+++ b/crates/vmux_service/Cargo.toml
@@ -45,6 +45,7 @@ vmux_service_client = { path = "../vmux_service_client" }
 vmux_wire = { path = "../vmux_wire" }
 agent-client-protocol = "1.0.1"
 tokio-util = { version = "0.7", features = ["compat"] }
+tempfile = "3.27.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 dioxus = { workspace = true }
@@ -59,7 +60,6 @@ objc2-service-management = "0.3"
 
 [dev-dependencies]
 serde_json = { workspace = true }
-tempfile = "3.27.0"
 tokio = { workspace = true, features = ["test-util", "macros", "rt"] }
 mockito = "1"
 serial_test = "3"

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -394,6 +394,7 @@ pub async fn run(
         cwd: shared.cwd.clone(),
         vibe_session_id: fs_session_id.clone(),
     };
+    let env = apply_vibe_mcp_env(&agent_id, env, &mcp_servers);
     let session_meta = session_meta_for_agent(&agent_id);
     let mut child = match Command::new(&command)
         .args(&args)
@@ -774,6 +775,61 @@ pub async fn run(
         )));
     }
     let _ = child.kill().await;
+}
+
+fn apply_vibe_mcp_env(
+    agent_id: &str,
+    mut env: Vec<(String, String)>,
+    mcp_servers: &[McpServer],
+) -> Vec<(String, String)> {
+    if !matches!(agent_id, "mistral-vibe" | "vibe") || mcp_servers.is_empty() {
+        return env;
+    }
+    let mut configured = env
+        .iter()
+        .rev()
+        .find(|(key, _)| key == "VIBE_MCP_SERVERS")
+        .and_then(
+            |(_, value)| match serde_json::from_str::<Vec<serde_json::Value>>(value) {
+                Ok(servers) => Some(servers),
+                Err(err) => {
+                    tracing::warn!("invalid VIBE_MCP_SERVERS JSON; discarding it: {err}");
+                    None
+                }
+            },
+        )
+        .unwrap_or_default();
+    for server in mcp_servers {
+        let McpServer::Stdio(server) = server else {
+            continue;
+        };
+        configured.retain(|existing| {
+            existing.get("name").and_then(serde_json::Value::as_str) != Some(&server.name)
+        });
+        let server_env: serde_json::Map<String, serde_json::Value> = server
+            .env
+            .iter()
+            .map(|var| {
+                (
+                    var.name.clone(),
+                    serde_json::Value::String(var.value.clone()),
+                )
+            })
+            .collect();
+        configured.push(serde_json::json!({
+            "name": server.name,
+            "transport": "stdio",
+            "command": server.command.to_string_lossy(),
+            "args": server.args,
+            "env": server_env,
+        }));
+    }
+    env.retain(|(key, _)| key != "VIBE_MCP_SERVERS");
+    env.push((
+        "VIBE_MCP_SERVERS".to_string(),
+        serde_json::to_string(&configured).unwrap(),
+    ));
+    env
 }
 
 fn acp_display_name(info: Option<&Implementation>) -> Option<String> {
@@ -1263,6 +1319,37 @@ mod tests {
             acp_display_name(Some(&named)).as_deref(),
             Some("claude-code-acp")
         );
+    }
+
+    #[test]
+    fn vibe_acp_injects_session_mcp_servers_into_vibe_config() {
+        let server = McpServer::Stdio(
+            agent_client_protocol::schema::v1::McpServerStdio::new("vmux", "/tmp/vmux")
+                .args(vec!["mcp".to_string(), "--profile".to_string()])
+                .env(vec![agent_client_protocol::schema::v1::EnvVariable::new(
+                    "VMUX_PROFILE",
+                    "dev",
+                )]),
+        );
+        let env = apply_vibe_mcp_env(
+            "mistral-vibe",
+            vec![(
+                "VIBE_MCP_SERVERS".to_string(),
+                r#"[{"name":"other","transport":"stdio","command":"other"}]"#.to_string(),
+            )],
+            &[server],
+        );
+        let value = env
+            .iter()
+            .find(|(key, _)| key == "VIBE_MCP_SERVERS")
+            .map(|(_, value)| serde_json::from_str::<serde_json::Value>(value).unwrap())
+            .unwrap();
+
+        assert_eq!(value[0]["name"], "other");
+        assert_eq!(value[1]["name"], "vmux");
+        assert_eq!(value[1]["command"], "/tmp/vmux");
+        assert_eq!(value[1]["args"], serde_json::json!(["mcp", "--profile"]));
+        assert_eq!(value[1]["env"]["VMUX_PROFILE"], "dev");
     }
 
     #[test]

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -70,6 +70,12 @@ pub struct AcpTerminal {
     pub output_byte_limit: Option<u64>,
 }
 
+#[derive(Clone)]
+struct AcpFsScope {
+    cwd: PathBuf,
+    vibe_session_id: Option<Arc<Mutex<Option<String>>>>,
+}
+
 /// State shared between the driver's request handlers and its prompt loop.
 pub struct AcpShared {
     pub sid: String,
@@ -382,6 +388,12 @@ pub async fn run(
     shared: Arc<AcpShared>,
     mut input_rx: mpsc::UnboundedReceiver<AcpInput>,
 ) {
+    let fs_session_id = matches!(agent_id.as_str(), "mistral-vibe" | "vibe")
+        .then(|| Arc::new(Mutex::new(resume.clone())));
+    let fs_scope = AcpFsScope {
+        cwd: shared.cwd.clone(),
+        vibe_session_id: fs_session_id.clone(),
+    };
     let session_meta = session_meta_for_agent(&agent_id);
     let mut child = match Command::new(&command)
         .args(&args)
@@ -413,8 +425,8 @@ pub async fn run(
     let wait_shared = shared.clone();
     let kill_shared = shared.clone();
     let release_shared = shared.clone();
-    let read_cwd = shared.cwd.clone();
-    let write_cwd = shared.cwd.clone();
+    let read_scope = fs_scope.clone();
+    let write_scope = fs_scope;
 
     let result = Client
         .builder()
@@ -454,7 +466,7 @@ pub async fn run(
             async move |req: ReadTextFileRequest,
                         responder: Responder<ReadTextFileResponse>,
                         _cx| {
-                match read_text_file(&read_cwd, &req) {
+                match read_text_file(&read_scope, &req) {
                     Ok(content) => responder.respond(ReadTextFileResponse::new(content)),
                     Err(err) => responder.respond_with_internal_error(err),
                 }
@@ -465,7 +477,7 @@ pub async fn run(
             async move |req: WriteTextFileRequest,
                         responder: Responder<WriteTextFileResponse>,
                         _cx| {
-                match write_text_file(&write_cwd, &req) {
+                match write_text_file(&write_scope, &req) {
                     Ok(()) => responder.respond(WriteTextFileResponse::new()),
                     Err(err) => responder.respond_with_internal_error(err),
                 }
@@ -571,6 +583,7 @@ pub async fn run(
                 main_shared.finish_history_replay(session_id.is_some());
             }
             if let Some(sid) = &session_id {
+                remember_acp_fs_session(&fs_session_id, sid);
                 main_shared.emit(ServiceMessage::AcpSessionCreated {
                     sid: main_shared.sid.clone(),
                     acp_session_id: sid.to_string(),
@@ -597,13 +610,15 @@ pub async fn run(
                 })
                 .await;
                 match ensured {
-                    Ok((sid, true)) => {
-                        main_shared.emit(ServiceMessage::AcpSessionCreated {
-                            sid: main_shared.sid.clone(),
-                            acp_session_id: sid.to_string(),
-                        });
+                    Ok((sid, created)) => {
+                        remember_acp_fs_session(&fs_session_id, &sid);
+                        if created {
+                            main_shared.emit(ServiceMessage::AcpSessionCreated {
+                                sid: main_shared.sid.clone(),
+                                acp_session_id: sid.to_string(),
+                            });
+                        }
                     }
-                    Ok(_) => {}
                     Err(err) => {
                         main_shared.emit_status(AgentRunStatus::Errored(format!(
                             "acp session/new failed: {err}"
@@ -653,6 +668,7 @@ pub async fn run(
                                 continue;
                             }
                         };
+                        remember_acp_fs_session(&fs_session_id, &active_session_id);
                         if created {
                             main_shared.emit(ServiceMessage::AcpSessionCreated {
                                 sid: main_shared.sid.clone(),
@@ -1128,6 +1144,61 @@ fn resolve_in_cwd(cwd: &std::path::Path, path: &std::path::Path) -> Option<PathB
     Some(abs)
 }
 
+fn remember_acp_fs_session(session: &Option<Arc<Mutex<Option<String>>>>, session_id: &SessionId) {
+    if let Some(session) = session {
+        *session.lock().unwrap() = Some(session_id.to_string());
+    }
+}
+
+fn resolve_acp_fs_path(scope: &AcpFsScope, path: &std::path::Path) -> Option<PathBuf> {
+    resolve_in_cwd(&scope.cwd, path).or_else(|| {
+        let session_id = scope.vibe_session_id.as_ref()?.lock().unwrap().clone()?;
+        resolve_vibe_scratchpad(&session_id, path)
+    })
+}
+
+fn resolve_vibe_scratchpad(session_id: &str, path: &std::path::Path) -> Option<PathBuf> {
+    if !path.is_absolute()
+        || path
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return None;
+    }
+    let short_id: String = session_id.chars().take(8).collect();
+    if short_id.len() != 8 {
+        return None;
+    }
+    let prefix = format!("vibe-scratchpad-{short_id}-");
+    let temp = std::env::temp_dir();
+    let real_temp = temp.canonicalize().ok()?;
+    for base in [&temp, &real_temp] {
+        let Ok(relative) = path.strip_prefix(base) else {
+            continue;
+        };
+        let Some(std::path::Component::Normal(root_name)) = relative.components().next() else {
+            continue;
+        };
+        let Some(root_name_str) = root_name.to_str() else {
+            continue;
+        };
+        if !root_name_str.starts_with(&prefix) || root_name_str.len() == prefix.len() {
+            continue;
+        }
+        let scratchpad = base.join(root_name);
+        let Ok(real_scratchpad) = scratchpad.canonicalize() else {
+            continue;
+        };
+        if !real_scratchpad.starts_with(&real_temp) {
+            continue;
+        }
+        if let Some(path) = resolve_in_cwd(&scratchpad, path) {
+            return Some(path);
+        }
+    }
+    None
+}
+
 fn slice_lines(text: &str, line: Option<u32>, limit: Option<u32>) -> String {
     if line.is_none() && limit.is_none() {
         return text.to_string();
@@ -1140,15 +1211,15 @@ fn slice_lines(text: &str, line: Option<u32>, limit: Option<u32>) -> String {
     lines.get(start..end).unwrap_or(&[]).join("\n")
 }
 
-fn read_text_file(cwd: &std::path::Path, req: &ReadTextFileRequest) -> Result<String, String> {
-    let path = resolve_in_cwd(cwd, &req.path).ok_or("path outside session cwd")?;
+fn read_text_file(scope: &AcpFsScope, req: &ReadTextFileRequest) -> Result<String, String> {
+    let path = resolve_acp_fs_path(scope, &req.path).ok_or("path outside session cwd")?;
     let text =
         std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
     Ok(slice_lines(&text, req.line, req.limit))
 }
 
-fn write_text_file(cwd: &std::path::Path, req: &WriteTextFileRequest) -> Result<(), String> {
-    let path = resolve_in_cwd(cwd, &req.path).ok_or("path outside session cwd")?;
+fn write_text_file(scope: &AcpFsScope, req: &WriteTextFileRequest) -> Result<(), String> {
+    let path = resolve_acp_fs_path(scope, &req.path).ok_or("path outside session cwd")?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
     }
@@ -1716,6 +1787,38 @@ mod tests {
         );
         assert!(resolve_in_cwd(cwd, std::path::Path::new("/etc/passwd")).is_none());
         assert!(resolve_in_cwd(cwd, std::path::Path::new("/work/../etc/passwd")).is_none());
+    }
+
+    #[test]
+    fn vibe_fs_scope_allows_only_current_session_scratchpad() {
+        let scratchpad =
+            std::env::temp_dir().join(format!("vibe-scratchpad-deadbeef-{}", std::process::id()));
+        std::fs::create_dir_all(&scratchpad).unwrap();
+        let scope = AcpFsScope {
+            cwd: PathBuf::from("/work"),
+            vibe_session_id: Some(Arc::new(Mutex::new(Some(
+                "deadbeef-0000-0000-0000-000000000000".to_string(),
+            )))),
+        };
+
+        assert!(resolve_acp_fs_path(&scope, &scratchpad.join("test.nu")).is_some());
+        assert!(
+            resolve_acp_fs_path(
+                &scope,
+                &scratchpad.canonicalize().unwrap().join("canonical.nu")
+            )
+            .is_some()
+        );
+        assert!(
+            resolve_acp_fs_path(
+                &scope,
+                &std::env::temp_dir().join("vibe-scratchpad-cafebabe-x/test.nu")
+            )
+            .is_none()
+        );
+        assert!(resolve_acp_fs_path(&scope, std::path::Path::new("/etc/passwd")).is_none());
+
+        std::fs::remove_dir_all(scratchpad).unwrap();
     }
 
     #[test]

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -73,7 +73,40 @@ pub struct AcpTerminal {
 #[derive(Clone)]
 struct AcpFsScope {
     cwd: PathBuf,
-    vibe_session_id: Option<Arc<Mutex<Option<String>>>>,
+    vibe_temp_root: Option<PathBuf>,
+}
+
+struct VibeTempRoot(tempfile::TempDir);
+
+impl VibeTempRoot {
+    fn create(agent_id: &str) -> std::io::Result<Option<Self>> {
+        if !matches!(agent_id, "mistral-vibe" | "vibe") {
+            return Ok(None);
+        }
+        tempfile::Builder::new()
+            .prefix("vmux-vibe-")
+            .tempdir()
+            .map(Self)
+            .map(Some)
+    }
+
+    fn path(&self) -> &std::path::Path {
+        self.0.path()
+    }
+
+    fn apply_env(&self, mut env: Vec<(String, String)>) -> Vec<(String, String)> {
+        env.retain(|(key, _)| key != "TMPDIR");
+        env.push((
+            "TMPDIR".to_string(),
+            self.path().to_string_lossy().into_owned(),
+        ));
+        env
+    }
+
+    async fn cleanup(self) {
+        let path = self.0.keep();
+        let _ = tokio::task::spawn_blocking(move || std::fs::remove_dir_all(path)).await;
+    }
 }
 
 /// State shared between the driver's request handlers and its prompt loop.
@@ -388,13 +421,26 @@ pub async fn run(
     shared: Arc<AcpShared>,
     mut input_rx: mpsc::UnboundedReceiver<AcpInput>,
 ) {
-    let fs_session_id = matches!(agent_id.as_str(), "mistral-vibe" | "vibe")
-        .then(|| Arc::new(Mutex::new(resume.clone())));
+    let vibe_temp_root = match VibeTempRoot::create(&agent_id) {
+        Ok(root) => root,
+        Err(err) => {
+            shared.emit_status(AgentRunStatus::Errored(format!(
+                "vibe temp directory failed: {err}"
+            )));
+            return;
+        }
+    };
     let fs_scope = AcpFsScope {
         cwd: shared.cwd.clone(),
-        vibe_session_id: fs_session_id.clone(),
+        vibe_temp_root: vibe_temp_root
+            .as_ref()
+            .map(|root| root.path().to_path_buf()),
     };
     let env = apply_vibe_mcp_env(&agent_id, env, &mcp_servers);
+    let env = match &vibe_temp_root {
+        Some(root) => root.apply_env(env),
+        None => env,
+    };
     let session_meta = session_meta_for_agent(&agent_id);
     let mut child = match Command::new(&command)
         .args(&args)
@@ -584,7 +630,6 @@ pub async fn run(
                 main_shared.finish_history_replay(session_id.is_some());
             }
             if let Some(sid) = &session_id {
-                remember_acp_fs_session(&fs_session_id, sid);
                 main_shared.emit(ServiceMessage::AcpSessionCreated {
                     sid: main_shared.sid.clone(),
                     acp_session_id: sid.to_string(),
@@ -612,7 +657,6 @@ pub async fn run(
                 .await;
                 match ensured {
                     Ok((sid, created)) => {
-                        remember_acp_fs_session(&fs_session_id, &sid);
                         if created {
                             main_shared.emit(ServiceMessage::AcpSessionCreated {
                                 sid: main_shared.sid.clone(),
@@ -669,7 +713,6 @@ pub async fn run(
                                 continue;
                             }
                         };
-                        remember_acp_fs_session(&fs_session_id, &active_session_id);
                         if created {
                             main_shared.emit(ServiceMessage::AcpSessionCreated {
                                 sid: main_shared.sid.clone(),
@@ -775,6 +818,9 @@ pub async fn run(
         )));
     }
     let _ = child.kill().await;
+    if let Some(root) = vibe_temp_root {
+        root.cleanup().await;
+    }
 }
 
 fn apply_vibe_mcp_env(
@@ -1200,20 +1246,12 @@ fn resolve_in_cwd(cwd: &std::path::Path, path: &std::path::Path) -> Option<PathB
     Some(abs)
 }
 
-fn remember_acp_fs_session(session: &Option<Arc<Mutex<Option<String>>>>, session_id: &SessionId) {
-    if let Some(session) = session {
-        *session.lock().unwrap() = Some(session_id.to_string());
-    }
-}
-
 fn resolve_acp_fs_path(scope: &AcpFsScope, path: &std::path::Path) -> Option<PathBuf> {
-    resolve_in_cwd(&scope.cwd, path).or_else(|| {
-        let session_id = scope.vibe_session_id.as_ref()?.lock().unwrap().clone()?;
-        resolve_vibe_scratchpad(&session_id, path)
-    })
+    resolve_in_cwd(&scope.cwd, path)
+        .or_else(|| resolve_vibe_scratchpad(scope.vibe_temp_root.as_ref()?, path))
 }
 
-fn resolve_vibe_scratchpad(session_id: &str, path: &std::path::Path) -> Option<PathBuf> {
+fn resolve_vibe_scratchpad(temp_root: &std::path::Path, path: &std::path::Path) -> Option<PathBuf> {
     if !path.is_absolute()
         || path
             .components()
@@ -1221,14 +1259,9 @@ fn resolve_vibe_scratchpad(session_id: &str, path: &std::path::Path) -> Option<P
     {
         return None;
     }
-    let short_id: String = session_id.chars().take(8).collect();
-    if short_id.len() != 8 {
-        return None;
-    }
-    let prefix = format!("vibe-scratchpad-{short_id}-");
-    let temp = std::env::temp_dir();
-    let real_temp = temp.canonicalize().ok()?;
-    for base in [&temp, &real_temp] {
+    let prefix = "vibe-scratchpad-";
+    let real_temp = temp_root.canonicalize().ok()?;
+    for base in [temp_root, real_temp.as_path()] {
         let Ok(relative) = path.strip_prefix(base) else {
             continue;
         };
@@ -1238,7 +1271,7 @@ fn resolve_vibe_scratchpad(session_id: &str, path: &std::path::Path) -> Option<P
         let Some(root_name_str) = root_name.to_str() else {
             continue;
         };
-        if !root_name_str.starts_with(&prefix) || root_name_str.len() == prefix.len() {
+        if !root_name_str.starts_with(prefix) || root_name_str.len() == prefix.len() {
             continue;
         }
         let scratchpad = base.join(root_name);
@@ -1246,6 +1279,13 @@ fn resolve_vibe_scratchpad(session_id: &str, path: &std::path::Path) -> Option<P
             continue;
         };
         if !real_scratchpad.starts_with(&real_temp) {
+            continue;
+        }
+        let Some(real_root_name) = real_scratchpad.file_name().and_then(|name| name.to_str())
+        else {
+            continue;
+        };
+        if !real_root_name.starts_with(prefix) || real_root_name.len() == prefix.len() {
             continue;
         }
         if let Some(path) = resolve_in_cwd(&scratchpad, path) {
@@ -1350,6 +1390,29 @@ mod tests {
         assert_eq!(value[1]["command"], "/tmp/vmux");
         assert_eq!(value[1]["args"], serde_json::json!(["mcp", "--profile"]));
         assert_eq!(value[1]["env"]["VMUX_PROFILE"], "dev");
+    }
+
+    #[test]
+    fn vibe_temp_root_overrides_child_tmpdir() {
+        let root = VibeTempRoot::create("mistral-vibe").unwrap().unwrap();
+        let env = root.apply_env(vec![
+            ("TMPDIR".to_string(), "/old".to_string()),
+            ("HOME".to_string(), "/home/test".to_string()),
+        ]);
+        let expected = root.path().to_string_lossy().into_owned();
+
+        assert_eq!(
+            env.iter()
+                .filter(|(key, _)| key == "TMPDIR")
+                .map(|(_, value)| value.as_str())
+                .collect::<Vec<_>>(),
+            vec![expected.as_str()]
+        );
+        assert!(
+            env.iter()
+                .any(|(key, value)| key == "HOME" && value == "/home/test")
+        );
+        assert!(VibeTempRoot::create("codex").unwrap().is_none());
     }
 
     #[test]
@@ -1877,15 +1940,13 @@ mod tests {
     }
 
     #[test]
-    fn vibe_fs_scope_allows_only_current_session_scratchpad() {
-        let scratchpad =
-            std::env::temp_dir().join(format!("vibe-scratchpad-deadbeef-{}", std::process::id()));
+    fn vibe_fs_scope_allows_only_process_temp_root() {
+        let temp_root = tempfile::tempdir().unwrap();
+        let scratchpad = temp_root.path().join("vibe-scratchpad-cafebabe-runtime");
         std::fs::create_dir_all(&scratchpad).unwrap();
         let scope = AcpFsScope {
             cwd: PathBuf::from("/work"),
-            vibe_session_id: Some(Arc::new(Mutex::new(Some(
-                "deadbeef-0000-0000-0000-000000000000".to_string(),
-            )))),
+            vibe_temp_root: Some(temp_root.path().to_path_buf()),
         };
 
         assert!(resolve_acp_fs_path(&scope, &scratchpad.join("test.nu")).is_some());
@@ -1899,13 +1960,29 @@ mod tests {
         assert!(
             resolve_acp_fs_path(
                 &scope,
-                &std::env::temp_dir().join("vibe-scratchpad-cafebabe-x/test.nu")
+                &std::env::temp_dir().join("vibe-scratchpad-deadbeef-foreign/test.nu")
             )
             .is_none()
         );
         assert!(resolve_acp_fs_path(&scope, std::path::Path::new("/etc/passwd")).is_none());
+    }
 
-        std::fs::remove_dir_all(scratchpad).unwrap();
+    #[cfg(unix)]
+    #[test]
+    fn vibe_fs_scope_rejects_scratchpad_symlink_outside_process_root() {
+        use std::os::unix::fs::symlink;
+
+        let temp_root = tempfile::tempdir().unwrap();
+        let foreign_root = tempfile::tempdir().unwrap();
+        let target = foreign_root.path().join("vibe-scratchpad-cafebabe-target");
+        let alias = temp_root.path().join("vibe-scratchpad-deadbeef-alias");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("secret.nu"), "secret").unwrap();
+        symlink(&target, &alias).unwrap();
+
+        assert!(resolve_vibe_scratchpad(temp_root.path(), &alias.join("secret.nu")).is_none());
+
+        std::fs::remove_file(alias).unwrap();
     }
 
     #[test]

--- a/crates/vmux_ui/src/favicon.rs
+++ b/crates/vmux_ui/src/favicon.rs
@@ -16,6 +16,7 @@ pub fn host_for_favicon_fallback(page_url: &str) -> Option<&str> {
 pub fn agent_host(url: &str) -> Option<&'static str> {
     const AGENTS: &[(&str, &str)] = &[
         ("vibe", "chat.mistral.ai"),
+        ("mistral-vibe", "chat.mistral.ai"),
         ("claude", "claude.ai"),
         ("codex", "chatgpt.com"),
         ("gemini", "gemini.google.com"),
@@ -160,6 +161,10 @@ mod tests {
         );
         assert_eq!(
             agent_host("vmux://agent/vibe/cli/abc"),
+            Some("chat.mistral.ai")
+        );
+        assert_eq!(
+            agent_host("vmux://agent/mistral-vibe/session-1"),
             Some("chat.mistral.ai")
         );
     }


### PR DESCRIPTION
## Context

Vibe 2.20.0 supports repeatable disabled-tool CLI arguments, so vmux no longer needs to reconstruct CLI tool settings from the user config. Vibe ACP also selected its native Bash adapter, which sent full shell commands through ACP terminal/create as executable names and failed before opening a usable terminal.

## Implementation

Pass CLI web-tool exclusions through --disabled-tools while leaving user config untouched. For Vibe ACP, preserve configured exclusions and disable native Bash so shell work routes through the vmux MCP run tool. Recognize the mistral-vibe ACP URL as the Vibe brand so startup avatars and page tabs resolve the Mistral favicon.

## Checks / QA

- Launch Vibe CLI and confirm user-configured tools remain available while web_search and web_fetch are unavailable.
- Launch Mistral Vibe ACP, request a shell command, and confirm it opens through the vmux run terminal.
- Confirm the Mistral favicon appears in the ACP startup card and page tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compatibility for Vibe and Mistral Vibe agents, including MCP server configuration and tool controls.
  * Improved session isolation for Vibe file access using dedicated scratchpad areas.
  * Added support for recognizing Mistral Vibe agent links.
* **Improvements**
  * Vibe agents now use compatible terminal handling.
  * Only the latest assistant “Thinking” section expands automatically.
  * Web search and web fetch tools are disabled by default for Vibe sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->