### PR TITLE
perf(pages): prewarm static vmux pages

### DIFF
--- a/crates/vmux_agent/src/agents_page.rs
+++ b/crates/vmux_agent/src/agents_page.rs
@@ -14,7 +14,7 @@ use bevy_cef::prelude::{BinEventEmitterPlugin, BinHostEmitEvent, BinReceive, Bro
 #[cfg(not(target_arch = "wasm32"))]
 use crossbeam_channel::{Receiver, Sender};
 #[cfg(not(target_arch = "wasm32"))]
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::acp_registry::Runtime;
@@ -27,6 +27,8 @@ use crate::agents_page::event::{
 use crate::client::acp::{AcpCatalog, AcpInstallGeneration};
 #[cfg(not(target_arch = "wasm32"))]
 use vmux_core::agent::AgentKind;
+#[cfg(not(target_arch = "wasm32"))]
+use vmux_core::page::PrewarmPage;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
@@ -37,10 +39,9 @@ pub const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageMa
     command_bar: true,
 };
 
-/// The most recent `vmux://agents` webview to push the catalog to.
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Resource, Default)]
-struct AgentsPageWebview(Option<Entity>);
+struct AgentsPageWebviews(HashSet<Entity>);
 
 /// Session install status per agent id (`status`, `detail`), overlaid on the disk-derived state.
 #[cfg(not(target_arch = "wasm32"))]
