### PR TITLE
fix(agent): show initial prompt in resume picker

### DIFF
--- a/crates/vmux_agent/src/client/cli/codex.rs
+++ b/crates/vmux_agent/src/client/cli/codex.rs
@@ -288,6 +288,7 @@ pub(crate) fn list_codex_sessions(root: &Path) -> Vec<ResumableSession> {
                     .and_then(|message| message.as_str())
                     .map(str::trim)
                     .filter(|message| !message.is_empty())
+                    .map(|message| message.lines().collect::<Vec<_>>().join(" "))
                     .map(|message| message.chars().take(80).collect())
             })
             .unwrap_or(fallback);
@@ -594,7 +595,7 @@ mod tests {
             concat!(
                 "{\"type\":\"session_meta\",\"payload\":{\"id\":\"cx-1\",\"cwd\":\"/w/x\"}}\n",
                 "{\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_message\",\"message\":\"hello\"}}\n",
-                "{\"type\":\"event_msg\",\"payload\":{\"type\":\"user_message\",\"message\":\"fix the approval flow\"}}\n",
+                "{\"type\":\"event_msg\",\"payload\":{\"type\":\"user_message\",\"message\":\"fix the\\napproval flow\"}}\n",
                 "{\"type\":\"event_msg\",\"payload\":{\"type\":\"user_message\",\"message\":\"second prompt\"}}\n"
             ),
         )

