### PR TITLE
fix(release): keep metadata in one release PR

### DIFF
--- a/.agents/skills/vmux-release/SKILL.md
+++ b/.agents/skills/vmux-release/SKILL.md
@@ -39,44 +39,59 @@ description: Use when releasing a new vmux version, cutting a vmux release, vali
    git push -u origin release/vX.Y.Z
    ```
 
-4. **Open PR.**
+4. **Open one release PR.**
    ```bash
    gh pr create --title "chore(release): vX.Y.Z" --body "Release vX.Y.Z"
    ```
 
-5. **Wait for CI green.** Lint + test always run; build-mac runs only if packaging-touching paths changed.
+5. **Wait for draft assets.** The first CI run builds, signs, notarizes, smoke-tests, and uploads four assets to a draft GitHub release. Its final `Require release metadata commit` step is expected to fail until the metadata commit exists.
 
-6. **Squash-merge PR to main.**
+6. **Update metadata on the same PR branch.**
+   ```bash
+   ./scripts/update-release-metadata.sh
+   git diff --check
+   ruby -c Casks/vmux.rb
+   jq empty website/public/updates.json
+   git add Casks/vmux.rb website/public/updates.json
+   git commit -m "chore(release): update vX.Y.Z metadata"
+   git push
+   ```
+   This reads the final draft assets, updates the Homebrew checksum and updater signature, and keeps the release to one PR with two commits. Never merge a version-only release PR.
+
+7. **Wait for the second CI run and review.** The idempotency guard reuses the draft assets instead of rebuilding them. Confirm every required check is green and every review thread is handled.
+
+8. **Squash-merge the single PR to main.**
    ```bash
    gh pr merge --squash --delete-branch
    ```
 
-7. **Watch release pipeline.**
+9. **Watch release pipeline.**
    ```bash
    gh run watch $(gh run list --workflow=release.yml --limit 1 --json databaseId --jq '.[0].databaseId')
    ```
-   Expected: ~50 min for the macOS sign + notarize + DMG build.
+   The expensive macOS build already ran on the PR. The main release workflow verifies committed metadata, retargets the tag to the merge commit, publishes the draft, and dispatches the website deploy.
 
-8. **Verify GH release.**
+10. **Verify GH release.**
    ```bash
    gh release view vX.Y.Z
    ```
    Assets present: `Vmux_X.Y.Z_aarch64.dmg`, `vmux-vX.Y.Z-aarch64-apple-darwin.tar.gz`, `Vmux-vX.Y.Z-aarch64-apple-darwin.app.tar.gz`, `Vmux-vX.Y.Z-aarch64-apple-darwin.app.tar.gz.sig`.
 
-9. **Verify auto-commit on main.**
+11. **Verify merged metadata on main.**
    ```bash
-   git pull --rebase origin main
-   git log -1 --stat
+   git fetch origin main
+   git show origin/main:Casks/vmux.rb
+   git show origin/main:website/public/updates.json
    ```
-   Expect a commit `chore(release): update cask and update manifest to X.Y.Z` touching `Casks/vmux.rb` and `website/public/updates.json`.
+   Both files must reference `vX.Y.Z`.
 
-10. **Verify website redeploy.** Wait ~5 min for `deploy-website.yml`, then:
+12. **Verify website redeploy.** Wait for `deploy-website.yml`, then:
    ```bash
    curl -fsSL https://vmux.ai/updates.json | jq .version
    ```
    Should print `"vX.Y.Z"`.
 
-11. **Smoke test.** On a clean macOS machine or VM:
+13. **Smoke test.** On a clean macOS machine or VM:
     ```bash
     brew tap vmux-ai/vmux https://github.com/vmux-ai/vmux
     brew install --cask vmux