@@ -85,8 +86,17 @@ pub struct AgentsManagerPlugin;
 #[cfg(not(target_arch = "wasm32"))]
 impl Plugin for AgentsManagerPlugin {
     fn build(&self, app: &mut App) {
-        app.world_mut().spawn(PAGE_MANIFEST);
-        app.init_resource::<AgentsPageWebview>()
+        app.world_mut().spawn((
+            PAGE_MANIFEST,
+            PrewarmPage {
+                host: "agents",
+                url: "vmux://agents/",
+                title: "Agents",
+                pool_size: 1,
+            },
+        ));
+        vmux_core::register_host_spawn(app, "agents");
+        app.init_resource::<AgentsPageWebviews>()
             .init_resource::<AgentsStatus>()
             .init_resource::<AgentsInstallChannel>()
             .init_resource::<AcpInstallGeneration>()
@@ -187,9 +197,9 @@ fn cli_agent_entries(mut is_installed: impl FnMut(AgentKind) -> bool) -> Vec<Age
 #[cfg(not(target_arch = "wasm32"))]
 fn on_catalog_request(
     trigger: On<BinReceive<AgentsCatalogRequest>>,
-    mut webview_res: ResMut<AgentsPageWebview>,
+    mut webviews: ResMut<AgentsPageWebviews>,
 ) {
-    webview_res.0 = Some(trigger.event().webview);
+    webviews.0.insert(trigger.event().webview);
 }
 
 /// Kick a background install (or update) for the requested agent.
@@ -270,29 +280,47 @@ fn drain_agent_installs(
 fn push_agents(
     catalog: Res<AcpCatalog>,
     status: Res<AgentsStatus>,
-    webview_res: Res<AgentsPageWebview>,
+    webviews: Res<AgentsPageWebviews>,
     browsers: NonSend<Browsers>,
     mut commands: Commands,
 ) {
-    if !catalog.is_changed() && !status.is_changed() && !webview_res.is_changed() {
+    if !catalog.is_changed() && !status.is_changed() && !webviews.is_changed() {
         return;
     }
-    let Some(webview) = webview_res.0 else {
-        return;
-    };
-    if !browsers.has_browser(webview) || !browsers.host_emit_ready(&webview) {
-        return;
+    let payload = catalog_snapshot(&catalog, &status);
+    for &webview in &webviews.0 {
+        if !browsers.has_browser(webview) || !browsers.host_emit_ready(&webview) {
+            continue;
+        }
+        commands.trigger(BinHostEmitEvent::from_rkyv(
+            webview,
+            AGENTS_CATALOG_EVENT,
+            &payload,
+        ));
     }
-    commands.trigger(BinHostEmitEvent::from_rkyv(
-        webview,
-        AGENTS_CATALOG_EVENT,
-        &catalog_snapshot(&catalog, &status),
-    ));
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn catalog_tracks_multiple_webviews() {
+        let mut app = App::new();
+        app.init_resource::<AgentsPageWebviews>()
+            .add_observer(on_catalog_request);
+        let first = app.world_mut().spawn_empty().id();
+        let second = app.world_mut().spawn_empty().id();
+        for webview in [first, second] {
+            app.world_mut().trigger(BinReceive {
+                webview,
+                payload: AgentsCatalogRequest {},
+            });
+        }
+
+        let webviews = app.world().resource::<AgentsPageWebviews>();
+        assert_eq!(webviews.0, HashSet::from([first, second]));
+    }
 
     #[test]
     fn cli_catalog_rows_report_install_state() {

--- a/crates/vmux_browser/src/extensions/manager_page.rs
+++ b/crates/vmux_browser/src/extensions/manager_page.rs
@@ -14,7 +14,7 @@ use vmux_core::event::extension::{
     ExtUninstallRequest, ExtensionsEvent,
 };
 use vmux_core::extension::store;
-use vmux_core::{CefPageAttachRequest, PageOpenError, PageOpenHandled, PageOpenSet, PageOpenTask};
+use vmux_core::page::PrewarmPage;
 
 const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
     host: "extensions",
@@ -49,11 +49,19 @@ pub struct ExtensionsPlugin;
 
 impl Plugin for ExtensionsPlugin {
     fn build(&self, app: &mut App) {
-        app.world_mut().spawn(PAGE_MANIFEST);
+        app.world_mut().spawn((
+            PAGE_MANIFEST,
+            PrewarmPage {
+                host: "extensions",
+                url: EXTENSIONS_PAGE_URL,
+                title: "Extensions",
+                pool_size: 1,
+            },
+        ));
+        vmux_core::register_host_spawn(app, "extensions");
         app.init_resource::<ExtOutbox>()
             .init_resource::<ExtSubscribers>()
             .init_resource::<WebStoreInjectors>()
-            .add_message::<CefPageAttachRequest>()
             .add_plugins(BinEventEmitterPlugin::<(
                 ExtToggleRequest,
                 ExtUninstallRequest,
@@ -74,33 +82,8 @@ impl Plugin for ExtensionsPlugin {
             .add_observer(on_add_extension)
             .add_systems(
                 Update,
-                handle_extensions_page_open.in_set(PageOpenSet::HandleKnownPages),
-            )
-            .add_systems(
-                Update,
                 (run_agent_installs, inject_on_cws_nav, drain_outbox),
             );
-    }
-}
-
-type PendingPageOpen = (Without<PageOpenHandled>, Without<PageOpenError>);
-
-fn handle_extensions_page_open(
-    tasks: Query<(Entity, &PageOpenTask), PendingPageOpen>,
-    mut attach_writer: MessageWriter<CefPageAttachRequest>,
-    mut commands: Commands,
-) {
-    for (entity, task) in &tasks {
-        if task.url != EXTENSIONS_PAGE_URL {
-            continue;
-        }
-        attach_writer.write(CefPageAttachRequest {
-            stack: task.stack,
-            url: task.url.clone(),
-            title: "Extensions".to_string(),
-            bg_color: None,
-        });
-        commands.entity(entity).insert(PageOpenHandled);
     }
 }
 

--- a/crates/vmux_core/src/page.rs
+++ b/crates/vmux_core/src/page.rs
@@ -21,6 +21,14 @@ pub struct PageManifest {
     pub command_bar: bool,
 }
 
+#[derive(Component, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PrewarmPage {
+    pub host: &'static str,
+    pub url: &'static str,
+    pub title: &'static str,
+    pub pool_size: usize,
+}
+
 impl PageManifest {
     pub fn embedded_host(&self) -> CefEmbeddedHost {
         CefEmbeddedHost {

--- a/crates/vmux_editor/src/lsp/manager_page.rs
+++ b/crates/vmux_editor/src/lsp/manager_page.rs
@@ -8,8 +8,7 @@ use vmux_core::event::{
     LspCatalogEvent, LspCatalogRequest, LspInstallProgress, LspInstallRequest, LspPackage,
     LspPkgStatus, LspPkgStatusEvent, LspUninstallRequest, LspUpdateRequest,
 };
-
-use vmux_core::{CefPageAttachRequest, PageOpenError, PageOpenHandled, PageOpenSet, PageOpenTask};
+use vmux_core::page::PrewarmPage;
 
 use crate::lsp::catalog::{self, Package};
 use crate::lsp::{install, purl, store, target};
@@ -35,9 +34,17 @@ pub struct ManagerPlugin;
 
 impl Plugin for ManagerPlugin {
     fn build(&self, app: &mut App) {
-        app.world_mut().spawn(PAGE_MANIFEST);
+        app.world_mut().spawn((
+            PAGE_MANIFEST,
+            PrewarmPage {
+                host: "lsp",
+                url: "vmux://lsp/",
+                title: "Language Servers",
+                pool_size: 1,
+            },
+        ));
+        vmux_core::register_host_spawn(app, "lsp");
         app.init_resource::<ManagerOutbox>()
-            .add_message::<CefPageAttachRequest>()
             .add_plugins(BinEventEmitterPlugin::<(
                 LspCatalogRequest,
                 LspInstallRequest,
@@ -48,32 +55,7 @@ impl Plugin for ManagerPlugin {
             .add_observer(on_install_request)
             .add_observer(on_uninstall_request)
             .add_observer(on_update_request)
-            .add_systems(
-                Update,
-                handle_lsp_page_open.in_set(PageOpenSet::HandleKnownPages),
-            )
             .add_systems(Update, drain_manager_outbox);
-    }
-}
-
-type PendingPageOpen = (Without<PageOpenHandled>, Without<PageOpenError>);
-
-fn handle_lsp_page_open(
-    tasks: Query<(Entity, &PageOpenTask), PendingPageOpen>,
-    mut attach_writer: MessageWriter<CefPageAttachRequest>,
-    mut commands: Commands,
-) {
-    for (entity, task) in &tasks {
-        if task.url != "vmux://lsp/" {
-            continue;
-        }
-        attach_writer.write(CefPageAttachRequest {
-            stack: task.stack,
-            url: task.url.clone(),
-            title: "Language Servers".to_string(),
-            bg_color: None,
-        });
-        commands.entity(entity).insert(PageOpenHandled);
     }
 }
 
@@ -380,35 +362,5 @@ mod tests {
         });
         app.update();
         assert!(outbox.0.lock().unwrap().is_empty());
-    }
-
-    #[test]
-    fn page_open_claims_lsp_url() {
-        let mut app = App::new();
-        app.add_plugins(MinimalPlugins)
-            .add_message::<CefPageAttachRequest>()
-            .add_systems(Update, handle_lsp_page_open);
-        let stack = app.world_mut().spawn_empty().id();
-        let claimed = app
-            .world_mut()
-            .spawn(PageOpenTask {
-                id: vmux_core::PageOpenId::new(),
-                stack,
-                url: "vmux://lsp/".to_string(),
-                request_id: None,
-            })
-            .id();
-        let other = app
-            .world_mut()
-            .spawn(PageOpenTask {
-                id: vmux_core::PageOpenId::new(),
-                stack,
-                url: "vmux://history/".to_string(),
-                request_id: None,
-            })
-            .id();
-        app.update();
-        assert!(app.world().get::<PageOpenHandled>(claimed).is_some());
-        assert!(app.world().get::<PageOpenHandled>(other).is_none());
     }
 }

--- a/crates/vmux_history/src/plugin.rs
+++ b/crates/vmux_history/src/plugin.rs
@@ -2,9 +2,7 @@ use std::time::Duration;
 
 use bevy::time::common_conditions::on_timer;
 use bevy_cef::prelude::BinEventEmitterPlugin;
-use vmux_core::{
-    CefPageAttachRequest, PageOpenError, PageOpenHandled, PageOpenSet, PageOpenTask,
-};
+use vmux_core::page::PrewarmPage;
 
 use crate::event::{
     HistoryChangedEvent, HistoryClearAllRequest, HistoryDeleteRequest, HistoryOpenRequest,
@@ -24,12 +22,20 @@ pub struct HistoryPlugin;
 
 impl Plugin for HistoryPlugin {
     fn build(&self, app: &mut App) {
-        app.world_mut().spawn(crate::PAGE_MANIFEST);
+        app.world_mut().spawn((
+            crate::PAGE_MANIFEST,
+            PrewarmPage {
+                host: "history",
+                url: "vmux://history/",
+                title: "History",
+                pool_size: 1,
+            },
+        ));
+        vmux_core::register_host_spawn(app, "history");
         app.add_systems(
             Update,
             (spawn_visits, record_requested_visits, broadcast_history_changed).chain(),
         )
-            .add_systems(Update, handle_history_page_open.in_set(PageOpenSet::HandleKnownPages))
             .add_systems(
                 Update,
                 prune_history.run_if(on_timer(Duration::from_secs(3600))),
@@ -51,28 +57,6 @@ impl Plugin for HistoryPlugin {
             .add_observer(on_history_open_request)
             .add_observer(on_history_suggestions_request)
             .add_message::<HistoryOpenIntent>()
-            .add_message::<CefPageAttachRequest>()
             .add_message::<vmux_core::event::RecordVisitRequest>();
-    }
-}
-
-type PendingPageOpen = (Without<PageOpenHandled>, Without<PageOpenError>);
-
-fn handle_history_page_open(
-    tasks: Query<(Entity, &PageOpenTask), PendingPageOpen>,
-    mut attach_writer: MessageWriter<CefPageAttachRequest>,
-    mut commands: Commands,
-) {
-    for (entity, task) in &tasks {
-        if task.url != "vmux://history/" {
-            continue;
-        }
-        attach_writer.write(CefPageAttachRequest {
-            stack: task.stack,
-            url: task.url.clone(),
-            title: "History".to_string(),
-            bg_color: None,
-        });
-        commands.entity(entity).insert(PageOpenHandled);
     }
 }

--- a/crates/vmux_layout/src/lib.rs
+++ b/crates/vmux_layout/src/lib.rs
@@ -48,6 +48,8 @@ pub mod stack;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod unit;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod warm_page;
+#[cfg(not(target_arch = "wasm32"))]
 mod webview_reveal;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/vmux_layout/src/plugin.rs
+++ b/crates/vmux_layout/src/plugin.rs
@@ -16,6 +16,7 @@ use crate::space::SpacePlugin;
 use crate::stack::StackPlugin;
 use crate::tab::TabPlugin;
 use crate::toggle::TogglePlugin;
+use crate::warm_page::PrewarmPagesPlugin;
 use crate::webview_reveal::WebviewRevealPlugin;
 use crate::window::WindowPlugin;
 use crate::worktree::WorktreePlugin;
@@ -93,6 +94,7 @@ impl Plugin for LayoutPlugin {
                 TogglePlugin,
                 WebviewRevealPlugin,
                 ArchivePlugin,
+                PrewarmPagesPlugin,
             ));
         #[cfg(feature = "player-mode")]
         app.add_plugins(FocusRingPlugin);

--- a/crates/vmux_layout/src/warm_page.rs
+++ b/crates/vmux_layout/src/warm_page.rs
@@ -1,0 +1,520 @@
+use std::collections::{HashMap, HashSet};
+use std::marker::PhantomData;
+
+use bevy::prelude::*;
+use bevy_cef::prelude::{CefKeyboardTarget, CefSystems, WebviewExtendStandardMaterial};
+use vmux_core::page::{PageReady, PrewarmPage};
+use vmux_core::{PageMetadata, PageOpenError, PageOpenHandled, PageOpenSet, PageOpenTask};
+
+use crate::cef::LayoutCef;
+use crate::window::VmuxWindow;
+
+/// A `vmux://` page that can keep hidden, fully-mounted webviews ready for reuse.
+pub trait WarmPage: Component {
+    const HOST: &'static str;
+    const URL: &'static str;
+    const TITLE: &'static str;
+    const POOL_SIZE: usize = 1;
+
+    fn spawn(
+        commands: &mut Commands,
+        meshes: &mut ResMut<Assets<Mesh>>,
+        webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
+    ) -> Entity;
+}
+
+/// Prewarms a page after the layout shell is ready and claims warm webviews on open.
+pub struct WarmPagePlugin<M: WarmPage>(PhantomData<fn() -> M>);
+
+impl<M: WarmPage> Default for WarmPagePlugin<M> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<M: WarmPage> Plugin for WarmPagePlugin<M> {
+    fn build(&self, app: &mut App) {
+        vmux_core::register_host_spawn(app, M::HOST);
+        app.init_resource::<WarmPageSpawnBudget>()
+            .add_systems(
+                Update,
+                handle_warm_page_open::<M>.in_set(PageOpenSet::HandleKnownPages),
+            )
+            .add_systems(
+                Update,
+                maintain_warm_page_pool::<M>.in_set(WarmPageSet::Fill),
+            );
+    }
+}
+
+/// Marks a hidden prewarmed webview that has not been claimed yet.
+#[derive(Component)]
+pub struct WarmPageSpare {
+    url: &'static str,
+}
+
+#[derive(Component)]
+struct WarmPagePoolNode {
+    url: &'static str,
+}
+
+type PendingPageOpen = (Without<PageOpenHandled>, Without<PageOpenError>);
+
+#[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum WarmPageSet {
+    Reset,
+    Fill,
+}
+
+#[derive(Resource)]
+struct WarmPageSpawnBudget(usize);
+
+impl Default for WarmPageSpawnBudget {
+    fn default() -> Self {
+        Self(1)
+    }
+}
+
+impl WarmPageSpawnBudget {
+    fn take(&mut self) -> bool {
+        if self.0 == 0 {
+            return false;
+        }
+        self.0 -= 1;
+        true
+    }
+}
+
+/// Prewarms plain registered pages that use the standard browser bundle.
+pub struct PrewarmPagesPlugin;
+
+impl Plugin for PrewarmPagesPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<WarmPageSpawnBudget>()
+            .configure_sets(
+                Update,
+                (WarmPageSet::Reset, WarmPageSet::Fill)
+                    .chain()
+                    .before(CefSystems::CreateAndResize),
+            )
+            .add_systems(
+                Update,
+                reset_warm_page_spawn_budget.in_set(WarmPageSet::Reset),
+            )
+            .add_systems(
+                Update,
+                handle_registered_page_open.in_set(PageOpenSet::HandleKnownPages),
+            )
+            .add_systems(
+                Update,
+                maintain_registered_page_pools.in_set(WarmPageSet::Fill),
+            );
+    }
+}
+
+fn reset_warm_page_spawn_budget(mut budget: ResMut<WarmPageSpawnBudget>) {
+    budget.0 = 1;
+}
+
+fn handle_registered_page_open(
+    pages: Query<&PrewarmPage>,
+    tasks: Query<(Entity, &PageOpenTask), PendingPageOpen>,
+    spares: Query<(Entity, &WarmPageSpare), With<PageReady>>,
+    children_q: Query<&Children>,
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
+) {
+    let pages: HashMap<&str, &PrewarmPage> = pages
+        .iter()
+        .filter(|page| page.pool_size > 0)
+        .map(|page| (page.url, page))
+        .collect();
+    let mut available: HashMap<&str, Vec<Entity>> = HashMap::new();
+    for (entity, spare) in &spares {
+        available.entry(spare.url).or_default().push(entity);
+    }
+    let mut handled_stacks = HashSet::new();
+
+    for (entity, task) in &tasks {
+        let Some(page) = pages.get(task.url.as_str()).copied() else {
+            continue;
+        };
+        if handled_stacks.insert((task.stack, page.url)) {
+            clear_stack_children(task.stack, &children_q, &mut commands);
+            commands.entity(task.stack).insert(PageMetadata {
+                url: page.url.to_string(),
+                title: page.title.to_string(),
+                ..default()
+            });
+            if let Some(spare) = available.get_mut(page.url).and_then(Vec::pop) {
+                commands
+                    .entity(spare)
+                    .insert((ChildOf(task.stack), CefKeyboardTarget))
+                    .remove::<WarmPageSpare>();
+            } else {
+                let webview = commands
+                    .spawn(crate::cef::Browser::new_with_title(
+                        &mut meshes,
+                        &mut webview_mt,
+                        page.url,
+                        page.title,
+                    ))
+                    .id();
+                commands
+                    .entity(webview)
+                    .insert((ChildOf(task.stack), CefKeyboardTarget));
+            }
+        }
+        commands.entity(entity).insert(PageOpenHandled);
+    }
+}
+
+fn maintain_registered_page_pools(
+    pages: Query<&PrewarmPage>,
+    pool_nodes: Query<(Entity, &WarmPagePoolNode)>,
+    vmux_window: Query<Entity, With<VmuxWindow>>,
+    layout_ready: Query<(), (With<LayoutCef>, With<PageReady>)>,
+    spares: Query<&WarmPageSpare>,
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
+    mut budget: ResMut<WarmPageSpawnBudget>,
+) {
+    if layout_ready.is_empty() {
+        return;
+    }
+    let Ok(window) = vmux_window.single() else {
+        return;
+    };
+    for page in &pages {
+        if page.pool_size == 0 || page.url.is_empty() {
+            continue;
+        }
+        let node = pool_node_for(page.url, window, &pool_nodes, &mut commands);
+        let count = spares.iter().filter(|spare| spare.url == page.url).count();
+        for _ in count..page.pool_size {
+            if !budget.take() {
+                return;
+            }
+            let webview = commands
+                .spawn(crate::cef::Browser::new_with_title(
+                    &mut meshes,
+                    &mut webview_mt,
+                    page.url,
+                    page.title,
+                ))
+                .id();
+            commands
+                .entity(webview)
+                .insert((WarmPageSpare { url: page.url }, ChildOf(node)));
+        }
+    }
+}
+
+fn handle_warm_page_open<M: WarmPage>(
+    tasks: Query<(Entity, &PageOpenTask), PendingPageOpen>,
+    spares: Query<(Entity, &WarmPageSpare), With<PageReady>>,
+    children_q: Query<&Children>,
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
+) {
+    let mut available: Vec<Entity> = spares
+        .iter()
+        .filter_map(|(entity, spare)| (spare.url == M::URL).then_some(entity))
+        .collect();
+    let mut handled_stacks = HashSet::new();
+
+    for (entity, task) in &tasks {
+        if task.url != M::URL {
+            continue;
+        }
+        if handled_stacks.insert(task.stack) {
+            clear_stack_children(task.stack, &children_q, &mut commands);
+            commands.entity(task.stack).insert(PageMetadata {
+                url: M::URL.to_string(),
+                title: M::TITLE.to_string(),
+                ..default()
+            });
+            if let Some(spare) = available.pop() {
+                commands
+                    .entity(spare)
+                    .insert((ChildOf(task.stack), CefKeyboardTarget))
+                    .remove::<WarmPageSpare>();
+            } else {
+                let page = M::spawn(&mut commands, &mut meshes, &mut webview_mt);
+                commands
+                    .entity(page)
+                    .insert((ChildOf(task.stack), CefKeyboardTarget));
+            }
+        }
+        commands.entity(entity).insert(PageOpenHandled);
+    }
+}
+
+fn maintain_warm_page_pool<M: WarmPage>(
+    pool_nodes: Query<(Entity, &WarmPagePoolNode)>,
+    vmux_window: Query<Entity, With<VmuxWindow>>,
+    layout_ready: Query<(), (With<LayoutCef>, With<PageReady>)>,
+    spares: Query<&WarmPageSpare>,
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
+    mut budget: ResMut<WarmPageSpawnBudget>,
+) {
+    if layout_ready.is_empty() || M::POOL_SIZE == 0 {
+        return;
+    }
+    let Ok(window) = vmux_window.single() else {
+        return;
+    };
+    let node = pool_node_for(M::URL, window, &pool_nodes, &mut commands);
+    let count = spares.iter().filter(|spare| spare.url == M::URL).count();
+    for _ in count..M::POOL_SIZE {
+        if !budget.take() {
+            return;
+        }
+        let page = M::spawn(&mut commands, &mut meshes, &mut webview_mt);
+        commands
+            .entity(page)
+            .insert((WarmPageSpare { url: M::URL }, ChildOf(node)));
+    }
+}
+
+fn pool_node_for(
+    url: &'static str,
+    window: Entity,
+    pool_nodes: &Query<(Entity, &WarmPagePoolNode)>,
+    commands: &mut Commands,
+) -> Entity {
+    pool_nodes
+        .iter()
+        .find_map(|(entity, node)| (node.url == url).then_some(entity))
+        .unwrap_or_else(|| {
+            commands
+                .spawn((
+                    WarmPagePoolNode { url },
+                    Node {
+                        width: Val::Px(0.0),
+                        height: Val::Px(0.0),
+                        position_type: PositionType::Absolute,
+                        ..default()
+                    },
+                    Visibility::Hidden,
+                    ChildOf(window),
+                ))
+                .id()
+        })
+}
+
+fn clear_stack_children(stack: Entity, children_q: &Query<&Children>, commands: &mut Commands) {
+    if let Ok(children) = children_q.get(stack) {
+        for child in children.iter() {
+            commands.entity(child).try_despawn();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vmux_core::{PageOpenId, PageOpenTask};
+
+    use crate::cef::Browser;
+
+    #[derive(Component)]
+    struct TestPage;
+
+    impl WarmPage for TestPage {
+        const HOST: &'static str = "test";
+        const URL: &'static str = "vmux://test/";
+        const TITLE: &'static str = "Test";
+
+        fn spawn(
+            commands: &mut Commands,
+            meshes: &mut ResMut<Assets<Mesh>>,
+            webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
+        ) -> Entity {
+            commands
+                .spawn((
+                    TestPage,
+                    Browser::new_with_title(meshes, webview_mt, Self::URL, Self::TITLE),
+                ))
+                .id()
+        }
+    }
+
+    fn app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+            .add_systems(Update, handle_warm_page_open::<TestPage>);
+        app
+    }
+
+    fn task(stack: Entity) -> PageOpenTask {
+        PageOpenTask {
+            id: PageOpenId::new(),
+            stack,
+            url: TestPage::URL.to_string(),
+            request_id: None,
+        }
+    }
+
+    #[test]
+    fn ready_spare_is_reparented() {
+        let mut app = app();
+        let stack = app.world_mut().spawn_empty().id();
+        let spare = app
+            .world_mut()
+            .spawn((TestPage, WarmPageSpare { url: TestPage::URL }, PageReady {}))
+            .id();
+        let task = app.world_mut().spawn(task(stack)).id();
+
+        app.update();
+
+        assert_eq!(
+            app.world()
+                .get::<ChildOf>(spare)
+                .map(|child| child.parent()),
+            Some(stack)
+        );
+        assert!(app.world().get::<WarmPageSpare>(spare).is_none());
+        assert!(app.world().get::<CefKeyboardTarget>(spare).is_some());
+        assert!(app.world().get::<PageOpenHandled>(task).is_some());
+    }
+
+    #[test]
+    fn unready_spare_falls_back_to_cold_page() {
+        let mut app = app();
+        let stack = app.world_mut().spawn_empty().id();
+        let spare = app
+            .world_mut()
+            .spawn((TestPage, WarmPageSpare { url: TestPage::URL }))
+            .id();
+        app.world_mut().spawn(task(stack));
+
+        app.update();
+
+        assert!(app.world().get::<WarmPageSpare>(spare).is_some());
+        let pages = app
+            .world_mut()
+            .query_filtered::<Entity, (With<TestPage>, With<ChildOf>)>()
+            .iter(app.world())
+            .count();
+        assert_eq!(pages, 1);
+    }
+
+    #[test]
+    fn pool_waits_for_layout_then_fills() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+            .init_resource::<WarmPageSpawnBudget>()
+            .add_systems(Update, maintain_warm_page_pool::<TestPage>);
+        app.world_mut().spawn(VmuxWindow);
+
+        app.update();
+        assert_eq!(
+            app.world_mut()
+                .query_filtered::<(), With<WarmPageSpare>>()
+                .iter(app.world())
+                .count(),
+            0
+        );
+
+        app.world_mut().spawn((LayoutCef, PageReady {}));
+        app.update();
+        assert_eq!(
+            app.world_mut()
+                .query_filtered::<(), With<WarmPageSpare>>()
+                .iter(app.world())
+                .count(),
+            TestPage::POOL_SIZE
+        );
+    }
+
+    #[test]
+    fn registered_page_claims_ready_spare() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+            .add_systems(Update, handle_registered_page_open);
+        app.world_mut().spawn(PrewarmPage {
+            host: "history",
+            url: "vmux://history/",
+            title: "History",
+            pool_size: 1,
+        });
+        let stack = app.world_mut().spawn_empty().id();
+        let spare = app
+            .world_mut()
+            .spawn((
+                WarmPageSpare {
+                    url: "vmux://history/",
+                },
+                PageReady {},
+            ))
+            .id();
+        let task = app
+            .world_mut()
+            .spawn(PageOpenTask {
+                id: PageOpenId::new(),
+                stack,
+                url: "vmux://history/".to_string(),
+                request_id: None,
+            })
+            .id();
+
+        app.update();
+
+        assert_eq!(
+            app.world()
+                .get::<ChildOf>(spare)
+                .map(|child| child.parent()),
+            Some(stack)
+        );
+        assert!(app.world().get::<WarmPageSpare>(spare).is_none());
+        assert!(app.world().get::<PageOpenHandled>(task).is_some());
+    }
+
+    #[test]
+    fn registered_pools_fill_for_every_page() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+            .init_resource::<WarmPageSpawnBudget>()
+            .add_systems(Update, maintain_registered_page_pools);
+        app.world_mut().spawn(VmuxWindow);
+        app.world_mut().spawn((LayoutCef, PageReady {}));
+        for (host, title) in [("history", "History"), ("lsp", "Language Servers")] {
+            app.world_mut().spawn(PrewarmPage {
+                host,
+                url: if host == "history" {
+                    "vmux://history/"
+                } else {
+                    "vmux://lsp/"
+                },
+                title,
+                pool_size: 1,
+            });
+        }
+
+        app.update();
+        app.world_mut().resource_mut::<WarmPageSpawnBudget>().0 = 1;
+        app.update();
+
+        assert_eq!(
+            app.world_mut()
+                .query_filtered::<(), With<WarmPageSpare>>()
+                .iter(app.world())
+                .count(),
+            2
+        );
+    }
+}

--- a/crates/vmux_setting/src/plugin.rs
+++ b/crates/vmux_setting/src/plugin.rs
@@ -2,8 +2,10 @@ pub mod runtime;
 pub mod view;
 
 use bevy::{ecs::message::MessageReader, prelude::*};
-use bevy_cef::prelude::{BinEventEmitterPlugin, WebviewExtendStandardMaterial};
+use bevy_cef::prelude::BinEventEmitterPlugin;
 use vmux_command::{ReadAppCommands, WriteAppCommands};
+use vmux_core::{PageOpenRequest, PageOpenTarget};
+use vmux_layout::warm_page::WarmPagePlugin;
 
 use crate::event::{
     CheckForUpdatesEvent, CheckForUpdatesRequest, CurrentUpdateCheckStatus, SettingsCommandEvent,
@@ -15,8 +17,8 @@ use runtime::{
 };
 use view::{
     broadcast_schema_to_views, broadcast_settings_to_views, broadcast_update_status_to_views,
-    handle_open_settings_command, handle_settings_page_open, on_check_for_updates,
-    on_settings_command, reset_sent_markers_on_page_ready,
+    handle_open_settings_command, on_check_for_updates, on_settings_command,
+    reset_sent_markers_on_page_ready,
 };
 
 /// Wires settings: RON load/save with debounce, schema and settings broadcasts, and the
@@ -62,10 +64,7 @@ impl Plugin for SettingsPlugin {
             )
             .add_message::<vmux_core::page::SettingsPageSpawnRequest>()
             .add_systems(Update, respond_settings_spawn.in_set(ReadAppCommands))
-            .add_systems(
-                Update,
-                handle_settings_page_open.in_set(vmux_core::PageOpenSet::HandleKnownPages),
-            )
+            .add_plugins(WarmPagePlugin::<view::Settings>::default())
             .add_plugins(BinEventEmitterPlugin::<(
                 SettingsCommandEvent,
                 CheckForUpdatesEvent,
@@ -92,14 +91,13 @@ impl Plugin for SettingsPlugin {
 
 fn respond_settings_spawn(
     mut reader: MessageReader<vmux_core::page::SettingsPageSpawnRequest>,
-    mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
+    mut page_open: MessageWriter<PageOpenRequest>,
 ) {
     for req in reader.read() {
-        let entity = commands
-            .spawn(view::Settings::new(&mut meshes, &mut webview_mt))
-            .id();
-        commands.entity(entity).insert(ChildOf(req.target_stack));
+        page_open.write(PageOpenRequest {
+            target: PageOpenTarget::Stack(req.target_stack),
+            url: crate::event::SETTINGS_PAGE_URL.to_string(),
+            request_id: None,
+        });
     }
 }

--- a/crates/vmux_setting/src/plugin/view.rs
+++ b/crates/vmux_setting/src/plugin/view.rs
@@ -2,12 +2,12 @@ use bevy::{picking::Pickable, prelude::*};
 use bevy_cef::prelude::*;
 use vmux_command::command::{AppCommand, LayoutCommand, WindowCommand};
 use vmux_core::page::PageReady;
-use vmux_core::{PageMetadata, PageOpenError, PageOpenHandled, PageOpenTask};
-use vmux_history::{CreatedAt, LastActivatedAt};
+use vmux_core::{PageMetadata, PageOpenRequest, PageOpenTarget};
 use vmux_layout::{
     Browser,
     pane::{Pane, PaneSplit},
-    stack::{FocusedStack, stack_bundle},
+    stack::FocusedStack,
+    warm_page::WarmPage,
 };
 
 use crate::event::{
@@ -63,40 +63,17 @@ impl Settings {
     }
 }
 
-/// Spawn the settings webview (with its [`Settings`] marker) when a `vmux://settings/`
-/// page is opened by URL, so the backend settings broadcasts target it. Without this,
-/// in-place navigation would reuse a markerless webview that never receives settings.
-pub(crate) fn handle_settings_page_open(
-    tasks: Query<(Entity, &PageOpenTask), (Without<PageOpenHandled>, Without<PageOpenError>)>,
-    children_q: Query<&Children>,
-    mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
-) {
-    let mut handled_stacks = std::collections::HashSet::new();
-    for (entity, task) in &tasks {
-        if task.url != SETTINGS_PAGE_URL {
-            continue;
-        }
-        if !handled_stacks.insert(task.stack) {
-            commands.entity(entity).insert(PageOpenHandled);
-            continue;
-        }
-        if let Ok(children) = children_q.get(task.stack) {
-            for child in children.iter() {
-                commands.entity(child).try_despawn();
-            }
-        }
-        commands.entity(task.stack).insert(PageMetadata {
-            title: "Settings".to_string(),
-            url: SETTINGS_PAGE_URL.to_string(),
-            ..default()
-        });
-        commands.spawn((
-            Settings::new(&mut meshes, &mut webview_mt),
-            ChildOf(task.stack),
-        ));
-        commands.entity(entity).insert(PageOpenHandled);
+impl WarmPage for Settings {
+    const HOST: &'static str = "settings";
+    const URL: &'static str = SETTINGS_PAGE_URL;
+    const TITLE: &'static str = "Settings";
+
+    fn spawn(
+        commands: &mut Commands,
+        meshes: &mut ResMut<Assets<Mesh>>,
+        webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
+    ) -> Entity {
+        commands.spawn(Settings::new(meshes, webview_mt)).id()
     }
 }
 
@@ -258,9 +235,7 @@ pub(crate) fn handle_open_settings_command(
     mut reader: MessageReader<AppCommand>,
     focus: Option<Res<FocusedStack>>,
     panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
-    mut commands: Commands,
+    mut page_open: MessageWriter<PageOpenRequest>,
 ) {
     for cmd in reader.read() {
         if !matches!(
@@ -275,20 +250,11 @@ pub(crate) fn handle_open_settings_command(
         let Some(pane) = focus.pane.filter(|p| panes.contains(*p)) else {
             continue;
         };
-        let tab = commands
-            .spawn((
-                stack_bundle(),
-                LastActivatedAt::now(),
-                CreatedAt::now(),
-                ChildOf(pane),
-            ))
-            .id();
-        commands.entity(tab).insert(PageMetadata {
+        page_open.write(PageOpenRequest {
+            target: PageOpenTarget::NewStackInPane(pane),
             url: SETTINGS_PAGE_URL.to_string(),
-            title: "Settings".to_string(),
-            ..default()
+            request_id: None,
         });
-        commands.spawn((Settings::new(&mut meshes, &mut webview_mt), ChildOf(tab)));
     }
 }
 
@@ -567,7 +533,8 @@ mod agent_schema_tests {
 #[cfg(test)]
 mod page_open_tests {
     use super::*;
-    use vmux_core::PageOpenId;
+    use vmux_core::{PageOpenHandled, PageOpenId, PageOpenTask};
+    use vmux_layout::warm_page::WarmPagePlugin;
 
     #[test]
     fn settings_page_open_spawns_marker_and_handles() {
@@ -575,7 +542,7 @@ mod page_open_tests {
         app.add_plugins(MinimalPlugins)
             .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
-            .add_systems(Update, handle_settings_page_open);
+            .add_plugins(WarmPagePlugin::<Settings>::default());
         let stack = app.world_mut().spawn_empty().id();
         let claimed = app
             .world_mut()
@@ -608,7 +575,7 @@ mod page_open_tests {
         app.add_plugins(MinimalPlugins)
             .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
-            .add_systems(Update, handle_settings_page_open);
+            .add_plugins(WarmPagePlugin::<Settings>::default());
         let stack = app.world_mut().spawn_empty().id();
         for _ in 0..2 {
             app.world_mut().spawn(PageOpenTask {

--- a/crates/vmux_space/src/plugin.rs
+++ b/crates/vmux_space/src/plugin.rs
@@ -4,11 +4,9 @@ use bevy::{ecs::message::MessageReader, prelude::*, window::PrimaryWindow};
 use bevy_cef::prelude::*;
 use vmux_core::page::PageReady;
 use vmux_core::profile;
-use vmux_core::{
-    PageMetadata, PageOpenError, PageOpenHandled, PageOpenRequest, PageOpenSet, PageOpenTarget,
-    PageOpenTask,
-};
+use vmux_core::{PageMetadata, PageOpenRequest, PageOpenTarget};
 use vmux_layout::stack::Stack;
+use vmux_layout::warm_page::WarmPagePlugin;
 use vmux_layout::{TabLayoutSpawnContent, TabLayoutSpawnRequest};
 
 use crate::event::{
@@ -73,10 +71,7 @@ impl Plugin for SpacePlugin {
                 Update,
                 respond_spaces_spawn.in_set(vmux_command::ReadAppCommands),
             )
-            .add_systems(
-                Update,
-                handle_spaces_page_open.in_set(PageOpenSet::HandleKnownPages),
-            )
+            .add_plugins(WarmPagePlugin::<Spaces>::default())
             .add_plugins(BinEventEmitterPlugin::<(SpaceCommandEvent,)>::for_hosts(&[
                 "spaces", "layout",
             ]))
@@ -154,42 +149,6 @@ fn update_effective_startup_dir(
     let next = (entity, vmux_setting::resolve_startup_dir(&settings, &id.0));
     if effective.0.as_ref() != Some(&next) {
         effective.0 = Some(next);
-    }
-}
-
-type PendingPageOpen = (Without<PageOpenHandled>, Without<PageOpenError>);
-
-fn handle_spaces_page_open(
-    tasks: Query<(Entity, &PageOpenTask), PendingPageOpen>,
-    children_q: Query<&Children>,
-    mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
-) {
-    for (entity, task) in &tasks {
-        if task.url != SPACES_PAGE_URL {
-            continue;
-        }
-        clear_stack_children(task.stack, &children_q, &mut commands);
-        commands.entity(task.stack).insert(PageMetadata {
-            title: "Spaces".to_string(),
-            url: SPACES_PAGE_URL.to_string(),
-            icon: vmux_core::PageIcon::None,
-            bg_color: None,
-        });
-        commands.spawn((
-            Spaces::new(&mut meshes, &mut webview_mt),
-            ChildOf(task.stack),
-        ));
-        commands.entity(entity).insert(PageOpenHandled);
-    }
-}
-
-fn clear_stack_children(stack: Entity, children_q: &Query<&Children>, commands: &mut Commands) {
-    if let Ok(children) = children_q.get(stack) {
-        for child in children.iter() {
-            commands.entity(child).try_despawn();
-        }
     }
 }
 
@@ -696,15 +655,14 @@ fn handle_open_in_new_space(
 
 fn respond_spaces_spawn(
     mut reader: MessageReader<vmux_core::page::SpacesPageSpawnRequest>,
-    mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
+    mut page_open: MessageWriter<PageOpenRequest>,
 ) {
     for req in reader.read() {
-        let entity = commands
-            .spawn(crate::spaces::Spaces::new(&mut meshes, &mut webview_mt))
-            .id();
-        commands.entity(entity).insert(ChildOf(req.target_stack));
+        page_open.write(PageOpenRequest {
+            target: PageOpenTarget::Stack(req.target_stack),
+            url: SPACES_PAGE_URL.to_string(),
+            request_id: None,
+        });
     }
 }
 

--- a/crates/vmux_space/src/spaces.rs
+++ b/crates/vmux_space/src/spaces.rs
@@ -2,6 +2,7 @@ use bevy::{picking::Pickable, prelude::*};
 use bevy_cef::prelude::*;
 use vmux_core::PageMetadata;
 use vmux_layout::cef::Browser;
+use vmux_layout::warm_page::WarmPage;
 
 use crate::event::SPACES_PAGE_URL;
 use crate::model::SpaceRecord;
@@ -64,6 +65,20 @@ impl Spaces {
                 Pickable::default(),
             ),
         )
+    }
+}
+
+impl WarmPage for Spaces {
+    const HOST: &'static str = "spaces";
+    const URL: &'static str = SPACES_PAGE_URL;
+    const TITLE: &'static str = "Spaces";
+
+    fn spawn(
+        commands: &mut Commands,
+        meshes: &mut ResMut<Assets<Mesh>>,
+        webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
+    ) -> Entity {
+        commands.spawn(Spaces::new(meshes, webview_mt)).id()
     }
 }
 

--- a/crates/vmux_team/src/plugin.rs
+++ b/crates/vmux_team/src/plugin.rs
@@ -9,15 +9,33 @@ use vmux_core::event::team::{
 };
 use vmux_core::page::PageReady;
 use vmux_core::team::{Agent, Profile, User};
-use vmux_core::{
-    PageMetadata, PageOpenError, PageOpenHandled, PageOpenSet, PageOpenTask, focus_pane_entity,
-};
+use vmux_core::{PageMetadata, focus_pane_entity};
 use vmux_layout::cef::LayoutCef;
 use vmux_layout::space::{ActiveSpaceEntity, Space, space_of};
 use vmux_layout::stack::Stack;
+use vmux_layout::warm_page::{WarmPage, WarmPagePlugin};
 
 #[derive(Component)]
 struct Team;
+
+impl WarmPage for Team {
+    const HOST: &'static str = "team";
+    const URL: &'static str = TEAM_PAGE_URL;
+    const TITLE: &'static str = "Team";
+
+    fn spawn(
+        commands: &mut Commands,
+        meshes: &mut ResMut<Assets<Mesh>>,
+        webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
+    ) -> Entity {
+        commands
+            .spawn((
+                vmux_layout::Browser::new_with_title(meshes, webview_mt, Self::URL, Self::TITLE),
+                Team,
+            ))
+            .id()
+    }
+}
 
 #[derive(Component)]
 struct TeamListSent;
@@ -32,10 +50,7 @@ impl Plugin for TeamPlugin {
         vmux_core::register_host_spawn(app, "team");
         app.add_systems(Startup, spawn_user_profile)
             .add_systems(Update, (sync_user_profile_name, emit_team).chain())
-            .add_systems(
-                Update,
-                handle_team_page_open.in_set(PageOpenSet::HandleKnownPages),
-            )
+            .add_plugins(WarmPagePlugin::<Team>::default())
             .add_plugins(BinEventEmitterPlugin::<(TeamCommandEvent,)>::for_hosts(&[
                 "team", "layout",
             ]))
@@ -261,42 +276,6 @@ fn emit_team(
     }
 }
 
-fn handle_team_page_open(
-    tasks: Query<(Entity, &PageOpenTask), (Without<PageOpenHandled>, Without<PageOpenError>)>,
-    children_q: Query<&Children>,
-    mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
-) {
-    for (entity, task) in &tasks {
-        if task.url != TEAM_PAGE_URL {
-            continue;
-        }
-        if let Ok(children) = children_q.get(task.stack) {
-            for child in children.iter() {
-                commands.entity(child).try_despawn();
-            }
-        }
-        commands.entity(task.stack).insert(PageMetadata {
-            title: "Team".to_string(),
-            url: TEAM_PAGE_URL.to_string(),
-            bg_color: None,
-            ..default()
-        });
-        commands.spawn((
-            vmux_layout::Browser::new_with_title(
-                &mut meshes,
-                &mut webview_mt,
-                TEAM_PAGE_URL,
-                "Team",
-            ),
-            Team,
-            ChildOf(task.stack),
-        ));
-        commands.entity(entity).insert(PageOpenHandled);
-    }
-}
-
 fn reset_team_sent_on_page_ready(
     trigger: On<BinReceive<PageReady>>,
     team_views: Query<(), With<Team>>,
@@ -458,12 +437,12 @@ mod tests {
 
     #[test]
     fn team_page_open_titles_webview_team() {
-        use vmux_core::page_open::PageOpenId;
+        use vmux_core::page_open::{PageOpenId, PageOpenTask};
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
-            .add_systems(Update, handle_team_page_open);
+            .add_plugins(WarmPagePlugin::<Team>::default());
 
         let stack = app.world_mut().spawn(Stack::default()).id();
         app.world_mut().spawn(PageOpenTask {

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -20,7 +20,8 @@ use vmux_command::{
 use vmux_core::page::PageReady;
 use vmux_core::terminal::{ProcessesMonitorSpawnRequest, TerminalSpawnRequest};
 use vmux_core::{
-    OscTitle, PageMetadata, PageOpenError, PageOpenHandled, PageOpenSet, PageOpenTask,
+    OscTitle, PageMetadata, PageOpenError, PageOpenHandled, PageOpenRequest, PageOpenSet,
+    PageOpenTarget, PageOpenTask,
 };
 use vmux_history::LastActivatedAt;
 use vmux_layout::Browser;
@@ -33,7 +34,6 @@ use vmux_setting::{AppSettings, SettingsSaveRequest};
 
 use crate::event::*;
 use crate::pid::{self, Pid};
-use crate::processes_monitor::ProcessesMonitor;
 use crate::{ProcessExited, RetainOnProcessExit, Terminal};
 
 const MULTI_CLICK_WINDOW: std::time::Duration = std::time::Duration::from_millis(300);
@@ -552,19 +552,6 @@ fn handle_terminal_page_open(
                     commands.entity(entity).insert(PageOpenError { message });
                 }
             }
-        } else if task.url.starts_with(vmux_layout::event::SERVICES_PAGE_URL) {
-            clear_stack_children(task.stack, &children_q, &mut commands);
-            commands.entity(task.stack).insert(PageMetadata {
-                url: vmux_layout::event::SERVICES_PAGE_URL.to_string(),
-                title: "Background Services".to_string(),
-                bg_color: Some(vmux_layout::event::TERMINAL_CEF_BG_COLOR.to_string()),
-                ..default()
-            });
-            commands.spawn((
-                ProcessesMonitor::new(&mut meshes, &mut webview_mt),
-                ChildOf(task.stack),
-            ));
-            commands.entity(entity).insert(PageOpenHandled);
         }
     }
 }
@@ -671,18 +658,14 @@ fn respond_terminal_spawn(
 
 fn respond_processes_monitor_spawn(
     mut reader: MessageReader<ProcessesMonitorSpawnRequest>,
-    mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
+    mut page_open: MessageWriter<PageOpenRequest>,
 ) {
     for req in reader.read() {
-        let entity = commands
-            .spawn(crate::processes_monitor::ProcessesMonitor::new(
-                &mut meshes,
-                &mut webview_mt,
-            ))
-            .id();
-        commands.entity(entity).insert(ChildOf(req.target_stack));
+        page_open.write(PageOpenRequest {
+            target: PageOpenTarget::Stack(req.target_stack),
+            url: vmux_layout::event::SERVICES_PAGE_URL.to_string(),
+            request_id: None,
+        });
     }
 }
 

--- a/crates/vmux_terminal/src/processes_monitor.rs
+++ b/crates/vmux_terminal/src/processes_monitor.rs
@@ -15,6 +15,7 @@ use vmux_layout::{
     event::SERVICES_PAGE_URL,
     pane::{Pane, PaneSplit},
     stack::{ActiveTabParam, Stack, focused_stack, stack_bundle},
+    warm_page::{WarmPage, WarmPagePlugin, WarmPageSpare},
 };
 
 #[derive(Component)]
@@ -59,6 +60,22 @@ impl ProcessesMonitor {
                 Pickable::default(),
             ),
         )
+    }
+}
+
+impl WarmPage for ProcessesMonitor {
+    const HOST: &'static str = "services";
+    const URL: &'static str = SERVICES_PAGE_URL;
+    const TITLE: &'static str = "Background Services";
+
+    fn spawn(
+        commands: &mut Commands,
+        meshes: &mut ResMut<Assets<Mesh>>,
+        webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
+    ) -> Entity {
+        commands
+            .spawn(ProcessesMonitor::new(meshes, webview_mt))
+            .id()
     }
 }
 
@@ -153,7 +170,8 @@ impl Plugin for ProcessesMonitorPlugin {
             )
             .add_observer(on_process_navigate)
             .add_observer(on_process_kill)
-            .add_observer(on_process_kill_all);
+            .add_observer(on_process_kill_all)
+            .add_plugins(WarmPagePlugin::<ProcessesMonitor>::default());
     }
 }
 
@@ -162,13 +180,14 @@ fn request_process_list(
     time: Res<Time>,
     mut timer: ResMut<ProcessesPollTimer>,
     service: Option<Res<ServiceClient>>,
-    monitors: Query<(), With<ProcessesMonitor>>,
+    monitors: Query<(), (With<ProcessesMonitor>, Without<WarmPageSpare>)>,
+    claimed: Query<(), (With<ProcessesMonitor>, Added<CefKeyboardTarget>)>,
 ) {
     if monitors.is_empty() {
         return;
     }
     timer.0.tick(time.delta());
-    if timer.0.just_finished()
+    if (!claimed.is_empty() || timer.0.just_finished())
         && let Some(service) = service
     {
         service.0.send(ClientMessage::ListProcesses);
@@ -178,7 +197,8 @@ fn request_process_list(
 fn sample_process_usage(
     time: Res<Time>,
     mut timer: ResMut<SysinfoPollTimer>,
-    monitors: Query<(), With<ProcessesMonitor>>,
+    monitors: Query<(), (With<ProcessesMonitor>, Without<WarmPageSpare>)>,
+    claimed: Query<(), (With<ProcessesMonitor>, Added<CefKeyboardTarget>)>,
     process_list: Res<ServiceProcessList>,
     mut sys: ResMut<SysinfoState>,
     mut usage: ResMut<ProcessUsage>,
@@ -187,7 +207,7 @@ fn sample_process_usage(
         return;
     }
     timer.0.tick(time.delta());
-    if !timer.0.just_finished() {
+    if claimed.is_empty() && !timer.0.just_finished() {
         return;
     }
 
@@ -248,12 +268,22 @@ fn broadcast_to_monitors(
     process_list: Res<ServiceProcessList>,
     usage: Res<ProcessUsage>,
     service: Option<Res<ServiceClient>>,
-    monitors: Query<Entity, (With<ProcessesMonitor>, With<PageReady>)>,
+    monitors: Query<
+        Entity,
+        (
+            With<ProcessesMonitor>,
+            With<PageReady>,
+            Without<WarmPageSpare>,
+        ),
+    >,
+    claimed: Query<(), (With<ProcessesMonitor>, Added<CefKeyboardTarget>)>,
     browsers: NonSend<Browsers>,
     terminal_pids: Query<&ProcessId, With<Terminal>>,
     mut commands: Commands,
 ) {
-    if monitors.is_empty() || !(process_list.is_changed() || usage.is_changed()) {
+    if monitors.is_empty()
+        || !(process_list.is_changed() || usage.is_changed() || !claimed.is_empty())
+    {
         return;
     }
 


### PR DESCRIPTION
## Context
Static `vmux://` pages currently pay browser creation and WASM startup cost on first open. Keeping ready pages parked after shell startup makes Settings, Spaces, History, and other manager pages appear immediately.

## Implementation
Adds a shared hidden warm-page pool that only claims fully mounted webviews and replenishes at one page per frame. Static standard pages register declaratively; marker-backed pages retain their typed host integration, and the Services monitor remains idle while parked. Dynamic terminal, agent, file, error, and debug pages remain cold because their content is instance-specific or internal.

## Checks / QA
- Launch vmux and open Settings, Extensions, History, Language Servers, Spaces, Team, Agents, and Services from the command bar.
- Confirm each page paints immediately with current host-provided data.
- Confirm parked Services does not create visible process-monitor activity or elevated idle CPU.