### PR TITLE
feat(ui): animate start prompt into agent page

### DIFF
--- a/crates/vmux_agent/Cargo.toml
+++ b/crates/vmux_agent/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = { workspace = true }
 rkyv = { workspace = true }
 similar = "2"
 unicode-segmentation = "1"
+vmux_command = { path = "../vmux_command" }
 vmux_terminal = { path = "../vmux_terminal" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -34,7 +35,6 @@ tokio = { workspace = true, features = ["rt"] }
 toml = { workspace = true }
 uuid = { workspace = true }
 url = { workspace = true }
-vmux_command = { path = "../vmux_command" }
 vmux_core = { path = "../vmux_core" }
 vmux_editor = { path = "../vmux_editor" }
 vmux_git = { path = "../vmux_git" }

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -2190,18 +2190,6 @@ mod native_tests {
     }
 
     #[test]
-    fn agent_surface_animates_around_the_stable_prompt_box() {
-        let page = include_str!("chat_page/page.rs");
-        let theme = include_str!("../../vmux_ui/assets/theme.css");
-
-        assert_eq!(page.matches("class: \"vmux-agent-surface-enter").count(), 2);
-        assert!(page.contains("vmux-agent-prompt-dock-enter"));
-        assert!(theme.contains("@keyframes vmux-agent-surface-in"));
-        assert!(theme.contains("@keyframes vmux-agent-prompt-dock-in"));
-        assert!(theme.contains(".vmux-agent-surface-enter"));
-    }
-
-    #[test]
     fn composer_slash_items_support_mouse_selection() {
         let source = include_str!("chat_page/page.rs");
         assert!(source.contains("onclick: move |_| run_slash_command"));

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -179,14 +179,14 @@ impl Plugin for AgentChatPagePlugin {
                 RuntimeSwitchRequest,
                 SelectModel,
                 ChatChooseWorkspace,
-            )>::for_hosts(&["agent"]))
+            )>::for_hosts(&["agent", "start"]))
             .add_plugins(BinEventEmitterPlugin::<(
                 ChatPickFiles,
                 ChatPasteMedia,
                 ChatMediaListRequest,
                 ChatAttachPaths,
                 ChatAttachmentPreviewRequest,
-            )>::for_hosts(&["agent"]))
+            )>::for_hosts(&["agent", "start"]))
             .add_observer(on_chat_submit)
             .add_observer(on_chat_approval)
             .add_observer(on_chat_cancel)
@@ -2130,11 +2130,14 @@ mod native_tests {
     #[test]
     fn composer_auto_grows_and_contains_action_button() {
         let source = include_str!("chat_page/page.rs");
+        let prompt_box = include_str!("../../vmux_ui/src/components/prompt_box.rs");
         assert!(source.contains("fn resize_prompt_textarea()"));
         assert!(source.contains("textarea.scroll_height().clamp(40, 160)"));
         assert!(source.contains("max-h-40 min-h-10"));
-        assert!(source.contains("rounded-2xl"));
-        assert!(source.contains("backdrop-blur-3xl backdrop-saturate-150"));
+        assert!(source.contains("PromptBox {"));
+        assert!(source.contains("PromptPopup {"));
+        assert!(prompt_box.contains("rounded-2xl"));
+        assert!(prompt_box.contains("backdrop-blur-3xl backdrop-saturate-150"));
         assert!(source.contains("h-8 w-8 shrink-0 self-center items-center justify-center"));
         assert!(source.contains("if draft.read().is_empty()"));
         assert!(source.contains("show_capability_examples"));
@@ -2177,15 +2180,25 @@ mod native_tests {
         let card = page
             .find("if workspace_selection_pending()")
             .expect("workspace card");
-        let composer = page
-            .find("relative flex items-center overflow-hidden rounded-2xl")
-            .expect("composer");
+        let composer = page.find("PromptBox {").expect("composer");
 
         assert!(card < composer);
         assert!(page.contains("Choose a workspace"));
         assert!(page.contains("Choose folder"));
         assert!(page.contains("try_cef_bin_emit_rkyv(&ChatChooseWorkspace)"));
         assert!(include_str!("chat_page.rs").contains("WorkspacePickerStartRequest"));
+    }
+
+    #[test]
+    fn agent_surface_animates_around_the_stable_prompt_box() {
+        let page = include_str!("chat_page/page.rs");
+        let theme = include_str!("../../vmux_ui/assets/theme.css");
+
+        assert_eq!(page.matches("class: \"vmux-agent-surface-enter").count(), 2);
+        assert!(page.contains("vmux-agent-prompt-dock-enter"));
+        assert!(theme.contains("@keyframes vmux-agent-surface-in"));
+        assert!(theme.contains("@keyframes vmux-agent-prompt-dock-in"));
+        assert!(theme.contains(".vmux-agent-surface-enter"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/composer.rs
+++ b/crates/vmux_agent/src/chat_page/composer.rs
@@ -28,12 +28,6 @@ pub(crate) enum PromptHistoryDirection {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct InlineMediaQuery<'a> {
-    pub start: usize,
-    pub query: &'a str,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum PromptEdit<'a> {
     Insert(&'a str),
     Backspace,
@@ -82,30 +76,6 @@ pub(crate) fn selector_mode(draft: &str) -> SelectorMode<'_> {
     } else {
         SelectorMode::Commands(token)
     }
-}
-
-pub(crate) fn inline_media_query(draft: &str) -> Option<InlineMediaQuery<'_>> {
-    draft.rmatch_indices('@').find_map(|(start, _)| {
-        let boundary = start == 0
-            || draft[..start]
-                .chars()
-                .next_back()
-                .is_some_and(char::is_whitespace);
-        let query = &draft[start + 1..];
-        (boundary && !query.chars().any(char::is_whitespace))
-            .then_some(InlineMediaQuery { start, query })
-    })
-}
-
-pub(crate) fn replace_inline_media_query(
-    draft: &str,
-    query: InlineMediaQuery<'_>,
-    replacement: &str,
-) -> String {
-    let mut value = String::with_capacity(draft.len() + replacement.len());
-    value.push_str(&draft[..query.start]);
-    value.push_str(replacement);
-    value
 }
 
 pub(crate) fn should_fetch_resume(draft: &str, commands: &[SlashCommandEntry]) -> bool {
@@ -453,40 +423,6 @@ mod tests {
     fn thinking_expands_only_until_the_next_block() {
         assert!(should_expand_thinking(0, 1));
         assert!(!should_expand_thinking(0, 2));
-    }
-
-    #[test]
-    fn inline_media_query_requires_a_token_boundary_and_open_tail() {
-        assert_eq!(
-            inline_media_query("inspect @Pictures/scr"),
-            Some(InlineMediaQuery {
-                start: 8,
-                query: "Pictures/scr",
-            })
-        );
-        assert_eq!(
-            inline_media_query("@"),
-            Some(InlineMediaQuery {
-                start: 0,
-                query: "",
-            })
-        );
-        assert_eq!(inline_media_query("mail@example.com"), None);
-        assert_eq!(inline_media_query("inspect @image.png next"), None);
-    }
-
-    #[test]
-    fn inline_media_replacement_preserves_prompt_prefix() {
-        let draft = "compare this @Pic";
-        let query = inline_media_query(draft).unwrap();
-        assert_eq!(
-            replace_inline_media_query(draft, query, "@Pictures/photo.png "),
-            "compare this @Pictures/photo.png "
-        );
-        assert_eq!(
-            replace_inline_media_query(draft, query, ""),
-            "compare this "
-        );
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -4,102 +4,12 @@
 
 /// Bin-event id: native → page conversation/run-state snapshot.
 pub const CHAT_SNAPSHOT_EVENT: &str = "chat_snapshot";
-/// Bin-event id: native → page files selected from disk or the clipboard.
-pub const CHAT_ATTACHMENTS_EVENT: &str = "chat_attachments";
-/// Bin-event id: native → page previews for media already present in the transcript.
-pub const CHAT_ATTACHMENT_PREVIEWS_EVENT: &str = "chat_attachment_previews";
-/// Bin-event id: native → page media entries matching an inline `@` query.
-pub const CHAT_MEDIA_ENTRIES_EVENT: &str = "chat_media_entries";
-
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    PartialEq,
-    Eq,
-    serde::Serialize,
-    serde::Deserialize,
-    rkyv::Archive,
-    rkyv::Serialize,
-    rkyv::Deserialize,
-)]
-pub struct ChatAttachment {
-    pub path: String,
-    pub name: String,
-    pub mime_type: String,
-    pub size: u64,
-    pub preview_data_url: String,
-}
-
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    PartialEq,
-    Eq,
-    serde::Serialize,
-    serde::Deserialize,
-    rkyv::Archive,
-    rkyv::Serialize,
-    rkyv::Deserialize,
-)]
-pub struct ChatSubmitAttachment {
-    pub path: String,
-    pub name: String,
-    pub mime_type: String,
-    pub size: u64,
-}
-
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    serde::Serialize,
-    serde::Deserialize,
-    rkyv::Archive,
-    rkyv::Serialize,
-    rkyv::Deserialize,
-)]
-pub struct ChatAttachments {
-    pub attachments: Vec<ChatAttachment>,
-}
-
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    PartialEq,
-    Eq,
-    serde::Serialize,
-    serde::Deserialize,
-    rkyv::Archive,
-    rkyv::Serialize,
-    rkyv::Deserialize,
-)]
-pub struct ChatMediaEntry {
-    pub path: String,
-    pub name: String,
-    pub parent: String,
-    pub mime_type: String,
-    pub is_dir: bool,
-    pub preview_data_url: String,
-}
-
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    serde::Serialize,
-    serde::Deserialize,
-    rkyv::Archive,
-    rkyv::Serialize,
-    rkyv::Deserialize,
-)]
-pub struct ChatMediaEntries {
-    pub request_id: u64,
-    pub query: String,
-    pub entries: Vec<ChatMediaEntry>,
-}
+pub use vmux_command::prompt_media::{
+    CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT,
+    ChatAttachPaths, ChatAttachment, ChatAttachmentPreviewRequest, ChatAttachments,
+    ChatMediaEntries, ChatMediaEntry, ChatMediaListRequest, ChatPasteMedia, ChatPickFiles,
+    ChatSubmitAttachment,
+};
 
 #[derive(
     Clone,
@@ -172,19 +82,6 @@ pub struct ChatSubmit {
     pub attachments: Vec<ChatSubmitAttachment>,
 }
 
-/// Page → native: open a multi-select file picker rooted at the user's home directory.
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    serde::Serialize,
-    serde::Deserialize,
-    rkyv::Archive,
-    rkyv::Serialize,
-    rkyv::Deserialize,
-)]
-pub struct ChatPickFiles;
-
 /// Page → native: open the workspace folder picker requested by the agent.
 #[derive(
     Clone,
@@ -197,65 +94,6 @@ pub struct ChatPickFiles;
     rkyv::Deserialize,
 )]
 pub struct ChatChooseWorkspace;
