### PR TITLE
feat(agent): add selection context shortcut

### DIFF
--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -24,14 +24,14 @@ use bevy_cef::prelude::{BinEventEmitterPlugin, BinHostEmitEvent, BinReceive, Bro
 #[cfg(not(target_arch = "wasm32"))]
 use crate::chat_page::event::{
     CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT,
-    CHAT_SNAPSHOT_EVENT, ChatApproval, ChatAttachPaths, ChatAttachment,
-    ChatAttachmentPreviewRequest, ChatAttachments, ChatCancel, ChatCancelQueuedPrompt,
-    ChatChooseWorkspace, ChatClearQueue, ChatEscape, ChatMediaEntries, ChatMediaEntry,
-    ChatMediaListRequest, ChatPasteMedia, ChatPickFiles, ChatResume, ChatSnapshot, ChatSubmit,
-    MODEL_STATE_EVENT, ModelOptionEntry, ModelState, QueuedPromptSnapshot,
-    RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions, ResumeListRequest,
-    ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry,
-    SlashCommands,
+    CHAT_SELECTION_CONTEXTS_EVENT, CHAT_SNAPSHOT_EVENT, ChatApproval, ChatAttachPaths,
+    ChatAttachment, ChatAttachmentPreviewRequest, ChatAttachments, ChatCancel,
+    ChatCancelQueuedPrompt, ChatChooseWorkspace, ChatClearQueue, ChatEscape, ChatMediaEntries,
+    ChatMediaEntry, ChatMediaListRequest, ChatPasteMedia, ChatPickFiles, ChatResume,
+    ChatSelectionContexts, ChatSnapshot, ChatSubmit, MODEL_STATE_EVENT, ModelOptionEntry,
+    ModelState, QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry,
+    ResumableSessions, ResumeListRequest, ResumeSession, RuntimeSwitchRequest,
+    SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry, SlashCommands,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use crate::chat_page::turns::group_turns;
@@ -140,6 +140,13 @@ fn approval_detail_label(path: &str) -> String {
 pub struct AgentChatPagePlugin;
 
 #[cfg(not(target_arch = "wasm32"))]
+#[derive(Component, Clone, Debug, Default)]
+pub(crate) struct PendingAgentSelectionContexts {
+    pub contexts: Vec<vmux_core::AgentSelectionContext>,
+    pub focus: bool,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Message)]
 struct AcpSetModelRequest {
     sid: String,
@@ -217,8 +224,41 @@ impl Plugin for AgentChatPagePlugin {
                     drain_chat_media_list_tasks,
                     drain_resume_list_tasks,
                     drain_resume_handoff_tasks,
+                    push_pending_selection_contexts_to_page,
                 ),
             );
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn push_pending_selection_contexts_to_page(
+    pending: Query<(Entity, &PendingAgentSelectionContexts)>,
+    children: Query<&Children>,
+    is_browser: Query<(), With<vmux_layout::Browser>>,
+    browsers: NonSend<Browsers>,
+    mut commands: Commands,
+) {
+    for (stack, pending) in &pending {
+        let Ok(children) = children.get(stack) else {
+            continue;
+        };
+        let Some(webview) = children.iter().find(|&child| is_browser.contains(child)) else {
+            continue;
+        };
+        if !browsers.has_browser(webview) || !browsers.host_emit_ready(&webview) {
+            continue;
+        }
+        commands.trigger(BinHostEmitEvent::from_rkyv(
+            webview,
+            CHAT_SELECTION_CONTEXTS_EVENT,
+            &ChatSelectionContexts {
+                contexts: pending.contexts.clone(),
+                focus: pending.focus,
+            },
+        ));
+        commands
+            .entity(stack)
+            .remove::<PendingAgentSelectionContexts>();
     }
 }
 
@@ -1042,6 +1082,7 @@ fn on_chat_submit(
     let webview = trigger.event().webview;
     let payload = &trigger.event().payload;
     let text = payload.text.clone();
+    let context = vmux_core::selection::render_selection_contexts(&payload.contexts);
     let attachments = payload
         .attachments
         .iter()
@@ -1053,14 +1094,14 @@ fn on_chat_submit(
             size: attachment.size,
         })
         .collect::<Vec<_>>();
-    if text.trim().is_empty() && attachments.is_empty() {
+    if text.trim().is_empty() && attachments.is_empty() && context.is_none() {
         return;
     }
     let Ok(parent) = child_of.get(webview) else {
         return;
     };
     if let Ok((mut queue, mut state)) = sessions.get_mut(parent.parent()) {
-        enqueue_prompt(&mut queue, &mut state, text, attachments);
+        enqueue_prompt(&mut queue, &mut state, text, context, attachments);
     }
 }
 
@@ -1069,9 +1110,10 @@ fn enqueue_prompt(
     queue: &mut PromptQueue,
     state: &mut AgentRunState,
     text: String,
+    context: Option<String>,
     attachments: Vec<AgentAttachment>,
 ) {
-    queue.enqueue_with_attachments(text, attachments);
+    queue.enqueue_with_context(text, context, attachments);
     if matches!(state, AgentRunState::Errored(_)) {
         *state = AgentRunState::Idle;
     }
@@ -1919,7 +1961,7 @@ mod native_tests {
         let mut queue = PromptQueue::default();
         let mut state = AgentRunState::Errored("failed".into());
 
-        enqueue_prompt(&mut queue, &mut state, "retry".into(), Vec::new());
+        enqueue_prompt(&mut queue, &mut state, "retry".into(), None, Vec::new());
 
         assert!(matches!(state, AgentRunState::Idle));
         assert_eq!(
@@ -1927,6 +1969,27 @@ mod native_tests {
             Some("retry")
         );
         assert!(!queue.paused);
+    }
+
+    #[test]
+    fn selection_context_stays_out_of_visible_prompt_text() {
+        let mut queue = PromptQueue::default();
+        let mut state = AgentRunState::Idle;
+
+        enqueue_prompt(
+            &mut queue,
+            &mut state,
+            "explain this".into(),
+            Some("Selected file context: main.rs\n\nlet x = 1;".into()),
+            Vec::new(),
+        );
+
+        let prompt = queue.items.front().unwrap();
+        assert_eq!(prompt.text, "explain this");
+        assert_eq!(
+            prompt.context.as_deref(),
+            Some("Selected file context: main.rs\n\nlet x = 1;")
+        );
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -10,6 +10,24 @@ pub const CHAT_ATTACHMENTS_EVENT: &str = "chat_attachments";
 pub const CHAT_ATTACHMENT_PREVIEWS_EVENT: &str = "chat_attachment_previews";
 /// Bin-event id: native → page media entries matching an inline `@` query.
 pub const CHAT_MEDIA_ENTRIES_EVENT: &str = "chat_media_entries";
+pub const CHAT_SELECTION_CONTEXTS_EVENT: &str = "chat_selection_contexts";
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatSelectionContexts {
+    pub contexts: Vec<vmux_core::AgentSelectionContext>,
+    pub focus: bool,
+}
 
 #[derive(
     Clone,
@@ -170,6 +188,8 @@ pub struct ChatSnapshot {
 pub struct ChatSubmit {
     pub text: String,
     pub attachments: Vec<ChatSubmitAttachment>,
+    #[serde(default)]
+    pub contexts: Vec<vmux_core::AgentSelectionContext>,
 }
 
 /// Page → native: open a multi-select file picker rooted at the user's home directory.
@@ -725,6 +745,23 @@ mod tests {
                 .preview_data_url
                 .starts_with("data:image/png")
         );
+    }
+
+    #[test]
+    fn chat_selection_contexts_rkyv_roundtrip() {
+        let value = ChatSelectionContexts {
+            contexts: vec![vmux_core::AgentSelectionContext::new(
+                "file",
+                "main.rs:2",
+                "/tmp/main.rs",
+                "let x = 1;",
+            )],
+            focus: true,
+        };
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&value).unwrap();
+        let back = rkyv::from_bytes::<ChatSelectionContexts, rkyv::rancor::Error>(&bytes).unwrap();
+        assert_eq!(back.contexts, value.contexts);
+        assert!(back.focus);
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -10,14 +10,15 @@ use crate::chat_page::composer::{
 };
 use crate::chat_page::event::{
     CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT,
-    CHAT_SNAPSHOT_EVENT, ChatApproval, ChatAttachPaths, ChatAttachment,
-    ChatAttachmentPreviewRequest, ChatAttachments, ChatBlock, ChatCancel, ChatCancelQueuedPrompt,
-    ChatChooseWorkspace, ChatClearQueue, ChatEscape, ChatItem, ChatMediaEntries, ChatMediaEntry,
-    ChatMediaListRequest, ChatPasteMedia, ChatPickFiles, ChatResume, ChatSnapshot, ChatSubmit,
-    ChatSubmitAttachment, ChatTurn, MODEL_STATE_EVENT, ModelOptionEntry, ModelState,
-    QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions,
-    ResumeListRequest, ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel,
-    SlashCommandEntry, SlashCommands, WORKING_VERBS,
+    CHAT_SELECTION_CONTEXTS_EVENT, CHAT_SNAPSHOT_EVENT, ChatApproval, ChatAttachPaths,
+    ChatAttachment, ChatAttachmentPreviewRequest, ChatAttachments, ChatBlock, ChatCancel,
+    ChatCancelQueuedPrompt, ChatChooseWorkspace, ChatClearQueue, ChatEscape, ChatItem,
+    ChatMediaEntries, ChatMediaEntry, ChatMediaListRequest, ChatPasteMedia, ChatPickFiles,
+    ChatResume, ChatSelectionContexts, ChatSnapshot, ChatSubmit, ChatSubmitAttachment, ChatTurn,
+    MODEL_STATE_EVENT, ModelOptionEntry, ModelState, QueuedPromptSnapshot,
+    RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions, ResumeListRequest,
+    ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry,
+    SlashCommands, WORKING_VERBS,
 };
 use dioxus::prelude::*;
 use std::borrow::Cow;
@@ -122,6 +123,15 @@ fn file_extension_label(name: &str) -> String {
 
 fn attachment_label(attachment: &ChatAttachment) -> String {
     file_extension_label(&attachment.name)
+}
+
+fn selection_context_title(context: &vmux_core::AgentSelectionContext) -> String {
+    let preview = context.text.chars().take(500).collect::<String>();
+    if context.source.is_empty() {
+        preview
+    } else {
+        format!("{}\n\n{preview}", context.source)
+    }
 }
 
 fn media_reference(entry: &ChatMediaEntry) -> String {
@@ -286,6 +296,7 @@ pub fn Page() -> Element {
     let mut workspace_picker_open = use_signal(|| false);
     let mut draft = use_signal(String::new);
     let mut attachments = use_signal(Vec::<ChatAttachment>::new);
+    let mut selection_contexts = use_signal(Vec::<vmux_core::AgentSelectionContext>::new);
     let mut attachment_previews = use_signal(HashMap::<String, ChatAttachment>::new);
     let mut attachment_preview_requests = use_signal(HashSet::<String>::new);
     let mut history_cursor = use_signal(|| None::<usize>);
@@ -421,6 +432,21 @@ pub fn Page() -> Element {
             attachments.set(next);
             focus_prompt_end();
         });
+    let _selection_contexts = use_bin_event_listener::<ChatSelectionContexts, _>(
+        CHAT_SELECTION_CONTEXTS_EVENT,
+        move |incoming| {
+            let mut next = selection_contexts.peek().clone();
+            for context in &incoming.contexts {
+                if !next.contains(context) {
+                    next.push(context.clone());
+                }
+            }
+            selection_contexts.set(next);
+            if incoming.focus {
+                focus_prompt_end();
+            }
+        },
+    );
     let _attachment_previews = use_bin_event_listener::<ChatAttachments, _>(
         CHAT_ATTACHMENT_PREVIEWS_EVENT,
         move |loaded| {
@@ -515,8 +541,10 @@ pub fn Page() -> Element {
     let agent_accent = agent_accent(&agent);
     let installing = status() == "installing";
     let installing_splash = installing && items.read().is_empty();
-    let show_capability_examples =
-        items.read().is_empty() && queued.read().is_empty() && attachments.read().is_empty();
+    let show_capability_examples = items.read().is_empty()
+        && queued.read().is_empty()
+        && attachments.read().is_empty()
+        && selection_contexts.read().is_empty();
     let install_detail = {
         let detail = error();
         if detail.is_empty() {
@@ -1036,6 +1064,37 @@ pub fn Page() -> Element {
                             }
                         }
                         div { class: "relative z-10 flex min-w-0 flex-1 flex-wrap items-center gap-1 px-2",
+                            for (i, context) in selection_contexts.read().iter().cloned().enumerate() {
+                                div {
+                                    key: "selection-context-{i}-{context.source}",
+                                    class: "group flex h-7 max-w-64 shrink-0 items-center gap-1.5 rounded-full bg-cyan-500/[0.10] pl-1 pr-1.5 text-xs text-foreground/80 ring-1 ring-inset ring-cyan-500/20",
+                                    title: selection_context_title(&context),
+                                    span { class: "flex h-5 min-w-5 items-center justify-center rounded-full bg-cyan-500/[0.12] px-1 font-mono text-[8px] font-semibold uppercase text-cyan-700 dark:text-cyan-300",
+                                        "{context.kind}"
+                                    }
+                                    span { class: "min-w-0 max-w-44 truncate", "{context.label}" }
+                                    button {
+                                        class: "flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-foreground/45 transition hover:bg-foreground/10 hover:text-foreground",
+                                        title: "Remove context",
+                                        onclick: move |_| {
+                                            let mut next = selection_contexts.peek().clone();
+                                            if i < next.len() {
+                                                next.remove(i);
+                                                selection_contexts.set(next);
+                                            }
+                                        },
+                                        svg {
+                                            class: "h-3 w-3",
+                                            view_box: "0 0 24 24",
+                                            fill: "none",
+                                            stroke: "currentColor",
+                                            stroke_width: "2.5",
+                                            stroke_linecap: "round",
+                                            path { d: "M6 6l12 12M18 6L6 18" }
+                                        }
+                                    }
+                                }
+                            }
                             for (i , attachment) in attachments.read().iter().cloned().enumerate() {
                                 div {
                                     key: "attachment-pill-{attachment.path}",
@@ -1280,6 +1339,7 @@ pub fn Page() -> Element {
                                         do_submit(
                                             draft,
                                             attachments,
+                                            selection_contexts,
                                             history_cursor,
                                             history_scratch,
                                             at_bottom,
@@ -1342,13 +1402,14 @@ pub fn Page() -> Element {
                             }
                         } else {
                             button {
-                                class: if draft.read().trim().is_empty() && attachments.read().is_empty() { "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 cursor-default self-center items-center justify-center rounded-lg bg-white/25 text-muted-foreground/35 shadow-sm ring-1 ring-inset ring-black/[0.06] dark:bg-white/[0.055] dark:ring-white/[0.08]" } else { "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg bg-gradient-to-br text-white shadow-lg transition hover:brightness-110 active:scale-95 {agent_accent.grad}" },
-                                disabled: draft.read().trim().is_empty() && attachments.read().is_empty(),
+                                class: if draft.read().trim().is_empty() && attachments.read().is_empty() && selection_contexts.read().is_empty() { "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 cursor-default self-center items-center justify-center rounded-lg bg-white/25 text-muted-foreground/35 shadow-sm ring-1 ring-inset ring-black/[0.06] dark:bg-white/[0.055] dark:ring-white/[0.08]" } else { "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg bg-gradient-to-br text-white shadow-lg transition hover:brightness-110 active:scale-95 {agent_accent.grad}" },
+                                disabled: draft.read().trim().is_empty() && attachments.read().is_empty() && selection_contexts.read().is_empty(),
                                 title: "Send (Enter)",
                                 onclick: move |_| {
                                     do_submit(
                                         draft,
                                         attachments,
+                                        selection_contexts,
                                         history_cursor,
                                         history_scratch,
                                         at_bottom,
@@ -1424,13 +1485,15 @@ fn select_resume_session(session: &ResumableSessionEntry, mut draft: Signal<Stri
 fn do_submit(
     mut draft: Signal<String>,
     mut attachments: Signal<Vec<ChatAttachment>>,
+    mut selection_contexts: Signal<Vec<vmux_core::AgentSelectionContext>>,
     mut history_cursor: Signal<Option<usize>>,
     mut history_scratch: Signal<String>,
     mut at_bottom: Signal<bool>,
 ) {
     let text = draft.peek().trim().to_string();
     let selected = attachments.peek().clone();
-    if text.is_empty() && selected.is_empty() {
+    let contexts = selection_contexts.peek().clone();
+    if text.is_empty() && selected.is_empty() && contexts.is_empty() {
         return;
     }
     let attachments_to_submit = selected
@@ -1445,6 +1508,7 @@ fn do_submit(
     if try_cef_bin_emit_rkyv(&ChatSubmit {
         text,
         attachments: attachments_to_submit,
+        contexts,
     })
     .is_err()
     {
@@ -1453,6 +1517,7 @@ fn do_submit(
     at_bottom.set(true);
     draft.set(String::new());
     attachments.set(Vec::new());
+    selection_contexts.set(Vec::new());
     history_cursor.set(None);
     history_scratch.set(String::new());
 }

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -71,6 +71,14 @@ fn acp_prompt_context(
     }
 }
 
+fn merge_prompt_context(primary: Option<String>, secondary: Option<String>) -> Option<String> {
+    match (primary, secondary) {
+        (Some(primary), Some(secondary)) => Some(format!("{primary}\n\n{secondary}")),
+        (Some(primary), None) => Some(primary),
+        (None, secondary) => secondary,
+    }
+}
+
 /// Marks a stack entity as an ACP agent session. vmux is ACP-only, so this is the agent
 /// identity (there is no `AgentVariant`/`AgentKind` for ACP).
 #[derive(Component, Clone, Debug)]
@@ -957,7 +965,8 @@ fn send_acp_input(
         }
         let workspace_state =
             ancestor_acp_workspace_state(entity, &child_of, &tabs, &workspaces, &pending_projects);
-        let context = acp_prompt_context(handoff, workspace_state);
+        let context =
+            merge_prompt_context(prompt.context, acp_prompt_context(handoff, workspace_state));
         service.0.send(ClientMessage::agent_input(
             session.sid.clone(),
             text,

--- a/crates/vmux_agent/src/client/page/plugin.rs
+++ b/crates/vmux_agent/src/client/page/plugin.rs
@@ -132,7 +132,7 @@ fn send_page_agent_input(
         service.0.send(ClientMessage::agent_input(
             session.sid.clone(),
             prompt.text,
-            None,
+            prompt.context,
             prompt.attachments,
         ));
         *state = AgentRunState::Streaming;

--- a/crates/vmux_agent/src/components.rs
+++ b/crates/vmux_agent/src/components.rs
@@ -42,6 +42,7 @@ pub struct PromptQueue {
 pub struct QueuedPrompt {
     pub id: u64,
     pub text: String,
+    pub context: Option<String>,
     pub attachments: Vec<AgentAttachment>,
 }
 
@@ -63,11 +64,21 @@ impl PromptQueue {
 
     /// Append one prompt with local file attachments and allow dispatch to continue.
     pub fn enqueue_with_attachments(&mut self, text: String, attachments: Vec<AgentAttachment>) {
+        self.enqueue_with_context(text, None, attachments);
+    }
+
+    pub fn enqueue_with_context(
+        &mut self,
+        text: String,
+        context: Option<String>,
+        attachments: Vec<AgentAttachment>,
+    ) {
         let id = self.next_id;
         self.next_id = self.next_id.wrapping_add(1);
         self.items.push_back(QueuedPrompt {
             id,
             text,
+            context,
             attachments,
         });
         self.paused = false;
@@ -129,6 +140,15 @@ impl PromptQueue {
                 prompt.text.push_str("\n\n");
             }
             prompt.text.push_str(&item.text);
+            prompt.context = match (prompt.context.take(), item.context) {
+                (Some(mut existing), Some(next)) => {
+                    existing.push_str("\n\n");
+                    existing.push_str(&next);
+                    Some(existing)
+                }
+                (Some(existing), None) => Some(existing),
+                (None, next) => next,
+            };
             prompt.attachments.extend(item.attachments);
         }
         Some(prompt)
@@ -227,6 +247,21 @@ mod tests {
         assert_eq!(
             q.take_next().map(|prompt| prompt.text),
             Some("first\n\nsecond".to_string())
+        );
+    }
+
+    #[test]
+    fn take_next_merges_private_context() {
+        let mut q = PromptQueue::default();
+        q.enqueue_with_context("first".into(), Some("context one".into()), Vec::new());
+        q.enqueue_with_context("second".into(), Some("context two".into()), Vec::new());
+
+        assert!(q.request_flush());
+        let prompt = q.take_next().unwrap();
+        assert_eq!(prompt.text, "first\n\nsecond");
+        assert_eq!(
+            prompt.context.as_deref(),
+            Some("context one\n\ncontext two")
         );
     }
 

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use bevy::prelude::*;
 use bevy::tasks::{IoTaskPool, Task, futures_lite::future};
 use bevy_cef::prelude::{CefKeyboardTarget, WebviewExtendStandardMaterial};
-use vmux_command::{AppCommand, WriteAppCommands};
+use vmux_command::{AppCommand, ReadAppCommands, WriteAppCommands};
 use vmux_core::agent::{
     AgentKind, AgentProviderTargetKind, PageAgentAttachDefaultRequest, PageAgentAttachRequest,
     PageAgentSpawnDefaultRequest, PageAgentSpawnStackRequest, PendingAgentPrompt, RestartAgentPty,
@@ -202,6 +202,7 @@ impl Plugin for AgentPlugin {
             .add_message::<vmux_core::notify::BellReceived>()
             .add_message::<vmux_core::notify::AgentAttention>()
             .add_message::<vmux_core::notify::OsNotify>()
+            .add_message::<vmux_core::selection::SelectionCaptured>()
             .add_observer(start_workspace_picker)
             .init_resource::<bevy::ecs::message::Messages<vmux_core::PageOpenRequest>>()
             .init_resource::<bevy::ecs::message::Messages<vmux_layout::OpenBesideRequest>>()
@@ -314,6 +315,13 @@ impl Plugin for AgentPlugin {
                     respond_page_agent_spawn_default,
                     respond_page_agent_attach_default,
                 ),
+            )
+            .add_systems(
+                Update,
+                route_selection_to_agent
+                    .in_set(vmux_core::selection::RouteSelectionSet)
+                    .after(vmux_core::selection::CaptureSelectionSet)
+                    .after(ReadAppCommands),
             )
             .add_systems(
                 Update,
@@ -4790,6 +4798,219 @@ fn respond_page_agent_spawn_default(
             );
         }
     }
+}
+
+enum SelectionAgentTarget {
+    Page {
+        stack: Entity,
+        activated_at: i64,
+    },
+    Cli {
+        stack: Entity,
+        terminal: Entity,
+        activated_at: i64,
+    },
+}
+
+impl SelectionAgentTarget {
+    fn activated_at(&self) -> i64 {
+        match self {
+            Self::Page { activated_at, .. } | Self::Cli { activated_at, .. } => *activated_at,
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn route_selection_to_agent(
+    mut selections: MessageReader<vmux_core::selection::SelectionCaptured>,
+    page_agents: Query<
+        (Entity, &LastActivatedAt),
+        (
+            With<vmux_layout::stack::Stack>,
+            Or<(
+                With<crate::components::AgentSession>,
+                With<crate::client::acp::AcpSession>,
+            )>,
+        ),
+    >,
+    cli_agents: Query<(Entity, &ChildOf), With<vmux_core::agent::AgentSession>>,
+    stack_times: Query<&LastActivatedAt, With<vmux_layout::stack::Stack>>,
+    tabs: Query<&vmux_layout::tab::Tab>,
+    child_of: Query<&ChildOf>,
+    mut pending_page: Query<&mut crate::chat_page::PendingAgentSelectionContexts>,
+    mut cli_prompts: Query<(
+        Option<&mut vmux_terminal::PromptCapture>,
+        Option<&mut vmux_terminal::BufferedAgentPrompt>,
+    )>,
+    idx: Option<Res<crate::client::page::strategy_index::PageStrategyIndex>>,
+    kind_q: Query<&crate::client::page::strategy_components::StrategyKind>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
+    mut commands: Commands,
+) {
+    let mut page_deliveries = std::collections::HashMap::<Entity, Vec<_>>::new();
+    let mut cli_deliveries = std::collections::HashMap::<Entity, Vec<_>>::new();
+    let mut cli_focus = std::collections::HashMap::<Entity, Entity>::new();
+
+    for selection in selections.read() {
+        let mut targets = Vec::new();
+        for (stack, activated_at) in &page_agents {
+            if selection.source_tab.is_none()
+                || ancestor_agent_tab(stack, &child_of, &tabs).map(|(tab, _)| tab)
+                    == selection.source_tab
+            {
+                targets.push(SelectionAgentTarget::Page {
+                    stack,
+                    activated_at: activated_at.0,
+                });
+            }
+        }
+        for (terminal, parent) in &cli_agents {
+            let stack = parent.parent();
+            if selection.source_tab.is_none()
+                || ancestor_agent_tab(stack, &child_of, &tabs).map(|(tab, _)| tab)
+                    == selection.source_tab
+            {
+                targets.push(SelectionAgentTarget::Cli {
+                    stack,
+                    terminal,
+                    activated_at: stack_times
+                        .get(stack)
+                        .map(|time| time.0)
+                        .unwrap_or(i64::MIN),
+                });
+            }
+        }
+        let target = targets
+            .into_iter()
+            .max_by_key(SelectionAgentTarget::activated_at)
+            .or_else(|| {
+                spawn_selection_agent(
+                    selection.source_pane?,
+                    idx.as_deref()?,
+                    &kind_q,
+                    &mut commands,
+                    &mut meshes,
+                    &mut webview_mt,
+                )
+                .map(|stack| SelectionAgentTarget::Page {
+                    stack,
+                    activated_at: i64::MAX,
+                })
+            });
+        match target {
+            Some(SelectionAgentTarget::Page { stack, .. }) => {
+                if let Some(context) = selection.context.clone() {
+                    page_deliveries.entry(stack).or_default().push(context);
+                } else {
+                    page_deliveries.entry(stack).or_default();
+                }
+            }
+            Some(SelectionAgentTarget::Cli {
+                stack, terminal, ..
+            }) => {
+                cli_focus.insert(terminal, stack);
+                if let Some(context) = selection.context.clone() {
+                    cli_deliveries.entry(terminal).or_default().push(context);
+                } else {
+                    cli_deliveries.entry(terminal).or_default();
+                }
+            }
+            None => {}
+        }
+    }
+
+    for (stack, contexts) in page_deliveries {
+        if let Ok(mut pending) = pending_page.get_mut(stack) {
+            for context in contexts {
+                if !pending.contexts.contains(&context) {
+                    pending.contexts.push(context);
+                }
+            }
+            pending.focus = true;
+        } else {
+            commands
+                .entity(stack)
+                .insert(crate::chat_page::PendingAgentSelectionContexts {
+                    contexts,
+                    focus: true,
+                });
+        }
+        if child_of.contains(stack) {
+            vmux_core::focus_pane_entity(stack, &mut commands, &child_of);
+        }
+    }
+
+    for (terminal, contexts) in cli_deliveries {
+        if let Some(text) = vmux_core::selection::render_selection_contexts(&contexts)
+            && let Ok((capture, buffered)) = cli_prompts.get_mut(terminal)
+        {
+            if let Some(mut capture) = capture {
+                append_prompt_text(&mut capture.draft, &text);
+                capture.skipped = false;
+            } else if let Some(mut buffered) = buffered {
+                append_prompt_text(&mut buffered.text, &text);
+                buffered.submit = false;
+            } else {
+                commands
+                    .entity(terminal)
+                    .insert(vmux_terminal::BufferedAgentPrompt {
+                        text,
+                        submit: false,
+                    });
+            }
+        }
+        if let Some(stack) = cli_focus.get(&terminal).copied() {
+            vmux_core::focus_pane_entity(stack, &mut commands, &child_of);
+        }
+    }
+}
+
+fn spawn_selection_agent(
+    pane: Entity,
+    idx: &crate::client::page::strategy_index::PageStrategyIndex,
+    kind_q: &Query<&crate::client::page::strategy_components::StrategyKind>,
+    commands: &mut Commands,
+    meshes: &mut ResMut<Assets<Mesh>>,
+    webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
+) -> Option<Entity> {
+    let provider = crate::providers::resolve_default_app_provider()?;
+    let stack = commands
+        .spawn((
+            vmux_layout::stack::stack_bundle(),
+            LastActivatedAt::now(),
+            ChildOf(pane),
+        ))
+        .id();
+    let sid = uuid::Uuid::new_v4().to_string();
+    if attach_page_agent_to_stack(
+        stack,
+        provider.provider,
+        provider.default_model,
+        &sid,
+        commands,
+        meshes,
+        webview_mt,
+        idx,
+        kind_q,
+    )
+    .is_none()
+    {
+        commands.entity(stack).despawn();
+        return None;
+    }
+    Some(stack)
+}
+
+fn append_prompt_text(draft: &mut String, text: &str) {
+    if !draft.is_empty() && !draft.ends_with("\n\n") {
+        if draft.ends_with('\n') {
+            draft.push('\n');
+        } else {
+            draft.push_str("\n\n");
+        }
+    }
+    draft.push_str(text);
 }
 
 fn respond_page_agent_attach_default(

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -28,6 +28,7 @@ use bevy_cef_core::prelude::{
 use bevy_cef_core::prelude::{NativeMouseButtons, NativeMouseMovePresenter};
 #[cfg(target_os = "macos")]
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{LazyLock, Mutex};
 use vmux_command::{
@@ -72,6 +73,19 @@ use vmux_ui::theme::{THEME_EVENT, ThemeEvent};
 /// Wires browser orchestration: resolves CEF embedded hosts from page manifests, manages
 /// the CEF backend, and forwards pointer and cursor input between the layout and pages.
 pub struct BrowserPlugin;
+
+const DOM_SELECTION_CHANNEL: &str = "vmux-selection";
+
+#[derive(Resource, Default)]
+struct PendingDomSelections(HashMap<u64, vmux_core::selection::DomSelectionRequest>);
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DomSelectionResult {
+    channel: String,
+    request_id: u64,
+    text: String,
+}
 
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
 enum BrowserSystems {
@@ -153,7 +167,11 @@ impl Plugin for BrowserPlugin {
             .init_resource::<crate::extensions::broker::PendingBridgeEvents>()
             .init_resource::<crate::extensions::model::ChromeModel>()
             .init_resource::<crate::extensions::model::ChromeStableIds>()
+            .init_resource::<PendingDomSelections>()
             .add_message::<crate::extensions::model::ChromeModelEvent>()
+            .add_message::<vmux_core::selection::CaptureSelectionRequest>()
+            .add_message::<vmux_core::selection::DomSelectionRequest>()
+            .add_message::<vmux_core::selection::SelectionCaptured>()
             .add_systems(
                 Update,
                 (
@@ -214,6 +232,7 @@ impl Plugin for BrowserPlugin {
                         DebugUpdateClear,
                         DebugSimulateDownload,
                     )>::for_hosts(&["debug"]),
+                    JsEmitEventPlugin::<DomSelectionResult>::default(),
                 ),
             )
             .add_observer(on_webview_ready_send_theme)
@@ -223,6 +242,14 @@ impl Plugin for BrowserPlugin {
             .add_observer(on_hard_reload_notify_header)
             .add_observer(on_debug_update_ready)
             .add_observer(on_debug_update_clear)
+            .add_observer(on_dom_selection_result)
+            .add_systems(
+                Update,
+                (capture_browser_selection, request_dom_selections)
+                    .chain()
+                    .in_set(vmux_core::selection::CaptureSelectionSet)
+                    .after(ReadAppCommands),
+            )
             .add_systems(
                 Update,
                 sync_appearance_to_cef
@@ -332,6 +359,130 @@ impl Plugin for BrowserPlugin {
                     .after(sync_windowed_command_bar),
             );
     }
+}
+
+fn capture_browser_selection(
+    mut requests: MessageReader<vmux_core::selection::CaptureSelectionRequest>,
+    terminals: Query<(), With<Terminal>>,
+    metadata: Query<&PageMetadata, With<Browser>>,
+    mut dom_requests: MessageWriter<vmux_core::selection::DomSelectionRequest>,
+) {
+    for capture in requests.read() {
+        let Some(webview) = capture.webview else {
+            continue;
+        };
+        if terminals.contains(webview) {
+            continue;
+        }
+        let Ok(meta) = metadata.get(webview) else {
+            continue;
+        };
+        if meta.url.starts_with("file:") {
+            continue;
+        }
+        let label = if meta.title.trim().is_empty() {
+            meta.url.clone()
+        } else {
+            meta.title.clone()
+        };
+        let kind = if meta.url.starts_with("http://") || meta.url.starts_with("https://") {
+            "browser"
+        } else {
+            "page"
+        };
+        dom_requests.write(vmux_core::selection::DomSelectionRequest {
+            capture: capture.clone(),
+            fallback: None,
+            kind: kind.to_string(),
+            label,
+            source: meta.url.clone(),
+        });
+    }
+}
+
+fn request_dom_selections(
+    mut requests: MessageReader<vmux_core::selection::DomSelectionRequest>,
+    browsers: NonSend<Browsers>,
+    mut pending: ResMut<PendingDomSelections>,
+    mut captured: MessageWriter<vmux_core::selection::SelectionCaptured>,
+) {
+    for request in requests.read() {
+        let Some(webview) = request.capture.webview else {
+            captured.write(selection_result(request, None));
+            continue;
+        };
+        if !browsers.has_browser(webview) {
+            captured.write(selection_result(request, None));
+            continue;
+        }
+        let script = format!(
+            r#"(function(){{
+                var text = "";
+                var active = document.activeElement;
+                var blocked = active instanceof HTMLInputElement && (active.type || "").toLowerCase() === "password";
+                if (active instanceof HTMLTextAreaElement) {{
+                    var start = active.selectionStart || 0;
+                    var end = active.selectionEnd || 0;
+                    if (end > start) text = active.value.slice(start, end);
+                }} else if (active instanceof HTMLInputElement && (active.type || "").toLowerCase() !== "password") {{
+                    var inputStart = active.selectionStart || 0;
+                    var inputEnd = active.selectionEnd || 0;
+                    if (inputEnd > inputStart) text = active.value.slice(inputStart, inputEnd);
+                }}
+                if (!text && !blocked) {{
+                    var selection = window.getSelection();
+                    if (selection && !selection.isCollapsed) text = selection.toString();
+                }}
+                cef.emit({{ channel: "{DOM_SELECTION_CHANNEL}", requestId: {}, text: text }});
+            }})();"#,
+            request.capture.request_id
+        );
+        pending
+            .0
+            .insert(request.capture.request_id, request.clone());
+        browsers.execute_js(&webview, &script);
+    }
+}
+
+fn selection_result(
+    request: &vmux_core::selection::DomSelectionRequest,
+    text: Option<String>,
+) -> vmux_core::selection::SelectionCaptured {
+    let context = text
+        .filter(|text| !text.trim().is_empty())
+        .map(|text| {
+            vmux_core::AgentSelectionContext::new(
+                request.kind.clone(),
+                request.label.clone(),
+                request.source.clone(),
+                text,
+            )
+        })
+        .or_else(|| request.fallback.clone());
+    vmux_core::selection::SelectionCaptured {
+        request_id: request.capture.request_id,
+        source_tab: request.capture.source_tab,
+        source_pane: request.capture.source_pane,
+        source_stack: request.capture.source_stack,
+        context,
+    }
+}
+
+fn on_dom_selection_result(
+    trigger: On<Receive<DomSelectionResult>>,
+    mut pending: ResMut<PendingDomSelections>,
+    mut captured: MessageWriter<vmux_core::selection::SelectionCaptured>,
+) {
+    if trigger.channel != DOM_SELECTION_CHANNEL {
+        return;
+    }
+    let Some(request) = pending.0.remove(&trigger.request_id) else {
+        return;
+    };
+    if request.capture.webview != Some(trigger.webview) {
+        return;
+    }
+    captured.write(selection_result(&request, Some(trigger.text.clone())));
 }
 
 fn on_webview_ready_send_theme(

--- a/crates/vmux_command/src/command.rs
+++ b/crates/vmux_command/src/command.rs
@@ -34,6 +34,23 @@ pub enum AppCommand {
     #[menu(label = "Bookmark")]
     #[mcp(skip)]
     Bookmark(BookmarkCommand),
+
+    #[menu(label = "Agent")]
+    #[mcp(skip)]
+    Agent(AgentCommand),
+}
+
+#[allow(dead_code)]
+#[derive(OsSubMenu, DefaultShortcuts, CommandBar, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AgentCommand {
+    #[default]
+    #[menu(
+        id = "agent_add_selection",
+        label = "Add Selection to Agent",
+        accel = "super+shift+l"
+    )]
+    #[shortcut(direct = "Super+Shift+L")]
+    AddSelection,
 }
 
 #[derive(OsSubMenuGroup, DefaultShortcuts, CommandBar, Debug, Clone, Copy, PartialEq, Eq)]
@@ -628,6 +645,30 @@ mod tests {
             shortcuts
                 .iter()
                 .any(|(shortcut, id)| shortcut == &hard_reload && id == "browser_hard_reload")
+        );
+    }
+
+    #[test]
+    fn add_selection_uses_cursor_shortcut() {
+        let add_selection = Shortcut::Direct(KeyCombo {
+            key: KeyCode::KeyL,
+            modifiers: Modifiers {
+                shift: true,
+                super_key: true,
+                ..Default::default()
+            },
+        });
+
+        assert!(
+            AppCommand::default_shortcuts()
+                .iter()
+                .any(|(shortcut, id)| {
+                    shortcut == &add_selection && id == "agent_add_selection"
+                })
+        );
+        assert_eq!(
+            AppCommand::from_menu_id("agent_add_selection"),
+            Some(AppCommand::Agent(AgentCommand::AddSelection))
         );
     }
 

--- a/crates/vmux_core/src/lib.rs
+++ b/crates/vmux_core/src/lib.rs
@@ -8,9 +8,11 @@ pub mod icon;
 pub mod media;
 pub mod process_id;
 pub mod scroll;
+pub mod selection;
 pub use editor::{CursorPos, EditMode, KeymapKind, SelSpan};
 pub use icon::{BuiltinIcon, PageIcon};
 pub use process_id::ProcessId;
+pub use selection::AgentSelectionContext;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod host_spawn;

--- a/crates/vmux_core/src/selection.rs
+++ b/crates/vmux_core/src/selection.rs
@@ -1,0 +1,156 @@
+#[cfg(not(target_arch = "wasm32"))]
+use bevy::prelude::*;
+
+pub const MAX_SELECTION_CONTEXT_CHARS: usize = 32_768;
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct AgentSelectionContext {
+    pub kind: String,
+    pub label: String,
+    pub source: String,
+    pub text: String,
+}
+
+impl AgentSelectionContext {
+    pub fn new(
+        kind: impl Into<String>,
+        label: impl Into<String>,
+        source: impl Into<String>,
+        text: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind: kind.into(),
+            label: label.into(),
+            source: source.into(),
+            text: truncate_selection_text(text.into()),
+        }
+    }
+}
+
+pub fn truncate_selection_text(text: String) -> String {
+    if text.chars().count() <= MAX_SELECTION_CONTEXT_CHARS {
+        return text;
+    }
+    let mut truncated = text
+        .chars()
+        .take(MAX_SELECTION_CONTEXT_CHARS)
+        .collect::<String>();
+    truncated.push_str("\n\n[Selection truncated]");
+    truncated
+}
+
+pub fn render_selection_contexts(contexts: &[AgentSelectionContext]) -> Option<String> {
+    if contexts.is_empty() {
+        return None;
+    }
+    let mut rendered = String::new();
+    for context in contexts {
+        if !rendered.is_empty() {
+            rendered.push_str("\n\n");
+        }
+        rendered.push_str("Selected ");
+        rendered.push_str(&context.kind);
+        rendered.push_str(" context: ");
+        rendered.push_str(&context.label);
+        if !context.source.is_empty() {
+            rendered.push_str(" (");
+            rendered.push_str(&context.source);
+            rendered.push(')');
+        }
+        rendered.push_str("\n\n");
+        rendered.push_str(&context.text);
+    }
+    Some(rendered)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Message, Clone, Debug)]
+pub struct CaptureSelectionRequest {
+    pub request_id: u64,
+    pub source_tab: Option<Entity>,
+    pub source_pane: Option<Entity>,
+    pub source_stack: Option<Entity>,
+    pub webview: Option<Entity>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Message, Clone, Debug)]
+pub struct DomSelectionRequest {
+    pub capture: CaptureSelectionRequest,
+    pub fallback: Option<AgentSelectionContext>,
+    pub kind: String,
+    pub label: String,
+    pub source: String,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Message, Clone, Debug)]
+pub struct SelectionCaptured {
+    pub request_id: u64,
+    pub source_tab: Option<Entity>,
+    pub source_pane: Option<Entity>,
+    pub source_stack: Option<Entity>,
+    pub context: Option<AgentSelectionContext>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Resource, Default)]
+pub struct SelectionRequestCounter(pub u64);
+
+#[cfg(not(target_arch = "wasm32"))]
+impl SelectionRequestCounter {
+    pub fn next_id(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(1);
+        self.0
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CaptureSelectionSet;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RouteSelectionSet;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selection_context_rendering_preserves_sources() {
+        let rendered = render_selection_contexts(&[
+            AgentSelectionContext::new("file", "main.rs:3-4", "/tmp/main.rs", "let x = 1;"),
+            AgentSelectionContext::new("browser", "Docs", "https://example.com", "API text"),
+        ])
+        .unwrap();
+
+        assert!(rendered.contains("main.rs:3-4 (/tmp/main.rs)"));
+        assert!(rendered.contains("Docs (https://example.com)"));
+        assert!(rendered.contains("let x = 1;"));
+        assert!(rendered.contains("API text"));
+    }
+
+    #[test]
+    fn long_selection_contexts_have_visible_truncation() {
+        let context = AgentSelectionContext::new(
+            "file",
+            "large.rs",
+            "/tmp/large.rs",
+            "x".repeat(MAX_SELECTION_CONTEXT_CHARS + 1),
+        );
+
+        assert!(context.text.ends_with("[Selection truncated]"));
+    }
+}

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -2764,6 +2764,9 @@ impl Plugin for EditorPlugin {
             .init_resource::<ExplorerChromeSynced>()
             .init_resource::<SharedFileViewMode>()
             .add_message::<vmux_core::event::RecordVisitRequest>()
+            .add_message::<vmux_core::selection::CaptureSelectionRequest>()
+            .add_message::<vmux_core::selection::DomSelectionRequest>()
+            .add_message::<vmux_core::selection::SelectionCaptured>()
             .add_plugins(crate::lsp::LspPlugin)
             .add_plugins(BinEventEmitterPlugin::<(
                 FileResizeEvent,
@@ -2802,6 +2805,12 @@ impl Plugin for EditorPlugin {
             .add_systems(
                 Update,
                 handle_file_page_open.in_set(PageOpenSet::HandleKnownPages),
+            )
+            .add_systems(
+                Update,
+                capture_file_selection
+                    .in_set(vmux_core::selection::CaptureSelectionSet)
+                    .after(vmux_command::ReadAppCommands),
             )
             .add_systems(
                 Update,
@@ -2872,6 +2881,89 @@ impl Plugin for EditorPlugin {
             .add_observer(on_explorer_close_editor)
             .add_observer(on_explorer_goto);
     }
+}
+
+fn capture_file_selection(
+    mut requests: MessageReader<vmux_core::selection::CaptureSelectionRequest>,
+    views: Query<(&FileView, Option<&EditState>, Option<&FileDir>)>,
+    mode: Res<SharedFileViewMode>,
+    mut dom_requests: MessageWriter<vmux_core::selection::DomSelectionRequest>,
+    mut captured: MessageWriter<vmux_core::selection::SelectionCaptured>,
+) {
+    for request in requests.read() {
+        let Some(webview) = request.webview else {
+            continue;
+        };
+        let Ok((view, edit, directory)) = views.get(webview) else {
+            continue;
+        };
+        let source = view.path.to_string_lossy().into_owned();
+        if let Some(edit) = edit
+            && mode.0 == FileViewMode::Editor
+        {
+            captured.write(vmux_core::selection::SelectionCaptured {
+                request_id: request.request_id,
+                source_tab: request.source_tab,
+                source_pane: request.source_pane,
+                source_stack: request.source_stack,
+                context: native_file_selection(&view.path, edit),
+            });
+            continue;
+        }
+        let kind = if edit.is_some() && mode.0 == FileViewMode::Diff {
+            "diff"
+        } else if directory.is_some() {
+            "directory"
+        } else {
+            "file"
+        };
+        dom_requests.write(vmux_core::selection::DomSelectionRequest {
+            capture: request.clone(),
+            fallback: None,
+            kind: kind.to_string(),
+            label: file_name(&view.path),
+            source,
+        });
+    }
+}
+
+fn native_file_selection(
+    path: &Path,
+    edit: &EditState,
+) -> Option<vmux_core::AgentSelectionContext> {
+    let selection = edit.core.primary();
+    if selection.is_empty() {
+        return None;
+    }
+    let range = selection.range();
+    let text = edit.core.buffer.rope.slice(range.clone()).to_string();
+    if text.trim().is_empty() {
+        return None;
+    }
+    let start_line = edit.core.buffer.char_to_line(range.start) + 1;
+    let end_line = edit.core.buffer.char_to_line(range.end.saturating_sub(1)) + 1;
+    let name = file_name(path);
+    let label = if start_line == end_line {
+        format!("{name}:{start_line}")
+    } else {
+        format!("{name}:{start_line}-{end_line}")
+    };
+    let kind = match path.extension().and_then(|extension| extension.to_str()) {
+        Some("md" | "markdown") => "note",
+        _ => "file",
+    };
+    Some(vmux_core::AgentSelectionContext::new(
+        kind,
+        label,
+        path.to_string_lossy(),
+        text,
+    ))
+}
+
+fn file_name(path: &Path) -> String {
+    path.file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.to_string_lossy().into_owned())
 }
 
 #[cfg(test)]

--- a/crates/vmux_layout/src/stack.rs
+++ b/crates/vmux_layout/src/stack.rs
@@ -12,8 +12,8 @@ use bevy::{
 };
 use moonshine_save::prelude::*;
 use vmux_command::{
-    AppCommand, BrowserCommand, LayoutCommand, OpenCommand, ReadAppCommands, ServiceCommand,
-    StackCommand,
+    AgentCommand, AppCommand, BrowserCommand, LayoutCommand, OpenCommand, ReadAppCommands,
+    ServiceCommand, StackCommand,
 };
 use vmux_core::{PageOpenRequest, PageOpenTarget};
 use vmux_history::LastActivatedAt;
@@ -58,7 +58,10 @@ impl Plugin for StackPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Stack>()
             .init_resource::<FocusedStack>()
+            .init_resource::<vmux_core::selection::SelectionRequestCounter>()
             .add_message::<CloseStackRequest>()
+            .add_message::<vmux_core::selection::CaptureSelectionRequest>()
+            .add_message::<vmux_core::selection::SelectionCaptured>()
             .add_systems(
                 Update,
                 (
@@ -66,6 +69,7 @@ impl Plugin for StackPlugin {
                         .in_set(ReadAppCommands)
                         .in_set(StackCommandSet),
                     handle_close_stack_requests.in_set(ReadAppCommands),
+                    request_selection_for_agent.in_set(ReadAppCommands),
                 ),
             )
             .add_systems(
@@ -78,6 +82,48 @@ impl Plugin for StackPlugin {
                     .after(crate::active::ensure_active_branch),
             )
             .add_systems(PostUpdate, sync_stack_picking);
+    }
+}
+
+fn request_selection_for_agent(
+    mut reader: MessageReader<AppCommand>,
+    focused: Res<FocusedStack>,
+    children: Query<&Children>,
+    browsers: Query<(), With<crate::Browser>>,
+    mut counter: ResMut<vmux_core::selection::SelectionRequestCounter>,
+    mut requests: MessageWriter<vmux_core::selection::CaptureSelectionRequest>,
+    mut captured: MessageWriter<vmux_core::selection::SelectionCaptured>,
+) {
+    for command in reader.read() {
+        if !matches!(command, AppCommand::Agent(AgentCommand::AddSelection)) {
+            continue;
+        }
+        let request_id = counter.next_id();
+        let webview = focused.stack.and_then(|stack| {
+            children
+                .get(stack)
+                .ok()?
+                .iter()
+                .find(|&child| browsers.contains(child))
+        });
+        let request = vmux_core::selection::CaptureSelectionRequest {
+            request_id,
+            source_tab: focused.tab,
+            source_pane: focused.pane,
+            source_stack: focused.stack,
+            webview,
+        };
+        if webview.is_some() {
+            requests.write(request);
+        } else {
+            captured.write(vmux_core::selection::SelectionCaptured {
+                request_id,
+                source_tab: request.source_tab,
+                source_pane: request.source_pane,
+                source_stack: request.source_stack,
+                context: None,
+            });
+        }
     }
 }
 

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -88,6 +89,15 @@ struct ServiceWakeCallback(Option<ServiceWake>);
 pub struct TerminalModeMap {
     pub modes: std::collections::HashMap<ProcessId, TerminalModeFlags>,
 }
+
+struct PendingTerminalSelection {
+    capture: vmux_core::selection::CaptureSelectionRequest,
+    label: String,
+    source: String,
+}
+
+#[derive(Resource, Default)]
+struct PendingTerminalSelections(HashMap<ProcessId, PendingTerminalSelection>);
 
 /// Optimistic copy-mode state owned by the desktop. The service confirms
 /// asynchronously via `TerminalMode`, but keyboard routing must switch on
@@ -344,6 +354,9 @@ impl Plugin for TerminalPlugin {
             .init_resource::<TerminalModeMap>()
             .init_resource::<LocalCopyModeState>()
             .init_resource::<TerminalWebShortcutState>()
+            .init_resource::<PendingTerminalSelections>()
+            .add_message::<vmux_core::selection::CaptureSelectionRequest>()
+            .add_message::<vmux_core::selection::SelectionCaptured>()
             .add_systems(Update, format_terminal_url.after(pid::track_pid_inserts))
             .add_plugins(BinEventEmitterPlugin::<(
                 TermResizeEvent,
@@ -376,6 +389,12 @@ impl Plugin for TerminalPlugin {
             .add_systems(
                 Update,
                 handle_terminal_font_size.after(vmux_command::ReadAppCommands),
+            )
+            .add_systems(
+                Update,
+                capture_terminal_selection
+                    .in_set(vmux_core::selection::CaptureSelectionSet)
+                    .after(vmux_command::ReadAppCommands),
             )
             .add_observer(on_term_ready)
             .add_observer(on_term_resize)
@@ -1184,6 +1203,62 @@ struct PollServiceWriters<'w> {
     command_lifecycle: MessageWriter<'w, CommandLifecycleEvent>,
     osc_title: MessageWriter<'w, OscTitleChanged>,
     bell: MessageWriter<'w, vmux_core::notify::BellReceived>,
+    selection_captured: MessageWriter<'w, vmux_core::selection::SelectionCaptured>,
+    pending_selections: ResMut<'w, PendingTerminalSelections>,
+}
+
+fn capture_terminal_selection(
+    mut requests: MessageReader<vmux_core::selection::CaptureSelectionRequest>,
+    terminals: Query<
+        (
+            &ProcessId,
+            &PageMetadata,
+            Option<&crate::launch::TerminalLaunch>,
+        ),
+        With<Terminal>,
+    >,
+    service: Option<Res<ServiceClient>>,
+    mut pending: ResMut<PendingTerminalSelections>,
+    mut captured: MessageWriter<vmux_core::selection::SelectionCaptured>,
+) {
+    for request in requests.read() {
+        let Some(webview) = request.webview else {
+            continue;
+        };
+        let Ok((process_id, metadata, launch)) = terminals.get(webview) else {
+            continue;
+        };
+        let label = if metadata.title.trim().is_empty() {
+            "Terminal".to_string()
+        } else {
+            metadata.title.clone()
+        };
+        let source = launch
+            .map(|launch| launch.cwd.clone())
+            .filter(|cwd| !cwd.is_empty())
+            .unwrap_or_else(|| metadata.url.clone());
+        let Some(service) = service.as_deref() else {
+            captured.write(vmux_core::selection::SelectionCaptured {
+                request_id: request.request_id,
+                source_tab: request.source_tab,
+                source_pane: request.source_pane,
+                source_stack: request.source_stack,
+                context: None,
+            });
+            continue;
+        };
+        pending.0.insert(
+            *process_id,
+            PendingTerminalSelection {
+                capture: request.clone(),
+                label,
+                source,
+            },
+        );
+        service.0.send(ClientMessage::GetSelectionText {
+            process_id: *process_id,
+        });
+    }
 }
 
 /// True when a rendered line carries any non-whitespace text. Used to decide
@@ -1598,11 +1673,27 @@ fn poll_service_messages(
                 );
                 set_local_copy_mode(&mut local_copy_mode, process_id, copy_mode);
             }
-            ServiceMessage::SelectionText {
-                process_id: _,
-                text,
-            } if !text.is_empty() => {
-                crate::clipboard::write(text);
+            ServiceMessage::SelectionText { process_id, text } => {
+                if let Some(pending) = writers.pending_selections.0.remove(&process_id) {
+                    writers
+                        .selection_captured
+                        .write(vmux_core::selection::SelectionCaptured {
+                            request_id: pending.capture.request_id,
+                            source_tab: pending.capture.source_tab,
+                            source_pane: pending.capture.source_pane,
+                            source_stack: pending.capture.source_stack,
+                            context: (!text.trim().is_empty()).then(|| {
+                                vmux_core::AgentSelectionContext::new(
+                                    "terminal",
+                                    pending.label,
+                                    pending.source,
+                                    text,
+                                )
+                            }),
+                        });
+                } else if !text.is_empty() {
+                    crate::clipboard::write(text);
+                }
             }
             ServiceMessage::AgentCommand {
                 request_id,

--- a/docs/specs/2026-07-20-selection-to-agent-design.md
+++ b/docs/specs/2026-07-20-selection-to-agent-design.md
@@ -1,0 +1,59 @@
+# Selection to Agent
+
+## Goal
+
+Let the user select text or an item in any page and press `Command+Shift+L` to attach that
+selection to the current agent composer.
+
+## Interaction
+
+- `Command+Shift+L` on macOS and `Ctrl+Shift+L` elsewhere runs **Add Selection to Agent**.
+- The command targets the most recently active agent in the current tab.
+- If the current tab has no agent, vmux opens the default page agent in the current pane.
+- The agent composer receives a source-aware context chip and keyboard focus.
+- The shortcut never submits the prompt.
+- Repeated invocations append context chips.
+- With no selection, the command only focuses or opens the agent.
+
+## Context model
+
+Each captured context is an immutable snapshot containing:
+
+- source kind;
+- short label;
+- source URL or path;
+- selected text.
+
+File selections include line ranges. Terminal selections include the terminal title and working
+directory. Browser selections include the page title and URL.
+
+The composer renders context separately from the editable prompt. Removing a chip excludes it
+from submission. Context is sent through the private agent context field, keeping the visible
+user message limited to text the user typed.
+
+## Capture adapters
+
+| Page | Capture |
+| --- | --- |
+| Terminal | Materialize the terminal selection through the service. |
+| File editor | Read the native editor selection and preserve line numbers. |
+| Diff and directory | Read the DOM selection. |
+| Browser and internal pages | Read the DOM or focused text-control selection. |
+| Agent transcript | Read the DOM selection and attach it back to the agent. |
+
+Password controls are never captured. Selection text is capped with an explicit truncation
+marker rather than silently cut.
+
+## Target behavior
+
+Page and ACP agents receive structured context chips. CLI agents receive the same context rendered
+into their prompt without submission. Targeting stays inside the source tab to avoid surprising
+cross-workspace jumps.
+
+## Deferred
+
+- Floating selection toolbar.
+- Context-menu action.
+- Jump-back navigation from chips.
+- Cross-origin iframe selection.
+- Multi-item directory selection.


### PR DESCRIPTION
## Context

Selected text from vmux pages could not be attached directly to an agent prompt. This adds a Cursor-style workflow for carrying explicit source context across terminals, files, diffs, notes, and browser pages.

## Implementation

Command+Shift+L captures the focused page selection and targets the most recently active agent in the current tab. Page agents receive removable source-aware context chips backed by private agent context; CLI agents receive editable text without automatic submission. Capture is source-specific, password-safe, and size-bounded.

## Checks / QA

- Select text in a terminal, file editor, diff, and browser; press Command+Shift+L; verify a context chip appears without submitting.
- Add multiple selections, remove one, then submit; verify only typed text appears in the visible user message.
- Invoke the shortcut without a selection; verify the current agent focuses or the default agent opens.
- Verify CLI agent context is inserted without submission.