### PR TITLE
feat(start): submit prompts to last active agent

### DIFF
--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -438,9 +438,9 @@ fn apply_agent_compatibility_env(
     agent_id: &str,
     env: Vec<(String, String)>,
 ) -> Vec<(String, String)> {
-    match agent_id {
-        "mistral-vibe" | "vibe" => apply_vibe_compatibility_env(env),
-        "codex" => apply_codex_compatibility_env(env),
+    match crate::acp_install::registry_id_alias(agent_id) {
+        "mistral-vibe" => apply_vibe_compatibility_env(env),
+        "codex-acp" => apply_codex_compatibility_env(env),
         _ => env,
     }
 }
@@ -1195,26 +1195,28 @@ mod tests {
 
     #[test]
     fn codex_acp_routes_shell_commands_through_vmux_run() {
-        let env = apply_agent_compatibility_env("codex", Vec::new());
-        let config = env
-            .iter()
-            .find(|(key, _)| key == "CODEX_CONFIG")
-            .map(|(_, value)| serde_json::from_str::<serde_json::Value>(value).unwrap())
-            .expect("codex ACP compatibility config");
+        for agent_id in ["codex", "codex-acp"] {
+            let env = apply_agent_compatibility_env(agent_id, Vec::new());
+            let config = env
+                .iter()
+                .find(|(key, _)| key == "CODEX_CONFIG")
+                .map(|(_, value)| serde_json::from_str::<serde_json::Value>(value).unwrap())
+                .expect("codex ACP compatibility config");
 
-        assert_eq!(config["features"]["shell_tool"], false);
-        assert_eq!(config["features"]["unified_exec"], false);
-        assert_eq!(config["tools"]["web_search"], false);
-        assert_eq!(
-            config["features"]["code_mode"]["direct_only_tool_namespaces"],
-            serde_json::json!([crate::client::cli::codex::DIRECT_ONLY_NAMESPACE])
-        );
-        assert!(
-            config["developer_instructions"]
-                .as_str()
-                .unwrap()
-                .contains("mcp__vmux__run")
-        );
+            assert_eq!(config["features"]["shell_tool"], false);
+            assert_eq!(config["features"]["unified_exec"], false);
+            assert_eq!(config["tools"]["web_search"], false);
+            assert_eq!(
+                config["features"]["code_mode"]["direct_only_tool_namespaces"],
+                serde_json::json!([crate::client::cli::codex::DIRECT_ONLY_NAMESPACE])
+            );
+            assert!(
+                config["developer_instructions"]
+                    .as_str()
+                    .unwrap()
+                    .contains("mcp__vmux__run")
+            );
+        }
     }
 
     #[test]

--- a/crates/vmux_agent/src/mcp.rs
+++ b/crates/vmux_agent/src/mcp.rs
@@ -20,7 +20,10 @@ pub fn resolve_acp(
 }
 
 fn acp_uses_native_terminals(agent_id: &str) -> bool {
-    !matches!(agent_id, "claude" | "codex" | "mistral-vibe" | "vibe")
+    !matches!(
+        crate::acp_install::registry_id_alias(agent_id),
+        "claude-acp" | "codex-acp" | "mistral-vibe"
+    )
 }
 
 fn resolve_inner(
@@ -139,7 +142,9 @@ mod tests {
     #[test]
     fn compatibility_acp_agents_keep_vmux_terminal_tools() {
         assert!(!acp_uses_native_terminals("codex"));
+        assert!(!acp_uses_native_terminals("codex-acp"));
         assert!(!acp_uses_native_terminals("claude"));
+        assert!(!acp_uses_native_terminals("claude-acp"));
         assert!(!acp_uses_native_terminals("mistral-vibe"));
         assert!(!acp_uses_native_terminals("vibe"));
         assert!(acp_uses_native_terminals("vibe-acp"));

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -308,7 +308,7 @@ impl Plugin for AgentPlugin {
                 Update,
                 (
                     crate::snapshot_updater::update_agents_snapshot,
-                    crate::snapshot_updater::update_last_active_agent,
+                    crate::snapshot_updater::update_recent_agents,
                     crate::snapshot_updater::update_agent_sessions_snapshot,
                 )
                     .in_set(vmux_command::snapshot::WriteCommandBarSnapshots),

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -5,7 +5,7 @@ use bevy_cef::prelude::{CefKeyboardTarget, WebviewExtendStandardMaterial};
 use vmux_command::{AppCommand, WriteAppCommands};
 use vmux_core::agent::{
     AgentKind, AgentProviderTargetKind, PageAgentAttachDefaultRequest, PageAgentAttachRequest,
-    PageAgentSpawnDefaultRequest, PageAgentSpawnStackRequest, RestartAgentPty,
+    PageAgentSpawnDefaultRequest, PageAgentSpawnStackRequest, PendingAgentPrompt, RestartAgentPty,
     SpawnAgentInStackRequest,
 };
 use vmux_core::{
@@ -308,6 +308,7 @@ impl Plugin for AgentPlugin {
                 Update,
                 (
                     crate::snapshot_updater::update_agents_snapshot,
+                    crate::snapshot_updater::update_last_active_agent,
                     crate::snapshot_updater::update_agent_sessions_snapshot,
                 )
                     .in_set(vmux_command::snapshot::WriteCommandBarSnapshots),
@@ -3060,7 +3061,10 @@ fn forward_record_stop_responses(
 }
 
 fn handle_agent_page_open(
-    tasks: Query<(Entity, &PageOpenTask), PendingPageOpen>,
+    mut open_q: ParamSet<(
+        Query<(Entity, &PageOpenTask), PendingPageOpen>,
+        Query<&PendingAgentPrompt>,
+    )>,
     children_q: Query<&Children>,
     agents: Query<&vmux_core::agent::AgentSession>,
     acp_sessions: Query<&crate::client::acp::AcpSession>,
@@ -3077,7 +3081,12 @@ fn handle_agent_page_open(
     tabs: Query<&vmux_layout::tab::Tab>,
     catalog: Option<Res<crate::client::acp::AcpCatalog>>,
 ) {
-    for (entity, task) in &tasks {
+    let tasks: Vec<(Entity, PageOpenTask)> = open_q
+        .p0()
+        .iter()
+        .map(|(entity, task)| (entity, task.clone()))
+        .collect();
+    for (entity, task) in tasks {
         if !task.url.starts_with("vmux://agent/") {
             continue;
         }
@@ -3093,8 +3102,14 @@ fn handle_agent_page_open(
                 continue;
             }
         };
+        let initial_prompt = open_q
+            .p1()
+            .get(task.stack)
+            .ok()
+            .map(|prompt| prompt.0.clone());
         match handle_agent_page_open_task(
-            task,
+            &task,
+            initial_prompt,
             &children_q,
             &agents,
             &acp_sessions,
@@ -3239,6 +3254,7 @@ fn handle_swap_stack_session(
 
 fn handle_agent_page_open_task(
     task: &PageOpenTask,
+    initial_prompt: Option<String>,
     children_q: &Query<&Children>,
     agents: &Query<&vmux_core::agent::AgentSession>,
     acp_sessions: &Query<&crate::client::acp::AcpSession>,
@@ -3273,6 +3289,7 @@ fn handle_agent_page_open_task(
                 task.stack, &provider, &model, &sid, commands, meshes, webview_mt, idx, kind_q,
             )
             .ok_or_else(|| format!("no Page agent strategy registered for {provider}/{model}"))?;
+            insert_initial_prompt_queue(task.stack, initial_prompt, commands);
             Ok(())
         }
         Some(crate::AgentUrl::PageDefault) => {
@@ -3300,6 +3317,7 @@ fn handle_agent_page_open_task(
                     provider.provider, provider.default_model
                 )
             })?;
+            insert_initial_prompt_queue(task.stack, initial_prompt, commands);
             Ok(())
         }
         Some(crate::AgentUrl::Cli { kind, sid }) => {
@@ -3310,7 +3328,7 @@ fn handle_agent_page_open_task(
                         cwd: default_cwd.to_path_buf(),
                         session_id: None,
                         stack: task.stack,
-                        initial_prompt: None,
+                        initial_prompt,
                     });
                 }
                 return Ok(());
@@ -3326,7 +3344,7 @@ fn handle_agent_page_open_task(
                 cwd: default_cwd.to_path_buf(),
                 session_id: Some(sid),
                 stack: task.stack,
-                initial_prompt: None,
+                initial_prompt,
             });
             Ok(())
         }
@@ -3347,7 +3365,7 @@ fn handle_agent_page_open_task(
                             cwd: default_cwd.to_path_buf(),
                             session_id: None,
                             stack: task.stack,
-                            initial_prompt: None,
+                            initial_prompt,
                         });
                     }
                     return Ok(());
@@ -3380,10 +3398,27 @@ fn handle_agent_page_open_task(
                 meshes,
                 webview_mt,
             );
+            insert_initial_prompt_queue(task.stack, initial_prompt, commands);
             Ok(())
         }
         None => Err(format!("malformed agent URL '{}'", task.url)),
     }
+}
+
+fn insert_initial_prompt_queue(
+    stack: Entity,
+    initial_prompt: Option<String>,
+    commands: &mut Commands,
+) {
+    let Some(prompt) = initial_prompt.filter(|prompt| !prompt.trim().is_empty()) else {
+        return;
+    };
+    let mut queue = crate::components::PromptQueue::default();
+    queue.enqueue(prompt);
+    commands
+        .entity(stack)
+        .insert(queue)
+        .remove::<PendingAgentPrompt>();
 }
 
 fn stack_has_agent_of_kind(
@@ -3586,6 +3621,7 @@ fn handle_spawn_agent_requests(
                             submit: true,
                         });
                 }
+                commands.entity(req.stack).remove::<PendingAgentPrompt>();
             }
             Err(e) => {
                 bevy::log::warn!("agent spawn ({:?}) failed: {e}", req.kind);
@@ -5405,6 +5441,79 @@ mod tests {
             spawns[0].cwd, dir,
             "claude page cwd resolves to space startup_dir"
         );
+    }
+
+    #[test]
+    fn fresh_cli_page_forwards_pending_prompt() {
+        let mut settings = test_settings();
+        settings.agent.acp.clear();
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<SpawnAgentInStackRequest>()
+            .insert_resource(settings)
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+            .add_systems(Update, handle_agent_page_open);
+        let stack = app
+            .world_mut()
+            .spawn((
+                vmux_layout::stack::stack_bundle(),
+                PendingAgentPrompt("fix the tests".to_string()),
+            ))
+            .id();
+        app.world_mut().spawn(PageOpenTask {
+            id: vmux_core::PageOpenId::new(),
+            stack,
+            url: "vmux://agent/codex/cli".to_string(),
+            request_id: None,
+        });
+
+        app.update();
+
+        let spawns: Vec<SpawnAgentInStackRequest> = app
+            .world_mut()
+            .resource_mut::<Messages<SpawnAgentInStackRequest>>()
+            .drain()
+            .collect();
+        assert_eq!(spawns.len(), 1);
+        assert_eq!(spawns[0].kind, AgentKind::Codex);
+        assert_eq!(spawns[0].initial_prompt.as_deref(), Some("fix the tests"));
+    }
+
+    #[test]
+    fn fresh_acp_page_queues_pending_prompt() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<SpawnAgentInStackRequest>()
+            .insert_resource(test_settings())
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+            .add_systems(Update, handle_agent_page_open);
+        let stack = app
+            .world_mut()
+            .spawn((
+                vmux_layout::stack::stack_bundle(),
+                PendingAgentPrompt("ship it".to_string()),
+            ))
+            .id();
+        app.world_mut().spawn(PageOpenTask {
+            id: vmux_core::PageOpenId::new(),
+            stack,
+            url: "vmux://agent/claude".to_string(),
+            request_id: None,
+        });
+
+        app.update();
+
+        let queue = app
+            .world()
+            .get::<crate::components::PromptQueue>(stack)
+            .unwrap();
+        assert_eq!(
+            queue.items.front().map(|item| item.text.as_str()),
+            Some("ship it")
+        );
+        assert!(app.world().get::<PendingAgentPrompt>(stack).is_none());
     }
 
     #[test]

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -3616,9 +3616,9 @@ fn handle_spawn_agent_requests(
                 if let Some(prompt) = req.initial_prompt.clone().filter(|p| !p.trim().is_empty()) {
                     commands
                         .entity(terminal)
-                        .insert(vmux_terminal::BufferedAgentPrompt {
-                            text: prompt,
-                            submit: true,
+                        .insert(vmux_terminal::PromptCapture {
+                            draft: prompt,
+                            skipped: false,
                         });
                 }
                 commands.entity(req.stack).remove::<PendingAgentPrompt>();
@@ -5478,6 +5478,48 @@ mod tests {
         assert_eq!(spawns.len(), 1);
         assert_eq!(spawns[0].kind, AgentKind::Codex);
         assert_eq!(spawns[0].initial_prompt.as_deref(), Some("fix the tests"));
+    }
+
+    #[test]
+    fn cli_initial_prompt_waits_for_terminal_readiness() {
+        let mut strategies = AgentStrategies::default();
+        strategies.register_cli(Box::new(crate::client::cli::codex::CodexStrategy));
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<SpawnAgentInStackRequest>()
+            .insert_resource(strategies)
+            .insert_resource(AgentExecutableOverride(std::collections::HashMap::from([
+                (AgentKind::Codex, true),
+            ])))
+            .insert_resource(test_settings())
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+            .add_systems(Update, handle_spawn_agent_requests);
+        let stack = app
+            .world_mut()
+            .spawn(vmux_layout::stack::stack_bundle())
+            .id();
+        app.world_mut()
+            .resource_mut::<Messages<SpawnAgentInStackRequest>>()
+            .write(SpawnAgentInStackRequest {
+                kind: AgentKind::Codex,
+                cwd: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../.."),
+                session_id: None,
+                stack,
+                initial_prompt: Some("@asdfas".to_string()),
+            });
+
+        app.update();
+        app.update();
+
+        let mut terminals = app.world_mut().query_filtered::<(
+            &vmux_terminal::PromptCapture,
+            Has<vmux_terminal::BufferedAgentPrompt>,
+        ), With<Terminal>>();
+        let (capture, buffered) = terminals.single(app.world()).unwrap();
+        assert_eq!(capture.draft, "@asdfas");
+        assert!(!capture.skipped);
+        assert!(!buffered);
     }
 
     #[test]

--- a/crates/vmux_agent/src/snapshot_updater.rs
+++ b/crates/vmux_agent/src/snapshot_updater.rs
@@ -19,17 +19,12 @@ pub(crate) fn update_agents_snapshot(
         ),
     >,
     page_idx: Option<Res<PageStrategyIndex>>,
-    settings: Option<Res<vmux_setting::AppSettings>>,
     catalog: Option<Res<crate::client::acp::AcpCatalog>>,
     install_generation: Option<Res<crate::client::acp::AcpInstallGeneration>>,
     mut snapshot: ResMut<CommandBarAgentsSnapshot>,
 ) {
     let providers_changed = !changed_q.is_empty();
     let idx_changed = page_idx
-        .as_ref()
-        .map(|r| r.is_changed() || r.is_added())
-        .unwrap_or(false);
-    let settings_changed = settings
         .as_ref()
         .map(|r| r.is_changed() || r.is_added())
         .unwrap_or(false);
@@ -43,7 +38,6 @@ pub(crate) fn update_agents_snapshot(
         .unwrap_or(false);
     if !providers_changed
         && !idx_changed
-        && !settings_changed
         && !catalog_changed
         && !installs_changed
         && (!snapshot.providers.is_empty()
@@ -57,11 +51,7 @@ pub(crate) fn update_agents_snapshot(
         .as_ref()
         .map(|c| c.agents.as_slice())
         .unwrap_or_default();
-    let configured = settings
-        .as_ref()
-        .map(|s| s.agent.acp.as_slice())
-        .unwrap_or_default();
-    snapshot.acp = acp_agent_summaries(configured, catalog_agents, |agent| {
+    snapshot.acp = acp_agent_summaries(catalog_agents, |agent| {
         crate::acp_install::is_agent_installed(agent)
     });
 
@@ -92,49 +82,24 @@ pub(crate) fn update_agents_snapshot(
 }
 
 fn acp_agent_summaries(
-    configured: &[vmux_setting::AcpAgentConfig],
     catalog: &[crate::acp_registry::RegistryAgent],
     is_installed: impl Fn(&crate::acp_registry::RegistryAgent) -> bool,
 ) -> Vec<AgentProviderSummary> {
-    let mut seen_registry_ids = std::collections::HashSet::new();
-    let mut agents = Vec::new();
-    for cfg in configured {
-        let registry_id = crate::acp_install::registry_id_alias(&cfg.id);
-        let registry = catalog.iter().find(|agent| agent.id == registry_id);
-        seen_registry_ids.insert(registry_id.to_string());
-        agents.push(AgentProviderSummary {
-            id: cfg.id.clone(),
-            name: registry
-                .map(|agent| agent.name.clone())
-                .unwrap_or_else(|| cfg.name.clone()),
-            url: format!("vmux://agent/{}", cfg.id),
-            icon: registry
-                .and_then(|agent| agent.icon.clone())
-                .unwrap_or_default(),
-        });
-    }
-    agents.extend(
-        catalog
-            .iter()
-            .filter(|agent| !seen_registry_ids.contains(&agent.id))
-            .filter(|agent| is_installed(agent))
-            .map(|agent| AgentProviderSummary {
-                id: agent.id.clone(),
-                name: agent.name.clone(),
-                url: format!("vmux://agent/{}", agent.id),
-                icon: agent.icon.clone().unwrap_or_default(),
-            }),
-    );
+    let mut agents: Vec<AgentProviderSummary> = catalog
+        .iter()
+        .filter(|agent| is_installed(agent))
+        .map(|agent| AgentProviderSummary {
+            id: agent.id.clone(),
+            name: agent.name.clone(),
+            url: format!("vmux://agent/{}", agent.id),
+            icon: agent.icon.clone().unwrap_or_default(),
+        })
+        .collect();
     agents.sort_by_key(|agent| agent.name.to_lowercase());
     agents
 }
 
-pub(crate) fn update_last_active_agent(
-    page_sessions: Query<(
-        Entity,
-        &crate::components::AgentSession,
-        Option<&LastActivatedAt>,
-    )>,
+pub(crate) fn update_recent_agents(
     acp_sessions: Query<(
         Entity,
         &crate::client::acp::AcpSession,
@@ -144,35 +109,20 @@ pub(crate) fn update_last_active_agent(
     stack_times: Query<&LastActivatedAt>,
     mut snapshot: ResMut<CommandBarAgentsSnapshot>,
 ) {
-    let mut newest: Option<(i64, u64, AgentPromptTarget)> = None;
+    let mut newest = std::collections::HashMap::<AgentPromptTarget, (i64, u64)>::new();
     let mut consider = |entity: Entity, timestamp: i64, target: AgentPromptTarget| {
         let key = (timestamp, entity.to_bits());
-        if newest
-            .as_ref()
-            .is_none_or(|(current_timestamp, current_entity, _)| {
-                key > (*current_timestamp, *current_entity)
-            })
-        {
-            newest = Some((key.0, key.1, target));
+        if newest.get(&target).is_none_or(|current| key > *current) {
+            newest.insert(target, key);
         }
     };
 
-    for (entity, session, timestamp) in &page_sessions {
-        consider(
-            entity,
-            timestamp.map(|timestamp| timestamp.0).unwrap_or(i64::MIN),
-            AgentPromptTarget::Page {
-                provider: session.provider.clone(),
-                model: session.model.clone(),
-            },
-        );
-    }
     for (entity, session, timestamp) in &acp_sessions {
         consider(
             entity,
             timestamp.map(|timestamp| timestamp.0).unwrap_or(i64::MIN),
             AgentPromptTarget::Acp {
-                id: session.agent_id.clone(),
+                id: crate::acp_install::registry_id_alias(&session.agent_id).to_string(),
             },
         );
     }
@@ -187,8 +137,11 @@ pub(crate) fn update_last_active_agent(
         );
     }
 
-    if let Some((_, _, target)) = newest {
-        snapshot.last_active = Some(target);
+    let mut recent: Vec<(AgentPromptTarget, (i64, u64))> = newest.into_iter().collect();
+    recent.sort_by_key(|(_, key)| std::cmp::Reverse(*key));
+    let recent = recent.into_iter().map(|(target, _)| target).collect();
+    if snapshot.recent != recent {
+        snapshot.recent = recent;
     }
 }
 
@@ -225,17 +178,6 @@ mod tests {
         }
     }
 
-    fn configured_agent(id: &str, name: &str) -> vmux_setting::AcpAgentConfig {
-        vmux_setting::AcpAgentConfig {
-            id: id.to_string(),
-            name: name.to_string(),
-            command: "agent".to_string(),
-            args: Vec::new(),
-            env: Vec::new(),
-            cwd: None,
-        }
-    }
-
     #[test]
     fn writes_empty_snapshot_when_no_resources() {
         let mut app = App::new();
@@ -258,10 +200,32 @@ mod tests {
     }
 
     #[test]
+    fn cli_snapshot_only_contains_ready_providers() {
+        let mut app = App::new();
+        app.init_resource::<CommandBarAgentsSnapshot>()
+            .add_systems(Update, update_agents_snapshot);
+        app.world_mut().spawn((
+            AgentProviderTargetKind(vmux_core::agent::AgentKind::Codex),
+            Name::new("Codex"),
+            Ready,
+        ));
+        app.world_mut().spawn((
+            AgentProviderTargetKind(vmux_core::agent::AgentKind::Claude),
+            Name::new("Claude"),
+        ));
+
+        app.update();
+
+        let providers = &app.world().resource::<CommandBarAgentsSnapshot>().providers;
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers[0].id, "codex");
+    }
+
+    #[test]
     fn installed_unconfigured_acp_is_in_snapshot() {
         let catalog = vec![registry_agent("new-agent", "New Agent")];
 
-        let agents = acp_agent_summaries(&[], &catalog, |_| true);
+        let agents = acp_agent_summaries(&catalog, |_| true);
 
         assert_eq!(agents.len(), 1);
         assert_eq!(agents[0].id, "new-agent");
@@ -269,35 +233,23 @@ mod tests {
     }
 
     #[test]
-    fn configured_acp_alias_is_not_duplicated() {
-        let configured = vec![configured_agent("claude", "Claude Code")];
-        let catalog = vec![registry_agent("claude-acp", "Claude Agent")];
+    fn uninstalled_acp_is_not_in_snapshot() {
+        let catalog = vec![
+            registry_agent("installed", "Installed"),
+            registry_agent("available", "Available"),
+        ];
 
-        let agents = acp_agent_summaries(&configured, &catalog, |_| true);
+        let agents = acp_agent_summaries(&catalog, |agent| agent.id == "installed");
 
         assert_eq!(agents.len(), 1);
-        assert_eq!(agents[0].id, "claude");
-        assert_eq!(agents[0].name, "Claude Agent");
+        assert_eq!(agents[0].id, "installed");
     }
 
     #[test]
-    fn last_active_agent_tracks_most_recent_session() {
+    fn recent_agents_are_deduped_and_sorted_by_last_use() {
         let mut app = App::new();
         app.init_resource::<CommandBarAgentsSnapshot>()
-            .add_systems(Update, update_last_active_agent);
-        let page = app
-            .world_mut()
-            .spawn((
-                crate::components::AgentSession {
-                    kind: vmux_core::agent::AgentKind::Vibe,
-                    variant: crate::AgentVariant::Page,
-                    sid: "page-session".to_string(),
-                    provider: "openai".to_string(),
-                    model: "gpt-5".to_string(),
-                },
-                LastActivatedAt(10),
-            ))
-            .id();
+            .add_systems(Update, update_recent_agents);
         let cli_stack = app.world_mut().spawn(LastActivatedAt(20)).id();
         app.world_mut().spawn((
             vmux_core::agent::AgentSession {
@@ -305,27 +257,37 @@ mod tests {
             },
             ChildOf(cli_stack),
         ));
+        app.world_mut().spawn((
+            crate::client::acp::AcpSession {
+                agent_id: "claude".to_string(),
+                sid: "acp-session".to_string(),
+                cwd: std::path::PathBuf::new(),
+                anchor: vmux_service::protocol::ProcessId::new(),
+                resume: None,
+            },
+            LastActivatedAt(30),
+        ));
+        app.world_mut().spawn((
+            crate::client::acp::AcpSession {
+                agent_id: "claude-acp".to_string(),
+                sid: "older-acp-session".to_string(),
+                cwd: std::path::PathBuf::new(),
+                anchor: vmux_service::protocol::ProcessId::new(),
+                resume: None,
+            },
+            LastActivatedAt(10),
+        ));
 
         app.update();
 
         assert_eq!(
-            app.world()
-                .resource::<CommandBarAgentsSnapshot>()
-                .last_active,
-            Some(AgentPromptTarget::Cli(vmux_core::agent::AgentKind::Codex))
-        );
-
-        app.world_mut().entity_mut(page).insert(LastActivatedAt(30));
-        app.update();
-
-        assert_eq!(
-            app.world()
-                .resource::<CommandBarAgentsSnapshot>()
-                .last_active,
-            Some(AgentPromptTarget::Page {
-                provider: "openai".to_string(),
-                model: "gpt-5".to_string(),
-            })
+            app.world().resource::<CommandBarAgentsSnapshot>().recent,
+            vec![
+                AgentPromptTarget::Acp {
+                    id: "claude-acp".to_string(),
+                },
+                AgentPromptTarget::Cli(vmux_core::agent::AgentKind::Codex),
+            ]
         );
     }
 }

--- a/crates/vmux_agent/src/snapshot_updater.rs
+++ b/crates/vmux_agent/src/snapshot_updater.rs
@@ -100,36 +100,32 @@ fn acp_agent_summaries(
 }
 
 pub(crate) fn update_recent_agents(
-    acp_sessions: Query<(
-        Entity,
-        &crate::client::acp::AcpSession,
-        Option<&LastActivatedAt>,
-    )>,
-    cli_sessions: Query<(Entity, &vmux_core::agent::AgentSession, &ChildOf)>,
+    acp_sessions: Query<(&crate::client::acp::AcpSession, Option<&LastActivatedAt>)>,
+    cli_sessions: Query<(&vmux_core::agent::AgentSession, &ChildOf)>,
     stack_times: Query<&LastActivatedAt>,
-    archived_pages: Query<(Entity, &ArchivedPage)>,
+    archived_pages: Query<&ArchivedPage>,
     mut snapshot: ResMut<CommandBarAgentsSnapshot>,
-    mut remembered: Local<std::collections::HashMap<AgentPromptTarget, (i64, u64)>>,
+    mut remembered: Local<std::collections::HashMap<AgentPromptTarget, i64>>,
 ) {
-    let mut consider = |entity: Entity, timestamp: i64, target: AgentPromptTarget| {
-        let key = (timestamp, entity.to_bits());
-        if remembered.get(&target).is_none_or(|current| key > *current) {
-            remembered.insert(target, key);
+    let mut consider = |timestamp: i64, target: AgentPromptTarget| {
+        if remembered
+            .get(&target)
+            .is_none_or(|current| timestamp > *current)
+        {
+            remembered.insert(target, timestamp);
         }
     };
 
-    for (entity, session, timestamp) in &acp_sessions {
+    for (session, timestamp) in &acp_sessions {
         consider(
-            entity,
             timestamp.map(|timestamp| timestamp.0).unwrap_or(i64::MIN),
             AgentPromptTarget::Acp {
                 id: crate::acp_install::registry_id_alias(&session.agent_id).to_string(),
             },
         );
     }
-    for (entity, session, child_of) in &cli_sessions {
+    for (session, child_of) in &cli_sessions {
         consider(
-            entity,
             stack_times
                 .get(child_of.parent())
                 .map(|timestamp| timestamp.0)
@@ -137,7 +133,7 @@ pub(crate) fn update_recent_agents(
             AgentPromptTarget::Cli(session.kind),
         );
     }
-    for (entity, page) in &archived_pages {
+    for page in &archived_pages {
         let target = match crate::url::AgentUrl::parse(&page.url) {
             Some(crate::url::AgentUrl::Cli { kind, .. }) => AgentPromptTarget::Cli(kind),
             Some(crate::url::AgentUrl::Acp { id, .. }) => AgentPromptTarget::Acp {
@@ -145,17 +141,29 @@ pub(crate) fn update_recent_agents(
             },
             _ => continue,
         };
-        consider(entity, page.closed_at, target);
+        consider(page.closed_at, target);
     }
 
     let mut recent: Vec<_> = remembered.iter().collect();
-    recent.sort_by_key(|(_, key)| std::cmp::Reverse(**key));
+    recent.sort_by_cached_key(|(target, timestamp)| {
+        (
+            std::cmp::Reverse(**timestamp),
+            agent_prompt_target_sort_name(target),
+        )
+    });
     let recent = recent
         .into_iter()
         .map(|(target, _)| target.clone())
         .collect();
     if snapshot.recent != recent {
         snapshot.recent = recent;
+    }
+}
+
+fn agent_prompt_target_sort_name(target: &AgentPromptTarget) -> String {
+    match target {
+        AgentPromptTarget::Cli(kind) => kind.display_name().to_lowercase(),
+        AgentPromptTarget::Acp { id } => id.to_lowercase(),
     }
 }
 
@@ -351,6 +359,42 @@ mod tests {
                     id: "codex-acp".to_string(),
                 },
                 AgentPromptTarget::Cli(vmux_core::agent::AgentKind::Claude),
+            ]
+        );
+    }
+
+    #[test]
+    fn equal_recent_agent_times_fall_back_to_name() {
+        let mut app = App::new();
+        app.init_resource::<CommandBarAgentsSnapshot>()
+            .add_systems(Update, update_recent_agents);
+        app.world_mut().spawn((
+            crate::client::acp::AcpSession {
+                agent_id: "claude-acp".to_string(),
+                sid: "acp-session".to_string(),
+                cwd: std::path::PathBuf::new(),
+                anchor: vmux_service::protocol::ProcessId::new(),
+                resume: None,
+            },
+            LastActivatedAt(10),
+        ));
+        let cli_stack = app.world_mut().spawn(LastActivatedAt(10)).id();
+        app.world_mut().spawn((
+            vmux_core::agent::AgentSession {
+                kind: vmux_core::agent::AgentKind::Codex,
+            },
+            ChildOf(cli_stack),
+        ));
+
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<CommandBarAgentsSnapshot>().recent,
+            vec![
+                AgentPromptTarget::Acp {
+                    id: "claude-acp".to_string(),
+                },
+                AgentPromptTarget::Cli(vmux_core::agent::AgentKind::Codex),
             ]
         );
     }

--- a/crates/vmux_agent/src/snapshot_updater.rs
+++ b/crates/vmux_agent/src/snapshot_updater.rs
@@ -1,10 +1,10 @@
 use bevy::prelude::*;
 use vmux_command::snapshot::{
-    AgentProviderSummary, AgentStrategySummary, CommandBarAgentsSnapshot,
+    AgentPromptTarget, AgentProviderSummary, AgentStrategySummary, CommandBarAgentsSnapshot,
 };
 
-use vmux_core::Ready;
 use vmux_core::agent::AgentProviderTargetKind;
+use vmux_core::{LastActivatedAt, Ready};
 
 use crate::client::page::strategy_index::PageStrategyIndex;
 
@@ -129,6 +129,69 @@ fn acp_agent_summaries(
     agents
 }
 
+pub(crate) fn update_last_active_agent(
+    page_sessions: Query<(
+        Entity,
+        &crate::components::AgentSession,
+        Option<&LastActivatedAt>,
+    )>,
+    acp_sessions: Query<(
+        Entity,
+        &crate::client::acp::AcpSession,
+        Option<&LastActivatedAt>,
+    )>,
+    cli_sessions: Query<(Entity, &vmux_core::agent::AgentSession, &ChildOf)>,
+    stack_times: Query<&LastActivatedAt>,
+    mut snapshot: ResMut<CommandBarAgentsSnapshot>,
+) {
+    let mut newest: Option<(i64, u64, AgentPromptTarget)> = None;
+    let mut consider = |entity: Entity, timestamp: i64, target: AgentPromptTarget| {
+        let key = (timestamp, entity.to_bits());
+        if newest
+            .as_ref()
+            .is_none_or(|(current_timestamp, current_entity, _)| {
+                key > (*current_timestamp, *current_entity)
+            })
+        {
+            newest = Some((key.0, key.1, target));
+        }
+    };
+
+    for (entity, session, timestamp) in &page_sessions {
+        consider(
+            entity,
+            timestamp.map(|timestamp| timestamp.0).unwrap_or(i64::MIN),
+            AgentPromptTarget::Page {
+                provider: session.provider.clone(),
+                model: session.model.clone(),
+            },
+        );
+    }
+    for (entity, session, timestamp) in &acp_sessions {
+        consider(
+            entity,
+            timestamp.map(|timestamp| timestamp.0).unwrap_or(i64::MIN),
+            AgentPromptTarget::Acp {
+                id: session.agent_id.clone(),
+            },
+        );
+    }
+    for (entity, session, child_of) in &cli_sessions {
+        consider(
+            entity,
+            stack_times
+                .get(child_of.parent())
+                .map(|timestamp| timestamp.0)
+                .unwrap_or(i64::MIN),
+            AgentPromptTarget::Cli(session.kind),
+        );
+    }
+
+    if let Some((_, _, target)) = newest {
+        snapshot.last_active = Some(target);
+    }
+}
+
 use crate::session::AgentSessionToEntity;
 use vmux_command::snapshot::CommandBarTerminalsSnapshot;
 
@@ -215,5 +278,54 @@ mod tests {
         assert_eq!(agents.len(), 1);
         assert_eq!(agents[0].id, "claude");
         assert_eq!(agents[0].name, "Claude Agent");
+    }
+
+    #[test]
+    fn last_active_agent_tracks_most_recent_session() {
+        let mut app = App::new();
+        app.init_resource::<CommandBarAgentsSnapshot>()
+            .add_systems(Update, update_last_active_agent);
+        let page = app
+            .world_mut()
+            .spawn((
+                crate::components::AgentSession {
+                    kind: vmux_core::agent::AgentKind::Vibe,
+                    variant: crate::AgentVariant::Page,
+                    sid: "page-session".to_string(),
+                    provider: "openai".to_string(),
+                    model: "gpt-5".to_string(),
+                },
+                LastActivatedAt(10),
+            ))
+            .id();
+        let cli_stack = app.world_mut().spawn(LastActivatedAt(20)).id();
+        app.world_mut().spawn((
+            vmux_core::agent::AgentSession {
+                kind: vmux_core::agent::AgentKind::Codex,
+            },
+            ChildOf(cli_stack),
+        ));
+
+        app.update();
+
+        assert_eq!(
+            app.world()
+                .resource::<CommandBarAgentsSnapshot>()
+                .last_active,
+            Some(AgentPromptTarget::Cli(vmux_core::agent::AgentKind::Codex))
+        );
+
+        app.world_mut().entity_mut(page).insert(LastActivatedAt(30));
+        app.update();
+
+        assert_eq!(
+            app.world()
+                .resource::<CommandBarAgentsSnapshot>()
+                .last_active,
+            Some(AgentPromptTarget::Page {
+                provider: "openai".to_string(),
+                model: "gpt-5".to_string(),
+            })
+        );
     }
 }

--- a/crates/vmux_agent/src/snapshot_updater.rs
+++ b/crates/vmux_agent/src/snapshot_updater.rs
@@ -4,7 +4,7 @@ use vmux_command::snapshot::{
 };
 
 use vmux_core::agent::AgentProviderTargetKind;
-use vmux_core::{LastActivatedAt, Ready};
+use vmux_core::{ArchivedPage, LastActivatedAt, Ready};
 
 use crate::client::page::strategy_index::PageStrategyIndex;
 
@@ -107,13 +107,14 @@ pub(crate) fn update_recent_agents(
     )>,
     cli_sessions: Query<(Entity, &vmux_core::agent::AgentSession, &ChildOf)>,
     stack_times: Query<&LastActivatedAt>,
+    archived_pages: Query<(Entity, &ArchivedPage)>,
     mut snapshot: ResMut<CommandBarAgentsSnapshot>,
+    mut remembered: Local<std::collections::HashMap<AgentPromptTarget, (i64, u64)>>,
 ) {
-    let mut newest = std::collections::HashMap::<AgentPromptTarget, (i64, u64)>::new();
     let mut consider = |entity: Entity, timestamp: i64, target: AgentPromptTarget| {
         let key = (timestamp, entity.to_bits());
-        if newest.get(&target).is_none_or(|current| key > *current) {
-            newest.insert(target, key);
+        if remembered.get(&target).is_none_or(|current| key > *current) {
+            remembered.insert(target, key);
         }
     };
 
@@ -136,10 +137,23 @@ pub(crate) fn update_recent_agents(
             AgentPromptTarget::Cli(session.kind),
         );
     }
+    for (entity, page) in &archived_pages {
+        let target = match crate::url::AgentUrl::parse(&page.url) {
+            Some(crate::url::AgentUrl::Cli { kind, .. }) => AgentPromptTarget::Cli(kind),
+            Some(crate::url::AgentUrl::Acp { id, .. }) => AgentPromptTarget::Acp {
+                id: crate::acp_install::registry_id_alias(&id).to_string(),
+            },
+            _ => continue,
+        };
+        consider(entity, page.closed_at, target);
+    }
 
-    let mut recent: Vec<(AgentPromptTarget, (i64, u64))> = newest.into_iter().collect();
-    recent.sort_by_key(|(_, key)| std::cmp::Reverse(*key));
-    let recent = recent.into_iter().map(|(target, _)| target).collect();
+    let mut recent: Vec<_> = remembered.iter().collect();
+    recent.sort_by_key(|(_, key)| std::cmp::Reverse(**key));
+    let recent = recent
+        .into_iter()
+        .map(|(target, _)| target.clone())
+        .collect();
     if snapshot.recent != recent {
         snapshot.recent = recent;
     }
@@ -287,6 +301,56 @@ mod tests {
                     id: "claude-acp".to_string(),
                 },
                 AgentPromptTarget::Cli(vmux_core::agent::AgentKind::Codex),
+            ]
+        );
+
+        let mut q = app
+            .world_mut()
+            .query_filtered::<Entity, With<crate::client::acp::AcpSession>>();
+        let acp_sessions: Vec<_> = q.iter(app.world()).collect();
+        for session in acp_sessions {
+            app.world_mut().despawn(session);
+        }
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<CommandBarAgentsSnapshot>().recent,
+            vec![
+                AgentPromptTarget::Acp {
+                    id: "claude-acp".to_string(),
+                },
+                AgentPromptTarget::Cli(vmux_core::agent::AgentKind::Codex),
+            ]
+        );
+    }
+
+    #[test]
+    fn closed_codex_acp_stays_ahead_of_older_claude_cli() {
+        let mut app = App::new();
+        app.init_resource::<CommandBarAgentsSnapshot>()
+            .add_systems(Update, update_recent_agents);
+        let cli_stack = app.world_mut().spawn(LastActivatedAt(20)).id();
+        app.world_mut().spawn((
+            vmux_core::agent::AgentSession {
+                kind: vmux_core::agent::AgentKind::Claude,
+            },
+            ChildOf(cli_stack),
+        ));
+        app.world_mut().spawn(ArchivedPage {
+            url: "vmux://agent/codex-acp/session-1".to_string(),
+            closed_at: 30,
+            ..default()
+        });
+
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<CommandBarAgentsSnapshot>().recent,
+            vec![
+                AgentPromptTarget::Acp {
+                    id: "codex-acp".to_string(),
+                },
+                AgentPromptTarget::Cli(vmux_core::agent::AgentKind::Claude),
             ]
         );
     }

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -825,6 +825,7 @@ fn dismiss_windowed_command_bar_on_outside_click(
                     action: "dismiss".to_string(),
                     value: String::new(),
                     target: None,
+                    agent_url: None,
                 },
             });
             break;
@@ -848,6 +849,7 @@ fn dismiss_windowed_command_bar_from_native_monitor(
             action: "dismiss".to_string(),
             value: String::new(),
             target: None,
+            agent_url: None,
         },
     });
 }

--- a/crates/vmux_command/src/event.rs
+++ b/crates/vmux_command/src/event.rs
@@ -251,6 +251,16 @@ pub fn should_open_typed_query_on_enter(
         && looks_like_url(query.trim())
 }
 
+pub fn should_submit_start_prompt(is_start: bool, nav_mode: bool, query: &str) -> bool {
+    let query = query.trim();
+    is_start
+        && !nav_mode
+        && !query.is_empty()
+        && !query.starts_with('>')
+        && !looks_like_url(query)
+        && !looks_like_explicit_path(query)
+}
+
 pub const PATH_COMPLETE_REQUEST: &str = "path-complete-request";
 pub const PATH_COMPLETE_RESPONSE: &str = "path-complete-response";
 
@@ -568,6 +578,37 @@ mod tests {
             false,
             "google.com"
         ));
+    }
+
+    #[test]
+    fn start_enter_submits_plain_text_as_prompt() {
+        assert!(should_submit_start_prompt(
+            true,
+            false,
+            "fix the failing test"
+        ));
+    }
+
+    #[test]
+    fn start_enter_keeps_explicit_navigation_inputs() {
+        for query in [
+            "https://example.com",
+            "example.com",
+            "vmux://settings/",
+            "/tmp/file",
+            "~/project",
+            "./src",
+            "../repo",
+            "> close tab",
+        ] {
+            assert!(!should_submit_start_prompt(true, false, query), "{query}");
+        }
+    }
+
+    #[test]
+    fn start_enter_keeps_keyboard_selected_result() {
+        assert!(!should_submit_start_prompt(true, true, "terminal"));
+        assert!(!should_submit_start_prompt(false, false, "ask the agent"));
     }
 
     #[test]

--- a/crates/vmux_command/src/event.rs
+++ b/crates/vmux_command/src/event.rs
@@ -252,17 +252,9 @@ pub fn should_open_typed_query_on_enter(
         && looks_like_url(query.trim())
 }
 
-pub fn should_submit_start_prompt(
-    is_start: bool,
-    nav_mode: bool,
-    has_result: bool,
-    query: &str,
-) -> bool {
+pub fn is_start_prompt_query(query: &str) -> bool {
     let query = query.trim();
-    is_start
-        && !nav_mode
-        && !has_result
-        && !query.is_empty()
+    !query.is_empty()
         && !query.starts_with('>')
         && !looks_like_url(query)
         && !looks_like_explicit_path(query)
@@ -590,22 +582,17 @@ mod tests {
     }
 
     #[test]
-    fn start_enter_submits_plain_text_as_prompt() {
-        assert!(should_submit_start_prompt(
-            true,
-            false,
-            false,
-            "fix the failing test"
-        ));
+    fn start_plain_text_is_prompt_query() {
+        assert!(is_start_prompt_query("fix the failing test"));
     }
 
     #[test]
-    fn start_enter_opens_matching_launcher_result() {
-        assert!(!should_submit_start_prompt(true, false, true, "codex"));
+    fn start_agent_name_is_still_prompt_query() {
+        assert!(is_start_prompt_query("codex"));
     }
 
     #[test]
-    fn start_enter_keeps_explicit_navigation_inputs() {
+    fn start_explicit_navigation_inputs_are_not_prompts() {
         for query in [
             "https://example.com",
             "example.com",
@@ -616,22 +603,8 @@ mod tests {
             "../repo",
             "> close tab",
         ] {
-            assert!(
-                !should_submit_start_prompt(true, false, false, query),
-                "{query}"
-            );
+            assert!(!is_start_prompt_query(query), "{query}");
         }
-    }
-
-    #[test]
-    fn start_enter_keeps_keyboard_selected_result() {
-        assert!(!should_submit_start_prompt(true, true, false, "terminal"));
-        assert!(!should_submit_start_prompt(
-            false,
-            false,
-            false,
-            "ask the agent"
-        ));
     }
 
     #[test]

--- a/crates/vmux_command/src/event.rs
+++ b/crates/vmux_command/src/event.rs
@@ -171,6 +171,7 @@ pub struct CommandBarActionEvent {
     pub action: String,
     pub value: String,
     pub target: Option<crate::open_target::OpenTarget>,
+    pub agent_url: Option<String>,
 }
 
 #[derive(
@@ -470,10 +471,12 @@ mod tests {
             action: "open".to_string(),
             value: "google.com".to_string(),
             target: None,
+            agent_url: None,
         };
         assert_eq!(evt.action, "open");
         assert_eq!(evt.value, "google.com");
         assert_eq!(evt.target, None);
+        assert_eq!(evt.agent_url, None);
     }
 
     #[test]

--- a/crates/vmux_command/src/event.rs
+++ b/crates/vmux_command/src/event.rs
@@ -251,10 +251,16 @@ pub fn should_open_typed_query_on_enter(
         && looks_like_url(query.trim())
 }
 
-pub fn should_submit_start_prompt(is_start: bool, nav_mode: bool, query: &str) -> bool {
+pub fn should_submit_start_prompt(
+    is_start: bool,
+    nav_mode: bool,
+    has_result: bool,
+    query: &str,
+) -> bool {
     let query = query.trim();
     is_start
         && !nav_mode
+        && !has_result
         && !query.is_empty()
         && !query.starts_with('>')
         && !looks_like_url(query)
@@ -585,8 +591,14 @@ mod tests {
         assert!(should_submit_start_prompt(
             true,
             false,
+            false,
             "fix the failing test"
         ));
+    }
+
+    #[test]
+    fn start_enter_opens_matching_launcher_result() {
+        assert!(!should_submit_start_prompt(true, false, true, "codex"));
     }
 
     #[test]
@@ -601,14 +613,22 @@ mod tests {
             "../repo",
             "> close tab",
         ] {
-            assert!(!should_submit_start_prompt(true, false, query), "{query}");
+            assert!(
+                !should_submit_start_prompt(true, false, false, query),
+                "{query}"
+            );
         }
     }
 
     #[test]
     fn start_enter_keeps_keyboard_selected_result() {
-        assert!(!should_submit_start_prompt(true, true, "terminal"));
-        assert!(!should_submit_start_prompt(false, false, "ask the agent"));
+        assert!(!should_submit_start_prompt(true, true, false, "terminal"));
+        assert!(!should_submit_start_prompt(
+            false,
+            false,
+            false,
+            "ask the agent"
+        ));
     }
 
     #[test]

--- a/crates/vmux_command/src/snapshot.rs
+++ b/crates/vmux_command/src/snapshot.rs
@@ -13,7 +13,7 @@ pub struct CommandBarAgentsSnapshot {
     pub strategies: Vec<AgentStrategySummary>,
     /// Installed registry ACP agents and their single-segment launch URLs.
     pub acp: Vec<AgentProviderSummary>,
-    /// Installed ACP and CLI agents with open sessions, most recently used first.
+    /// Installed ACP and CLI agents, most recently used first.
     pub recent: Vec<AgentPromptTarget>,
 }
 

--- a/crates/vmux_command/src/snapshot.rs
+++ b/crates/vmux_command/src/snapshot.rs
@@ -11,22 +11,19 @@ pub struct WriteCommandBarSnapshots;
 pub struct CommandBarAgentsSnapshot {
     pub providers: Vec<AgentProviderSummary>,
     pub strategies: Vec<AgentStrategySummary>,
-    /// Configured ACP agents (`settings.agent.acp`): `id`, display `name`, and the
-    /// single-segment `vmux://agent/<id>` launch url.
+    /// Installed registry ACP agents and their single-segment launch URLs.
     pub acp: Vec<AgentProviderSummary>,
-    /// Fresh-session target matching the most recently activated agent session.
-    pub last_active: Option<AgentPromptTarget>,
+    /// Installed ACP and CLI agents with open sessions, most recently used first.
+    pub recent: Vec<AgentPromptTarget>,
 }
 
-/// Agent runtime used when the start launcher submits a prompt.
-#[derive(Clone, Debug, PartialEq, Eq)]
+/// Agent identity used for recent-first launcher ordering.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum AgentPromptTarget {
     /// Built-in terminal CLI.
     Cli(AgentKind),
     /// Registry-driven ACP agent.
     Acp { id: String },
-    /// Provider-direct Page agent.
-    Page { provider: String, model: String },
 }
 
 #[derive(Clone, Debug, Default)]
@@ -115,7 +112,7 @@ mod tests {
         assert!(s.providers.is_empty());
         assert!(s.strategies.is_empty());
         assert!(s.acp.is_empty());
-        assert!(s.last_active.is_none());
+        assert!(s.recent.is_empty());
     }
 
     #[test]

--- a/crates/vmux_command/src/snapshot.rs
+++ b/crates/vmux_command/src/snapshot.rs
@@ -14,6 +14,19 @@ pub struct CommandBarAgentsSnapshot {
     /// Configured ACP agents (`settings.agent.acp`): `id`, display `name`, and the
     /// single-segment `vmux://agent/<id>` launch url.
     pub acp: Vec<AgentProviderSummary>,
+    /// Fresh-session target matching the most recently activated agent session.
+    pub last_active: Option<AgentPromptTarget>,
+}
+
+/// Agent runtime used when the start launcher submits a prompt.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AgentPromptTarget {
+    /// Built-in terminal CLI.
+    Cli(AgentKind),
+    /// Registry-driven ACP agent.
+    Acp { id: String },
+    /// Provider-direct Page agent.
+    Page { provider: String, model: String },
 }
 
 #[derive(Clone, Debug, Default)]
@@ -102,6 +115,7 @@ mod tests {
         assert!(s.providers.is_empty());
         assert!(s.strategies.is_empty());
         assert!(s.acp.is_empty());
+        assert!(s.last_active.is_none());
     }
 
     #[test]

--- a/crates/vmux_core/src/agent.rs
+++ b/crates/vmux_core/src/agent.rs
@@ -115,6 +115,10 @@ pub struct SpawnAgentInStackRequest {
     pub initial_prompt: Option<String>,
 }
 
+/// Prompt waiting for the next agent attached to this stack.
+#[derive(Component, Clone, Debug)]
+pub struct PendingAgentPrompt(pub String);
+
 /// Swap the agent session shown on `stack` in place: tear down the current session and
 /// re-attach `target_url` (an ACP or CLI agent url) with the given `cwd`. Same tab position.
 /// Used by `/resume` (pick a past session) and the ACP↔CLI runtime handoff (`/cli`).

--- a/crates/vmux_layout/src/command_bar/handler.rs
+++ b/crates/vmux_layout/src/command_bar/handler.rs
@@ -32,9 +32,7 @@ use vmux_command::{
     AppCommand, BrowserBarCommand, BrowserCommand, LayoutCommand, PaneCommand, ReadAppCommands,
     SpaceCommand, StackCommand,
 };
-use vmux_core::agent::{
-    AgentKind, PageAgentAttachRequest, PageAgentSpawnStackRequest, PendingAgentPrompt,
-};
+use vmux_core::agent::{PageAgentAttachRequest, PageAgentSpawnStackRequest, PendingAgentPrompt};
 use vmux_core::event::space::SpaceCommandEvent;
 use vmux_core::page::{SettingsPageSpawnRequest, SpacesPageSpawnRequest};
 use vmux_core::terminal::{ProcessesMonitorSpawnRequest, Terminal, TerminalSpawnRequest};
@@ -203,30 +201,9 @@ fn command_shortcut(id: &str) -> String {
         .unwrap_or_default()
 }
 
-/// Launcher entries for the built-in CLI agents: `vmux://agent/<kind>/cli` opens a fresh
-/// terminal-hosted CLI session (distinct from the single-segment ACP entries).
-fn agent_pages() -> Vec<CommandBarPage> {
-    AgentKind::all()
-        .iter()
-        .map(|kind| CommandBarPage {
-            host: "agent".to_string(),
-            url: format!("{}cli", kind.cli_url_prefix()),
-            title: format!("{} (CLI)", kind.display_name()),
-            keywords: vec![
-                kind.as_url_segment().to_string(),
-                "cli".to_string(),
-                "agent".to_string(),
-            ],
-            icon: vmux_core::PageIcon::None,
-            shortcut: String::new(),
-        })
-        .collect()
-}
-
-/// Launcher entries for configured ACP agents (`settings.agent.acp`), each opening the native
-/// chat at its single-segment `vmux://agent/<id>` url.
-fn acp_agent_pages(agents_snapshot: &CommandBarAgentsSnapshot) -> Vec<CommandBarPage> {
-    agents_snapshot
+/// Launcher entries for installed ACP and CLI agents, most recently used first.
+fn agent_pages(agents_snapshot: &CommandBarAgentsSnapshot) -> Vec<CommandBarPage> {
+    let mut pages: Vec<CommandBarPage> = agents_snapshot
         .acp
         .iter()
         .map(|agent| CommandBarPage {
@@ -241,7 +218,41 @@ fn acp_agent_pages(agents_snapshot: &CommandBarAgentsSnapshot) -> Vec<CommandBar
             },
             shortcut: String::new(),
         })
-        .collect()
+        .collect();
+    pages.extend(
+        agents_snapshot
+            .providers
+            .iter()
+            .map(|agent| CommandBarPage {
+                host: "agent".to_string(),
+                url: agent.url.clone(),
+                title: format!("{} (CLI)", agent.name),
+                keywords: vec![agent.id.clone(), "cli".to_string(), "agent".to_string()],
+                icon: vmux_core::PageIcon::None,
+                shortcut: String::new(),
+            }),
+    );
+    let recent_rank: std::collections::HashMap<String, usize> = agents_snapshot
+        .recent
+        .iter()
+        .enumerate()
+        .map(|(rank, target)| {
+            let url = match target {
+                AgentPromptTarget::Cli(kind) => format!("{}cli", kind.cli_url_prefix()),
+                AgentPromptTarget::Acp { id } => format!("vmux://agent/{id}"),
+            };
+            (url, rank)
+        })
+        .collect();
+    pages.sort_by(|a, b| {
+        recent_rank
+            .get(&a.url)
+            .copied()
+            .unwrap_or(usize::MAX)
+            .cmp(&recent_rank.get(&b.url).copied().unwrap_or(usize::MAX))
+            .then_with(|| a.title.to_lowercase().cmp(&b.title.to_lowercase()))
+    });
+    pages
 }
 
 pub fn match_command(id: &str) -> Option<AppCommand> {
@@ -1130,8 +1141,7 @@ pub(crate) fn build_command_bar_open_payload(
         })
         .collect();
     let mut pages = pages_snapshot.pages.clone();
-    pages.extend(acp_agent_pages(agents_snapshot));
-    pages.extend(agent_pages());
+    pages.extend(agent_pages(agents_snapshot));
     let history_shortcut = command_shortcut("browser_open_history");
     if !history_shortcut.is_empty()
         && let Some(page) = pages.iter_mut().find(|page| page.host == "history")
@@ -1231,28 +1241,8 @@ fn normalize_url(value: &str) -> String {
     }
 }
 
-fn prompt_agent_url(snapshot: &CommandBarAgentsSnapshot, sid: &str) -> String {
-    match snapshot.last_active.as_ref() {
-        Some(AgentPromptTarget::Cli(kind)) => format!("{}cli", kind.cli_url_prefix()),
-        Some(AgentPromptTarget::Acp { id }) => format!("vmux://agent/{id}"),
-        Some(AgentPromptTarget::Page { provider, model }) => {
-            format!("vmux://agent/{provider}/{model}/{sid}")
-        }
-        None => snapshot
-            .acp
-            .first()
-            .map(|agent| agent.url.clone())
-            .or_else(|| snapshot.providers.first().map(|agent| agent.url.clone()))
-            .or_else(|| {
-                snapshot.strategies.first().map(|strategy| {
-                    format!(
-                        "vmux://agent/{}/{}/{sid}",
-                        strategy.provider, strategy.model
-                    )
-                })
-            })
-            .unwrap_or_else(|| "vmux://agent/".to_string()),
-    }
+fn prompt_agent_url(snapshot: &CommandBarAgentsSnapshot) -> Option<String> {
+    agent_pages(snapshot).first().map(|page| page.url.clone())
 }
 
 fn on_command_bar_action(
@@ -1310,9 +1300,9 @@ fn on_command_bar_action(
                     &queries.pane_children,
                     &queries.stack_ts,
                 );
-                if let Some(stack) = empty_stack.or(focused_stack) {
-                    let sid = uuid::Uuid::new_v4().to_string();
-                    let url = prompt_agent_url(&resource_params.p2(), &sid);
+                if let Some(stack) = empty_stack.or(focused_stack)
+                    && let Some(url) = prompt_agent_url(&resource_params.p2())
+                {
                     commands
                         .entity(stack)
                         .insert(PendingAgentPrompt(prompt.to_string()));
@@ -1997,6 +1987,7 @@ mod tests {
     use bevy::ecs::schedule::{NodeId, Schedules, SystemSet};
     use vmux_command::event::CommandBarSpace;
     use vmux_command::{CommandPlugin, ReadAppCommands};
+    use vmux_core::agent::AgentKind;
 
     #[test]
     fn command_bar_open_does_not_block_on_command_bar_listener() {
@@ -2915,40 +2906,47 @@ mod tests {
     }
 
     #[test]
-    fn prompt_prefers_last_active_agent() {
+    fn prompt_prefers_most_recent_installed_agent() {
         let snapshot = CommandBarAgentsSnapshot {
-            last_active: Some(AgentPromptTarget::Page {
-                provider: "openai".to_string(),
-                model: "gpt-5".to_string(),
-            }),
+            recent: vec![AgentPromptTarget::Cli(AgentKind::Codex)],
+            providers: vec![vmux_command::snapshot::AgentProviderSummary {
+                id: "codex".to_string(),
+                name: "Codex".to_string(),
+                url: "vmux://agent/codex/cli".to_string(),
+                icon: String::new(),
+            }],
             acp: vec![vmux_command::snapshot::AgentProviderSummary {
-                id: "claude".to_string(),
-                name: "Claude Code".to_string(),
-                url: "vmux://agent/claude".to_string(),
+                id: "claude-acp".to_string(),
+                name: "Claude Agent".to_string(),
+                url: "vmux://agent/claude-acp".to_string(),
                 icon: String::new(),
             }],
             ..Default::default()
         };
 
         assert_eq!(
-            prompt_agent_url(&snapshot, "new-session"),
-            "vmux://agent/openai/gpt-5/new-session"
+            prompt_agent_url(&snapshot).as_deref(),
+            Some("vmux://agent/codex/cli")
         );
     }
 
     #[test]
-    fn prompt_falls_back_to_available_acp_agent() {
+    fn prompt_falls_back_to_installed_agent() {
         let snapshot = CommandBarAgentsSnapshot {
             acp: vec![vmux_command::snapshot::AgentProviderSummary {
-                id: "claude".to_string(),
-                name: "Claude Code".to_string(),
-                url: "vmux://agent/claude".to_string(),
+                id: "claude-acp".to_string(),
+                name: "Claude Agent".to_string(),
+                url: "vmux://agent/claude-acp".to_string(),
                 icon: String::new(),
             }],
             ..Default::default()
         };
 
-        assert_eq!(prompt_agent_url(&snapshot, "unused"), "vmux://agent/claude");
+        assert_eq!(
+            prompt_agent_url(&snapshot).as_deref(),
+            Some("vmux://agent/claude-acp")
+        );
+        assert_eq!(prompt_agent_url(&CommandBarAgentsSnapshot::default()), None);
     }
 
     #[test]
@@ -2972,41 +2970,35 @@ mod tests {
     }
 
     #[test]
-    fn agent_pages_lists_all_kinds_with_favicon() {
-        let pages = agent_pages();
-        assert_eq!(pages.len(), 3);
-        assert!(
-            pages
-                .iter()
-                .all(|p| matches!(p.icon, vmux_core::PageIcon::None) && p.host == "agent")
-        );
-        assert!(
-            pages
-                .iter()
-                .any(|p| p.url == "vmux://agent/vibe/cli" && p.title == "Vibe (CLI)")
-        );
-        assert!(pages.iter().any(|p| p.url == "vmux://agent/claude/cli"));
-        assert!(pages.iter().any(|p| p.url == "vmux://agent/codex/cli"));
-    }
-
-    #[test]
-    fn acp_agent_pages_maps_configured_agents() {
+    fn agent_pages_lists_only_snapshot_agents_in_recent_order() {
         let snapshot = CommandBarAgentsSnapshot {
+            providers: vec![vmux_command::snapshot::AgentProviderSummary {
+                id: "codex".to_string(),
+                name: "Codex".to_string(),
+                url: "vmux://agent/codex/cli".to_string(),
+                icon: String::new(),
+            }],
             acp: vec![vmux_command::snapshot::AgentProviderSummary {
-                id: "claude".to_string(),
-                name: "Claude Code".to_string(),
-                url: "vmux://agent/claude".to_string(),
+                id: "claude-acp".to_string(),
+                name: "Claude Agent".to_string(),
+                url: "vmux://agent/claude-acp".to_string(),
                 icon: "https://cdn.example/claude-acp.svg".to_string(),
             }],
+            recent: vec![
+                AgentPromptTarget::Cli(AgentKind::Codex),
+                AgentPromptTarget::Acp {
+                    id: "claude-acp".to_string(),
+                },
+            ],
             ..Default::default()
         };
-        let pages = acp_agent_pages(&snapshot);
-        assert_eq!(pages.len(), 1);
-        assert_eq!(pages[0].url, "vmux://agent/claude");
-        assert_eq!(pages[0].title, "Claude Code");
+        let pages = agent_pages(&snapshot);
+        assert_eq!(pages.len(), 2);
+        assert_eq!(pages[0].url, "vmux://agent/codex/cli");
+        assert_eq!(pages[0].title, "Codex (CLI)");
         assert_eq!(pages[0].host, "agent");
         assert!(matches!(
-            pages[0].icon,
+            pages[1].icon,
             vmux_core::PageIcon::Favicon(ref u) if u == "https://cdn.example/claude-acp.svg"
         ));
     }

--- a/crates/vmux_layout/src/command_bar/handler.rs
+++ b/crates/vmux_layout/src/command_bar/handler.rs
@@ -209,7 +209,7 @@ fn agent_pages(agents_snapshot: &CommandBarAgentsSnapshot) -> Vec<CommandBarPage
         .map(|agent| CommandBarPage {
             host: "agent".to_string(),
             url: agent.url.clone(),
-            title: agent.name.clone(),
+            title: format!("{} (ACP)", agent.name),
             keywords: vec![agent.id.clone(), "acp".to_string(), "agent".to_string()],
             icon: if agent.icon.is_empty() {
                 vmux_core::PageIcon::None
@@ -1241,8 +1241,15 @@ fn normalize_url(value: &str) -> String {
     }
 }
 
-fn prompt_agent_url(snapshot: &CommandBarAgentsSnapshot) -> Option<String> {
-    agent_pages(snapshot).first().map(|page| page.url.clone())
+fn prompt_agent_url(
+    snapshot: &CommandBarAgentsSnapshot,
+    requested_url: Option<&str>,
+) -> Option<String> {
+    let pages = agent_pages(snapshot);
+    requested_url
+        .and_then(|requested| pages.iter().find(|page| page.url == requested))
+        .or_else(|| pages.first())
+        .map(|page| page.url.clone())
 }
 
 fn on_command_bar_action(
@@ -1301,7 +1308,8 @@ fn on_command_bar_action(
                     &queries.stack_ts,
                 );
                 if let Some(stack) = empty_stack.or(focused_stack)
-                    && let Some(url) = prompt_agent_url(&resource_params.p2())
+                    && let Some(url) =
+                        prompt_agent_url(&resource_params.p2(), evt.agent_url.as_deref())
                 {
                     commands
                         .entity(stack)
@@ -1818,6 +1826,7 @@ fn reveal_command_bar(
                     action: "dismiss".to_string(),
                     value: String::new(),
                     target: None,
+                    agent_url: None,
                 },
             });
             continue;
@@ -2652,6 +2661,7 @@ mod tests {
                     action: "dismiss".to_string(),
                     value: String::new(),
                     target: None,
+                    agent_url: None,
                 },
             });
         app.world_mut().flush();
@@ -2925,7 +2935,7 @@ mod tests {
         };
 
         assert_eq!(
-            prompt_agent_url(&snapshot).as_deref(),
+            prompt_agent_url(&snapshot, None).as_deref(),
             Some("vmux://agent/codex/cli")
         );
     }
@@ -2943,10 +2953,42 @@ mod tests {
         };
 
         assert_eq!(
-            prompt_agent_url(&snapshot).as_deref(),
+            prompt_agent_url(&snapshot, None).as_deref(),
             Some("vmux://agent/claude-acp")
         );
-        assert_eq!(prompt_agent_url(&CommandBarAgentsSnapshot::default()), None);
+        assert_eq!(
+            prompt_agent_url(&CommandBarAgentsSnapshot::default(), None),
+            None
+        );
+    }
+
+    #[test]
+    fn prompt_uses_selected_installed_agent_and_rejects_stale_url() {
+        let snapshot = CommandBarAgentsSnapshot {
+            providers: vec![vmux_command::snapshot::AgentProviderSummary {
+                id: "codex".to_string(),
+                name: "Codex".to_string(),
+                url: "vmux://agent/codex/cli".to_string(),
+                icon: String::new(),
+            }],
+            acp: vec![vmux_command::snapshot::AgentProviderSummary {
+                id: "claude-acp".to_string(),
+                name: "Claude Agent".to_string(),
+                url: "vmux://agent/claude-acp".to_string(),
+                icon: String::new(),
+            }],
+            recent: vec![AgentPromptTarget::Cli(AgentKind::Codex)],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            prompt_agent_url(&snapshot, Some("vmux://agent/claude-acp")).as_deref(),
+            Some("vmux://agent/claude-acp")
+        );
+        assert_eq!(
+            prompt_agent_url(&snapshot, Some("vmux://agent/uninstalled")).as_deref(),
+            Some("vmux://agent/codex/cli")
+        );
     }
 
     #[test]
@@ -2997,6 +3039,7 @@ mod tests {
         assert_eq!(pages[0].url, "vmux://agent/codex/cli");
         assert_eq!(pages[0].title, "Codex (CLI)");
         assert_eq!(pages[0].host, "agent");
+        assert_eq!(pages[1].title, "Claude Agent (ACP)");
         assert!(matches!(
             pages[1].icon,
             vmux_core::PageIcon::Favicon(ref u) if u == "https://cdn.example/claude-acp.svg"

--- a/crates/vmux_layout/src/command_bar/handler.rs
+++ b/crates/vmux_layout/src/command_bar/handler.rs
@@ -25,14 +25,16 @@ use vmux_command::event::{
 use vmux_command::open::OpenCommand;
 use vmux_command::open_target::OpenTarget;
 use vmux_command::snapshot::{
-    CommandBarAgentsSnapshot, CommandBarPagesSnapshot, CommandBarSpacesSnapshot,
+    AgentPromptTarget, CommandBarAgentsSnapshot, CommandBarPagesSnapshot, CommandBarSpacesSnapshot,
     CommandBarTerminalsSnapshot, WriteCommandBarSnapshots,
 };
 use vmux_command::{
     AppCommand, BrowserBarCommand, BrowserCommand, LayoutCommand, PaneCommand, ReadAppCommands,
     SpaceCommand, StackCommand,
 };
-use vmux_core::agent::{AgentKind, PageAgentAttachRequest, PageAgentSpawnStackRequest};
+use vmux_core::agent::{
+    AgentKind, PageAgentAttachRequest, PageAgentSpawnStackRequest, PendingAgentPrompt,
+};
 use vmux_core::event::space::SpaceCommandEvent;
 use vmux_core::page::{SettingsPageSpawnRequest, SpacesPageSpawnRequest};
 use vmux_core::terminal::{ProcessesMonitorSpawnRequest, Terminal, TerminalSpawnRequest};
@@ -1229,6 +1231,30 @@ fn normalize_url(value: &str) -> String {
     }
 }
 
+fn prompt_agent_url(snapshot: &CommandBarAgentsSnapshot, sid: &str) -> String {
+    match snapshot.last_active.as_ref() {
+        Some(AgentPromptTarget::Cli(kind)) => format!("{}cli", kind.cli_url_prefix()),
+        Some(AgentPromptTarget::Acp { id }) => format!("vmux://agent/{id}"),
+        Some(AgentPromptTarget::Page { provider, model }) => {
+            format!("vmux://agent/{provider}/{model}/{sid}")
+        }
+        None => snapshot
+            .acp
+            .first()
+            .map(|agent| agent.url.clone())
+            .or_else(|| snapshot.providers.first().map(|agent| agent.url.clone()))
+            .or_else(|| {
+                snapshot.strategies.first().map(|strategy| {
+                    format!(
+                        "vmux://agent/{}/{}/{sid}",
+                        strategy.provider, strategy.model
+                    )
+                })
+            })
+            .unwrap_or_else(|| "vmux://agent/".to_string()),
+    }
+}
+
 fn on_command_bar_action(
     trigger: On<BinReceive<CommandBarActionEvent>>,
     mut modal_q: Query<(Entity, &mut Node, &mut Visibility), With<Modal>>,
@@ -1273,6 +1299,34 @@ fn on_command_bar_action(
     let mut custom_keyboard_restore = false;
 
     match evt.action.as_str() {
+        "prompt" => {
+            let prompt = evt.value.trim();
+            if !prompt.is_empty() {
+                let (_, _, focused_stack) = focused_stack(
+                    queries.active_tab_param.get(),
+                    &queries.all_children,
+                    &queries.leaf_panes,
+                    &queries.pane_ts,
+                    &queries.pane_children,
+                    &queries.stack_ts,
+                );
+                if let Some(stack) = empty_stack.or(focused_stack) {
+                    let sid = uuid::Uuid::new_v4().to_string();
+                    let url = prompt_agent_url(&resource_params.p2(), &sid);
+                    commands
+                        .entity(stack)
+                        .insert(PendingAgentPrompt(prompt.to_string()));
+                    writer_params.p1().write(PageOpenRequest {
+                        target: PageOpenTarget::Stack(stack),
+                        url,
+                        request_id: None,
+                    });
+                    new_stack_ctx.stack = None;
+                    new_stack_ctx.previous_stack = None;
+                    custom_keyboard_restore = true;
+                }
+            }
+        }
         "open" => {
             let expanded = if evt.value.starts_with('~') {
                 std::env::var("HOME")
@@ -2858,6 +2912,43 @@ mod tests {
     fn normalize_url_preserves_data_scheme() {
         let data = "data:text/html,<style>body{background:white}</style><h1>x</h1>";
         assert_eq!(normalize_url(data), data);
+    }
+
+    #[test]
+    fn prompt_prefers_last_active_agent() {
+        let snapshot = CommandBarAgentsSnapshot {
+            last_active: Some(AgentPromptTarget::Page {
+                provider: "openai".to_string(),
+                model: "gpt-5".to_string(),
+            }),
+            acp: vec![vmux_command::snapshot::AgentProviderSummary {
+                id: "claude".to_string(),
+                name: "Claude Code".to_string(),
+                url: "vmux://agent/claude".to_string(),
+                icon: String::new(),
+            }],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            prompt_agent_url(&snapshot, "new-session"),
+            "vmux://agent/openai/gpt-5/new-session"
+        );
+    }
+
+    #[test]
+    fn prompt_falls_back_to_available_acp_agent() {
+        let snapshot = CommandBarAgentsSnapshot {
+            acp: vec![vmux_command::snapshot::AgentProviderSummary {
+                id: "claude".to_string(),
+                name: "Claude Code".to_string(),
+                url: "vmux://agent/claude".to_string(),
+                icon: String::new(),
+            }],
+            ..Default::default()
+        };
+
+        assert_eq!(prompt_agent_url(&snapshot, "unused"), "vmux://agent/claude");
     }
 
     #[test]

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -5,8 +5,8 @@ use crate::command_bar::keyboard::{
     ignore_physical_rerouted_ctrl_keydown, utf16_offset_to_byte,
 };
 use crate::command_bar::results::{
-    CommandBarResultItem as ResultItem, active_space_index, agent_page_results, filter_results,
-    replacement_agent_url, space_switch_results,
+    CommandBarResultItem as ResultItem, active_space_index, agent_page_results, agent_page_url,
+    filter_results, space_switch_results,
 };
 use crate::command_bar::style::{
     command_bar_input_class, command_bar_input_row_class, command_bar_input_wrap_class,
@@ -20,7 +20,7 @@ use vmux_command::event::{
     CommandBarActionEvent, CommandBarOpenEvent, HISTORY_SUGGESTIONS_RESPONSE_EVENT, HistoryEntry,
     HistorySuggestionsRequest, HistorySuggestionsResponse, PATH_COMPLETE_RESPONSE,
     PathCompleteRequest, PathCompleteResponse, PathEntry, command_bar_should_refocus, is_data_uri,
-    looks_like_url, should_open_typed_query_on_enter, should_submit_start_prompt,
+    is_start_prompt_query, looks_like_url, should_open_typed_query_on_enter,
 };
 use vmux_command::open_target::OpenTarget;
 use vmux_ui::components::icon::Icon;
@@ -73,7 +73,6 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let mut suggestions_request_id = use_signal(|| 0u64);
     let mut last_open_id = use_signal(|| u64::MAX);
     let mut last_focus_open_id = use_signal(|| u64::MAX);
-    let mut selected_agent_url = use_signal(String::new);
 
     use_effect(move || {
         let s = state();
@@ -146,14 +145,6 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     });
 
     use_effect(move || {
-        let pages = state().pages;
-        let current = selected_agent_url();
-        if let Some(replacement) = replacement_agent_url(&pages, &current) {
-            selected_agent_url.set(replacement);
-        }
-    });
-
-    use_effect(move || {
         let _ = query();
         let _ = selected();
         let _ = nav_mode();
@@ -168,11 +159,6 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let tabs = state_val.tabs.clone();
     let commands = state_val.commands.clone();
     let pages = state_val.pages.clone();
-    let agent_pages: Vec<_> = pages
-        .iter()
-        .filter(|page| page.host == "agent")
-        .cloned()
-        .collect();
     let work_dirs = state_val.work_dirs.clone();
     let recent_files = state_val.recent_files.clone();
     let open_target = state_val.target;
@@ -180,14 +166,13 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let is_new_tab = matches!(open_target, Some(OpenTarget::InNewStack));
 
     let q = query();
+    let start_prompt_mode = matches!(variant, PaletteVariant::Start) && is_start_prompt_query(&q);
+    let start_agent_mode =
+        matches!(variant, PaletteVariant::Start) && (q.trim().is_empty() || start_prompt_mode);
     let results: Vec<ResultItem> = if space_switch {
         space_switch_results(&spaces, &pages, &q)
-    } else if matches!(variant, PaletteVariant::Start)
-        && !q.trim_start().starts_with('>')
-        && !looks_like_url(q.trim())
-        && completion_query(&q).is_none()
-    {
-        agent_page_results(&pages, &q)
+    } else if start_agent_mode {
+        agent_page_results(&pages)
     } else {
         let history = history_suggestions();
         let r = filter_results(
@@ -237,7 +222,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let sel = selected().min(results.len().saturating_sub(1));
     let active_item = results.get(sel).cloned();
     let nav = nav_mode();
-    let display_text = if nav {
+    let display_text = if nav && !start_prompt_mode {
         match &active_item {
             Some(ResultItem::Command { name, .. }) => format!("> {name}"),
             Some(ResultItem::Navigate { url }) => url.clone(),
@@ -302,6 +287,15 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     });
 
     let execute = move |item: &ResultItem| {
+        let prompt = query();
+        if matches!(variant, PaletteVariant::Start)
+            && is_start_prompt_query(&prompt)
+            && let Some(agent_url) = agent_page_url(item)
+        {
+            on_close.call(());
+            emit_prompt_action(prompt.trim(), open_target, agent_url);
+            return;
+        }
         on_close.call(());
         match item {
             ResultItem::Terminal { path } => {
@@ -516,18 +510,13 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                                         execute(item);
                                     }
                                 } else {
-                                    if should_submit_start_prompt(
-                                        matches!(variant, PaletteVariant::Start),
-                                        nav_mode(),
-                                        results.get(sel).is_some(),
-                                        &q,
-                                    ) {
-                                        on_close.call(());
-                                        emit_prompt_action(
-                                            q.trim(),
-                                            open_target,
-                                            &selected_agent_url(),
-                                        );
+                                    if start_prompt_mode {
+                                        if let Some(item) = results.get(sel) {
+                                            execute(item);
+                                        } else {
+                                            on_close.call(());
+                                            emit_prompt_action(q.trim(), open_target, "");
+                                        }
                                         return;
                                     }
                                     let prefer_page = matches!(
@@ -549,36 +538,6 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                                 }
                             }
                         },
-                    }
-                }
-                if matches!(variant, PaletteVariant::Start) && !agent_pages.is_empty() {
-                    div {
-                        id: "start-agent-select",
-                        class: "flex max-w-48 shrink-0 items-center gap-1.5 rounded-md bg-foreground/5 px-2 text-muted-foreground",
-                        if let Some(agent) = agent_pages
-                            .iter()
-                            .find(|agent| agent.url == selected_agent_url())
-                        {
-                            PageIconView {
-                                icon: agent.icon.clone(),
-                                url: agent.url.clone(),
-                                img_class: "h-4 w-4 shrink-0 rounded-sm object-contain".to_string(),
-                                icon_class: "h-4 w-4 shrink-0 text-muted-foreground".to_string(),
-                            }
-                        }
-                        select {
-                            aria_label: "Prompt agent",
-                            title: "Prompt agent",
-                            class: "min-w-0 max-w-40 cursor-pointer bg-transparent py-1.5 text-sm text-foreground outline-none",
-                            value: "{selected_agent_url}",
-                            onchange: move |e| {
-                                selected_agent_url.set(e.value());
-                                focus_command_bar_input();
-                            },
-                            for agent in &agent_pages {
-                                option { value: "{agent.url}", "{agent.title}" }
-                            }
-                        }
                     }
                 }
             }
@@ -679,7 +638,9 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                                     }
                                 }
                                 span { class: result_trailing_slot_class(),
-                                    if shortcut.is_empty() {
+                                    if start_prompt_mode && agent_page_url(item).is_some() {
+                                        "Prompt"
+                                    } else if shortcut.is_empty() {
                                         "New tab"
                                     } else {
                                         span { class: result_shortcut_badge_class(), "{shortcut}" }
@@ -849,17 +810,6 @@ fn emit_prompt_action(value: &str, target: Option<OpenTarget>, agent_url: &str) 
         target,
         agent_url: (!agent_url.is_empty()).then(|| agent_url.to_string()),
     });
-}
-
-fn focus_command_bar_input() {
-    let Some(input) = web_sys::window()
-        .and_then(|window| window.document())
-        .and_then(|document| document.get_element_by_id("command-bar-input"))
-    else {
-        return;
-    };
-    let input: web_sys::HtmlInputElement = input.unchecked_into();
-    let _ = input.focus();
 }
 
 fn focus_and_install_ctrl_bindings() {

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -5,8 +5,8 @@ use crate::command_bar::keyboard::{
     ignore_physical_rerouted_ctrl_keydown, utf16_offset_to_byte,
 };
 use crate::command_bar::results::{
-    CommandBarResultItem as ResultItem, active_space_index, agent_page_results, agent_page_url,
-    filter_results, space_switch_results,
+    CommandBarResultItem as ResultItem, active_space_index, agent_page_url, filter_results,
+    space_switch_results, start_page_results,
 };
 use crate::command_bar::style::{
     command_bar_input_class, command_bar_input_row_class, command_bar_input_wrap_class,
@@ -172,7 +172,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let results: Vec<ResultItem> = if space_switch {
         space_switch_results(&spaces, &pages, &q)
     } else if start_agent_mode {
-        agent_page_results(&pages, &q)
+        start_page_results(&pages, &q)
     } else {
         let history = history_suggestions();
         let r = filter_results(

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -73,6 +73,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let mut suggestions_request_id = use_signal(|| 0u64);
     let mut last_open_id = use_signal(|| u64::MAX);
     let mut last_focus_open_id = use_signal(|| u64::MAX);
+    let mut selected_agent_url = use_signal(String::new);
 
     use_effect(move || {
         let s = state();
@@ -145,6 +146,23 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     });
 
     use_effect(move || {
+        let pages = state().pages;
+        let current = selected_agent_url();
+        if !pages
+            .iter()
+            .any(|page| page.host == "agent" && page.url == current)
+        {
+            selected_agent_url.set(
+                pages
+                    .iter()
+                    .find(|page| page.host == "agent")
+                    .map(|page| page.url.clone())
+                    .unwrap_or_default(),
+            );
+        }
+    });
+
+    use_effect(move || {
         let _ = query();
         let _ = selected();
         let _ = nav_mode();
@@ -159,6 +177,11 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let tabs = state_val.tabs.clone();
     let commands = state_val.commands.clone();
     let pages = state_val.pages.clone();
+    let agent_pages: Vec<_> = pages
+        .iter()
+        .filter(|page| page.host == "agent")
+        .cloned()
+        .collect();
     let work_dirs = state_val.work_dirs.clone();
     let recent_files = state_val.recent_files.clone();
     let open_target = state_val.target;
@@ -509,7 +532,11 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                                         &q,
                                     ) {
                                         on_close.call(());
-                                        emit_action_with_target("prompt", q.trim(), open_target);
+                                        emit_prompt_action(
+                                            q.trim(),
+                                            open_target,
+                                            &selected_agent_url(),
+                                        );
                                         return;
                                     }
                                     let prefer_page = matches!(
@@ -531,6 +558,36 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                                 }
                             }
                         },
+                    }
+                }
+                if matches!(variant, PaletteVariant::Start) && !agent_pages.is_empty() {
+                    div {
+                        id: "start-agent-select",
+                        class: "flex max-w-48 shrink-0 items-center gap-1.5 rounded-md bg-foreground/5 px-2 text-muted-foreground",
+                        if let Some(agent) = agent_pages
+                            .iter()
+                            .find(|agent| agent.url == selected_agent_url())
+                        {
+                            PageIconView {
+                                icon: agent.icon.clone(),
+                                url: agent.url.clone(),
+                                img_class: "h-4 w-4 shrink-0 rounded-sm object-contain".to_string(),
+                                icon_class: "h-4 w-4 shrink-0 text-muted-foreground".to_string(),
+                            }
+                        }
+                        select {
+                            aria_label: "Prompt agent",
+                            title: "Prompt agent",
+                            class: "min-w-0 max-w-40 cursor-pointer bg-transparent py-1.5 text-sm text-foreground outline-none",
+                            value: "{selected_agent_url}",
+                            onchange: move |e| {
+                                selected_agent_url.set(e.value());
+                                focus_command_bar_input();
+                            },
+                            for agent in &agent_pages {
+                                option { value: "{agent.url}", "{agent.title}" }
+                            }
+                        }
                     }
                 }
             }
@@ -790,7 +847,28 @@ pub(crate) fn emit_action_with_target(action: &str, value: &str, target: Option<
         action: action.to_string(),
         value: value.to_string(),
         target,
+        agent_url: None,
     });
+}
+
+fn emit_prompt_action(value: &str, target: Option<OpenTarget>, agent_url: &str) {
+    let _ = try_cef_bin_emit_rkyv(&CommandBarActionEvent {
+        action: "prompt".to_string(),
+        value: value.to_string(),
+        target,
+        agent_url: (!agent_url.is_empty()).then(|| agent_url.to_string()),
+    });
+}
+
+fn focus_command_bar_input() {
+    let Some(input) = web_sys::window()
+        .and_then(|window| window.document())
+        .and_then(|document| document.get_element_by_id("command-bar-input"))
+    else {
+        return;
+    };
+    let input: web_sys::HtmlInputElement = input.unchecked_into();
+    let _ = input.focus();
 }
 
 fn focus_and_install_ctrl_bindings() {

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -6,7 +6,7 @@ use crate::command_bar::keyboard::{
 };
 use crate::command_bar::results::{
     CommandBarResultItem as ResultItem, active_space_index, agent_page_results, filter_results,
-    space_switch_results,
+    replacement_agent_url, space_switch_results,
 };
 use crate::command_bar::style::{
     command_bar_input_class, command_bar_input_row_class, command_bar_input_wrap_class,
@@ -148,17 +148,8 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     use_effect(move || {
         let pages = state().pages;
         let current = selected_agent_url();
-        if !pages
-            .iter()
-            .any(|page| page.host == "agent" && page.url == current)
-        {
-            selected_agent_url.set(
-                pages
-                    .iter()
-                    .find(|page| page.host == "agent")
-                    .map(|page| page.url.clone())
-                    .unwrap_or_default(),
-            );
+        if let Some(replacement) = replacement_agent_url(&pages, &current) {
+            selected_agent_url.set(replacement);
         }
     });
 

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -5,7 +5,8 @@ use crate::command_bar::keyboard::{
     ignore_physical_rerouted_ctrl_keydown, utf16_offset_to_byte,
 };
 use crate::command_bar::results::{
-    CommandBarResultItem as ResultItem, active_space_index, filter_results, space_switch_results,
+    CommandBarResultItem as ResultItem, active_space_index, agent_page_results, filter_results,
+    space_switch_results,
 };
 use crate::command_bar::style::{
     command_bar_input_class, command_bar_input_row_class, command_bar_input_wrap_class,
@@ -167,6 +168,12 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let q = query();
     let results: Vec<ResultItem> = if space_switch {
         space_switch_results(&spaces, &pages, &q)
+    } else if matches!(variant, PaletteVariant::Start)
+        && !q.trim_start().starts_with('>')
+        && !looks_like_url(q.trim())
+        && completion_query(&q).is_none()
+    {
+        agent_page_results(&pages, &q)
     } else {
         let history = history_suggestions();
         let r = filter_results(

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -172,7 +172,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let results: Vec<ResultItem> = if space_switch {
         space_switch_results(&spaces, &pages, &q)
     } else if start_agent_mode {
-        agent_page_results(&pages)
+        agent_page_results(&pages, &q)
     } else {
         let history = history_suggestions();
         let r = filter_results(

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -19,7 +19,7 @@ use vmux_command::event::{
     CommandBarActionEvent, CommandBarOpenEvent, HISTORY_SUGGESTIONS_RESPONSE_EVENT, HistoryEntry,
     HistorySuggestionsRequest, HistorySuggestionsResponse, PATH_COMPLETE_RESPONSE,
     PathCompleteRequest, PathCompleteResponse, PathEntry, command_bar_should_refocus, is_data_uri,
-    looks_like_url, should_open_typed_query_on_enter,
+    looks_like_url, should_open_typed_query_on_enter, should_submit_start_prompt,
 };
 use vmux_command::open_target::OpenTarget;
 use vmux_ui::components::icon::Icon;
@@ -495,6 +495,15 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                                         execute(item);
                                     }
                                 } else {
+                                    if should_submit_start_prompt(
+                                        matches!(variant, PaletteVariant::Start),
+                                        nav_mode(),
+                                        &q,
+                                    ) {
+                                        on_close.call(());
+                                        emit_action_with_target("prompt", q.trim(), open_target);
+                                        return;
+                                    }
                                     let prefer_page = matches!(
                                         results.get(sel),
                                         Some(ResultItem::Page { url, .. })

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -505,6 +505,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                                     if should_submit_start_prompt(
                                         matches!(variant, PaletteVariant::Start),
                                         nav_mode(),
+                                        results.get(sel).is_some(),
                                         &q,
                                     ) {
                                         on_close.call(());

--- a/crates/vmux_layout/src/command_bar/results.rs
+++ b/crates/vmux_layout/src/command_bar/results.rs
@@ -126,11 +126,12 @@ fn page_results(pages: &[CommandBarPage], search_lower: &str) -> Vec<CommandBarR
         .collect()
 }
 
-/// Installed agent launcher rows in recent-first input order.
-pub fn agent_page_results(pages: &[CommandBarPage]) -> Vec<CommandBarResultItem> {
+/// Installed agent launcher rows in recent-first input order, filtered by query.
+pub fn agent_page_results(pages: &[CommandBarPage], query: &str) -> Vec<CommandBarResultItem> {
+    let search_lower = query.trim().to_lowercase();
     pages
         .iter()
-        .filter(|page| page.host == "agent")
+        .filter(|page| page.host == "agent" && page_matches(page, &search_lower))
         .map(|page| CommandBarResultItem::Page {
             url: page.url.clone(),
             title: page.title.clone(),
@@ -649,7 +650,7 @@ mod tests {
             shortcut: String::new(),
         });
 
-        let results = agent_page_results(&pages);
+        let results = agent_page_results(&pages, "");
         let urls: Vec<_> = results
             .iter()
             .filter_map(|result| match result {
@@ -662,8 +663,29 @@ mod tests {
     }
 
     #[test]
+    fn start_agent_pages_filter_by_query() {
+        let mut pages = sample_pages();
+        pages.push(CommandBarPage {
+            host: "agent".into(),
+            url: "vmux://agent/codex/cli".into(),
+            title: "Codex (CLI)".into(),
+            keywords: vec!["codex".into(), "agent".into()],
+            icon: vmux_core::PageIcon::None,
+            shortcut: String::new(),
+        });
+
+        let results = agent_page_results(&pages, "vibe");
+
+        assert_eq!(results.len(), 1);
+        assert!(matches!(
+            &results[0],
+            CommandBarResultItem::Page { url, .. } if url == "vmux://agent/vibe/"
+        ));
+    }
+
+    #[test]
     fn prompt_agent_url_only_accepts_agent_page_rows() {
-        let agent = agent_page_results(&sample_pages()).remove(0);
+        let agent = agent_page_results(&sample_pages(), "").remove(0);
         let settings = CommandBarResultItem::Page {
             url: "vmux://settings/".into(),
             title: "Settings".into(),

--- a/crates/vmux_layout/src/command_bar/results.rs
+++ b/crates/vmux_layout/src/command_bar/results.rs
@@ -155,6 +155,28 @@ pub fn agent_page_url(item: &CommandBarResultItem) -> Option<&str> {
     }
 }
 
+pub fn start_page_results(pages: &[CommandBarPage], query: &str) -> Vec<CommandBarResultItem> {
+    let search_lower = query.trim().to_lowercase();
+    let mut results = agent_page_results(pages, query);
+    let mut app_pages: Vec<_> = pages
+        .iter()
+        .filter(|page| page.host != "agent" && page.host != "start")
+        .filter(|page| page_matches(page, &search_lower))
+        .collect();
+    app_pages.sort_by_key(|page| page.url.to_lowercase());
+    results.extend(
+        app_pages
+            .into_iter()
+            .map(|page| CommandBarResultItem::Page {
+                url: page.url.clone(),
+                title: page.title.clone(),
+                icon: page.icon.clone(),
+                shortcut: page.shortcut.clone(),
+            }),
+    );
+    results
+}
+
 fn work_dir_results(dirs: &[CommandBarWorkDir], search_lower: &str) -> Vec<CommandBarResultItem> {
     dirs.iter()
         .filter(|d| search_lower.is_empty() || d.path.to_lowercase().contains(search_lower))
@@ -706,6 +728,42 @@ mod tests {
         let urls: Vec<_> = results.iter().filter_map(agent_page_url).collect();
 
         assert_eq!(urls, vec!["vmux://agent/vibe/", "vmux://agent/codex/cli"]);
+    }
+
+    #[test]
+    fn start_page_lists_agents_before_other_vmux_pages() {
+        let results = start_page_results(&sample_pages(), "");
+        let urls: Vec<_> = results
+            .iter()
+            .filter_map(|result| match result {
+                CommandBarResultItem::Page { url, .. } => Some(url.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            urls,
+            vec![
+                "vmux://agent/vibe/",
+                "vmux://history/",
+                "vmux://settings/",
+                "vmux://spaces/"
+            ]
+        );
+    }
+
+    #[test]
+    fn start_page_filters_vmux_pages_but_keeps_prompt_agents() {
+        let results = start_page_results(&sample_pages(), "settings");
+        let urls: Vec<_> = results
+            .iter()
+            .filter_map(|result| match result {
+                CommandBarResultItem::Page { url, .. } => Some(url.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(urls, vec!["vmux://agent/vibe/", "vmux://settings/"]);
     }
 
     #[test]

--- a/crates/vmux_layout/src/command_bar/results.rs
+++ b/crates/vmux_layout/src/command_bar/results.rs
@@ -126,12 +126,19 @@ fn page_results(pages: &[CommandBarPage], search_lower: &str) -> Vec<CommandBarR
         .collect()
 }
 
-/// Installed agent launcher rows in recent-first input order, filtered by query.
+/// Installed agent launcher rows in recent-first input order. A matching query narrows the
+/// choices; ordinary prompt text that matches no agent keeps every choice visible.
 pub fn agent_page_results(pages: &[CommandBarPage], query: &str) -> Vec<CommandBarResultItem> {
     let search_lower = query.trim().to_lowercase();
-    pages
+    let agents: Vec<_> = pages.iter().filter(|page| page.host == "agent").collect();
+    let matches: Vec<_> = agents
         .iter()
-        .filter(|page| page.host == "agent" && page_matches(page, &search_lower))
+        .copied()
+        .filter(|page| page_matches(page, &search_lower))
+        .collect();
+    let visible = if matches.is_empty() { agents } else { matches };
+    visible
+        .into_iter()
         .map(|page| CommandBarResultItem::Page {
             url: page.url.clone(),
             title: page.title.clone(),
@@ -681,6 +688,24 @@ mod tests {
             &results[0],
             CommandBarResultItem::Page { url, .. } if url == "vmux://agent/vibe/"
         ));
+    }
+
+    #[test]
+    fn start_prompt_text_keeps_all_agent_choices_visible() {
+        let mut pages = sample_pages();
+        pages.push(CommandBarPage {
+            host: "agent".into(),
+            url: "vmux://agent/codex/cli".into(),
+            title: "Codex (CLI)".into(),
+            keywords: vec!["codex".into(), "agent".into()],
+            icon: vmux_core::PageIcon::None,
+            shortcut: String::new(),
+        });
+
+        let results = agent_page_results(&pages, "show me something fun in terminal");
+        let urls: Vec<_> = results.iter().filter_map(agent_page_url).collect();
+
+        assert_eq!(urls, vec!["vmux://agent/vibe/", "vmux://agent/codex/cli"]);
     }
 
     #[test]

--- a/crates/vmux_layout/src/command_bar/results.rs
+++ b/crates/vmux_layout/src/command_bar/results.rs
@@ -163,7 +163,7 @@ pub fn start_page_results(pages: &[CommandBarPage], query: &str) -> Vec<CommandB
         .filter(|page| page.host != "agent" && page.host != "start")
         .filter(|page| page_matches(page, &search_lower))
         .collect();
-    app_pages.sort_by_key(|page| page.url.to_lowercase());
+    app_pages.sort_by_cached_key(|page| page.url.to_lowercase());
     results.extend(
         app_pages
             .into_iter()

--- a/crates/vmux_layout/src/command_bar/results.rs
+++ b/crates/vmux_layout/src/command_bar/results.rs
@@ -126,6 +126,21 @@ fn page_results(pages: &[CommandBarPage], search_lower: &str) -> Vec<CommandBarR
         .collect()
 }
 
+/// Installed agent launcher rows in input order, filtered by the start-page query.
+pub fn agent_page_results(pages: &[CommandBarPage], query: &str) -> Vec<CommandBarResultItem> {
+    let search_lower = query.trim().to_lowercase();
+    pages
+        .iter()
+        .filter(|page| page.host == "agent" && page_matches(page, &search_lower))
+        .map(|page| CommandBarResultItem::Page {
+            url: page.url.clone(),
+            title: page.title.clone(),
+            icon: page.icon.clone(),
+            shortcut: page.shortcut.clone(),
+        })
+        .collect()
+}
+
 fn work_dir_results(dirs: &[CommandBarWorkDir], search_lower: &str) -> Vec<CommandBarResultItem> {
     dirs.iter()
         .filter(|d| search_lower.is_empty() || d.path.to_lowercase().contains(search_lower))
@@ -614,6 +629,30 @@ mod tests {
             CommandBarResultItem::Page { title, icon, .. }
                 if title == "Vibe" && matches!(icon, vmux_core::PageIcon::None)
         )));
+    }
+
+    #[test]
+    fn start_agent_pages_preserve_input_order_and_exclude_other_pages() {
+        let mut pages = sample_pages();
+        pages.push(CommandBarPage {
+            host: "agent".into(),
+            url: "vmux://agent/codex/cli".into(),
+            title: "Codex (CLI)".into(),
+            keywords: vec!["codex".into(), "agent".into()],
+            icon: vmux_core::PageIcon::None,
+            shortcut: String::new(),
+        });
+
+        let results = agent_page_results(&pages, "");
+        let urls: Vec<_> = results
+            .iter()
+            .filter_map(|result| match result {
+                CommandBarResultItem::Page { url, .. } => Some(url.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(urls, vec!["vmux://agent/vibe/", "vmux://agent/codex/cli"]);
     }
 
     #[test]

--- a/crates/vmux_layout/src/command_bar/results.rs
+++ b/crates/vmux_layout/src/command_bar/results.rs
@@ -126,12 +126,11 @@ fn page_results(pages: &[CommandBarPage], search_lower: &str) -> Vec<CommandBarR
         .collect()
 }
 
-/// Installed agent launcher rows in input order, filtered by the start-page query.
-pub fn agent_page_results(pages: &[CommandBarPage], query: &str) -> Vec<CommandBarResultItem> {
-    let search_lower = query.trim().to_lowercase();
+/// Installed agent launcher rows in recent-first input order.
+pub fn agent_page_results(pages: &[CommandBarPage]) -> Vec<CommandBarResultItem> {
     pages
         .iter()
-        .filter(|page| page.host == "agent" && page_matches(page, &search_lower))
+        .filter(|page| page.host == "agent")
         .map(|page| CommandBarResultItem::Page {
             url: page.url.clone(),
             title: page.title.clone(),
@@ -141,19 +140,11 @@ pub fn agent_page_results(pages: &[CommandBarPage], query: &str) -> Vec<CommandB
         .collect()
 }
 
-pub fn replacement_agent_url(pages: &[CommandBarPage], current: &str) -> Option<String> {
-    if pages
-        .iter()
-        .any(|page| page.host == "agent" && page.url == current)
-    {
-        return None;
+pub fn agent_page_url(item: &CommandBarResultItem) -> Option<&str> {
+    match item {
+        CommandBarResultItem::Page { url, .. } if url.starts_with("vmux://agent/") => Some(url),
+        _ => None,
     }
-    let replacement = pages
-        .iter()
-        .find(|page| page.host == "agent")
-        .map(|page| page.url.clone())
-        .unwrap_or_default();
-    (replacement != current).then_some(replacement)
 }
 
 fn work_dir_results(dirs: &[CommandBarWorkDir], search_lower: &str) -> Vec<CommandBarResultItem> {
@@ -658,7 +649,7 @@ mod tests {
             shortcut: String::new(),
         });
 
-        let results = agent_page_results(&pages, "");
+        let results = agent_page_results(&pages);
         let urls: Vec<_> = results
             .iter()
             .filter_map(|result| match result {
@@ -671,19 +662,17 @@ mod tests {
     }
 
     #[test]
-    fn empty_agent_pages_do_not_replace_empty_selection() {
-        assert_eq!(replacement_agent_url(&sample_pages()[..1], ""), None);
-    }
+    fn prompt_agent_url_only_accepts_agent_page_rows() {
+        let agent = agent_page_results(&sample_pages()).remove(0);
+        let settings = CommandBarResultItem::Page {
+            url: "vmux://settings/".into(),
+            title: "Settings".into(),
+            icon: vmux_core::PageIcon::None,
+            shortcut: String::new(),
+        };
 
-    #[test]
-    fn agent_selection_only_changes_when_missing() {
-        let pages = sample_pages();
-
-        assert_eq!(replacement_agent_url(&pages, "vmux://agent/vibe/"), None);
-        assert_eq!(
-            replacement_agent_url(&pages, "vmux://agent/missing/"),
-            Some("vmux://agent/vibe/".to_string())
-        );
+        assert_eq!(agent_page_url(&agent), Some("vmux://agent/vibe/"));
+        assert_eq!(agent_page_url(&settings), None);
     }
 
     #[test]

--- a/crates/vmux_layout/src/command_bar/results.rs
+++ b/crates/vmux_layout/src/command_bar/results.rs
@@ -141,6 +141,21 @@ pub fn agent_page_results(pages: &[CommandBarPage], query: &str) -> Vec<CommandB
         .collect()
 }
 
+pub fn replacement_agent_url(pages: &[CommandBarPage], current: &str) -> Option<String> {
+    if pages
+        .iter()
+        .any(|page| page.host == "agent" && page.url == current)
+    {
+        return None;
+    }
+    let replacement = pages
+        .iter()
+        .find(|page| page.host == "agent")
+        .map(|page| page.url.clone())
+        .unwrap_or_default();
+    (replacement != current).then_some(replacement)
+}
+
 fn work_dir_results(dirs: &[CommandBarWorkDir], search_lower: &str) -> Vec<CommandBarResultItem> {
     dirs.iter()
         .filter(|d| search_lower.is_empty() || d.path.to_lowercase().contains(search_lower))
@@ -653,6 +668,22 @@ mod tests {
             .collect();
 
         assert_eq!(urls, vec!["vmux://agent/vibe/", "vmux://agent/codex/cli"]);
+    }
+
+    #[test]
+    fn empty_agent_pages_do_not_replace_empty_selection() {
+        assert_eq!(replacement_agent_url(&sample_pages()[..1], ""), None);
+    }
+
+    #[test]
+    fn agent_selection_only_changes_when_missing() {
+        let pages = sample_pages();
+
+        assert_eq!(replacement_agent_url(&pages, "vmux://agent/vibe/"), None);
+        assert_eq!(
+            replacement_agent_url(&pages, "vmux://agent/missing/"),
+            Some("vmux://agent/vibe/".to_string())
+        );
     }
 
     #[test]

--- a/crates/vmux_layout/src/command_bar/style.rs
+++ b/crates/vmux_layout/src/command_bar/style.rs
@@ -299,7 +299,7 @@ mod tests {
     fn start_shows_agents_as_result_rows() {
         let source = include_str!("palette.rs");
 
-        assert!(source.contains("agent_page_results(&pages, &q)"));
+        assert!(source.contains("start_page_results(&pages, &q)"));
         assert!(source.contains("agent_page_url(item)"));
         assert!(!source.contains("start-agent-select"));
     }

--- a/crates/vmux_layout/src/command_bar/style.rs
+++ b/crates/vmux_layout/src/command_bar/style.rs
@@ -287,6 +287,14 @@ mod tests {
     }
 
     #[test]
+    fn start_enter_emits_prompt_action() {
+        let source = include_str!("palette.rs");
+
+        assert!(source.contains("should_submit_start_prompt("));
+        assert!(source.contains("emit_action_with_target(\"prompt\", q.trim(), open_target)"));
+    }
+
+    #[test]
     fn results_list_disables_horizontal_scroll() {
         let class = result_list_class();
 

--- a/crates/vmux_layout/src/command_bar/style.rs
+++ b/crates/vmux_layout/src/command_bar/style.rs
@@ -299,7 +299,7 @@ mod tests {
     fn start_shows_agents_as_result_rows() {
         let source = include_str!("palette.rs");
 
-        assert!(source.contains("agent_page_results(&pages)"));
+        assert!(source.contains("agent_page_results(&pages, &q)"));
         assert!(source.contains("agent_page_url(item)"));
         assert!(!source.contains("start-agent-select"));
     }

--- a/crates/vmux_layout/src/command_bar/style.rs
+++ b/crates/vmux_layout/src/command_bar/style.rs
@@ -291,7 +291,17 @@ mod tests {
         let source = include_str!("palette.rs");
 
         assert!(source.contains("should_submit_start_prompt("));
-        assert!(source.contains("emit_action_with_target(\"prompt\", q.trim(), open_target)"));
+        assert!(source.contains("emit_prompt_action("));
+        assert!(source.contains("agent_url: (!agent_url.is_empty())"));
+    }
+
+    #[test]
+    fn start_shows_agent_selector() {
+        let source = include_str!("palette.rs");
+
+        assert!(source.contains("id: \"start-agent-select\""));
+        assert!(source.contains("aria_label: \"Prompt agent\""));
+        assert!(source.contains("page.host == \"agent\""));
     }
 
     #[test]

--- a/crates/vmux_layout/src/command_bar/style.rs
+++ b/crates/vmux_layout/src/command_bar/style.rs
@@ -290,18 +290,18 @@ mod tests {
     fn start_enter_emits_prompt_action() {
         let source = include_str!("palette.rs");
 
-        assert!(source.contains("should_submit_start_prompt("));
+        assert!(source.contains("is_start_prompt_query("));
         assert!(source.contains("emit_prompt_action("));
         assert!(source.contains("agent_url: (!agent_url.is_empty())"));
     }
 
     #[test]
-    fn start_shows_agent_selector() {
+    fn start_shows_agents_as_result_rows() {
         let source = include_str!("palette.rs");
 
-        assert!(source.contains("id: \"start-agent-select\""));
-        assert!(source.contains("aria_label: \"Prompt agent\""));
-        assert!(source.contains("page.host == \"agent\""));
+        assert!(source.contains("agent_page_results(&pages)"));
+        assert!(source.contains("agent_page_url(item)"));
+        assert!(!source.contains("start-agent-select"));
     }
 
     #[test]

--- a/crates/vmux_layout/src/start/page.rs
+++ b/crates/vmux_layout/src/start/page.rs
@@ -202,8 +202,7 @@ fn install_keep_input_focused_on_click() {
         {
             let on_input = el.closest("#command-bar-input").ok().flatten().is_some();
             let on_results = el.closest("#command-bar-results").ok().flatten().is_some();
-            let on_agent_select = el.closest("#start-agent-select").ok().flatten().is_some();
-            if on_input || on_results || on_agent_select {
+            if on_input || on_results {
                 return;
             }
         }

--- a/crates/vmux_layout/src/start/page.rs
+++ b/crates/vmux_layout/src/start/page.rs
@@ -202,7 +202,8 @@ fn install_keep_input_focused_on_click() {
         {
             let on_input = el.closest("#command-bar-input").ok().flatten().is_some();
             let on_results = el.closest("#command-bar-results").ok().flatten().is_some();
-            if on_input || on_results {
+            let on_agent_select = el.closest("#start-agent-select").ok().flatten().is_some();
+            if on_input || on_results || on_agent_select {
                 return;
             }
         }

--- a/crates/vmux_layout/src/start/plugin.rs
+++ b/crates/vmux_layout/src/start/plugin.rs
@@ -46,9 +46,8 @@ struct WarmStartReady;
 struct WarmStartPoolNode;
 
 /// Marks a live `vmux://start/` page that has received the current launcher payload.
-/// Cleared implicitly by re-pushing whenever the work snapshot changes, so a page that
-/// becomes ready after the snapshot was populated still gets the data (fixes the race
-/// where the one-shot mount fetch missed a not-yet-spawned pane).
+/// Cleared implicitly by re-pushing whenever a launcher snapshot changes, so a page that
+/// becomes ready after snapshots were populated still gets the data.
 #[derive(Component)]
 struct StartWorkSynced;
 
@@ -84,9 +83,9 @@ impl Plugin for StartPlugin {
     }
 }
 
-/// Keep every live `vmux://start/` page's launcher payload current, so open-pane dirs
-/// and recent files auto-appear without a reopen. Pushes to a ready start page when the
-/// work snapshot changed this frame, or when the page is newly ready and not yet synced
+/// Keep every live `vmux://start/` page's launcher payload current, so open-pane dirs,
+/// recent files, agent order, spaces, and pages auto-update without a reopen. Pushes to a ready
+/// start page when a launcher snapshot changed this frame, or when newly ready and not yet synced
 /// (covers panes that spawn before the start page's CEF is ready). Uses `open_id: 0`,
 /// which does not reset the palette's input/selection.
 fn sync_live_start_pages(
@@ -106,10 +105,14 @@ fn sync_live_start_pages(
     browsers: NonSend<Browsers>,
     mut commands: Commands,
 ) {
-    // Refresh on work-snapshot changes and on focus/tab changes (so the tabs list
-    // and active markers stay current), plus first-sync for newly-ready pages.
     let focus_changed = focused.is_changed();
-    let changed = work_snapshot.is_changed() || focus_changed;
+    let changed = should_refresh_start_payload(
+        spaces_snapshot.is_changed(),
+        agents_snapshot.is_changed(),
+        pages_snapshot.is_changed(),
+        work_snapshot.is_changed(),
+        focus_changed,
+    );
     let targets: Vec<(Entity, bool)> = starts
         .iter()
         .filter_map(|(e, src, synced, keyboard_target)| {
@@ -158,6 +161,16 @@ fn sync_live_start_pages(
         // it) before this command applies — `try_insert` skips silently instead of panicking.
         commands.entity(e).try_insert(StartWorkSynced);
     }
+}
+
+fn should_refresh_start_payload(
+    spaces_changed: bool,
+    agents_changed: bool,
+    pages_changed: bool,
+    work_changed: bool,
+    focus_changed: bool,
+) -> bool {
+    spaces_changed || agents_changed || pages_changed || work_changed || focus_changed
 }
 
 fn should_focus_start_sync(
@@ -464,6 +477,16 @@ mod tests {
         assert!(should_focus_start_sync(true, true, true, false));
         assert!(should_focus_start_sync(true, true, false, true));
         assert!(!should_focus_start_sync(true, true, false, false));
+    }
+
+    #[test]
+    fn start_sync_refreshes_when_agent_recency_changes() {
+        assert!(should_refresh_start_payload(
+            false, true, false, false, false
+        ));
+        assert!(!should_refresh_start_payload(
+            false, false, false, false, false
+        ));
     }
 
     fn start_task(stack: Entity) -> PageOpenTask {

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -3221,18 +3221,32 @@ fn terminal_loading_labels(session: Option<&vmux_core::agent::AgentSession>) -> 
 
 fn arm_agent_loading(
     newly_ready: Query<
-        (Entity, Option<&vmux_core::agent::AgentSession>),
+        (
+            Entity,
+            Option<&vmux_core::agent::AgentSession>,
+            Option<&PromptCapture>,
+        ),
         (With<Terminal>, Added<PageReady>, Without<AgentLoading>),
     >,
     mut commands: Commands,
 ) {
-    for (entity, session) in &newly_ready {
+    for (entity, session, capture) in &newly_ready {
         let (label, segment) = terminal_loading_labels(session);
         commands.entity(entity).insert(AgentLoading {
             since: Instant::now(),
         });
-        if session.is_some() {
+        if session.is_some() && capture.is_none() {
             commands.entity(entity).insert(PromptCapture::default());
+        }
+        if let Some(capture) = capture {
+            commands.trigger(BinHostEmitEvent::from_rkyv(
+                entity,
+                AGENT_PROMPT_DRAFT_EVENT,
+                &AgentPromptDraftEvent {
+                    draft: capture.draft.clone(),
+                    skipped: capture.skipped,
+                },
+            ));
         }
         commands.trigger(BinHostEmitEvent::from_rkyv(
             entity,
@@ -3248,7 +3262,11 @@ fn arm_agent_loading(
 
 fn arm_agent_loading_on_restart(
     restarted: Query<
-        (Entity, Option<&vmux_core::agent::AgentSession>),
+        (
+            Entity,
+            Option<&vmux_core::agent::AgentSession>,
+            Option<&PromptCapture>,
+        ),
         (
             With<Terminal>,
             With<PageReady>,
@@ -3258,13 +3276,23 @@ fn arm_agent_loading_on_restart(
     >,
     mut commands: Commands,
 ) {
-    for (entity, session) in &restarted {
+    for (entity, session, capture) in &restarted {
         let (label, segment) = terminal_loading_labels(session);
         commands.entity(entity).insert(AgentLoading {
             since: Instant::now(),
         });
-        if session.is_some() {
+        if session.is_some() && capture.is_none() {
             commands.entity(entity).insert(PromptCapture::default());
+        }
+        if let Some(capture) = capture {
+            commands.trigger(BinHostEmitEvent::from_rkyv(
+                entity,
+                AGENT_PROMPT_DRAFT_EVENT,
+                &AgentPromptDraftEvent {
+                    draft: capture.draft.clone(),
+                    skipped: capture.skipped,
+                },
+            ));
         }
         commands.trigger(BinHostEmitEvent::from_rkyv(
             entity,
@@ -5168,6 +5196,33 @@ mod tests {
             .id();
         app.update();
         assert!(app.world().get::<AgentLoading>(e).is_some());
+    }
+
+    #[test]
+    fn agent_loading_preserves_initial_prompt_capture() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_systems(Update, arm_agent_loading);
+        let e = app
+            .world_mut()
+            .spawn((
+                Terminal,
+                AgentSession {
+                    kind: AgentKind::Vibe,
+                },
+                PromptCapture {
+                    draft: "@asdfas".to_string(),
+                    skipped: false,
+                },
+                PageReady {},
+            ))
+            .id();
+
+        app.update();
+
+        let capture = app.world().get::<PromptCapture>(e).unwrap();
+        assert_eq!(capture.draft, "@asdfas");
+        assert!(!capture.skipped);
     }
 
     #[test]

--- a/crates/vmux_ui/src/agent_accent.rs
+++ b/crates/vmux_ui/src/agent_accent.rs
@@ -55,11 +55,13 @@ mod tests {
 
     #[test]
     fn claude_uses_rose_orange() {
-        let a = agent_accent("claude");
-        assert_eq!(a.grad, "from-orange-400 to-rose-500");
-        assert_eq!(a.accent_text, "text-rose-600 dark:text-rose-400");
-        assert_eq!(a.accent_bg, "bg-rose-400");
-        assert_eq!(a.rain_rgb, "251 113 133");
+        for id in ["claude", "claude-acp"] {
+            let a = agent_accent(id);
+            assert_eq!(a.grad, "from-orange-400 to-rose-500");
+            assert_eq!(a.accent_text, "text-rose-600 dark:text-rose-400");
+            assert_eq!(a.accent_bg, "bg-rose-400");
+            assert_eq!(a.rain_rgb, "251 113 133");
+        }
     }
 
     #[test]

--- a/crates/vmux_ui/src/agent_accent.rs
+++ b/crates/vmux_ui/src/agent_accent.rs
@@ -10,7 +10,7 @@ pub struct AgentAccent {
 
 pub fn agent_accent(segment: &str) -> AgentAccent {
     match segment {
-        "claude" => AgentAccent {
+        "claude" | "claude-acp" => AgentAccent {
             glow_top: "pointer-events-none absolute -top-1/3 left-1/2 h-[60vh] w-[60vh] -translate-x-1/2 rounded-full bg-rose-500/20 blur-[120px]",
             glow_bottom: "pointer-events-none absolute -bottom-1/4 right-1/4 h-[44vh] w-[44vh] rounded-full bg-orange-400/10 blur-[120px]",
             grad: "from-orange-400 to-rose-500",
@@ -19,7 +19,7 @@ pub fn agent_accent(segment: &str) -> AgentAccent {
             cta_shadow: "shadow-lg shadow-rose-500/25 hover:shadow-rose-500/40",
             rain_rgb: "251 113 133",
         },
-        "codex" => AgentAccent {
+        "codex" | "codex-acp" => AgentAccent {
             glow_top: "pointer-events-none absolute -top-1/3 left-1/2 h-[60vh] w-[60vh] -translate-x-1/2 rounded-full bg-emerald-500/20 blur-[120px]",
             glow_bottom: "pointer-events-none absolute -bottom-1/4 right-1/4 h-[44vh] w-[44vh] rounded-full bg-teal-400/10 blur-[120px]",
             grad: "from-emerald-500 to-teal-600",
@@ -64,10 +64,12 @@ mod tests {
 
     #[test]
     fn codex_uses_emerald_teal() {
-        let a = agent_accent("codex");
-        assert_eq!(a.grad, "from-emerald-500 to-teal-600");
-        assert_eq!(a.accent_text, "text-emerald-600 dark:text-emerald-400");
-        assert_eq!(a.rain_rgb, "52 211 153");
+        for id in ["codex", "codex-acp"] {
+            let a = agent_accent(id);
+            assert_eq!(a.grad, "from-emerald-500 to-teal-600");
+            assert_eq!(a.accent_text, "text-emerald-600 dark:text-emerald-400");
+            assert_eq!(a.rain_rgb, "52 211 153");
+        }
     }
 
     #[test]

--- a/crates/vmux_ui/src/favicon.rs
+++ b/crates/vmux_ui/src/favicon.rs
@@ -18,7 +18,9 @@ pub fn agent_host(url: &str) -> Option<&'static str> {
         ("vibe", "chat.mistral.ai"),
         ("mistral-vibe", "chat.mistral.ai"),
         ("claude", "claude.ai"),
+        ("claude-acp", "claude.ai"),
         ("codex", "chatgpt.com"),
+        ("codex-acp", "chatgpt.com"),
         ("gemini", "gemini.google.com"),
     ];
     for &(kind, host) in AGENTS {
@@ -172,7 +174,9 @@ mod tests {
     #[test]
     fn agent_host_maps_claude_and_codex() {
         assert_eq!(agent_host("vmux://agent/claude/x"), Some("claude.ai"));
+        assert_eq!(agent_host("vmux://agent/claude-acp/x"), Some("claude.ai"));
         assert_eq!(agent_host("vmux://agent/codex/x"), Some("chatgpt.com"));
+        assert_eq!(agent_host("vmux://agent/codex-acp/x"), Some("chatgpt.com"));
     }
 
     #[test]


### PR DESCRIPTION
## Context

The `vmux://start/` launcher advertises “Search or ask,” but submitting plain text previously opened search results and its agent list included curated/unavailable entries.

## Implementation

- Plain-text Enter starts a fresh session with the most recently used installed agent.
- The start launcher lists only installed ACP agents and detected CLI executables.
- ACP and CLI entries are merged in most-recently-used order, with alphabetical fallback.
- Matching agent queries open the matching launcher result; explicit URLs, paths, commands, and keyboard-selected navigation keep their existing behavior.
- Initial prompts are carried through the existing agent page-open flow and submitted after startup.

## Checks / QA

- Open `vmux://start/`; confirm only installed ACP and CLI agents appear.
- Use multiple agents; confirm the list reorders by most recent activation.
- Type a matching agent name and press Enter; confirm that agent opens.
- Type a non-matching prompt and press Enter; confirm the most recently used installed agent starts and receives it.
- Confirm typed URLs, paths, commands, and arrow-selected results still open normally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Start prompts can be routed from the command bar and command palette to specific agent pages (optionally targeting by agent URL).
  * Agent launchers now include “recent” ordering across CLI and ACP.
  * Expanded agent branding/accent support for Claude ACP and Codex ACP variants.
  * Command-bar agent search/presentation is improved for prompt-query vs navigation behavior.
* **Bug Fixes**
  * Pending initial prompts are delivered correctly across page/CLI/ACP agent opens and are preserved through agent loading/restores.
  * Agent snapshots and recent-agent targeting refresh more reliably and emit correct action metadata.
* **Documentation**
  * Clarified launcher/work sync refresh behavior and triggering logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->