### PR TITLE
fix(agent): follow ACP edits and prepare workspaces

### DIFF
--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -20,8 +20,8 @@ use crate::events::{AgentApprovalReply, AgentApprovalRequest, ApprovalDecision};
 use crate::handoff::{ImportedConversation, PendingHandoff};
 use crate::run_state::AgentRunState;
 
-const UNBOUND_WORKSPACE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): This tab has no selected workspace. If the user's request requires inspecting, searching, editing, testing, or running an existing project, your first project action must be to call the vmux choose_workspace tool. Do not search the user's home directory for repositories, do not access project paths directly, and never run git worktree add yourself. General questions and self-contained terminal demonstrations may run in the temporary current directory. After a Git folder is selected, use a branch already named by the user; if none was named, ask the user which branch to create, then call the vmux create_worktree tool with that exact branch before touching project files.";
-const PENDING_WORKTREE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): The user selected a Git project, but this tab has no worktree yet. Do not access the project path directly and never run git worktree add yourself. Use a branch already named by the user; if none was named, ask which branch to create. Then call the vmux create_worktree tool with that exact branch before inspecting, editing, testing, or running the project.";
+const UNBOUND_WORKSPACE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): This tab has no selected workspace. If the user's request requires inspecting, searching, editing, testing, or running an existing project, your first project action must be to call the vmux choose_workspace tool. Do not search the user's home directory for repositories, do not access project paths directly, and never run git worktree add yourself. General questions and self-contained terminal demonstrations may run in the temporary current directory. vmux uses a selected linked worktree directly and creates an isolated managed worktree when the user selects a normal Git checkout.";
+const PENDING_WORKTREE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): Workspace activation is pending. Do not access project paths directly or run git worktree add yourself. Wait for vmux to finish preparing the selected workspace before inspecting, editing, testing, or running the project.";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum AcpWorkspaceState {
@@ -1000,11 +1000,12 @@ mod tests {
         assert!(context.contains("choose_workspace"));
         assert!(context.contains("Do not search the user's home directory"));
         assert!(context.contains("never run git worktree add"));
-        assert!(context.contains("create_worktree"));
+        assert!(context.contains("selected linked worktree directly"));
+        assert!(context.contains("creates an isolated managed worktree"));
     }
 
     #[test]