@@ -86,13 +101,15 @@ description: Use when releasing a new vmux version, cutting a vmux release, vali
     ```
     Confirm app launches and `About` shows the new version.
 
-12. **(Optional) Test auto-update.** Install previous version, launch, wait for poll interval (default 1h). App should download + replace itself with the new version on next launch.
+14. **(Optional) Test auto-update.** Install previous version, launch, wait for poll interval (default 1h). App should download + replace itself with the new version on next launch.
 
 ## If something goes wrong
 
-- **Release pipeline fails partway:** check `gh run view --log-failed`. Common: notarization timeout (Apple side, retry the run), missing secret (re-add).
-- **detect-version says version unchanged after cask + manifest auto-commit:** expected. The auto-commit does not change `Cargo.toml`, so release should skip.
+- **First CI fails only at `Require release metadata commit`:** expected. Run `./scripts/update-release-metadata.sh`, commit both metadata files to the same branch, and push.
+- **Metadata helper says release or assets are missing:** the first macOS CI job has not finished creating the draft release. Wait for it, then retry.
+- **Second CI rebuilds the macOS assets:** the cask URL does not match the draft release. Re-run the metadata helper and inspect the diff.
+- **Release pipeline fails metadata verification:** the release PR was merged without matching cask/updater metadata. Do not publish manually; repair the release process before retrying.
+- **Release pipeline fails partway:** check `gh run view --log-failed`. Common: notarization timeout (Apple side, retry the PR CI run), missing secret (re-add).
 - **detect-version says version unchanged after the release bump merge:** unexpected. The merged release commit did not change `Cargo.toml` version. Confirm the bump landed; check `git show main:Cargo.toml | head -10`.
 - **Tag already exists:** release.yml resumes if the existing `vX.Y.Z` tag points at the release SHA. It aborts if the tag points elsewhere. Fix by bumping version higher and pushing a new commit to main, or only delete the bad tag if you are certain it is safe.
-- **Cask commit conflicts:** rare; another commit landed on main between release start and cask push. The workflow does `git pull --rebase origin main` before push; if that fails, re-run the workflow.
 - **vmux.ai/updates.json shows old version:** `deploy-website.yml` didn't fire. Check workflow runs; manually re-run via `gh workflow run deploy-website.yml`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -558,3 +558,9 @@ jobs:
               --generate-notes \
               "${ASSETS[@]}"
           fi
+
+      - name: Require release metadata commit
+        if: env.IS_RELEASE_PR == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/update-release-metadata.sh --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,11 @@ jobs:
             exit 0
           fi
           echo "Detected version bump: $PREV_VERSION -> $VERSION"
-          echo "should_release=true" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          {
+            echo "should_release=true"
+            echo "version=$VERSION"
+            echo "tag=v$VERSION"
+          } >> "$GITHUB_OUTPUT"
 
   publish:
     name: Publish Release
@@ -65,20 +67,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Verify draft release exists with all assets
+      - name: Verify release assets and committed metadata
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          if ! gh release view "$TAG" --json isDraft,assets >/tmp/r.json 2>/dev/null; then
-            echo "::error::No release for $TAG. CI on the release PR should have created a draft. Aborting."
-            exit 1
-          fi
-          asset_count=$(jq '.assets | length' /tmp/r.json)
-          if [ "$asset_count" -lt 4 ]; then
-            echo "::error::Release $TAG has only $asset_count assets; expected 4. Aborting."
-            exit 1
-          fi
+        run: ./scripts/update-release-metadata.sh --check
 
       - name: Re-target tag to current main HEAD
         env:

--- a/scripts/update-release-metadata.sh
+++ b/scripts/update-release-metadata.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MODE="${1:-update}"
+
+if [[ "$MODE" != "update" && "$MODE" != "--check" ]]; then
+    echo "usage: $0 [--check]" >&2
+    exit 2
+fi
+
+for command in gh jq sed cmp mktemp; do
+    if ! command -v "$command" >/dev/null 2>&1; then
+        echo "missing required command: $command" >&2
+        exit 1
+    fi
+done
+
+VERSION="$(sed -n 's/^version = "\([^"]*\)"/\1/p' "$ROOT/Cargo.toml" | head -n 1)"
+if [[ -z "$VERSION" ]]; then
+    echo "workspace version not found" >&2
+    exit 1
+fi
+
+TAG="v$VERSION"
+DMG_NAME="Vmux_${VERSION}_aarch64.dmg"
+BINARY_NAME="vmux-v${VERSION}-aarch64-apple-darwin.tar.gz"
+APP_NAME="Vmux-v${VERSION}-aarch64-apple-darwin.app.tar.gz"
+SIG_NAME="${APP_NAME}.sig"
+DMG_URL="https://github.com/vmux-ai/vmux/releases/download/${TAG}/${DMG_NAME}"
+APP_URL="https://github.com/vmux-ai/vmux/releases/download/${TAG}/${APP_NAME}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+RELEASE_JSON="$TMP_DIR/release.json"
+if ! gh release view "$TAG" --json isDraft,assets > "$RELEASE_JSON"; then
+    echo "unable to read release $TAG; wait for release PR CI or check GitHub access" >&2
+    exit 1
+fi
+
+for asset in "$DMG_NAME" "$BINARY_NAME" "$APP_NAME" "$SIG_NAME"; do
+    if ! jq -e --arg name "$asset" '.assets[] | select(.name == $name)' "$RELEASE_JSON" >/dev/null; then
+        echo "release $TAG is missing asset: $asset" >&2
+        exit 1
+    fi
+done
+
+DMG_DIGEST="$(jq -er --arg name "$DMG_NAME" '.assets[] | select(.name == $name) | .digest' "$RELEASE_JSON")"
+DMG_SHA="${DMG_DIGEST#sha256:}"
+if [[ ! "$DMG_SHA" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "invalid DMG digest: $DMG_DIGEST" >&2
+    exit 1
+fi
+
+MANIFEST="$ROOT/website/public/updates.json"
+CURRENT_VERSION="$(jq -r '.version // empty' "$MANIFEST")"
+CURRENT_PUB_DATE="$(jq -r '.pub_date // empty' "$MANIFEST")"
+if [[ "$CURRENT_VERSION" == "$TAG" && -n "$CURRENT_PUB_DATE" ]]; then
+    PUB_DATE="$CURRENT_PUB_DATE"
+else
+    PUB_DATE="$(jq -er --arg name "$APP_NAME" '.assets[] | select(.name == $name) | .createdAt' "$RELEASE_JSON")"
+fi
+
+ASSET_DIR="$TMP_DIR/assets"
+mkdir "$ASSET_DIR"
+gh release download "$TAG" --pattern "$SIG_NAME" --dir "$ASSET_DIR"
+SIGNATURE="$(<"$ASSET_DIR/$SIG_NAME")"
+if [[ -z "$SIGNATURE" ]]; then
+    echo "empty update signature" >&2
+    exit 1
+fi
+
+CASK="$ROOT/Casks/vmux.rb"
+EXPECTED_CASK="$TMP_DIR/vmux.rb"
+sed \
+    -e "s/^  version \".*\"/  version \"${VERSION}\"/" \
+    -e "s/^  sha256 \".*\"/  sha256 \"${DMG_SHA}\"/" \
+    -e "s|^  url \".*\"|  url \"${DMG_URL}\"|" \
+    "$CASK" > "$EXPECTED_CASK"
+
+EXPECTED_MANIFEST="$TMP_DIR/updates.json"
+jq \
+    --arg version "$TAG" \
+    --arg pub_date "$PUB_DATE" \
+    --arg app_url "$APP_URL" \
+    --arg signature "$SIGNATURE" \
+    --arg dmg_url "$DMG_URL" \
+    --arg dmg_name "$DMG_NAME" \
+    '
+      .version = $version
+      | .pub_date = $pub_date
+      | .platforms["macos-aarch64"].url = $app_url
+      | .platforms["macos-aarch64"].signature = $signature
+      | .platforms["macos-aarch64"].format = "app"
+      | .downloads["macos-aarch64"].url = $dmg_url
+      | .downloads["macos-aarch64"].filename = $dmg_name
+    ' \
+    "$MANIFEST" > "$EXPECTED_MANIFEST"
+
+if [[ "$MODE" == "--check" ]]; then
+    mismatch=0
+    if ! cmp -s "$CASK" "$EXPECTED_CASK"; then
+        echo "Casks/vmux.rb does not match release $TAG" >&2
+        mismatch=1
+    fi
+    if ! cmp -s "$MANIFEST" "$EXPECTED_MANIFEST"; then
+        echo "website/public/updates.json does not match release $TAG" >&2
+        mismatch=1
+    fi
+    if [[ "$mismatch" -ne 0 ]]; then
+        echo "run ./scripts/update-release-metadata.sh on the release PR branch, commit, and push" >&2
+        exit 1
+    fi
+    echo "release metadata matches $TAG"
+    exit 0
+fi
+
+cp "$EXPECTED_CASK" "$CASK"
+cp "$EXPECTED_MANIFEST" "$MANIFEST"
+echo "updated release metadata for $TAG"


### PR DESCRIPTION
## Context

Release v0.0.26 needed a second PR because the version-only PR was merged before the cask and updater metadata were committed. Future releases should use one PR containing the version commit followed by the generated metadata commit.

## Implementation

Adds a deterministic release-metadata helper that reads the draft assets, updates the cask checksum and updater signature, and verifies exact matches. PR CI now blocks version-only release merges, the publish workflow rechecks metadata, and the release skill documents the two-commit/one-PR flow.

## Checks / QA

- Run ./scripts/update-release-metadata.sh --check against v0.0.26 and confirm it passes.
- Change the cask checksum locally and confirm the check rejects it with the same-PR repair command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved release automation for macOS downloads, signatures, and update metadata.
  * Added validation to ensure release metadata is current before publishing.
  * Added safeguards for release assets, version details, and website update information.

* **Documentation**
  * Expanded release workflow instructions and troubleshooting guidance.
  * Added optional steps for testing automatic updates.

* **Bug Fixes**
  * Prevented releases from proceeding when required metadata or assets are missing or outdated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->