### PR TITLE
refactor(ui): map host events into Dioxus state

### DIFF
--- a/crates/vmux_layout/src/page.rs
+++ b/crates/vmux_layout/src/page.rs
@@ -14,9 +14,7 @@ use vmux_core::event::extension::{
 use vmux_core::event::team::{TEAM_EVENT, TeamCommandEvent, TeamEvent, TeamMemberRow};
 use vmux_ui::components::icon::Icon;
 use vmux_ui::favicon::{favicon_src_for_url, host_for_favicon_fallback};
-use vmux_ui::hooks::{
-    try_cef_bin_emit_rkyv, use_bin_event_listener, use_bin_event_state, use_theme,
-};
+use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_event, use_theme};
 use vmux_ui::icon::PageIconView;
 use wasm_bindgen::JsCast;
 
@@ -69,15 +67,15 @@ pub fn Page() -> Element {
         },
     );
 
-    let boundary_state = use_bin_event_state::<crate::event::TabBoundaryEvent>(
+    let boundary_state = use_event::<crate::event::TabBoundaryEvent>(
         crate::event::TAB_BOUNDARY_EVENT,
         crate::event::TabBoundaryEvent::default,
     );
 
-    let team_state = use_bin_event_state::<TeamEvent>(TEAM_EVENT, TeamEvent::default);
+    let team_state = use_event::<TeamEvent>(TEAM_EVENT, TeamEvent::default);
 
     let extensions_state =
-        use_bin_event_state::<ExtensionsEvent>(EXTENSIONS_LIST_EVENT, ExtensionsEvent::default);
+        use_event::<ExtensionsEvent>(EXTENSIONS_LIST_EVENT, ExtensionsEvent::default);
     use_effect(move || {
         let _ = try_cef_bin_emit_rkyv(&ExtListRequest);
     });

--- a/crates/vmux_layout/src/page.rs
+++ b/crates/vmux_layout/src/page.rs
@@ -14,7 +14,9 @@ use vmux_core::event::extension::{
 use vmux_core::event::team::{TEAM_EVENT, TeamCommandEvent, TeamEvent, TeamMemberRow};
 use vmux_ui::components::icon::Icon;
 use vmux_ui::favicon::{favicon_src_for_url, host_for_favicon_fallback};
-use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_theme};
+use vmux_ui::hooks::{
+    try_cef_bin_emit_rkyv, use_bin_event_listener, use_bin_event_state, use_theme,
+};
 use vmux_ui::icon::PageIconView;
 use wasm_bindgen::JsCast;
 
@@ -67,24 +69,15 @@ pub fn Page() -> Element {
         },
     );
 