--- a/crates/vmux_agent/src/client/cli/codex.rs
+++ b/crates/vmux_agent/src/client/cli/codex.rs
@@ -254,8 +254,9 @@ pub(crate) fn list_codex_sessions(root: &Path) -> Vec<ResumableSession> {
         let Ok(file) = std::fs::File::open(path) else {
             return;
         };
+        let mut reader = BufReader::new(file);
         let mut line = String::new();
-        let Ok(read) = BufReader::new(file).read_line(&mut line) else {
+        let Ok(read) = reader.read_line(&mut line) else {
             return;
         };
         if read == 0 {
@@ -267,13 +268,29 @@ pub(crate) fn list_codex_sessions(root: &Path) -> Vec<ResumableSession> {
         if head.kind != "session_meta" {
             return;
         }
-        let title = head
+        let fallback = head
             .payload
             .id
             .split('-')
             .next()
             .unwrap_or(&head.payload.id)
             .to_string();
+        let title = lines_skipping_invalid_utf8(reader)
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(&line).ok())
+            .find_map(|value| {
+                (value.get("type").and_then(|value| value.as_str()) == Some("event_msg"))
+                    .then(|| value.get("payload"))
+                    .flatten()
+                    .filter(|payload| {
+                        payload.get("type").and_then(|value| value.as_str()) == Some("user_message")
+                    })
+                    .and_then(|payload| payload.get("message"))
+                    .and_then(|message| message.as_str())
+                    .map(str::trim)
+                    .filter(|message| !message.is_empty())
+                    .map(|message| message.chars().take(80).collect())
+            })
+            .unwrap_or(fallback);
         out.push(ResumableSession {
             kind: AgentKind::Codex,
             sid: head.payload.id.clone(),
@@ -562,7 +579,30 @@ mod tests {
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].sid, "cx-1");
         assert_eq!(out[0].cwd, PathBuf::from("/w/x"));
+        assert_eq!(out[0].title, "cx");
         assert!(out[0].cross_runtime);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn list_sessions_uses_first_user_prompt_as_title() {
+        let tmp = unique_tmp("codex-list-title");
+        let day = tmp.join("2026/07");
+        std::fs::create_dir_all(&day).unwrap();
+        std::fs::write(
+            day.join("sess.jsonl"),
+            concat!(
+                "{\"type\":\"session_meta\",\"payload\":{\"id\":\"cx-1\",\"cwd\":\"/w/x\"}}\n",
+                "{\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_message\",\"message\":\"hello\"}}\n",
+                "{\"type\":\"event_msg\",\"payload\":{\"type\":\"user_message\",\"message\":\"fix the approval flow\"}}\n",
+                "{\"type\":\"event_msg\",\"payload\":{\"type\":\"user_message\",\"message\":\"second prompt\"}}\n"
+            ),
+        )
+        .unwrap();
+
+        let out = list_codex_sessions(&tmp);
+
+        assert_eq!(out[0].title, "fix the approval flow");
         let _ = std::fs::remove_dir_all(&tmp);
     }
 

--- a/crates/vmux_agent/src/client/cli/vibe.rs
+++ b/crates/vmux_agent/src/client/cli/vibe.rs
@@ -321,6 +321,8 @@ pub(crate) fn discover_vibe_session_id(
 }
 
 pub(crate) fn list_vibe_sessions(root: &Path) -> Vec<ResumableSession> {
+    use std::io::BufReader;
+
     let mut out = Vec::new();
     let Ok(entries) = std::fs::read_dir(root) else {
         return out;
@@ -353,12 +355,31 @@ pub(crate) fn list_vibe_sessions(root: &Path) -> Vec<ResumableSession> {
         if cwd.as_os_str().is_empty() {
             continue;
         }
+        let title = std::fs::File::open(path.join("messages.jsonl"))
+            .ok()
+            .and_then(|file| {
+                lines_skipping_invalid_utf8(BufReader::new(file))
+                    .filter_map(|line| serde_json::from_str::<serde_json::Value>(&line).ok())
+                    .filter(|value| {
+                        value.get("injected").and_then(|value| value.as_bool()) != Some(true)
+                    })
+                    .find_map(|value| {
+                        (value.get("role").and_then(|value| value.as_str()) == Some("user"))
+                            .then(|| value.get("content"))
+                            .flatten()
+                            .and_then(|content| content.as_str())
+                            .map(str::trim)
+                            .filter(|content| !content.is_empty())
+                            .map(|content| content.chars().take(80).collect())
+                    })
+            })
+            .unwrap_or_else(|| short_id.to_string());
         out.push(ResumableSession {
             kind: AgentKind::Vibe,
             sid: short_id.to_string(),
             cwd,
             mtime,
-            title: short_id.to_string(),
+            title,
             cross_runtime: true,
         });
     }
@@ -770,7 +791,35 @@ mod tests {
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].sid, "vb-1");
         assert_eq!(out[0].cwd, PathBuf::from("/w/y"));
+        assert_eq!(out[0].title, "vb-1");
         assert!(out[0].cross_runtime);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn list_sessions_uses_first_user_prompt_as_title() {
+        let tmp = unique_tmp("vibe-list-title");
+        let sdir = tmp.join("session_vb-1");
+        std::fs::create_dir_all(&sdir).unwrap();
+        std::fs::write(
+            sdir.join("meta.json"),
+            b"{\"environment\":{\"working_directory\":\"/w/y\"}}",
+        )
+        .unwrap();
+        std::fs::write(
+            sdir.join("messages.jsonl"),
+            concat!(
+                "{\"role\":\"user\",\"content\":\"hidden\",\"injected\":true}\n",
+                "{\"role\":\"assistant\",\"content\":\"hello\",\"injected\":false}\n",
+                "{\"role\":\"user\",\"content\":\"fix the approval flow\",\"injected\":false}\n",
+                "{\"role\":\"user\",\"content\":\"second prompt\",\"injected\":false}\n"
+            ),
+        )
+        .unwrap();
+
+        let out = list_vibe_sessions(&tmp);
+
+        assert_eq!(out[0].title, "fix the approval flow");
         let _ = std::fs::remove_dir_all(&tmp);
     }
 

--- a/crates/vmux_agent/src/client/cli/vibe.rs
+++ b/crates/vmux_agent/src/client/cli/vibe.rs
@@ -370,6 +370,7 @@ pub(crate) fn list_vibe_sessions(root: &Path) -> Vec<ResumableSession> {
                             .and_then(|content| content.as_str())
                             .map(str::trim)
                             .filter(|content| !content.is_empty())
+                            .map(|content| content.lines().collect::<Vec<_>>().join(" "))
                             .map(|content| content.chars().take(80).collect())
                     })
             })
@@ -811,7 +812,7 @@ mod tests {
             concat!(
                 "{\"role\":\"user\",\"content\":\"hidden\",\"injected\":true}\n",
                 "{\"role\":\"assistant\",\"content\":\"hello\",\"injected\":false}\n",
-                "{\"role\":\"user\",\"content\":\"fix the approval flow\",\"injected\":false}\n",
+                "{\"role\":\"user\",\"content\":\"fix the\\napproval flow\",\"injected\":false}\n",
                 "{\"role\":\"user\",\"content\":\"second prompt\",\"injected\":false}\n"
             ),
         )


### PR DESCRIPTION
## Context

Resume rows for Codex and Vibe sessions showed opaque session ID prefixes, making past sessions difficult to identify. Showing the first user prompt makes the intended conversation recognizable at a glance.

## Implementation

Read the first non-empty user message while discovering Codex and Vibe sessions, limit it to 80 characters, and retain the existing short session ID fallback when no usable prompt exists. Injected Vibe messages are ignored.

## Checks / QA

Open an agent chat, type `/resume `, and confirm Codex and Vibe rows show their initial user prompt. Confirm sessions without a readable prompt still show a short session ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session lists now use the first meaningful user prompt as the session title.
  * Titles are trimmed and limited to 80 characters for readability.
  * Automatically generated or injected messages are excluded from title selection.

* **Bug Fixes**
  * Sessions without a usable prompt continue to display a short ID-based title.
  * Invalid transcript data no longer prevents session titles from being detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->