### PR TITLE
feat(agent): resume CLI sessions in ACP

### DIFF
--- a/crates/vmux_agent/src/mcp.rs
+++ b/crates/vmux_agent/src/mcp.rs
@@ -6,7 +6,7 @@ pub use vmux_core::agent::McpServerConfig;
 use crate::exec;
 
 pub fn resolve(cwd: &Path, anchor: ProcessId) -> Result<McpServerConfig, String> {
-    resolve_inner(cwd, anchor, false)
+    resolve_inner(cwd, anchor, false, false)
 }
 
 /// Resolve the MCP sidecar for an ACP agent. Agents that use ACP client terminals hide the
@@ -16,7 +16,7 @@ pub fn resolve_acp(
     anchor: ProcessId,
     agent_id: &str,
 ) -> Result<McpServerConfig, String> {
-    resolve_inner(cwd, anchor, acp_uses_native_terminals(agent_id))
+    resolve_inner(cwd, anchor, true, acp_uses_native_terminals(agent_id))
 }
 
 fn acp_uses_native_terminals(agent_id: &str) -> bool {
@@ -26,11 +26,12 @@ fn acp_uses_native_terminals(agent_id: &str) -> bool {
 fn resolve_inner(
     cwd: &Path,
     anchor: ProcessId,
+    acp_session: bool,
     acp_terminals: bool,
 ) -> Result<McpServerConfig, String> {
     let sidecar = vmux_sidecar_path()?;
     let profile = vmux_core::profile::active_profile_name();
-    resolve_with_sidecar(&sidecar, cwd, anchor, &profile, acp_terminals)
+    resolve_with_sidecar(&sidecar, cwd, anchor, &profile, acp_session, acp_terminals)
 }
 
 fn resolve_with_sidecar(
@@ -38,12 +39,13 @@ fn resolve_with_sidecar(
     cwd: &Path,
     anchor: ProcessId,
     profile: &str,
+    acp_session: bool,
     acp_terminals: bool,
 ) -> Result<McpServerConfig, String> {
     if exec::is_executable_path(sidecar) {
         return Ok(McpServerConfig {
             command: sidecar.to_string_lossy().to_string(),
-            args: mcp_subcommand_args(anchor, profile, acp_terminals),
+            args: mcp_subcommand_args(anchor, profile, acp_session, acp_terminals),
             cwd: None,
         });
     }
@@ -53,7 +55,12 @@ fn resolve_with_sidecar(
         .into_iter()
         .map(str::to_string)
         .collect();
-    args.extend(mcp_subcommand_args(anchor, profile, acp_terminals));
+    args.extend(mcp_subcommand_args(
+        anchor,
+        profile,
+        acp_session,
+        acp_terminals,
+    ));
     Ok(McpServerConfig {
         command: "cargo".to_string(),
         args,
@@ -61,7 +68,12 @@ fn resolve_with_sidecar(
     })
 }
 
-fn mcp_subcommand_args(anchor: ProcessId, profile: &str, acp_terminals: bool) -> Vec<String> {
+fn mcp_subcommand_args(
+    anchor: ProcessId,
+    profile: &str,
+    acp_session: bool,
+    acp_terminals: bool,
+) -> Vec<String> {
     let mut args = vec![
         "mcp".to_string(),
         "--anchor".to_string(),
@@ -69,6 +81,9 @@ fn mcp_subcommand_args(anchor: ProcessId, profile: &str, acp_terminals: bool) ->
         "--profile".to_string(),
         profile.to_string(),
     ];
+    if acp_session {
+        args.push("--acp-session".to_string());
+    }
     if acp_terminals {
         args.push("--acp-terminals".to_string());
     }
@@ -102,7 +117,7 @@ mod tests {
     fn mcp_args_always_append_profile() {
         let anchor = ProcessId::new();
         for profile in ["personal", "gregor"] {
-            let args = mcp_subcommand_args(anchor, profile, false);
+            let args = mcp_subcommand_args(anchor, profile, false, false);
             assert!(
                 args.windows(2)
                     .any(|w| w[0] == "--profile" && w[1] == profile)
@@ -113,8 +128,10 @@ mod tests {
     #[test]
     fn acp_args_append_acp_terminals_flag() {
         let anchor = ProcessId::new();
-        let plain = mcp_subcommand_args(anchor, "personal", false);
-        let acp = mcp_subcommand_args(anchor, "personal", true);
+        let plain = mcp_subcommand_args(anchor, "personal", false, false);
+        let acp = mcp_subcommand_args(anchor, "personal", true, true);
+        assert!(!plain.iter().any(|a| a == "--acp-session"));
+        assert!(acp.iter().any(|a| a == "--acp-session"));
         assert!(!plain.iter().any(|a| a == "--acp-terminals"));
         assert!(acp.iter().any(|a| a == "--acp-terminals"));
     }
@@ -141,6 +158,7 @@ mod tests {
             &workspace,
             anchor,
             "personal",
+            false,
             false,
         )
         .unwrap();
@@ -180,6 +198,7 @@ mod tests {
             &workspace,
             anchor,
             "personal",
+            false,
             false,
         )
         .unwrap();

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -256,6 +256,7 @@ impl Plugin for AgentPlugin {
                 (
                     forward_history_open_intent,
                     handle_agent_tool_calls,
+                    handle_resume_in_acp,
                     handle_agent_commands,
                     handle_agent_file_touch.before(vmux_layout::worktree::TabDirectoryRebindSet),
                 )
@@ -457,6 +458,23 @@ fn acp_profile_name_for_id(
         .to_string()
 }
 
+fn acp_target_id_for_kind(
+    kind: AgentKind,
+    configs: &[vmux_setting::AcpAgentConfig],
+    catalog: Option<&crate::client::acp::AcpCatalog>,
+) -> Option<String> {
+    configs
+        .iter()
+        .find(|config| crate::strategy::acp_agent_kind(&config.id) == Some(kind))
+        .map(|config| config.id.clone())
+        .or_else(|| {
+            let id = kind.as_url_segment();
+            acp_registry_agent_for_id(catalog, id)
+                .is_some()
+                .then(|| id.to_string())
+        })
+}
+
 #[allow(dead_code)]
 pub fn page_agent_placeholder_url(provider: &str, model: &str, sid: &str) -> String {
     let html = format!(
@@ -636,6 +654,82 @@ fn handle_agent_tool_calls(
                     });
                 }
             }
+        }
+    }
+}
+
+fn handle_resume_in_acp(
+    mut reader: MessageReader<AgentCommandRequest>,
+    cli_sessions: Query<
+        (
+            &ProcessId,
+            &ChildOf,
+            &AgentSession,
+            Option<&SessionId>,
+            &TerminalLaunch,
+        ),
+        With<Terminal>,
+    >,
+    settings: Res<AppSettings>,
+    catalog: Option<Res<crate::client::acp::AcpCatalog>>,
+    mut swap: MessageWriter<vmux_core::agent::SwapStackSession>,
+    service: Option<Res<ServiceClient>>,
+) {
+    for request in reader.read() {
+        let ServiceAgentCommand::ResumeInAcp { anchor } = &request.command else {
+            continue;
+        };
+        let result = if !matches!(
+            &request.origin,
+            CommandOrigin::Agent {
+                anchor: Some(origin_anchor),
+                ..
+            } if origin_anchor == anchor
+        ) {
+            AgentCommandResult::Error("resume_in_acp: caller anchor mismatch".to_string())
+        } else if let Some((_, child_of, session, session_id, launch)) = cli_sessions
+            .iter()
+            .find(|(process_id, ..)| *process_id == anchor)
+        {
+            if !crate::strategy::kind_supports_cross_runtime(session.kind) {
+                AgentCommandResult::Error(format!(
+                    "resume_in_acp: {} does not support ACP resume",
+                    session.kind.display_name()
+                ))
+            } else if let Some(session_id) = session_id {
+                if let Some(agent_id) =
+                    acp_target_id_for_kind(session.kind, &settings.agent.acp, catalog.as_deref())
+                {
+                    swap.write(vmux_core::agent::SwapStackSession {
+                        stack: child_of.parent(),
+                        target_url: crate::AgentUrl::Acp {
+                            id: agent_id,
+                            sid: Some(session_id.0.clone()),
+                        }
+                        .format(),
+                        cwd: PathBuf::from(&launch.cwd),
+                        handoff: None,
+                    });
+                    AgentCommandResult::Ok
+                } else {
+                    AgentCommandResult::Error(format!(
+                        "resume_in_acp: no ACP runtime available for {}",
+                        session.kind.display_name()
+                    ))
+                }
+            } else {
+                AgentCommandResult::Error(
+                    "resume_in_acp: current CLI session id is not available yet".to_string(),
+                )
+            }
+        } else {
+            AgentCommandResult::Error("resume_in_acp: current CLI session not found".to_string())
+        };
+        if let Some(service) = service.as_ref() {
+            service.0.send(ClientMessage::AgentCommandResponse {
+                request_id: request.request_id,
+                result,
+            });
         }
     }
 }
@@ -1737,7 +1831,8 @@ fn handle_agent_commands(
             ServiceAgentCommand::OpenBeside { .. }
             | ServiceAgentCommand::Run { .. }
             | ServiceAgentCommand::RunWithPlacementOverride { .. }
-            | ServiceAgentCommand::CreateWorktree { .. } => {
+            | ServiceAgentCommand::CreateWorktree { .. }
+            | ServiceAgentCommand::ResumeInAcp { .. } => {
                 continue;
             }
         };
@@ -3991,6 +4086,74 @@ mod tests {
             acp_profile_name_for_id(&config.id, Some(&config), None),
             "claude"
         );
+    }
+
+    #[test]
+    fn acp_target_id_accepts_registry_alias_config() {
+        let config = vmux_setting::AcpAgentConfig {
+            id: "claude-acp".into(),
+            name: "Claude".into(),
+            command: "npx".into(),
+            args: vec![],
+            env: vec![],
+            cwd: None,
+        };
+
+        assert_eq!(
+            acp_target_id_for_kind(AgentKind::Claude, &[config], None).as_deref(),
+            Some("claude-acp")
+        );
+    }
+
+    #[test]
+    fn resume_in_acp_command_swaps_current_cli_stack() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<AgentCommandRequest>()
+            .add_message::<vmux_core::agent::SwapStackSession>()
+            .insert_resource(test_settings())
+            .add_systems(Update, handle_resume_in_acp);
+        let stack = app.world_mut().spawn_empty().id();
+        let anchor = ProcessId::new();
+        app.world_mut().spawn((
+            Terminal,
+            anchor,
+            ChildOf(stack),
+            AgentSession {
+                kind: AgentKind::Claude,
+            },
+            SessionId("session-7".into()),
+            TerminalLaunch {
+                command: "claude".into(),
+                args: vec![],
+                cwd: "/workspace/project".into(),
+                env: vec![],
+                kind: vmux_terminal::launch::TerminalKind::Claude,
+            },
+        ));
+        app.world_mut()
+            .resource_mut::<Messages<AgentCommandRequest>>()
+            .write(AgentCommandRequest {
+                request_id: AgentRequestId::new(),
+                origin: CommandOrigin::Agent {
+                    sid: None,
+                    anchor: Some(anchor),
+                },
+                command: ServiceAgentCommand::ResumeInAcp { anchor },
+            });
+
+        app.update();
+
+        let swaps: Vec<_> = app
+            .world_mut()
+            .resource_mut::<Messages<vmux_core::agent::SwapStackSession>>()
+            .drain()
+            .collect();
+        assert_eq!(swaps.len(), 1);
+        assert_eq!(swaps[0].stack, stack);
+        assert_eq!(swaps[0].target_url, "vmux://agent/claude/session-7");
+        assert_eq!(swaps[0].cwd, PathBuf::from("/workspace/project"));
+        assert!(swaps[0].handoff.is_none());
     }
     use vmux_layout::settings::{
         FocusRingSettings, LayoutSettings, PaneSettings, SideSheetSettings, WindowSettings,

--- a/crates/vmux_cli/src/commands.rs
+++ b/crates/vmux_cli/src/commands.rs
@@ -21,6 +21,9 @@ pub enum Command {
         anchor: Option<String>,
         #[arg(long)]
         profile: Option<String>,
+        /// Serve tools to an ACP agent rather than a CLI agent.
+        #[arg(long)]
+        acp_session: bool,
         /// Serve the ACP toolset: hide `run` + `read_terminal` (ACP sessions use ACP-native
         /// terminals instead); `terminal_send` stays.
         #[arg(long)]

--- a/crates/vmux_cli/src/commands/mcp.rs
+++ b/crates/vmux_cli/src/commands/mcp.rs
@@ -3,6 +3,7 @@ use std::io;
 pub async fn run(
     anchor: Option<String>,
     profile: Option<String>,
+    acp_session: bool,
     acp_terminals: bool,
 ) -> io::Result<()> {
     if let Some(p) = profile
@@ -12,5 +13,5 @@ pub async fn run(
         unsafe { std::env::set_var("VMUX_PROFILE", p) };
     }
     let anchor = anchor.and_then(|s| s.parse::<vmux_service::protocol::ProcessId>().ok());
-    vmux_mcp::protocol::run_stdio(anchor, acp_terminals).await
+    vmux_mcp::protocol::run_stdio(anchor, acp_session, acp_terminals).await
 }

--- a/crates/vmux_cli/src/main.rs
+++ b/crates/vmux_cli/src/main.rs
@@ -14,8 +14,9 @@ async fn main() -> std::io::Result<()> {
         Some(Command::Mcp {
             anchor,
             profile,
+            acp_session,
             acp_terminals,
-        }) => commands::mcp::run(anchor, profile, acp_terminals).await,
+        }) => commands::mcp::run(anchor, profile, acp_session, acp_terminals).await,
         Some(Command::Notify {
             title,
             body,

--- a/crates/vmux_mcp/src/protocol.rs
+++ b/crates/vmux_mcp/src/protocol.rs
@@ -26,6 +26,7 @@ pub fn read_json_line(reader: &mut impl BufRead) -> io::Result<Option<Value>> {
 
 pub async fn run_stdio(
     anchor: Option<vmux_service::protocol::ProcessId>,
+    acp_session: bool,
     acp_terminals: bool,
 ) -> io::Result<()> {
     let stdin = io::stdin();
@@ -34,7 +35,7 @@ pub async fn run_stdio(
     let mut writer = stdout.lock();
 
     while let Some(message) = read_json_line(&mut reader)? {
-        if let Some(response) = handle_message(message, anchor, acp_terminals).await {
+        if let Some(response) = handle_message(message, anchor, acp_session, acp_terminals).await {
             serde_json::to_writer(&mut writer, &response)?;
             writer.write_all(b"\n")?;
             writer.flush()?;
@@ -46,6 +47,7 @@ pub async fn run_stdio(
 async fn handle_message(
     message: Value,
     anchor: Option<vmux_service::protocol::ProcessId>,
+    acp_session: bool,
     acp_terminals: bool,
 ) -> Option<Value> {
     let id = message.get("id").cloned()?;
@@ -54,10 +56,10 @@ async fn handle_message(
 
     let result = match method {
         "initialize" => Ok(initialize_result(&params)),
-        "tools/list" => {
-            Ok(json!({ "tools": crate::tools::tool_definitions_filtered(acp_terminals) }))
-        }
-        "tools/call" => tool_call_result(&params, anchor, acp_terminals).await,
+        "tools/list" => Ok(json!({
+            "tools": crate::tools::tool_definitions_filtered(acp_session, acp_terminals)
+        })),
+        "tools/call" => tool_call_result(&params, anchor, acp_session, acp_terminals).await,
         _ => {
             return Some(json!({
                 "jsonrpc": "2.0",
@@ -104,14 +106,21 @@ fn initialize_result(params: &Value) -> Value {
 async fn tool_call_result(
     params: &Value,
     anchor: Option<vmux_service::protocol::ProcessId>,
+    acp_session: bool,
     acp_terminals: bool,
 ) -> Result<Value, String> {
     let name = params
         .get("name")
         .and_then(Value::as_str)
         .ok_or_else(|| "tools/call missing name".to_string())?;
-    if acp_terminals && matches!(name, "run" | "read_terminal") {
-        return Err(format!("tool {name} is unavailable for ACP sessions"));
+    let normalized_name = name.strip_prefix("vmux_").unwrap_or(name);
+    if acp_session && normalized_name == "resume_in_acp" {
+        return Err("tool resume_in_acp is unavailable for ACP sessions".to_string());
+    }
+    if acp_terminals && matches!(normalized_name, "run" | "read_terminal") {
+        return Err(format!(
+            "tool {normalized_name} is unavailable for ACP sessions"
+        ));
     }
     let arguments = params
         .get("arguments")
@@ -801,6 +810,7 @@ mod tests {
                 }),
                 None,
                 true,
+                true,
             )
             .await
             .unwrap();
@@ -811,6 +821,29 @@ mod tests {
                 format!("tool {name} is unavailable for ACP sessions")
             );
         }
+    }
+
+    #[tokio::test]
+    async fn acp_tools_call_rejects_resume_in_acp() {
+        let response = handle_message(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": { "name": "resume_in_acp", "arguments": {} }
+            }),
+            None,
+            true,
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response["result"]["isError"], true);
+        assert_eq!(
+            response["result"]["content"][0]["text"],
+            "tool resume_in_acp is unavailable for ACP sessions"
+        );
     }
 
     #[test]

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -458,6 +458,19 @@ its absolute path — do your work there. No-op-safe: returns the existing path 
     }
 }
 
+fn resume_in_acp_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "resume_in_acp".into(),
+        description: "Continue the current CLI conversation in its ACP chat runtime. Replaces this CLI page in place while preserving the session id and working directory. Call only when the user asks to switch or continue in ACP."
+            .into(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
+        }),
+    }
+}
+
 fn read_terminal_definition() -> ToolDefinition {
     ToolDefinition {
         name: "read_terminal".into(),
@@ -593,13 +606,12 @@ name=<feature> to drop a demo straight into the repo."
 }
 
 pub fn tool_definitions() -> Vec<ToolDefinition> {
-    tool_definitions_filtered(false)
+    tool_definitions_filtered(false, false)
 }
 
-/// Build the MCP tool list. When `acp_terminals` is set (ACP sessions, which get terminals through
-/// the ACP terminal methods), `run` + `read_terminal` are omitted; `terminal_send` (no ACP
-/// equivalent for keystrokes/TUIs) is always kept.
-pub fn tool_definitions_filtered(acp_terminals: bool) -> Vec<ToolDefinition> {
+/// Build the MCP tool list. ACP sessions omit the CLI-only runtime switch. When
+/// `acp_terminals` is set, `run` + `read_terminal` are also omitted; `terminal_send` stays.
+pub fn tool_definitions_filtered(acp_session: bool, acp_terminals: bool) -> Vec<ToolDefinition> {
     let mut defs: Vec<ToolDefinition> = vmux_command_mcp::tool_entries()
         .into_iter()
         .chain(McpParamTool::mcp_tool_entries())
@@ -617,6 +629,9 @@ pub fn tool_definitions_filtered(acp_terminals: bool) -> Vec<ToolDefinition> {
     defs.push(open_file_definition());
     defs.push(read_file_definition());
     defs.push(grep_definition());
+    if !acp_session {
+        defs.push(resume_in_acp_definition());
+    }
     if !acp_terminals {
         defs.push(run_definition());
     }
@@ -652,6 +667,13 @@ pub fn dispatch_with_anchor(
             Some("bottom") => Ok(Some(AgentPaneDirection::Bottom)),
             Some(other) => Err(format!("unknown direction: {other}")),
         }
+    }
+    if name == "resume_in_acp" {
+        let anchor = anchor
+            .ok_or("resume_in_acp requires an agent anchor (not available to this client)")?;
+        return Ok(DispatchTarget::Command(AgentCommand::ResumeInAcp {
+            anchor,
+        }));
     }
     if name == "open_page" {
         let anchor =
@@ -1310,7 +1332,7 @@ mod tests {
 
     #[test]
     fn acp_terminals_toolset_hides_run_and_read_terminal_keeps_send() {
-        let names: Vec<String> = tool_definitions_filtered(true)
+        let names: Vec<String> = tool_definitions_filtered(true, true)
             .into_iter()
             .map(|def| def.name)
             .collect();
@@ -1318,6 +1340,24 @@ mod tests {
         assert!(!names.contains(&"read_terminal".to_string()));
         assert!(names.contains(&"terminal_send".to_string()));
         assert!(names.contains(&"open_page".to_string()));
+        assert!(!names.contains(&"resume_in_acp".to_string()));
+    }
+
+    #[test]
+    fn cli_toolset_lists_resume_in_acp() {
+        assert!(tool_names().contains(&"resume_in_acp".to_string()));
+    }
+
+    #[test]
+    fn resume_in_acp_dispatches_with_anchor() {
+        let anchor = vmux_service::protocol::ProcessId::new();
+        let target =
+            dispatch_with_anchor("resume_in_acp", serde_json::json!({}), Some(anchor)).unwrap();
+        assert!(matches!(
+            target,
+            DispatchTarget::Command(AgentCommand::ResumeInAcp { anchor: got }) if got == anchor
+        ));
+        assert!(dispatch_from_tool_call("resume_in_acp", serde_json::json!({})).is_err());
     }
 
     #[test]

--- a/crates/vmux_wire/src/protocol.rs
+++ b/crates/vmux_wire/src/protocol.rs
@@ -184,6 +184,11 @@ pub enum AgentCommand {
         terminal: Option<ProcessId>,
         done_marker: Option<String>,
     },
+    /// Replace the calling CLI session with its ACP runtime, preserving session id and cwd.
+    /// Appended to keep existing rkyv variant layouts and positional discriminants stable.
+    ResumeInAcp {
+        anchor: ProcessId,
+    },
 }
 
 pub const AGENT_QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);


### PR DESCRIPTION
## Context
ACP chats can already continue in the CLI through /cli, but CLI agents had no reverse handoff. This adds a CLI-only MCP action that resumes the current conversation in ACP without changing its pane, session, or working directory.

## Implementation
The MCP sidecar now distinguishes CLI and ACP sessions, exposing resume_in_acp only to CLI agents. The desktop resolves the caller anchor to the live CLI session, selects the matching configured or registry ACP runtime, and routes the existing session id and cwd through SwapStackSession.

## Checks / QA
- Start a resumable CLI agent session, call resume_in_acp, and confirm ACP replaces it in the same pane with the same conversation and cwd.
- Confirm ACP agent tool lists do not expose resume_in_acp.