### PR TITLE
fix(start): do not prompt on agent name matches

### DIFF
--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -5,8 +5,8 @@ use crate::command_bar::keyboard::{
     ignore_physical_rerouted_ctrl_keydown, utf16_offset_to_byte,
 };
 use crate::command_bar::results::{
-    CommandBarResultItem as ResultItem, active_space_index, agent_page_url, filter_results,
-    space_switch_results, start_page_results,
+    CommandBarResultItem as ResultItem, active_space_index, agent_page_matches_query,
+    agent_page_url, filter_results, space_switch_results, start_page_results,
 };
 use crate::command_bar::style::{
     command_bar_input_class, command_bar_input_row_class, command_bar_input_wrap_class,
@@ -293,7 +293,11 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
             && let Some(agent_url) = agent_page_url(item)
         {
             on_close.call(());
-            emit_prompt_action(prompt.trim(), open_target, agent_url);
+            if agent_page_matches_query(item, &prompt) {
+                emit_action_with_target("open", agent_url, open_target);
+            } else {
+                emit_prompt_action(prompt.trim(), open_target, agent_url);
+            }
             return;
         }
         on_close.call(());
@@ -638,7 +642,10 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                                     }
                                 }
                                 span { class: result_trailing_slot_class(),
-                                    if start_prompt_mode && agent_page_url(item).is_some() {
+                                    if start_prompt_mode
+                                        && agent_page_url(item).is_some()
+                                        && !agent_page_matches_query(item, &q)
+                                    {
                                         "Prompt"
                                     } else if shortcut.is_empty() {
                                         "New tab"

--- a/crates/vmux_layout/src/command_bar/results.rs
+++ b/crates/vmux_layout/src/command_bar/results.rs
@@ -155,6 +155,20 @@ pub fn agent_page_url(item: &CommandBarResultItem) -> Option<&str> {
     }
 }
 
+#[cfg(any(target_arch = "wasm32", test))]
+pub(crate) fn agent_page_matches_query(item: &CommandBarResultItem, query: &str) -> bool {
+    let CommandBarResultItem::Page { url, title, .. } = item else {
+        return false;
+    };
+    if !url.starts_with("vmux://agent/") {
+        return false;
+    }
+    let search_lower = query.trim().to_lowercase();
+    !search_lower.is_empty()
+        && (title.to_lowercase().contains(&search_lower)
+            || url.to_lowercase().contains(&search_lower))
+}
+
 pub fn start_page_results(pages: &[CommandBarPage], query: &str) -> Vec<CommandBarResultItem> {
     let search_lower = query.trim().to_lowercase();
     let mut results = agent_page_results(pages, query);
@@ -710,6 +724,26 @@ mod tests {
             &results[0],
             CommandBarResultItem::Page { url, .. } if url == "vmux://agent/vibe/"
         ));
+    }
+
+    #[test]
+    fn start_agent_name_match_is_not_a_prompt() {
+        let mut pages = sample_pages();
+        pages.push(CommandBarPage {
+            host: "agent".into(),
+            url: "vmux://agent/codex-acp".into(),
+            title: "Codex (ACP)".into(),
+            keywords: vec!["codex-acp".into(), "acp".into(), "agent".into()],
+            icon: vmux_core::PageIcon::None,
+            shortcut: String::new(),
+        });
+        let codex = agent_page_results(&pages, "cod").remove(0);
+
+        assert!(agent_page_matches_query(&codex, "cod"));
+        assert!(agent_page_matches_query(&codex, "codex"));
+        assert!(agent_page_matches_query(&codex, "Codex (ACP)"));
+        assert!(agent_page_matches_query(&codex, "codex-acp"));
+        assert!(!agent_page_matches_query(&codex, "fix the failing test"));
     }
 
     #[test]


### PR DESCRIPTION
## Context
The start launcher treats plain text as a prompt. Typing a full or partial agent name such as cod and selecting Codex (ACP) incorrectly sends that search text as the first chat message.

## Implementation
Agent selections now distinguish launcher-query matches from real prompt text using the selected agent title and URL. Matching queries open an empty chat; unrelated text still starts the selected agent with that prompt. The result row label follows the same decision.

## Checks / QA
- On the start page, type cod and select Codex (ACP); verify the chat opens without an initial message.
- Type fix the failing test and select Codex (ACP); verify it is sent as the first prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved command palette behavior for agent pages: matching agent names now opens the page directly, while other text can be sent as a prompt.
  * Updated result indicators to more accurately distinguish page matches from prompt actions.

* **Bug Fixes**
  * Fixed agent-name query matching, including partial and variant names, while preventing unrelated prompt text from being treated as a page match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->