### PR TITLE
feat(agent): refine prompt history and media attachments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9484,6 +9484,7 @@ dependencies = [
  "futures-lite",
  "futures-util",
  "gloo-timers",
+ "image",
  "js-sys",
  "mockito",
  "notify 6.1.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9473,6 +9473,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "vmux_agent"
 version = "0.0.25"
 dependencies = [
+ "base64 0.22.1",
  "bevy",
  "bevy_cef",
  "bevy_ecs",
@@ -9488,6 +9489,7 @@ dependencies = [
  "notify 6.1.1",
  "pulldown-cmark",
  "reqwest",
+ "rfd",
  "rkyv",
  "serde",
  "serde_json",
@@ -9846,6 +9848,7 @@ version = "0.0.25"
 dependencies = [
  "agent-client-protocol",
  "alacritty_terminal",
+ "base64 0.22.1",
  "bevy",
  "bevy_ecs",
  "chrono",
@@ -9868,6 +9871,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "url",
  "vmux_core",
  "vmux_service_client",
  "vmux_ui",

--- a/crates/vmux_agent/Cargo.toml
+++ b/crates/vmux_agent/Cargo.toml
@@ -17,6 +17,7 @@ unicode-segmentation = "1"
 vmux_terminal = { path = "../vmux_terminal" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+base64 = "0.22"
 bevy = { workspace = true }
 bevy_cef = { workspace = true }
 bevy_ecs = { workspace = true }
@@ -24,6 +25,7 @@ bevy_reflect = { workspace = true }
 chrono = { workspace = true }
 notify = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json", "blocking"] }
+rfd = { workspace = true }
 crossbeam-channel = "0.5"
 futures-lite = "2"
 futures-util = "0.3"

--- a/crates/vmux_agent/Cargo.toml
+++ b/crates/vmux_agent/Cargo.toml
@@ -29,6 +29,7 @@ rfd = { workspace = true }
 crossbeam-channel = "0.5"
 futures-lite = "2"
 futures-util = "0.3"
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
 tokio = { workspace = true, features = ["rt"] }
 toml = { workspace = true }
 uuid = { workspace = true }

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -289,6 +289,12 @@ struct ChatMediaListTask {
 
 #[cfg(not(target_arch = "wasm32"))]
 const ATTACHMENT_PREVIEW_LIMIT: u64 = 8 * 1024 * 1024;
+#[cfg(not(target_arch = "wasm32"))]
+const MEDIA_THUMBNAIL_SOURCE_LIMIT: u64 = 25 * 1024 * 1024;
+#[cfg(not(target_arch = "wasm32"))]
+const MEDIA_THUMBNAIL_TOTAL_LIMIT: u64 = 64 * 1024 * 1024;
+#[cfg(not(target_arch = "wasm32"))]
+const MEDIA_THUMBNAIL_MAX_EDGE: u32 = 96;
 
 #[cfg(not(target_arch = "wasm32"))]
 fn attachment_mime(path: &std::path::Path) -> String {
@@ -348,6 +354,37 @@ fn chat_attachment(path: std::path::PathBuf) -> Option<ChatAttachment> {
         size: metadata.len(),
         preview_data_url,
     })
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn media_thumbnail_data_url(path: &std::path::Path, source_size: u64) -> String {
+    if source_size > MEDIA_THUMBNAIL_SOURCE_LIMIT {
+        return String::new();
+    }
+    let Some(mime) = vmux_core::media::image_mime(&path.to_string_lossy()) else {
+        return String::new();
+    };
+    if mime == "image/svg+xml" || mime == "image/avif" {
+        return String::new();
+    }
+    let Ok(bytes) = std::fs::read(path) else {
+        return String::new();
+    };
+    let Ok(image) = image::load_from_memory(&bytes) else {
+        return String::new();
+    };
+    let thumbnail = image.thumbnail(MEDIA_THUMBNAIL_MAX_EDGE, MEDIA_THUMBNAIL_MAX_EDGE);
+    let mut output = std::io::Cursor::new(Vec::new());
+    if thumbnail
+        .write_to(&mut output, image::ImageFormat::Png)
+        .is_err()
+    {
+        return String::new();
+    }
+    format!(
+        "data:image/png;base64,{}",
+        base64::engine::general_purpose::STANDARD.encode(output.into_inner())
+    )
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -499,6 +536,7 @@ fn chat_media_entries(request_id: u64, query: String) -> ChatMediaEntries {
                 parent,
                 mime_type,
                 is_dir,
+                preview_data_url: String::new(),
             })
         })
         .collect::<Vec<_>>();
@@ -510,6 +548,23 @@ fn chat_media_entries(request_id: u64, query: String) -> ChatMediaEntries {
         })
     });
     entries.truncate(100);
+    let mut remaining_thumbnail_bytes = MEDIA_THUMBNAIL_TOTAL_LIMIT;
+    for entry in &mut entries {
+        if entry.is_dir || !entry.mime_type.starts_with("image/") {
+            continue;
+        }
+        let source_size = std::fs::metadata(&entry.path)
+            .map(|metadata| metadata.len())
+            .unwrap_or(u64::MAX);
+        if source_size > remaining_thumbnail_bytes {
+            continue;
+        }
+        entry.preview_data_url =
+            media_thumbnail_data_url(std::path::Path::new(&entry.path), source_size);
+        if !entry.preview_data_url.is_empty() {
+            remaining_thumbnail_bytes = remaining_thumbnail_bytes.saturating_sub(source_size);
+        }
+    }
     ChatMediaEntries {
         request_id,
         query,
@@ -1508,6 +1563,25 @@ mod native_tests {
     }
 
     #[test]
+    fn media_thumbnail_is_small_png_data_url() {
+        let path =
+            std::env::temp_dir().join(format!("vmux-media-thumbnail-{}.png", uuid::Uuid::new_v4()));
+        let image = image::RgbaImage::from_pixel(240, 120, image::Rgba([20, 40, 60, 255]));
+        image.save(&path).unwrap();
+        let source_size = std::fs::metadata(&path).unwrap().len();
+
+        let data_url = media_thumbnail_data_url(&path, source_size);
+
+        std::fs::remove_file(path).unwrap();
+        let encoded = data_url.strip_prefix("data:image/png;base64,").unwrap();
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .unwrap();
+        let thumbnail = image::load_from_memory(&bytes).unwrap();
+        assert_eq!(thumbnail.width().max(thumbnail.height()), 96);
+    }
+
+    #[test]
     fn runtime_switch_builtin_acp_agents_to_cli() {
         let cases = [
             ("claude", "claude"),
@@ -2044,6 +2118,8 @@ mod native_tests {
         assert!(source.contains("attachments_to_submit"));
         assert!(source.contains("ChatMediaListRequest"));
         assert!(source.contains("select_media_entry"));
+        assert!(source.contains("entry.preview_data_url"));
+        assert!(source.contains("h-12 w-16"));
         assert!(source.contains("CHAT_ATTACHMENT_PREVIEWS_EVENT"));
         assert!(source.contains("render_user_attachment"));
         assert!(source.contains("max-h-80 max-w-full object-contain"));

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -13,6 +13,8 @@ mod turns;
 pub mod page;
 
 #[cfg(not(target_arch = "wasm32"))]
+use base64::Engine;
+#[cfg(not(target_arch = "wasm32"))]
 use bevy::prelude::*;
 #[cfg(not(target_arch = "wasm32"))]
 use bevy::tasks::{IoTaskPool, Task, futures_lite::future};
@@ -21,11 +23,12 @@ use bevy_cef::prelude::{BinEventEmitterPlugin, BinHostEmitEvent, BinReceive, Bro
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::chat_page::event::{
-    CHAT_SNAPSHOT_EVENT, ChatApproval, ChatCancel, ChatCancelQueuedPrompt, ChatClearQueue,
-    ChatEscape, ChatResume, ChatSnapshot, ChatSubmit, MODEL_STATE_EVENT, ModelOptionEntry,
-    ModelState, QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry,
-    ResumableSessions, ResumeListRequest, ResumeSession, RuntimeSwitchRequest,
-    SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry, SlashCommands,
+    CHAT_ATTACHMENTS_EVENT, CHAT_SNAPSHOT_EVENT, ChatApproval, ChatAttachment, ChatAttachments,
+    ChatCancel, ChatCancelQueuedPrompt, ChatClearQueue, ChatEscape, ChatPasteMedia, ChatPickFiles,
+    ChatResume, ChatSnapshot, ChatSubmit, MODEL_STATE_EVENT, ModelOptionEntry, ModelState,
+    QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions,
+    ResumeListRequest, ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel,
+    SlashCommandEntry, SlashCommands,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use crate::chat_page::turns::group_turns;
@@ -52,7 +55,7 @@ use vmux_core::team::Profile;
 #[cfg(not(target_arch = "wasm32"))]
 use vmux_service::client::ServiceClient;
 #[cfg(not(target_arch = "wasm32"))]
-use vmux_service::protocol::ClientMessage;
+use vmux_service::protocol::{AgentAttachment, ClientMessage};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
@@ -173,6 +176,9 @@ impl Plugin for AgentChatPagePlugin {
                 RuntimeSwitchRequest,
                 SelectModel,
             )>::for_hosts(&["agent"]))
+            .add_plugins(
+                BinEventEmitterPlugin::<(ChatPickFiles, ChatPasteMedia)>::for_hosts(&["agent"]),
+            )
             .add_observer(on_chat_submit)
             .add_observer(on_chat_approval)
             .add_observer(on_chat_cancel)
@@ -180,6 +186,8 @@ impl Plugin for AgentChatPagePlugin {
             .add_observer(on_chat_clear_queue)
             .add_observer(on_chat_cancel_queued_prompt)
             .add_observer(on_chat_escape)
+            .add_observer(on_chat_pick_files)
+            .add_observer(on_chat_paste_media)
             .add_observer(on_resume_list_request)
             .add_observer(on_resume_session)
             .add_observer(on_runtime_switch_request)
@@ -193,6 +201,7 @@ impl Plugin for AgentChatPagePlugin {
                     push_acp_model_state_to_page,
                     push_removed_acp_model_state_to_page,
                     send_acp_model_requests,
+                    drain_chat_attachment_tasks,
                     drain_resume_list_tasks,
                     drain_resume_handoff_tasks,
                 ),
@@ -251,6 +260,144 @@ struct ResumeHandoffTask {
     target_url: String,
     cwd: std::path::PathBuf,
     task: Task<Result<StackSessionHandoff, String>>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Component)]
+struct ChatAttachmentTask {
+    webview: Entity,
+    task: Task<ChatAttachments>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+const ATTACHMENT_PREVIEW_LIMIT: u64 = 8 * 1024 * 1024;
+
+#[cfg(not(target_arch = "wasm32"))]
+fn attachment_mime(path: &std::path::Path) -> String {
+    let path_str = path.to_string_lossy();
+    if let Some(mime) = vmux_core::media::media_mime(&path_str) {
+        return mime.to_string();
+    }
+    let extension = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    match extension.as_str() {
+        "tif" | "tiff" => "image/tiff",
+        "heic" | "heif" => "image/heic",
+        "json" => "application/json",
+        "csv" => "text/csv",
+        "html" | "htm" => "text/html",
+        "md" | "markdown" => "text/markdown",
+        "txt" | "rs" | "toml" | "ron" | "yaml" | "yml" | "js" | "ts" | "tsx" | "jsx" | "css"
+        | "sh" | "zsh" | "bash" | "py" | "go" | "c" | "h" | "cc" | "cpp" | "hpp" | "java"
+        | "kt" | "swift" => "text/plain",
+        "zip" => "application/zip",
+        "gz" => "application/gzip",
+        "tar" => "application/x-tar",
+        _ => "application/octet-stream",
+    }
+    .to_string()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn chat_attachment(path: std::path::PathBuf) -> Option<ChatAttachment> {
+    let metadata = std::fs::metadata(&path).ok()?;
+    if !metadata.is_file() {
+        return None;
+    }
+    let name = path.file_name()?.to_string_lossy().into_owned();
+    let mime_type = attachment_mime(&path);
+    let preview_data_url =
+        if mime_type.starts_with("image/") && metadata.len() <= ATTACHMENT_PREVIEW_LIMIT {
+            std::fs::read(&path)
+                .ok()
+                .map(|bytes| {
+                    format!(
+                        "data:{mime_type};base64,{}",
+                        base64::engine::general_purpose::STANDARD.encode(bytes)
+                    )
+                })
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
+    Some(ChatAttachment {
+        path: path.to_string_lossy().into_owned(),
+        name,
+        mime_type,
+        size: metadata.len(),
+        preview_data_url,
+    })
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn spawn_chat_attachment_task(
+    webview: Entity,
+    paths: Vec<std::path::PathBuf>,
+    commands: &mut Commands,
+) {
+    if paths.is_empty() {
+        return;
+    }
+    let task = IoTaskPool::get().spawn(async move {
+        ChatAttachments {
+            attachments: paths.into_iter().filter_map(chat_attachment).collect(),
+        }
+    });
+    commands.spawn(ChatAttachmentTask { webview, task });
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn on_chat_pick_files(trigger: On<BinReceive<ChatPickFiles>>, mut commands: Commands) {
+    let mut dialog = rfd::FileDialog::new();
+    if let Some(home) = std::env::var_os("HOME") {
+        dialog = dialog.set_directory(std::path::PathBuf::from(home));
+    }
+    let Some(paths) = dialog.pick_files() else {
+        return;
+    };
+    spawn_chat_attachment_task(trigger.event().webview, paths, &mut commands);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn clipboard_image_path() -> Option<std::path::PathBuf> {
+    if let Some(path) = vmux_terminal::clipboard::image_file_path() {
+        return Some(std::path::PathBuf::from(path));
+    }
+    let png = vmux_terminal::clipboard::read_image_png()?;
+    let directory = std::env::temp_dir().join("vmux-prompt-attachments");
+    std::fs::create_dir_all(&directory).ok()?;
+    let path = directory.join(format!("clipboard-{}.png", uuid::Uuid::new_v4()));
+    std::fs::write(&path, png).ok()?;
+    Some(path)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn on_chat_paste_media(trigger: On<BinReceive<ChatPasteMedia>>, mut commands: Commands) {
+    let Some(path) = clipboard_image_path() else {
+        return;
+    };
+    spawn_chat_attachment_task(trigger.event().webview, vec![path], &mut commands);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn drain_chat_attachment_tasks(
+    mut tasks: Query<(Entity, &mut ChatAttachmentTask)>,
+    mut commands: Commands,
+) {
+    for (entity, mut pending) in &mut tasks {
+        let Some(attachments) = future::block_on(future::poll_once(&mut pending.task)) else {
+            continue;
+        };
+        commands.trigger(BinHostEmitEvent::from_rkyv(
+            pending.webview,
+            CHAT_ATTACHMENTS_EVENT,
+            &attachments,
+        ));
+        commands.entity(entity).despawn();
+    }
 }
 
 /// Push the current transcript + slash commands to any chat webview that is ready but not yet
@@ -492,6 +639,11 @@ fn snapshot_of(
             .map(|item| QueuedPromptSnapshot {
                 id: item.id,
                 text: item.text.clone(),
+                attachment_names: item
+                    .attachments
+                    .iter()
+                    .map(|attachment| attachment.name.clone())
+                    .collect(),
             })
             .collect(),
         paused: queue.paused,
@@ -552,18 +704,38 @@ fn on_chat_submit(
     mut sessions: Query<(&mut PromptQueue, &mut AgentRunState)>,
 ) {
     let webview = trigger.event().webview;
-    let text = trigger.event().payload.text.clone();
+    let payload = &trigger.event().payload;
+    let text = payload.text.clone();
+    let attachments = payload
+        .attachments
+        .iter()
+        .filter(|attachment| !attachment.path.is_empty())
+        .map(|attachment| AgentAttachment {
+            path: attachment.path.clone(),
+            name: attachment.name.clone(),
+            mime_type: attachment.mime_type.clone(),
+            size: attachment.size,
+        })
+        .collect::<Vec<_>>();
+    if text.trim().is_empty() && attachments.is_empty() {
+        return;
+    }
     let Ok(parent) = child_of.get(webview) else {
         return;
     };
     if let Ok((mut queue, mut state)) = sessions.get_mut(parent.parent()) {
-        enqueue_prompt(&mut queue, &mut state, text);
+        enqueue_prompt(&mut queue, &mut state, text, attachments);
     }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn enqueue_prompt(queue: &mut PromptQueue, state: &mut AgentRunState, text: String) {
-    queue.enqueue(text);
+fn enqueue_prompt(
+    queue: &mut PromptQueue,
+    state: &mut AgentRunState,
+    text: String,
+    attachments: Vec<AgentAttachment>,
+) {
+    queue.enqueue_with_attachments(text, attachments);
     if matches!(state, AgentRunState::Errored(_)) {
         *state = AgentRunState::Idle;
     }
@@ -727,10 +899,16 @@ fn relative_time(mtime: std::time::SystemTime) -> String {
 /// The slash commands offered on an ACP pane.
 #[cfg(not(target_arch = "wasm32"))]
 fn slash_commands_for(cross_runtime: bool, has_models: bool) -> Vec<SlashCommandEntry> {
-    let mut v = vec![SlashCommandEntry {
-        name: "resume".into(),
-        description: "Resume a past session".into(),
-    }];
+    let mut v = vec![
+        SlashCommandEntry {
+            name: "upload".into(),
+            description: "Attach files".into(),
+        },
+        SlashCommandEntry {
+            name: "resume".into(),
+            description: "Resume a past session".into(),
+        },
+    ];
     if has_models {
         v.push(SlashCommandEntry {
             name: "model".into(),
@@ -1118,13 +1296,15 @@ mod native_tests {
 
     #[test]
     fn slash_commands_include_cli_only_when_cross_runtime() {
-        assert_eq!(slash_commands_for(false, false).len(), 1);
+        let base = slash_commands_for(false, false);
+        assert_eq!(base.len(), 2);
+        assert_eq!(base[0].name, "upload");
         let with_model = slash_commands_for(false, true);
-        assert_eq!(with_model.len(), 2);
-        assert_eq!(with_model[1].name, "model");
+        assert_eq!(with_model.len(), 3);
+        assert_eq!(with_model[2].name, "model");
         let with_cli = slash_commands_for(true, false);
-        assert_eq!(with_cli.len(), 2);
-        assert_eq!(with_cli[1].name, "cli");
+        assert_eq!(with_cli.len(), 3);
+        assert_eq!(with_cli[2].name, "cli");
     }
 
     #[test]
@@ -1373,7 +1553,7 @@ mod native_tests {
         let mut queue = PromptQueue::default();
         let mut state = AgentRunState::Errored("failed".into());
 
-        enqueue_prompt(&mut queue, &mut state, "retry".into());
+        enqueue_prompt(&mut queue, &mut state, "retry".into(), Vec::new());
 
         assert!(matches!(state, AgentRunState::Idle));
         assert_eq!(
@@ -1582,9 +1762,8 @@ mod native_tests {
         assert!(source.contains("backdrop-blur-3xl backdrop-saturate-150"));
         assert!(source.contains("h-8 w-8 shrink-0 self-center items-center justify-center"));
         assert!(source.contains("if draft.read().is_empty()"));
-        assert!(source.contains(
-            "let show_capability_examples = items.read().is_empty() && queued.read().is_empty();"
-        ));
+        assert!(source.contains("show_capability_examples"));
+        assert!(source.contains("attachments.read().is_empty()"));
         assert!(source.contains("if show_capability_examples"));
         assert!(source.contains("Type / for quick access"));
         assert!(!source.contains("agent-chat-caret relative top-px ml-px h-4 w-1.5 shrink-0"));
@@ -1594,6 +1773,18 @@ mod native_tests {
         assert!(source.contains("onkeyup"));
         assert!(source.contains("onscroll"));
         assert!(source.contains("placeholder:text-transparent"));
+    }
+
+    #[test]
+    fn composer_supports_history_uploads_and_clipboard_media() {
+        let source = include_str!("chat_page/page.rs");
+        assert!(source.contains("prompt_history_direction"));
+        assert!(source.contains("move_prompt_history"));
+        assert!(source.contains("ChatPickFiles"));
+        assert!(source.contains("ChatPasteMedia"));
+        assert!(source.contains("preview_data_url"));
+        assert!(source.contains("Remove attachment"));
+        assert!(source.contains("attachments_to_submit"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -23,12 +23,13 @@ use bevy_cef::prelude::{BinEventEmitterPlugin, BinHostEmitEvent, BinReceive, Bro
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::chat_page::event::{
-    CHAT_ATTACHMENTS_EVENT, CHAT_SNAPSHOT_EVENT, ChatApproval, ChatAttachment, ChatAttachments,
-    ChatCancel, ChatCancelQueuedPrompt, ChatClearQueue, ChatEscape, ChatPasteMedia, ChatPickFiles,
-    ChatResume, ChatSnapshot, ChatSubmit, MODEL_STATE_EVENT, ModelOptionEntry, ModelState,
-    QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions,
-    ResumeListRequest, ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel,
-    SlashCommandEntry, SlashCommands,
+    CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT, CHAT_SNAPSHOT_EVENT, ChatApproval,
+    ChatAttachPaths, ChatAttachment, ChatAttachments, ChatCancel, ChatCancelQueuedPrompt,
+    ChatClearQueue, ChatEscape, ChatMediaEntries, ChatMediaEntry, ChatMediaListRequest,
+    ChatPasteMedia, ChatPickFiles, ChatResume, ChatSnapshot, ChatSubmit, MODEL_STATE_EVENT,
+    ModelOptionEntry, ModelState, QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT,
+    ResumableSessionEntry, ResumableSessions, ResumeListRequest, ResumeSession,
+    RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry, SlashCommands,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use crate::chat_page::turns::group_turns;
@@ -176,9 +177,12 @@ impl Plugin for AgentChatPagePlugin {
                 RuntimeSwitchRequest,
                 SelectModel,
             )>::for_hosts(&["agent"]))
-            .add_plugins(
-                BinEventEmitterPlugin::<(ChatPickFiles, ChatPasteMedia)>::for_hosts(&["agent"]),
-            )
+            .add_plugins(BinEventEmitterPlugin::<(
+                ChatPickFiles,
+                ChatPasteMedia,
+                ChatMediaListRequest,
+                ChatAttachPaths,
+            )>::for_hosts(&["agent"]))
             .add_observer(on_chat_submit)
             .add_observer(on_chat_approval)
             .add_observer(on_chat_cancel)
@@ -188,6 +192,8 @@ impl Plugin for AgentChatPagePlugin {
             .add_observer(on_chat_escape)
             .add_observer(on_chat_pick_files)
             .add_observer(on_chat_paste_media)
+            .add_observer(on_chat_media_list_request)
+            .add_observer(on_chat_attach_paths)
             .add_observer(on_resume_list_request)
             .add_observer(on_resume_session)
             .add_observer(on_runtime_switch_request)
@@ -202,6 +208,7 @@ impl Plugin for AgentChatPagePlugin {
                     push_removed_acp_model_state_to_page,
                     send_acp_model_requests,
                     drain_chat_attachment_tasks,
+                    drain_chat_media_list_tasks,
                     drain_resume_list_tasks,
                     drain_resume_handoff_tasks,
                 ),
@@ -267,6 +274,13 @@ struct ResumeHandoffTask {
 struct ChatAttachmentTask {
     webview: Entity,
     task: Task<ChatAttachments>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Component)]
+struct ChatMediaListTask {
+    webview: Entity,
+    task: Task<ChatMediaEntries>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -350,6 +364,178 @@ fn spawn_chat_attachment_task(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+fn decode_media_query_path(value: &str) -> std::path::PathBuf {
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%'
+            && index + 2 < bytes.len()
+            && let (Some(high), Some(low)) = (
+                char::from(bytes[index + 1]).to_digit(16),
+                char::from(bytes[index + 2]).to_digit(16),
+            )
+        {
+            decoded.push(((high << 4) | low) as u8);
+            index += 3;
+        } else {
+            decoded.push(bytes[index]);
+            index += 1;
+        }
+    }
+    std::path::PathBuf::from(String::from_utf8_lossy(&decoded).into_owned())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn chat_media_entries(request_id: u64, query: String) -> ChatMediaEntries {
+    let Some(home) = std::env::var_os("HOME").map(std::path::PathBuf::from) else {
+        return ChatMediaEntries {
+            request_id,
+            query,
+            entries: Vec::new(),
+        };
+    };
+    let candidate = if let Some(rest) = query.strip_prefix("file://") {
+        decode_media_query_path(rest)
+    } else if let Some(rest) = query.strip_prefix("~/") {
+        home.join(decode_media_query_path(rest))
+    } else if query == "~" {
+        home.clone()
+    } else {
+        let path = decode_media_query_path(&query);
+        if path.is_absolute() {
+            path
+        } else {
+            home.join(path)
+        }
+    };
+    let query_is_dir = query.is_empty() || query.ends_with('/') || candidate.is_dir();
+    let (directory, filter) = if query_is_dir {
+        (candidate, String::new())
+    } else {
+        (
+            candidate
+                .parent()
+                .map(std::path::Path::to_path_buf)
+                .unwrap_or_else(|| home.clone()),
+            candidate
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default()
+                .to_ascii_lowercase(),
+        )
+    };
+    let Ok(home) = home.canonicalize() else {
+        return ChatMediaEntries {
+            request_id,
+            query,
+            entries: Vec::new(),
+        };
+    };
+    let Ok(directory) = directory.canonicalize() else {
+        return ChatMediaEntries {
+            request_id,
+            query,
+            entries: Vec::new(),
+        };
+    };
+    if !directory.starts_with(&home) {
+        return ChatMediaEntries {
+            request_id,
+            query,
+            entries: Vec::new(),
+        };
+    }
+    let mut entries = std::fs::read_dir(&directory)
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let path = entry.path();
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if name.starts_with('.')
+                || (!filter.is_empty() && !name.to_ascii_lowercase().contains(&filter))
+            {
+                return None;
+            }
+            let is_dir = entry.file_type().ok()?.is_dir();
+            let mime_type = if is_dir {
+                String::new()
+            } else {
+                attachment_mime(&path)
+            };
+            if !is_dir
+                && !mime_type.starts_with("image/")
+                && !mime_type.starts_with("audio/")
+                && !mime_type.starts_with("video/")
+                && mime_type != "application/pdf"
+            {
+                return None;
+            }
+            let parent = path
+                .parent()
+                .and_then(|parent| parent.strip_prefix(&home).ok())
+                .map(|parent| {
+                    if parent.as_os_str().is_empty() {
+                        "~".to_string()
+                    } else {
+                        format!("~/{}", parent.to_string_lossy())
+                    }
+                })
+                .unwrap_or_else(|| "~".to_string());
+            Some(ChatMediaEntry {
+                path: path.to_string_lossy().into_owned(),
+                name,
+                parent,
+                mime_type,
+                is_dir,
+            })
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by(|a, b| {
+        b.is_dir.cmp(&a.is_dir).then_with(|| {
+            a.name
+                .to_ascii_lowercase()
+                .cmp(&b.name.to_ascii_lowercase())
+        })
+    });
+    entries.truncate(100);
+    ChatMediaEntries {
+        request_id,
+        query,
+        entries,
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn on_chat_media_list_request(
+    trigger: On<BinReceive<ChatMediaListRequest>>,
+    mut commands: Commands,
+) {
+    let request = trigger.event().payload.clone();
+    let task = IoTaskPool::get()
+        .spawn(async move { chat_media_entries(request.request_id, request.query) });
+    commands.spawn(ChatMediaListTask {
+        webview: trigger.event().webview,
+        task,
+    });
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn on_chat_attach_paths(trigger: On<BinReceive<ChatAttachPaths>>, mut commands: Commands) {
+    let paths = trigger
+        .event()
+        .payload
+        .paths
+        .iter()
+        .filter(|path| !path.is_empty())
+        .map(std::path::PathBuf::from)
+        .collect();
+    spawn_chat_attachment_task(trigger.event().webview, paths, &mut commands);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 fn on_chat_pick_files(trigger: On<BinReceive<ChatPickFiles>>, mut commands: Commands) {
     let mut dialog = rfd::FileDialog::new();
     if let Some(home) = std::env::var_os("HOME") {
@@ -395,6 +581,24 @@ fn drain_chat_attachment_tasks(
             pending.webview,
             CHAT_ATTACHMENTS_EVENT,
             &attachments,
+        ));
+        commands.entity(entity).despawn();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn drain_chat_media_list_tasks(
+    mut tasks: Query<(Entity, &mut ChatMediaListTask)>,
+    mut commands: Commands,
+) {
+    for (entity, mut pending) in &mut tasks {
+        let Some(entries) = future::block_on(future::poll_once(&mut pending.task)) else {
+            continue;
+        };
+        commands.trigger(BinHostEmitEvent::from_rkyv(
+            pending.webview,
+            CHAT_MEDIA_ENTRIES_EVENT,
+            &entries,
         ));
         commands.entity(entity).despawn();
     }
@@ -1251,6 +1455,14 @@ mod native_tests {
     use std::path::Path;
 
     #[test]
+    fn media_query_paths_decode_percent_escapes() {
+        assert_eq!(
+            decode_media_query_path("Pictures/My%20Image%25.png"),
+            std::path::PathBuf::from("Pictures/My Image%.png")
+        );
+    }
+
+    #[test]
     fn runtime_switch_builtin_acp_agents_to_cli() {
         let cases = [
             ("claude", "claude"),
@@ -1765,7 +1977,7 @@ mod native_tests {
         assert!(source.contains("show_capability_examples"));
         assert!(source.contains("attachments.read().is_empty()"));
         assert!(source.contains("if show_capability_examples"));
-        assert!(source.contains("Type / for quick access"));
+        assert!(source.contains("Type / for commands or @ for media"));
         assert!(!source.contains("agent-chat-caret relative top-px ml-px h-4 w-1.5 shrink-0"));
         assert!(source.contains("prompt_prefix_at_utf16"));
         assert!(source.contains("agent-chat-caret"));
@@ -1785,6 +1997,8 @@ mod native_tests {
         assert!(source.contains("preview_data_url"));
         assert!(source.contains("Remove attachment"));
         assert!(source.contains("attachments_to_submit"));
+        assert!(source.contains("ChatMediaListRequest"));
+        assert!(source.contains("select_media_entry"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -23,8 +23,9 @@ use bevy_cef::prelude::{BinEventEmitterPlugin, BinHostEmitEvent, BinReceive, Bro
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::chat_page::event::{
-    CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT, CHAT_SNAPSHOT_EVENT, ChatApproval,
-    ChatAttachPaths, ChatAttachment, ChatAttachments, ChatCancel, ChatCancelQueuedPrompt,
+    CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT,
+    CHAT_SNAPSHOT_EVENT, ChatApproval, ChatAttachPaths, ChatAttachment,
+    ChatAttachmentPreviewRequest, ChatAttachments, ChatCancel, ChatCancelQueuedPrompt,
     ChatClearQueue, ChatEscape, ChatMediaEntries, ChatMediaEntry, ChatMediaListRequest,
     ChatPasteMedia, ChatPickFiles, ChatResume, ChatSnapshot, ChatSubmit, MODEL_STATE_EVENT,
     ModelOptionEntry, ModelState, QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT,
@@ -182,6 +183,7 @@ impl Plugin for AgentChatPagePlugin {
                 ChatPasteMedia,
                 ChatMediaListRequest,
                 ChatAttachPaths,
+                ChatAttachmentPreviewRequest,
             )>::for_hosts(&["agent"]))
             .add_observer(on_chat_submit)
             .add_observer(on_chat_approval)
@@ -194,6 +196,7 @@ impl Plugin for AgentChatPagePlugin {
             .add_observer(on_chat_paste_media)
             .add_observer(on_chat_media_list_request)
             .add_observer(on_chat_attach_paths)
+            .add_observer(on_chat_attachment_preview_request)
             .add_observer(on_resume_list_request)
             .add_observer(on_resume_session)
             .add_observer(on_runtime_switch_request)
@@ -273,6 +276,7 @@ struct ResumeHandoffTask {
 #[derive(Component)]
 struct ChatAttachmentTask {
     webview: Entity,
+    event: &'static str,
     task: Task<ChatAttachments>,
 }
 
@@ -349,6 +353,7 @@ fn chat_attachment(path: std::path::PathBuf) -> Option<ChatAttachment> {
 #[cfg(not(target_arch = "wasm32"))]
 fn spawn_chat_attachment_task(
     webview: Entity,
+    event: &'static str,
     paths: Vec<std::path::PathBuf>,
     commands: &mut Commands,
 ) {
@@ -360,7 +365,11 @@ fn spawn_chat_attachment_task(
             attachments: paths.into_iter().filter_map(chat_attachment).collect(),
         }
     });
-    commands.spawn(ChatAttachmentTask { webview, task });
+    commands.spawn(ChatAttachmentTask {
+        webview,
+        event,
+        task,
+    });
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -532,7 +541,33 @@ fn on_chat_attach_paths(trigger: On<BinReceive<ChatAttachPaths>>, mut commands: 
         .filter(|path| !path.is_empty())
         .map(std::path::PathBuf::from)
         .collect();
-    spawn_chat_attachment_task(trigger.event().webview, paths, &mut commands);
+    spawn_chat_attachment_task(
+        trigger.event().webview,
+        CHAT_ATTACHMENTS_EVENT,
+        paths,
+        &mut commands,
+    );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn on_chat_attachment_preview_request(
+    trigger: On<BinReceive<ChatAttachmentPreviewRequest>>,
+    mut commands: Commands,
+) {
+    let paths = trigger
+        .event()
+        .payload
+        .paths
+        .iter()
+        .filter(|path| !path.is_empty())
+        .map(std::path::PathBuf::from)
+        .collect();
+    spawn_chat_attachment_task(
+        trigger.event().webview,
+        CHAT_ATTACHMENT_PREVIEWS_EVENT,
+        paths,
+        &mut commands,
+    );
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -544,7 +579,12 @@ fn on_chat_pick_files(trigger: On<BinReceive<ChatPickFiles>>, mut commands: Comm
     let Some(paths) = dialog.pick_files() else {
         return;
     };
-    spawn_chat_attachment_task(trigger.event().webview, paths, &mut commands);
+    spawn_chat_attachment_task(
+        trigger.event().webview,
+        CHAT_ATTACHMENTS_EVENT,
+        paths,
+        &mut commands,
+    );
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -565,7 +605,12 @@ fn on_chat_paste_media(trigger: On<BinReceive<ChatPasteMedia>>, mut commands: Co
     let Some(path) = clipboard_image_path() else {
         return;
     };
-    spawn_chat_attachment_task(trigger.event().webview, vec![path], &mut commands);
+    spawn_chat_attachment_task(
+        trigger.event().webview,
+        CHAT_ATTACHMENTS_EVENT,
+        vec![path],
+        &mut commands,
+    );
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -579,7 +624,7 @@ fn drain_chat_attachment_tasks(
         };
         commands.trigger(BinHostEmitEvent::from_rkyv(
             pending.webview,
-            CHAT_ATTACHMENTS_EVENT,
+            pending.event,
             &attachments,
         ));
         commands.entity(entity).despawn();
@@ -1658,7 +1703,7 @@ mod native_tests {
             source_kind: AgentKind::Codex,
             source_sid: "codex-1".into(),
             messages: vec![
-                crate::Message::User { text: "one".into() },
+                crate::Message::user("one"),
                 crate::Message::Assistant {
                     blocks: vec![crate::AssistantBlock::ToolUse {
                         call_id: "call-1".into(),
@@ -1999,6 +2044,9 @@ mod native_tests {
         assert!(source.contains("attachments_to_submit"));
         assert!(source.contains("ChatMediaListRequest"));
         assert!(source.contains("select_media_entry"));
+        assert!(source.contains("CHAT_ATTACHMENT_PREVIEWS_EVENT"));
+        assert!(source.contains("render_user_attachment"));
+        assert!(source.contains("max-h-80 max-w-full object-contain"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -2120,6 +2120,8 @@ mod native_tests {
         assert!(source.contains("select_media_entry"));
         assert!(source.contains("entry.preview_data_url"));
         assert!(source.contains("h-12 w-16"));
+        assert!(source.contains("attachment-pill-{attachment.path}"));
+        assert!(source.contains("String::new()"));
         assert!(source.contains("CHAT_ATTACHMENT_PREVIEWS_EVENT"));
         assert!(source.contains("render_user_attachment"));
         assert!(source.contains("max-h-80 max-w-full object-contain"));

--- a/crates/vmux_agent/src/chat_page/composer.rs
+++ b/crates/vmux_agent/src/chat_page/composer.rs
@@ -27,6 +27,12 @@ pub(crate) enum PromptHistoryDirection {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct InlineMediaQuery<'a> {
+    pub start: usize,
+    pub query: &'a str,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum PromptEdit<'a> {
     Insert(&'a str),
     Backspace,
@@ -75,6 +81,30 @@ pub(crate) fn selector_mode(draft: &str) -> SelectorMode<'_> {
     } else {
         SelectorMode::Commands(token)
     }
+}
+
+pub(crate) fn inline_media_query(draft: &str) -> Option<InlineMediaQuery<'_>> {
+    draft.rmatch_indices('@').find_map(|(start, _)| {
+        let boundary = start == 0
+            || draft[..start]
+                .chars()
+                .next_back()
+                .is_some_and(char::is_whitespace);
+        let query = &draft[start + 1..];
+        (boundary && !query.chars().any(char::is_whitespace))
+            .then_some(InlineMediaQuery { start, query })
+    })
+}
+
+pub(crate) fn replace_inline_media_query(
+    draft: &str,
+    query: InlineMediaQuery<'_>,
+    replacement: &str,
+) -> String {
+    let mut value = String::with_capacity(draft.len() + replacement.len());
+    value.push_str(&draft[..query.start]);
+    value.push_str(replacement);
+    value
 }
 
 pub(crate) fn should_fetch_resume(draft: &str, commands: &[SlashCommandEntry]) -> bool {
@@ -462,6 +492,36 @@ mod tests {
     fn thinking_expands_only_until_the_next_block() {
         assert!(should_expand_thinking(0, 1));
         assert!(!should_expand_thinking(0, 2));
+    }
+
+    #[test]
+    fn inline_media_query_requires_a_token_boundary_and_open_tail() {
+        assert_eq!(
+            inline_media_query("inspect @Pictures/scr"),
+            Some(InlineMediaQuery {
+                start: 8,
+                query: "Pictures/scr",
+            })
+        );
+        assert_eq!(
+            inline_media_query("@"),
+            Some(InlineMediaQuery {
+                start: 0,
+                query: "",
+            })
+        );
+        assert_eq!(inline_media_query("mail@example.com"), None);
+        assert_eq!(inline_media_query("inspect @image.png next"), None);
+    }
+
+    #[test]
+    fn inline_media_replacement_preserves_prompt_prefix() {
+        let draft = "compare this @Pic";
+        let query = inline_media_query(draft).unwrap();
+        assert_eq!(
+            replace_inline_media_query(draft, query, "@Pictures/photo.png "),
+            "compare this @Pictures/photo.png "
+        );
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/composer.rs
+++ b/crates/vmux_agent/src/chat_page/composer.rs
@@ -522,6 +522,10 @@ mod tests {
             replace_inline_media_query(draft, query, "@Pictures/photo.png "),
             "compare this @Pictures/photo.png "
         );
+        assert_eq!(
+            replace_inline_media_query(draft, query, ""),
+            "compare this "
+        );
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/composer.rs
+++ b/crates/vmux_agent/src/chat_page/composer.rs
@@ -266,7 +266,7 @@ pub(crate) fn chat_page_title(items: &[ChatItem], status: &str, agent_name: &str
     let topic = items
         .iter()
         .filter_map(|item| match item {
-            ChatItem::User { text } => Some(text.as_str()),
+            ChatItem::User { text, .. } => Some(text.as_str()),
             ChatItem::Turn(_) => None,
         })
         .map(normalize_chat_page_title)
@@ -685,16 +685,12 @@ mod tests {
     #[test]
     fn chat_page_title_uses_first_prompt_as_stable_topic() {
         let items = vec![
-            ChatItem::User {
-                text: "  Fix the\ndynamic   agent page title  ".into(),
-            },
+            ChatItem::user("  Fix the\ndynamic   agent page title  "),
             ChatItem::Turn(ChatTurn {
                 running: true,
                 ..Default::default()
             }),
-            ChatItem::User {
-                text: "continue".into(),
-            },
+            ChatItem::user("continue"),
         ];
 
         assert_eq!(
@@ -712,9 +708,7 @@ mod tests {
         fn title(block: ChatBlock) -> String {
             chat_page_title(
                 &[
-                    ChatItem::User {
-                        text: "Ship dynamic titles".into(),
-                    },
+                    ChatItem::user("Ship dynamic titles"),
                     ChatItem::Turn(ChatTurn {
                         blocks: vec![block],
                         running: true,
@@ -776,31 +770,21 @@ mod tests {
     fn chat_page_title_falls_back_to_agent_and_truncates_topic() {
         assert_eq!(chat_page_title(&[], "idle", "Codex"), "Codex");
 
-        let items = vec![ChatItem::User {
-            text: "a".repeat(CHAT_PAGE_TITLE_MAX_GRAPHEMES + 10),
-        }];
+        let items = vec![ChatItem::user(
+            "a".repeat(CHAT_PAGE_TITLE_MAX_GRAPHEMES + 10),
+        )];
         let title = chat_page_title(&items, "idle", "Codex");
         assert_eq!(title.graphemes(true).count(), CHAT_PAGE_TITLE_MAX_GRAPHEMES);
         assert!(title.ends_with('…'));
         assert_eq!(
-            chat_page_title(
-                &[ChatItem::User {
-                    text: "Fix \u{202E}\x1b title".into(),
-                }],
-                "idle",
-                "Codex"
-            ),
+            chat_page_title(&[ChatItem::user("Fix \u{202E}\x1b title")], "idle", "Codex"),
             "Fix title"
         );
         assert_eq!(
             chat_page_title(
                 &[
-                    ChatItem::User {
-                        text: "\u{202E}".into(),
-                    },
-                    ChatItem::User {
-                        text: "Keep 👩‍💻 and فارسی\u{200C}".into(),
-                    },
+                    ChatItem::user("\u{202E}"),
+                    ChatItem::user("Keep 👩‍💻 and فارسی\u{200C}"),
                 ],
                 "errored",
                 "Codex"

--- a/crates/vmux_agent/src/chat_page/composer.rs
+++ b/crates/vmux_agent/src/chat_page/composer.rs
@@ -21,6 +21,12 @@ pub(crate) enum MenuDirection {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PromptHistoryDirection {
+    Older,
+    Newer,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum PromptEdit<'a> {
     Insert(&'a str),
     Backspace,
@@ -158,6 +164,59 @@ pub(crate) fn move_selection(current: usize, len: usize, direction: MenuDirectio
     match direction {
         MenuDirection::Next => (current + 1) % len,
         MenuDirection::Previous => (current + len - 1) % len,
+    }
+}
+
+pub(crate) fn prompt_history_direction(
+    key: &str,
+    ctrl: bool,
+    value: &str,
+    selection_start: u32,
+    selection_end: u32,
+) -> Option<PromptHistoryDirection> {
+    if selection_start != selection_end {
+        return None;
+    }
+    if ctrl {
+        return match key {
+            "n" | "N" => Some(PromptHistoryDirection::Newer),
+            "p" | "P" => Some(PromptHistoryDirection::Older),
+            _ => None,
+        };
+    }
+    let caret = utf16_to_byte(value, selection_start);
+    match key {
+        "ArrowUp" if !value[..caret].contains('\n') => Some(PromptHistoryDirection::Older),
+        "ArrowDown" if !value[caret..].contains('\n') => Some(PromptHistoryDirection::Newer),
+        _ => None,
+    }
+}
+
+pub(crate) fn move_prompt_history(
+    history: &[String],
+    cursor: Option<usize>,
+    scratch: &str,
+    current: &str,
+    direction: PromptHistoryDirection,
+) -> (String, Option<usize>, String) {
+    if history.is_empty() {
+        return (current.to_string(), cursor, scratch.to_string());
+    }
+    match direction {
+        PromptHistoryDirection::Older => {
+            let next = cursor.map_or(history.len() - 1, |index| index.saturating_sub(1));
+            let scratch = if cursor.is_none() { current } else { scratch };
+            (history[next].clone(), Some(next), scratch.to_string())
+        }
+        PromptHistoryDirection::Newer => match cursor {
+            Some(index) if index + 1 < history.len() => (
+                history[index + 1].clone(),
+                Some(index + 1),
+                scratch.to_string(),
+            ),
+            Some(_) => (scratch.to_string(), None, scratch.to_string()),
+            None => (current.to_string(), None, scratch.to_string()),
+        },
     }
 }
 
@@ -486,6 +545,73 @@ mod tests {
         assert_eq!(menu_direction("p", true), Some(MenuDirection::Previous));
         assert_eq!(menu_direction("n", false), None);
         assert_eq!(menu_direction("ArrowDown", true), None);
+    }
+
+    #[test]
+    fn prompt_history_uses_arrows_at_text_boundaries_and_ctrl_np_anywhere() {
+        assert_eq!(
+            prompt_history_direction("ArrowUp", false, "first\nsecond", 2, 2),
+            Some(PromptHistoryDirection::Older)
+        );
+        assert_eq!(
+            prompt_history_direction("ArrowUp", false, "first\nsecond", 8, 8),
+            None
+        );
+        assert_eq!(
+            prompt_history_direction("ArrowDown", false, "first\nsecond", 8, 8),
+            Some(PromptHistoryDirection::Newer)
+        );
+        assert_eq!(
+            prompt_history_direction("p", true, "first\nsecond", 8, 8),
+            Some(PromptHistoryDirection::Older)
+        );
+        assert_eq!(
+            prompt_history_direction("n", true, "first\nsecond", 2, 4),
+            None
+        );
+    }
+
+    #[test]
+    fn prompt_history_restores_unsent_scratch_after_newest_entry() {
+        let history = vec!["first".to_string(), "second".to_string()];
+        let (value, cursor, scratch) = move_prompt_history(
+            &history,
+            None,
+            "",
+            "unfinished",
+            PromptHistoryDirection::Older,
+        );
+        assert_eq!(
+            (value.as_str(), cursor, scratch.as_str()),
+            ("second", Some(1), "unfinished")
+        );
+
+        let (value, cursor, scratch) = move_prompt_history(
+            &history,
+            cursor,
+            &scratch,
+            &value,
+            PromptHistoryDirection::Older,
+        );
+        assert_eq!((value.as_str(), cursor), ("first", Some(0)));
+
+        let (value, cursor, scratch) = move_prompt_history(
+            &history,
+            cursor,
+            &scratch,
+            &value,
+            PromptHistoryDirection::Newer,
+        );
+        assert_eq!((value.as_str(), cursor), ("second", Some(1)));
+
+        let (value, cursor, _) = move_prompt_history(
+            &history,
+            cursor,
+            &scratch,
+            &value,
+            PromptHistoryDirection::Newer,
+        );
+        assert_eq!((value.as_str(), cursor), ("unfinished", None));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -82,6 +82,7 @@ pub struct ChatMediaEntry {
     pub parent: String,
     pub mime_type: String,
     pub is_dir: bool,
+    pub preview_data_url: String,
 }
 
 #[derive(
@@ -696,12 +697,18 @@ mod tests {
                 parent: "~/Pictures".into(),
                 mime_type: "image/png".into(),
                 is_dir: false,
+                preview_data_url: "data:image/png;base64,cG5n".into(),
             }],
         };
         let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&value).unwrap();
         let back = rkyv::from_bytes::<ChatMediaEntries, rkyv::rancor::Error>(&bytes).unwrap();
         assert_eq!(back.request_id, 7);
         assert_eq!(back.entries[0].name, "screenshot.png");
+        assert!(
+            back.entries[0]
+                .preview_data_url
+                .starts_with("data:image/png")
+        );
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -6,6 +6,8 @@
 pub const CHAT_SNAPSHOT_EVENT: &str = "chat_snapshot";
 /// Bin-event id: native → page files selected from disk or the clipboard.
 pub const CHAT_ATTACHMENTS_EVENT: &str = "chat_attachments";
+/// Bin-event id: native → page previews for media already present in the transcript.
+pub const CHAT_ATTACHMENT_PREVIEWS_EVENT: &str = "chat_attachment_previews";
 /// Bin-event id: native → page media entries matching an inline `@` query.
 pub const CHAT_MEDIA_ENTRIES_EVENT: &str = "chat_media_entries";
 
@@ -222,6 +224,21 @@ pub struct ChatMediaListRequest {
     rkyv::Deserialize,
 )]
 pub struct ChatAttachPaths {
+    pub paths: Vec<String>,
+}
+
+/// Page → native: load previews for media already present in the transcript.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatAttachmentPreviewRequest {
     pub paths: Vec<String>,
 }
 
@@ -523,8 +540,21 @@ pub struct ChatPlanStep {
 /// `group_turns`, carried as JSON in [`ChatSnapshot::messages_json`].
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub enum ChatItem {
-    User { text: String },
+    User {
+        text: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        attachments: Vec<ChatSubmitAttachment>,
+    },
     Turn(ChatTurn),
+}
+
+impl ChatItem {
+    pub fn user(text: impl Into<String>) -> Self {
+        Self::User {
+            text: text.into(),
+            attachments: Vec::new(),
+        }
+    }
 }
 
 /// One assistant turn: its ordered prose/activity timeline and run-state.
@@ -677,7 +707,15 @@ mod tests {
     #[test]
     fn chat_item_turn_roundtrip() {
         let items = vec![
-            ChatItem::User { text: "hi".into() },
+            ChatItem::User {
+                text: "hi".into(),
+                attachments: vec![ChatSubmitAttachment {
+                    path: "/tmp/image.png".into(),
+                    name: "image.png".into(),
+                    mime_type: "image/png".into(),
+                    size: 3,
+                }],
+            },
             ChatItem::Turn(ChatTurn {
                 blocks: vec![
                     ChatBlock::Thinking("hmm".into()),
@@ -696,6 +734,11 @@ mod tests {
         let json = serde_json::to_string(&items).unwrap();
         let back: Vec<ChatItem> = serde_json::from_str(&json).unwrap();
         assert_eq!(back.len(), 2);
+        assert!(matches!(
+            &back[0],
+            ChatItem::User { attachments, .. }
+                if attachments.first().is_some_and(|attachment| attachment.name == "image.png")
+        ));
         let ChatItem::Turn(turn) = &back[1] else {
             panic!("expected turn")
         };

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -4,6 +4,61 @@
 
 /// Bin-event id: native → page conversation/run-state snapshot.
 pub const CHAT_SNAPSHOT_EVENT: &str = "chat_snapshot";
+/// Bin-event id: native → page files selected from disk or the clipboard.
+pub const CHAT_ATTACHMENTS_EVENT: &str = "chat_attachments";
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatAttachment {
+    pub path: String,
+    pub name: String,
+    pub mime_type: String,
+    pub size: u64,
+    pub preview_data_url: String,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatSubmitAttachment {
+    pub path: String,
+    pub name: String,
+    pub mime_type: String,
+    pub size: u64,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatAttachments {
+    pub attachments: Vec<ChatAttachment>,
+}
 
 #[derive(
     Clone,
@@ -18,6 +73,7 @@ pub const CHAT_SNAPSHOT_EVENT: &str = "chat_snapshot";
 pub struct QueuedPromptSnapshot {
     pub id: u64,
     pub text: String,
+    pub attachment_names: Vec<String>,
 }
 
 /// Native → page: the full conversation plus run-state, pushed on every change.
@@ -71,7 +127,34 @@ pub struct ChatSnapshot {
 )]
 pub struct ChatSubmit {
     pub text: String,
+    pub attachments: Vec<ChatSubmitAttachment>,
 }
+
+/// Page → native: open a multi-select file picker rooted at the user's home directory.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatPickFiles;
+
+/// Page → native: attach image media from the system clipboard, if present.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatPasteMedia;
 
 /// Page → native: the user answered a permission prompt. `decision`: 0 = deny, 1 = allow,
 /// 2 = allow-always.
@@ -478,10 +561,12 @@ mod tests {
                 QueuedPromptSnapshot {
                     id: 4,
                     text: "a".into(),
+                    attachment_names: vec!["image.png".into()],
                 },
                 QueuedPromptSnapshot {
                     id: 9,
                     text: "b".into(),
+                    attachment_names: Vec::new(),
                 },
             ],
             paused: true,

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -6,6 +6,8 @@
 pub const CHAT_SNAPSHOT_EVENT: &str = "chat_snapshot";
 /// Bin-event id: native → page files selected from disk or the clipboard.
 pub const CHAT_ATTACHMENTS_EVENT: &str = "chat_attachments";
+/// Bin-event id: native → page media entries matching an inline `@` query.
+pub const CHAT_MEDIA_ENTRIES_EVENT: &str = "chat_media_entries";
 
 #[derive(
     Clone,
@@ -58,6 +60,42 @@ pub struct ChatSubmitAttachment {
 )]
 pub struct ChatAttachments {
     pub attachments: Vec<ChatAttachment>,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatMediaEntry {
+    pub path: String,
+    pub name: String,
+    pub parent: String,
+    pub mime_type: String,
+    pub is_dir: bool,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatMediaEntries {
+    pub request_id: u64,
+    pub query: String,
+    pub entries: Vec<ChatMediaEntry>,
 }
 
 #[derive(
@@ -155,6 +193,37 @@ pub struct ChatPickFiles;
     rkyv::Deserialize,
 )]
 pub struct ChatPasteMedia;
+
+/// Page → native: list media and directories for an inline `@` query.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatMediaListRequest {
+    pub request_id: u64,
+    pub query: String,
+}
+
+/// Page → native: attach paths selected from the inline `@` menu.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatAttachPaths {
+    pub paths: Vec<String>,
+}
 
 /// Page → native: the user answered a permission prompt. `decision`: 0 = deny, 1 = allow,
 /// 2 = allow-always.
@@ -584,6 +653,25 @@ mod tests {
         assert_eq!(back.handoff_source, "Codex");
         assert!(back.handoff_truncated);
         assert_eq!(back.handoff_message_count, 2);
+    }
+
+    #[test]
+    fn chat_media_entries_rkyv_roundtrip() {
+        let value = ChatMediaEntries {
+            request_id: 7,
+            query: "Pictures/scr".into(),
+            entries: vec![ChatMediaEntry {
+                path: "/Users/me/Pictures/screenshot.png".into(),
+                name: "screenshot.png".into(),
+                parent: "~/Pictures".into(),
+                mime_type: "image/png".into(),
+                is_dir: false,
+            }],
+        };
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&value).unwrap();
+        let back = rkyv::from_bytes::<ChatMediaEntries, rkyv::rancor::Error>(&bytes).unwrap();
+        assert_eq!(back.request_id, 7);
+        assert_eq!(back.entries[0].name, "screenshot.png");
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -2,19 +2,21 @@
 
 use crate::chat_page::composer::{
     PromptEdit, PromptHistoryDirection, ResumeMenuState, SelectorMode, ToolActivity,
-    chat_page_title, edit_prompt, filter_models, filter_sessions, is_handoff_boundary,
-    menu_direction, move_prompt_history, move_selection, prompt_history_direction,
-    prompt_prefix_at_utf16, resume_menu_state, selector_mode, should_clear_draft_on_escape,
-    should_expand_thinking, should_fetch_resume, tool_activity,
+    chat_page_title, edit_prompt, filter_models, filter_sessions, inline_media_query,
+    is_handoff_boundary, menu_direction, move_prompt_history, move_selection,
+    prompt_history_direction, prompt_prefix_at_utf16, replace_inline_media_query,
+    resume_menu_state, selector_mode, should_clear_draft_on_escape, should_fetch_resume,
+    should_expand_thinking, tool_activity,
 };
 use crate::chat_page::event::{
-    CHAT_ATTACHMENTS_EVENT, CHAT_SNAPSHOT_EVENT, ChatApproval, ChatAttachment, ChatAttachments,
-    ChatBlock, ChatCancel, ChatCancelQueuedPrompt, ChatClearQueue, ChatEscape, ChatItem,
-    ChatPasteMedia, ChatPickFiles, ChatResume, ChatSnapshot, ChatSubmit, ChatSubmitAttachment,
-    ChatTurn, MODEL_STATE_EVENT, ModelOptionEntry, ModelState, QueuedPromptSnapshot,
-    RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions, ResumeListRequest,
-    ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry,
-    SlashCommands, WORKING_VERBS,
+    CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT, CHAT_SNAPSHOT_EVENT, ChatApproval,
+    ChatAttachPaths, ChatAttachment, ChatAttachments, ChatBlock, ChatCancel,
+    ChatCancelQueuedPrompt, ChatClearQueue, ChatEscape, ChatItem, ChatMediaEntries, ChatMediaEntry,
+    ChatMediaListRequest, ChatPasteMedia, ChatPickFiles, ChatResume, ChatSnapshot, ChatSubmit,
+    ChatSubmitAttachment, ChatTurn, MODEL_STATE_EVENT, ModelOptionEntry, ModelState,
+    QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions,
+    ResumeListRequest, ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel,
+    SlashCommandEntry, SlashCommands, WORKING_VERBS,
 };
 use dioxus::prelude::*;
 use std::borrow::Cow;
@@ -107,13 +109,53 @@ fn prompt_history(items: &[ChatItem], queued: &[QueuedPromptSnapshot]) -> Vec<St
     history
 }
 
-fn attachment_label(attachment: &ChatAttachment) -> String {
-    std::path::Path::new(&attachment.name)
+fn file_extension_label(name: &str) -> String {
+    std::path::Path::new(name)
         .extension()
         .and_then(|extension| extension.to_str())
         .map(|extension| extension.to_ascii_uppercase())
         .filter(|extension| !extension.is_empty())
         .unwrap_or_else(|| "FILE".to_string())
+}
+
+fn attachment_label(attachment: &ChatAttachment) -> String {
+    file_extension_label(&attachment.name)
+}
+
+fn media_reference(entry: &ChatMediaEntry) -> String {
+    let encode = |value: &str| value.replace('%', "%25").replace(' ', "%20");
+    if entry.parent == "~" {
+        format!("~/{name}", name = encode(&entry.name))
+    } else {
+        format!(
+            "{parent}/{name}",
+            parent = encode(&entry.parent),
+            name = encode(&entry.name)
+        )
+    }
+}
+
+fn select_media_entry(
+    entry: &ChatMediaEntry,
+    mut draft: Signal<String>,
+    mut menu_sel: Signal<usize>,
+) {
+    let value = draft.peek().clone();
+    let Some(query) = inline_media_query(&value) else {
+        return;
+    };
+    let reference = media_reference(entry);
+    let replacement = if entry.is_dir {
+        format!("@{reference}/")
+    } else {
+        let _ = try_cef_bin_emit_rkyv(&ChatAttachPaths {
+            paths: vec![entry.path.clone()],
+        });
+        format!("@{reference} ")
+    };
+    draft.set(replace_inline_media_query(&value, query, &replacement));
+    menu_sel.set(0);
+    focus_prompt_end();
 }
 
 fn dispatch_input_event(textarea: &web_sys::HtmlTextAreaElement) {
@@ -154,18 +196,20 @@ fn install_global_prompt_input(draft: Signal<String>, slash_cmds: Signal<Vec<Sla
             return;
         }
 
-        let selector_open = match selector_mode(&draft.peek()) {
-            SelectorMode::Resume(_) => true,
-            SelectorMode::Models(_) => true,
-            SelectorMode::Commands(query) => {
-                let query = query.to_lowercase();
-                slash_cmds
-                    .peek()
-                    .iter()
-                    .any(|command| command.name.starts_with(&query))
-            }
-            SelectorMode::None => false,
-        };
+        let draft_value = draft.peek();
+        let selector_open = inline_media_query(&draft_value).is_some()
+            || match selector_mode(&draft_value) {
+                SelectorMode::Resume(_) => true,
+                SelectorMode::Models(_) => true,
+                SelectorMode::Commands(query) => {
+                    let query = query.to_lowercase();
+                    slash_cmds
+                        .peek()
+                        .iter()
+                        .any(|command| command.name.starts_with(&query))
+                }
+                SelectorMode::None => false,
+            };
         let key = event.key();
         let direction = if event.meta_key() || event.alt_key() {
             None
@@ -244,6 +288,10 @@ pub fn Page() -> Element {
     let mut slash_cmds = use_signal(Vec::<SlashCommandEntry>::new);
     let mut sessions = use_signal(Vec::<ResumableSessionEntry>::new);
     let mut models = use_signal(Vec::<ModelOptionEntry>::new);
+    let mut media_entries = use_signal(Vec::<ChatMediaEntry>::new);
+    let mut media_request_id = use_signal(|| 0u64);
+    let mut media_requested_query = use_signal(|| None::<String>);
+    let mut media_loading = use_signal(|| false);
     let mut current_model_id = use_signal(String::new);
     let mut current_model = use_signal(String::new);
     let mut menu_sel = use_signal(|| 0usize);
@@ -330,6 +378,15 @@ pub fn Page() -> Element {
             attachments.set(next);
             focus_prompt_end();
         });
+    let _media_entries =
+        use_bin_event_listener::<ChatMediaEntries, _>(CHAT_MEDIA_ENTRIES_EVENT, move |response| {
+            if response.request_id != media_request_id() {
+                return;
+            }
+            media_entries.set(response.entries.clone());
+            media_loading.set(false);
+            menu_sel.set(0);
+        });
 
     let _cmds = use_bin_event_listener::<SlashCommands, _>(SLASH_COMMANDS_EVENT, move |s| {
         slash_cmds.set(s.commands.clone());
@@ -358,6 +415,30 @@ pub fn Page() -> Element {
         } else if !should_fetch && resume_requested() {
             resume_requested.set(false);
             resume_loading.set(false);
+        }
+    });
+
+    use_effect(move || {
+        let value = draft();
+        let Some(query) = inline_media_query(&value).map(|query| query.query.to_string()) else {
+            media_entries.set(Vec::new());
+            if media_requested_query.peek().is_some() {
+                media_request_id.set(media_request_id().wrapping_add(1).max(1));
+            }
+            media_requested_query.set(None);
+            media_loading.set(false);
+            return;
+        };
+        if media_requested_query().as_deref() == Some(query.as_str()) {
+            return;
+        }
+        let request_id = media_request_id().wrapping_add(1).max(1);
+        media_request_id.set(request_id);
+        media_requested_query.set(Some(query.clone()));
+        media_entries.set(Vec::new());
+        media_loading.set(true);
+        if try_cef_bin_emit_rkyv(&ChatMediaListRequest { request_id, query }).is_err() {
+            media_loading.set(false);
         }
     });
 
@@ -409,6 +490,7 @@ pub fn Page() -> Element {
         SelectorMode::Models(query) => Some(query),
         _ => None,
     };
+    let media_query = inline_media_query(&draft_val);
     let filtered_cmds: Vec<SlashCommandEntry> = command_query
         .map(|query| {
             let query = query.to_lowercase();
@@ -429,6 +511,7 @@ pub fn Page() -> Element {
     let cmd_menu_open = command_query.is_some() && !filtered_cmds.is_empty();
     let session_menu_open = resume_query.is_some();
     let model_menu_open = model_query.is_some();
+    let media_menu_open = media_query.is_some();
     let resume_state = resume_query.map(|_| {
         resume_menu_state(
             resume_requested(),
@@ -443,6 +526,7 @@ pub fn Page() -> Element {
         let _ = draft.read();
         let _ = sessions.read().len();
         let _ = models.read().len();
+        let _ = media_entries.read().len();
         if let Some(element) = web_sys::window()
             .and_then(|window| window.document())
             .and_then(|document| {
@@ -618,6 +702,49 @@ pub fn Page() -> Element {
                 class: "relative z-10 bg-gradient-to-t from-background via-background/95 to-transparent px-4 pb-4 pt-8",
                 div {
                     class: "relative mx-auto flex max-w-3xl flex-col gap-2",
+                    if media_menu_open {
+                        div { class: "absolute bottom-full left-0 z-20 mb-2 max-h-80 w-full overflow-y-auto rounded-xl border border-foreground/10 bg-background/95 shadow-xl backdrop-blur-xl",
+                            if media_loading() {
+                                div { class: "px-3.5 py-2 text-sm text-muted-foreground", "Loading media…" }
+                            } else if media_entries.read().is_empty() {
+                                div { class: "px-3.5 py-2 text-sm text-muted-foreground", "No matching media" }
+                            } else {
+                                for (i , entry) in media_entries.read().iter().cloned().enumerate() {
+                                    {
+                                        let entry = entry.clone();
+                                        rsx! {
+                                            div {
+                                                key: "media-{entry.path}",
+                                                id: "agent-selector-item-{i}",
+                                                class: if i == menu_sel() { "flex cursor-pointer items-center gap-3 bg-foreground/10 px-3.5 py-2" } else { "flex cursor-pointer items-center gap-3 px-3.5 py-2" },
+                                                onclick: move |_| select_media_entry(&entry, draft, menu_sel),
+                                                div { class: "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-foreground/[0.06] text-muted-foreground",
+                                                    if entry.is_dir {
+                                                        svg {
+                                                            class: "h-4 w-4",
+                                                            view_box: "0 0 24 24",
+                                                            fill: "none",
+                                                            stroke: "currentColor",
+                                                            stroke_width: "2",
+                                                            stroke_linecap: "round",
+                                                            stroke_linejoin: "round",
+                                                            path { d: "M3 6h6l2 2h10v10H3z" }
+                                                        }
+                                                    } else {
+                                                        span { class: "font-mono text-[9px] font-semibold", "{file_extension_label(&entry.name)}" }
+                                                    }
+                                                }
+                                                div { class: "min-w-0 flex-1",
+                                                    div { class: "truncate text-sm text-foreground", "{entry.name}" }
+                                                    div { class: "truncate text-xs text-muted-foreground", "{entry.parent}" }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                     if cmd_menu_open {
                         div { class: "absolute bottom-full left-0 z-20 mb-2 w-full overflow-hidden rounded-xl border border-foreground/10 bg-background/95 shadow-xl backdrop-blur-xl",
                             for (i , command) in filtered_cmds.iter().enumerate() {
@@ -852,7 +979,7 @@ pub fn Page() -> Element {
                                             terminal: false,
                                         }
                                     } else {
-                                        div { class: "max-w-full truncate whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50", "Type / for quick access" }
+                                        div { class: "max-w-full truncate whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50", "Type / for commands or @ for media" }
                                     }
                                 }
                             }
@@ -922,10 +1049,19 @@ pub fn Page() -> Element {
                                         ),
                                         SelectorMode::None => (Vec::new(), Vec::new(), Vec::new(), false, false),
                                     };
-                                    let selector_open = session_selector_open
+                                    let media_selector_open = inline_media_query(&draft_now).is_some();
+                                    let media_items = if media_selector_open {
+                                        media_entries.peek().clone()
+                                    } else {
+                                        Vec::new()
+                                    };
+                                    let selector_open = media_selector_open
+                                        || session_selector_open
                                         || model_selector_open
                                         || !cmd_items.is_empty();
-                                    let selector_len = if session_selector_open {
+                                    let selector_len = if media_selector_open {
+                                        media_items.len()
+                                    } else if session_selector_open {
                                         sess_items.len()
                                     } else if model_selector_open {
                                         model_items.len()
@@ -955,7 +1091,11 @@ pub fn Page() -> Element {
                                     {
                                         e.prevent_default();
                                         let selected = *menu_sel.peek();
-                                        if session_selector_open {
+                                        if media_selector_open {
+                                            if let Some(entry) = media_items.get(selected) {
+                                                select_media_entry(entry, draft, menu_sel);
+                                            }
+                                        } else if session_selector_open {
                                             if let Some(session) = sess_items.get(selected) {
                                                 select_resume_session(session, draft);
                                             }
@@ -970,11 +1110,16 @@ pub fn Page() -> Element {
                                     }
                                     if selector_open && e.key() == Key::Escape && !command_modifier {
                                         e.prevent_default();
-                                        draft.set(String::new());
+                                        if let Some(query) = inline_media_query(&draft_now) {
+                                            draft.set(replace_inline_media_query(&draft_now, query, ""));
+                                            focus_prompt_end();
+                                        } else {
+                                            draft.set(String::new());
+                                        }
                                         menu_sel.set(0);
                                         return;
                                     }
-                                    if (session_selector_open || model_selector_open)
+                                    if (media_selector_open || session_selector_open || model_selector_open)
                                         && matches!(e.key(), Key::Enter | Key::Escape)
                                     {
                                         return;

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -150,10 +150,14 @@ fn select_media_entry(
     let replacement = if entry.is_dir {
         format!("@{reference}/")
     } else {
-        let _ = try_cef_bin_emit_rkyv(&ChatAttachPaths {
+        if try_cef_bin_emit_rkyv(&ChatAttachPaths {
             paths: vec![entry.path.clone()],
-        });
-        format!("@{reference} ")
+        })
+        .is_err()
+        {
+            return;
+        }
+        String::new()
     };
     draft.set(replace_inline_media_query(&value, query, &replacement));
     menu_sel.set(0);
@@ -955,48 +959,6 @@ pub fn Page() -> Element {
                             }
                         }
                     }
-                    if !attachments.read().is_empty() {
-                        div { class: "flex gap-2 overflow-x-auto pb-0.5",
-                            for (i , attachment) in attachments.read().iter().cloned().enumerate() {
-                                div {
-                                    key: "attachment-{attachment.path}",
-                                    class: "group relative h-20 w-24 shrink-0 overflow-hidden rounded-xl bg-foreground/[0.06] ring-1 ring-inset ring-foreground/10",
-                                    if attachment.preview_data_url.is_empty() {
-                                        div { class: "flex h-14 items-center justify-center bg-foreground/[0.04] font-mono text-[10px] font-semibold tracking-wide text-muted-foreground",
-                                            "{attachment_label(&attachment)}"
-                                        }
-                                    } else {
-                                        img {
-                                            src: "{attachment.preview_data_url}",
-                                            alt: "{attachment.name}",
-                                            class: "h-14 w-full object-cover",
-                                        }
-                                    }
-                                    div { class: "truncate px-2 py-1 text-[10px] text-muted-foreground", "{attachment.name}" }
-                                    button {
-                                        class: "absolute right-1 top-1 flex h-5 w-5 items-center justify-center rounded-full bg-black/65 text-white opacity-80 transition hover:opacity-100",
-                                        title: "Remove attachment",
-                                        onclick: move |_| {
-                                            let mut next = attachments.peek().clone();
-                                            if i < next.len() {
-                                                next.remove(i);
-                                                attachments.set(next);
-                                            }
-                                        },
-                                        svg {
-                                            class: "h-3 w-3",
-                                            view_box: "0 0 24 24",
-                                            fill: "none",
-                                            stroke: "currentColor",
-                                            stroke_width: "2.5",
-                                            stroke_linecap: "round",
-                                            path { d: "M6 6l12 12M18 6L6 18" }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
                     div { class: "relative flex items-center overflow-hidden rounded-2xl bg-white/45 p-1 shadow-[0_18px_55px_-24px_rgba(0,0,0,0.65),inset_0_1px_0_rgba(255,255,255,0.18),inset_0_-1px_0_rgba(255,255,255,0.04)] ring-1 ring-inset ring-black/10 backdrop-blur-3xl backdrop-saturate-150 transition-all duration-200 focus-within:bg-white/55 focus-within:ring-black/20 focus-within:shadow-[0_22px_65px_-24px_rgba(0,0,0,0.72),inset_0_1px_0_rgba(255,255,255,0.22)] dark:bg-white/[0.045] dark:ring-white/[0.16] dark:focus-within:bg-white/[0.065] dark:focus-within:ring-white/25",
                         div { class: "pointer-events-none absolute inset-px rounded-[0.9rem] bg-gradient-to-b from-white/[0.12] via-white/[0.025] to-transparent dark:from-white/[0.10]" }
                         div { class: "pointer-events-none absolute -left-12 -top-12 h-24 w-72 rotate-[-5deg] rounded-full bg-white/[0.09] blur-2xl" }
@@ -1017,32 +979,71 @@ pub fn Page() -> Element {
                                 path { d: "M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48" }
                             }
                         }
-                        div { class: "relative z-10 min-w-0 flex-1 overflow-hidden",
-                            if draft.read().is_empty() {
-                                div { class: "pointer-events-none absolute inset-0 flex -translate-y-px items-center overflow-hidden px-3.5",
-                                    if show_capability_examples {
-                                        PromptGhost {
-                                            accent_bg: agent_accent.accent_bg.to_string(),
-                                            terminal: false,
+                        div { class: "relative z-10 flex min-w-0 flex-1 flex-wrap items-center gap-1 px-2",
+                            for (i , attachment) in attachments.read().iter().cloned().enumerate() {
+                                div {
+                                    key: "attachment-pill-{attachment.path}",
+                                    class: "group flex h-7 max-w-56 shrink-0 items-center gap-1.5 rounded-full bg-foreground/[0.08] pl-1 pr-1.5 text-xs text-foreground/80 ring-1 ring-inset ring-foreground/10",
+                                    if attachment.preview_data_url.is_empty() {
+                                        span { class: "flex h-5 min-w-5 items-center justify-center rounded-full bg-foreground/[0.08] px-1 font-mono text-[8px] font-semibold text-muted-foreground",
+                                            "{attachment_label(&attachment)}"
                                         }
                                     } else {
-                                        div { class: "max-w-full truncate whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50", "Type / for commands or @ for media" }
+                                        img {
+                                            src: "{attachment.preview_data_url}",
+                                            alt: "{attachment.name}",
+                                            class: "h-5 w-5 rounded-full object-cover",
+                                        }
+                                    }
+                                    span { class: "min-w-0 max-w-40 truncate", "{attachment.name}" }
+                                    button {
+                                        class: "flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-foreground/45 transition hover:bg-foreground/10 hover:text-foreground",
+                                        title: "Remove attachment",
+                                        onclick: move |_| {
+                                            let mut next = attachments.peek().clone();
+                                            if i < next.len() {
+                                                next.remove(i);
+                                                attachments.set(next);
+                                            }
+                                        },
+                                        svg {
+                                            class: "h-3 w-3",
+                                            view_box: "0 0 24 24",
+                                            fill: "none",
+                                            stroke: "currentColor",
+                                            stroke_width: "2.5",
+                                            stroke_linecap: "round",
+                                            path { d: "M6 6l12 12M18 6L6 18" }
+                                        }
                                     }
                                 }
                             }
-                            if let Some(prefix) = prompt_caret_prefix.as_ref() {
-                                div { class: "pointer-events-none absolute inset-0 z-20 overflow-hidden",
-                                    div {
-                                        class: "min-h-10 w-full whitespace-pre-wrap break-words px-3.5 py-2 text-[15px] leading-6 text-transparent",
-                                        style: "transform:translateY(-{prompt_scroll_offset}px);",
-                                        span { "{prefix}" }
-                                        span { class: "agent-chat-caret relative top-px ml-px inline-block h-4 w-1.5 align-middle {agent_accent.accent_bg}" }
+                            div { class: "relative min-w-32 flex-1 overflow-hidden",
+                                if draft.read().is_empty() {
+                                    div { class: "pointer-events-none absolute inset-0 flex -translate-y-px items-center overflow-hidden px-1.5",
+                                        if show_capability_examples {
+                                            PromptGhost {
+                                                accent_bg: agent_accent.accent_bg.to_string(),
+                                                terminal: false,
+                                            }
+                                        } else {
+                                            div { class: "max-w-full truncate whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50", "Type / for commands or @ for media" }
+                                        }
                                     }
                                 }
-                            }
-                            textarea {
+                                if let Some(prefix) = prompt_caret_prefix.as_ref() {
+                                    div { class: "pointer-events-none absolute inset-0 z-20 overflow-hidden",
+                                        div {
+                                            class: "min-h-10 w-full whitespace-pre-wrap break-words px-1.5 py-2 text-[15px] leading-6 text-transparent",
+                                            style: "transform:translateY(-{prompt_scroll_offset}px);",
+                                            span { "{prefix}" }
+                                            span { class: "agent-chat-caret relative top-px ml-px inline-block h-4 w-1.5 align-middle {agent_accent.accent_bg}" }
+                                        }
+                                    }
+                                }
+                                textarea {
                                 id: PROMPT_ID,
-                                class: "agent-chat-prompt relative z-10 max-h-40 min-h-10 w-full resize-none bg-transparent px-3.5 py-2 text-[15px] leading-6 placeholder:text-transparent focus:outline-none",
+                                class: "agent-chat-prompt relative z-10 max-h-40 min-h-10 w-full resize-none bg-transparent px-1.5 py-2 text-[15px] leading-6 placeholder:text-transparent focus:outline-none",
                                 rows: "1",
                                 placeholder: "Message the agent…",
                                 value: "{draft}",
@@ -1245,6 +1246,7 @@ pub fn Page() -> Element {
                                         let _ = try_cef_bin_emit_rkyv(&ChatCancel);
                                     }
                                 },
+                                }
                             }
                         }
                         if matches!(status().as_str(), "streaming" | "awaiting") {

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -1,15 +1,17 @@
 #![allow(non_snake_case)]
 
 use crate::chat_page::composer::{
-    PromptEdit, ResumeMenuState, SelectorMode, ToolActivity, chat_page_title, edit_prompt,
-    filter_models, filter_sessions, is_handoff_boundary, menu_direction, move_selection,
+    PromptEdit, PromptHistoryDirection, ResumeMenuState, SelectorMode, ToolActivity,
+    chat_page_title, edit_prompt, filter_models, filter_sessions, is_handoff_boundary,
+    menu_direction, move_prompt_history, move_selection, prompt_history_direction,
     prompt_prefix_at_utf16, resume_menu_state, selector_mode, should_clear_draft_on_escape,
     should_expand_thinking, should_fetch_resume, tool_activity,
 };
 use crate::chat_page::event::{
-    CHAT_SNAPSHOT_EVENT, ChatApproval, ChatBlock, ChatCancel, ChatCancelQueuedPrompt,
-    ChatClearQueue, ChatEscape, ChatItem, ChatResume, ChatSnapshot, ChatSubmit, ChatTurn,
-    MODEL_STATE_EVENT, ModelOptionEntry, ModelState, QueuedPromptSnapshot,
+    CHAT_ATTACHMENTS_EVENT, CHAT_SNAPSHOT_EVENT, ChatApproval, ChatAttachment, ChatAttachments,
+    ChatBlock, ChatCancel, ChatCancelQueuedPrompt, ChatClearQueue, ChatEscape, ChatItem,
+    ChatPasteMedia, ChatPickFiles, ChatResume, ChatSnapshot, ChatSubmit, ChatSubmitAttachment,
+    ChatTurn, MODEL_STATE_EVENT, ModelOptionEntry, ModelState, QueuedPromptSnapshot,
     RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions, ResumeListRequest,
     ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry,
     SlashCommands, WORKING_VERBS,
@@ -68,6 +70,50 @@ fn sync_prompt_caret(mut caret: Signal<Option<u32>>, mut scroll_top: Signal<i32>
     let end = textarea.selection_end().ok().flatten().unwrap_or(start);
     caret.set((start == end).then_some(start));
     scroll_top.set(textarea.scroll_top());
+}
+
+fn focus_prompt_end() {
+    let closure = Closure::once(move || {
+        let Some(textarea) = prompt_textarea() else {
+            return;
+        };
+        let end = textarea.value().encode_utf16().count() as u32;
+        let _ = textarea.focus();
+        let _ = textarea.set_selection_range(end, end);
+    });
+    if let Some(window) = web_sys::window() {
+        let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(
+            closure.as_ref().unchecked_ref(),
+            0,
+        );
+    }
+    closure.forget();
+}
+
+fn prompt_history(items: &[ChatItem], queued: &[QueuedPromptSnapshot]) -> Vec<String> {
+    let mut history = items
+        .iter()
+        .filter_map(|item| match item {
+            ChatItem::User { text } if !text.trim().is_empty() => Some(text.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    history.extend(
+        queued
+            .iter()
+            .filter(|prompt| !prompt.text.trim().is_empty())
+            .map(|prompt| prompt.text.clone()),
+    );
+    history
+}
+
+fn attachment_label(attachment: &ChatAttachment) -> String {
+    std::path::Path::new(&attachment.name)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| extension.to_ascii_uppercase())
+        .filter(|extension| !extension.is_empty())
+        .unwrap_or_else(|| "FILE".to_string())
 }
 
 fn dispatch_input_event(textarea: &web_sys::HtmlTextAreaElement) {
@@ -131,7 +177,7 @@ fn install_global_prompt_input(draft: Signal<String>, slash_cmds: Signal<Vec<Sla
             && !event.alt_key()
             && matches!(key.as_str(), "Enter" | "Escape");
         let selector_key = direction.is_some() || plain_invoke_or_close;
-        if selector_open && selector_key {
+        if direction.is_some() || (selector_open && selector_key) {
             event.prevent_default();
             event.stop_propagation();
             let _ = textarea.focus();
@@ -185,6 +231,9 @@ pub fn Page() -> Element {
     let mut handoff_truncated = use_signal(|| false);
     let mut handoff_message_count = use_signal(|| 0u32);
     let mut draft = use_signal(String::new);
+    let mut attachments = use_signal(Vec::<ChatAttachment>::new);
+    let mut history_cursor = use_signal(|| None::<usize>);
+    let mut history_scratch = use_signal(String::new);
     let mut prompt_caret = use_signal(|| None::<u32>);
     let prompt_scroll_top = use_signal(|| 0i32);
     let mut elapsed = use_signal(|| 0u32);
@@ -270,6 +319,17 @@ pub fn Page() -> Element {
             approval.set(None);
         }
     });
+    let _attachments =
+        use_bin_event_listener::<ChatAttachments, _>(CHAT_ATTACHMENTS_EVENT, move |selected| {
+            let mut next = attachments.peek().clone();
+            for attachment in &selected.attachments {
+                if !next.iter().any(|existing| existing.path == attachment.path) {
+                    next.push(attachment.clone());
+                }
+            }
+            attachments.set(next);
+            focus_prompt_end();
+        });
 
     let _cmds = use_bin_event_listener::<SlashCommands, _>(SLASH_COMMANDS_EVENT, move |s| {
         slash_cmds.set(s.commands.clone());
@@ -321,7 +381,8 @@ pub fn Page() -> Element {
     let agent_accent = agent_accent(&agent);
     let installing = status() == "installing";
     let installing_splash = installing && items.read().is_empty();
-    let show_capability_examples = items.read().is_empty() && queued.read().is_empty();
+    let show_capability_examples =
+        items.read().is_empty() && queued.read().is_empty() && attachments.read().is_empty();
     let install_detail = {
         let detail = error();
         if detail.is_empty() {
@@ -646,7 +707,20 @@ pub fn Page() -> Element {
                                     key: "q{queued_prompt.id}",
                                     class: "group flex max-w-[80%] items-center gap-2 rounded-2xl border border-dashed border-foreground/20 bg-foreground/[0.03] py-2 pl-3.5 pr-2 text-sm text-muted-foreground",
                                     span { class: "shrink-0 text-[10px] uppercase tracking-wide text-foreground/40", "queued" }
-                                    span { class: "min-w-0 flex-1 whitespace-pre-wrap break-words", "{queued_prompt.text}" }
+                                    span { class: "min-w-0 flex-1 whitespace-pre-wrap break-words",
+                                        if !queued_prompt.text.is_empty() {
+                                            "{queued_prompt.text}"
+                                        }
+                                        if !queued_prompt.attachment_names.is_empty() {
+                                            span { class: "block text-xs text-foreground/45",
+                                                "Attached: "
+                                                for (i , name) in queued_prompt.attachment_names.iter().enumerate() {
+                                                    if i > 0 { ", " }
+                                                    "{name}"
+                                                }
+                                            }
+                                        }
+                                    }
                                     button {
                                         class: "flex shrink-0 items-center rounded-lg p-1 text-foreground/35 opacity-70 transition hover:bg-foreground/10 hover:text-foreground hover:opacity-100 focus:opacity-100",
                                         title: "Cancel queued prompt",
@@ -707,9 +781,68 @@ pub fn Page() -> Element {
                             }
                         }
                     }
+                    if !attachments.read().is_empty() {
+                        div { class: "flex gap-2 overflow-x-auto pb-0.5",
+                            for (i , attachment) in attachments.read().iter().cloned().enumerate() {
+                                div {
+                                    key: "attachment-{attachment.path}",
+                                    class: "group relative h-20 w-24 shrink-0 overflow-hidden rounded-xl bg-foreground/[0.06] ring-1 ring-inset ring-foreground/10",
+                                    if attachment.preview_data_url.is_empty() {
+                                        div { class: "flex h-14 items-center justify-center bg-foreground/[0.04] font-mono text-[10px] font-semibold tracking-wide text-muted-foreground",
+                                            "{attachment_label(&attachment)}"
+                                        }
+                                    } else {
+                                        img {
+                                            src: "{attachment.preview_data_url}",
+                                            alt: "{attachment.name}",
+                                            class: "h-14 w-full object-cover",
+                                        }
+                                    }
+                                    div { class: "truncate px-2 py-1 text-[10px] text-muted-foreground", "{attachment.name}" }
+                                    button {
+                                        class: "absolute right-1 top-1 flex h-5 w-5 items-center justify-center rounded-full bg-black/65 text-white opacity-80 transition hover:opacity-100",
+                                        title: "Remove attachment",
+                                        onclick: move |_| {
+                                            let mut next = attachments.peek().clone();
+                                            if i < next.len() {
+                                                next.remove(i);
+                                                attachments.set(next);
+                                            }
+                                        },
+                                        svg {
+                                            class: "h-3 w-3",
+                                            view_box: "0 0 24 24",
+                                            fill: "none",
+                                            stroke: "currentColor",
+                                            stroke_width: "2.5",
+                                            stroke_linecap: "round",
+                                            path { d: "M6 6l12 12M18 6L6 18" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                     div { class: "relative flex items-center overflow-hidden rounded-2xl bg-white/45 p-1 shadow-[0_18px_55px_-24px_rgba(0,0,0,0.65),inset_0_1px_0_rgba(255,255,255,0.18),inset_0_-1px_0_rgba(255,255,255,0.04)] ring-1 ring-inset ring-black/10 backdrop-blur-3xl backdrop-saturate-150 transition-all duration-200 focus-within:bg-white/55 focus-within:ring-black/20 focus-within:shadow-[0_22px_65px_-24px_rgba(0,0,0,0.72),inset_0_1px_0_rgba(255,255,255,0.22)] dark:bg-white/[0.045] dark:ring-white/[0.16] dark:focus-within:bg-white/[0.065] dark:focus-within:ring-white/25",
                         div { class: "pointer-events-none absolute inset-px rounded-[0.9rem] bg-gradient-to-b from-white/[0.12] via-white/[0.025] to-transparent dark:from-white/[0.10]" }
                         div { class: "pointer-events-none absolute -left-12 -top-12 h-24 w-72 rotate-[-5deg] rounded-full bg-white/[0.09] blur-2xl" }
+                        button {
+                            class: "relative z-10 ml-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg text-foreground/45 transition hover:bg-foreground/10 hover:text-foreground",
+                            title: "Attach files (/upload)",
+                            onclick: move |_| {
+                                let _ = try_cef_bin_emit_rkyv(&ChatPickFiles);
+                            },
+                            svg {
+                                class: "h-4 w-4",
+                                view_box: "0 0 24 24",
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_width: "2",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                path { d: "M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48" }
+                            }
+                        }
                         div { class: "relative z-10 min-w-0 flex-1 overflow-hidden",
                             if draft.read().is_empty() {
                                 div { class: "pointer-events-none absolute inset-0 flex -translate-y-px items-center overflow-hidden px-3.5",
@@ -741,8 +874,13 @@ pub fn Page() -> Element {
                                 value: "{draft}",
                                 oninput: move |e| {
                                     draft.set(e.value());
+                                    history_cursor.set(None);
+                                    history_scratch.set(String::new());
                                     menu_sel.set(0);
                                     sync_prompt_caret(prompt_caret, prompt_scroll_top);
+                                },
+                                onpaste: move |_| {
+                                    let _ = try_cef_bin_emit_rkyv(&ChatPasteMedia);
                                 },
                                 onfocus: move |_| sync_prompt_caret(prompt_caret, prompt_scroll_top),
                                 onblur: move |_| prompt_caret.set(None),
@@ -842,9 +980,61 @@ pub fn Page() -> Element {
                                         return;
                                     }
 
+                                    if !selector_open
+                                        && !e.modifiers().meta()
+                                        && !e.modifiers().alt()
+                                        && let Some(textarea) = prompt_textarea()
+                                    {
+                                        let start = textarea
+                                            .selection_start()
+                                            .ok()
+                                            .flatten()
+                                            .unwrap_or_default();
+                                        let end = textarea
+                                            .selection_end()
+                                            .ok()
+                                            .flatten()
+                                            .unwrap_or(start);
+                                        if let Some(direction) = prompt_history_direction(
+                                            &key,
+                                            e.modifiers().ctrl(),
+                                            &draft_now,
+                                            start,
+                                            end,
+                                        ) {
+                                            let history = prompt_history(&items.peek(), &queued.peek());
+                                            let current_cursor = *history_cursor.peek();
+                                            let should_handle = match direction {
+                                                PromptHistoryDirection::Older => !history.is_empty(),
+                                                PromptHistoryDirection::Newer => current_cursor.is_some(),
+                                            };
+                                            if should_handle {
+                                                e.prevent_default();
+                                                let (value, cursor, scratch) = move_prompt_history(
+                                                    &history,
+                                                    current_cursor,
+                                                    &history_scratch.peek(),
+                                                    &draft_now,
+                                                    direction,
+                                                );
+                                                draft.set(value);
+                                                history_cursor.set(cursor);
+                                                history_scratch.set(scratch);
+                                                focus_prompt_end();
+                                                return;
+                                            }
+                                        }
+                                    }
+
                                     if e.key() == Key::Enter && !e.modifiers().shift() {
                                         e.prevent_default();
-                                        do_submit(draft, at_bottom);
+                                        do_submit(
+                                            draft,
+                                            attachments,
+                                            history_cursor,
+                                            history_scratch,
+                                            at_bottom,
+                                        );
                                     } else if e.key() == Key::Escape {
                                         e.prevent_default();
                                         let _ = try_cef_bin_emit_rkyv(&ChatEscape);
@@ -902,10 +1092,18 @@ pub fn Page() -> Element {
                             }
                         } else {
                             button {
-                                class: if draft.read().trim().is_empty() { "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 cursor-default self-center items-center justify-center rounded-lg bg-white/25 text-muted-foreground/35 shadow-sm ring-1 ring-inset ring-black/[0.06] dark:bg-white/[0.055] dark:ring-white/[0.08]" } else { "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg bg-gradient-to-br text-white shadow-lg transition hover:brightness-110 active:scale-95 {agent_accent.grad}" },
-                                disabled: draft.read().trim().is_empty(),
+                                class: if draft.read().trim().is_empty() && attachments.read().is_empty() { "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 cursor-default self-center items-center justify-center rounded-lg bg-white/25 text-muted-foreground/35 shadow-sm ring-1 ring-inset ring-black/[0.06] dark:bg-white/[0.055] dark:ring-white/[0.08]" } else { "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg bg-gradient-to-br text-white shadow-lg transition hover:brightness-110 active:scale-95 {agent_accent.grad}" },
+                                disabled: draft.read().trim().is_empty() && attachments.read().is_empty(),
                                 title: "Send (Enter)",
-                                onclick: move |_| do_submit(draft, at_bottom),
+                                onclick: move |_| {
+                                    do_submit(
+                                        draft,
+                                        attachments,
+                                        history_cursor,
+                                        history_scratch,
+                                        at_bottom,
+                                    )
+                                },
                                 svg {
                                     class: "h-4 w-4",
                                     view_box: "0 0 24 24",
@@ -931,6 +1129,10 @@ pub fn Page() -> Element {
 /// via the normal Enter path).
 fn run_slash_command(name: &str, mut draft: Signal<String>, mut menu_sel: Signal<usize>) {
     match name {
+        "upload" => {
+            let _ = try_cef_bin_emit_rkyv(&ChatPickFiles);
+            draft.set(String::new());
+        }
         "resume" => {
             menu_sel.set(0);
             draft.set("/resume ".to_string());
@@ -969,16 +1171,40 @@ fn select_resume_session(session: &ResumableSessionEntry, mut draft: Signal<Stri
 
 /// Emit the draft as a submit intent, clearing the input only if the IPC succeeded so a failed
 /// emit never silently swallows the user's message. The queued/sent turn arrives via snapshot.
-fn do_submit(mut draft: Signal<String>, mut at_bottom: Signal<bool>) {
+fn do_submit(
+    mut draft: Signal<String>,
+    mut attachments: Signal<Vec<ChatAttachment>>,
+    mut history_cursor: Signal<Option<usize>>,
+    mut history_scratch: Signal<String>,
+    mut at_bottom: Signal<bool>,
+) {
     let text = draft.peek().trim().to_string();
-    if text.is_empty() {
+    let selected = attachments.peek().clone();
+    if text.is_empty() && selected.is_empty() {
         return;
     }
-    if try_cef_bin_emit_rkyv(&ChatSubmit { text }).is_err() {
+    let attachments_to_submit = selected
+        .iter()
+        .map(|attachment| ChatSubmitAttachment {
+            path: attachment.path.clone(),
+            name: attachment.name.clone(),
+            mime_type: attachment.mime_type.clone(),
+            size: attachment.size,
+        })
+        .collect();
+    if try_cef_bin_emit_rkyv(&ChatSubmit {
+        text,
+        attachments: attachments_to_submit,
+    })
+    .is_err()
+    {
         return;
     }
     at_bottom.set(true);
     draft.set(String::new());
+    attachments.set(Vec::new());
+    history_cursor.set(None);
+    history_scratch.set(String::new());
 }
 
 fn send_approval(call_id: String, decision: u8) {

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -759,7 +759,7 @@ pub fn Page() -> Element {
                                                 id: "agent-selector-item-{i}",
                                                 class: if i == menu_sel() { "flex cursor-pointer items-center gap-3 bg-foreground/10 px-3.5 py-2" } else { "flex cursor-pointer items-center gap-3 px-3.5 py-2" },
                                                 onclick: move |_| select_media_entry(&entry, draft, menu_sel),
-                                                div { class: "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-foreground/[0.06] text-muted-foreground",
+                                                div { class: "flex h-12 w-16 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-foreground/[0.06] text-muted-foreground ring-1 ring-inset ring-foreground/10",
                                                     if entry.is_dir {
                                                         svg {
                                                             class: "h-4 w-4",
@@ -770,6 +770,12 @@ pub fn Page() -> Element {
                                                             stroke_linecap: "round",
                                                             stroke_linejoin: "round",
                                                             path { d: "M3 6h6l2 2h10v10H3z" }
+                                                        }
+                                                    } else if !entry.preview_data_url.is_empty() {
+                                                        img {
+                                                            src: "{entry.preview_data_url}",
+                                                            alt: "{entry.name}",
+                                                            class: "h-full w-full object-contain",
                                                         }
                                                     } else {
                                                         span { class: "font-mono text-[9px] font-semibold", "{file_extension_label(&entry.name)}" }

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -9,17 +9,19 @@ use crate::chat_page::composer::{
     should_expand_thinking, tool_activity,
 };
 use crate::chat_page::event::{
-    CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT, CHAT_SNAPSHOT_EVENT, ChatApproval,
-    ChatAttachPaths, ChatAttachment, ChatAttachments, ChatBlock, ChatCancel,
-    ChatCancelQueuedPrompt, ChatClearQueue, ChatEscape, ChatItem, ChatMediaEntries, ChatMediaEntry,
-    ChatMediaListRequest, ChatPasteMedia, ChatPickFiles, ChatResume, ChatSnapshot, ChatSubmit,
-    ChatSubmitAttachment, ChatTurn, MODEL_STATE_EVENT, ModelOptionEntry, ModelState,
-    QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions,
-    ResumeListRequest, ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel,
-    SlashCommandEntry, SlashCommands, WORKING_VERBS,
+    CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT,
+    CHAT_SNAPSHOT_EVENT, ChatApproval, ChatAttachPaths, ChatAttachment,
+    ChatAttachmentPreviewRequest, ChatAttachments, ChatBlock, ChatCancel, ChatCancelQueuedPrompt,
+    ChatClearQueue, ChatEscape, ChatItem, ChatMediaEntries, ChatMediaEntry, ChatMediaListRequest,
+    ChatPasteMedia, ChatPickFiles, ChatResume, ChatSnapshot, ChatSubmit, ChatSubmitAttachment,
+    ChatTurn, MODEL_STATE_EVENT, ModelOptionEntry, ModelState, QueuedPromptSnapshot,
+    RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions, ResumeListRequest,
+    ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry,
+    SlashCommands, WORKING_VERBS,
 };
 use dioxus::prelude::*;
 use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
 use vmux_terminal::matrix_rain::MatrixRain;
 use vmux_terminal::page::PromptGhost;
 use vmux_ui::agent_accent::agent_accent;
@@ -96,7 +98,7 @@ fn prompt_history(items: &[ChatItem], queued: &[QueuedPromptSnapshot]) -> Vec<St
     let mut history = items
         .iter()
         .filter_map(|item| match item {
-            ChatItem::User { text } if !text.trim().is_empty() => Some(text.clone()),
+            ChatItem::User { text, .. } if !text.trim().is_empty() => Some(text.clone()),
             _ => None,
         })
         .collect::<Vec<_>>();
@@ -276,6 +278,8 @@ pub fn Page() -> Element {
     let mut handoff_message_count = use_signal(|| 0u32);
     let mut draft = use_signal(String::new);
     let mut attachments = use_signal(Vec::<ChatAttachment>::new);
+    let mut attachment_previews = use_signal(HashMap::<String, ChatAttachment>::new);
+    let mut attachment_preview_requests = use_signal(HashSet::<String>::new);
     let mut history_cursor = use_signal(|| None::<usize>);
     let mut history_scratch = use_signal(String::new);
     let mut prompt_caret = use_signal(|| None::<u32>);
@@ -345,6 +349,30 @@ pub fn Page() -> Element {
 
     let _listener = use_bin_event_listener::<ChatSnapshot, _>(CHAT_SNAPSHOT_EVENT, move |snap| {
         if let Ok(parsed) = serde_json::from_str::<Vec<ChatItem>>(&snap.messages_json) {
+            let known = attachment_previews
+                .peek()
+                .keys()
+                .cloned()
+                .collect::<HashSet<_>>();
+            let mut requested = attachment_preview_requests.peek().clone();
+            let paths = parsed
+                .iter()
+                .filter_map(|item| match item {
+                    ChatItem::User { attachments, .. } => Some(attachments),
+                    _ => None,
+                })
+                .flatten()
+                .filter(|attachment| attachment.mime_type.starts_with("image/"))
+                .filter(|attachment| {
+                    !known.contains(&attachment.path) && requested.insert(attachment.path.clone())
+                })
+                .map(|attachment| attachment.path.clone())
+                .collect::<Vec<_>>();
+            if !paths.is_empty()
+                && try_cef_bin_emit_rkyv(&ChatAttachmentPreviewRequest { paths }).is_ok()
+            {
+                attachment_preview_requests.set(requested);
+            }
             items.set(parsed);
         }
         status.set(snap.status.clone());
@@ -370,14 +398,27 @@ pub fn Page() -> Element {
     let _attachments =
         use_bin_event_listener::<ChatAttachments, _>(CHAT_ATTACHMENTS_EVENT, move |selected| {
             let mut next = attachments.peek().clone();
+            let mut previews = attachment_previews.peek().clone();
             for attachment in &selected.attachments {
+                previews.insert(attachment.path.clone(), attachment.clone());
                 if !next.iter().any(|existing| existing.path == attachment.path) {
                     next.push(attachment.clone());
                 }
             }
+            attachment_previews.set(previews);
             attachments.set(next);
             focus_prompt_end();
         });
+    let _attachment_previews = use_bin_event_listener::<ChatAttachments, _>(
+        CHAT_ATTACHMENT_PREVIEWS_EVENT,
+        move |loaded| {
+            let mut previews = attachment_previews.peek().clone();
+            for attachment in &loaded.attachments {
+                previews.insert(attachment.path.clone(), attachment.clone());
+            }
+            attachment_previews.set(previews);
+        },
+    );
     let _media_entries =
         use_bin_event_listener::<ChatMediaEntries, _>(CHAT_MEDIA_ENTRIES_EVENT, move |response| {
             if response.request_id != media_request_id() {
@@ -612,7 +653,7 @@ pub fn Page() -> Element {
                         }
                     }
                     for (i , item) in items.read().iter().enumerate() {
-                        {render_item(i, item, &verb(), elapsed())}
+                        {render_item(i, item, &verb(), elapsed(), attachment_previews)}
                         if !handoff_source().is_empty()
                             && is_handoff_boundary(i, handoff_message_count())
                         {
@@ -1356,16 +1397,64 @@ fn send_approval(call_id: String, decision: u8) {
     let _ = try_cef_bin_emit_rkyv(&ChatApproval { call_id, decision });
 }
 
-fn render_item(key: usize, item: &ChatItem, verb: &str, elapsed: u32) -> Element {
+fn render_item(
+    key: usize,
+    item: &ChatItem,
+    verb: &str,
+    elapsed: u32,
+    attachment_previews: Signal<HashMap<String, ChatAttachment>>,
+) -> Element {
     match item {
-        ChatItem::User { text } => rsx! {
+        ChatItem::User { text, attachments } => rsx! {
             div {
                 key: "{key}",
-                class: "max-w-[80%] self-end whitespace-pre-wrap rounded-2xl bg-foreground/[0.08] px-4 py-2.5 text-sm",
-                "{text}"
+                class: "flex max-w-[80%] self-end flex-col gap-2 rounded-2xl bg-foreground/[0.08] p-2.5 text-sm",
+                if !text.is_empty() {
+                    div { class: "whitespace-pre-wrap px-1.5", "{text}" }
+                }
+                if !attachments.is_empty() {
+                    div { class: "flex flex-wrap justify-end gap-2",
+                        for attachment in attachments {
+                            {render_user_attachment(attachment, attachment_previews)}
+                        }
+                    }
+                }
             }
         },
         ChatItem::Turn(turn) => render_turn(key, turn, verb, elapsed),
+    }
+}
+
+fn render_user_attachment(
+    attachment: &ChatSubmitAttachment,
+    previews: Signal<HashMap<String, ChatAttachment>>,
+) -> Element {
+    let preview_data_url = previews
+        .peek()
+        .get(&attachment.path)
+        .map(|preview| preview.preview_data_url.clone())
+        .unwrap_or_default();
+    if attachment.mime_type.starts_with("image/") && !preview_data_url.is_empty() {
+        return rsx! {
+            figure {
+                key: "message-attachment-{attachment.path}",
+                class: "max-w-full overflow-hidden rounded-xl bg-black/10 ring-1 ring-inset ring-foreground/10",
+                img {
+                    src: "{preview_data_url}",
+                    alt: "{attachment.name}",
+                    class: "max-h-80 max-w-full object-contain",
+                }
+                figcaption { class: "max-w-72 truncate px-2.5 py-1.5 text-[10px] text-muted-foreground", "{attachment.name}" }
+            }
+        };
+    }
+    rsx! {
+        div {
+            key: "message-attachment-{attachment.path}",
+            class: "flex min-w-32 max-w-64 items-center gap-2 rounded-xl bg-foreground/[0.06] px-3 py-2 ring-1 ring-inset ring-foreground/10",
+            span { class: "font-mono text-[10px] font-semibold tracking-wide text-muted-foreground", "{file_extension_label(&attachment.name)}" }
+            span { class: "truncate text-xs text-muted-foreground", "{attachment.name}" }
+        }
     }
 }
 

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -202,20 +202,22 @@ fn install_global_prompt_input(draft: Signal<String>, slash_cmds: Signal<Vec<Sla
             return;
         }
 
-        let draft_value = draft.peek();
-        let selector_open = inline_media_query(&draft_value).is_some()
-            || match selector_mode(&draft_value) {
-                SelectorMode::Resume(_) => true,
-                SelectorMode::Models(_) => true,
-                SelectorMode::Commands(query) => {
-                    let query = query.to_lowercase();
-                    slash_cmds
-                        .peek()
-                        .iter()
-                        .any(|command| command.name.starts_with(&query))
+        let selector_open = {
+            let draft_value = draft.peek();
+            inline_media_query(&draft_value).is_some()
+                || match selector_mode(&draft_value) {
+                    SelectorMode::Resume(_) => true,
+                    SelectorMode::Models(_) => true,
+                    SelectorMode::Commands(query) => {
+                        let query = query.to_lowercase();
+                        slash_cmds
+                            .peek()
+                            .iter()
+                            .any(|command| command.name.starts_with(&query))
+                    }
+                    SelectorMode::None => false,
                 }
-                SelectorMode::None => false,
-            };
+        };
         let key = event.key();
         let direction = if event.meta_key() || event.alt_key() {
             None

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -5,8 +5,8 @@ use crate::chat_page::composer::{
     chat_page_title, edit_prompt, filter_models, filter_sessions, inline_media_query,
     is_handoff_boundary, menu_direction, move_prompt_history, move_selection,
     prompt_history_direction, prompt_prefix_at_utf16, replace_inline_media_query,
-    resume_menu_state, selector_mode, should_clear_draft_on_escape, should_fetch_resume,
-    should_expand_thinking, tool_activity,
+    resume_menu_state, selector_mode, should_clear_draft_on_escape, should_expand_thinking,
+    should_fetch_resume, tool_activity,
 };
 use crate::chat_page::event::{
     CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT,

--- a/crates/vmux_agent/src/chat_page/turns.rs
+++ b/crates/vmux_agent/src/chat_page/turns.rs
@@ -2,7 +2,7 @@
 //! user bubbles and grouped assistant turns. Pure + unit-tested — the brain for the dumb chat
 //! page (see the context-collapse design).
 
-use crate::chat_page::event::{ChatBlock, ChatItem, ChatPlanStep, ChatTurn};
+use crate::chat_page::event::{ChatBlock, ChatItem, ChatPlanStep, ChatSubmitAttachment, ChatTurn};
 use vmux_service::message::{AssistantBlock, Message, PlanStep};
 
 /// Group `messages` into `ChatItem`s: one `ChatItem::User` per user message, followed by one
@@ -16,9 +16,20 @@ pub fn group_turns(messages: &[Message], durations: &[u32], running: bool) -> Ve
 
     for msg in messages {
         match msg {
-            Message::User { text } => {
+            Message::User { text, attachments } => {
                 flush(&mut items, &mut current, &mut ordinal, durations);
-                items.push(ChatItem::User { text: text.clone() });
+                items.push(ChatItem::User {
+                    text: text.clone(),
+                    attachments: attachments
+                        .iter()
+                        .map(|attachment| ChatSubmitAttachment {
+                            path: attachment.path.clone(),
+                            name: attachment.name.clone(),
+                            mime_type: attachment.mime_type.clone(),
+                            size: attachment.size,
+                        })
+                        .collect(),
+                });
                 current = Some(ChatTurn::default());
             }
             Message::Assistant { blocks } => {
@@ -162,7 +173,7 @@ mod tests {
     #[test]
     fn splits_steps_and_answer_folds_tool_result() {
         let msgs = vec![
-            Message::User { text: "hi".into() },
+            Message::user("hi"),
             assistant(vec![AssistantBlock::Thinking("t".into()), tool("c1")]),
             Message::ToolResult {
                 call_id: "c1".into(),
@@ -173,7 +184,7 @@ mod tests {
         ];
         let items = group_turns(&msgs, &[], false);
         assert_eq!(items.len(), 2);
-        assert!(matches!(&items[0], ChatItem::User { text } if text == "hi"));
+        assert!(matches!(&items[0], ChatItem::User { text, .. } if text == "hi"));
         let ChatItem::Turn(t) = &items[1] else {
             panic!()
         };
@@ -185,11 +196,34 @@ mod tests {
     }
 
     #[test]
+    fn user_attachments_are_projected_into_chat_items() {
+        let messages = vec![Message::user_with_attachments(
+            "inspect",
+            vec![vmux_service::protocol::AgentAttachment {
+                path: "/tmp/image.png".into(),
+                name: "image.png".into(),
+                mime_type: "image/png".into(),
+                size: 3,
+            }],
+        )];
+
+        let items = group_turns(&messages, &[], false);
+
+        assert!(matches!(
+            &items[0],
+            ChatItem::User { text, attachments }
+                if text == "inspect"
+                    && attachments.len() == 1
+                    && attachments[0].path == "/tmp/image.png"
+        ));
+    }
+
+    #[test]
     fn one_turn_per_user_durations_by_ordinal() {
         let msgs = vec![
-            Message::User { text: "a".into() },
+            Message::user("a"),
             assistant(vec![AssistantBlock::Text("1".into())]),
-            Message::User { text: "b".into() },
+            Message::user("b"),
             assistant(vec![AssistantBlock::Text("2".into())]),
         ];
         let items = group_turns(&msgs, &[5, 9], false);
@@ -207,9 +241,9 @@ mod tests {
     #[test]
     fn missing_duration_is_none() {
         let msgs = vec![
-            Message::User { text: "a".into() },
+            Message::user("a"),
             assistant(vec![AssistantBlock::Text("1".into())]),
-            Message::User { text: "b".into() },
+            Message::user("b"),
             assistant(vec![AssistantBlock::Text("2".into())]),
         ];
         let items = group_turns(&msgs, &[5], false);
@@ -222,7 +256,7 @@ mod tests {
     #[test]
     fn running_marks_and_nulls_last_turn() {
         let msgs = vec![
-            Message::User { text: "a".into() },
+            Message::user("a"),
             assistant(vec![AssistantBlock::Text("1".into())]),
         ];
         let items = group_turns(&msgs, &[5], true);
@@ -235,7 +269,7 @@ mod tests {
 
     #[test]
     fn running_emits_empty_tail_turn_after_user() {
-        let msgs = vec![Message::User { text: "a".into() }];
+        let msgs = vec![Message::user("a")];
         let items = group_turns(&msgs, &[], true);
         assert_eq!(items.len(), 2);
         let ChatItem::Turn(t) = &items[1] else {
@@ -249,7 +283,7 @@ mod tests {
     #[test]
     fn preserves_step_and_prose_order() {
         let msgs = vec![
-            Message::User { text: "a".into() },
+            Message::user("a"),
             assistant(vec![
                 AssistantBlock::Text("before".into()),
                 tool("c1"),
@@ -268,7 +302,7 @@ mod tests {
     #[test]
     fn unmatched_tool_result_remains_a_step() {
         let msgs = vec![
-            Message::User { text: "a".into() },
+            Message::user("a"),
             Message::ToolResult {
                 call_id: "missing".into(),
                 content: "output".into(),
@@ -285,7 +319,7 @@ mod tests {
     #[test]
     fn guardian_and_results_count_as_one_tool_step() {
         let msgs = vec![
-            Message::User { text: "a".into() },
+            Message::user("a"),
             assistant(vec![
                 AssistantBlock::ToolUse {
                     call_id: "read-1".into(),
@@ -314,7 +348,7 @@ mod tests {
     #[test]
     fn collapses_consecutive_reconnect_updates() {
         let msgs = vec![
-            Message::User { text: "a".into() },
+            Message::user("a"),
             assistant(vec![AssistantBlock::Text(
                 "Reconnecting... 1/5\n\nReconnecting… 2/5\nReconnecting 3/5".into(),
             )]),
@@ -337,7 +371,7 @@ mod tests {
     #[test]
     fn reconnect_updates_do_not_swallow_prose() {
         let msgs = vec![
-            Message::User { text: "a".into() },
+            Message::user("a"),
             assistant(vec![AssistantBlock::Text(
                 "before\nReconnecting... 2/5\nafter".into(),
             )]),

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -804,12 +804,12 @@ fn send_acp_input(
         {
             imported.first_prompt = Some(text.clone());
         }
-        service.0.send(ClientMessage::AgentInput {
-            sid: session.sid.clone(),
+        service.0.send(ClientMessage::agent_input(
+            session.sid.clone(),
             text,
             context,
-            attachments: prompt.attachments,
-        });
+            prompt.attachments,
+        ));
         *state = AgentRunState::Streaming;
     }
 }

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -791,9 +791,10 @@ fn send_acp_input(
         if !queue.ready(matches!(*state, AgentRunState::Idle)) {
             continue;
         }
-        let Some(text) = queue.take_next() else {
+        let Some(prompt) = queue.take_next() else {
             continue;
         };
+        let text = prompt.text;
         let context = pending
             .as_deref_mut()
             .and_then(PendingHandoff::context_for_send);
@@ -807,6 +808,7 @@ fn send_acp_input(
             sid: session.sid.clone(),
             text,
             context,
+            attachments: prompt.attachments,
         });
         *state = AgentRunState::Streaming;
     }

--- a/crates/vmux_agent/src/client/cli/claude.rs
+++ b/crates/vmux_agent/src/client/cli/claude.rs
@@ -315,7 +315,7 @@ pub(crate) fn load_claude_transcript(
             continue;
         };
         match value.get("type").and_then(Value::as_str) {
-            Some("user") => messages.push(Message::User { text }),
+            Some("user") => messages.push(Message::user(text)),
             Some("assistant") => messages.push(Message::Assistant {
                 blocks: vec![AssistantBlock::Text(text)],
             }),
@@ -605,9 +605,7 @@ mod tests {
         assert_eq!(
             messages,
             vec![
-                Message::User {
-                    text: "fix auth".into()
-                },
+                Message::user("fix auth"),
                 Message::Assistant {
                     blocks: vec![AssistantBlock::Text("working".into())]
                 }
@@ -634,9 +632,7 @@ mod tests {
         assert_eq!(
             messages,
             vec![
-                Message::User {
-                    text: "before".into()
-                },
+                Message::user("before"),
                 Message::Assistant {
                     blocks: vec![AssistantBlock::Text("after".into())]
                 }

--- a/crates/vmux_agent/src/client/cli/codex.rs
+++ b/crates/vmux_agent/src/client/cli/codex.rs
@@ -334,9 +334,7 @@ pub(crate) fn load_codex_transcript(root: &Path, session_id: &str) -> Result<Vec
             continue;
         };
         match payload.get("type").and_then(|v| v.as_str()) {
-            Some("user_message") => messages.push(Message::User {
-                text: text.to_string(),
-            }),
+            Some("user_message") => messages.push(Message::user(text)),
             Some("agent_message") => messages.push(Message::Assistant {
                 blocks: vec![AssistantBlock::Text(text.to_string())],
             }),
@@ -611,9 +609,7 @@ mod tests {
         assert_eq!(
             messages,
             vec![
-                Message::User {
-                    text: "fix auth".into()
-                },
+                Message::user("fix auth"),
                 Message::Assistant {
                     blocks: vec![AssistantBlock::Text("working".into())]
                 }
@@ -646,9 +642,7 @@ mod tests {
         assert_eq!(
             messages,
             vec![
-                Message::User {
-                    text: "before".into()
-                },
+                Message::user("before"),
                 Message::Assistant {
                     blocks: vec![AssistantBlock::Text("after".into())]
                 }

--- a/crates/vmux_agent/src/client/cli/vibe.rs
+++ b/crates/vmux_agent/src/client/cli/vibe.rs
@@ -384,7 +384,7 @@ pub(crate) fn load_vibe_transcript(root: &Path, session_id: &str) -> Result<Vec<
             continue;
         };
         match value.get("role").and_then(|v| v.as_str()) {
-            Some("user") => messages.push(Message::User { text }),
+            Some("user") => messages.push(Message::user(text)),
             Some("assistant") => messages.push(Message::Assistant {
                 blocks: vec![AssistantBlock::Text(text)],
             }),
@@ -802,9 +802,7 @@ mod tests {
         assert_eq!(
             messages,
             vec![
-                Message::User {
-                    text: "fix auth".into()
-                },
+                Message::user("fix auth"),
                 Message::Assistant {
                     blocks: vec![AssistantBlock::Text("working".into())]
                 }
@@ -833,9 +831,7 @@ mod tests {
         assert_eq!(
             messages,
             vec![
-                Message::User {
-                    text: "before".into()
-                },
+                Message::user("before"),
                 Message::Assistant {
                     blocks: vec![AssistantBlock::Text("after".into())]
                 }

--- a/crates/vmux_agent/src/client/page/plugin.rs
+++ b/crates/vmux_agent/src/client/page/plugin.rs
@@ -126,13 +126,14 @@ fn send_page_agent_input(
         if !queue.ready(matches!(*state, AgentRunState::Idle)) {
             continue;
         }
-        let Some(text) = queue.take_next() else {
+        let Some(prompt) = queue.take_next() else {
             continue;
         };
         service.0.send(ClientMessage::AgentInput {
             sid: session.sid.clone(),
-            text,
+            text: prompt.text,
             context: None,
+            attachments: prompt.attachments,
         });
         *state = AgentRunState::Streaming;
     }

--- a/crates/vmux_agent/src/client/page/plugin.rs
+++ b/crates/vmux_agent/src/client/page/plugin.rs
@@ -129,12 +129,12 @@ fn send_page_agent_input(
         let Some(prompt) = queue.take_next() else {
             continue;
         };
-        service.0.send(ClientMessage::AgentInput {
-            sid: session.sid.clone(),
-            text: prompt.text,
-            context: None,
-            attachments: prompt.attachments,
-        });
+        service.0.send(ClientMessage::agent_input(
+            session.sid.clone(),
+            prompt.text,
+            None,
+            prompt.attachments,
+        ));
         *state = AgentRunState::Streaming;
     }
 }

--- a/crates/vmux_agent/src/components.rs
+++ b/crates/vmux_agent/src/components.rs
@@ -2,6 +2,7 @@ use std::collections::{HashSet, VecDeque};
 
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
+use vmux_service::protocol::AgentAttachment;
 
 use crate::message::Message;
 use crate::{AgentKind, AgentVariant};
@@ -41,6 +42,7 @@ pub struct PromptQueue {
 pub struct QueuedPrompt {
     pub id: u64,
     pub text: String,
+    pub attachments: Vec<AgentAttachment>,
 }
 
 impl PromptQueue {
@@ -56,9 +58,18 @@ impl PromptQueue {
 
     /// Append one prompt and allow dispatch to continue.
     pub fn enqueue(&mut self, text: String) {
+        self.enqueue_with_attachments(text, Vec::new());
+    }
+
+    /// Append one prompt with local file attachments and allow dispatch to continue.
+    pub fn enqueue_with_attachments(&mut self, text: String, attachments: Vec<AgentAttachment>) {
         let id = self.next_id;
         self.next_id = self.next_id.wrapping_add(1);
-        self.items.push_back(QueuedPrompt { id, text });
+        self.items.push_back(QueuedPrompt {
+            id,
+            text,
+            attachments,
+        });
         self.paused = false;
     }
 
@@ -104,18 +115,23 @@ impl PromptQueue {
     }
 
     /// Take one FIFO prompt, or all prompts joined by blank lines for a pending flush.
-    pub fn take_next(&mut self) -> Option<String> {
+    pub fn take_next(&mut self) -> Option<QueuedPrompt> {
         if !self.flush_pending {
-            return self.items.pop_front().map(|item| item.text);
+            return self.items.pop_front();
         }
         self.flush_pending = false;
-        let mut text = self.items.pop_front()?.text;
-        text.reserve(self.items.iter().map(|item| item.text.len() + 2).sum());
+        let mut prompt = self.items.pop_front()?;
+        prompt
+            .text
+            .reserve(self.items.iter().map(|item| item.text.len() + 2).sum());
         for item in self.items.drain(..) {
-            text.push_str("\n\n");
-            text.push_str(&item.text);
+            if !prompt.text.is_empty() && !item.text.is_empty() {
+                prompt.text.push_str("\n\n");
+            }
+            prompt.text.push_str(&item.text);
+            prompt.attachments.extend(item.attachments);
         }
-        Some(text)
+        Some(prompt)
     }
 }
 
@@ -146,7 +162,10 @@ mod tests {
         let mut q = PromptQueue::default();
         q.enqueue("first".into());
         q.enqueue("second".into());
-        assert_eq!(q.take_next(), Some("first".to_string()));
+        assert_eq!(
+            q.take_next().map(|prompt| prompt.text),
+            Some("first".to_string())
+        );
         assert_eq!(
             q.items.front().map(|item| item.text.as_str()),
             Some("second")
@@ -160,9 +179,40 @@ mod tests {
         q.enqueue("second".into());
 
         assert!(q.request_flush());
-        assert_eq!(q.take_next(), Some("first\n\nsecond".to_string()));
+        assert_eq!(
+            q.take_next().map(|prompt| prompt.text),
+            Some("first\n\nsecond".to_string())
+        );
         assert!(q.items.is_empty());
         assert!(!q.flush_pending);
+    }
+
+    #[test]
+    fn take_next_merges_attachments_for_flush() {
+        let mut q = PromptQueue::default();
+        q.enqueue_with_attachments(
+            String::new(),
+            vec![AgentAttachment {
+                path: "/tmp/a.png".into(),
+                name: "a.png".into(),
+                mime_type: "image/png".into(),
+                size: 3,
+            }],
+        );
+        q.enqueue_with_attachments(
+            "describe both".into(),
+            vec![AgentAttachment {
+                path: "/tmp/b.png".into(),
+                name: "b.png".into(),
+                mime_type: "image/png".into(),
+                size: 4,
+            }],
+        );
+
+        assert!(q.request_flush());
+        let prompt = q.take_next().unwrap();
+        assert_eq!(prompt.text, "describe both");
+        assert_eq!(prompt.attachments.len(), 2);
     }
 
     #[test]
@@ -174,7 +224,10 @@ mod tests {
         q.enqueue("second".into());
 
         assert!(q.flush_pending);
-        assert_eq!(q.take_next(), Some("first\n\nsecond".to_string()));
+        assert_eq!(
+            q.take_next().map(|prompt| prompt.text),
+            Some("first\n\nsecond".to_string())
+        );
     }
 
     #[test]

--- a/crates/vmux_agent/src/handoff.rs
+++ b/crates/vmux_agent/src/handoff.rs
@@ -77,7 +77,7 @@ pub fn build_context(messages: &[Message], limit: usize) -> BuiltContext {
 
 fn context_segment(message: &Message) -> Option<String> {
     match message {
-        Message::User { text } if !text.trim().is_empty() => Some(format!("User:\n{text}")),
+        Message::User { text, .. } if !text.trim().is_empty() => Some(format!("User:\n{text}")),
         Message::Assistant { blocks } => {
             let text = blocks
                 .iter()
@@ -100,7 +100,7 @@ pub fn wire_prompt(context: &str, display_text: &str) -> String {
 pub fn sanitize_replayed_messages(messages: &mut [Message], first_prompt: Option<&str>) {
     let mut fallback = first_prompt;
     for message in messages {
-        let Message::User { text } = message else {
+        let Message::User { text, .. } = message else {
             continue;
         };
         if let Some(display_text) =
@@ -186,9 +186,7 @@ mod tests {
     use crate::{AssistantBlock, Message};
 
     fn user(text: &str) -> Message {
-        Message::User {
-            text: text.to_string(),
-        }
+        Message::user(text)
     }
 
     fn assistant(text: &str) -> Message {

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -3903,9 +3903,7 @@ mod tests {
     fn cross_agent_swap_attaches_fresh_target_with_imported_history() {
         let mut app = swap_test_app();
         let (stack, _child) = spawn_stack_child(&mut app);
-        let messages = vec![crate::Message::User {
-            text: "fix auth".into(),
-        }];
+        let messages = vec![crate::Message::user("fix auth")];
         app.world_mut()
             .resource_mut::<Messages<vmux_core::agent::SwapStackSession>>()
             .write(vmux_core::agent::SwapStackSession {

--- a/crates/vmux_service/Cargo.toml
+++ b/crates/vmux_service/Cargo.toml
@@ -23,6 +23,7 @@ rkyv = { workspace = true }
 serde = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+base64 = "0.22"
 bevy = { workspace = true }
 bevy_ecs = { workspace = true }
 libc = "0.2"
@@ -44,6 +45,7 @@ vmux_wire = { path = "../vmux_wire" }
 agent-client-protocol = "1.0.1"
 tokio-util = { version = "0.7", features = ["compat"] }
 tempfile = "3.27.0"
+url = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 dioxus = { workspace = true }

--- a/crates/vmux_service/src/acp.rs
+++ b/crates/vmux_service/src/acp.rs
@@ -130,6 +130,7 @@ mod tests {
             AcpInput::User {
                 text: "x".to_string(),
                 context: None,
+                attachments: Vec::new(),
             }
         ));
         assert!(mgr.subscribe("nope").is_none());

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -10,18 +10,20 @@ use std::sync::{Arc, Mutex};
 
 use agent_client_protocol::schema::ProtocolVersion;
 use agent_client_protocol::schema::v1::{
-    CancelNotification, ContentBlock, CreateTerminalRequest, CreateTerminalResponse,
-    Implementation, InitializeRequest, KillTerminalRequest, KillTerminalResponse,
+    AudioContent, CancelNotification, ContentBlock, CreateTerminalRequest, CreateTerminalResponse,
+    ImageContent, Implementation, InitializeRequest, KillTerminalRequest, KillTerminalResponse,
     LoadSessionRequest, McpServer, NewSessionRequest, PermissionOption, PermissionOptionId,
-    PromptRequest, ReadTextFileRequest, ReadTextFileResponse, ReleaseTerminalRequest,
-    ReleaseTerminalResponse, RequestPermissionOutcome, RequestPermissionRequest,
-    RequestPermissionResponse, SelectedPermissionOutcome, SessionConfigKind, SessionConfigOption,
-    SessionConfigOptionCategory, SessionConfigSelectOptions, SessionId, SessionNotification,
-    SessionUpdate, SetSessionConfigOptionRequest, TerminalExitStatus, TerminalId,
-    TerminalOutputRequest, TerminalOutputResponse, TextContent, WaitForTerminalExitRequest,
-    WaitForTerminalExitResponse, WriteTextFileRequest, WriteTextFileResponse,
+    PromptCapabilities, PromptRequest, ReadTextFileRequest, ReadTextFileResponse,
+    ReleaseTerminalRequest, ReleaseTerminalResponse, RequestPermissionOutcome,
+    RequestPermissionRequest, RequestPermissionResponse, ResourceLink, SelectedPermissionOutcome,
+    SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory,
+    SessionConfigSelectOptions, SessionId, SessionNotification, SessionUpdate,
+    SetSessionConfigOptionRequest, TerminalExitStatus, TerminalId, TerminalOutputRequest,
+    TerminalOutputResponse, TextContent, WaitForTerminalExitRequest, WaitForTerminalExitResponse,
+    WriteTextFileRequest, WriteTextFileResponse,
 };
 use agent_client_protocol::{Client, Responder};
+use base64::Engine;
 use tokio::process::Command;
 use tokio::sync::{broadcast, mpsc, oneshot, watch};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
@@ -30,8 +32,8 @@ use vmux_core::ProcessId;
 use super::projector::{AcpProjector, Intent};
 use crate::process::{ProcessManager, PtyInputWriter};
 use crate::protocol::{
-    AgentCommand, AgentRequestId, AgentRunStatus, ApprovalDecision, ServiceMessage,
-    compose_agent_prompt,
+    AgentAttachment, AgentCommand, AgentRequestId, AgentRunStatus, ApprovalDecision,
+    ServiceMessage, compose_agent_prompt,
 };
 
 const HISTORY_REPLAY_SNAPSHOT_INTERVAL: usize = 8;
@@ -41,6 +43,7 @@ pub enum AcpInput {
     User {
         text: String,
         context: Option<String>,
+        attachments: Vec<AgentAttachment>,
     },
     Approve {
         call_id: String,
@@ -410,6 +413,80 @@ fn approval_details(
     (name, args_json)
 }
 
+fn attachment_uri(path: &str) -> String {
+    url::Url::from_file_path(path)
+        .map(|url| url.to_string())
+        .unwrap_or_else(|_| format!("file://{path}"))
+}
+
+fn prompt_display_text(text: &str, attachments: &[AgentAttachment]) -> String {
+    if attachments.is_empty() {
+        return text.to_string();
+    }
+    let names = attachments
+        .iter()
+        .map(|attachment| attachment.name.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    if text.is_empty() {
+        format!("Attached: {names}")
+    } else {
+        format!("{text}\n\nAttached: {names}")
+    }
+}
+
+fn prompt_content_blocks(
+    text: &str,
+    context: Option<&str>,
+    attachments: &[AgentAttachment],
+    capabilities: &PromptCapabilities,
+) -> Vec<ContentBlock> {
+    let mut blocks = Vec::with_capacity(attachments.len() + 1);
+    let text = compose_agent_prompt(text, context);
+    if !text.is_empty() {
+        blocks.push(ContentBlock::Text(TextContent::new(text)));
+    }
+    for attachment in attachments {
+        let uri = attachment_uri(&attachment.path);
+        let bytes = if (capabilities.image && attachment.mime_type.starts_with("image/"))
+            || (capabilities.audio && attachment.mime_type.starts_with("audio/"))
+        {
+            std::fs::read(&attachment.path).ok()
+        } else {
+            None
+        };
+        if capabilities.image
+            && attachment.mime_type.starts_with("image/")
+            && let Some(bytes) = bytes.as_ref()
+        {
+            blocks.push(ContentBlock::Image(
+                ImageContent::new(
+                    base64::engine::general_purpose::STANDARD.encode(bytes),
+                    attachment.mime_type.clone(),
+                )
+                .uri(uri),
+            ));
+            continue;
+        }
+        if capabilities.audio
+            && attachment.mime_type.starts_with("audio/")
+            && let Some(bytes) = bytes
+        {
+            blocks.push(ContentBlock::Audio(AudioContent::new(
+                base64::engine::general_purpose::STANDARD.encode(bytes),
+                attachment.mime_type.clone(),
+            )));
+            continue;
+        }
+        blocks.push(ContentBlock::ResourceLink(
+            ResourceLink::new(attachment.name.clone(), uri)
+                .mime_type(Some(attachment.mime_type.clone()))
+                .size(i64::try_from(attachment.size).ok()),
+        ));
+    }
+    blocks
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     command: String,
@@ -601,6 +678,7 @@ pub async fn run(
             // terminal methods, backed by real visible panes (see `create_terminal` et al.).
             init.client_capabilities.terminal = true;
             let init_resp = cx.send_request(init).block_task().await?;
+            let prompt_capabilities = init_resp.agent_capabilities.prompt_capabilities.clone();
 
             if let Some(name) = acp_display_name(init_resp.agent_info.as_ref()) {
                 main_shared.publish_agent_info(name);
@@ -676,13 +754,17 @@ pub async fn run(
 
             while let Some(input) = input_rx.recv().await {
                 match input {
-                    AcpInput::User { text, context } => {
+                    AcpInput::User {
+                        text,
+                        context,
+                        attachments,
+                    } => {
                         main_shared.cancel_requested.store(false, Ordering::SeqCst);
                         main_shared
                             .projector
                             .lock()
                             .unwrap()
-                            .push_user(text.clone());
+                            .push_user(prompt_display_text(&text, &attachments));
                         main_shared.emit(main_shared.snapshot_message());
                         main_shared.emit_status(AgentRunStatus::Streaming);
                         let ensured = ensure_session(&mut session_id, || {
@@ -721,13 +803,16 @@ pub async fn run(
                         }
                         let cx_prompt = cx.clone();
                         let shared = main_shared.clone();
+                        let prompt_capabilities = prompt_capabilities.clone();
                         cx.spawn(async move {
                             let prompt = PromptRequest::new(
                                 active_session_id,
-                                vec![ContentBlock::Text(TextContent::new(compose_agent_prompt(
+                                prompt_content_blocks(
                                     &text,
                                     context.as_deref(),
-                                )))],
+                                    &attachments,
+                                    &prompt_capabilities,
+                                ),
                             );
                             let errored = match cx_prompt.send_request(prompt).block_task().await {
                                 Ok(_) => None,
@@ -1344,6 +1429,50 @@ mod tests {
 
     fn opt(id: &str, kind: PermissionOptionKind) -> PermissionOption {
         PermissionOption::new(id.to_string(), id.to_string(), kind)
+    }
+
+    #[test]
+    fn prompt_content_embeds_supported_images() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("image.png");
+        std::fs::write(&path, b"png").unwrap();
+        let attachment = AgentAttachment {
+            path: path.to_string_lossy().into_owned(),
+            name: "image.png".into(),
+            mime_type: "image/png".into(),
+            size: 3,
+        };
+        let mut capabilities = PromptCapabilities::default();
+        capabilities.image = true;
+
+        let blocks = prompt_content_blocks("inspect", None, &[attachment], &capabilities);
+
+        assert!(matches!(&blocks[0], ContentBlock::Text(text) if text.text == "inspect"));
+        assert!(matches!(
+            &blocks[1],
+            ContentBlock::Image(image)
+                if image.data == base64::engine::general_purpose::STANDARD.encode(b"png")
+                    && image.mime_type == "image/png"
+        ));
+    }
+
+    #[test]
+    fn prompt_content_links_files_without_media_capability() {
+        let attachment = AgentAttachment {
+            path: "/tmp/report.txt".into(),
+            name: "report.txt".into(),
+            mime_type: "text/plain".into(),
+            size: 12,
+        };
+
+        let blocks = prompt_content_blocks("", None, &[attachment], &PromptCapabilities::default());
+
+        assert!(matches!(
+            &blocks[0],
+            ContentBlock::ResourceLink(link)
+                if link.name == "report.txt" && link.uri == "file:///tmp/report.txt"
+        ));
+        assert_eq!(prompt_display_text("", &[]), "");
     }
 
     #[test]

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashMap;
 use std::future::Future;
+use std::io::Read;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -37,6 +38,8 @@ use crate::protocol::{
 };
 
 const HISTORY_REPLAY_SNAPSHOT_INTERVAL: usize = 8;
+const PROMPT_MEDIA_FILE_LIMIT: u64 = 8 * 1024 * 1024;
+const PROMPT_MEDIA_TOTAL_LIMIT: u64 = 64 * 1024 * 1024;
 
 /// A command pushed into a live ACP session from the GUI side.
 pub enum AcpInput {
@@ -419,48 +422,68 @@ fn attachment_uri(path: &str) -> String {
         .unwrap_or_else(|_| format!("file://{path}"))
 }
 
-fn prompt_content_blocks(
+async fn encoded_media(path: String, limit: u64) -> Option<(String, u64)> {
+    tokio::task::spawn_blocking(move || {
+        let metadata = std::fs::metadata(&path).ok()?;
+        if !metadata.is_file() || metadata.len() > limit {
+            return None;
+        }
+        let mut bytes = Vec::new();
+        std::fs::File::open(path)
+            .ok()?
+            .take(limit.saturating_add(1))
+            .read_to_end(&mut bytes)
+            .ok()?;
+        let size = u64::try_from(bytes.len()).ok()?;
+        (size <= limit).then(|| {
+            (
+                base64::engine::general_purpose::STANDARD.encode(bytes),
+                size,
+            )
+        })
+    })
+    .await
+    .ok()
+    .flatten()
+}
+
+async fn prompt_content_blocks(
     text: &str,
     context: Option<&str>,
     attachments: &[AgentAttachment],
     capabilities: &PromptCapabilities,
 ) -> Vec<ContentBlock> {
     let mut blocks = Vec::with_capacity(attachments.len() + 1);
+    let mut remaining_media_bytes = PROMPT_MEDIA_TOTAL_LIMIT;
     let text = compose_agent_prompt(text, context);
     if !text.is_empty() {
         blocks.push(ContentBlock::Text(TextContent::new(text)));
     }
     for attachment in attachments {
         let uri = attachment_uri(&attachment.path);
-        let bytes = if (capabilities.image && attachment.mime_type.starts_with("image/"))
-            || (capabilities.audio && attachment.mime_type.starts_with("audio/"))
-        {
-            std::fs::read(&attachment.path).ok()
+        let media_supported = (capabilities.image && attachment.mime_type.starts_with("image/"))
+            || (capabilities.audio && attachment.mime_type.starts_with("audio/"));
+        let limit = PROMPT_MEDIA_FILE_LIMIT.min(remaining_media_bytes);
+        let encoded = if media_supported && attachment.size <= limit && limit > 0 {
+            encoded_media(attachment.path.clone(), limit).await
         } else {
             None
         };
-        if capabilities.image
-            && attachment.mime_type.starts_with("image/")
-            && let Some(bytes) = bytes.as_ref()
-        {
-            blocks.push(ContentBlock::Image(
-                ImageContent::new(
-                    base64::engine::general_purpose::STANDARD.encode(bytes),
+        if let Some((data, size)) = encoded {
+            remaining_media_bytes = remaining_media_bytes.saturating_sub(size);
+            if capabilities.image && attachment.mime_type.starts_with("image/") {
+                blocks.push(ContentBlock::Image(
+                    ImageContent::new(data, attachment.mime_type.clone()).uri(uri),
+                ));
+                continue;
+            }
+            if capabilities.audio && attachment.mime_type.starts_with("audio/") {
+                blocks.push(ContentBlock::Audio(AudioContent::new(
+                    data,
                     attachment.mime_type.clone(),
-                )
-                .uri(uri),
-            ));
-            continue;
-        }
-        if capabilities.audio
-            && attachment.mime_type.starts_with("audio/")
-            && let Some(bytes) = bytes
-        {
-            blocks.push(ContentBlock::Audio(AudioContent::new(
-                base64::engine::general_purpose::STANDARD.encode(bytes),
-                attachment.mime_type.clone(),
-            )));
-            continue;
+                )));
+                continue;
+            }
         }
         blocks.push(ContentBlock::ResourceLink(
             ResourceLink::new(attachment.name.clone(), uri)
@@ -796,7 +819,8 @@ pub async fn run(
                                     context.as_deref(),
                                     &attachments,
                                     &prompt_capabilities,
-                                ),
+                                )
+                                .await,
                             );
                             let errored = match cx_prompt.send_request(prompt).block_task().await {
                                 Ok(_) => None,
@@ -1415,8 +1439,8 @@ mod tests {
         PermissionOption::new(id.to_string(), id.to_string(), kind)
     }
 
-    #[test]
-    fn prompt_content_embeds_supported_images() {
+    #[tokio::test]
+    async fn prompt_content_embeds_supported_images() {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("image.png");
         std::fs::write(&path, b"png").unwrap();
@@ -1429,7 +1453,7 @@ mod tests {
         let mut capabilities = PromptCapabilities::default();
         capabilities.image = true;
 
-        let blocks = prompt_content_blocks("inspect", None, &[attachment], &capabilities);
+        let blocks = prompt_content_blocks("inspect", None, &[attachment], &capabilities).await;
 
         assert!(matches!(&blocks[0], ContentBlock::Text(text) if text.text == "inspect"));
         assert!(matches!(
@@ -1440,8 +1464,8 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn prompt_content_links_files_without_media_capability() {
+    #[tokio::test]
+    async fn prompt_content_links_files_without_media_capability() {
         let attachment = AgentAttachment {
             path: "/tmp/report.txt".into(),
             name: "report.txt".into(),
@@ -1449,12 +1473,40 @@ mod tests {
             size: 12,
         };
 
-        let blocks = prompt_content_blocks("", None, &[attachment], &PromptCapabilities::default());
+        let blocks =
+            prompt_content_blocks("", None, &[attachment], &PromptCapabilities::default()).await;
 
         assert!(matches!(
             &blocks[0],
             ContentBlock::ResourceLink(link)
                 if link.name == "report.txt" && link.uri == "file:///tmp/report.txt"
+        ));
+    }
+
+    #[tokio::test]
+    async fn prompt_content_links_supported_media_above_embed_limit() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("large.png");
+        std::fs::File::create(&path)
+            .unwrap()
+            .set_len(PROMPT_MEDIA_FILE_LIMIT + 1)
+            .unwrap();
+        let attachment = AgentAttachment {
+            path: path.to_string_lossy().into_owned(),
+            name: "large.png".into(),
+            mime_type: "image/png".into(),
+            size: PROMPT_MEDIA_FILE_LIMIT + 1,
+        };
+        let mut capabilities = PromptCapabilities::default();
+        capabilities.image = true;
+
+        let blocks = prompt_content_blocks("", None, &[attachment], &capabilities).await;
+
+        assert!(matches!(
+            &blocks[0],
+            ContentBlock::ResourceLink(link)
+                if link.name == "large.png"
+                    && link.size == i64::try_from(PROMPT_MEDIA_FILE_LIMIT + 1).ok()
         ));
     }
 

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -419,22 +419,6 @@ fn attachment_uri(path: &str) -> String {
         .unwrap_or_else(|_| format!("file://{path}"))
 }
 
-fn prompt_display_text(text: &str, attachments: &[AgentAttachment]) -> String {
-    if attachments.is_empty() {
-        return text.to_string();
-    }
-    let names = attachments
-        .iter()
-        .map(|attachment| attachment.name.as_str())
-        .collect::<Vec<_>>()
-        .join(", ");
-    if text.is_empty() {
-        format!("Attached: {names}")
-    } else {
-        format!("{text}\n\nAttached: {names}")
-    }
-}
-
 fn prompt_content_blocks(
     text: &str,
     context: Option<&str>,
@@ -764,7 +748,7 @@ pub async fn run(
                             .projector
                             .lock()
                             .unwrap()
-                            .push_user(prompt_display_text(&text, &attachments));
+                            .push_user(text.clone(), attachments.clone());
                         main_shared.emit(main_shared.snapshot_message());
                         main_shared.emit_status(AgentRunStatus::Streaming);
                         let ensured = ensure_session(&mut session_id, || {
@@ -1472,7 +1456,6 @@ mod tests {
             ContentBlock::ResourceLink(link)
                 if link.name == "report.txt" && link.uri == "file:///tmp/report.txt"
         ));
-        assert_eq!(prompt_display_text("", &[]), "");
     }
 
     #[test]

--- a/crates/vmux_service/src/acp/projector.rs
+++ b/crates/vmux_service/src/acp/projector.rs
@@ -4,6 +4,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::message::{AssistantBlock, Message, PlanStep};
+use crate::protocol::AgentAttachment;
 use agent_client_protocol::schema::v1::{
     ContentBlock, Plan, PlanEntryStatus, SessionUpdate, ToolCall, ToolCallContent,
     ToolCallLocation, ToolCallStatus, ToolCallUpdate, ToolKind,
@@ -158,8 +159,9 @@ impl AcpProjector {
     /// Record the user's prompt as its own turn. ACP never echoes the prompt back as a
     /// `session/update`, so without this the transcript the chat renders would omit it and
     /// the optimistic user bubble would vanish on the next snapshot.
-    pub fn push_user(&mut self, text: String) {
-        self.messages.push(Message::User { text });
+    pub fn push_user(&mut self, text: String, attachments: Vec<AgentAttachment>) {
+        self.messages
+            .push(Message::user_with_attachments(text, attachments));
     }
 
     /// Feed one update; returns the side effects the driver should emit.
@@ -200,8 +202,8 @@ impl AcpProjector {
         };
         let text = text.text;
         match self.messages.last_mut() {
-            Some(Message::User { text: existing }) => existing.push_str(&text),
-            _ => self.messages.push(Message::User { text }),
+            Some(Message::User { text: existing, .. }) => existing.push_str(&text),
+            _ => self.messages.push(Message::user(text)),
         }
         vec![Intent::Snapshot]
     }
@@ -570,13 +572,20 @@ mod tests {
     #[test]
     fn push_user_records_a_turn_before_following_assistant_text() {
         let mut p = AcpProjector::new();
-        p.push_user("hi".to_string());
+        let attachment = AgentAttachment {
+            path: "/tmp/image.png".into(),
+            name: "image.png".into(),
+            mime_type: "image/png".into(),
+            size: 3,
+        };
+        p.push_user("hi".to_string(), vec![attachment.clone()]);
         p.apply(chunk("hello"));
         assert_eq!(p.messages().len(), 2);
         assert_eq!(
             p.messages()[0],
             Message::User {
-                text: "hi".to_string()
+                text: "hi".to_string(),
+                attachments: vec![attachment],
             }
         );
         assert_eq!(

--- a/crates/vmux_service/src/agent.rs
+++ b/crates/vmux_service/src/agent.rs
@@ -5,7 +5,9 @@ use tokio::sync::{Mutex, broadcast, mpsc};
 
 use crate::agent_broker::AgentBroker;
 use crate::message::{AssistantBlock, Message};
-use crate::protocol::{AgentRequestId, AgentRunStatus, ApprovalDecision, ServiceMessage};
+use crate::protocol::{
+    AgentAttachment, AgentRequestId, AgentRunStatus, ApprovalDecision, ServiceMessage,
+};
 use crate::providers::{anthropic, mistral, openai};
 use crate::stream::{BuildRequest, ParseSse, StreamEvent, ToolDef};
 
@@ -37,7 +39,10 @@ pub fn resolve_provider(provider: &str) -> Option<PageProvider> {
 }
 
 pub enum SessionInput {
-    User(String),
+    User {
+        text: String,
+        attachments: Vec<AgentAttachment>,
+    },
     Approve {
         call_id: String,
         decision: ApprovalDecision,
@@ -169,10 +174,12 @@ enum Decision {
     Closed,
 }
 
-async fn recv_user(input_rx: &mut mpsc::UnboundedReceiver<SessionInput>) -> Option<String> {
+async fn recv_user(
+    input_rx: &mut mpsc::UnboundedReceiver<SessionInput>,
+) -> Option<(String, Vec<AgentAttachment>)> {
     loop {
         match input_rx.recv().await {
-            Some(SessionInput::User(text)) => return Some(text),
+            Some(SessionInput::User { text, attachments }) => return Some((text, attachments)),
             Some(SessionInput::Approve { .. }) | Some(SessionInput::Cancel) => continue,
             Some(SessionInput::Close) | None => return None,
         }
@@ -195,7 +202,7 @@ async fn await_decision(
                 };
             }
             Some(SessionInput::Cancel) => return Decision::Cancelled,
-            Some(SessionInput::Approve { .. }) | Some(SessionInput::User(_)) => continue,
+            Some(SessionInput::Approve { .. }) | Some(SessionInput::User { .. }) => continue,
             Some(SessionInput::Close) | None => return Decision::Closed,
         }
     }
@@ -220,10 +227,13 @@ async fn run_session(
     };
 
     loop {
-        let Some(text) = recv_user(&mut input_rx).await else {
+        let Some((text, attachments)) = recv_user(&mut input_rx).await else {
             return;
         };
-        messages.lock().await.push(Message::User { text });
+        messages
+            .lock()
+            .await
+            .push(Message::user_with_attachments(text, attachments));
 
         let Some(key) = api_key.as_deref() else {
             let _ = stream_tx.send(ServiceMessage::AgentRunStatusChanged {
@@ -263,7 +273,7 @@ async fn run_session(
                                 http.abort();
                                 return;
                             }
-                            Some(SessionInput::User(_)) | Some(SessionInput::Approve { .. }) => {}
+                            Some(SessionInput::User { .. }) | Some(SessionInput::Approve { .. }) => {}
                         }
                     }
                     event = ev_rx.recv() => {

--- a/crates/vmux_service/src/message.rs
+++ b/crates/vmux_service/src/message.rs
@@ -1,9 +1,13 @@
 use serde::{Deserialize, Serialize};
 
+use crate::protocol::AgentAttachment;
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum Message {
     User {
         text: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        attachments: Vec<AgentAttachment>,
     },
     Assistant {
         blocks: Vec<AssistantBlock>,
@@ -13,6 +17,25 @@ pub enum Message {
         content: String,
         is_error: bool,
     },
+}
+
+impl Message {
+    pub fn user(text: impl Into<String>) -> Self {
+        Self::User {
+            text: text.into(),
+            attachments: Vec::new(),
+        }
+    }
+
+    pub fn user_with_attachments(
+        text: impl Into<String>,
+        attachments: Vec<AgentAttachment>,
+    ) -> Self {
+        Self::User {
+            text: text.into(),
+            attachments,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -54,10 +77,17 @@ mod tests {
 
     #[test]
     fn user_roundtrip() {
-        let m = Message::User { text: "hi".into() };
+        let m = Message::user("hi");
         let json = serde_json::to_string(&m).unwrap();
         let back: Message = serde_json::from_str(&json).unwrap();
         assert_eq!(m, back);
+        assert!(!json.contains("attachments"));
+    }
+
+    #[test]
+    fn user_deserializes_legacy_message_without_attachments() {
+        let message: Message = serde_json::from_str(r#"{"User":{"text":"hi"}}"#).unwrap();
+        assert_eq!(message, Message::user("hi"));
     }
 
     #[test]

--- a/crates/vmux_service/src/providers/anthropic.rs
+++ b/crates/vmux_service/src/providers/anthropic.rs
@@ -43,7 +43,7 @@ fn messages_to_anthropic_blocks(messages: &[Message]) -> Vec<Value> {
     let mut out = Vec::new();
     for msg in messages {
         match msg {
-            Message::User { text } => out.push(json!({
+            Message::User { text, .. } => out.push(json!({
                 "role":"user",
                 "content":[{"type":"text","text":text}]
             })),
@@ -248,7 +248,7 @@ mod tests {
 
     #[test]
     fn build_request_sets_x_api_key_and_version_header() {
-        let msgs = vec![Message::User { text: "hi".into() }];
+        let msgs = vec![Message::user("hi")];
         let req = build_request("claude-sonnet-4-6", &msgs, &[], "test-key");
         assert_eq!(req.url().as_str(), ENDPOINT);
         assert_eq!(req.headers().get("x-api-key").unwrap(), "test-key");

--- a/crates/vmux_service/src/providers/mistral.rs
+++ b/crates/vmux_service/src/providers/mistral.rs
@@ -46,7 +46,7 @@ mod tests {
 
     #[test]
     fn build_request_sets_headers_and_url() {
-        let msgs = vec![Message::User { text: "hi".into() }];
+        let msgs = vec![Message::user("hi")];
         let req = build_request("devstral-2", &msgs, &[], "test-key");
         assert_eq!(req.url().as_str(), ENDPOINT);
         let auth = req

--- a/crates/vmux_service/src/providers/openai.rs
+++ b/crates/vmux_service/src/providers/openai.rs
@@ -42,7 +42,7 @@ fn messages_to_responses_input(messages: &[Message]) -> Vec<Value> {
     let mut out = Vec::new();
     for msg in messages {
         match msg {
-            Message::User { text } => out.push(json!({
+            Message::User { text, .. } => out.push(json!({
                 "type":"message","role":"user","content":[{"type":"input_text","text":text}]
             })),
             Message::Assistant { blocks } => {
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn build_request_uses_responses_endpoint_and_bearer_auth() {
-        let msgs = vec![Message::User { text: "hi".into() }];
+        let msgs = vec![Message::user("hi")];
         let req = build_request("gpt-5", &msgs, &[], "test-key");
         assert_eq!(req.url().as_str(), ENDPOINT);
         assert_eq!(

--- a/crates/vmux_service/src/providers/openai_shared.rs
+++ b/crates/vmux_service/src/providers/openai_shared.rs
@@ -93,7 +93,7 @@ pub fn messages_to_chat_completions(messages: &[Message]) -> Vec<Value> {
     let mut out = Vec::new();
     for msg in messages {
         match msg {
-            Message::User { text } => out.push(json!({"role":"user","content":text})),
+            Message::User { text, .. } => out.push(json!({"role":"user","content":text})),
             Message::Assistant { blocks } => {
                 let mut content = String::new();
                 let mut tool_calls = Vec::new();
@@ -208,7 +208,7 @@ mod tests {
     #[test]
     fn messages_to_chat_completions_roundtrip() {
         let msgs = vec![
-            Message::User { text: "hi".into() },
+            Message::user("hi"),
             Message::Assistant {
                 blocks: vec![AssistantBlock::Text("hello".into())],
             },

--- a/crates/vmux_service/src/server.rs
+++ b/crates/vmux_service/src/server.rs
@@ -1,5 +1,7 @@
 use crate::process::{Process, ProcessManager, PtyInputWriter};
-use crate::protocol::{ClientMessage, ProcessId, ServiceMessage, validate_agent_command};
+use crate::protocol::{
+    AgentAttachment, ClientMessage, ProcessId, ServiceMessage, validate_agent_command,
+};
 use crate::{read_message, write_message};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -34,6 +36,24 @@ type PendingCommands = Arc<
         >,
     >,
 >;
+
+fn page_agent_prompt(text: String, attachments: &[AgentAttachment]) -> String {
+    if attachments.is_empty() {
+        return text;
+    }
+    let mut prompt = text;
+    if !prompt.is_empty() {
+        prompt.push_str("\n\n");
+    }
+    prompt.push_str("Attached files:\n");
+    for attachment in attachments {
+        prompt.push_str("- ");
+        prompt.push_str(&attachment.path);
+        prompt.push('\n');
+    }
+    prompt.pop();
+    prompt
+}
 
 /// Acquire the manager lock and run `f` against the process if it exists.
 /// Returns Some(result) when the process was found, None otherwise.
@@ -776,17 +796,26 @@ async fn handle_client(
                 }
             }
 
-            ClientMessage::AgentInput { sid, text, context } => {
+            ClientMessage::AgentInput {
+                sid,
+                text,
+                context,
+                attachments,
+            } => {
                 if acp_manager.lock().await.contains(&sid) {
-                    acp_manager
-                        .lock()
-                        .await
-                        .input(&sid, crate::acp::AcpInput::User { text, context });
+                    acp_manager.lock().await.input(
+                        &sid,
+                        crate::acp::AcpInput::User {
+                            text,
+                            context,
+                            attachments,
+                        },
+                    );
                 } else {
-                    agent_manager
-                        .lock()
-                        .await
-                        .input(&sid, crate::agent::SessionInput::User(text));
+                    agent_manager.lock().await.input(
+                        &sid,
+                        crate::agent::SessionInput::User(page_agent_prompt(text, &attachments)),
+                    );
                 }
             }
 
@@ -967,6 +996,20 @@ mod tests {
     use super::*;
     use crate::protocol::{AgentCommandResult, AgentQuery, AgentQueryResult, AgentRequestId};
     use tokio::sync::oneshot;
+
+    #[test]
+    fn page_agent_prompt_appends_attachment_paths() {
+        let attachments = vec![AgentAttachment {
+            path: "/tmp/report.txt".into(),
+            name: "report.txt".into(),
+            mime_type: "text/plain".into(),
+            size: 12,
+        }];
+        assert_eq!(
+            page_agent_prompt("review".into(), &attachments),
+            "review\n\nAttached files:\n- /tmp/report.txt"
+        );
+    }
 
     #[test]
     fn acp_spawn_replays_agent_info_after_subscribing() {

--- a/crates/vmux_service/src/server.rs
+++ b/crates/vmux_service/src/server.rs
@@ -55,6 +55,36 @@ fn page_agent_prompt(text: String, attachments: &[AgentAttachment]) -> String {
     prompt
 }
 
+async fn route_agent_input(
+    acp_manager: &Arc<Mutex<crate::acp::AcpSessionManager>>,
+    agent_manager: &Arc<Mutex<crate::agent::AgentSessionManager>>,
+    sid: String,
+    text: String,
+    context: Option<String>,
+    attachments: Vec<AgentAttachment>,
+) {
+    let acp = acp_manager.lock().await;
+    if acp.contains(&sid) {
+        acp.input(
+            &sid,
+            crate::acp::AcpInput::User {
+                text,
+                context,
+                attachments,
+            },
+        );
+        return;
+    }
+    drop(acp);
+    agent_manager.lock().await.input(
+        &sid,
+        crate::agent::SessionInput::User {
+            text: page_agent_prompt(text, &attachments),
+            attachments,
+        },
+    );
+}
+
 /// Acquire the manager lock and run `f` against the process if it exists.
 /// Returns Some(result) when the process was found, None otherwise.
 async fn with_process_mut<F, R>(
@@ -796,30 +826,26 @@ async fn handle_client(
                 }
             }
 
-            ClientMessage::AgentInput {
+            ClientMessage::AgentInput { sid, text, context } => {
+                route_agent_input(&acp_manager, &agent_manager, sid, text, context, Vec::new())
+                    .await;
+            }
+
+            ClientMessage::AgentInputWithAttachments {
                 sid,
                 text,
                 context,
                 attachments,
             } => {
-                if acp_manager.lock().await.contains(&sid) {
-                    acp_manager.lock().await.input(
-                        &sid,
-                        crate::acp::AcpInput::User {
-                            text,
-                            context,
-                            attachments,
-                        },
-                    );
-                } else {
-                    agent_manager.lock().await.input(
-                        &sid,
-                        crate::agent::SessionInput::User {
-                            text: page_agent_prompt(text, &attachments),
-                            attachments,
-                        },
-                    );
-                }
+                route_agent_input(
+                    &acp_manager,
+                    &agent_manager,
+                    sid,
+                    text,
+                    context,
+                    attachments,
+                )
+                .await;
             }
 
             ClientMessage::AcpSetModel {

--- a/crates/vmux_service/src/server.rs
+++ b/crates/vmux_service/src/server.rs
@@ -814,7 +814,10 @@ async fn handle_client(
                 } else {
                     agent_manager.lock().await.input(
                         &sid,
-                        crate::agent::SessionInput::User(page_agent_prompt(text, &attachments)),
+                        crate::agent::SessionInput::User {
+                            text: page_agent_prompt(text, &attachments),
+                            attachments,
+                        },
                     );
                 }
             }

--- a/crates/vmux_wire/src/protocol.rs
+++ b/crates/vmux_wire/src/protocol.rs
@@ -488,7 +488,6 @@ pub enum ClientMessage {
         sid: String,
         text: String,
         context: Option<String>,
-        attachments: Vec<AgentAttachment>,
     },
     /// Select a model exposed by an ACP session's model configuration option.
     AcpSetModel {
@@ -532,6 +531,33 @@ pub enum ClientMessage {
         resume_acp_session_id: Option<String>,
     },
     Status,
+    AgentInputWithAttachments {
+        sid: String,
+        text: String,
+        context: Option<String>,
+        attachments: Vec<AgentAttachment>,
+    },
+}
+
+impl ClientMessage {
+    /// Build a legacy-compatible prompt message when no attachments are present.
+    pub fn agent_input(
+        sid: String,
+        text: String,
+        context: Option<String>,
+        attachments: Vec<AgentAttachment>,
+    ) -> Self {
+        if attachments.is_empty() {
+            Self::AgentInput { sid, text, context }
+        } else {
+            Self::AgentInputWithAttachments {
+                sid,
+                text,
+                context,
+                attachments,
+            }
+        }
+    }
 }
 
 pub const PRIVATE_CONTEXT_PREFIX: &str = "<vmux_handoff_context>";
@@ -1337,6 +1363,11 @@ mod tests {
                 sid: "s".into(),
                 text: "hi".into(),
                 context: Some("prior conversation".into()),
+            },
+            ClientMessage::AgentInputWithAttachments {
+                sid: "s".into(),
+                text: "inspect".into(),
+                context: None,
                 attachments: vec![AgentAttachment {
                     path: "/tmp/image.png".into(),
                     name: "image.png".into(),
@@ -1366,6 +1397,30 @@ mod tests {
             let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&msg).unwrap();
             rkyv::from_bytes::<ClientMessage, rkyv::rancor::Error>(&bytes).unwrap();
         }
+    }
+
+    #[test]
+    fn agent_input_builder_preserves_legacy_variant_without_attachments() {
+        assert!(matches!(
+            ClientMessage::agent_input("s".into(), "hi".into(), None, Vec::new()),
+            ClientMessage::AgentInput { sid, text, context }
+                if sid == "s" && text == "hi" && context.is_none()
+        ));
+        assert!(matches!(
+            ClientMessage::agent_input(
+                "s".into(),
+                "inspect".into(),
+                None,
+                vec![AgentAttachment {
+                    path: "/tmp/image.png".into(),
+                    name: "image.png".into(),
+                    mime_type: "image/png".into(),
+                    size: 42,
+                }],
+            ),
+            ClientMessage::AgentInputWithAttachments { attachments, .. }
+                if attachments.len() == 1
+        ));
     }
 
     #[test]

--- a/crates/vmux_wire/src/protocol.rs
+++ b/crates/vmux_wire/src/protocol.rs
@@ -355,6 +355,15 @@ pub fn validate_agent_command(command: &AgentCommand) -> Result<(), &'static str
     }
 }
 
+/// A local file attached to an agent prompt.
+#[derive(Debug, Clone, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub struct AgentAttachment {
+    pub path: String,
+    pub name: String,
+    pub mime_type: String,
+    pub size: u64,
+}
+
 /// Messages sent from the GUI client to the service.
 #[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum ClientMessage {
@@ -469,6 +478,7 @@ pub enum ClientMessage {
         sid: String,
         text: String,
         context: Option<String>,
+        attachments: Vec<AgentAttachment>,
     },
     /// Select a model exposed by an ACP session's model configuration option.
     AcpSetModel {
@@ -1317,6 +1327,12 @@ mod tests {
                 sid: "s".into(),
                 text: "hi".into(),
                 context: Some("prior conversation".into()),
+                attachments: vec![AgentAttachment {
+                    path: "/tmp/image.png".into(),
+                    name: "image.png".into(),
+                    mime_type: "image/png".into(),
+                    size: 42,
+                }],
             },
             ClientMessage::AcpSetModel {
                 sid: "s".into(),

--- a/crates/vmux_wire/src/protocol.rs
+++ b/crates/vmux_wire/src/protocol.rs
@@ -356,7 +356,17 @@ pub fn validate_agent_command(command: &AgentCommand) -> Result<(), &'static str
 }
 
 /// A local file attached to an agent prompt.
-#[derive(Debug, Clone, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
 pub struct AgentAttachment {
     pub path: String,
     pub name: String,


### PR DESCRIPTION
## Context

Prompt composition lacked history navigation and a direct way to include local media. This adds keyboard-first history recall and file attachment flows for typed, selected, and pasted media.

## Implementation

Adds scratch-preserving prompt history navigation with arrow keys and Ctrl+N/P. Introduces multi-file upload, clipboard image capture, attachment previews, queue-safe attachment transport, and inline `@` media browsing rooted at the user home directory. ACP sessions receive structured image, audio, or resource blocks according to advertised capabilities; other agents receive local attachment paths in prompt text.

## Checks / QA

- Recall older and newer prompts with Up/Down and Ctrl+P/N, including restoration of an unsent draft.
- Run `/upload` or use the attachment button, select multiple files, remove previews, and submit an attachments-only prompt.
- Paste a copied image into the composer and verify its preview.
- Type `@` in a prompt, navigate media with Up/Down or Ctrl+P/N, drill into directories, and select multiple references.
- Queue prompts with attachments and verify names and attachments survive normal dispatch and queue flush.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for attaching local files and pasted images to chat prompts.
  * Added attachment previews, removal controls, queued attachment names, and an upload command.
  * Added inline `@` media search with selectable file and directory results.
  * Added attachment support across agent sessions, including image, audio, and resource content where supported.
  * Added prompt history navigation and improved empty-submission handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->