### PR TITLE
fix(agent): canonicalize ACP URLs

### DIFF
--- a/crates/vmux_agent/src/acp_install.rs
+++ b/crates/vmux_agent/src/acp_install.rs
@@ -352,6 +352,16 @@ pub fn registry_id_alias(id: &str) -> &str {
     }
 }
 
+pub(crate) fn agent_url_id(id: &str) -> &str {
+    id.strip_suffix("-acp").unwrap_or(id)
+}
+
+pub(crate) fn agent_ids_match(left: &str, right: &str) -> bool {
+    let left = registry_id_alias(left);
+    let right = registry_id_alias(right);
+    left == right || agent_url_id(left) == agent_url_id(right)
+}
+
 /// Resolve an agent by launcher id against the registry (cached, else fetched) and ensure it is
 /// installed, returning how to launch it. Runs on a background thread (blocking I/O).
 pub fn resolve_from_registry(
@@ -359,13 +369,17 @@ pub fn resolve_from_registry(
     emit: impl FnMut(InstallPhase, Option<u8>, &str),
 ) -> Result<ResolvedAgent, String> {
     let reg_id = registry_id_alias(agent_id);
-    let find = |reg: acp_registry::Registry| reg.agents.into_iter().find(|a| a.id == reg_id);
+    let find = |reg: acp_registry::Registry| {
+        reg.agents
+            .into_iter()
+            .find(|agent| agent_ids_match(&agent.id, agent_id))
+    };
     let agent = match acp_registry::load_cached().and_then(find) {
         Some(a) => a,
         None => acp_registry::fetch_blocking()?
             .agents
             .into_iter()
-            .find(|a| a.id == reg_id)
+            .find(|agent| agent_ids_match(&agent.id, agent_id))
             .ok_or_else(|| format!("agent not in ACP registry: {agent_id} ({reg_id})"))?,
     };
     ensure_installed(&agent, emit)
@@ -477,6 +491,21 @@ mod tests {
             "vibe-darwin-arm64.tar.gz"
         );
         assert_eq!(archive_filename("https://x/y/bin.zip?token=1"), "bin.zip");
+    }
+
+    #[test]
+    fn acp_registry_suffix_is_omitted_from_agent_urls() {
+        assert_eq!(agent_url_id("codex-acp"), "codex");
+        assert_eq!(agent_url_id("custom-acp"), "custom");
+        assert_eq!(agent_url_id("mistral-vibe"), "mistral-vibe");
+    }
+
+    #[test]
+    fn agent_ids_match_url_and_registry_forms() {
+        assert!(agent_ids_match("codex", "codex-acp"));
+        assert!(agent_ids_match("custom", "custom-acp"));
+        assert!(agent_ids_match("vibe", "mistral-vibe"));
+        assert!(!agent_ids_match("codex", "custom-acp"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -470,7 +470,7 @@ fn install_acp_session_when_focused(
             .agent
             .acp
             .iter()
-            .find(|c| c.id == session.agent_id)
+            .find(|config| crate::acp_install::agent_ids_match(&config.id, &session.agent_id))
             .cloned();
 
         *state = AgentRunState::Installing {

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -395,6 +395,7 @@ pub fn attach_acp_agent_to_stack(
     meshes: &mut ResMut<Assets<Mesh>>,
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
+    let agent_id = crate::acp_install::agent_url_id(agent_id);
     // A resume carries the agent-assigned session id in the url; a fresh open is bare and gets
     // redirected to `vmux://agent/<id>/<acp-session-id>` once the agent returns its id.
     let url = match resume {
@@ -445,8 +446,10 @@ fn acp_registry_agent_for_id<'a>(
     catalog: Option<&'a crate::client::acp::AcpCatalog>,
     id: &str,
 ) -> Option<&'a crate::acp_registry::RegistryAgent> {
-    let registry_id = crate::acp_install::registry_id_alias(id);
-    catalog?.agents.iter().find(|agent| agent.id == registry_id)
+    catalog?
+        .agents
+        .iter()
+        .find(|agent| crate::acp_install::agent_ids_match(&agent.id, id))
 }
 
 fn acp_icon_for_id(catalog: Option<&crate::client::acp::AcpCatalog>, id: &str) -> Option<String> {
@@ -4062,7 +4065,11 @@ fn handle_swap_stack_session(
             }
         };
         if let crate::AgentUrl::Acp { id, .. } = &target
-            && !settings.agent.acp.iter().any(|cfg| cfg.id == *id)
+            && !settings
+                .agent
+                .acp
+                .iter()
+                .any(|cfg| crate::acp_install::agent_ids_match(&cfg.id, id))
             && acp_registry_agent_for_id(catalog.as_deref(), id).is_none()
         {
             bevy::log::warn!("swap: ACP agent unavailable for '{id}'");
@@ -4129,7 +4136,11 @@ fn handle_swap_stack_session(
                 });
             }
             crate::AgentUrl::Acp { id, sid } => {
-                let cfg = settings.agent.acp.iter().find(|cfg| cfg.id == id);
+                let cfg = settings
+                    .agent
+                    .acp
+                    .iter()
+                    .find(|cfg| crate::acp_install::agent_ids_match(&cfg.id, &id));
                 let routing_sid = uuid::Uuid::new_v4().to_string();
                 let icon = acp_icon_for_id(catalog.as_deref(), &id);
                 let name = acp_profile_name_for_id(&id, cfg, catalog.as_deref());
@@ -4253,7 +4264,9 @@ fn handle_agent_page_open_task(
         Some(crate::AgentUrl::Acp { id, sid }) => {
             // ACP agents own the canonical single-segment names (claude/codex/…) plus the
             // two-segment `<id>/<acp-session-id>` session form.
-            let cfg = acp_configs.iter().find(|config| config.id == id);
+            let cfg = acp_configs
+                .iter()
+                .find(|config| crate::acp_install::agent_ids_match(&config.id, &id));
             if cfg.is_none() && acp_registry_agent_for_id(catalog, &id).is_none() {
                 // Not an ACP agent. A bare `vmux://agent/<kind>` for a built-in CLI kind falls
                 // back to a fresh CLI session (CLI's own url is `<kind>/cli`); this keeps the
@@ -4278,7 +4291,7 @@ fn handle_agent_page_open_task(
             // redirect) is a no-op instead of re-spawning the session.
             if acp_sessions
                 .get(task.stack)
-                .is_ok_and(|session| session.agent_id == id)
+                .is_ok_and(|session| crate::acp_install::agent_ids_match(&session.agent_id, &id))
             {
                 return Ok(());
             }
@@ -6464,7 +6477,7 @@ mod tests {
             .spawn(PageOpenTask {
                 id: vmux_core::PageOpenId::new(),
                 stack,
-                url: "vmux://agent/custom-acp".to_string(),
+                url: "vmux://agent/custom".to_string(),
                 request_id: None,
             })
             .id();
@@ -6476,8 +6489,9 @@ mod tests {
             .world()
             .get::<crate::client::acp::AcpSession>(stack)
             .unwrap();
-        assert_eq!(session.agent_id, "custom-acp");
+        assert_eq!(session.agent_id, "custom");
         let meta = app.world().get::<PageMetadata>(stack).unwrap();
+        assert_eq!(meta.url, "vmux://agent/custom");
         assert_eq!(meta.title, "Custom ACP");
         assert_eq!(meta.icon.favicon_url(), "https://cdn.example/custom.svg");
     }

--- a/crates/vmux_agent/src/snapshot_updater.rs
+++ b/crates/vmux_agent/src/snapshot_updater.rs
@@ -91,7 +91,10 @@ fn acp_agent_summaries(
         .map(|agent| AgentProviderSummary {
             id: agent.id.clone(),
             name: agent.name.clone(),
-            url: format!("vmux://agent/{}", agent.id),
+            url: format!(
+                "vmux://agent/{}",
+                crate::acp_install::agent_url_id(&agent.id)
+            ),
             icon: agent.icon.clone().unwrap_or_default(),
         })
         .collect();
@@ -120,7 +123,10 @@ pub(crate) fn update_recent_agents(
         consider(
             timestamp.map(|timestamp| timestamp.0).unwrap_or(i64::MIN),
             AgentPromptTarget::Acp {
-                id: crate::acp_install::registry_id_alias(&session.agent_id).to_string(),
+                id: crate::acp_install::agent_url_id(crate::acp_install::registry_id_alias(
+                    &session.agent_id,
+                ))
+                .to_string(),
             },
         );
     }
@@ -137,7 +143,8 @@ pub(crate) fn update_recent_agents(
         let target = match crate::url::AgentUrl::parse(&page.url) {
             Some(crate::url::AgentUrl::Cli { kind, .. }) => AgentPromptTarget::Cli(kind),
             Some(crate::url::AgentUrl::Acp { id, .. }) => AgentPromptTarget::Acp {
-                id: crate::acp_install::registry_id_alias(&id).to_string(),
+                id: crate::acp_install::agent_url_id(crate::acp_install::registry_id_alias(&id))
+                    .to_string(),
             },
             _ => continue,
         };
@@ -245,12 +252,12 @@ mod tests {
 
     #[test]
     fn installed_unconfigured_acp_is_in_snapshot() {
-        let catalog = vec![registry_agent("new-agent", "New Agent")];
+        let catalog = vec![registry_agent("new-agent-acp", "New Agent")];
 
         let agents = acp_agent_summaries(&catalog, |_| true);
 
         assert_eq!(agents.len(), 1);
-        assert_eq!(agents[0].id, "new-agent");
+        assert_eq!(agents[0].id, "new-agent-acp");
         assert_eq!(agents[0].url, "vmux://agent/new-agent");
     }
 
@@ -306,7 +313,7 @@ mod tests {
             app.world().resource::<CommandBarAgentsSnapshot>().recent,
             vec![
                 AgentPromptTarget::Acp {
-                    id: "claude-acp".to_string(),
+                    id: "claude".to_string(),
                 },
                 AgentPromptTarget::Cli(vmux_core::agent::AgentKind::Codex),
             ]
@@ -325,7 +332,7 @@ mod tests {
             app.world().resource::<CommandBarAgentsSnapshot>().recent,
             vec![
                 AgentPromptTarget::Acp {
-                    id: "claude-acp".to_string(),
+                    id: "claude".to_string(),
                 },
                 AgentPromptTarget::Cli(vmux_core::agent::AgentKind::Codex),
             ]
@@ -356,7 +363,7 @@ mod tests {
             app.world().resource::<CommandBarAgentsSnapshot>().recent,
             vec![
                 AgentPromptTarget::Acp {
-                    id: "codex-acp".to_string(),
+                    id: "codex".to_string(),
                 },
                 AgentPromptTarget::Cli(vmux_core::agent::AgentKind::Claude),
             ]
@@ -392,7 +399,7 @@ mod tests {
             app.world().resource::<CommandBarAgentsSnapshot>().recent,
             vec![
                 AgentPromptTarget::Acp {
-                    id: "claude-acp".to_string(),
+                    id: "claude".to_string(),
                 },
                 AgentPromptTarget::Cli(vmux_core::agent::AgentKind::Codex),
             ]

--- a/crates/vmux_layout/src/command_bar/handler.rs
+++ b/crates/vmux_layout/src/command_bar/handler.rs
@@ -2928,7 +2928,7 @@ mod tests {
             acp: vec![vmux_command::snapshot::AgentProviderSummary {
                 id: "claude-acp".to_string(),
                 name: "Claude Agent".to_string(),
-                url: "vmux://agent/claude-acp".to_string(),
+                url: "vmux://agent/claude".to_string(),
                 icon: String::new(),
             }],
             ..Default::default()
@@ -2946,7 +2946,7 @@ mod tests {
             acp: vec![vmux_command::snapshot::AgentProviderSummary {
                 id: "claude-acp".to_string(),
                 name: "Claude Agent".to_string(),
-                url: "vmux://agent/claude-acp".to_string(),
+                url: "vmux://agent/claude".to_string(),
                 icon: String::new(),
             }],
             ..Default::default()
@@ -2954,7 +2954,7 @@ mod tests {
 
         assert_eq!(
             prompt_agent_url(&snapshot, None).as_deref(),
-            Some("vmux://agent/claude-acp")
+            Some("vmux://agent/claude")
         );
         assert_eq!(
             prompt_agent_url(&CommandBarAgentsSnapshot::default(), None),
@@ -2974,7 +2974,7 @@ mod tests {
             acp: vec![vmux_command::snapshot::AgentProviderSummary {
                 id: "claude-acp".to_string(),
                 name: "Claude Agent".to_string(),
-                url: "vmux://agent/claude-acp".to_string(),
+                url: "vmux://agent/claude".to_string(),
                 icon: String::new(),
             }],
             recent: vec![AgentPromptTarget::Cli(AgentKind::Codex)],
@@ -2982,8 +2982,8 @@ mod tests {
         };
 
         assert_eq!(
-            prompt_agent_url(&snapshot, Some("vmux://agent/claude-acp")).as_deref(),
-            Some("vmux://agent/claude-acp")
+            prompt_agent_url(&snapshot, Some("vmux://agent/claude")).as_deref(),
+            Some("vmux://agent/claude")
         );
         assert_eq!(
             prompt_agent_url(&snapshot, Some("vmux://agent/uninstalled")).as_deref(),
@@ -3023,13 +3023,13 @@ mod tests {
             acp: vec![vmux_command::snapshot::AgentProviderSummary {
                 id: "claude-acp".to_string(),
                 name: "Claude Agent".to_string(),
-                url: "vmux://agent/claude-acp".to_string(),
+                url: "vmux://agent/claude".to_string(),
                 icon: "https://cdn.example/claude-acp.svg".to_string(),
             }],
             recent: vec![
                 AgentPromptTarget::Cli(AgentKind::Codex),
                 AgentPromptTarget::Acp {
-                    id: "claude-acp".to_string(),
+                    id: "claude".to_string(),
                 },
             ],
             ..Default::default()


### PR DESCRIPTION
## Context

ACP registry slugs such as `codex-acp` leaked into vmux agent URLs. Agent URLs should use the canonical name, such as `vmux://agent/codex`.

## Implementation

Strip the `-acp` registry suffix from generated URLs and recent-agent identities. Keep registry, configured, and canonical IDs interoperable for lookup, installation fallback, session attachment, and resume flows.

## Checks / QA

- Open an installed Codex or Claude ACP agent and confirm its URL omits `-acp`.
- Resume the ACP session and confirm the session URL stays canonical.
