### PR TITLE
fix(acp): route Codex approvals to user

### DIFF
--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -664,6 +664,11 @@ fn apply_codex_compatibility_env(mut env: Vec<(String, String)>) -> Vec<(String,
         bevy::log::warn!("{warning}");
     }
 
+    config.insert(
+        "approvals_reviewer".to_string(),
+        serde_json::Value::String("user".to_string()),
+    );
+
     let features = config
         .entry("features")
         .or_insert_with(|| serde_json::json!({}));
@@ -1580,6 +1585,7 @@ mod tests {
             assert_eq!(config["features"]["shell_tool"], false);
             assert_eq!(config["features"]["unified_exec"], false);
             assert_eq!(config["tools"]["web_search"], false);
+            assert_eq!(config["approvals_reviewer"], "user");
             assert_eq!(
                 config["features"]["code_mode"]["direct_only_tool_namespaces"],
                 serde_json::json!([crate::client::cli::codex::DIRECT_ONLY_NAMESPACE])


### PR DESCRIPTION
## Context
Codex ACP inherited the global automatic reviewer setting. When that reviewer stream failed, vmux received a denial instead of the ACP permission request needed to show its user approval controls.

## Implementation
Force Codex ACP sessions launched by vmux to use the user as the approval reviewer. Tool calls continue through the existing vmux permission prompt, including Deny, Allow, and session-scoped Allow always behavior.

## Checks / QA
- Open a new Codex ACP page.
- Request workspace selection and confirm the vmux approval prompt appears.
- Click Deny and confirm the tool does not run.
- Retry with Allow and confirm the tool runs once.
- Retry with Allow always and confirm later calls to the same tool run without another prompt.