### PR TITLE
feat(agent): nest tool output under activity calls

### DIFF
--- a/crates/vmux_agent/src/chat_page/composer.rs
+++ b/crates/vmux_agent/src/chat_page/composer.rs
@@ -1,5 +1,6 @@
 use super::event::{
     ChatBlock, ChatItem, ModelOptionEntry, ResumableSessionEntry, SlashCommandEntry,
+    is_guardian_tool,
 };
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -210,13 +211,7 @@ fn streaming_title_emoji(items: &[ChatItem]) -> &'static str {
 
 pub(crate) fn tool_activity(name: &str) -> ToolActivity {
     let lower = name.to_ascii_lowercase();
-    if lower.contains("guardian")
-        || lower.contains("approval")
-        || lower == "review"
-        || lower.ends_with("_review")
-        || lower.ends_with(".review")
-        || lower.ends_with(":review")
-    {
+    if is_guardian_tool(name) {
         ToolActivity::Guardian
     } else if lower.contains("read_file") || lower.contains("read file") {
         ToolActivity::ReadFile

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -388,6 +388,36 @@ pub struct ChatTurn {
     pub step_count: u32,
 }
 
+impl ChatTurn {
+    #[cfg(any(test, target_arch = "wasm32"))]
+    pub(crate) fn tool_result(&self, call_id: &str) -> Option<(&str, bool)> {
+        if call_id.is_empty() {
+            return None;
+        }
+        self.blocks.iter().find_map(|block| match block {
+            ChatBlock::ToolResult {
+                call_id: result_call_id,
+                content,
+                is_error,
+            } if result_call_id == call_id => Some((content.as_str(), *is_error)),
+            _ => None,
+        })
+    }
+
+    pub(crate) fn has_tool_use(&self, call_id: &str) -> bool {
+        !call_id.is_empty()
+            && self.blocks.iter().any(|block| {
+                matches!(
+                    block,
+                    ChatBlock::ToolUse {
+                        call_id: tool_call_id,
+                        ..
+                    } if tool_call_id == call_id
+                )
+            })
+    }
+}
+
 /// The curated verbs the running-turn header cycles through (owned by the shared contract, not
 /// the view). The page picks one at random every few seconds while streaming.
 pub const WORKING_VERBS: &[&str] = &[
@@ -492,6 +522,57 @@ mod tests {
     #[test]
     fn working_verbs_nonempty() {
         assert!(!WORKING_VERBS.is_empty());
+    }
+
+    #[test]
+    fn tool_results_associate_by_call_id() {
+        let turn = ChatTurn {
+            blocks: vec![
+                ChatBlock::ToolUse {
+                    call_id: "read-1".into(),
+                    name: "read_file".into(),
+                    args: "{}".into(),
+                },
+                ChatBlock::ToolUse {
+                    call_id: "review-1".into(),
+                    name: "guardian_review".into(),
+                    args: "{}".into(),
+                },
+                ChatBlock::ToolResult {
+                    call_id: "read-1".into(),
+                    content: "file contents".into(),
+                    is_error: false,
+                },
+            ],
+            ..Default::default()
+        };
+
+        assert_eq!(turn.tool_result("read-1"), Some(("file contents", false)));
+        assert_eq!(turn.tool_result("review-1"), None);
+        assert!(turn.has_tool_use("read-1"));
+        assert!(!turn.has_tool_use("missing"));
+    }
+
+    #[test]
+    fn empty_call_ids_do_not_associate() {
+        let turn = ChatTurn {
+            blocks: vec![
+                ChatBlock::ToolUse {
+                    call_id: String::new(),
+                    name: "read_file".into(),
+                    args: "{}".into(),
+                },
+                ChatBlock::ToolResult {
+                    call_id: String::new(),
+                    content: "file contents".into(),
+                    is_error: false,
+                },
+            ],
+            ..Default::default()
+        };
+
+        assert_eq!(turn.tool_result(""), None);
+        assert!(!turn.has_tool_use(""));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -388,33 +388,52 @@ pub struct ChatTurn {
     pub step_count: u32,
 }
 
+pub(crate) fn is_guardian_tool(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    lower.contains("guardian")
+        || lower.contains("approval")
+        || lower == "review"
+        || lower.ends_with("_review")
+        || lower.ends_with(".review")
+        || lower.ends_with(":review")
+}
+
 impl ChatTurn {
-    #[cfg(any(test, target_arch = "wasm32"))]
-    pub(crate) fn tool_result(&self, call_id: &str) -> Option<(&str, bool)> {
-        if call_id.is_empty() {
-            return None;
-        }
-        self.blocks.iter().find_map(|block| match block {
-            ChatBlock::ToolResult {
-                call_id: result_call_id,
-                content,
-                is_error,
-            } if result_call_id == call_id => Some((content.as_str(), *is_error)),
+    pub(crate) fn parent_tool_index(&self, index: usize) -> Option<usize> {
+        match self.blocks.get(index)? {
+            ChatBlock::ToolUse { name, .. } if is_guardian_tool(name) => {
+                self.guardian_parent_index(index)
+            }
+            ChatBlock::ToolResult { call_id, .. } if !call_id.is_empty() => {
+                let tool_index = self.blocks.iter().position(|block| {
+                    matches!(
+                        block,
+                        ChatBlock::ToolUse {
+                            call_id: tool_call_id,
+                            ..
+                        } if tool_call_id == call_id
+                    )
+                })?;
+                match &self.blocks[tool_index] {
+                    ChatBlock::ToolUse { name, .. } if is_guardian_tool(name) => {
+                        self.guardian_parent_index(tool_index).or(Some(tool_index))
+                    }
+                    _ => Some(tool_index),
+                }
+            }
             _ => None,
-        })
+        }
     }
 
-    pub(crate) fn has_tool_use(&self, call_id: &str) -> bool {
-        !call_id.is_empty()
-            && self.blocks.iter().any(|block| {
-                matches!(
-                    block,
-                    ChatBlock::ToolUse {
-                        call_id: tool_call_id,
-                        ..
-                    } if tool_call_id == call_id
-                )
-            })
+    fn guardian_parent_index(&self, index: usize) -> Option<usize> {
+        for (candidate, block) in self.blocks[..index].iter().enumerate().rev() {
+            match block {
+                ChatBlock::ToolUse { name, .. } if is_guardian_tool(name) => {}
+                ChatBlock::ToolUse { .. } => return Some(candidate),
+                _ => return None,
+            }
+        }
+        None
     }
 }
 
@@ -525,7 +544,7 @@ mod tests {
     }
 
     #[test]
-    fn tool_results_associate_by_call_id() {
+    fn tool_children_associate_with_their_parent_call() {
         let turn = ChatTurn {
             blocks: vec![
                 ChatBlock::ToolUse {
@@ -543,14 +562,19 @@ mod tests {
                     content: "file contents".into(),
                     is_error: false,
                 },
+                ChatBlock::ToolResult {
+                    call_id: "review-1".into(),
+                    content: "review complete".into(),
+                    is_error: false,
+                },
             ],
             ..Default::default()
         };
 
-        assert_eq!(turn.tool_result("read-1"), Some(("file contents", false)));
-        assert_eq!(turn.tool_result("review-1"), None);
-        assert!(turn.has_tool_use("read-1"));
-        assert!(!turn.has_tool_use("missing"));
+        assert_eq!(turn.parent_tool_index(0), None);
+        assert_eq!(turn.parent_tool_index(1), Some(0));
+        assert_eq!(turn.parent_tool_index(2), Some(0));
+        assert_eq!(turn.parent_tool_index(3), Some(0));
     }
 
     #[test]
@@ -571,8 +595,30 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(turn.tool_result(""), None);
-        assert!(!turn.has_tool_use(""));
+        assert_eq!(turn.parent_tool_index(0), None);
+        assert_eq!(turn.parent_tool_index(1), None);
+    }
+
+    #[test]
+    fn standalone_guardian_owns_its_result() {
+        let turn = ChatTurn {
+            blocks: vec![
+                ChatBlock::ToolUse {
+                    call_id: "review-1".into(),
+                    name: "guardian_review".into(),
+                    args: "{}".into(),
+                },
+                ChatBlock::ToolResult {
+                    call_id: "review-1".into(),
+                    content: "review complete".into(),
+                    is_error: false,
+                },
+            ],
+            ..Default::default()
+        };
+
+        assert_eq!(turn.parent_tool_index(0), None);
+        assert_eq!(turn.parent_tool_index(1), Some(0));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -957,10 +957,20 @@ fn render_item(key: usize, item: &ChatItem, verb: &str, elapsed: u32) -> Element
 
 fn render_turn(key: usize, turn: &ChatTurn, verb: &str, elapsed: u32) -> Element {
     let reconnecting = matches!(turn.blocks.last(), Some(ChatBlock::Reconnect { .. }));
+    let blocks = turn
+        .blocks
+        .iter()
+        .enumerate()
+        .filter_map(|(key, block)| match block {
+            ChatBlock::ToolResult { call_id, .. } if turn.has_tool_use(call_id) => None,
+            ChatBlock::ToolUse { call_id, .. } => Some((key, block, turn.tool_result(call_id))),
+            _ => Some((key, block, None)),
+        })
+        .collect::<Vec<_>>();
     rsx! {
         div { key: "{key}", class: "flex max-w-[90%] flex-col gap-2.5 self-start",
-            for (j , block) in turn.blocks.iter().enumerate() {
-                {render_block(j, block)}
+            for (j , block , tool_result) in blocks {
+                {render_block(j, block, tool_result)}
             }
             if turn.running && !reconnecting {
                 {render_working(verb, elapsed)}
@@ -1031,11 +1041,9 @@ fn render_activity_icon(kind: ActivityIcon) -> Element {
             "m12 3-1.9 5.8a2 2 0 0 1-1.3 1.3L3 12l5.8 1.9a2 2 0 0 1 1.3 1.3L12 21l1.9-5.8a2 2 0 0 1 1.3-1.3L21 12l-5.8-1.9a2 2 0 0 1-1.3-1.3Z",
         ],
         ActivityIcon::ReadFile => &[
-            "M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z",
-            "M14 2v4a2 2 0 0 0 2 2h4",
-            "M16 13H8",
-            "M16 17H8",
-            "M10 9H8",
+            "M12 7v14",
+            "M3 18a1 1 0 0 1-1-1V5a2 2 0 0 1 2-2h5a3 3 0 0 1 3 3v15a3 3 0 0 0-3-3Z",
+            "M21 18a1 1 0 0 0 1-1V5a2 2 0 0 0-2-2h-5a3 3 0 0 0-3 3v15a3 3 0 0 1 3-3Z",
         ],
         ActivityIcon::Search => &["M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z", "m21 21-4.35-4.35"],
         ActivityIcon::Image => &[
@@ -1125,7 +1133,7 @@ fn tool_presentation(name: &str) -> (ActivityIcon, Cow<'static, str>) {
     }
 }
 
-fn render_block(key: usize, block: &ChatBlock) -> Element {
+fn render_block(key: usize, block: &ChatBlock, tool_result: Option<(&str, bool)>) -> Element {
     match block {
         ChatBlock::Text(text) => rsx! {
             div {
@@ -1151,14 +1159,19 @@ fn render_block(key: usize, block: &ChatBlock) -> Element {
             rsx! {
                 div { key: "{key}", class: "grid grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-2.5 py-1",
                     {render_activity_icon(icon)}
-                    details { class: "disclosure min-w-0 text-sm text-muted-foreground",
-                        summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
-                            span { class: "font-medium", "{label}" }
-                            {render_disclosure_icon()}
+                    div { class: "min-w-0",
+                        details { class: "disclosure text-sm text-muted-foreground",
+                            summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
+                                span { class: "font-medium", "{label}" }
+                                {render_disclosure_icon()}
+                            }
+                            div { class: "mt-1 text-[11px] font-medium text-foreground/45", "{name}" }
+                            if !args.is_empty() && args != "{}" {
+                                pre { class: "mt-1.5 max-h-56 overflow-auto whitespace-pre-wrap rounded-lg bg-foreground/[0.04] p-2 font-mono text-[11px] text-muted-foreground ring-1 ring-inset ring-foreground/10", "{args}" }
+                            }
                         }
-                        div { class: "mt-1 text-[11px] font-medium text-foreground/45", "{name}" }
-                        if !args.is_empty() && args != "{}" {
-                            pre { class: "mt-1.5 max-h-56 overflow-auto whitespace-pre-wrap rounded-lg bg-foreground/[0.04] p-2 font-mono text-[11px] text-muted-foreground ring-1 ring-inset ring-foreground/10", "{args}" }
+                        if let Some((content, is_error)) = tool_result {
+                            {render_nested_tool_result(content, is_error)}
                         }
                     }
                 }
@@ -1232,37 +1245,57 @@ fn render_block(key: usize, block: &ChatBlock) -> Element {
         }
         ChatBlock::ToolResult {
             content, is_error, ..
-        } => {
-            let tone = if *is_error {
-                "text-red-500"
-            } else {
-                "text-muted-foreground"
-            };
-            let label = if *is_error { "Error" } else { "Output" };
-            let icon = if *is_error {
-                ActivityIcon::Error
-            } else {
-                ActivityIcon::Output
-            };
-            rsx! {
-                div { key: "{key}", class: "grid grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-2.5 py-1",
-                    {render_activity_icon(icon)}
-                    details { class: "disclosure min-w-0 text-sm {tone}",
-                        summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
-                            span { class: "font-medium", "{label}" }
-                            {render_disclosure_icon()}
-                        }
-                        pre { class: "mt-1.5 max-h-72 overflow-auto whitespace-pre-wrap rounded-lg bg-foreground/[0.04] p-2 font-mono text-[11px] text-muted-foreground ring-1 ring-inset ring-foreground/10", "{content}" }
-                    }
-                }
-            }
-        }
+        } => render_standalone_tool_result(key, content, *is_error),
         ChatBlock::Reconnect { attempt, total } => rsx! {
             div { key: "{key}", class: "grid grid-cols-[1.25rem_minmax(0,1fr)] items-center gap-2.5 py-1 text-sm text-muted-foreground",
                 {render_activity_icon(ActivityIcon::Reconnect)}
                 span { class: "font-medium tabular-nums", "Reconnecting {attempt}/{total}" }
             }
         },
+    }
+}
+
+fn render_nested_tool_result(content: &str, is_error: bool) -> Element {
+    let tone = if is_error {
+        "text-red-500"
+    } else {
+        "text-muted-foreground"
+    };
+    let label = if is_error { "Error" } else { "Output" };
+    rsx! {
+        details { class: "disclosure ml-0.5 mt-1.5 border-l border-foreground/15 pl-3 text-xs {tone}",
+            summary { class: "flex cursor-pointer select-none items-center gap-2 py-0.5 list-none [&::-webkit-details-marker]:hidden",
+                span { class: "font-medium", "{label}" }
+                {render_disclosure_icon()}
+            }
+            pre { class: "mt-1.5 max-h-72 overflow-auto whitespace-pre-wrap rounded-lg bg-foreground/[0.04] p-2 font-mono text-[11px] text-muted-foreground ring-1 ring-inset ring-foreground/10", "{content}" }
+        }
+    }
+}
+
+fn render_standalone_tool_result(key: usize, content: &str, is_error: bool) -> Element {
+    let tone = if is_error {
+        "text-red-500"
+    } else {
+        "text-muted-foreground"
+    };
+    let label = if is_error { "Error" } else { "Output" };
+    let icon = if is_error {
+        ActivityIcon::Error
+    } else {
+        ActivityIcon::Output
+    };
+    rsx! {
+        div { key: "{key}", class: "grid grid-cols-[1.25rem_minmax(0,1fr)] items-start gap-2.5 py-1",
+            {render_activity_icon(icon)}
+            details { class: "disclosure min-w-0 text-sm {tone}",
+                summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
+                    span { class: "font-medium", "{label}" }
+                    {render_disclosure_icon()}
+                }
+                pre { class: "mt-1.5 max-h-72 overflow-auto whitespace-pre-wrap rounded-lg bg-foreground/[0.04] p-2 font-mono text-[11px] text-muted-foreground ring-1 ring-inset ring-foreground/10", "{content}" }
+            }
+        }
     }
 }
 

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -961,16 +961,23 @@ fn render_turn(key: usize, turn: &ChatTurn, verb: &str, elapsed: u32) -> Element
         .blocks
         .iter()
         .enumerate()
-        .filter_map(|(key, block)| match block {
-            ChatBlock::ToolResult { call_id, .. } if turn.has_tool_use(call_id) => None,
-            ChatBlock::ToolUse { call_id, .. } => Some((key, block, turn.tool_result(call_id))),
-            _ => Some((key, block, None)),
+        .filter_map(|(key, block)| {
+            if turn.parent_tool_index(key).is_some() {
+                return None;
+            }
+            let children = turn
+                .blocks
+                .iter()
+                .enumerate()
+                .filter(|(child_key, _)| turn.parent_tool_index(*child_key) == Some(key))
+                .collect::<Vec<_>>();
+            Some((key, block, children))
         })
         .collect::<Vec<_>>();
     rsx! {
         div { key: "{key}", class: "flex max-w-[90%] flex-col gap-2.5 self-start",
-            for (j , block , tool_result) in blocks {
-                {render_block(j, block, tool_result)}
+            for (j , block , children) in blocks {
+                {render_block(j, block, &children)}
             }
             if turn.running && !reconnecting {
                 {render_working(verb, elapsed)}
@@ -1133,7 +1140,7 @@ fn tool_presentation(name: &str) -> (ActivityIcon, Cow<'static, str>) {
     }
 }
 
-fn render_block(key: usize, block: &ChatBlock, tool_result: Option<(&str, bool)>) -> Element {
+fn render_block(key: usize, block: &ChatBlock, children: &[(usize, &ChatBlock)]) -> Element {
     match block {
         ChatBlock::Text(text) => rsx! {
             div {
@@ -1170,8 +1177,12 @@ fn render_block(key: usize, block: &ChatBlock, tool_result: Option<(&str, bool)>
                                 pre { class: "mt-1.5 max-h-56 overflow-auto whitespace-pre-wrap rounded-lg bg-foreground/[0.04] p-2 font-mono text-[11px] text-muted-foreground ring-1 ring-inset ring-foreground/10", "{args}" }
                             }
                         }
-                        if let Some((content, is_error)) = tool_result {
-                            {render_nested_tool_result(content, is_error)}
+                        if !children.is_empty() {
+                            div { class: "ml-0.5 mt-1.5 flex flex-col gap-1 border-l border-foreground/15 pl-3",
+                                for (child_key , child) in children {
+                                    {render_tool_child(*child_key, child)}
+                                }
+                            }
                         }
                     }
                 }
@@ -1255,7 +1266,31 @@ fn render_block(key: usize, block: &ChatBlock, tool_result: Option<(&str, bool)>
     }
 }
 
-fn render_nested_tool_result(content: &str, is_error: bool) -> Element {
+fn render_tool_child(key: usize, block: &ChatBlock) -> Element {
+    match block {
+        ChatBlock::ToolUse { name, args, .. } => {
+            let (_, label) = tool_presentation(name);
+            rsx! {
+                details { key: "{key}", class: "disclosure text-xs text-muted-foreground",
+                    summary { class: "flex cursor-pointer select-none items-center gap-2 py-0.5 list-none [&::-webkit-details-marker]:hidden",
+                        span { class: "font-medium", "{label}" }
+                        {render_disclosure_icon()}
+                    }
+                    div { class: "mt-1 text-[11px] font-medium text-foreground/45", "{name}" }
+                    if !args.is_empty() && args != "{}" {
+                        pre { class: "mt-1.5 max-h-56 overflow-auto whitespace-pre-wrap rounded-lg bg-foreground/[0.04] p-2 font-mono text-[11px] text-muted-foreground ring-1 ring-inset ring-foreground/10", "{args}" }
+                    }
+                }
+            }
+        }
+        ChatBlock::ToolResult {
+            content, is_error, ..
+        } => render_nested_tool_result(key, content, *is_error),
+        _ => rsx! {},
+    }
+}
+
+fn render_nested_tool_result(key: usize, content: &str, is_error: bool) -> Element {
     let tone = if is_error {
         "text-red-500"
     } else {
@@ -1263,7 +1298,7 @@ fn render_nested_tool_result(content: &str, is_error: bool) -> Element {
     };
     let label = if is_error { "Error" } else { "Output" };
     rsx! {
-        details { class: "disclosure ml-0.5 mt-1.5 border-l border-foreground/15 pl-3 text-xs {tone}",
+        details { key: "{key}", class: "disclosure text-xs {tone}",
             summary { class: "flex cursor-pointer select-none items-center gap-2 py-0.5 list-none [&::-webkit-details-marker]:hidden",
                 span { class: "font-medium", "{label}" }
                 {render_disclosure_icon()}

--- a/crates/vmux_agent/src/chat_page/turns.rs
+++ b/crates/vmux_agent/src/chat_page/turns.rs
@@ -88,10 +88,9 @@ fn flush(
         turn.step_count = turn
             .blocks
             .iter()
-            .filter(|block| match block {
-                ChatBlock::Text(_) => false,
-                ChatBlock::ToolResult { call_id, .. } => !turn.has_tool_use(call_id),
-                _ => true,
+            .enumerate()
+            .filter(|(index, block)| {
+                !matches!(block, ChatBlock::Text(_)) && turn.parent_tool_index(*index).is_none()
             })
             .count() as u32;
         turn.duration_secs = durations.get(*ordinal).copied();
@@ -272,6 +271,35 @@ mod tests {
             Message::User { text: "a".into() },
             Message::ToolResult {
                 call_id: "missing".into(),
+                content: "output".into(),
+                is_error: false,
+            },
+        ];
+        let items = group_turns(&msgs, &[], false);
+        let ChatItem::Turn(turn) = &items[1] else {
+            panic!()
+        };
+        assert_eq!(turn.step_count, 1);
+    }
+
+    #[test]
+    fn guardian_and_results_count_as_one_tool_step() {
+        let msgs = vec![
+            Message::User { text: "a".into() },
+            assistant(vec![
+                AssistantBlock::ToolUse {
+                    call_id: "read-1".into(),
+                    name: "read_file".into(),
+                    args: "{}".into(),
+                },
+                AssistantBlock::ToolUse {
+                    call_id: "review-1".into(),
+                    name: "guardian_review".into(),
+                    args: "{}".into(),
+                },
+            ]),
+            Message::ToolResult {
+                call_id: "read-1".into(),
                 content: "output".into(),
                 is_error: false,
             },

--- a/crates/vmux_agent/src/chat_page/turns.rs
+++ b/crates/vmux_agent/src/chat_page/turns.rs
@@ -88,7 +88,11 @@ fn flush(
         turn.step_count = turn
             .blocks
             .iter()
-            .filter(|block| !matches!(block, ChatBlock::Text(_)))
+            .filter(|block| match block {
+                ChatBlock::Text(_) => false,
+                ChatBlock::ToolResult { call_id, .. } => !turn.has_tool_use(call_id),
+                _ => true,
+            })
             .count() as u32;
         turn.duration_secs = durations.get(*ordinal).copied();
         *ordinal += 1;
@@ -174,7 +178,7 @@ mod tests {
         let ChatItem::Turn(t) = &items[1] else {
             panic!()
         };
-        assert_eq!(t.step_count, 3);
+        assert_eq!(t.step_count, 2);
         assert_eq!(t.blocks.len(), 4);
         assert!(matches!(t.blocks[2], ChatBlock::ToolResult { .. }));
         assert!(matches!(&t.blocks[3], ChatBlock::Text(text) if text == "done"));
@@ -260,6 +264,23 @@ mod tests {
         assert!(matches!(&turn.blocks[0], ChatBlock::Text(text) if text == "before"));
         assert!(matches!(&turn.blocks[1], ChatBlock::ToolUse { .. }));
         assert!(matches!(&turn.blocks[2], ChatBlock::Text(text) if text == "after"));
+    }
+
+    #[test]
+    fn unmatched_tool_result_remains_a_step() {
+        let msgs = vec![
+            Message::User { text: "a".into() },
+            Message::ToolResult {
+                call_id: "missing".into(),
+                content: "output".into(),
+                is_error: false,
+            },
+        ];
+        let items = group_turns(&msgs, &[], false);
+        let ChatItem::Turn(turn) = &items[1] else {
+            panic!()
+        };
+        assert_eq!(turn.step_count, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Context
Agent activity timelines showed guardian reviews and tool outputs as separate top-level steps, obscuring which file read, command, or search produced them. File-read activity also used a generic document icon.

## Implementation
Group guardian reviews and results under the owning tool call, using transcript order for guardian ownership and call IDs for outputs. Keep unmatched activity standalone, count each group as one step, and use an open-book icon for file reads.

## Checks / QA
- Run agent tasks that read files, search files, and run commands.
- Confirm read activities use the open-book icon.
- Confirm Guardian Review and Output or Error appear under the correct tool call and expand independently.