-    let mut boundary_state = use_signal(crate::event::TabBoundaryEvent::default);
-    let _boundary_listener = use_bin_event_listener::<crate::event::TabBoundaryEvent, _>(
+    let boundary_state = use_bin_event_state::<crate::event::TabBoundaryEvent>(
         crate::event::TAB_BOUNDARY_EVENT,
-        move |data| {
-            boundary_state.set(data);
-        },
+        crate::event::TabBoundaryEvent::default,
     );
 
-    let mut team_state = use_signal(TeamEvent::default);
-    let _team_listener = use_bin_event_listener::<TeamEvent, _>(TEAM_EVENT, move |data| {
-        team_state.set(data);
-    });
+    let team_state = use_bin_event_state::<TeamEvent>(TEAM_EVENT, TeamEvent::default);
 
-    let mut extensions_state = use_signal(ExtensionsEvent::default);
-    let _extensions_listener =
-        use_bin_event_listener::<ExtensionsEvent, _>(EXTENSIONS_LIST_EVENT, move |data| {
-            extensions_state.set(data);
-        });
+    let extensions_state =
+        use_bin_event_state::<ExtensionsEvent>(EXTENSIONS_LIST_EVENT, ExtensionsEvent::default);
     use_effect(move || {
         let _ = try_cef_bin_emit_rkyv(&ExtListRequest);
     });

--- a/crates/vmux_layout/src/start/page.rs
+++ b/crates/vmux_layout/src/start/page.rs
@@ -2,7 +2,9 @@
 
 use dioxus::prelude::*;
 use vmux_command::event::{COMMAND_BAR_OPEN_EVENT, CommandBarOpenEvent};
-use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_theme};
+use vmux_ui::hooks::{
+    try_cef_bin_emit_rkyv, use_bin_event_listener, use_bin_event_state, use_theme,
+};
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 
@@ -16,13 +18,11 @@ const START_FOCUS_PENDING: &str = "_startFocusPending";
 #[component]
 pub fn Page() -> Element {
     use_theme();
-    let mut state = use_signal(CommandBarOpenEvent::default);
+    let state = use_bin_event_state::<CommandBarOpenEvent>(
+        COMMAND_BAR_OPEN_EVENT,
+        CommandBarOpenEvent::default,
+    );
     let mut mounted = use_signal(|| false);
-
-    let _open_listener =
-        use_bin_event_listener::<CommandBarOpenEvent, _>(COMMAND_BAR_OPEN_EVENT, move |data| {
-            state.set(data);
-        });
 
     let _focus_listener =
         use_bin_event_listener::<StartFocusInput, _>(START_FOCUS_INPUT_EVENT, move |_| {

--- a/crates/vmux_layout/src/start/page.rs
+++ b/crates/vmux_layout/src/start/page.rs
@@ -2,9 +2,7 @@
 
 use dioxus::prelude::*;
 use vmux_command::event::{COMMAND_BAR_OPEN_EVENT, CommandBarOpenEvent};
-use vmux_ui::hooks::{
-    try_cef_bin_emit_rkyv, use_bin_event_listener, use_bin_event_state, use_theme,
-};
+use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_event, use_theme};
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 
@@ -18,10 +16,8 @@ const START_FOCUS_PENDING: &str = "_startFocusPending";
 #[component]
 pub fn Page() -> Element {
     use_theme();
-    let state = use_bin_event_state::<CommandBarOpenEvent>(
-        COMMAND_BAR_OPEN_EVENT,
-        CommandBarOpenEvent::default,
-    );
+    let state =
+        use_event::<CommandBarOpenEvent>(COMMAND_BAR_OPEN_EVENT, CommandBarOpenEvent::default);
     let mut mounted = use_signal(|| false);
 
     let _focus_listener =

--- a/crates/vmux_service/src/page.rs
+++ b/crates/vmux_service/src/page.rs
@@ -2,21 +2,17 @@
 
 use crate::event::*;
 use dioxus::prelude::*;
-use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_theme};
+use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_state, use_theme};
 
 #[component]
 pub fn Page() -> Element {
     use_theme();
-    let mut state = use_signal(|| ProcessesListEvent {
-        connected: false,
-        processes: Vec::new(),
-    });
-    let mut search = use_signal(String::new);
-
-    let _listener =
-        use_bin_event_listener::<ProcessesListEvent, _>(PROCESSES_LIST_EVENT, move |event| {
-            state.set(event);
+    let state =
+        use_bin_event_state::<ProcessesListEvent>(PROCESSES_LIST_EVENT, || ProcessesListEvent {
+            connected: false,
+            processes: Vec::new(),
         });
+    let mut search = use_signal(String::new);
 
     let data = state.read();
     let query = search.read().to_lowercase();

--- a/crates/vmux_service/src/page.rs
+++ b/crates/vmux_service/src/page.rs
@@ -2,16 +2,15 @@
 
 use crate::event::*;
 use dioxus::prelude::*;
-use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_state, use_theme};
+use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_event, use_theme};
 
 #[component]
 pub fn Page() -> Element {
     use_theme();
-    let state =
-        use_bin_event_state::<ProcessesListEvent>(PROCESSES_LIST_EVENT, || ProcessesListEvent {
-            connected: false,
-            processes: Vec::new(),
-        });
+    let state = use_event::<ProcessesListEvent>(PROCESSES_LIST_EVENT, || ProcessesListEvent {
+        connected: false,
+        processes: Vec::new(),
+    });
     let mut search = use_signal(String::new);
 
     let data = state.read();

--- a/crates/vmux_team/src/page.rs
+++ b/crates/vmux_team/src/page.rs
@@ -3,12 +3,12 @@
 use dioxus::prelude::*;
 use vmux_core::event::team::{TEAM_EVENT, TeamEvent, TeamMemberRow};
 use vmux_ui::favicon::favicon_src_for_url;
-use vmux_ui::hooks::{use_bin_event_state, use_theme};
+use vmux_ui::hooks::{use_event, use_theme};
 
 #[component]
 pub fn Page() -> Element {
     use_theme();
-    let team = use_bin_event_state::<TeamEvent>(TEAM_EVENT, TeamEvent::default);
+    let team = use_event::<TeamEvent>(TEAM_EVENT, TeamEvent::default);
 
     let members = team().members;
     let count = members.len();

--- a/crates/vmux_team/src/page.rs
+++ b/crates/vmux_team/src/page.rs
@@ -3,13 +3,12 @@
 use dioxus::prelude::*;
 use vmux_core::event::team::{TEAM_EVENT, TeamEvent, TeamMemberRow};
 use vmux_ui::favicon::favicon_src_for_url;
-use vmux_ui::hooks::{use_bin_event_listener, use_theme};
+use vmux_ui::hooks::{use_bin_event_state, use_theme};
 
 #[component]
 pub fn Page() -> Element {
     use_theme();
-    let mut team = use_signal(TeamEvent::default);
-    let _listener = use_bin_event_listener::<TeamEvent, _>(TEAM_EVENT, move |data| team.set(data));
+    let team = use_bin_event_state::<TeamEvent>(TEAM_EVENT, TeamEvent::default);
 
     let members = team().members;
     let count = members.len();

--- a/crates/vmux_ui/src/hooks.rs
+++ b/crates/vmux_ui/src/hooks.rs
@@ -6,7 +6,7 @@ mod use_theme;
 #[allow(unused_imports)]
 pub use event_listener::{
     BevyState, EventListenerError, decode_bin_host_emit_js, try_cef_bin_emit_rkyv,
-    try_cef_bin_listen, try_emit_page_ready, use_bin_event_listener,
+    try_cef_bin_listen, try_emit_page_ready, use_bin_event_listener, use_bin_event_state,
 };
 
 pub use use_theme::use_theme;

--- a/crates/vmux_ui/src/hooks.rs
+++ b/crates/vmux_ui/src/hooks.rs
@@ -6,7 +6,7 @@ mod use_theme;
 #[allow(unused_imports)]
 pub use event_listener::{
     BevyState, EventListenerError, decode_bin_host_emit_js, try_cef_bin_emit_rkyv,
-    try_cef_bin_listen, try_emit_page_ready, use_bin_event_listener, use_bin_event_state,
+    try_cef_bin_listen, try_emit_page_ready, use_bin_event_listener, use_event,
 };
 
 pub use use_theme::use_theme;

--- a/crates/vmux_ui/src/hooks/event_listener.rs
+++ b/crates/vmux_ui/src/hooks/event_listener.rs
@@ -237,3 +237,15 @@ where
 
     BevyState { is_loading, error }
 }
+
+/// Maps the latest binary host event into a Dioxus signal.
+pub fn use_bin_event_state<T>(name: &'static str, init: impl FnOnce() -> T) -> Signal<T>
+where
+    T: rkyv::Archive + 'static,
+    T::Archived: rkyv::Deserialize<T, rkyv::api::high::HighDeserializer<rkyv::rancor::Error>>
+        + for<'a> rkyv::bytecheck::CheckBytes<rkyv::api::high::HighValidator<'a, rkyv::rancor::Error>>,
+{
+    let mut state = use_signal(init);
+    let _listener = use_bin_event_listener::<T, _>(name, move |event| state.set(event));
+    state
+}

--- a/crates/vmux_ui/src/hooks/event_listener.rs
+++ b/crates/vmux_ui/src/hooks/event_listener.rs
@@ -239,7 +239,7 @@ where
 }
 
 /// Maps the latest binary host event into a Dioxus signal.
-pub fn use_bin_event_state<T>(name: &'static str, init: impl FnOnce() -> T) -> Signal<T>
+pub fn use_event<T>(name: &'static str, init: impl FnOnce() -> T) -> Signal<T>
 where
     T: rkyv::Archive + 'static,
     T::Archived: rkyv::Deserialize<T, rkyv::api::high::HighDeserializer<rkyv::rancor::Error>>


### PR DESCRIPTION
## Context
Dioxus pages repeat `use_signal` plus `use_bin_event_listener` boilerplate when a host event should replace local state. This obscures frontend logic.

## Implementation
Adds `use_event`, which owns the listener and updates a `Signal<T>` with each decoded host event. Migrates direct state mappings while keeping reducer and side-effect listeners explicit.

## Checks / QA
- Open Team, Background Services, and Start pages; verify host-driven state renders.
- Trigger team, extension, and tab-boundary updates; verify layout chrome updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined event handling across page, service, team, and start views.
  * Added a shared event-state hook for more consistent updates from host events.
  * Existing event-driven displays and interactions continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->