### PR TITLE
feat(start): add configurable web search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9578,6 +9578,7 @@ dependencies = [
  "rkyv",
  "serde",
  "serde_json",
+ "url",
  "vmux_core",
  "vmux_history",
  "vmux_macro",

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -6550,6 +6550,7 @@ mod tests {
         AppSettings {
             browser: BrowserSettings {
                 startup_url: "about:blank".to_string(),
+                ..Default::default()
             },
             layout: LayoutSettings {
                 radius: 0.0,

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -5377,6 +5377,7 @@ mod tests {
         AppSettings {
             browser: vmux_setting::BrowserSettings {
                 startup_url: "about:blank".to_string(),
+                ..Default::default()
             },
             layout: vmux_layout::settings::LayoutSettings {
                 radius,
@@ -6514,6 +6515,7 @@ mod tests {
             AppSettings {
                 browser: BrowserSettings {
                     startup_url: "about:blank".to_string(),
+                    ..Default::default()
                 },
                 layout: LayoutSettings {
                     radius: 0.0,

--- a/crates/vmux_command/Cargo.toml
+++ b/crates/vmux_command/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/lib.rs"
 rkyv = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+url = { workspace = true }
 vmux_core = { path = "../vmux_core" }
 vmux_history = { path = "../vmux_history", default-features = false }
 

--- a/crates/vmux_command/src/event.rs
+++ b/crates/vmux_command/src/event.rs
@@ -5,6 +5,45 @@ pub use vmux_history::event::{
 
 pub const COMMAND_BAR_OPEN_EVENT: &str = "command-bar-open";
 
+/// Search provider used when command-bar input is not a URL or local path.
+#[cfg_attr(not(target_arch = "wasm32"), derive(bevy::prelude::Resource))]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum SearchEngine {
+    #[default]
+    Google,
+    Bing,
+    DuckDuckGo,
+    Brave,
+    Kagi,
+}
+
+impl SearchEngine {
+    /// Build a search result URL for `query`.
+    pub fn search_url(self, query: &str) -> String {
+        let query: String = url::form_urlencoded::byte_serialize(query.trim().as_bytes()).collect();
+        match self {
+            Self::Google => format!("https://www.google.com/search?q={query}"),
+            Self::Bing => format!("https://www.bing.com/search?q={query}"),
+            Self::DuckDuckGo => format!("https://duckduckgo.com/?q={query}"),
+            Self::Brave => format!("https://search.brave.com/search?q={query}"),
+            Self::Kagi => format!("https://kagi.com/search?q={query}"),
+        }
+    }
+}
+
 #[derive(
     Clone,
     Debug,
@@ -319,16 +358,20 @@ pub fn is_data_uri(s: &str) -> bool {
 }
 
 pub fn looks_like_url(s: &str) -> bool {
-    if s.contains("://") || is_data_uri(s) {
+    let s = s.trim();
+    if is_data_uri(s) {
         return true;
     }
-    if s.contains(' ')
+    if s.chars().any(char::is_whitespace)
         || s.starts_with('/')
         || s.starts_with("~/")
         || s.starts_with("./")
         || s.starts_with("../")
     {
         return false;
+    }
+    if s.contains("://") {
+        return true;
     }
     let before_slash = s.split('/').next().unwrap_or(s);
     before_slash.contains('.')
@@ -422,6 +465,14 @@ mod tests {
     fn looks_like_url_rejects_spaces() {
         assert!(!looks_like_url("search query"));
         assert!(!looks_like_url("hello world.txt"));
+    }
+
+    #[test]
+    fn multiline_prompt_with_embedded_url_is_not_a_url() {
+        let prompt = "Continue DSK-627 in:\n\nWorktree:\n  /tmp/dashboard\n\nPR:\n  https://github.com/mistralai/dashboard/pull/39364";
+
+        assert!(!looks_like_url(prompt));
+        assert!(is_start_prompt_query(prompt));
     }
 
     #[test]
@@ -571,6 +622,30 @@ mod tests {
     #[test]
     fn start_plain_text_is_prompt_query() {
         assert!(is_start_prompt_query("fix the failing test"));
+    }
+
+    #[test]
+    fn search_engines_build_encoded_urls() {
+        assert_eq!(
+            SearchEngine::Google.search_url("hello world"),
+            "https://www.google.com/search?q=hello+world"
+        );
+        assert_eq!(
+            SearchEngine::Bing.search_url("hello world"),
+            "https://www.bing.com/search?q=hello+world"
+        );
+        assert_eq!(
+            SearchEngine::DuckDuckGo.search_url("hello world"),
+            "https://duckduckgo.com/?q=hello+world"
+        );
+        assert_eq!(
+            SearchEngine::Brave.search_url("hello world"),
+            "https://search.brave.com/search?q=hello+world"
+        );
+        assert_eq!(
+            SearchEngine::Kagi.search_url("hello world"),
+            "https://kagi.com/search?q=hello+world"
+        );
     }
 
     #[test]

--- a/crates/vmux_desktop/src/os_menu.rs
+++ b/crates/vmux_desktop/src/os_menu.rs
@@ -448,6 +448,7 @@ mod tests {
         AppSettings {
             browser: BrowserSettings {
                 startup_url: "about:blank".to_string(),
+                ..Default::default()
             },
             layout: LayoutSettings {
                 radius: 0.0,

--- a/crates/vmux_desktop/src/persistence.rs
+++ b/crates/vmux_desktop/src/persistence.rs
@@ -892,6 +892,7 @@ mod tests {
         AppSettings {
             browser: BrowserSettings {
                 startup_url: "about:blank".to_string(),
+                ..Default::default()
             },
             layout: LayoutSettings {
                 radius: 0.0,

--- a/crates/vmux_desktop/src/shortcut.rs
+++ b/crates/vmux_desktop/src/shortcut.rs
@@ -293,6 +293,7 @@ mod tests {
         AppSettings {
             browser: BrowserSettings {
                 startup_url: "about:blank".to_string(),
+                ..Default::default()
             },
             layout: LayoutSettings {
                 radius: 0.0,

--- a/crates/vmux_layout/src/command_bar/handler.rs
+++ b/crates/vmux_layout/src/command_bar/handler.rs
@@ -20,7 +20,7 @@ use vmux_command::event::{
     COMMAND_BAR_OPEN_EVENT, CommandBarActionEvent, CommandBarCommandEntry, CommandBarOpenEvent,
     CommandBarPage, CommandBarReadyEvent, CommandBarRenderedEvent, CommandBarSizeEvent,
     CommandBarSpace, CommandBarTab, PATH_COMPLETE_RESPONSE, PathCompleteRequest,
-    PathCompleteResponse, PathEntry,
+    PathCompleteResponse, PathEntry, SearchEngine,
 };
 use vmux_command::open::OpenCommand;
 use vmux_command::open_target::OpenTarget;
@@ -1261,13 +1261,16 @@ fn build_open_command(target: Option<OpenTarget>, url: String) -> OpenCommand {
     }
 }
 
-fn normalize_url(value: &str) -> String {
-    if value.contains("://") || vmux_command::event::is_data_uri(value) {
+fn normalize_url(value: &str, search_engine: SearchEngine) -> String {
+    let value = value.trim();
+    if vmux_command::event::is_data_uri(value)
+        || (value.contains("://") && vmux_command::event::looks_like_url(value))
+    {
         value.to_string()
-    } else if value.contains('.') && !value.contains(' ') {
+    } else if vmux_command::event::looks_like_url(value) {
         format!("https://{}", value)
     } else {
-        format!("https://www.google.com/search?q={}", value)
+        search_engine.search_url(value)
     }
 }
 
@@ -1284,6 +1287,7 @@ fn prompt_agent_url(
 
 fn on_command_bar_action(
     trigger: On<BinReceive<CommandBarActionEvent>>,
+    search_engine: Option<Res<SearchEngine>>,
     mut modal_q: Query<(Entity, &mut Node, &mut Visibility), With<Modal>>,
     queries: CommandBarActionQueries,
     mut stack_params: ParamSet<(
@@ -1420,7 +1424,10 @@ fn on_command_bar_action(
                     custom_keyboard_restore = true;
                 }
             } else {
-                let url = normalize_url(&evt.value);
+                let url = normalize_url(
+                    &evt.value,
+                    search_engine.as_deref().copied().unwrap_or_default(),
+                );
                 let inline_transition = if matches!(evt.target, None | Some(OpenTarget::InPlace))
                     && crate::start::supports_inline_agent_transition(&url)
                     && let Some(stack) = inline_transition_stack
@@ -2955,31 +2962,61 @@ mod tests {
 
     #[test]
     fn normalize_url_adds_https_for_domain() {
-        assert_eq!(normalize_url("google.com"), "https://google.com");
+        assert_eq!(
+            normalize_url("google.com", SearchEngine::Google),
+            "https://google.com"
+        );
     }
 
     #[test]
     fn normalize_url_preserves_explicit_protocol() {
-        assert_eq!(normalize_url("http://example.com"), "http://example.com");
-        assert_eq!(normalize_url("https://example.com"), "https://example.com");
+        assert_eq!(
+            normalize_url("http://example.com", SearchEngine::Google),
+            "http://example.com"
+        );
+        assert_eq!(
+            normalize_url("https://example.com", SearchEngine::Google),
+            "https://example.com"
+        );
     }
 
     #[test]
     fn normalize_url_search_query_becomes_google() {
-        let result = normalize_url("hello world");
-        assert!(result.starts_with("https://www.google.com/search?q="));
-        assert!(result.contains("hello world"));
+        assert_eq!(
+            normalize_url("hello world", SearchEngine::Google),
+            "https://www.google.com/search?q=hello+world"
+        );
+    }
+
+    #[test]
+    fn normalize_url_uses_selected_search_engine() {
+        assert_eq!(
+            normalize_url("hello world", SearchEngine::DuckDuckGo),
+            "https://duckduckgo.com/?q=hello+world"
+        );
+    }
+
+    #[test]
+    fn normalize_url_searches_multiline_text_with_embedded_url() {
+        let prompt = "Continue DSK-627\nPR: https://github.com/example/repo/pull/1";
+        assert_eq!(
+            normalize_url(prompt, SearchEngine::Google),
+            "https://www.google.com/search?q=Continue+DSK-627%0APR%3A+https%3A%2F%2Fgithub.com%2Fexample%2Frepo%2Fpull%2F1"
+        );
     }
 
     #[test]
     fn normalize_url_preserves_vmux_protocol() {
-        assert_eq!(normalize_url("vmux://terminal/123"), "vmux://terminal/123");
+        assert_eq!(
+            normalize_url("vmux://terminal/123", SearchEngine::Google),
+            "vmux://terminal/123"
+        );
     }
 
     #[test]
     fn normalize_url_preserves_data_scheme() {
         let data = "data:text/html,<style>body{background:white}</style><h1>x</h1>";
-        assert_eq!(normalize_url(data), data);
+        assert_eq!(normalize_url(data, SearchEngine::Google), data);
     }
 
     #[test]

--- a/crates/vmux_layout/src/command_bar/results.rs
+++ b/crates/vmux_layout/src/command_bar/results.rs
@@ -188,9 +188,10 @@ pub fn start_page_results(pages: &[CommandBarPage], query: &str) -> Vec<CommandB
                 shortcut: page.shortcut.clone(),
             }),
     );
-    if !query.trim().is_empty() {
+    let trimmed = query.trim();
+    if !trimmed.is_empty() {
         results.push(CommandBarResultItem::Navigate {
-            url: query.trim().to_string(),
+            url: trimmed.to_string(),
         });
     }
     results

--- a/crates/vmux_layout/src/command_bar/results.rs
+++ b/crates/vmux_layout/src/command_bar/results.rs
@@ -188,6 +188,11 @@ pub fn start_page_results(pages: &[CommandBarPage], query: &str) -> Vec<CommandB
                 shortcut: page.shortcut.clone(),
             }),
     );
+    if !query.trim().is_empty() {
+        results.push(CommandBarResultItem::Navigate {
+            url: query.trim().to_string(),
+        });
+    }
     results
 }
 
@@ -797,6 +802,16 @@ mod tests {
             .collect();
 
         assert_eq!(urls, vec!["vmux://agent/vibe/", "vmux://settings/"]);
+    }
+
+    #[test]
+    fn start_page_offers_web_search_for_prompt_text() {
+        let results = start_page_results(&sample_pages(), "fix the failing test");
+
+        assert!(matches!(
+            results.last(),
+            Some(CommandBarResultItem::Navigate { url }) if url == "fix the failing test"
+        ));
     }
 
     #[test]

--- a/crates/vmux_setting/src/lib.rs
+++ b/crates/vmux_setting/src/lib.rs
@@ -42,3 +42,5 @@ pub use plugin::runtime::{
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use plugin::view::Settings;
+#[cfg(not(target_arch = "wasm32"))]
+pub use vmux_command::event::SearchEngine;

--- a/crates/vmux_setting/src/plugin.rs
+++ b/crates/vmux_setting/src/plugin.rs
@@ -3,6 +3,7 @@ pub mod view;
 
 use bevy::{ecs::message::MessageReader, prelude::*};
 use bevy_cef::prelude::BinEventEmitterPlugin;
+use vmux_command::event::SearchEngine;
 use vmux_command::{ReadAppCommands, WriteAppCommands};
 use vmux_core::{PageOpenRequest, PageOpenTarget};
 use vmux_layout::warm_page::WarmPagePlugin;
@@ -31,6 +32,7 @@ impl Plugin for SettingsPlugin {
         vmux_core::register_host_spawn(app, "settings");
         app.init_resource::<LastSelfWriteHash>()
             .init_resource::<SettingsSaveDebounce>()
+            .init_resource::<SearchEngine>()
             .init_resource::<CurrentUpdateCheckStatus>()
             .add_message::<SettingsWriteRequest>()
             .add_message::<SettingsSaveRequest>()
@@ -62,6 +64,7 @@ impl Plugin for SettingsPlugin {
                 )
                     .chain(),
             )
+            .add_systems(Update, sync_search_engine)
             .add_message::<vmux_core::page::SettingsPageSpawnRequest>()
             .add_systems(Update, respond_settings_spawn.in_set(ReadAppCommands))
             .add_plugins(WarmPagePlugin::<view::Settings>::default())
@@ -86,6 +89,18 @@ impl Plugin for SettingsPlugin {
                     .in_set(ReadAppCommands)
                     .after(WriteAppCommands),
             );
+    }
+}
+
+fn sync_search_engine(
+    settings: Option<Res<runtime::AppSettings>>,
+    mut search_engine: ResMut<SearchEngine>,
+) {
+    let Some(settings) = settings else {
+        return;
+    };
+    if *search_engine != settings.browser.search_engine {
+        *search_engine = settings.browser.search_engine;
     }
 }
 

--- a/crates/vmux_setting/src/plugin/runtime.rs
+++ b/crates/vmux_setting/src/plugin/runtime.rs
@@ -4,6 +4,7 @@ use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use serde::{Deserialize, Serialize};
 use std::sync::{Mutex, mpsc};
 use std::time::{Duration, Instant};
+use vmux_command::event::SearchEngine;
 use vmux_layout::settings::ConfirmCloseSettings;
 pub use vmux_layout::settings::LayoutSettings;
 #[cfg(test)]
@@ -480,11 +481,20 @@ impl KeyComboDef {
 pub struct BrowserSettings {
     #[serde(default = "default_browser_startup_url")]
     pub startup_url: String,
+    #[serde(default)]
+    pub search_engine: SearchEngine,
 }
 
 fn default_browser_settings() -> BrowserSettings {
     BrowserSettings {
         startup_url: default_browser_startup_url(),
+        search_engine: SearchEngine::default(),
+    }
+}
+
+impl Default for BrowserSettings {
+    fn default() -> Self {
+        default_browser_settings()
     }
 }
 
@@ -1295,6 +1305,7 @@ mod tests {
         AppSettings {
             browser: BrowserSettings {
                 startup_url: default_browser_startup_url(),
+                search_engine: SearchEngine::default(),
             },
             layout: LayoutSettings {
                 radius: 0.0,
@@ -1774,6 +1785,13 @@ mod tests {
         let s = parse_settings("()").unwrap();
         assert_eq!(s.shortcuts.leader.key, "b");
         assert_eq!(s.browser.startup_url, "vmux://start/");
+        assert_eq!(s.browser.search_engine, SearchEngine::Google);
+    }
+
+    #[test]
+    fn parse_settings_selects_search_engine() {
+        let s = parse_settings(r#"(browser: (search_engine: duckduckgo))"#).unwrap();
+        assert_eq!(s.browser.search_engine, SearchEngine::DuckDuckGo);
     }
 
     #[test]

--- a/crates/vmux_setting/src/plugin/view.rs
+++ b/crates/vmux_setting/src/plugin/view.rs
@@ -309,7 +309,7 @@ fn build_settings_schema() -> SettingsSchema {
                 id: "browser".to_string(),
                 title: "Browser".to_string(),
                 description: None,
-                synthetic_keys: vec!["startup_url".to_string()],
+                synthetic_keys: vec![],
                 root_path: "browser".to_string(),
             },
         ],
@@ -348,7 +348,7 @@ fn build_settings_schema() -> SettingsSchema {
             field(
                 "browser",
                 FieldSpec {
-                    order: vec!["startup_url".into()],
+                    order: vec!["startup_url".into(), "search_engine".into()],
                     ..Default::default()
                 },
             ),
@@ -358,6 +358,37 @@ fn build_settings_schema() -> SettingsSchema {
                     label: Some("Startup URL".into()),
                     hint: Some("Empty opens the command bar prompt.".into()),
                     placeholder: Some("https://example.com".into()),
+                    ..Default::default()
+                },
+            ),
+            field(
+                "browser.search_engine",
+                FieldSpec {
+                    label: Some("Search engine".into()),
+                    hint: Some("Used for web searches from Start and the command bar.".into()),
+                    widget: Some(WidgetKind::Select),
+                    options: vec![
+                        SelectOption {
+                            value: "google".into(),
+                            label: "Google".into(),
+                        },
+                        SelectOption {
+                            value: "bing".into(),
+                            label: "Bing".into(),
+                        },
+                        SelectOption {
+                            value: "duckduckgo".into(),
+                            label: "DuckDuckGo".into(),
+                        },
+                        SelectOption {
+                            value: "brave".into(),
+                            label: "Brave Search".into(),
+                        },
+                        SelectOption {
+                            value: "kagi".into(),
+                            label: "Kagi".into(),
+                        },
+                    ],
                     ..Default::default()
                 },
             ),
@@ -512,6 +543,29 @@ mod appearance_schema_tests {
         assert_eq!(mode.widget, Some(WidgetKind::Select));
         let vals: Vec<_> = mode.options.iter().map(|o| o.value.as_str()).collect();
         assert_eq!(vals, vec!["device", "light", "dark"]);
+    }
+}
+
+#[cfg(test)]
+mod browser_schema_tests {
+    use super::*;
+
+    #[test]
+    fn schema_exposes_search_engine_select() {
+        let schema = build_settings_schema();
+        let field = schema
+            .field("browser.search_engine")
+            .expect("search engine field");
+        assert_eq!(field.widget, Some(WidgetKind::Select));
+        let values: Vec<_> = field
+            .options
+            .iter()
+            .map(|option| option.value.as_str())
+            .collect();
+        assert_eq!(
+            values,
+            vec!["google", "bing", "duckduckgo", "brave", "kagi"]
+        );
     }
 }
 

--- a/crates/vmux_setting/src/settings.ron
+++ b/crates/vmux_setting/src/settings.ron
@@ -1,6 +1,7 @@
 (
     browser: (
         startup_url: "vmux://start/",
+        search_engine: google,
     ),
     layout: (
         window: (

--- a/crates/vmux_space/src/plugin.rs
+++ b/crates/vmux_space/src/plugin.rs
@@ -653,6 +653,7 @@ mod tests {
         AppSettings {
             browser: BrowserSettings {
                 startup_url: "about:blank".to_string(),
+                ..Default::default()
             },
             layout: LayoutSettings {
                 radius: 0.0,

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -4054,6 +4054,7 @@ mod tests {
         AppSettings {
             browser: BrowserSettings {
                 startup_url: "about:blank".to_string(),
+                ..Default::default()
             },
             layout: LayoutSettings {
                 radius: 0.0,


### PR DESCRIPTION
## Context

The Start launcher had no explicit web-search choice for plain text. Multiline prompts containing embedded URLs were also misclassified as navigation, hiding agent thread choices.

## Implementation

Keep agent choices as the default Start results while adding a web-search row. Search normalization now uses a typed Browser setting with Google, Bing, DuckDuckGo, Brave Search, and Kagi options, and URL detection requires the full input to be URL-like.

## Checks / QA

- Open vmux://start, type a plain query, and select the Search row.
- Paste a multiline prompt containing a GitHub URL and verify agent choices remain visible.
- Change Settings > Browser > Search engine and verify new searches use the selected provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable browser search engines: Google, Bing, DuckDuckGo, Brave, and Kagi.
  - Added a browser settings selector for choosing the default search engine.
  - Non-URL prompts in the command bar can now open search results using the selected engine.
  - Improved URL handling for search queries, multiline text, paths, data URLs, and existing protocols.

- **Bug Fixes**
  - Prevented multiline prompts containing embedded URLs from being misidentified as direct URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->