-    fn pending_worktree_context_requires_branch_and_managed_creation() {
+    fn pending_worktree_context_requires_waiting_for_activation() {
         let context = acp_prompt_context(
             Some("prior conversation".into()),
             Some(AcpWorkspaceState::PendingWorktree),
@@ -1012,8 +1013,8 @@ mod tests {
         .unwrap();
 
         assert!(context.starts_with("prior conversation\n\n"));
-        assert!(context.contains("ask which branch to create"));
-        assert!(context.contains("create_worktree"));
+        assert!(context.contains("activation is pending"));
+        assert!(context.contains("Wait for vmux"));
         assert!(context.contains("before inspecting"));
     }
 

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -2456,8 +2456,15 @@ fn workspace_picker_task(
     proxy: Option<&bevy::winit::EventLoopProxyWrapper>,
 ) -> Task<Option<PathBuf>> {
     let wake = proxy.map(|proxy| (**proxy).clone());
+    let initial_dir = std::env::current_dir()
+        .ok()
+        .filter(|path| path.is_dir())
+        .or_else(|| std::env::var_os("HOME").map(PathBuf::from))
+        .filter(|path| path.is_dir())
+        .unwrap_or_else(|| PathBuf::from("/"));
     IoTaskPool::get().spawn(async move {
         let selected = rfd::AsyncFileDialog::new()
+            .set_directory(initial_dir)
             .pick_folder()
             .await
             .map(|handle| handle.path().to_path_buf());
@@ -2500,16 +2507,9 @@ fn bind_tab_workspace(tab: &mut vmux_layout::tab::Tab, project_dir: &Path, execu
     }
 }
 
-fn git_workspace_continuation(path: &Path, branch: &str) -> String {
+fn workspace_ready_continuation(path: &Path) -> String {
     format!(
-        "VMUX WORKSPACE SELECTION COMPLETED: The user selected Git project {}. Its current branch is {branch}. Continue the original user request in this same conversation. Do not inspect or modify the project directly yet. If the original request specified a branch, call create_worktree with that exact branch. Otherwise ask the user which new branch to create, then call create_worktree.",
-        path.display()
-    )
-}
-
-fn directory_workspace_continuation(path: &Path) -> String {
-    format!(
-        "VMUX WORKSPACE SELECTION COMPLETED: The user selected workspace {}. Continue the original user request in this same conversation using this directory.",
+        "VMUX WORKSPACE SELECTION COMPLETED: Workspace {} is ready. Continue the original user request in this same conversation using this directory.",
         path.display()
     )
 }
@@ -2570,6 +2570,85 @@ fn activate_agent_worktree(
     let rebind = ancestor_acp_stack(agent_entity, acp_sessions, child_of)
         .and_then(|stack| rebind_acp_workspace(stack, &execution_dir, acp_sessions, commands));
     Ok((execution_dir, rebind))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn activate_agent_directory(
+    tab_entity: Entity,
+    agent_entity: Entity,
+    project_dir: &Path,
+    execution_dir: &Path,
+    tabs: &mut Query<&mut vmux_layout::tab::Tab>,
+    acp_sessions: &mut Query<&mut crate::client::acp::AcpSession>,
+    child_of: &Query<&ChildOf>,
+    commands: &mut Commands,
+) -> Result<Option<ClientMessage>, String> {
+    {
+        let Ok(mut tab) = tabs.get_mut(tab_entity) else {
+            return Err("tab not found".to_string());
+        };
+        bind_tab_workspace(&mut tab, project_dir, execution_dir);
+    }
+    commands
+        .entity(tab_entity)
+        .insert((
+            vmux_layout::tab::TabWorkspace {
+                project_dir: project_dir.to_string_lossy().into_owned(),
+            },
+            vmux_layout::tab::TabDirDecided,
+        ))
+        .remove::<PendingAgentProject>()
+        .remove::<vmux_layout::tab::TabWorktree>()
+        .remove::<vmux_layout::worktree::TabWorktreeReady>()
+        .remove::<vmux_layout::tab::TabWorktreeUnavailable>();
+    Ok(ancestor_acp_stack(agent_entity, acp_sessions, child_of)
+        .and_then(|stack| rebind_acp_workspace(stack, execution_dir, acp_sessions, commands)))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn activate_selected_workspace(
+    tab_entity: Entity,
+    agent_entity: Entity,
+    selected: &Path,
+    managed_root: &Path,
+    tabs: &mut Query<&mut vmux_layout::tab::Tab>,
+    acp_sessions: &mut Query<&mut crate::client::acp::AcpSession>,
+    child_of: &Query<&ChildOf>,
+    commands: &mut Commands,
+) -> Result<(PathBuf, Option<ClientMessage>), String> {
+    if vmux_git::worktree::checkout_info(selected).is_ok()
+        && !vmux_git::worktree::is_linked_worktree(selected)
+    {
+        let name = tabs
+            .get(tab_entity)
+            .map(|tab| tab.name.clone())
+            .map_err(|_| "tab not found".to_string())?;
+        let slug_hint = vmux_layout::worktree::tab_worktree_slug_hint(&name, selected);
+        let activation =
+            vmux_layout::worktree::create_worktree_blocking(selected, &slug_hint, managed_root)?;
+        activate_agent_worktree(
+            tab_entity,
+            agent_entity,
+            selected,
+            activation,
+            tabs,
+            acp_sessions,
+            child_of,
+            commands,
+        )
+    } else {
+        let rebind = activate_agent_directory(
+            tab_entity,
+            agent_entity,
+            selected,
+            selected,
+            tabs,
+            acp_sessions,
+            child_of,
+            commands,
+        )?;
+        Ok((selected.to_path_buf(), rebind))
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -3230,12 +3309,14 @@ fn drain_workspace_picker_tasks(
     mut tabs: Query<&mut vmux_layout::tab::Tab>,
     mut acp_sessions: Query<&mut crate::client::acp::AcpSession>,
     child_of: Query<&ChildOf>,
+    managed_root: Option<Res<vmux_layout::worktree::ManagedWorktreeRoot>>,
     mut commands: Commands,
     service: Option<Res<ServiceClient>>,
 ) {
     let Some(service) = service else {
         return;
     };
+    let managed_root = managed_root.as_deref().cloned().unwrap_or_default().0;
     for (picker_entity, mut picker) in &mut pickers {
         let Some(selected) = future::block_on(future::poll_once(&mut picker.task)) else {
             continue;
@@ -3246,42 +3327,27 @@ fn drain_workspace_picker_tasks(
                 Ok(selected) if selected.is_dir() => {
                     if tabs.get(picker.tab_entity).is_err() {
                         failed_workspace_continuation("The workspace tab no longer exists")
-                    } else if let Ok(checkout) = vmux_git::worktree::checkout_info(&selected) {
-                        let branch = vmux_git::worktree::head_ref(&checkout.root)
-                            .unwrap_or_else(|_| "unknown".to_string());
-                        commands
-                            .entity(picker.tab_entity)
-                            .insert(PendingAgentProject(selected.clone()));
-                        git_workspace_continuation(&selected, &branch)
                     } else {
-                        if let Ok(mut tab) = tabs.get_mut(picker.tab_entity) {
-                            bind_tab_workspace(&mut tab, &selected, &selected);
+                        match activate_selected_workspace(
+                            picker.tab_entity,
+                            picker.agent_entity,
+                            &selected,
+                            &managed_root,
+                            &mut tabs,
+                            &mut acp_sessions,
+                            &child_of,
+                            &mut commands,
+                        ) {
+                            Ok((execution_dir, rebind)) => {
+                                if let Some(message) = rebind {
+                                    service.0.send(message);
+                                }
+                                workspace_ready_continuation(&execution_dir)
+                            }
+                            Err(error) => failed_workspace_continuation(&format!(
+                                "The selected workspace could not be prepared: {error}"
+                            )),
                         }
-                        let path = selected.to_string_lossy().into_owned();
-                        commands
-                            .entity(picker.tab_entity)
-                            .insert((
-                                vmux_layout::tab::TabWorkspace {
-                                    project_dir: path.clone(),
-                                },
-                                vmux_layout::tab::TabDirDecided,
-                            ))
-                            .remove::<PendingAgentProject>()
-                            .remove::<vmux_layout::tab::TabWorktree>()
-                            .remove::<vmux_layout::worktree::TabWorktreeReady>()
-                            .remove::<vmux_layout::tab::TabWorktreeUnavailable>();
-                        if let Some(stack) =
-                            ancestor_acp_stack(picker.agent_entity, &acp_sessions, &child_of)
-                            && let Some(message) = rebind_acp_workspace(
-                                stack,
-                                &selected,
-                                &mut acp_sessions,
-                                &mut commands,
-                            )
-                        {
-                            service.0.send(message);
-                        }
-                        directory_workspace_continuation(Path::new(&path))
                     }
                 }
                 Ok(_) => failed_workspace_continuation("The selected workspace is not a directory"),
@@ -4828,15 +4894,12 @@ mod tests {
 
     #[test]
     fn workspace_selection_continuations_resume_original_request() {
-        let git = git_workspace_continuation(Path::new("/repo/dashboard"), "main");
-        let directory = directory_workspace_continuation(Path::new("/tmp/project"));
+        let ready = workspace_ready_continuation(Path::new("/repo/dashboard"));
         let cancelled = failed_workspace_continuation("The user cancelled workspace selection");
 
-        assert!(git.contains("same conversation"));
-        assert!(git.contains("ask the user which new branch"));
-        assert!(git.contains("create_worktree"));
-        assert!(directory.contains("same conversation"));
-        assert!(directory.contains("/tmp/project"));
+        assert!(ready.contains("same conversation"));
+        assert!(ready.contains("Workspace /repo/dashboard is ready"));
+        assert!(!ready.contains("create_worktree"));
         assert!(cancelled.contains("Do not retry automatically"));
     }
 
@@ -5006,6 +5069,128 @@ mod tests {
             ClientMessage::RebindAcpWorkspace { sid, cwd }
                 if sid == "routing-session" && cwd == execution_dir.to_string_lossy()
         ));
+    }
+
+    #[test]
+    fn selected_workspace_reuses_linked_worktree_or_creates_managed_checkout() {
+        use bevy::ecs::system::RunSystemOnce;
+
+        let repo = init_worktree_test_repo();
+        let project_dir = repo.path().canonicalize().unwrap();
+        let external_root = tempfile::tempdir().unwrap();
+        let external = external_root.path().join("existing");
+        vmux_git::worktree::worktree_add(&project_dir, &external, "feature/existing", "main")
+            .unwrap();
+        let external = external.canonicalize().unwrap();
+        let managed_root = tempfile::tempdir().unwrap();
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+
+        let linked_tab = app
+            .world_mut()
+            .spawn(vmux_layout::tab::Tab {
+                name: "Existing".into(),
+                startup_dir: None,
+            })
+            .id();
+        let linked_agent = app.world_mut().spawn(ChildOf(linked_tab)).id();
+        let external_for_system = external.clone();
+        let managed_root_for_system = managed_root.path().to_path_buf();
+        let linked_execution = app
+            .world_mut()
+            .run_system_once(
+                move |mut tabs: Query<&mut vmux_layout::tab::Tab>,
+                      mut sessions: Query<&mut crate::client::acp::AcpSession>,
+                      child_of: Query<&ChildOf>,
+                      mut commands: Commands| {
+                    activate_selected_workspace(
+                        linked_tab,
+                        linked_agent,
+                        &external_for_system,
+                        &managed_root_for_system,
+                        &mut tabs,
+                        &mut sessions,
+                        &child_of,
+                        &mut commands,
+                    )
+                },
+            )
+            .unwrap()
+            .unwrap()
+            .0;
+
+        assert_eq!(linked_execution, external);
+        assert!(
+            app.world()
+                .get::<vmux_layout::tab::TabWorktree>(linked_tab)
+                .is_none()
+        );
+        assert_eq!(
+            app.world()
+                .get::<vmux_layout::tab::TabWorkspace>(linked_tab)
+                .unwrap()
+                .project_dir,
+            external.to_string_lossy()
+        );
+        assert_eq!(
+            vmux_git::worktree::worktree_list(&project_dir)
+                .unwrap()
+                .len(),
+            2
+        );
+
+        let managed_tab = app
+            .world_mut()
+            .spawn(vmux_layout::tab::Tab {
+                name: "Managed".into(),
+                startup_dir: None,
+            })
+            .id();
+        let managed_agent = app.world_mut().spawn(ChildOf(managed_tab)).id();
+        let project_for_system = project_dir.clone();
+        let managed_root_for_system = managed_root.path().to_path_buf();
+        let managed_execution = app
+            .world_mut()
+            .run_system_once(
+                move |mut tabs: Query<&mut vmux_layout::tab::Tab>,
+                      mut sessions: Query<&mut crate::client::acp::AcpSession>,
+                      child_of: Query<&ChildOf>,
+                      mut commands: Commands| {
+                    activate_selected_workspace(
+                        managed_tab,
+                        managed_agent,
+                        &project_for_system,
+                        &managed_root_for_system,
+                        &mut tabs,
+                        &mut sessions,
+                        &child_of,
+                        &mut commands,
+                    )
+                },
+            )
+            .unwrap()
+            .unwrap()
+            .0;
+
+        assert!(managed_execution.starts_with(managed_root.path().canonicalize().unwrap()));
+        assert!(
+            app.world()
+                .get::<vmux_layout::tab::TabWorktree>(managed_tab)
+                .is_some()
+        );
+        assert_eq!(
+            app.world()
+                .get::<vmux_layout::tab::TabWorkspace>(managed_tab)
+                .unwrap()
+                .project_dir,
+            project_dir.to_string_lossy()
+        );
+        assert_eq!(
+            vmux_git::worktree::worktree_list(&project_dir)
+                .unwrap()
+                .len(),
+            3
+        );
     }
 
     fn swap_test_app() -> App {
@@ -7746,6 +7931,7 @@ mod tests {
         assert!(selection.contains("session_entity"));
         assert!(selection.contains("picker_started"));
         assert!(task.contains("rfd::AsyncFileDialog::new()"));
+        assert!(task.contains(".set_directory(initial_dir)"));
         assert!(task.contains("IoTaskPool::get().spawn"));
         assert!(task.contains("WinitUserEvent::WakeUp"));
     }

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -444,7 +444,7 @@ is typed into an interactive shell, so the terminal stays usable afterwards."
 fn create_worktree_definition() -> ToolDefinition {
     ToolDefinition {
         name: "create_worktree".into(),
-        description: "Create vmux's isolated worktree for the project selected with choose_workspace. Never run git worktree add manually. The branch must come from the user; if they did not specify one, ask them in chat before calling this tool. Returns the absolute worktree path."
+        description: "Create vmux's isolated worktree on an exact user-specified branch for the current project. Use only when the user explicitly asks for that branch; normal workspace selection and automatic isolation are handled by choose_workspace. Never run git worktree add manually. Returns the absolute worktree path."
             .into(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -460,7 +460,7 @@ fn create_worktree_definition() -> ToolDefinition {
 fn choose_workspace_definition() -> ToolDefinition {
     ToolDefinition {
         name: "choose_workspace".into(),
-        description: "Request the native workspace chooser before inspecting, searching, editing, testing, or running an existing project when this conversation has no project yet. The request returns immediately: stop the current turn and do not call this tool again while selection is pending. vmux resumes this same conversation after the user chooses or cancels. Do not search the user's home directory for repositories or create a worktree manually. Do not call for general questions or self-contained terminal demonstrations. For Git projects, call create_worktree with a branch already specified by the user; if none was specified, ask the user which branch to create first."
+        description: "Request the native workspace chooser before inspecting, searching, editing, testing, or running an existing project when this conversation has no project yet. vmux uses a selected linked worktree directly, creates an isolated managed worktree for a normal Git checkout, or binds a non-Git directory. The request returns immediately: stop the current turn and do not call this tool again while selection is pending. vmux resumes this same conversation after the workspace is ready or selection is cancelled. Do not search the user's home directory for repositories or create a worktree manually. Do not call for general questions or self-contained terminal demonstrations."
             .into(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -1413,8 +1413,10 @@ mod tests {
         assert!(
             choose_definition
                 .description
-                .contains("if none was specified")
+                .contains("linked worktree directly")
         );
+        assert!(choose_definition.description.contains("managed worktree"));
+        assert!(choose_definition.description.contains("workspace is ready"));
         assert!(
             choose_definition
                 .description

--- a/crates/vmux_service/src/acp/projector.rs
+++ b/crates/vmux_service/src/acp/projector.rs
@@ -104,6 +104,19 @@ fn file_touch_intents(kind: ToolKind, locations: &[ToolCallLocation]) -> Vec<Int
         .collect()
 }
 
+fn locations_from_diffs(content: &[ToolCallContent]) -> Vec<ToolCallLocation> {
+    let mut paths = HashSet::new();
+    let mut locations = Vec::new();
+    for item in content {
+        if let ToolCallContent::Diff(diff) = item
+            && paths.insert(diff.path.clone())
+        {
+            locations.push(ToolCallLocation::new(diff.path.clone()));
+        }
+    }
+    locations
+}
+
 fn edit_tool_kind(kind: ToolKind) -> bool {
     matches!(kind, ToolKind::Edit | ToolKind::Delete | ToolKind::Move)
 }
@@ -382,11 +395,16 @@ impl AcpProjector {
     fn apply_tool_call(&mut self, tc: ToolCall) -> Vec<Intent> {
         let call_id = tc.tool_call_id.to_string();
         self.upsert_tool_use(&call_id, &tc.title, &raw_input_json(tc.raw_input.as_ref()));
+        let diff_locations = tc
+            .locations
+            .is_empty()
+            .then(|| locations_from_diffs(&tc.content));
+        let locations = diff_locations.as_deref().unwrap_or(&tc.locations);
         let mut intents = vec![Intent::Snapshot];
         intents.extend(self.project_tool_file_touches(
             &call_id,
             Some(tc.kind),
-            Some(&tc.locations),
+            Some(locations),
             Some(tc.status),
             true,
         ));
@@ -406,11 +424,25 @@ impl AcpProjector {
             &title,
             &raw_input_json(update.fields.raw_input.as_ref()),
         );
+        let diff_locations = update
+            .fields
+            .content
+            .as_deref()
+            .map(locations_from_diffs)
+            .unwrap_or_default();
+        let locations = update.fields.locations.as_deref();
+        let locations = if locations.is_none_or(|locations| locations.is_empty())
+            && !diff_locations.is_empty()
+        {
+            Some(diff_locations.as_slice())
+        } else {
+            locations
+        };
         let mut intents = vec![Intent::Snapshot];
         intents.extend(self.project_tool_file_touches(
             &call_id,
             update.fields.kind,
-            update.fields.locations.as_deref(),
+            locations,
             update.fields.status,
             false,
         ));
@@ -716,6 +748,34 @@ mod tests {
                 Some(AssistantBlock::ToolUse { call_id, .. }) if call_id == "c1"
             )),
             other => panic!("expected assistant message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn edit_diff_without_locations_emits_and_retries_file_touch() {
+        use agent_client_protocol::schema::v1::{ToolCallUpdate, ToolCallUpdateFields};
+
+        let mut p = AcpProjector::new();
+        let started = p.apply(SessionUpdate::ToolCall(
+            ToolCall::new("c1", "Editing files")
+                .kind(ToolKind::Edit)
+                .content(vec![ToolCallContent::Diff(Diff::new(
+                    "/repo/src/main.rs",
+                    "new",
+                ))]),
+        ));
+        let completed = p.apply(SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+            "c1",
+            ToolCallUpdateFields::new().status(ToolCallStatus::Completed),
+        )));
+
+        for intents in [started, completed] {
+            assert!(intents.iter().any(|intent| matches!(
+                intent,
+                Intent::FileTouched { path, line: None, kind }
+                    if path == "/repo/src/main.rs"
+                        && *kind == crate::protocol::FileTouchKind::Edit
+            )));
         }
     }
 

--- a/docs/specs/2026-07-17-managed-tab-worktrees-design.md
+++ b/docs/specs/2026-07-17-managed-tab-worktrees-design.md
@@ -46,17 +46,17 @@ temporary runtime cwd. The home directory is not persisted as the tab workspace.
 The agent calls `choose_workspace` only when the request requires project files. The chat shows an
 inline workspace-selection card above the composer instead of opening the native folder picker
 immediately. The picker opens only after the user clicks `Choose folder`, keeping the agent's
-request visible and making the system dialog intentional. Non-Git selections become `TabWorkspace`
-directly. Git selections remain pending while the agent asks the user which branch to create. The
-agent then calls `create_worktree` with the exact user-selected branch. Generated names such as
-`Tab 2` are replaced by the selected folder name, and the branch name is sanitized only for the
-managed checkout directory slug.
+request visible and making the system dialog intentional. It starts in the app launch directory so
+a build launched from an existing worktree opens there directly. Non-Git selections become
+`TabWorkspace` directly, selected linked worktrees are reused, and normal Git checkouts receive a
+vmux-managed worktree automatically. Generated names such as `Tab 2` are replaced by the selected
+folder name.
 
 While a tab is unbound, vmux adds private host context to ACP prompts requiring `choose_workspace`
 before any existing-project operation. The context explicitly forbids repository discovery under
 the user's home directory and manual `git worktree add`, while still allowing general questions and
-self-contained terminal demonstrations. A selected Git project receives a pending-worktree policy
-until `create_worktree` completes.
+self-contained terminal demonstrations. Workspace selection resumes the conversation only after
+the selected directory or generated worktree is ready.
 
 Workspace activation mutates the existing tab and ACP session in place. The chat entity, webview,
 transcript, routing session id, and agent process remain unchanged. Tab cwd and host-side ACP file
@@ -75,8 +75,9 @@ global root avoids repository pollution and local `.git/info/exclude` mutations.
 repository-local worktrees remain valid and are not moved.
 
 Automatically prepared managed worktrees keep dedicated `vmux/<slug>[-N]` branches. Conversational
-workspace setup uses the exact branch name supplied by the user. Branch ownership stays one
-worktree at a time. The persisted tab checkout path and branch make creation idempotent.
+workspace selection uses the same generated branch scheme; explicit `create_worktree` requests use
+the exact branch name supplied by the user. Branch ownership stays one worktree at a time. The
+persisted tab checkout path and branch make creation idempotent.
 
 ## Recovery
 
@@ -93,8 +94,7 @@ avoids repeating Git subprocesses for every later agent open.
 ## Ordering
 
 Configured Git tabs still activate before agent page opening. Empty tabs start immediately and
-activate later through agent tools. Agent command batches process `choose_workspace` and
-`create_worktree` before sibling commands; commands are skipped when worktree activation fails
+activate later through `choose_workspace`; commands are skipped when worktree activation fails
 rather than running in the project checkout.
 
 ## ACP Workspace Updates
@@ -132,11 +132,12 @@ model. Existing orphaned worktrees are left untouched.
 - An agent tab without a configured startup directory starts immediately in the user's home
   directory and dispatches its first prompt.
 - General prompts do not open the workspace picker.
-- Selecting a Git workspace asks for a branch, creates a slugged checkout on that exact branch,
-  and updates the existing tab and ACP session.
+- Selecting an existing linked worktree reuses it without nesting another worktree.
+- Selecting a normal Git checkout creates a managed worktree and updates the existing tab and ACP
+  session.
 - Workspace activation preserves the original chat view, transcript, and routing session.
 - Non-Git tabs do not create worktrees.
 - Missing managed checkouts recover from their branch; invalid external checkouts remain marked.
-- `create_worktree` is idempotent and ordered before sibling run commands.
+- Explicit `create_worktree` requests remain idempotent and ordered before sibling run commands.
 - ACP worktree metadata validates, crosses the service protocol, and rebinds only the matching tab.
 - Persistence saves project identity and worktree ownership without resetting existing stores.


### PR DESCRIPTION
## Context

Codex ACP can emit edit diffs without ACP locations, so vmux renders the diff but does not open the edited file in the follow pane. Workspace selection also forced users to reveal hidden `.worktrees` directories and required a second agent-driven worktree step.

## Implementation

- Derive fallback file locations from unique diff paths only when explicit ACP locations are missing or empty.
- Start the native workspace picker in the app launch directory.
- Reuse selected linked worktrees directly.
- Automatically create a vmux-managed worktree when a normal Git checkout is selected.
- Bind non-Git directories directly.
- Update ACP host policy, MCP descriptions, tests, and the managed-worktree design spec.

## Checks / QA

- Full pre-push fmt, clippy, tests, and doctests pass.
- Start a Codex ACP session and ask it to edit a file; confirm the file page opens beside the agent.
- From an unbound agent tab, choose the current linked worktree; confirm the picker opens there and the conversation continues in that worktree.
- Choose a normal Git checkout; confirm vmux creates and uses a managed worktree automatically.
- Choose a non-Git directory; confirm vmux uses it directly.
- In the macOS picker, hidden files can still be toggled with Command-Shift-Period.