-
-/// Page → native: attach image media from the system clipboard, if present.
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    serde::Serialize,
-    serde::Deserialize,
-    rkyv::Archive,
-    rkyv::Serialize,
-    rkyv::Deserialize,
-)]
-pub struct ChatPasteMedia;
-
-/// Page → native: list media and directories for an inline `@` query.
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    serde::Serialize,
-    serde::Deserialize,
-    rkyv::Archive,
-    rkyv::Serialize,
-    rkyv::Deserialize,
-)]
-pub struct ChatMediaListRequest {
-    pub request_id: u64,
-    pub query: String,
-}
-
-/// Page → native: attach paths selected from the inline `@` menu.
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    serde::Serialize,
-    serde::Deserialize,
-    rkyv::Archive,
-    rkyv::Serialize,
-    rkyv::Deserialize,
-)]
-pub struct ChatAttachPaths {
-    pub paths: Vec<String>,
-}
-
-/// Page → native: load previews for media already present in the transcript.
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    serde::Serialize,
-    serde::Deserialize,
-    rkyv::Archive,
-    rkyv::Serialize,
-    rkyv::Deserialize,
-)]
-pub struct ChatAttachmentPreviewRequest {
-    pub paths: Vec<String>,
-}
 
 /// Page → native: the user answered a permission prompt. `decision`: 0 = deny, 1 = allow,
 /// 2 = allow-always.

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -2,11 +2,10 @@
 
 use crate::chat_page::composer::{
     PromptEdit, PromptHistoryDirection, ResumeMenuState, SelectorMode, ToolActivity,
-    chat_page_title, edit_prompt, filter_models, filter_sessions, inline_media_query,
-    is_handoff_boundary, menu_direction, move_prompt_history, move_selection,
-    prompt_history_direction, prompt_prefix_at_utf16, replace_inline_media_query,
-    resume_menu_state, selector_mode, should_clear_draft_on_escape, should_expand_thinking,
-    should_fetch_resume, tool_activity,
+    chat_page_title, edit_prompt, filter_models, filter_sessions, is_handoff_boundary,
+    menu_direction, move_prompt_history, move_selection, prompt_history_direction,
+    prompt_prefix_at_utf16, resume_menu_state, selector_mode, should_clear_draft_on_escape,
+    should_expand_thinking, should_fetch_resume, tool_activity,
 };
 use crate::chat_page::event::{
     CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT,
@@ -22,12 +21,13 @@ use crate::chat_page::event::{
 use dioxus::prelude::*;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
+use vmux_command::prompt_media::{inline_media_query, media_reference, replace_inline_media_query};
 use vmux_terminal::matrix_rain::MatrixRain;
-use vmux_terminal::page::PromptGhost;
 use vmux_ui::agent_accent::agent_accent;
 use vmux_ui::components::prompt_box::{PromptBox, PromptPopup};
 use vmux_ui::favicon::favicon_src_for_url;
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_theme};
+use vmux_ui::prompt_ghost::PromptGhost;
 use wasm_bindgen::{JsCast, closure::Closure};
 
 const PROMPT_ID: &str = "agent-chat-prompt";
@@ -149,19 +149,6 @@ fn file_extension_label(name: &str) -> String {
 
 fn attachment_label(attachment: &ChatAttachment) -> String {
     file_extension_label(&attachment.name)
-}
-
-fn media_reference(entry: &ChatMediaEntry) -> String {
-    let encode = |value: &str| value.replace('%', "%25").replace(' ', "%20");
-    if entry.parent == "~" {
-        format!("~/{name}", name = encode(&entry.name))
-    } else {
-        format!(
-            "{parent}/{name}",
-            parent = encode(&entry.parent),
-            name = encode(&entry.name)
-        )
-    }
 }
 
 fn select_media_entry(
@@ -299,10 +286,12 @@ fn install_global_prompt_input(draft: Signal<String>, slash_cmds: Signal<Vec<Sla
 pub fn Page(
     #[props(default)] agent_override: Option<String>,
     #[props(default)] transition_prompt: Option<String>,
+    #[props(default)] transition_attachments: Option<Vec<ChatAttachment>>,
 ) -> Element {
     use_theme();
     let agent = agent_override.unwrap_or_else(current_agent);
     let mut transition_preview = use_signal(|| transition_prompt.unwrap_or_default());
+    let mut transition_attachments = use_signal(|| transition_attachments.unwrap_or_default());
     let mut items = use_signal(Vec::<ChatItem>::new);
     let mut status = use_signal(|| "installing".to_string());
     let mut error = use_signal(String::new);
@@ -419,6 +408,7 @@ pub fn Page(
         error.set(snap.error.clone());
         queued.set(snap.queued.clone());
         transition_preview.set(String::new());
+        transition_attachments.set(Vec::new());
         paused.set(snap.paused);
         agent_name.set(snap.agent_name.clone());
         agent_icon.set(snap.agent_icon.clone());
@@ -563,8 +553,10 @@ pub fn Page(
     let rain_accent = accent_rgb(&theme_accent, agent_accent.rain_rgb);
     let installing = status() == "installing";
     let installing_splash = installing && items.read().is_empty();
-    let show_capability_examples =
-        items.read().is_empty() && queued.read().is_empty() && attachments.read().is_empty();
+    let show_capability_examples = items.read().is_empty()
+        && queued.read().is_empty()
+        && attachments.read().is_empty()
+        && transition_attachments.read().is_empty();
     let install_detail = {
         let detail = error();
         if detail.is_empty() {
@@ -1084,6 +1076,24 @@ pub fn Page(
                             }
                         }
                         div { class: "relative z-10 flex min-w-0 flex-1 flex-wrap items-center gap-1 px-2",
+                            for attachment in transition_attachments.read().iter() {
+                                div {
+                                    key: "transition-attachment-{attachment.path}",
+                                    class: "flex h-7 max-w-56 shrink-0 items-center gap-1.5 rounded-full bg-foreground/[0.08] pl-1 pr-2 text-xs text-foreground/80 ring-1 ring-inset ring-foreground/10",
+                                    if attachment.preview_data_url.is_empty() {
+                                        span { class: "flex h-5 min-w-5 items-center justify-center rounded-full bg-foreground/[0.08] px-1 font-mono text-[8px] font-semibold text-muted-foreground",
+                                            "{attachment_label(attachment)}"
+                                        }
+                                    } else {
+                                        img {
+                                            src: "{attachment.preview_data_url}",
+                                            alt: "{attachment.name}",
+                                            class: "h-5 w-5 rounded-full object-cover",
+                                        }
+                                    }
+                                    span { class: "min-w-0 max-w-40 truncate", "{attachment.name}" }
+                                }
+                            }
                             for (i , attachment) in attachments.read().iter().cloned().enumerate() {
                                 div {
                                     key: "attachment-pill-{attachment.path}",

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -2279,9 +2279,9 @@ const MD_CSS: &str = r#"
 .agent-chat-prompt{caret-color:transparent}
 .agent-chat-caret{animation:agent-chat-caret-blink 1s step-end infinite;background:var(--agent-accent)}
 @keyframes agent-chat-caret-blink{0%,49%{opacity:1}50%,100%{opacity:0}}
-.agent-chat-prompt-shell::before{content:"";position:absolute;inset:-28px -42px;z-index:-1;border-radius:2.5rem;background:radial-gradient(60% 90% at 50% 75%,color-mix(in srgb,var(--agent-accent) 18%,transparent),transparent 72%);filter:blur(16px);pointer-events:none}
-.agent-chat-prompt-box{border-color:color-mix(in srgb,var(--agent-accent) 20%,transparent);box-shadow:0 22px 70px -28px color-mix(in srgb,var(--agent-accent) 42%,rgba(0,0,0,0.72)),inset 0 1px 0 rgba(255,255,255,0.16),inset 0 -1px 0 rgba(255,255,255,0.04)}
-.agent-chat-prompt-box:focus-within{border-color:color-mix(in srgb,var(--agent-accent) 36%,transparent);box-shadow:0 26px 78px -26px color-mix(in srgb,var(--agent-accent) 56%,rgba(0,0,0,0.74)),inset 0 1px 0 rgba(255,255,255,0.2)}
+.agent-chat-prompt-shell::before{content:"";position:absolute;inset:-28px -42px;z-index:-1;border-radius:2.5rem;background:radial-gradient(60% 90% at 50% 75%,rgba(255,255,255,0.1),transparent 72%);filter:blur(16px);pointer-events:none}
+.agent-chat-prompt-box{border-color:rgba(255,255,255,0.18);box-shadow:0 22px 70px -28px rgba(255,255,255,0.2),inset 0 1px 0 rgba(255,255,255,0.16),inset 0 -1px 0 rgba(255,255,255,0.04)}
+.agent-chat-prompt-box:focus-within{border-color:rgba(255,255,255,0.28);box-shadow:0 26px 78px -26px rgba(255,255,255,0.28),inset 0 1px 0 rgba(255,255,255,0.2)}
 .agent-chat-page{background-image:radial-gradient(80% 55% at 15% 0%,color-mix(in srgb,var(--agent-accent) 9%,transparent),transparent 65%),radial-gradient(75% 55% at 90% 10%,color-mix(in srgb,var(--agent-accent) 7%,transparent),transparent 62%),radial-gradient(65% 45% at 55% 100%,color-mix(in srgb,var(--agent-accent) 5%,transparent),transparent 70%)}
 .agent-chat-glow-primary{background:color-mix(in srgb,var(--agent-accent) 8%,transparent)}
 .agent-chat-glow-secondary{background:color-mix(in srgb,var(--agent-accent) 6%,transparent)}

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -321,7 +321,7 @@ pub fn Page(
     let mut attachment_preview_requests = use_signal(HashSet::<String>::new);
     let mut history_cursor = use_signal(|| None::<usize>);
     let mut history_scratch = use_signal(String::new);
-    let mut prompt_caret = use_signal(|| None::<u32>);
+    let prompt_caret = use_signal(|| Some(0u32));
     let prompt_scroll_top = use_signal(|| 0i32);
     let mut elapsed = use_signal(|| 0u32);
     let mut at_bottom = use_signal(|| true);
@@ -343,6 +343,7 @@ pub fn Page(
     let mut verb = use_signal(|| "Working".to_string());
 
     use_effect(move || install_global_prompt_input(draft, slash_cmds));
+    use_effect(focus_prompt_end);
     use_effect(move || {
         let _ = draft.read();
         resize_prompt_textarea();
@@ -803,7 +804,7 @@ pub fn Page(
             div {
                 class: "relative z-10 bg-gradient-to-t from-background via-background/95 to-transparent px-4 pb-4 pt-8",
                 div {
-                    class: "vmux-agent-prompt-dock-enter relative mx-auto flex max-w-3xl flex-col gap-2",
+                    class: "agent-chat-prompt-shell vmux-agent-prompt-dock-enter relative mx-auto flex max-w-3xl flex-col gap-2",
                     if media_menu_open {
                         PromptPopup {
                             if media_loading() {
@@ -1064,7 +1065,7 @@ pub fn Page(
                             }
                         }
                     }
-                    PromptBox {
+                    PromptBox { class: "agent-chat-prompt-box",
                         button {
                             class: "relative z-10 ml-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg text-foreground/45 transition hover:bg-foreground/10 hover:text-foreground",
                             title: "Attach files (/upload)",
@@ -1142,13 +1143,14 @@ pub fn Page(
                                             class: "min-h-10 w-full whitespace-pre-wrap break-words px-1.5 py-2 text-[15px] leading-6 text-transparent",
                                             style: "transform:translateY(-{prompt_scroll_offset}px);",
                                             span { "{prefix}" }
-                                            span { class: "agent-chat-caret relative top-px ml-px inline-block h-4 w-1.5 align-middle {agent_accent.accent_bg}" }
+                                            span { class: "agent-chat-caret relative top-px ml-px inline-block h-4 w-1.5 align-middle" }
                                         }
                                     }
                                 }
                                 textarea {
                                 id: PROMPT_ID,
                                 class: "agent-chat-prompt relative z-10 max-h-40 min-h-10 w-full resize-none bg-transparent px-1.5 py-2 text-[15px] leading-6 placeholder:text-transparent focus:outline-none",
+                                autofocus: true,
                                 rows: "1",
                                 placeholder: "Message the agent…",
                                 value: "{draft}",
@@ -1163,7 +1165,7 @@ pub fn Page(
                                     let _ = try_cef_bin_emit_rkyv(&ChatPasteMedia);
                                 },
                                 onfocus: move |_| sync_prompt_caret(prompt_caret, prompt_scroll_top),
-                                onblur: move |_| prompt_caret.set(None),
+                                onblur: move |_| sync_prompt_caret(prompt_caret, prompt_scroll_top),
                                 onkeyup: move |_| sync_prompt_caret(prompt_caret, prompt_scroll_top),
                                 onmouseup: move |_| sync_prompt_caret(prompt_caret, prompt_scroll_top),
                                 onscroll: move |_| sync_prompt_caret(prompt_caret, prompt_scroll_top),
@@ -2275,8 +2277,11 @@ fn md_to_html(src: &str) -> String {
 /// light and dark.
 const MD_CSS: &str = r#"
 .agent-chat-prompt{caret-color:transparent}
-.agent-chat-caret{animation:agent-chat-caret-blink 1s step-end infinite}
+.agent-chat-caret{animation:agent-chat-caret-blink 1s step-end infinite;background:var(--agent-accent)}
 @keyframes agent-chat-caret-blink{0%,49%{opacity:1}50%,100%{opacity:0}}
+.agent-chat-prompt-shell::before{content:"";position:absolute;inset:-28px -42px;z-index:-1;border-radius:2.5rem;background:radial-gradient(60% 90% at 50% 75%,color-mix(in srgb,var(--agent-accent) 18%,transparent),transparent 72%);filter:blur(16px);pointer-events:none}
+.agent-chat-prompt-box{border-color:color-mix(in srgb,var(--agent-accent) 20%,transparent);box-shadow:0 22px 70px -28px color-mix(in srgb,var(--agent-accent) 42%,rgba(0,0,0,0.72)),inset 0 1px 0 rgba(255,255,255,0.16),inset 0 -1px 0 rgba(255,255,255,0.04)}
+.agent-chat-prompt-box:focus-within{border-color:color-mix(in srgb,var(--agent-accent) 36%,transparent);box-shadow:0 26px 78px -26px color-mix(in srgb,var(--agent-accent) 56%,rgba(0,0,0,0.74)),inset 0 1px 0 rgba(255,255,255,0.2)}
 .agent-chat-page{background-image:radial-gradient(80% 55% at 15% 0%,color-mix(in srgb,var(--agent-accent) 9%,transparent),transparent 65%),radial-gradient(75% 55% at 90% 10%,color-mix(in srgb,var(--agent-accent) 7%,transparent),transparent 62%),radial-gradient(65% 45% at 55% 100%,color-mix(in srgb,var(--agent-accent) 5%,transparent),transparent 70%)}
 .agent-chat-glow-primary{background:color-mix(in srgb,var(--agent-accent) 8%,transparent)}
 .agent-chat-glow-secondary{background:color-mix(in srgb,var(--agent-accent) 6%,transparent)}

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -25,6 +25,7 @@ use std::collections::{HashMap, HashSet};
 use vmux_terminal::matrix_rain::MatrixRain;
 use vmux_terminal::page::PromptGhost;
 use vmux_ui::agent_accent::agent_accent;
+use vmux_ui::components::prompt_box::{PromptBox, PromptPopup};
 use vmux_ui::favicon::favicon_src_for_url;
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_theme};
 use wasm_bindgen::{JsCast, closure::Closure};
@@ -295,9 +296,13 @@ fn install_global_prompt_input(draft: Signal<String>, slash_cmds: Signal<Vec<Sla
 }
 
 #[component]
-pub fn Page() -> Element {
+pub fn Page(
+    #[props(default)] agent_override: Option<String>,
+    #[props(default)] transition_prompt: Option<String>,
+) -> Element {
     use_theme();
-    let agent = current_agent();
+    let agent = agent_override.unwrap_or_else(current_agent);
+    let mut transition_preview = use_signal(|| transition_prompt.unwrap_or_default());
     let mut items = use_signal(Vec::<ChatItem>::new);
     let mut status = use_signal(|| "installing".to_string());
     let mut error = use_signal(String::new);
@@ -336,6 +341,14 @@ pub fn Page() -> Element {
     let mut resume_requested = use_signal(|| false);
     let mut resume_loading = use_signal(|| false);
     let mut verb = use_signal(|| "Working".to_string());
+
+    use_future(move || async move {
+        if transition_preview.peek().is_empty() {
+            return;
+        }
+        gloo_timers::future::TimeoutFuture::new(340).await;
+        transition_preview.set(String::new());
+    });
 
     use_effect(move || install_global_prompt_input(draft, slash_cmds));
     use_effect(move || {
@@ -652,7 +665,7 @@ pub fn Page() -> Element {
                     div { class: "agent-chat-glow agent-chat-glow-tertiary absolute bottom-[-12rem] left-1/3 h-96 w-96 rounded-full blur-[140px]" }
                 }
             }
-            header { class: "agent-chat-header relative z-10 flex items-center gap-2.5 border-b bg-background/55 px-5 py-3 shadow-[0_1px_0_rgba(255,255,255,0.02)] backdrop-blur-xl",
+            header { class: "agent-chat-header vmux-agent-surface-enter relative z-10 flex items-center gap-2.5 border-b bg-background/55 px-5 py-3 shadow-[0_1px_0_rgba(255,255,255,0.02)] backdrop-blur-xl",
                 {avatar_node(&agent_icon(), &accent(), &agent, &header_name, "h-6 w-6 text-[11px]")}
                 span { class: "h-2.5 w-2.5 rounded-full {status_dot_class(&status())}" }
                 span { class: "bg-gradient-to-b from-foreground to-foreground/60 bg-clip-text text-sm font-semibold capitalize text-transparent",
@@ -666,7 +679,7 @@ pub fn Page() -> Element {
             }
             div {
                 id: "chat-scroll",
-                class: "relative z-10 flex-1 overflow-y-auto px-4 py-6",
+                class: "vmux-agent-surface-enter vmux-agent-surface-enter-delayed relative z-10 flex-1 overflow-y-auto px-4 py-6",
                 onscroll: move |_| {
                     if let Some(el) = web_sys::window()
                         .and_then(|w| w.document())
@@ -797,9 +810,9 @@ pub fn Page() -> Element {
             div {
                 class: "relative z-10 bg-gradient-to-t from-background via-background/95 to-transparent px-4 pb-4 pt-8",
                 div {
-                    class: "relative mx-auto flex max-w-3xl flex-col gap-2",
+                    class: "vmux-agent-prompt-dock-enter relative mx-auto flex max-w-3xl flex-col gap-2",
                     if media_menu_open {
-                        div { class: "absolute bottom-full left-0 z-20 mb-2 max-h-80 w-full overflow-y-auto rounded-xl border border-foreground/10 bg-background/95 shadow-xl backdrop-blur-xl",
+                        PromptPopup {
                             if media_loading() {
                                 div { class: "px-3.5 py-2 text-sm text-muted-foreground", "Loading media…" }
                             } else if media_entries.read().is_empty() {
@@ -848,7 +861,7 @@ pub fn Page() -> Element {
                         }
                     }
                     if cmd_menu_open {
-                        div { class: "absolute bottom-full left-0 z-20 mb-2 w-full overflow-hidden rounded-xl border border-foreground/10 bg-background/95 shadow-xl backdrop-blur-xl",
+                        PromptPopup {
                             for (i , command) in filtered_cmds.iter().enumerate() {
                                 {
                                     let command = command.clone();
@@ -867,7 +880,7 @@ pub fn Page() -> Element {
                         }
                     }
                     if session_menu_open {
-                        div { class: "absolute bottom-full left-0 z-20 mb-2 max-h-80 w-full overflow-y-auto rounded-xl border border-foreground/10 bg-background/95 shadow-xl backdrop-blur-xl",
+                        PromptPopup {
                             if resume_state == Some(ResumeMenuState::Loading) {
                                 div { class: "px-3.5 py-2 text-sm text-muted-foreground", "Loading sessions…" }
                             } else if resume_state == Some(ResumeMenuState::Empty) {
@@ -899,7 +912,7 @@ pub fn Page() -> Element {
                         }
                     }
                     if model_menu_open {
-                        div { class: "absolute bottom-full left-0 z-20 mb-2 max-h-80 w-full overflow-y-auto rounded-xl border border-foreground/10 bg-background/95 shadow-xl backdrop-blur-xl",
+                        PromptPopup {
                             if filtered_models.is_empty() {
                                 div { class: "px-3.5 py-2 text-sm text-muted-foreground", "No matching models" }
                             } else {
@@ -977,7 +990,7 @@ pub fn Page() -> Element {
                             }
                         }
                     }
-                    if !queued.read().is_empty() {
+                    if transition_preview.read().is_empty() && !queued.read().is_empty() {
                         div { class: "flex flex-col items-end gap-1.5",
                             for queued_prompt in queued.read().iter().cloned() {
                                 div {
@@ -1058,9 +1071,7 @@ pub fn Page() -> Element {
                             }
                         }
                     }
-                    div { class: "relative flex items-center overflow-hidden rounded-2xl bg-white/45 p-1 shadow-[0_18px_55px_-24px_rgba(0,0,0,0.65),inset_0_1px_0_rgba(255,255,255,0.18),inset_0_-1px_0_rgba(255,255,255,0.04)] ring-1 ring-inset ring-black/10 backdrop-blur-3xl backdrop-saturate-150 transition-all duration-200 focus-within:bg-white/55 focus-within:ring-black/20 focus-within:shadow-[0_22px_65px_-24px_rgba(0,0,0,0.72),inset_0_1px_0_rgba(255,255,255,0.22)] dark:bg-white/[0.045] dark:ring-white/[0.16] dark:focus-within:bg-white/[0.065] dark:focus-within:ring-white/25",
-                        div { class: "pointer-events-none absolute inset-px rounded-[0.9rem] bg-gradient-to-b from-white/[0.12] via-white/[0.025] to-transparent dark:from-white/[0.10]" }
-                        div { class: "pointer-events-none absolute -left-12 -top-12 h-24 w-72 rotate-[-5deg] rounded-full bg-white/[0.09] blur-2xl" }
+                    PromptBox {
                         button {
                             class: "relative z-10 ml-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg text-foreground/45 transition hover:bg-foreground/10 hover:text-foreground",
                             title: "Attach files (/upload)",
@@ -1120,7 +1131,9 @@ pub fn Page() -> Element {
                             div { class: "relative min-w-32 flex-1 overflow-hidden",
                                 if draft.read().is_empty() {
                                     div { class: "pointer-events-none absolute inset-0 flex -translate-y-px items-center overflow-hidden px-1.5",
-                                        if show_capability_examples {
+                                        if !transition_preview.read().is_empty() {
+                                            div { class: "max-w-full truncate whitespace-nowrap text-[15px] leading-6 text-foreground", "{transition_preview}" }
+                                        } else if show_capability_examples {
                                             PromptGhost {
                                                 accent_bg: agent_accent.accent_bg.to_string(),
                                                 terminal: false,

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -342,14 +342,6 @@ pub fn Page(
     let mut resume_loading = use_signal(|| false);
     let mut verb = use_signal(|| "Working".to_string());
 
-    use_future(move || async move {
-        if transition_preview.peek().is_empty() {
-            return;
-        }
-        gloo_timers::future::TimeoutFuture::new(340).await;
-        transition_preview.set(String::new());
-    });
-
     use_effect(move || install_global_prompt_input(draft, slash_cmds));
     use_effect(move || {
         let _ = draft.read();
@@ -425,6 +417,7 @@ pub fn Page(
         status.set(snap.status.clone());
         error.set(snap.error.clone());
         queued.set(snap.queued.clone());
+        transition_preview.set(String::new());
         paused.set(snap.paused);
         agent_name.set(snap.agent_name.clone());
         agent_icon.set(snap.agent_icon.clone());

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -21,7 +21,9 @@ use crate::chat_page::event::{
 use dioxus::prelude::*;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
-use vmux_command::prompt_media::{inline_media_query, media_reference, replace_inline_media_query};
+use vmux_command::prompt_media::{
+    inline_media_query, media_display_path, media_reference, replace_inline_media_query,
+};
 use vmux_terminal::matrix_rain::MatrixRain;
 use vmux_ui::agent_accent::agent_accent;
 use vmux_ui::components::prompt_box::{PromptBox, PromptPopup};
@@ -807,6 +809,7 @@ pub fn Page(
                                 for (i , entry) in media_entries.read().iter().cloned().enumerate() {
                                     {
                                         let entry = entry.clone();
+                                        let display_path = media_display_path(&entry);
                                         rsx! {
                                             div {
                                                 key: "media-{entry.path}",
@@ -837,7 +840,7 @@ pub fn Page(
                                                 }
                                                 div { class: "min-w-0 flex-1",
                                                     div { class: "truncate text-sm text-foreground", "{entry.name}" }
-                                                    div { class: "truncate text-xs text-muted-foreground", "{entry.parent}" }
+                                                    div { class: "truncate text-xs text-muted-foreground", "{display_path}" }
                                                 }
                                             }
                                         }

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -1785,6 +1785,11 @@ fn activity_icon_paths(kind: ActivityIcon) -> &'static [&'static str] {
 }
 
 fn render_activity_icon(kind: ActivityIcon) -> Element {
+    if kind == ActivityIcon::Thinking {
+        return rsx! {
+            span { class: "flex h-6 w-6 shrink-0 items-center justify-center text-[17px] leading-none", aria_hidden: "true", "🧠" }
+        };
+    }
     if kind == ActivityIcon::Python {
         return rsx! {
             span { class: "python-activity-icon flex h-6 w-6 shrink-0 items-center justify-center rounded-lg ring-1 ring-inset", aria_hidden: "true",

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -705,7 +705,7 @@ pub fn Page(
                             }
                         }
                     } else if items.read().is_empty() && status() == "idle" {
-                        div { class: "flex flex-col items-center gap-3 py-24 text-center",
+                        div { class: "vmux-agent-ready-enter flex flex-col items-center gap-3 py-24 text-center",
                             {avatar_node(&agent_icon(), &accent(), &agent, &header_name, "h-14 w-14 text-xl")}
                             h2 { class: "bg-gradient-to-b from-foreground to-foreground/50 bg-clip-text text-3xl font-semibold capitalize tracking-tight text-transparent",
                                 "{header_name}"

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -927,6 +927,7 @@ fn send_acp_input(
         &AcpSession,
         &mut AgentRunState,
         &mut PromptQueue,
+        Has<AcpInstallStarted>,
         Option<&mut PendingHandoff>,
         Option<&mut ImportedConversation>,
     )>,
@@ -939,8 +940,10 @@ fn send_acp_input(
     let Some(service) = service else {
         return;
     };
-    for (entity, session, mut state, mut queue, mut pending, mut imported) in &mut q {
-        if !queue.ready(matches!(*state, AgentRunState::Idle)) {
+    for (entity, session, mut state, mut queue, install_started, mut pending, mut imported) in
+        &mut q
+    {
+        if !acp_prompt_dispatch_ready(&state, &queue, install_started) {
             continue;
         }
         let Some(prompt) = queue.take_next() else {
@@ -969,6 +972,14 @@ fn send_acp_input(
     }
 }
 
+fn acp_prompt_dispatch_ready(
+    state: &AgentRunState,
+    queue: &PromptQueue,
+    install_started: bool,
+) -> bool {
+    install_started && queue.ready(matches!(state, AgentRunState::Idle))
+}
+
 fn close_acp_session_on_remove(
     trigger: On<Remove, AcpSession>,
     sessions: Query<&AcpSession>,
@@ -991,6 +1002,31 @@ mod tests {
 
     fn s(k: &str, v: &str) -> (String, String) {
         (k.to_string(), v.to_string())
+    }
+
+    #[test]
+    fn queued_prompt_waits_for_acp_install_start() {
+        let mut queue = PromptQueue::default();
+        queue.enqueue("hello".to_string());
+
+        assert!(!acp_prompt_dispatch_ready(
+            &AgentRunState::Idle,
+            &queue,
+            false
+        ));
+        assert!(acp_prompt_dispatch_ready(
+            &AgentRunState::Idle,
+            &queue,
+            true
+        ));
+        assert!(!acp_prompt_dispatch_ready(
+            &AgentRunState::Installing {
+                pct: None,
+                message: "Preparing agent…".to_string(),
+            },
+            &queue,
+            true
+        ));
     }
 
     #[test]

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -7328,7 +7328,10 @@ mod tests {
             .add_systems(Update, handle_agent_page_open);
         let stack = app
             .world_mut()
-            .spawn(vmux_layout::stack::stack_bundle())
+            .spawn((
+                vmux_layout::stack::stack_bundle(),
+                PendingAgentPrompt("keep this prompt".to_string()),
+            ))
             .id();
         let webview = app
             .world_mut()
@@ -7374,6 +7377,15 @@ mod tests {
             app.world().get::<PageMetadata>(webview).unwrap().url,
             "vmux://agent/claude"
         );
+        let queue = app
+            .world()
+            .get::<crate::components::PromptQueue>(stack)
+            .unwrap();
+        assert_eq!(
+            queue.items.front().map(|item| item.text.as_str()),
+            Some("keep this prompt")
+        );
+        assert!(app.world().get::<PendingAgentPrompt>(stack).is_none());
         assert!(
             app.world()
                 .get::<vmux_layout::start::StartAgentTransition>(stack)

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -6,8 +6,8 @@ use bevy_cef::prelude::{CefKeyboardTarget, WebviewExtendStandardMaterial};
 use vmux_command::{AppCommand, WriteAppCommands};
 use vmux_core::agent::{
     AgentKind, AgentProviderTargetKind, PageAgentAttachDefaultRequest, PageAgentAttachRequest,
-    PageAgentSpawnDefaultRequest, PageAgentSpawnStackRequest, PendingAgentPrompt, RestartAgentPty,
-    SpawnAgentInStackRequest,
+    PageAgentSpawnDefaultRequest, PageAgentSpawnStackRequest, PendingAgentPrompt,
+    PendingAgentPromptAttachments, RestartAgentPty, SpawnAgentInStackRequest,
 };
 use vmux_core::{
     LastActivatedAt, PageMetadata, PageOpenError, PageOpenHandled, PageOpenSet, PageOpenTask, Ready,
@@ -18,6 +18,7 @@ use vmux_layout::{
     stack::FocusedStack,
 };
 use vmux_service::client::ServiceClient;
+use vmux_service::protocol::AgentAttachment;
 use vmux_service::protocol::{
     AgentCommand as ServiceAgentCommand, AgentCommandResult, AgentQuery, AgentQueryResult,
     AgentRequestId, AgentShellMode, ClientMessage, ProcessId,
@@ -4221,7 +4222,7 @@ fn prepare_agent_tab_worktrees(
 fn handle_agent_page_open(
     mut open_q: ParamSet<(
         Query<(Entity, &PageOpenTask), PendingPageOpen>,
-        Query<&PendingAgentPrompt>,
+        Query<(&PendingAgentPrompt, Option<&PendingAgentPromptAttachments>)>,
     )>,
     children_q: Query<&Children>,
     agents: Query<&vmux_core::agent::AgentSession>,
@@ -4270,11 +4271,18 @@ fn handle_agent_page_open(
                 continue;
             }
         };
-        let initial_prompt = open_q
+        let (initial_prompt, initial_attachments) = open_q
             .p1()
             .get(task.stack)
-            .ok()
-            .map(|prompt| prompt.0.clone());
+            .map(|(prompt, attachments)| {
+                (
+                    Some(prompt.0.clone()),
+                    attachments
+                        .map(|attachments| attachments.0.clone())
+                        .unwrap_or_default(),
+                )
+            })
+            .unwrap_or_default();
         let transition_webview = transitions
             .get(task.stack)
             .ok()
@@ -4283,6 +4291,7 @@ fn handle_agent_page_open(
         match handle_agent_page_open_task(
             &task,
             initial_prompt,
+            initial_attachments,
             transition_webview,
             &children_q,
             &agents,
@@ -4405,6 +4414,7 @@ fn handle_swap_stack_session(
                     session_id,
                     stack: ev.stack,
                     initial_prompt: None,
+                    initial_attachments: Vec::new(),
                 });
             }
             crate::AgentUrl::Acp { id, sid } => {
@@ -4440,6 +4450,7 @@ fn handle_swap_stack_session(
 fn handle_agent_page_open_task(
     task: &PageOpenTask,
     initial_prompt: Option<String>,
+    initial_attachments: Vec<AgentAttachment>,
     transition_webview: Option<Entity>,
     children_q: &Query<&Children>,
     agents: &Query<&vmux_core::agent::AgentSession>,
@@ -4486,7 +4497,7 @@ fn handle_agent_page_open_task(
                 kind_q,
             )
             .ok_or_else(|| format!("no Page agent strategy registered for {provider}/{model}"))?;
-            insert_initial_prompt_queue(task.stack, initial_prompt, commands);
+            insert_initial_prompt_queue(task.stack, initial_prompt, initial_attachments, commands);
             Ok(())
         }
         Some(crate::AgentUrl::PageDefault) => {
@@ -4517,7 +4528,7 @@ fn handle_agent_page_open_task(
                     provider.provider, provider.default_model
                 )
             })?;
-            insert_initial_prompt_queue(task.stack, initial_prompt, commands);
+            insert_initial_prompt_queue(task.stack, initial_prompt, initial_attachments, commands);
             Ok(())
         }
         Some(crate::AgentUrl::Cli { kind, sid }) => {
@@ -4529,6 +4540,7 @@ fn handle_agent_page_open_task(
                         session_id: None,
                         stack: task.stack,
                         initial_prompt,
+                        initial_attachments,
                     });
                 }
                 return Ok(());
@@ -4545,6 +4557,7 @@ fn handle_agent_page_open_task(
                 session_id: Some(sid),
                 stack: task.stack,
                 initial_prompt,
+                initial_attachments,
             });
             Ok(())
         }
@@ -4568,6 +4581,7 @@ fn handle_agent_page_open_task(
                             session_id: None,
                             stack: task.stack,
                             initial_prompt,
+                            initial_attachments,
                         });
                     }
                     return Ok(());
@@ -4603,7 +4617,7 @@ fn handle_agent_page_open_task(
                 meshes,
                 webview_mt,
             );
-            insert_initial_prompt_queue(task.stack, initial_prompt, commands);
+            insert_initial_prompt_queue(task.stack, initial_prompt, initial_attachments, commands);
             Ok(())
         }
         None => Err(format!("malformed agent URL '{}'", task.url)),
@@ -4613,17 +4627,42 @@ fn handle_agent_page_open_task(
 fn insert_initial_prompt_queue(
     stack: Entity,
     initial_prompt: Option<String>,
+    initial_attachments: Vec<AgentAttachment>,
     commands: &mut Commands,
 ) {
-    let Some(prompt) = initial_prompt.filter(|prompt| !prompt.trim().is_empty()) else {
+    let prompt = initial_prompt.unwrap_or_default();
+    if prompt.trim().is_empty() && initial_attachments.is_empty() {
         return;
-    };
+    }
     let mut queue = crate::components::PromptQueue::default();
-    queue.enqueue(prompt);
+    queue.enqueue_with_attachments(prompt, initial_attachments);
     commands
         .entity(stack)
         .insert(queue)
-        .remove::<PendingAgentPrompt>();
+        .remove::<(PendingAgentPrompt, PendingAgentPromptAttachments)>();
+}
+
+fn cli_initial_prompt(
+    kind: AgentKind,
+    prompt: Option<&str>,
+    attachments: &[AgentAttachment],
+) -> Option<String> {
+    let mut parts = Vec::new();
+    if let Some(prompt) = prompt.filter(|prompt| !prompt.trim().is_empty()) {
+        parts.push(prompt.to_string());
+    }
+    parts.extend(attachments.iter().filter_map(|attachment| {
+        if attachment.path.is_empty() {
+            return None;
+        }
+        let path = vmux_terminal::image_path_payload(kind == AgentKind::Vibe, &attachment.path);
+        Some(if kind == AgentKind::Vibe {
+            format!("@{path}")
+        } else {
+            path
+        })
+    }));
+    (!parts.is_empty()).then(|| parts.join(" "))
 }
 
 fn stack_has_agent_of_kind(
@@ -4818,7 +4857,11 @@ fn handle_spawn_agent_requests(
                         cwd: req.cwd.clone(),
                     });
                 }
-                if let Some(prompt) = req.initial_prompt.clone().filter(|p| !p.trim().is_empty()) {
+                if let Some(prompt) = cli_initial_prompt(
+                    req.kind,
+                    req.initial_prompt.as_deref(),
+                    &req.initial_attachments,
+                ) {
                     commands
                         .entity(terminal)
                         .insert(vmux_terminal::PromptCapture {
@@ -4826,7 +4869,9 @@ fn handle_spawn_agent_requests(
                             skipped: false,
                         });
                 }
-                commands.entity(req.stack).remove::<PendingAgentPrompt>();
+                commands
+                    .entity(req.stack)
+                    .remove::<(PendingAgentPrompt, PendingAgentPromptAttachments)>();
             }
             Err(e) => {
                 bevy::log::warn!("agent spawn ({:?}) failed: {e}", req.kind);
@@ -7331,6 +7376,12 @@ mod tests {
             .spawn((
                 vmux_layout::stack::stack_bundle(),
                 PendingAgentPrompt("keep this prompt".to_string()),
+                PendingAgentPromptAttachments(vec![AgentAttachment {
+                    path: "/tmp/reference.png".to_string(),
+                    name: "reference.png".to_string(),
+                    mime_type: "image/png".to_string(),
+                    size: 42,
+                }]),
             ))
             .id();
         let webview = app
@@ -7385,7 +7436,20 @@ mod tests {
             queue.items.front().map(|item| item.text.as_str()),
             Some("keep this prompt")
         );
+        assert_eq!(
+            queue
+                .items
+                .front()
+                .and_then(|item| item.attachments.first())
+                .map(|attachment| attachment.path.as_str()),
+            Some("/tmp/reference.png")
+        );
         assert!(app.world().get::<PendingAgentPrompt>(stack).is_none());
+        assert!(
+            app.world()
+                .get::<PendingAgentPromptAttachments>(stack)
+                .is_none()
+        );
         assert!(
             app.world()
                 .get::<vmux_layout::start::StartAgentTransition>(stack)
@@ -7654,6 +7718,7 @@ mod tests {
                 session_id: None,
                 stack,
                 initial_prompt: Some("@asdfas".to_string()),
+                initial_attachments: Vec::new(),
             });
 
         app.update();
@@ -7667,6 +7732,25 @@ mod tests {
         assert_eq!(capture.draft, "@asdfas");
         assert!(!capture.skipped);
         assert!(!buffered);
+    }
+
+    #[test]
+    fn cli_initial_prompt_keeps_media_paths() {
+        let attachments = vec![AgentAttachment {
+            path: "/tmp/reference image.png".to_string(),
+            name: "reference image.png".to_string(),
+            mime_type: "image/png".to_string(),
+            size: 42,
+        }];
+
+        assert_eq!(
+            cli_initial_prompt(AgentKind::Codex, Some("describe this"), &attachments).as_deref(),
+            Some("describe this /tmp/reference image.png")
+        );
+        assert_eq!(
+            cli_initial_prompt(AgentKind::Vibe, Some("describe this"), &attachments).as_deref(),
+            Some("describe this @'/tmp/reference image.png'")
+        );
     }
 
     #[test]

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -348,6 +348,24 @@ pub fn attach_page_agent_to_stack(
     idx: &crate::client::page::strategy_index::PageStrategyIndex,
     kind_q: &Query<&crate::client::page::strategy_components::StrategyKind>,
 ) -> Option<()> {
+    attach_page_agent_to_stack_with_webview(
+        stack, provider, model, sid, None, commands, meshes, webview_mt, idx, kind_q,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn attach_page_agent_to_stack_with_webview(
+    stack: Entity,
+    provider: &str,
+    model: &str,
+    sid: &str,
+    webview: Option<Entity>,
+    commands: &mut Commands,
+    meshes: &mut ResMut<Assets<Mesh>>,
+    webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
+    idx: &crate::client::page::strategy_index::PageStrategyIndex,
+    kind_q: &Query<&crate::client::page::strategy_components::StrategyKind>,
+) -> Option<()> {
     let entity = idx.get_by_strs(provider, model)?;
     let kind = kind_q.get(entity).ok()?.0;
     let url = format!("{}{sid}", crate::url::page_url_prefix(provider, model));
@@ -375,11 +393,26 @@ pub fn attach_page_agent_to_stack(
         },
     ));
     let url = format!("vmux://agent/{provider}");
-    commands.spawn((
-        vmux_layout::Browser::new(meshes, webview_mt, &url),
-        crate::chat_page::AgentChatView,
-        ChildOf(stack),
-    ));
+    if let Some(webview) = webview {
+        commands
+            .entity(webview)
+            .insert((
+                crate::chat_page::AgentChatView,
+                PageMetadata {
+                    url,
+                    title: format!("{provider}/{model}"),
+                    bg_color: Some(vmux_layout::event::TERMINAL_CEF_BG_COLOR.to_string()),
+                    ..default()
+                },
+            ))
+            .remove::<crate::chat_page::ChatSynced>();
+    } else {
+        commands.spawn((
+            vmux_layout::Browser::new(meshes, webview_mt, &url),
+            crate::chat_page::AgentChatView,
+            ChildOf(stack),
+        ));
+    }
     Some(())
 }
 
@@ -392,6 +425,25 @@ pub fn attach_acp_agent_to_stack(
     cwd: &std::path::Path,
     icon: Option<&str>,
     resume: Option<&str>,
+    commands: &mut Commands,
+    meshes: &mut ResMut<Assets<Mesh>>,
+    webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
+) {
+    attach_acp_agent_to_stack_with_webview(
+        stack, agent_id, name, sid, cwd, icon, resume, None, commands, meshes, webview_mt,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn attach_acp_agent_to_stack_with_webview(
+    stack: Entity,
+    agent_id: &str,
+    name: &str,
+    sid: &str,
+    cwd: &std::path::Path,
+    icon: Option<&str>,
+    resume: Option<&str>,
+    webview: Option<Entity>,
     commands: &mut Commands,
     meshes: &mut ResMut<Assets<Mesh>>,
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
@@ -434,12 +486,28 @@ pub fn attach_acp_agent_to_stack(
         commands.entity(stack).insert(imported);
     }
     // The webview carries the anchor `ProcessId`, so vmux_mcp tool calls resolve to this pane.
-    commands.spawn((
-        vmux_layout::Browser::new(meshes, webview_mt, &url),
-        crate::chat_page::AgentChatView,
-        ChildOf(stack),
-        anchor,
-    ));
+    if let Some(webview) = webview {
+        commands
+            .entity(webview)
+            .insert((
+                crate::chat_page::AgentChatView,
+                PageMetadata {
+                    url,
+                    title: name.to_string(),
+                    bg_color: Some(vmux_layout::event::TERMINAL_CEF_BG_COLOR.to_string()),
+                    icon: vmux_core::PageIcon::favicon(icon.unwrap_or("")),
+                },
+                anchor,
+            ))
+            .remove::<crate::chat_page::ChatSynced>();
+    } else {
+        commands.spawn((
+            vmux_layout::Browser::new(meshes, webview_mt, &url),
+            crate::chat_page::AgentChatView,
+            ChildOf(stack),
+            anchor,
+        ));
+    }
 }
 
 /// The registry icon URL for an ACP agent id, if the catalog is loaded and lists it.
@@ -4169,6 +4237,7 @@ fn handle_agent_page_open(
     settings: Res<AppSettings>,
     workspace: AgentPageOpenWorkspace,
     catalog: Option<Res<crate::client::acp::AcpCatalog>>,
+    transitions: Query<&vmux_layout::start::StartAgentTransition>,
 ) {
     let tasks: Vec<(Entity, PageOpenTask)> = open_q
         .p0()
@@ -4206,9 +4275,15 @@ fn handle_agent_page_open(
             .get(task.stack)
             .ok()
             .map(|prompt| prompt.0.clone());
+        let transition_webview = transitions
+            .get(task.stack)
+            .ok()
+            .map(|transition| transition.webview)
+            .filter(|_| vmux_layout::start::supports_inline_agent_transition(&task.url));
         match handle_agent_page_open_task(
             &task,
             initial_prompt,
+            transition_webview,
             &children_q,
             &agents,
             &acp_sessions,
@@ -4226,6 +4301,9 @@ fn handle_agent_page_open(
         ) {
             Ok(()) => {
                 commands.entity(entity).insert(PageOpenHandled);
+                commands
+                    .entity(task.stack)
+                    .remove::<vmux_layout::start::StartAgentTransition>();
             }
             Err(message) => {
                 commands.entity(entity).insert(PageOpenError { message });
@@ -4362,6 +4440,7 @@ fn handle_swap_stack_session(
 fn handle_agent_page_open_task(
     task: &PageOpenTask,
     initial_prompt: Option<String>,
+    transition_webview: Option<Entity>,
     children_q: &Query<&Children>,
     agents: &Query<&vmux_core::agent::AgentSession>,
     acp_sessions: &Query<&crate::client::acp::AcpSession>,
@@ -4390,10 +4469,21 @@ fn handle_agent_page_open_task(
             model,
             sid,
         }) => {
-            clear_stack_children(task.stack, children_q, commands);
+            if transition_webview.is_none() {
+                clear_stack_children(task.stack, children_q, commands);
+            }
             let idx = idx.ok_or_else(|| "page strategy index not registered".to_string())?;
-            attach_page_agent_to_stack(
-                task.stack, &provider, &model, &sid, commands, meshes, webview_mt, idx, kind_q,
+            attach_page_agent_to_stack_with_webview(
+                task.stack,
+                &provider,
+                &model,
+                &sid,
+                transition_webview,
+                commands,
+                meshes,
+                webview_mt,
+                idx,
+                kind_q,
             )
             .ok_or_else(|| format!("no Page agent strategy registered for {provider}/{model}"))?;
             insert_initial_prompt_queue(task.stack, initial_prompt, commands);
@@ -4406,12 +4496,15 @@ fn handle_agent_page_open_task(
             })?;
             let idx = idx.ok_or_else(|| "page strategy index not registered".to_string())?;
             let sid = uuid::Uuid::new_v4().to_string();
-            clear_stack_children(task.stack, children_q, commands);
-            attach_page_agent_to_stack(
+            if transition_webview.is_none() {
+                clear_stack_children(task.stack, children_q, commands);
+            }
+            attach_page_agent_to_stack_with_webview(
                 task.stack,
                 provider.provider,
                 provider.default_model,
                 &sid,
+                transition_webview,
                 commands,
                 meshes,
                 webview_mt,
@@ -4489,13 +4582,15 @@ fn handle_agent_page_open_task(
             {
                 return Ok(());
             }
-            clear_stack_children(task.stack, children_q, commands);
+            if transition_webview.is_none() {
+                clear_stack_children(task.stack, children_q, commands);
+            }
             // `sid` (when present) is the agent-assigned ACP session id from a restored url — pass
             // it as the resume target. Fresh opens mint a routing sid and load nothing.
             let routing_sid = uuid::Uuid::new_v4().to_string();
             let icon = acp_icon_for_id(catalog, &id);
             let name = acp_profile_name_for_id(&id, cfg, catalog);
-            attach_acp_agent_to_stack(
+            attach_acp_agent_to_stack_with_webview(
                 task.stack,
                 &id,
                 &name,
@@ -4503,6 +4598,7 @@ fn handle_agent_page_open_task(
                 default_cwd,
                 icon.as_deref(),
                 sid.as_deref(),
+                transition_webview,
                 commands,
                 meshes,
                 webview_mt,
@@ -7218,6 +7314,70 @@ mod tests {
                 .filter(|child_of| child_of.parent() == stack)
                 .count(),
             1
+        );
+    }
+
+    #[test]
+    fn inline_start_transition_reuses_the_existing_webview() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<SpawnAgentInStackRequest>()
+            .insert_resource(test_settings())
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+            .add_systems(Update, handle_agent_page_open);
+        let stack = app
+            .world_mut()
+            .spawn(vmux_layout::stack::stack_bundle())
+            .id();
+        let webview = app
+            .world_mut()
+            .spawn((
+                vmux_layout::Browser,
+                bevy_cef::prelude::WebviewSource::new("vmux://start/"),
+                PageMetadata {
+                    url: "vmux://start/".to_string(),
+                    title: "Start".to_string(),
+                    ..default()
+                },
+                vmux_layout::start::StartAgentTransitionView,
+                ChildOf(stack),
+            ))
+            .id();
+        app.world_mut()
+            .entity_mut(stack)
+            .insert(vmux_layout::start::StartAgentTransition { webview });
+        app.world_mut().spawn(PageOpenTask {
+            id: vmux_core::PageOpenId::new(),
+            stack,
+            url: "vmux://agent/claude".to_string(),
+            request_id: None,
+        });
+
+        app.update();
+
+        assert!(app.world().get_entity(webview).is_ok());
+        assert!(
+            app.world()
+                .get::<crate::chat_page::AgentChatView>(webview)
+                .is_some()
+        );
+        assert!(
+            matches!(
+                app.world()
+                    .get::<bevy_cef::prelude::WebviewSource>(webview),
+                Some(bevy_cef::prelude::WebviewSource::Url(url)) if url == "vmux://start/"
+            ),
+            "the existing document remains loaded"
+        );
+        assert_eq!(
+            app.world().get::<PageMetadata>(webview).unwrap().url,
+            "vmux://agent/claude"
+        );
+        assert!(
+            app.world()
+                .get::<vmux_layout::start::StartAgentTransition>(stack)
+                .is_none()
         );
     }
 

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -837,6 +837,7 @@ fn dismiss_windowed_command_bar_on_outside_click(
                     value: String::new(),
                     target: None,
                     agent_url: None,
+                    attachments: Vec::new(),
                 },
             });
             break;
@@ -861,6 +862,7 @@ fn dismiss_windowed_command_bar_from_native_monitor(
             value: String::new(),
             target: None,
             agent_url: None,
+            attachments: Vec::new(),
         },
     });
 }

--- a/crates/vmux_command/src/event.rs
+++ b/crates/vmux_command/src/event.rs
@@ -459,22 +459,6 @@ mod tests {
     }
 
     #[test]
-    fn action_event_fields() {
-        let evt = CommandBarActionEvent {
-            action: "open".to_string(),
-            value: "google.com".to_string(),
-            target: None,
-            agent_url: None,
-            attachments: Vec::new(),
-        };
-        assert_eq!(evt.action, "open");
-        assert_eq!(evt.value, "google.com");
-        assert_eq!(evt.target, None);
-        assert_eq!(evt.agent_url, None);
-        assert!(evt.attachments.is_empty());
-    }
-
-    #[test]
     fn command_bar_open_event_carries_space_name() {
         let event = CommandBarOpenEvent {
             space_name: "Work".to_string(),

--- a/crates/vmux_command/src/event.rs
+++ b/crates/vmux_command/src/event.rs
@@ -172,6 +172,7 @@ pub struct CommandBarActionEvent {
     pub value: String,
     pub target: Option<crate::open_target::OpenTarget>,
     pub agent_url: Option<String>,
+    pub attachments: Vec<crate::prompt_media::ChatSubmitAttachment>,
 }
 
 #[derive(
@@ -464,11 +465,13 @@ mod tests {
             value: "google.com".to_string(),
             target: None,
             agent_url: None,
+            attachments: Vec::new(),
         };
         assert_eq!(evt.action, "open");
         assert_eq!(evt.value, "google.com");
         assert_eq!(evt.target, None);
         assert_eq!(evt.agent_url, None);
+        assert!(evt.attachments.is_empty());
     }
 
     #[test]

--- a/crates/vmux_command/src/lib.rs
+++ b/crates/vmux_command/src/lib.rs
@@ -5,6 +5,7 @@ pub mod event;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod open;
 pub mod open_target;
+pub mod prompt_media;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod bundle;

--- a/crates/vmux_command/src/prompt_media.rs
+++ b/crates/vmux_command/src/prompt_media.rs
@@ -1,0 +1,239 @@
+pub const CHAT_ATTACHMENTS_EVENT: &str = "chat_attachments";
+pub const CHAT_ATTACHMENT_PREVIEWS_EVENT: &str = "chat_attachment_previews";
+pub const CHAT_MEDIA_ENTRIES_EVENT: &str = "chat_media_entries";
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatAttachment {
+    pub path: String,
+    pub name: String,
+    pub mime_type: String,
+    pub size: u64,
+    pub preview_data_url: String,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatSubmitAttachment {
+    pub path: String,
+    pub name: String,
+    pub mime_type: String,
+    pub size: u64,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatAttachments {
+    pub attachments: Vec<ChatAttachment>,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatMediaEntry {
+    pub path: String,
+    pub name: String,
+    pub parent: String,
+    pub mime_type: String,
+    pub is_dir: bool,
+    pub preview_data_url: String,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatMediaEntries {
+    pub request_id: u64,
+    pub query: String,
+    pub entries: Vec<ChatMediaEntry>,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatPickFiles;
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatPasteMedia;
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatMediaListRequest {
+    pub request_id: u64,
+    pub query: String,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatAttachPaths {
+    pub paths: Vec<String>,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatAttachmentPreviewRequest {
+    pub paths: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InlineMediaQuery<'a> {
+    pub start: usize,
+    pub query: &'a str,
+}
+
+pub fn inline_media_query(draft: &str) -> Option<InlineMediaQuery<'_>> {
+    draft.rmatch_indices('@').find_map(|(start, _)| {
+        let boundary = start == 0
+            || draft[..start]
+                .chars()
+                .next_back()
+                .is_some_and(char::is_whitespace);
+        let query = &draft[start + 1..];
+        (boundary && !query.chars().any(char::is_whitespace))
+            .then_some(InlineMediaQuery { start, query })
+    })
+}
+
+pub fn replace_inline_media_query(
+    draft: &str,
+    query: InlineMediaQuery<'_>,
+    replacement: &str,
+) -> String {
+    let mut value = String::with_capacity(draft.len() + replacement.len());
+    value.push_str(&draft[..query.start]);
+    value.push_str(replacement);
+    value
+}
+
+pub fn media_reference(entry: &ChatMediaEntry) -> String {
+    let encode = |value: &str| value.replace('%', "%25").replace(' ', "%20");
+    if entry.parent == "~" {
+        format!("~/{name}", name = encode(&entry.name))
+    } else {
+        format!(
+            "{parent}/{name}",
+            parent = encode(&entry.parent),
+            name = encode(&entry.name)
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inline_media_query_requires_a_token_boundary_and_open_tail() {
+        assert_eq!(
+            inline_media_query("inspect @Pictures/scr"),
+            Some(InlineMediaQuery {
+                start: 8,
+                query: "Pictures/scr",
+            })
+        );
+        assert_eq!(
+            inline_media_query("@"),
+            Some(InlineMediaQuery {
+                start: 0,
+                query: "",
+            })
+        );
+        assert_eq!(inline_media_query("mail@example.com"), None);
+        assert_eq!(inline_media_query("inspect @image.png next"), None);
+    }
+
+    #[test]
+    fn inline_media_replacement_preserves_prompt_prefix() {
+        let draft = "inspect @Pictures/scr";
+        let query = inline_media_query(draft).unwrap();
+        assert_eq!(
+            replace_inline_media_query(draft, query, "@Pictures/photo.png "),
+            "inspect @Pictures/photo.png "
+        );
+        assert_eq!(replace_inline_media_query(draft, query, ""), "inspect ");
+    }
+}

--- a/crates/vmux_command/src/prompt_media.rs
+++ b/crates/vmux_command/src/prompt_media.rs
@@ -202,6 +202,14 @@ pub fn media_reference(entry: &ChatMediaEntry) -> String {
     }
 }
 
+pub fn media_display_path(entry: &ChatMediaEntry) -> String {
+    if entry.parent == "~" {
+        format!("~/{}", entry.name)
+    } else {
+        format!("{}/{}", entry.parent.trim_end_matches('/'), entry.name)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -235,5 +243,22 @@ mod tests {
             "inspect @Pictures/photo.png "
         );
         assert_eq!(replace_inline_media_query(draft, query, ""), "inspect ");
+    }
+
+    #[test]
+    fn media_display_path_includes_entry_name() {
+        let entry = ChatMediaEntry {
+            name: "Accessibility".into(),
+            parent: "~/Library".into(),
+            ..Default::default()
+        };
+        assert_eq!(media_display_path(&entry), "~/Library/Accessibility");
+
+        let root_entry = ChatMediaEntry {
+            name: "Pictures".into(),
+            parent: "~".into(),
+            ..Default::default()
+        };
+        assert_eq!(media_display_path(&root_entry), "~/Pictures");
     }
 }

--- a/crates/vmux_core/src/agent.rs
+++ b/crates/vmux_core/src/agent.rs
@@ -113,11 +113,16 @@ pub struct SpawnAgentInStackRequest {
     /// Optional prompt to deliver into the agent once its TUI is ready. `None`
     /// opens the agent with no pre-filled prompt.
     pub initial_prompt: Option<String>,
+    pub initial_attachments: Vec<vmux_wire::protocol::AgentAttachment>,
 }
 
 /// Prompt waiting for the next agent attached to this stack.
 #[derive(Component, Clone, Debug)]
 pub struct PendingAgentPrompt(pub String);
+
+/// Attachments waiting for the next agent attached to this stack.
+#[derive(Component, Clone, Debug, Default)]
+pub struct PendingAgentPromptAttachments(pub Vec<vmux_wire::protocol::AgentAttachment>);
 
 /// Swap the agent session shown on `stack` in place: tear down the current session and
 /// re-attach `target_url` (an ACP or CLI agent url) with the given `cwd`. Same tab position.

--- a/crates/vmux_desktop/src/persistence.rs
+++ b/crates/vmux_desktop/src/persistence.rs
@@ -595,6 +595,7 @@ pub(crate) fn rebuild_space_views(
                             session_id,
                             stack: entity,
                             initial_prompt: None,
+                            initial_attachments: Vec::new(),
                         });
                     }
                     _ => {

--- a/crates/vmux_layout/src/archive.rs
+++ b/crates/vmux_layout/src/archive.rs
@@ -617,6 +617,7 @@ fn reopen_page_content(page: &ArchivedPage, stack: Entity, commands: &mut Comman
             session_id,
             stack,
             initial_prompt: None,
+            initial_attachments: Vec::new(),
         };
         commands.queue(move |world: &mut World| {
             world.write_message(request);

--- a/crates/vmux_layout/src/command_bar/handler.rs
+++ b/crates/vmux_layout/src/command_bar/handler.rs
@@ -32,7 +32,10 @@ use vmux_command::{
     AppCommand, BrowserBarCommand, BrowserCommand, LayoutCommand, PaneCommand, ReadAppCommands,
     SpaceCommand, StackCommand,
 };
-use vmux_core::agent::{PageAgentAttachRequest, PageAgentSpawnStackRequest, PendingAgentPrompt};
+use vmux_core::agent::{
+    PageAgentAttachRequest, PageAgentSpawnStackRequest, PendingAgentPrompt,
+    PendingAgentPromptAttachments,
+};
 use vmux_core::event::space::SpaceCommandEvent;
 use vmux_core::page::{SettingsPageSpawnRequest, SpacesPageSpawnRequest};
 use vmux_core::terminal::{ProcessesMonitorSpawnRequest, Terminal, TerminalSpawnRequest};
@@ -1326,7 +1329,18 @@ fn on_command_bar_action(
     match evt.action.as_str() {
         "prompt" => {
             let prompt = evt.value.trim();
-            if !prompt.is_empty() {
+            let attachments = evt
+                .attachments
+                .iter()
+                .filter(|attachment| !attachment.path.is_empty())
+                .map(|attachment| vmux_wire::protocol::AgentAttachment {
+                    path: attachment.path.clone(),
+                    name: attachment.name.clone(),
+                    mime_type: attachment.mime_type.clone(),
+                    size: attachment.size,
+                })
+                .collect::<Vec<_>>();
+            if !prompt.is_empty() || !attachments.is_empty() {
                 let (_, _, focused_stack) = focused_stack(
                     queries.active_tab_param.get(),
                     &queries.all_children,
@@ -1347,6 +1361,15 @@ fn on_command_bar_action(
                     commands
                         .entity(stack)
                         .insert(PendingAgentPrompt(prompt.to_string()));
+                    if !attachments.is_empty() {
+                        commands
+                            .entity(stack)
+                            .insert(PendingAgentPromptAttachments(attachments));
+                    } else {
+                        commands
+                            .entity(stack)
+                            .remove::<PendingAgentPromptAttachments>();
+                    }
                     writer_params.p1().write(PageOpenRequest {
                         target: PageOpenTarget::Stack(stack),
                         url,
@@ -1869,6 +1892,7 @@ fn reveal_command_bar(
                     value: String::new(),
                     target: None,
                     agent_url: None,
+                    attachments: Vec::new(),
                 },
             });
             continue;
@@ -2704,6 +2728,7 @@ mod tests {
                     value: String::new(),
                     target: None,
                     agent_url: None,
+                    attachments: Vec::new(),
                 },
             });
         app.world_mut().flush();

--- a/crates/vmux_layout/src/command_bar/handler.rs
+++ b/crates/vmux_layout/src/command_bar/handler.rs
@@ -1235,6 +1235,10 @@ fn mark_start_agent_transition(stack: Entity, webview: Entity, commands: &mut Co
         .insert(crate::start::StartAgentTransitionView);
 }
 
+fn use_legacy_default_agent_open(url: &str, inline_transition: bool) -> bool {
+    matches!(url, "vmux://agent/" | "vmux://agent") && !inline_transition
+}
+
 fn build_open_command(target: Option<OpenTarget>, url: String) -> OpenCommand {
     match target {
         Some(OpenTarget::InPlace) | None => OpenCommand::InPlace { url: Some(url) },
@@ -1394,13 +1398,16 @@ fn on_command_bar_action(
                 }
             } else {
                 let url = normalize_url(&evt.value);
-                if matches!(evt.target, None | Some(OpenTarget::InPlace))
+                let inline_transition = if matches!(evt.target, None | Some(OpenTarget::InPlace))
                     && crate::start::supports_inline_agent_transition(&url)
                     && let Some(stack) = inline_transition_stack
                 {
                     mark_start_agent_transition(stack, webview, &mut commands);
-                }
-                if matches!(url.as_str(), "vmux://agent/" | "vmux://agent") {
+                    true
+                } else {
+                    false
+                };
+                if use_legacy_default_agent_open(&url, inline_transition) {
                     if let Some(stack_e) = empty_stack {
                         page_default_attach_writer.write(
                             vmux_core::agent::PageAgentAttachDefaultRequest { stack: stack_e },
@@ -2995,6 +3002,14 @@ mod tests {
             prompt_agent_url(&CommandBarAgentsSnapshot::default(), None),
             None
         );
+    }
+
+    #[test]
+    fn inline_default_agent_open_uses_standard_page_flow() {
+        assert!(use_legacy_default_agent_open("vmux://agent/", false));
+        assert!(use_legacy_default_agent_open("vmux://agent", false));
+        assert!(!use_legacy_default_agent_open("vmux://agent/", true));
+        assert!(!use_legacy_default_agent_open("vmux://agent/codex", false));
     }
 
     #[test]

--- a/crates/vmux_layout/src/command_bar/handler.rs
+++ b/crates/vmux_layout/src/command_bar/handler.rs
@@ -1210,6 +1210,29 @@ struct CommandBarActionQueries<'w, 's> {
             Without<Modal>,
         ),
     >,
+    webview_sources: Query<'w, 's, &'static WebviewSource>,
+}
+
+fn start_agent_transition_stack(
+    webview: Entity,
+    queries: &CommandBarActionQueries,
+) -> Option<Entity> {
+    let WebviewSource::Url(url) = queries.webview_sources.get(webview).ok()? else {
+        return None;
+    };
+    if !url.starts_with(crate::start::START_PAGE_URL) {
+        return None;
+    }
+    queries.child_of_q.get(webview).ok().map(|parent| parent.0)
+}
+
+fn mark_start_agent_transition(stack: Entity, webview: Entity, commands: &mut Commands) {
+    commands
+        .entity(stack)
+        .insert(crate::start::StartAgentTransition { webview });
+    commands
+        .entity(webview)
+        .insert(crate::start::StartAgentTransitionView);
 }
 
 fn build_open_command(target: Option<OpenTarget>, url: String) -> OpenCommand {
@@ -1294,6 +1317,7 @@ fn on_command_bar_action(
     let mut empty_stack = new_stack_ctx.stack;
     let previous_stack = new_stack_ctx.previous_stack;
     let mut custom_keyboard_restore = false;
+    let inline_transition_stack = start_agent_transition_stack(webview, &queries);
 
     match evt.action.as_str() {
         "prompt" => {
@@ -1311,6 +1335,11 @@ fn on_command_bar_action(
                     && let Some(url) =
                         prompt_agent_url(&resource_params.p2(), evt.agent_url.as_deref())
                 {
+                    if inline_transition_stack == Some(stack)
+                        && crate::start::supports_inline_agent_transition(&url)
+                    {
+                        mark_start_agent_transition(stack, webview, &mut commands);
+                    }
                     commands
                         .entity(stack)
                         .insert(PendingAgentPrompt(prompt.to_string()));
@@ -1365,6 +1394,12 @@ fn on_command_bar_action(
                 }
             } else {
                 let url = normalize_url(&evt.value);
+                if matches!(evt.target, None | Some(OpenTarget::InPlace))
+                    && crate::start::supports_inline_agent_transition(&url)
+                    && let Some(stack) = inline_transition_stack
+                {
+                    mark_start_agent_transition(stack, webview, &mut commands);
+                }
                 if matches!(url.as_str(), "vmux://agent/" | "vmux://agent") {
                     if let Some(stack_e) = empty_stack {
                         page_default_attach_writer.write(

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -24,6 +24,7 @@ use vmux_command::event::{
 };
 use vmux_command::open_target::OpenTarget;
 use vmux_ui::components::icon::Icon;
+use vmux_ui::components::prompt_box::{PromptBox, PromptPopup};
 use vmux_ui::favicon::Favicon;
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener};
 use vmux_ui::icon::PageIconView;
@@ -39,6 +40,12 @@ pub enum PaletteVariant {
     Start,
 }
 
+#[derive(Clone, PartialEq)]
+pub struct StartAgentTransition {
+    pub agent_url: String,
+    pub prompt: String,
+}
+
 /// Props for [`CommandPalette`].
 #[derive(Props, Clone, PartialEq)]
 pub struct PaletteProps {
@@ -52,6 +59,8 @@ pub struct PaletteProps {
     pub on_dismiss: EventHandler<()>,
     /// Called on query/selection change (the modal re-emits its size).
     pub on_activity: EventHandler<()>,
+    #[props(default)]
+    pub on_start_agent_transition: Option<EventHandler<StartAgentTransition>>,
 }
 
 /// The shared command-bar body: input, live-filtered results, file-path completion,
@@ -61,9 +70,11 @@ pub struct PaletteProps {
 pub fn CommandPalette(props: PaletteProps) -> Element {
     let state = props.state;
     let variant = props.variant;
+    let is_start = matches!(variant, PaletteVariant::Start);
     let on_close = props.on_close;
     let on_dismiss = props.on_dismiss;
     let on_activity = props.on_activity;
+    let on_start_agent_transition = props.on_start_agent_transition;
 
     let mut query = use_signal(String::new);
     let mut selected = use_signal(|| 0usize);
@@ -166,9 +177,8 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let is_new_tab = matches!(open_target, Some(OpenTarget::InNewStack));
 
     let q = query();
-    let start_prompt_mode = matches!(variant, PaletteVariant::Start) && is_start_prompt_query(&q);
-    let start_agent_mode =
-        matches!(variant, PaletteVariant::Start) && (q.trim().is_empty() || start_prompt_mode);
+    let start_prompt_mode = is_start && is_start_prompt_query(&q);
+    let start_agent_mode = is_start && (q.trim().is_empty() || start_prompt_mode);
     let results: Vec<ResultItem> = if space_switch {
         space_switch_results(&spaces, &pages, &q)
     } else if start_agent_mode {
@@ -205,7 +215,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
             combined.extend(r);
             combined
         };
-        if matches!(variant, PaletteVariant::Start) {
+        if is_start {
             r.into_iter()
                 .filter(|item| {
                     !matches!(
@@ -288,6 +298,16 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
 
     let execute = move |item: &ResultItem| {
         let prompt = query();
+        if is_start
+            && let Some(agent_url) = agent_page_url(item)
+            && crate::start::supports_inline_agent_transition(agent_url)
+            && let Some(handler) = on_start_agent_transition
+        {
+            handler.call(StartAgentTransition {
+                agent_url: agent_url.to_string(),
+                prompt: prompt.trim().to_string(),
+            });
+        }
         if matches!(variant, PaletteVariant::Start)
             && is_start_prompt_query(&prompt)
             && let Some(agent_url) = agent_page_url(item)
@@ -359,8 +379,11 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     };
 
     rsx! {
-        div { class: "p-2",
-            div { class: command_bar_input_row_class(),
+        div { class: "relative",
+            PromptBox {
+                glass: is_start,
+                class: if is_start { "" } else { "p-2" },
+                div { class: if is_start { "relative z-10 flex min-w-0 w-full items-center gap-2 overflow-hidden px-2" } else { command_bar_input_row_class() },
                 if !space_name.is_empty() {
                     span {
                         title: "{space_name}",
@@ -436,7 +459,10 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                             selected.set(0);
                             nav_mode.set(false);
                         },
-                        onkeydown: move |e| {
+                        onkeydown: {
+                            let q = q.clone();
+                            let results = results.clone();
+                            move |e| {
                             if e.key() == Key::Tab {
                                 e.prevent_default();
                                 let gt = ghost_text.clone();
@@ -541,6 +567,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                                     }
                                 }
                             }
+                            }
                         },
                     }
                 }
@@ -569,9 +596,12 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                     }
                 }
             }
-        }
-        if !results.is_empty() {
-            div { id: "command-bar-results", class: result_list_class(),
+            }
+            if !results.is_empty() {
+                PromptPopup {
+                    upward: is_start,
+                    id: "command-bar-results",
+                    class: if is_start { "" } else { result_list_class() },
                 for (i, item) in results.iter().enumerate() {
                     div {
                         key: "{i}",
@@ -788,6 +818,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                             },
                         }
                     }
+                }
                 }
             }
         }

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -6,7 +6,7 @@ use crate::command_bar::keyboard::{
 };
 use crate::command_bar::results::{
     CommandBarResultItem as ResultItem, active_space_index, agent_page_matches_query,
-    agent_page_url, filter_results, space_switch_results, start_page_results,
+    agent_page_results, agent_page_url, filter_results, space_switch_results, start_page_results,
 };
 use crate::command_bar::style::{
     command_bar_input_class, command_bar_input_row_class, command_bar_input_wrap_class,
@@ -23,12 +23,18 @@ use vmux_command::event::{
     is_start_prompt_query, looks_like_url, should_open_typed_query_on_enter,
 };
 use vmux_command::open_target::OpenTarget;
+use vmux_command::prompt_media::{
+    CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT, ChatAttachPaths, ChatAttachment,
+    ChatAttachments, ChatMediaEntries, ChatMediaEntry, ChatMediaListRequest, ChatPasteMedia,
+    ChatPickFiles, inline_media_query, media_reference, replace_inline_media_query,
+};
 use vmux_ui::agent_accent::agent_accent;
 use vmux_ui::components::icon::Icon;
 use vmux_ui::components::prompt_box::{PromptBox, PromptPopup, PromptPopupPlacement};
 use vmux_ui::favicon::Favicon;
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener};
 use vmux_ui::icon::PageIconView;
+use vmux_ui::prompt_ghost::PromptGhost;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 
@@ -45,6 +51,7 @@ pub enum PaletteVariant {
 pub struct StartAgentTransition {
     pub agent_url: String,
     pub prompt: String,
+    pub attachments: Vec<vmux_command::prompt_media::ChatAttachment>,
 }
 
 /// Props for [`CommandPalette`].
@@ -85,6 +92,12 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let mut suggestions_request_id = use_signal(|| 0u64);
     let mut last_open_id = use_signal(|| u64::MAX);
     let mut last_focus_open_id = use_signal(|| u64::MAX);
+    let mut attachments = use_signal(Vec::<ChatAttachment>::new);
+    let mut media_entries = use_signal(Vec::<ChatMediaEntry>::new);
+    let mut media_request_id = use_signal(|| 0u64);
+    let mut media_requested_query = use_signal(|| None::<String>);
+    let mut media_loading = use_signal(|| false);
+    let mut media_selected = use_signal(|| 0usize);
 
     use_effect(move || {
         let s = state();
@@ -99,6 +112,13 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
             nav_mode.set(false);
             path_completions.set(Vec::new());
             history_suggestions.set(Vec::new());
+            if is_start {
+                attachments.set(Vec::new());
+                media_entries.set(Vec::new());
+                media_requested_query.set(None);
+                media_loading.set(false);
+                media_selected.set(0);
+            }
         }
     });
 
@@ -126,6 +146,31 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
         },
     );
 
+    let _attachments_listener =
+        use_bin_event_listener::<ChatAttachments, _>(CHAT_ATTACHMENTS_EVENT, move |selected| {
+            if !is_start {
+                return;
+            }
+            let mut next = attachments.peek().clone();
+            for attachment in &selected.attachments {
+                if !next.iter().any(|existing| existing.path == attachment.path) {
+                    next.push(attachment.clone());
+                }
+            }
+            attachments.set(next);
+            focus_command_input_end();
+        });
+
+    let _media_entries_listener =
+        use_bin_event_listener::<ChatMediaEntries, _>(CHAT_MEDIA_ENTRIES_EVENT, move |response| {
+            if !is_start || response.request_id != media_request_id() {
+                return;
+            }
+            media_entries.set(response.entries.clone());
+            media_loading.set(false);
+            media_selected.set(0);
+        });
+
     use_effect(move || {
         let q = query();
         let trimmed = q.trim();
@@ -146,6 +191,41 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
             limit: 5,
             request_id: id,
         });
+    });
+
+    use_effect(move || {
+        if !is_start {
+            return;
+        }
+        let value = query();
+        let Some(media_query) = inline_media_query(&value).map(|query| query.query.to_string())
+        else {
+            media_entries.set(Vec::new());
+            if media_requested_query.peek().is_some() {
+                media_request_id.set(media_request_id().wrapping_add(1).max(1));
+            }
+            media_requested_query.set(None);
+            media_loading.set(false);
+            media_selected.set(0);
+            return;
+        };
+        if media_requested_query().as_deref() == Some(media_query.as_str()) {
+            return;
+        }
+        let request_id = media_request_id().wrapping_add(1).max(1);
+        media_request_id.set(request_id);
+        media_requested_query.set(Some(media_query.clone()));
+        media_entries.set(Vec::new());
+        media_loading.set(true);
+        media_selected.set(0);
+        if try_cef_bin_emit_rkyv(&ChatMediaListRequest {
+            request_id,
+            query: media_query,
+        })
+        .is_err()
+        {
+            media_loading.set(false);
+        }
     });
 
     use_effect(move || {
@@ -178,6 +258,9 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let is_new_tab = matches!(open_target, Some(OpenTarget::InNewStack));
 
     let q = query();
+    let media_query = is_start.then(|| inline_media_query(&q)).flatten();
+    let media_menu_open = media_query.is_some();
+    let media_sel = media_selected().min(media_entries.read().len().saturating_sub(1));
     let start_prompt_mode = is_start && is_start_prompt_query(&q);
     let results: Vec<ResultItem> = if space_switch {
         space_switch_results(&spaces, &pages, &q)
@@ -231,6 +314,9 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
             r
         }
     };
+    let default_agent_item = is_start
+        .then(|| agent_page_results(&pages, "").into_iter().next())
+        .flatten();
     let sel = selected().min(results.len().saturating_sub(1));
     let active_item = results.get(sel).cloned();
     let active_agent_accent = active_item
@@ -305,6 +391,21 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
         }
     });
 
+    use_effect(move || {
+        let selected = media_selected();
+        let _ = media_entries.read().len();
+        if let Some(element) = web_sys::window()
+            .and_then(|window| window.document())
+            .and_then(|document| {
+                document.get_element_by_id(&format!("command-bar-media-item-{selected}"))
+            })
+        {
+            let options = web_sys::ScrollIntoViewOptions::new();
+            options.set_block(web_sys::ScrollLogicalPosition::Nearest);
+            element.scroll_into_view_with_scroll_into_view_options(&options);
+        }
+    });
+
     let execute = move |item: &ResultItem| {
         let prompt = query();
         let transition = if is_start
@@ -317,20 +418,22 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                 StartAgentTransition {
                     agent_url: agent_url.to_string(),
                     prompt: prompt.trim().to_string(),
+                    attachments: attachments.peek().clone(),
                 },
             ))
         } else {
             None
         };
         if matches!(variant, PaletteVariant::Start)
-            && is_start_prompt_query(&prompt)
+            && (is_start_prompt_query(&prompt) || !attachments.peek().is_empty())
             && let Some(agent_url) = agent_page_url(item)
         {
             on_close.call(());
-            if agent_page_matches_query(item, &prompt) {
+            let selected_attachments = attachments.peek().clone();
+            if agent_page_matches_query(item, &prompt) && selected_attachments.is_empty() {
                 emit_action_with_target("open", agent_url, open_target);
             } else {
-                emit_prompt_action(prompt.trim(), open_target, agent_url);
+                emit_prompt_action(prompt.trim(), open_target, agent_url, &selected_attachments);
             }
             if let Some((handler, next)) = transition {
                 handler.call(next);
@@ -409,12 +512,59 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
             PromptBox {
                 glass: is_start,
                 class: if is_start { "" } else { "p-2" },
-                div { class: if is_start { "relative z-10 flex min-w-0 w-full items-center gap-2 overflow-hidden px-2" } else { command_bar_input_row_class() },
+                div { class: if is_start { "relative z-10 flex min-w-0 w-full flex-wrap items-center gap-2 overflow-hidden px-2 py-1" } else { command_bar_input_row_class() },
                 if !is_start && !space_name.is_empty() {
                     span {
                         title: "{space_name}",
                         class: "max-w-36 shrink-0 truncate rounded-md bg-glass-hover px-2 py-1 text-ui-xs font-medium text-muted-foreground",
                         "{space_name}"
+                    }
+                }
+                if is_start {
+                    button {
+                        class: "relative z-10 ml-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg text-foreground/45 transition hover:bg-foreground/10 hover:text-foreground",
+                        title: "Attach files",
+                        onmousedown: move |event| event.prevent_default(),
+                        onclick: move |_| {
+                            let _ = try_cef_bin_emit_rkyv(&ChatPickFiles);
+                        },
+                        Icon { class: "h-4 w-4",
+                            path { d: "M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48" }
+                        }
+                    }
+                    for (i, attachment) in attachments.read().iter().cloned().enumerate() {
+                        div {
+                            key: "start-attachment-{attachment.path}",
+                            class: "group relative z-10 flex h-7 max-w-48 shrink-0 items-center gap-1.5 rounded-full bg-foreground/[0.08] pl-1 pr-1.5 text-xs text-foreground/80 ring-1 ring-inset ring-foreground/10",
+                            if attachment.preview_data_url.is_empty() {
+                                span { class: "flex h-5 min-w-5 items-center justify-center rounded-full bg-foreground/[0.08] px-1 font-mono text-[8px] font-semibold text-muted-foreground",
+                                    "{file_extension_label(&attachment.name)}"
+                                }
+                            } else {
+                                img {
+                                    src: "{attachment.preview_data_url}",
+                                    alt: "{attachment.name}",
+                                    class: "h-5 w-5 rounded-full object-cover",
+                                }
+                            }
+                            span { class: "min-w-0 max-w-28 truncate", "{attachment.name}" }
+                            button {
+                                class: "flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-foreground/45 transition hover:bg-foreground/10 hover:text-foreground",
+                                title: "Remove attachment",
+                                onmousedown: move |event| event.prevent_default(),
+                                onclick: move |_| {
+                                    let mut next = attachments.peek().clone();
+                                    if i < next.len() {
+                                        next.remove(i);
+                                        attachments.set(next);
+                                    }
+                                    focus_command_input_end();
+                                },
+                                Icon { class: "h-3 w-3",
+                                    path { d: "M6 6l12 12M18 6L6 18" }
+                                }
+                            }
+                        }
                     }
                 }
                 if !is_start {
@@ -466,7 +616,15 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                     }
                 }
                 }
-                div { class: command_bar_input_wrap_class(),
+                div { class: if is_start { "relative min-w-48 flex-1 overflow-hidden" } else { command_bar_input_wrap_class() },
+                    if is_start && q.is_empty() && ghost_text.is_empty() {
+                        div { class: "pointer-events-none absolute inset-0 flex -translate-y-px items-center overflow-hidden px-1.5",
+                            PromptGhost {
+                                accent_bg: "bg-foreground/70".to_string(),
+                                terminal: false,
+                            }
+                        }
+                    }
                     if !ghost_text.is_empty() {
                         div {
                             class: "pointer-events-none absolute inset-0 flex items-center",
@@ -478,7 +636,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                         id: "command-bar-input",
                         r#type: "text",
                         "data-ghost": "{ghost_text}",
-                        class: if is_start { "w-full min-w-0 cursor-text bg-transparent px-1.5 py-2 text-[15px] leading-6 text-foreground caret-foreground outline-none placeholder:text-muted-foreground/50" } else { command_bar_input_class() },
+                        class: if is_start { "relative z-10 w-full min-w-0 cursor-text bg-transparent px-1.5 py-2 text-[15px] leading-6 text-foreground caret-foreground outline-none placeholder:text-transparent" } else { command_bar_input_class() },
                         placeholder: if is_start { "Ask anything…" } else { placeholder },
                         value: "{display_text}",
                         autofocus: true,
@@ -487,9 +645,15 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                             selected.set(0);
                             nav_mode.set(false);
                         },
+                        onpaste: move |_| {
+                            if is_start {
+                                let _ = try_cef_bin_emit_rkyv(&ChatPasteMedia);
+                            }
+                        },
                         onkeydown: {
                             let q = q.clone();
                             let results = results.clone();
+                            let default_agent_item = default_agent_item.clone();
                             move |e| {
                             if e.key() == Key::Tab {
                                 e.prevent_default();
@@ -549,6 +713,39 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                             let go_up = (e.key() == Key::ArrowUp && !ctrl)
                                 || (ctrl && matches!(e.code(), Code::KeyP | Code::KeyK));
 
+                            if media_menu_open {
+                                if go_down {
+                                    e.prevent_default();
+                                    let max = media_entries.read().len().saturating_sub(1);
+                                    media_selected.set((media_sel + 1).min(max));
+                                    return;
+                                }
+                                if go_up {
+                                    e.prevent_default();
+                                    media_selected.set(media_sel.saturating_sub(1));
+                                    return;
+                                }
+                                if e.key() == Key::Enter {
+                                    e.prevent_default();
+                                    if let Some(entry) = media_entries.read().get(media_sel).cloned() {
+                                        select_start_media_entry(
+                                            &entry,
+                                            query,
+                                            media_selected,
+                                        );
+                                    }
+                                    return;
+                                }
+                                if e.key() == Key::Escape {
+                                    e.prevent_default();
+                                    if let Some(media_query) = inline_media_query(&q) {
+                                        query.set(replace_inline_media_query(&q, media_query, ""));
+                                    }
+                                    media_selected.set(0);
+                                    return;
+                                }
+                            }
+
                             if go_down {
                                 e.prevent_default();
                                 let max = results.len().saturating_sub(1);
@@ -563,6 +760,23 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                             {
                                 on_dismiss.call(());
                             } else if e.key() == Key::Enter {
+                                if is_start
+                                    && q.trim().is_empty()
+                                    && !attachments.peek().is_empty()
+                                {
+                                    if let Some(item) = default_agent_item.as_ref() {
+                                        execute(item);
+                                    } else {
+                                        let selected_attachments = attachments.peek().clone();
+                                        emit_prompt_action(
+                                            "",
+                                            open_target,
+                                            "",
+                                            &selected_attachments,
+                                        );
+                                    }
+                                    return;
+                                }
                                 if space_switch {
                                     if let Some(item) = results.get(sel) {
                                         execute(item);
@@ -573,7 +787,13 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                                             execute(item);
                                         } else {
                                             on_close.call(());
-                                            emit_prompt_action(q.trim(), open_target, "");
+                                            let selected_attachments = attachments.peek().clone();
+                                            emit_prompt_action(
+                                                q.trim(),
+                                                open_target,
+                                                "",
+                                                &selected_attachments,
+                                            );
                                         }
                                         return;
                                     }
@@ -601,18 +821,31 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                 }
                 if is_start {
                     button {
-                        class: if q.trim().is_empty() { "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 cursor-default self-center items-center justify-center rounded-lg bg-white/25 text-muted-foreground/35 shadow-sm ring-1 ring-inset ring-black/[0.06] dark:bg-white/[0.055] dark:ring-white/[0.08]" } else { "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg bg-foreground text-background shadow-lg transition hover:brightness-110 active:scale-95" },
-                        disabled: q.trim().is_empty(),
+                        class: if q.trim().is_empty() && attachments.read().is_empty() { "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 cursor-default self-center items-center justify-center rounded-lg bg-white/25 text-muted-foreground/35 shadow-sm ring-1 ring-inset ring-black/[0.06] dark:bg-white/[0.055] dark:ring-white/[0.08]" } else { "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg bg-foreground text-background shadow-lg transition hover:brightness-110 active:scale-95" },
+                        disabled: q.trim().is_empty() && attachments.read().is_empty(),
                         title: "Send (Enter)",
                         onclick: {
                             let results = results.clone();
                             let q = q.clone();
+                            let default_agent_item = default_agent_item.clone();
                             move |_| {
                                 if let Some(item) = results.get(sel) {
                                     execute(item);
-                                } else if !q.trim().is_empty() {
-                                    on_close.call(());
-                                    emit_prompt_action(q.trim(), open_target, "");
+                                } else if !q.trim().is_empty() || !attachments.peek().is_empty() {
+                                    if q.trim().is_empty()
+                                        && let Some(item) = default_agent_item.as_ref()
+                                    {
+                                        execute(item);
+                                    } else {
+                                        on_close.call(());
+                                        let selected_attachments = attachments.peek().clone();
+                                        emit_prompt_action(
+                                            q.trim(),
+                                            open_target,
+                                            "",
+                                            &selected_attachments,
+                                        );
+                                    }
                                 }
                             }
                         },
@@ -648,7 +881,56 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                 }
             }
             }
-            if !results.is_empty() {
+            if media_menu_open {
+                PromptPopup {
+                    placement: PromptPopupPlacement::Downward,
+                    id: "command-bar-results",
+                    if media_loading() {
+                        div { class: "px-3.5 py-2 text-sm text-muted-foreground", "Loading media…" }
+                    } else if media_entries.read().is_empty() {
+                        div { class: "px-3.5 py-2 text-sm text-muted-foreground", "No matching media" }
+                    } else {
+                        for (i, entry) in media_entries.read().iter().cloned().enumerate() {
+                            {
+                                let entry = entry.clone();
+                                rsx! {
+                                    div {
+                                        key: "start-media-{entry.path}",
+                                        id: "command-bar-media-item-{i}",
+                                        class: if i == media_sel { "flex cursor-pointer items-center gap-3 bg-foreground/10 px-3.5 py-2" } else { "flex cursor-pointer items-center gap-3 px-3.5 py-2" },
+                                        onmouseenter: move |_| media_selected.set(i),
+                                        onclick: move |_| select_start_media_entry(
+                                            &entry,
+                                            query,
+                                            media_selected,
+                                        ),
+                                        div { class: "flex h-12 w-16 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-foreground/[0.06] text-muted-foreground ring-1 ring-inset ring-foreground/10",
+                                            if entry.is_dir {
+                                                Icon { class: "h-4 w-4",
+                                                    path { d: "M3 6h6l2 2h10v10H3z" }
+                                                }
+                                            } else if !entry.preview_data_url.is_empty() {
+                                                img {
+                                                    src: "{entry.preview_data_url}",
+                                                    alt: "{entry.name}",
+                                                    class: "h-full w-full object-contain",
+                                                }
+                                            } else {
+                                                span { class: "font-mono text-[9px] font-semibold", "{file_extension_label(&entry.name)}" }
+                                            }
+                                        }
+                                        div { class: "min-w-0 flex-1",
+                                            div { class: "truncate text-sm text-foreground", "{entry.name}" }
+                                            div { class: "truncate text-xs text-muted-foreground", "{entry.parent}" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if !media_menu_open && !results.is_empty() {
                 PromptPopup {
                     placement: if is_start { PromptPopupPlacement::Downward } else { PromptPopupPlacement::Inline },
                     id: "command-bar-results",
@@ -906,6 +1188,68 @@ fn completion_query(input: &str) -> Option<String> {
     }
 }
 
+fn file_extension_label(name: &str) -> String {
+    std::path::Path::new(name)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| extension.to_ascii_uppercase())
+        .filter(|extension| !extension.is_empty())
+        .unwrap_or_else(|| "FILE".to_string())
+}
+
+fn focus_command_input_end() {
+    let closure = Closure::once(move || {
+        let Some(input) = web_sys::window()
+            .and_then(|window| window.document())
+            .and_then(|document| document.get_element_by_id("command-bar-input"))
+            .and_then(|element| element.dyn_into::<web_sys::HtmlInputElement>().ok())
+        else {
+            return;
+        };
+        let end = input.value().encode_utf16().count() as u32;
+        let _ = input.focus();
+        let _ = input.set_selection_range(end, end);
+    });
+    if let Some(window) = web_sys::window() {
+        let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(
+            closure.as_ref().unchecked_ref(),
+            0,
+        );
+    }
+    closure.forget();
+}
+
+fn select_start_media_entry(
+    entry: &ChatMediaEntry,
+    mut query: Signal<String>,
+    mut selected: Signal<usize>,
+) {
+    let value = query.peek().clone();
+    let Some(media_query) = inline_media_query(&value) else {
+        return;
+    };
+    let reference = media_reference(entry);
+    let replacement = if entry.is_dir {
+        format!("@{reference}/")
+    } else {
+        if try_cef_bin_emit_rkyv(&ChatAttachPaths {
+            paths: vec![entry.path.clone()],
+        })
+        .is_err()
+        {
+            return;
+        }
+        String::new()
+    };
+    query.set(replace_inline_media_query(
+        &value,
+        media_query,
+        &replacement,
+    ));
+    selected.set(0);
+    focus_command_input_end();
+}
+
 /// Emit a command-bar action to the host with no explicit open target.
 pub(crate) fn emit_action(action: &str, value: &str) {
     emit_action_with_target(action, value, None);
@@ -918,15 +1262,32 @@ pub(crate) fn emit_action_with_target(action: &str, value: &str, target: Option<
         value: value.to_string(),
         target,
         agent_url: None,
+        attachments: Vec::new(),
     });
 }
 
-fn emit_prompt_action(value: &str, target: Option<OpenTarget>, agent_url: &str) {
+fn emit_prompt_action(
+    value: &str,
+    target: Option<OpenTarget>,
+    agent_url: &str,
+    attachments: &[ChatAttachment],
+) {
     let _ = try_cef_bin_emit_rkyv(&CommandBarActionEvent {
         action: "prompt".to_string(),
         value: value.to_string(),
         target,
         agent_url: (!agent_url.is_empty()).then(|| agent_url.to_string()),
+        attachments: attachments
+            .iter()
+            .map(
+                |attachment| vmux_command::prompt_media::ChatSubmitAttachment {
+                    path: attachment.path.clone(),
+                    name: attachment.name.clone(),
+                    mime_type: attachment.mime_type.clone(),
+                    size: attachment.size,
+                },
+            )
+            .collect(),
     });
 }
 

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -23,8 +23,9 @@ use vmux_command::event::{
     is_start_prompt_query, looks_like_url, should_open_typed_query_on_enter,
 };
 use vmux_command::open_target::OpenTarget;
+use vmux_ui::agent_accent::agent_accent;
 use vmux_ui::components::icon::Icon;
-use vmux_ui::components::prompt_box::{PromptBox, PromptPopup};
+use vmux_ui::components::prompt_box::{PromptBox, PromptPopup, PromptPopupPlacement};
 use vmux_ui::favicon::Favicon;
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener};
 use vmux_ui::icon::PageIconView;
@@ -178,10 +179,11 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
 
     let q = query();
     let start_prompt_mode = is_start && is_start_prompt_query(&q);
-    let start_agent_mode = is_start && (q.trim().is_empty() || start_prompt_mode);
     let results: Vec<ResultItem> = if space_switch {
         space_switch_results(&spaces, &pages, &q)
-    } else if start_agent_mode {
+    } else if is_start && q.trim().is_empty() {
+        Vec::new()
+    } else if start_prompt_mode {
         start_page_results(&pages, &q)
     } else {
         let history = history_suggestions();
@@ -231,6 +233,13 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     };
     let sel = selected().min(results.len().saturating_sub(1));
     let active_item = results.get(sel).cloned();
+    let active_agent_accent = active_item
+        .as_ref()
+        .and_then(agent_page_url)
+        .and_then(|url| url.strip_prefix("vmux://agent/"))
+        .and_then(|path| path.split('/').next())
+        .filter(|agent| !agent.is_empty())
+        .map(agent_accent);
     let nav = nav_mode();
     let display_text = if nav && !start_prompt_mode {
         match &active_item {
@@ -298,16 +307,21 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
 
     let execute = move |item: &ResultItem| {
         let prompt = query();
-        if is_start
+        let transition = if is_start
             && let Some(agent_url) = agent_page_url(item)
             && crate::start::supports_inline_agent_transition(agent_url)
             && let Some(handler) = on_start_agent_transition
         {
-            handler.call(StartAgentTransition {
-                agent_url: agent_url.to_string(),
-                prompt: prompt.trim().to_string(),
-            });
-        }
+            Some((
+                handler,
+                StartAgentTransition {
+                    agent_url: agent_url.to_string(),
+                    prompt: prompt.trim().to_string(),
+                },
+            ))
+        } else {
+            None
+        };
         if matches!(variant, PaletteVariant::Start)
             && is_start_prompt_query(&prompt)
             && let Some(agent_url) = agent_page_url(item)
@@ -317,6 +331,9 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                 emit_action_with_target("open", agent_url, open_target);
             } else {
                 emit_prompt_action(prompt.trim(), open_target, agent_url);
+            }
+            if let Some((handler, next)) = transition {
+                handler.call(next);
             }
             return;
         }
@@ -361,6 +378,9 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                 emit_action_with_target("open", url, open_target);
             }
         }
+        if let Some((handler, next)) = transition {
+            handler.call(next);
+        }
     };
 
     let placeholder = if space_switch {
@@ -380,6 +400,12 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
 
     rsx! {
         div { class: "relative",
+            if is_start {
+                if let Some(accent) = active_agent_accent {
+                    div { class: "{accent.glow_top} transition-all duration-500 ease-out" }
+                    div { class: "{accent.glow_bottom} transition-all duration-500 ease-out" }
+                }
+            }
             PromptBox {
                 glass: is_start,
                 class: if is_start { "" } else { "p-2" },
@@ -599,7 +625,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
             }
             if !results.is_empty() {
                 PromptPopup {
-                    upward: is_start,
+                    placement: if is_start { PromptPopupPlacement::Downward } else { PromptPopupPlacement::Inline },
                     id: "command-bar-results",
                     class: if is_start { "" } else { result_list_class() },
                 for (i, item) in results.iter().enumerate() {
@@ -610,6 +636,11 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                         onclick: {
                             let item = item.clone();
                             move |_| { execute(&item); }
+                        },
+                        onmouseenter: move |_| {
+                            if is_start {
+                                selected.set(i);
+                            }
                         },
                         match item {
                             ResultItem::Terminal { path } => rsx! {

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -410,13 +410,14 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                 glass: is_start,
                 class: if is_start { "" } else { "p-2" },
                 div { class: if is_start { "relative z-10 flex min-w-0 w-full items-center gap-2 overflow-hidden px-2" } else { command_bar_input_row_class() },
-                if !space_name.is_empty() {
+                if !is_start && !space_name.is_empty() {
                     span {
                         title: "{space_name}",
                         class: "max-w-36 shrink-0 truncate rounded-md bg-glass-hover px-2 py-1 text-ui-xs font-medium text-muted-foreground",
                         "{space_name}"
                     }
                 }
+                if !is_start {
                 {
                     let icon_class = "h-4 w-4 shrink-0 text-muted-foreground";
                     let (is_command, is_path, is_url) = if nav {
@@ -464,6 +465,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                         } }
                     }
                 }
+                }
                 div { class: command_bar_input_wrap_class(),
                     if !ghost_text.is_empty() {
                         div {
@@ -476,8 +478,8 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                         id: "command-bar-input",
                         r#type: "text",
                         "data-ghost": "{ghost_text}",
-                        class: command_bar_input_class(),
-                        placeholder,
+                        class: if is_start { "w-full min-w-0 cursor-text bg-transparent px-1.5 py-2 text-[15px] leading-6 text-foreground caret-foreground outline-none placeholder:text-muted-foreground/50" } else { command_bar_input_class() },
+                        placeholder: if is_start { "Ask anything…" } else { placeholder },
                         value: "{display_text}",
                         autofocus: true,
                         oninput: move |e| {
@@ -595,6 +597,29 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                             }
                             }
                         },
+                    }
+                }
+                if is_start {
+                    button {
+                        class: if q.trim().is_empty() { "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 cursor-default self-center items-center justify-center rounded-lg bg-white/25 text-muted-foreground/35 shadow-sm ring-1 ring-inset ring-black/[0.06] dark:bg-white/[0.055] dark:ring-white/[0.08]" } else { "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg bg-foreground text-background shadow-lg transition hover:brightness-110 active:scale-95" },
+                        disabled: q.trim().is_empty(),
+                        title: "Send (Enter)",
+                        onclick: {
+                            let results = results.clone();
+                            let q = q.clone();
+                            move |_| {
+                                if let Some(item) = results.get(sel) {
+                                    execute(item);
+                                } else if !q.trim().is_empty() {
+                                    on_close.call(());
+                                    emit_prompt_action(q.trim(), open_target, "");
+                                }
+                            }
+                        },
+                        Icon { class: "h-4 w-4",
+                            path { d: "M12 19V5" }
+                            path { d: "M5 12l7-7 7 7" }
+                        }
                     }
                 }
                 if matches!(variant, PaletteVariant::Modal) {

--- a/crates/vmux_layout/src/command_bar/style.rs
+++ b/crates/vmux_layout/src/command_bar/style.rs
@@ -293,28 +293,46 @@ mod tests {
         assert!(source.contains("is_start_prompt_query("));
         assert!(source.contains("emit_prompt_action("));
         assert!(source.contains("agent_url: (!agent_url.is_empty())"));
+        let emit = source
+            .find("emit_prompt_action(prompt.trim(), open_target, agent_url)")
+            .unwrap();
+        let transition = source[emit..].find("handler.call(next)").unwrap();
+        assert!(transition > 0);
     }
 
     #[test]
-    fn start_shows_agents_as_result_rows() {
+    fn start_hides_agents_until_the_user_types() {
         let source = include_str!("palette.rs");
 
+        assert!(source.contains("is_start && q.trim().is_empty()"));
+        assert!(source.contains("else if start_prompt_mode"));
         assert!(source.contains("start_page_results(&pages, &q)"));
         assert!(source.contains("agent_page_url(item)"));
         assert!(!source.contains("start-agent-select"));
     }
 
     #[test]
-    fn start_uses_the_shared_center_prompt_and_upward_popup() {
+    fn start_uses_the_shared_center_prompt_and_downward_popup() {
         let palette = include_str!("palette.rs");
         let page = include_str!("../start/page.rs");
 
         assert!(palette.contains("PromptBox {"));
         assert!(palette.contains("PromptPopup {"));
-        assert!(palette.contains("upward: is_start"));
+        assert!(palette.contains("PromptPopupPlacement::Downward"));
         assert!(page.contains("max-w-3xl"));
         assert!(page.contains("items-center justify-center"));
         assert!(page.contains("relative w-full"));
+    }
+
+    #[test]
+    fn start_tracks_the_selected_agent_accent() {
+        let palette = include_str!("palette.rs");
+
+        assert!(palette.contains("map(agent_accent)"));
+        assert!(palette.contains("accent.glow_top"));
+        assert!(palette.contains("accent.glow_bottom"));
+        assert!(palette.contains("onmouseenter: move |_|"));
+        assert!(palette.contains("selected.set(i)"));
     }
 
     #[test]

--- a/crates/vmux_layout/src/command_bar/style.rs
+++ b/crates/vmux_layout/src/command_bar/style.rs
@@ -293,46 +293,15 @@ mod tests {
         assert!(source.contains("is_start_prompt_query("));
         assert!(source.contains("emit_prompt_action("));
         assert!(source.contains("agent_url: (!agent_url.is_empty())"));
-        let emit = source
-            .find("emit_prompt_action(prompt.trim(), open_target, agent_url)")
-            .unwrap();
-        let transition = source[emit..].find("handler.call(next)").unwrap();
-        assert!(transition > 0);
     }
 
     #[test]
-    fn start_hides_agents_until_the_user_types() {
+    fn start_shows_agents_as_result_rows() {
         let source = include_str!("palette.rs");
 
-        assert!(source.contains("is_start && q.trim().is_empty()"));
-        assert!(source.contains("else if start_prompt_mode"));
         assert!(source.contains("start_page_results(&pages, &q)"));
         assert!(source.contains("agent_page_url(item)"));
         assert!(!source.contains("start-agent-select"));
-    }
-
-    #[test]
-    fn start_uses_the_shared_center_prompt_and_downward_popup() {
-        let palette = include_str!("palette.rs");
-        let page = include_str!("../start/page.rs");
-
-        assert!(palette.contains("PromptBox {"));
-        assert!(palette.contains("PromptPopup {"));
-        assert!(palette.contains("PromptPopupPlacement::Downward"));
-        assert!(page.contains("max-w-3xl"));
-        assert!(page.contains("items-center justify-center"));
-        assert!(page.contains("relative w-full"));
-    }
-
-    #[test]
-    fn start_tracks_the_selected_agent_accent() {
-        let palette = include_str!("palette.rs");
-
-        assert!(palette.contains("map(agent_accent)"));
-        assert!(palette.contains("accent.glow_top"));
-        assert!(palette.contains("accent.glow_bottom"));
-        assert!(palette.contains("onmouseenter: move |_|"));
-        assert!(palette.contains("selected.set(i)"));
     }
 
     #[test]

--- a/crates/vmux_layout/src/command_bar/style.rs
+++ b/crates/vmux_layout/src/command_bar/style.rs
@@ -305,6 +305,19 @@ mod tests {
     }
 
     #[test]
+    fn start_uses_the_shared_center_prompt_and_upward_popup() {
+        let palette = include_str!("palette.rs");
+        let page = include_str!("../start/page.rs");
+
+        assert!(palette.contains("PromptBox {"));
+        assert!(palette.contains("PromptPopup {"));
+        assert!(palette.contains("upward: is_start"));
+        assert!(page.contains("max-w-3xl"));
+        assert!(page.contains("items-center justify-center"));
+        assert!(page.contains("relative w-full"));
+    }
+
+    #[test]
     fn results_list_disables_horizontal_scroll() {
         let class = result_list_class();
 

--- a/crates/vmux_layout/src/start.rs
+++ b/crates/vmux_layout/src/start.rs
@@ -3,6 +3,11 @@
 
 pub mod event;
 
+/// Whether an agent page can replace the launcher inside its existing webview.
+pub fn supports_inline_agent_transition(url: &str) -> bool {
+    url.starts_with("vmux://agent/") && !url.contains("/cli") && !url.contains("/setup")
+}
+
 #[cfg(target_arch = "wasm32")]
 pub mod page;
 
@@ -10,6 +15,16 @@ pub mod page;
 mod plugin;
 #[cfg(not(target_arch = "wasm32"))]
 pub use plugin::StartPlugin;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(bevy::prelude::Component, Clone, Copy, Debug)]
+pub struct StartAgentTransition {
+    pub webview: bevy::prelude::Entity,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(bevy::prelude::Component)]
+pub struct StartAgentTransitionView;
 
 /// Canonical URL of the start launcher page.
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/vmux_layout/src/start.rs
+++ b/crates/vmux_layout/src/start.rs
@@ -5,7 +5,12 @@ pub mod event;
 
 /// Whether an agent page can replace the launcher inside its existing webview.
 pub fn supports_inline_agent_transition(url: &str) -> bool {
-    url.starts_with("vmux://agent/") && !url.contains("/cli") && !url.contains("/setup")
+    let Some(path) = url.strip_prefix("vmux://agent/") else {
+        return false;
+    };
+    !path
+        .split('/')
+        .any(|segment| matches!(segment, "cli" | "setup"))
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/vmux_layout/src/start/page.rs
+++ b/crates/vmux_layout/src/start/page.rs
@@ -6,15 +6,18 @@ use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_event, u
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 
-use crate::command_bar::palette::{CommandPalette, PaletteVariant};
+use crate::command_bar::palette::{CommandPalette, PaletteVariant, StartAgentTransition};
 use crate::start::event::{START_FOCUS_INPUT_EVENT, StartDataRequest, StartFocusInput};
 
 const START_FOCUS_PENDING: &str = "_startFocusPending";
+const START_TRANSITIONED: &str = "_startTransitioned";
 
 /// The `vmux://start/` launcher page: a cinematic centered hero that requests its
 /// entries on mount and renders [`CommandPalette`] in [`PaletteVariant::Start`].
 #[component]
-pub fn Page() -> Element {
+pub fn Page(
+    #[props(default)] on_agent_transition: Option<EventHandler<StartAgentTransition>>,
+) -> Element {
     use_theme();
     let state =
         use_event::<CommandBarOpenEvent>(COMMAND_BAR_OPEN_EVENT, CommandBarOpenEvent::default);
@@ -30,6 +33,7 @@ pub fn Page() -> Element {
             doc.set_title("Start");
         }
         let _ = try_cef_bin_emit_rkyv(&StartDataRequest);
+        set_start_transitioned(false);
         mounted.set(true);
     });
 
@@ -46,7 +50,7 @@ pub fn Page() -> Element {
 
     rsx! {
         main {
-            class: "relative isolate flex min-h-screen flex-col items-center justify-center overflow-hidden bg-background px-6 text-foreground",
+            class: "relative isolate flex h-screen items-center justify-center overflow-hidden bg-background px-6 text-foreground",
             style: "background-image:radial-gradient(140% 100% at 50% -12%, rgba(129,140,248,0.05), transparent 55%);",
             div { class: "pointer-events-none absolute inset-0 -z-10 overflow-hidden",
                 div { class: "absolute left-1/2 top-[16%] h-[36rem] w-[36rem] -translate-x-1/2 rounded-full blur-[150px] dark:bg-indigo-500/15" }
@@ -54,21 +58,21 @@ pub fn Page() -> Element {
                 div { class: "absolute right-[12%] top-1/4 h-80 w-80 rounded-full blur-[130px] dark:bg-violet-500/12" }
                 div { class: "absolute inset-x-0 bottom-0 h-1/3 bg-gradient-to-t from-transparent to-transparent dark:from-black/40" }
             }
-            div {
-                class: "relative flex w-full max-w-2xl flex-col items-center gap-8 transition-all duration-700 ease-out motion-reduce:transition-none {reveal}",
+            div { class: "relative z-10 flex w-full max-w-3xl flex-col items-center gap-8 transition-all duration-700 ease-out motion-reduce:transition-none {reveal}",
                 div { class: "flex flex-col items-center gap-2",
                     h1 { class: "bg-gradient-to-b from-foreground to-foreground/55 bg-clip-text text-6xl font-semibold leading-none tracking-tight text-transparent",
                         "vmux"
                     }
                     p { class: "text-base text-muted-foreground", "One prompt. Anything, done." }
                 }
-                div { class: "w-full overflow-hidden rounded-2xl bg-foreground/[0.05] ring-1 ring-inset ring-foreground/10 shadow-2xl dark:shadow-[0_40px_120px_-32px_rgba(0,0,0,0.85)] backdrop-blur-2xl",
+                div { class: "relative w-full",
                     CommandPalette {
                         state,
                         variant: PaletteVariant::Start,
                         on_close: move |_| {},
                         on_dismiss: move |_| {},
                         on_activity: move |_| {},
+                        on_start_agent_transition: on_agent_transition,
                     }
                 }
             }
@@ -82,6 +86,9 @@ fn focus_start_input() {
     let Some(window) = web_sys::window() else {
         return;
     };
+    if start_transitioned(&window) {
+        return;
+    }
     if start_focus_pending(&window) {
         return;
     }
@@ -116,6 +123,28 @@ fn set_start_focus_pending(window: &web_sys::Window, pending: bool) {
         &JsValue::from_str(START_FOCUS_PENDING),
         &JsValue::from_bool(pending),
     );
+}
+
+fn start_transitioned(window: &web_sys::Window) -> bool {
+    js_sys::Reflect::get(window, &JsValue::from_str(START_TRANSITIONED))
+        .map(|value| value.is_truthy())
+        .unwrap_or(false)
+}
+
+fn set_start_transitioned(transitioned: bool) {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let _ = js_sys::Reflect::set(
+        &window,
+        &JsValue::from_str(START_TRANSITIONED),
+        &JsValue::from_bool(transitioned),
+    );
+}
+
+/// Disable launcher-only focus capture before switching this document to an agent page.
+pub fn begin_agent_transition() {
+    set_start_transitioned(true);
 }
 
 /// Focus the input if it is not already the active element; returns true once the document holds
@@ -196,6 +225,18 @@ fn install_keep_input_focused_on_click() {
     };
 
     let closure = Closure::wrap(Box::new(move |e: web_sys::Event| {
+        let Some(window) = web_sys::window() else {
+            return;
+        };
+        if start_transitioned(&window) {
+            return;
+        }
+        let Some(document) = window.document() else {
+            return;
+        };
+        let Some(input) = document.get_element_by_id("command-bar-input") else {
+            return;
+        };
         if let Some(el) = e
             .target()
             .and_then(|t| t.dyn_into::<web_sys::Element>().ok())
@@ -207,13 +248,8 @@ fn install_keep_input_focused_on_click() {
             }
         }
         e.prevent_default();
-        if let Some(input) = web_sys::window()
-            .and_then(|w| w.document())
-            .and_then(|d| d.get_element_by_id("command-bar-input"))
-        {
-            let input: web_sys::HtmlInputElement = input.unchecked_into();
-            let _ = input.focus();
-        }
+        let input: web_sys::HtmlInputElement = input.unchecked_into();
+        let _ = input.focus();
     }) as Box<dyn FnMut(web_sys::Event)>);
     let target: &web_sys::EventTarget = document.as_ref();
     let opts = web_sys::AddEventListenerOptions::new();

--- a/crates/vmux_layout/src/start/plugin.rs
+++ b/crates/vmux_layout/src/start/plugin.rs
@@ -95,12 +95,15 @@ fn sync_live_start_pages(
     pages_snapshot: Res<CommandBarPagesSnapshot>,
     work_snapshot: Res<CommandBarWorkSnapshot>,
     focused: Res<crate::stack::FocusedStack>,
-    starts: Query<(
-        Entity,
-        &WebviewSource,
-        Has<StartWorkSynced>,
-        Has<CefKeyboardTarget>,
-    )>,
+    starts: Query<
+        (
+            Entity,
+            &WebviewSource,
+            Has<StartWorkSynced>,
+            Has<CefKeyboardTarget>,
+        ),
+        Without<crate::start::StartAgentTransitionView>,
+    >,
     added_keyboard_targets: Query<(), Added<CefKeyboardTarget>>,
     browsers: NonSend<Browsers>,
     mut commands: Commands,
@@ -418,6 +421,22 @@ mod tests {
         app.add_plugins(StartPlugin);
         let mut q = app.world_mut().query::<&PageManifest>();
         assert!(q.iter(app.world()).any(|m| m.host == "start"));
+    }
+
+    #[test]
+    fn inline_transition_only_supports_page_agents() {
+        assert!(crate::start::supports_inline_agent_transition(
+            "vmux://agent/codex"
+        ));
+        assert!(crate::start::supports_inline_agent_transition(
+            "vmux://agent/openai/gpt-5/session"
+        ));
+        assert!(!crate::start::supports_inline_agent_transition(
+            "vmux://agent/codex/cli"
+        ));
+        assert!(!crate::start::supports_inline_agent_transition(
+            "vmux://agent/vibe/setup"
+        ));
     }
 
     #[test]

--- a/crates/vmux_layout/src/start/plugin.rs
+++ b/crates/vmux_layout/src/start/plugin.rs
@@ -437,6 +437,12 @@ mod tests {
         assert!(!crate::start::supports_inline_agent_transition(
             "vmux://agent/vibe/setup"
         ));
+        assert!(crate::start::supports_inline_agent_transition(
+            "vmux://agent/cliff"
+        ));
+        assert!(crate::start::supports_inline_agent_transition(
+            "vmux://agent/setupwizard"
+        ));
     }
 
     #[test]

--- a/crates/vmux_server/src/lib.rs
+++ b/crates/vmux_server/src/lib.rs
@@ -34,6 +34,7 @@ fn inline_agent_transition() -> Option<vmux_layout::command_bar::palette::StartA
             |agent_url| vmux_layout::command_bar::palette::StartAgentTransition {
                 agent_url,
                 prompt: String::new(),
+                attachments: Vec::new(),
             },
         )
 }
@@ -65,6 +66,7 @@ fn StartAgentPage() -> Element {
             vmux_agent::chat_page::page::Page {
                 agent_override: Some(inline_agent_id(&active.agent_url)),
                 transition_prompt: Some(active.prompt),
+                transition_attachments: Some(active.attachments),
             }
         };
     }

--- a/crates/vmux_server/src/lib.rs
+++ b/crates/vmux_server/src/lib.rs
@@ -20,6 +20,66 @@ struct WebPageManifest {
 }
 
 #[cfg(all(target_arch = "wasm32", feature = "web"))]
+const INLINE_AGENT_WINDOW_PREFIX: &str = "vmux-inline-agent:";
+
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
+fn inline_agent_transition() -> Option<vmux_layout::command_bar::palette::StartAgentTransition> {
+    web_sys::window()
+        .and_then(|window| window.name().ok())
+        .and_then(|name| {
+            name.strip_prefix(INLINE_AGENT_WINDOW_PREFIX)
+                .map(str::to_string)
+        })
+        .map(
+            |agent_url| vmux_layout::command_bar::palette::StartAgentTransition {
+                agent_url,
+                prompt: String::new(),
+            },
+        )
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
+fn set_inline_agent_url(agent_url: &str) {
+    if let Some(window) = web_sys::window() {
+        let _ = window.set_name(&format!("{INLINE_AGENT_WINDOW_PREFIX}{agent_url}"));
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
+fn inline_agent_id(agent_url: &str) -> String {
+    agent_url
+        .strip_prefix("vmux://agent/")
+        .and_then(|path| path.split('/').next())
+        .filter(|segment| !segment.is_empty())
+        .unwrap_or("agent")
+        .to_string()
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
+#[allow(non_snake_case)]
+#[component]
+fn StartAgentPage() -> Element {
+    let mut transition = use_signal(inline_agent_transition);
+    if let Some(active) = transition() {
+        return rsx! {
+            vmux_agent::chat_page::page::Page {
+                agent_override: Some(inline_agent_id(&active.agent_url)),
+                transition_prompt: Some(active.prompt),
+            }
+        };
+    }
+    rsx! {
+        vmux_layout::start::page::Page {
+            on_agent_transition: move |next: vmux_layout::command_bar::palette::StartAgentTransition| {
+                vmux_layout::start::page::begin_agent_transition();
+                set_inline_agent_url(&next.agent_url);
+                transition.set(Some(next));
+            },
+        }
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
 macro_rules! web_pages {
     ($($render:ident: $host:literal => $page:path),+ $(,)?) => {
         $(
@@ -57,7 +117,7 @@ web_pages! {
     render_files: "files" => vmux_editor::page::Page,
     render_lsp: "lsp" => vmux_editor::lsp_page::Page,
     render_extensions: "extensions" => vmux_layout::extensions_page::Page,
-    render_start: "start" => vmux_layout::start::page::Page,
+    render_start: "start" => StartAgentPage,
 }
 
 #[cfg(all(target_arch = "wasm32", feature = "web"))]
@@ -100,6 +160,16 @@ mod host_tests {
         assert_eq!(host_for("file:", ""), "files");
         assert_eq!(host_for("vmux:", "terminal"), "terminal");
         assert_eq!(host_for("https:", "example.com"), "example.com");
+    }
+
+    #[test]
+    fn start_route_keeps_one_document_for_agent_transition() {
+        let source = include_str!("lib.rs");
+
+        assert!(source.contains("fn StartAgentPage()"));
+        assert!(source.contains("use_signal(inline_agent_transition)"));
+        assert!(source.contains("set_inline_agent_url(&next.agent_url)"));
+        assert!(source.contains("render_start: \"start\" => StartAgentPage"));
     }
 }
 

--- a/crates/vmux_server/src/lib.rs
+++ b/crates/vmux_server/src/lib.rs
@@ -161,16 +161,6 @@ mod host_tests {
         assert_eq!(host_for("vmux:", "terminal"), "terminal");
         assert_eq!(host_for("https:", "example.com"), "example.com");
     }
-
-    #[test]
-    fn start_route_keeps_one_document_for_agent_transition() {
-        let source = include_str!("lib.rs");
-
-        assert!(source.contains("fn StartAgentPage()"));
-        assert!(source.contains("use_signal(inline_agent_transition)"));
-        assert!(source.contains("set_inline_agent_url(&next.agent_url)"));
-        assert!(source.contains("render_start: \"start\" => StartAgentPage"));
-    }
 }
 
 #[cfg(all(target_arch = "wasm32", feature = "web"))]

--- a/crates/vmux_terminal/src/page.rs
+++ b/crates/vmux_terminal/src/page.rs
@@ -1,8 +1,5 @@
 #![allow(non_snake_case)]
 
-use std::cell::RefCell;
-use std::rc::Rc;
-
 use crate::event::*;
 use crate::matrix_rain::MatrixRain;
 use crate::render_model::{
@@ -16,6 +13,7 @@ use unicode_width::UnicodeWidthChar;
 use vmux_ui::agent_accent::agent_accent;
 use vmux_ui::favicon::Favicon;
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_theme};
+use vmux_ui::prompt_ghost::PromptGhost;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 
@@ -995,156 +993,4 @@ fn row_selection_cols(
     } else {
         Some((start, end_exclusive))
     }
-}
-
-const AGENT_PROMPT_EXAMPLES: &[&str] = &[
-    "Find me the best flight from Paris to Tokyo next month",
-    "Find a quiet hotel with AC near central Paris for this weekend",
-    "Plan a five-day food and culture trip through Kyoto",
-    "Build me a relaxed weekend itinerary for Lisbon",
-    "Compare rail passes for a two-week trip around Europe",
-    "Find highly rated restaurants nearby with vegetarian options",
-    "Research the visa requirements for my next international trip",
-    "Create a lightweight packing list for a ten-day winter trip",
-    "Plan a scenic road trip from San Francisco to Portland",
-    "Compare the best neighborhoods for a month-long stay in Tokyo",
-    "Find quiet coworking spaces with day passes and fast Wi-Fi",
-    "Plan a memorable surprise birthday weekend on a sensible budget",
-    "Build a healthy weekly meal plan and shopping list for two",
-    "Turn this grocery budget into affordable meals for the week",
-    "Create a beginner workout plan I can do at home in 30 minutes",
-    "Make a six-week study plan for conversational Japanese",
-    "Compare the best noise-canceling headphones under $300",
-    "Find an ergonomic standing desk setup for a small apartment",
-    "Research the best compact camera for travel and street photography",
-    "Compare lightweight laptops for coding, travel, and battery life",
-    "Summarize these PDFs and extract the decisions and action items",
-    "Turn my meeting notes into a clear project plan with owners",
-    "Draft a concise follow-up email from these scattered notes",
-    "Organize my Downloads folder into a clean, useful structure",
-    "Find duplicate photos and help me safely clean them up",
-    "Analyze this CSV and explain the most important trends",
-    "Turn these receipts into a categorized expense report",
-    "Build a landing site for my new restaurant — make it themeable",
-    "Prototype a clean dashboard from this product brief",
-    "Debug the failing tests and explain the root cause",
-    "Explain how this codebase works and where I should start",
-    "Refactor this module without changing its behavior",
-    "Add the requested feature and verify the important edge cases",
-    "Review my staged changes for bugs, security, and maintainability",
-    "Open a PR for my staged changes",
-    "Generate release notes from the changes since the last version",
-    "Investigate these application logs and find the likely failure",
-    "Find the performance bottleneck and propose the smallest fix",
-    "Update outdated dependencies and resolve compatibility issues",
-    "Set up this project locally and verify the development workflow",
-    "Automate this repetitive workflow with a reliable script",
-    "Research my competitors and summarize their positioning",
-    "Create a launch plan for this product with milestones and risks",
-    "Turn this rough brief into a prioritized execution checklist",
-    "Find the latest reliable information and summarize the sources",
-    "Compare my subscriptions and identify easy ways to save money",
-    "Design a comfortable home office setup for a tight space",
-    "Create a realistic monthly budget from these transactions",
-];
-
-const TERMINAL_PROMPT_EXAMPLES: &[&str] = &[
-    "git status --short",
-    "rg \"TODO|FIXME\" .",
-    "find . -type f -size +100M",
-    "git log --oneline -10",
-];
-
-const PROMPT_CARET_CSS: &str = ".vmux-prompt-caret{animation:vmux-prompt-caret-blink 1s step-end infinite}@keyframes vmux-prompt-caret-blink{0%,49%{opacity:1}50%,100%{opacity:0}}";
-
-/// Placeholder that types example prompts one character at a time with a blinking caret.
-#[component]
-pub fn PromptGhost(accent_bg: String, terminal: bool) -> Element {
-    let examples = if terminal {
-        TERMINAL_PROMPT_EXAMPLES
-    } else {
-        AGENT_PROMPT_EXAMPLES
-    };
-    let ex_idx = use_signal(|| random_prompt_example_index(examples.len(), None));
-    let typed = use_signal(|| 0usize);
-    let cb: Rc<RefCell<Option<Closure<dyn FnMut()>>>> = use_hook(|| Rc::new(RefCell::new(None)));
-    let timer: Rc<RefCell<Option<i32>>> = use_hook(|| Rc::new(RefCell::new(None)));
-    use_effect({
-        let cb = cb.clone();
-        let timer = timer.clone();
-        move || start_prompt_typewriter(examples, ex_idx, typed, cb.clone(), timer.clone())
-    });
-    use_drop({
-        let cb = cb.clone();
-        let timer = timer.clone();
-        move || {
-            if let Some(id) = timer.borrow_mut().take()
-                && let Some(win) = web_sys::window()
-            {
-                win.clear_interval_with_handle(id);
-            }
-            *cb.borrow_mut() = None;
-        }
-    });
-    let example = examples[ex_idx() % examples.len()];
-    let full = example.chars().count();
-    let shown: String = example.chars().take(typed().min(full)).collect();
-    let ghost_class = if terminal {
-        "w-80 whitespace-pre-wrap break-words font-mono text-sm text-muted-foreground/50"
-    } else {
-        "flex max-w-full items-center whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50"
-    };
-    let caret_class = if terminal {
-        format!("vmux-prompt-caret ml-px inline-block h-3.5 w-1.5 align-middle {accent_bg}")
-    } else {
-        format!("vmux-prompt-caret relative top-px ml-px h-4 w-1.5 shrink-0 {accent_bg}")
-    };
-    rsx! {
-        style { dangerous_inner_html: PROMPT_CARET_CSS }
-        div {
-            class: "{ghost_class}",
-            span { class: if terminal { "" } else { "min-w-0 truncate" }, "{shown}" }
-            span { class: "{caret_class}" }
-        }
-    }
-}
-
-fn random_prompt_example_index(len: usize, current: Option<usize>) -> usize {
-    if len <= 1 {
-        return 0;
-    }
-    let next = ((js_sys::Math::random() * len as f64) as usize).min(len - 1);
-    if current == Some(next) {
-        (next + 1) % len
-    } else {
-        next
-    }
-}
-
-fn start_prompt_typewriter(
-    examples: &'static [&'static str],
-    mut ex_idx: Signal<usize>,
-    mut typed: Signal<usize>,
-    cb_cell: Rc<RefCell<Option<Closure<dyn FnMut()>>>>,
-    timer_cell: Rc<RefCell<Option<i32>>>,
-) {
-    const PAUSE_TICKS: usize = 40;
-    let cb = Closure::wrap(Box::new(move || {
-        let idx = *ex_idx.peek();
-        let full = examples[idx % examples.len()].chars().count();
-        let t = *typed.peek();
-        if t >= full + PAUSE_TICKS {
-            typed.set(0);
-            ex_idx.set(random_prompt_example_index(examples.len(), Some(idx)));
-        } else {
-            typed.set(t + 1);
-        }
-    }) as Box<dyn FnMut()>);
-    if let Some(win) = web_sys::window()
-        && let Ok(id) = win
-            .set_interval_with_callback_and_timeout_and_arguments_0(cb.as_ref().unchecked_ref(), 50)
-    {
-        *timer_cell.borrow_mut() = Some(id);
-    }
-    *cb_cell.borrow_mut() = Some(cb);
 }

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -2481,7 +2481,7 @@ fn bracketed_paste(payload: &[u8]) -> Vec<u8> {
 /// (it prepends its own `@` on paste; the quotes keep paths with spaces as one
 /// token, with embedded `'` shell-escaped); Claude Code and Codex auto-detect a
 /// bare path.
-fn image_path_payload(is_vibe: bool, path: &str) -> String {
+pub fn image_path_payload(is_vibe: bool, path: &str) -> String {
     if is_vibe {
         format!("'{}'", path.replace('\'', "'\\''"))
     } else {
@@ -4676,34 +4676,12 @@ mod tests {
         assert!(page.contains("MatrixRain {"));
         assert!(page.contains("accent.rain_rgb"));
         assert!(page.contains("terminal: true"));
-        assert!(page.contains("git status --short"));
         assert!(page.contains("type a command · runs when ready"));
 
         let rain = include_str!("matrix_rain.rs");
         assert!(rain.contains("request_animation_frame"));
         assert!(rain.contains("use_drop"));
         assert!(rain.contains("prefers-reduced-motion"));
-    }
-
-    #[test]
-    fn prompt_ghost_rotates_many_random_agent_examples() {
-        let source = include_str!("page.rs");
-        let examples = source
-            .split("const AGENT_PROMPT_EXAMPLES")
-            .nth(1)
-            .and_then(|tail| tail.split("];").next())
-            .unwrap_or_default();
-        assert!(
-            examples
-                .lines()
-                .filter(|line| line.trim_start().starts_with('"'))
-                .count()
-                >= 40
-        );
-        assert!(source.contains("random_prompt_example_index"));
-        assert!(source.contains("js_sys::Math::random()"));
-        assert!(source.contains("relative top-px ml-px h-4 w-1.5 shrink-0"));
-        assert!(source.contains("vmux-prompt-caret-blink 1s step-end infinite"));
     }
 
     #[test]

--- a/crates/vmux_ui/assets/theme.css
+++ b/crates/vmux_ui/assets/theme.css
@@ -280,6 +280,15 @@
   animation-delay: 40ms;
 }
 
+@keyframes vmux-agent-ready-in {
+  from { opacity: 0; transform: translateY(12px) scale(0.985); filter: blur(4px); }
+  to { opacity: 1; transform: translateY(0) scale(1); filter: blur(0); }
+}
+
+.vmux-agent-ready-enter {
+  animation: vmux-agent-ready-in 360ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
 @keyframes vmux-agent-prompt-dock-in {
   from { opacity: 0.92; transform: translateY(calc(-50vh + 7rem)); }
   to { opacity: 1; transform: translateY(0); }
@@ -291,6 +300,7 @@
 
 @media (prefers-reduced-motion: reduce) {
   .vmux-agent-prompt-dock-enter,
+  .vmux-agent-ready-enter,
   .vmux-agent-surface-enter,
   .vmux-prompt-popup-upward,
   .vmux-prompt-popup-downward { animation: none; }

--- a/crates/vmux_ui/assets/theme.css
+++ b/crates/vmux_ui/assets/theme.css
@@ -247,6 +247,44 @@
   to { opacity: 1; }
 }
 
+@keyframes vmux-prompt-popup-in {
+  from { opacity: 0; transform: translateY(8px) scale(0.985); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.vmux-prompt-popup {
+  animation: vmux-prompt-popup-in 160ms cubic-bezier(0.16, 1, 0.3, 1);
+  transform-origin: bottom center;
+}
+
+@keyframes vmux-agent-surface-in {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.vmux-agent-surface-enter {
+  animation: vmux-agent-surface-in 260ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.vmux-agent-surface-enter-delayed {
+  animation-delay: 40ms;
+}
+
+@keyframes vmux-agent-prompt-dock-in {
+  from { opacity: 0.92; transform: translateY(calc(-50vh + 7rem)); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.vmux-agent-prompt-dock-enter {
+  animation: vmux-agent-prompt-dock-in 320ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vmux-agent-prompt-dock-enter,
+  .vmux-agent-surface-enter,
+  .vmux-prompt-popup { animation: none; }
+}
+
 @keyframes spin-once {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }

--- a/crates/vmux_ui/assets/theme.css
+++ b/crates/vmux_ui/assets/theme.css
@@ -247,14 +247,24 @@
   to { opacity: 1; }
 }
 
-@keyframes vmux-prompt-popup-in {
+@keyframes vmux-prompt-popup-upward-in {
   from { opacity: 0; transform: translateY(8px) scale(0.985); }
   to { opacity: 1; transform: translateY(0) scale(1); }
 }
 
-.vmux-prompt-popup {
-  animation: vmux-prompt-popup-in 160ms cubic-bezier(0.16, 1, 0.3, 1);
+@keyframes vmux-prompt-popup-downward-in {
+  from { opacity: 0; transform: translateY(-8px) scale(0.985); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.vmux-prompt-popup-upward {
+  animation: vmux-prompt-popup-upward-in 160ms cubic-bezier(0.16, 1, 0.3, 1);
   transform-origin: bottom center;
+}
+
+.vmux-prompt-popup-downward {
+  animation: vmux-prompt-popup-downward-in 180ms cubic-bezier(0.16, 1, 0.3, 1);
+  transform-origin: top center;
 }
 
 @keyframes vmux-agent-surface-in {
@@ -282,7 +292,8 @@
 @media (prefers-reduced-motion: reduce) {
   .vmux-agent-prompt-dock-enter,
   .vmux-agent-surface-enter,
-  .vmux-prompt-popup { animation: none; }
+  .vmux-prompt-popup-upward,
+  .vmux-prompt-popup-downward { animation: none; }
 }
 
 @keyframes spin-once {

--- a/crates/vmux_ui/src/components.rs
+++ b/crates/vmux_ui/src/components.rs
@@ -26,6 +26,7 @@ pub mod navbar;
 pub mod pagination;
 pub mod popover;
 pub mod progress;
+pub mod prompt_box;
 pub mod radio_group;
 pub mod scroll_area;
 pub mod select;

--- a/crates/vmux_ui/src/components/prompt_box.rs
+++ b/crates/vmux_ui/src/components/prompt_box.rs
@@ -4,7 +4,15 @@ use dioxus_primitives::merge_attributes;
 
 const PROMPT_BOX_ROOT: &str = "vmux-prompt-box relative flex items-center overflow-hidden rounded-2xl bg-white/45 p-1 shadow-[0_18px_55px_-24px_rgba(0,0,0,0.65),inset_0_1px_0_rgba(255,255,255,0.18),inset_0_-1px_0_rgba(255,255,255,0.04)] ring-1 ring-inset ring-black/10 backdrop-blur-3xl backdrop-saturate-150 transition-all duration-200 focus-within:bg-white/55 focus-within:ring-black/20 focus-within:shadow-[0_22px_65px_-24px_rgba(0,0,0,0.72),inset_0_1px_0_rgba(255,255,255,0.22)] dark:bg-white/[0.045] dark:ring-white/[0.16] dark:focus-within:bg-white/[0.065] dark:focus-within:ring-white/25";
 
-const PROMPT_POPUP_ROOT: &str = "vmux-prompt-popup absolute bottom-full left-0 z-20 mb-2 max-h-80 w-full overflow-x-hidden overflow-y-auto rounded-2xl border border-foreground/10 bg-background/95 shadow-xl backdrop-blur-xl";
+const PROMPT_POPUP_ROOT: &str = "vmux-prompt-popup absolute left-0 z-20 max-h-80 w-full overflow-x-hidden overflow-y-auto rounded-2xl border border-foreground/10 bg-background/95 shadow-xl backdrop-blur-xl";
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub enum PromptPopupPlacement {
+    #[default]
+    Upward,
+    Downward,
+    Inline,
+}
 
 /// Shared glass prompt surface used by launcher and agent composers.
 #[component]
@@ -30,14 +38,22 @@ pub fn PromptBox(
     }
 }
 
-/// Shared upward-opening menu surface for prompt suggestions and selectors.
+/// Shared animated menu surface for prompt suggestions and selectors.
 #[component]
 pub fn PromptPopup(
-    #[props(default = true)] upward: bool,
+    #[props(default)] placement: PromptPopupPlacement,
     #[props(extends = GlobalAttributes)] attributes: Vec<Attribute>,
     children: Element,
 ) -> Element {
-    let class = if upward { PROMPT_POPUP_ROOT } else { "" };
+    let class = match placement {
+        PromptPopupPlacement::Upward => {
+            format!("{PROMPT_POPUP_ROOT} vmux-prompt-popup-upward bottom-full mb-2")
+        }
+        PromptPopupPlacement::Downward => {
+            format!("{PROMPT_POPUP_ROOT} vmux-prompt-popup-downward top-full mt-2")
+        }
+        PromptPopupPlacement::Inline => String::new(),
+    };
     let base = attributes!(div {
         class,
         "data-slot": "prompt-popup",

--- a/crates/vmux_ui/src/components/prompt_box.rs
+++ b/crates/vmux_ui/src/components/prompt_box.rs
@@ -1,0 +1,49 @@
+use dioxus::prelude::*;
+use dioxus_primitives::dioxus_attributes::attributes;
+use dioxus_primitives::merge_attributes;
+
+const PROMPT_BOX_ROOT: &str = "vmux-prompt-box relative flex items-center overflow-hidden rounded-2xl bg-white/45 p-1 shadow-[0_18px_55px_-24px_rgba(0,0,0,0.65),inset_0_1px_0_rgba(255,255,255,0.18),inset_0_-1px_0_rgba(255,255,255,0.04)] ring-1 ring-inset ring-black/10 backdrop-blur-3xl backdrop-saturate-150 transition-all duration-200 focus-within:bg-white/55 focus-within:ring-black/20 focus-within:shadow-[0_22px_65px_-24px_rgba(0,0,0,0.72),inset_0_1px_0_rgba(255,255,255,0.22)] dark:bg-white/[0.045] dark:ring-white/[0.16] dark:focus-within:bg-white/[0.065] dark:focus-within:ring-white/25";
+
+const PROMPT_POPUP_ROOT: &str = "vmux-prompt-popup absolute bottom-full left-0 z-20 mb-2 max-h-80 w-full overflow-x-hidden overflow-y-auto rounded-2xl border border-foreground/10 bg-background/95 shadow-xl backdrop-blur-xl";
+
+/// Shared glass prompt surface used by launcher and agent composers.
+#[component]
+pub fn PromptBox(
+    #[props(default = true)] glass: bool,
+    #[props(extends = GlobalAttributes)] attributes: Vec<Attribute>,
+    children: Element,
+) -> Element {
+    let class = if glass { PROMPT_BOX_ROOT } else { "" };
+    let base = attributes!(div {
+        class,
+        "data-slot": "prompt-box",
+    });
+    let merged = merge_attributes(vec![base, attributes]);
+    rsx! {
+        div { ..merged,
+            if glass {
+                div { class: "pointer-events-none absolute inset-px rounded-[0.9rem] bg-gradient-to-b from-white/[0.12] via-white/[0.025] to-transparent dark:from-white/[0.10]" }
+                div { class: "pointer-events-none absolute -left-12 -top-12 h-24 w-72 rotate-[-5deg] rounded-full bg-white/[0.09] blur-2xl" }
+            }
+            {children}
+        }
+    }
+}
+
+/// Shared upward-opening menu surface for prompt suggestions and selectors.
+#[component]
+pub fn PromptPopup(
+    #[props(default = true)] upward: bool,
+    #[props(extends = GlobalAttributes)] attributes: Vec<Attribute>,
+    children: Element,
+) -> Element {
+    let class = if upward { PROMPT_POPUP_ROOT } else { "" };
+    let base = attributes!(div {
+        class,
+        "data-slot": "prompt-popup",
+    });
+    let merged = merge_attributes(vec![base, attributes]);
+    rsx! {
+        div { ..merged, {children} }
+    }
+}

--- a/crates/vmux_ui/src/lib.rs
+++ b/crates/vmux_ui/src/lib.rs
@@ -13,6 +13,8 @@ pub mod file_icon;
 
 pub mod icon;
 
+pub mod prompt_ghost;
+
 pub mod theme;
 
 #[cfg(any(target_arch = "wasm32", test))]

--- a/crates/vmux_ui/src/prompt_ghost.rs
+++ b/crates/vmux_ui/src/prompt_ghost.rs
@@ -56,6 +56,27 @@ pub const TERMINAL_PROMPT_EXAMPLES: &[&str] = &[
     "git log --oneline -10",
 ];
 
+#[cfg(any(test, target_arch = "wasm32"))]
+const PROMPT_PAUSE_TICKS: usize = 40;
+
+#[cfg(any(test, target_arch = "wasm32"))]
+fn distinct_prompt_example_index(len: usize, current: Option<usize>, candidate: usize) -> usize {
+    if len <= 1 {
+        return 0;
+    }
+    let next = candidate.min(len - 1);
+    if current == Some(next) {
+        (next + 1) % len
+    } else {
+        next
+    }
+}
+
+#[cfg(any(test, target_arch = "wasm32"))]
+fn next_prompt_typed_count(typed: usize, full: usize) -> Option<usize> {
+    (typed < full + PROMPT_PAUSE_TICKS).then_some(typed + 1)
+}
+
 #[cfg(target_arch = "wasm32")]
 mod component {
     use std::cell::RefCell;
@@ -64,7 +85,10 @@ mod component {
     use dioxus::prelude::*;
     use wasm_bindgen::{JsCast, closure::Closure};
 
-    use super::{AGENT_PROMPT_EXAMPLES, TERMINAL_PROMPT_EXAMPLES};
+    use super::{
+        AGENT_PROMPT_EXAMPLES, TERMINAL_PROMPT_EXAMPLES, distinct_prompt_example_index,
+        next_prompt_typed_count,
+    };
 
     const PROMPT_CARET_CSS: &str = ".vmux-prompt-caret{animation:vmux-prompt-caret-blink 1s step-end infinite}@keyframes vmux-prompt-caret-blink{0%,49%{opacity:1}50%,100%{opacity:0}}";
     type PromptTimerCallback = Rc<RefCell<Option<Closure<dyn FnMut()>>>>;
@@ -121,15 +145,8 @@ mod component {
     }
 
     fn random_prompt_example_index(len: usize, current: Option<usize>) -> usize {
-        if len <= 1 {
-            return 0;
-        }
-        let next = ((js_sys::Math::random() * len as f64) as usize).min(len - 1);
-        if current == Some(next) {
-            (next + 1) % len
-        } else {
-            next
-        }
+        let candidate = (js_sys::Math::random() * len as f64) as usize;
+        distinct_prompt_example_index(len, current, candidate)
     }
 
     fn start_prompt_typewriter(
@@ -139,16 +156,15 @@ mod component {
         cb_cell: PromptTimerCallback,
         timer_cell: Rc<RefCell<Option<i32>>>,
     ) {
-        const PAUSE_TICKS: usize = 40;
         let cb = Closure::wrap(Box::new(move || {
             let idx = *ex_idx.peek();
             let full = examples[idx % examples.len()].chars().count();
             let t = *typed.peek();
-            if t >= full + PAUSE_TICKS {
+            if let Some(next) = next_prompt_typed_count(t, full) {
+                typed.set(next);
+            } else {
                 typed.set(0);
                 ex_idx.set(random_prompt_example_index(examples.len(), Some(idx)));
-            } else {
-                typed.set(t + 1);
             }
         }) as Box<dyn FnMut()>);
         if let Some(win) = web_sys::window()
@@ -171,8 +187,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn agent_examples_cover_many_prompt_shapes() {
-        assert!(AGENT_PROMPT_EXAMPLES.len() >= 40);
-        assert!(TERMINAL_PROMPT_EXAMPLES.contains(&"git status --short"));
+    fn prompt_example_index_never_repeats_current() {
+        for current in 0..4 {
+            assert_ne!(
+                distinct_prompt_example_index(4, Some(current), current),
+                current
+            );
+        }
+    }
+
+    #[test]
+    fn prompt_typewriter_resets_after_pause() {
+        let full = 12;
+        assert_eq!(
+            next_prompt_typed_count(full + PROMPT_PAUSE_TICKS - 1, full),
+            Some(full + PROMPT_PAUSE_TICKS)
+        );
+        assert_eq!(
+            next_prompt_typed_count(full + PROMPT_PAUSE_TICKS, full),
+            None
+        );
     }
 }

--- a/crates/vmux_ui/src/prompt_ghost.rs
+++ b/crates/vmux_ui/src/prompt_ghost.rs
@@ -1,0 +1,178 @@
+pub const AGENT_PROMPT_EXAMPLES: &[&str] = &[
+    "Find me the best flight from Paris to Tokyo next month",
+    "Find a quiet hotel with AC near central Paris for this weekend",
+    "Plan a five-day food and culture trip through Kyoto",
+    "Build me a relaxed weekend itinerary for Lisbon",
+    "Compare rail passes for a two-week trip around Europe",
+    "Find highly rated restaurants nearby with vegetarian options",
+    "Research the visa requirements for my next international trip",
+    "Create a lightweight packing list for a ten-day winter trip",
+    "Plan a scenic road trip from San Francisco to Portland",
+    "Compare the best neighborhoods for a month-long stay in Tokyo",
+    "Find quiet coworking spaces with day passes and fast Wi-Fi",
+    "Plan a memorable surprise birthday weekend on a sensible budget",
+    "Build a healthy weekly meal plan and shopping list for two",
+    "Turn this grocery budget into affordable meals for the week",
+    "Create a beginner workout plan I can do at home in 30 minutes",
+    "Make a six-week study plan for conversational Japanese",
+    "Compare the best noise-canceling headphones under $300",
+    "Find an ergonomic standing desk setup for a small apartment",
+    "Research the best compact camera for travel and street photography",
+    "Compare lightweight laptops for coding, travel, and battery life",
+    "Summarize these PDFs and extract the decisions and action items",
+    "Turn my meeting notes into a clear project plan with owners",
+    "Draft a concise follow-up email from these scattered notes",
+    "Organize my Downloads folder into a clean, useful structure",
+    "Find duplicate photos and help me safely clean them up",
+    "Analyze this CSV and explain the most important trends",
+    "Turn these receipts into a categorized expense report",
+    "Build a landing site for my new restaurant — make it themeable",
+    "Prototype a clean dashboard from this product brief",
+    "Debug the failing tests and explain the root cause",
+    "Explain how this codebase works and where I should start",
+    "Refactor this module without changing its behavior",
+    "Add the requested feature and verify the important edge cases",
+    "Review my staged changes for bugs, security, and maintainability",
+    "Open a PR for my staged changes",
+    "Generate release notes from the changes since the last version",
+    "Investigate these application logs and find the likely failure",
+    "Find the performance bottleneck and propose the smallest fix",
+    "Update outdated dependencies and resolve compatibility issues",
+    "Set up this project locally and verify the development workflow",
+    "Automate this repetitive workflow with a reliable script",
+    "Research my competitors and summarize their positioning",
+    "Create a launch plan for this product with milestones and risks",
+    "Turn this rough brief into a prioritized execution checklist",
+    "Find the latest reliable information and summarize the sources",
+    "Compare my subscriptions and identify easy ways to save money",
+    "Design a comfortable home office setup for a tight space",
+    "Create a realistic monthly budget from these transactions",
+];
+
+pub const TERMINAL_PROMPT_EXAMPLES: &[&str] = &[
+    "git status --short",
+    "rg \"TODO|FIXME\" .",
+    "find . -type f -size +100M",
+    "git log --oneline -10",
+];
+
+#[cfg(target_arch = "wasm32")]
+mod component {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    use dioxus::prelude::*;
+    use wasm_bindgen::{JsCast, closure::Closure};
+
+    use super::{AGENT_PROMPT_EXAMPLES, TERMINAL_PROMPT_EXAMPLES};
+
+    const PROMPT_CARET_CSS: &str = ".vmux-prompt-caret{animation:vmux-prompt-caret-blink 1s step-end infinite}@keyframes vmux-prompt-caret-blink{0%,49%{opacity:1}50%,100%{opacity:0}}";
+    type PromptTimerCallback = Rc<RefCell<Option<Closure<dyn FnMut()>>>>;
+
+    #[component]
+    pub fn PromptGhost(accent_bg: String, terminal: bool) -> Element {
+        let examples = if terminal {
+            TERMINAL_PROMPT_EXAMPLES
+        } else {
+            AGENT_PROMPT_EXAMPLES
+        };
+        let ex_idx = use_signal(|| random_prompt_example_index(examples.len(), None));
+        let typed = use_signal(|| 0usize);
+        let cb: PromptTimerCallback = use_hook(|| Rc::new(RefCell::new(None)));
+        let timer: Rc<RefCell<Option<i32>>> = use_hook(|| Rc::new(RefCell::new(None)));
+        use_effect({
+            let cb = cb.clone();
+            let timer = timer.clone();
+            move || start_prompt_typewriter(examples, ex_idx, typed, cb.clone(), timer.clone())
+        });
+        use_drop({
+            let cb = cb.clone();
+            let timer = timer.clone();
+            move || {
+                if let Some(id) = timer.borrow_mut().take()
+                    && let Some(win) = web_sys::window()
+                {
+                    win.clear_interval_with_handle(id);
+                }
+                *cb.borrow_mut() = None;
+            }
+        });
+        let example = examples[ex_idx() % examples.len()];
+        let full = example.chars().count();
+        let shown: String = example.chars().take(typed().min(full)).collect();
+        let ghost_class = if terminal {
+            "w-80 whitespace-pre-wrap break-words font-mono text-sm text-muted-foreground/50"
+        } else {
+            "flex max-w-full items-center whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50"
+        };
+        let caret_class = if terminal {
+            format!("vmux-prompt-caret ml-px inline-block h-3.5 w-1.5 align-middle {accent_bg}")
+        } else {
+            format!("vmux-prompt-caret relative top-px ml-px h-4 w-1.5 shrink-0 {accent_bg}")
+        };
+        rsx! {
+            style { dangerous_inner_html: PROMPT_CARET_CSS }
+            div {
+                class: "{ghost_class}",
+                span { class: if terminal { "" } else { "min-w-0 truncate" }, "{shown}" }
+                span { class: "{caret_class}" }
+            }
+        }
+    }
+
+    fn random_prompt_example_index(len: usize, current: Option<usize>) -> usize {
+        if len <= 1 {
+            return 0;
+        }
+        let next = ((js_sys::Math::random() * len as f64) as usize).min(len - 1);
+        if current == Some(next) {
+            (next + 1) % len
+        } else {
+            next
+        }
+    }
+
+    fn start_prompt_typewriter(
+        examples: &'static [&'static str],
+        mut ex_idx: Signal<usize>,
+        mut typed: Signal<usize>,
+        cb_cell: PromptTimerCallback,
+        timer_cell: Rc<RefCell<Option<i32>>>,
+    ) {
+        const PAUSE_TICKS: usize = 40;
+        let cb = Closure::wrap(Box::new(move || {
+            let idx = *ex_idx.peek();
+            let full = examples[idx % examples.len()].chars().count();
+            let t = *typed.peek();
+            if t >= full + PAUSE_TICKS {
+                typed.set(0);
+                ex_idx.set(random_prompt_example_index(examples.len(), Some(idx)));
+            } else {
+                typed.set(t + 1);
+            }
+        }) as Box<dyn FnMut()>);
+        if let Some(win) = web_sys::window()
+            && let Ok(id) = win.set_interval_with_callback_and_timeout_and_arguments_0(
+                cb.as_ref().unchecked_ref(),
+                50,
+            )
+        {
+            *timer_cell.borrow_mut() = Some(id);
+        }
+        *cb_cell.borrow_mut() = Some(cb);
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use component::PromptGhost;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_examples_cover_many_prompt_shapes() {
+        assert!(AGENT_PROMPT_EXAMPLES.len() >= 40);
+        assert!(TERMINAL_PROMPT_EXAMPLES.contains(&"git status --short"));
+    }
+}


### PR DESCRIPTION
## Context

The start launcher and agent page used separate prompt surfaces and replaced the underlying webview when opening an agent. This caused a visible jump and lost prompt state.

## Implementation

- Share the glass prompt surface across start and agent pages.
- Transition start to agent inside the same Dioxus document and reuse the existing CEF webview.
- Animate the prompt from the centered launcher to the bottom composer.
- Reveal agent choices below the start prompt while typing and transition theme accents smoothly.
- Add animated prompt examples, file picker, clipboard media, inline `@` media search, attachment chips, and attachment handoff to the selected agent.
- Preserve prompt text and attachments while automatically starting the conversation.
- Use neutral white lighting on the agent composer and keep matrix rain scoped to agent loading.

## Checks

- Workspace fmt, clippy, tests, and doctests pass locally through the pre-push hook.
- wasm32 web check passes.
- GitHub Linux lint/tests and macOS build/package pass.
- CodeRabbit review passes with all threads resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Start agents inline from the launcher, reusing the existing start experience during transitions.
  * Prompts can include media attachments with previews and attachment pills.
  * Media selection/search is available in the launcher start flow with keyboard navigation.
  * Unified `PromptBox`/`PromptPopup` rendering across launcher and chat.

* **Improvements**
  * Added smoother prompt/popup animations with reduced-motion support.
  * Queued prompts now dispatch only after required agent/installation readiness.

* **Bug Fixes**
  * Fixed command-bar action payloads to include attachment data.
  * Improved transition rendering and caret behavior in the chat composer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->