### PR TITLE
refactor(ui): share prompt composer across start and agent

### DIFF
--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -2162,6 +2162,7 @@ mod native_tests {
     fn composer_supports_history_uploads_and_clipboard_media() {
         let source = include_str!("chat_page/page.rs");
         let composer = include_str!("../../vmux_ui/src/components/prompt_composer.rs");
+        let media_options = include_str!("../../vmux_ui/src/components/prompt_media_options.rs");
         assert!(source.contains("prompt_history_direction"));
         assert!(source.contains("move_prompt_history"));
         assert!(source.contains("ChatPickFiles"));
@@ -2172,7 +2173,7 @@ mod native_tests {
         assert!(source.contains("ChatMediaListRequest"));
         assert!(source.contains("select_media_entry"));
         assert!(source.contains("entry.preview_data_url"));
-        assert!(source.contains("h-12 w-16"));
+        assert!(media_options.contains("h-12 w-16"));
         assert!(source.contains("attachment-pill-{}"));
         assert!(source.contains("String::new()"));
         assert!(source.contains("CHAT_ATTACHMENT_PREVIEWS_EVENT"));
@@ -2199,9 +2200,15 @@ mod native_tests {
     fn start_and_agent_share_prompt_composer() {
         let agent = include_str!("chat_page/page.rs");
         let start = include_str!("../../vmux_layout/src/command_bar/palette.rs");
+        let media_options = include_str!("../../vmux_ui/src/components/prompt_media_options.rs");
 
         assert!(agent.contains("PromptComposer {"));
         assert!(start.contains("PromptComposer {"));
+        assert!(agent.contains("PromptMediaOptions {"));
+        assert!(start.contains("PromptMediaOptions {"));
+        assert!(agent.contains("display_path: media_display_path(entry)"));
+        assert!(start.contains("display_path: media_display_path(entry)"));
+        assert!(media_options.contains("{item.display_path}"));
         assert!(start.contains("PromptPopupPlacement::Downward"));
         assert!(agent.contains("PromptPopup {"));
     }

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -2197,23 +2197,6 @@ mod native_tests {
     }
 
     #[test]
-    fn start_and_agent_share_prompt_composer() {
-        let agent = include_str!("chat_page/page.rs");
-        let start = include_str!("../../vmux_layout/src/command_bar/palette.rs");
-        let media_options = include_str!("../../vmux_ui/src/components/prompt_media_options.rs");
-
-        assert!(agent.contains("PromptComposer {"));
-        assert!(start.contains("PromptComposer {"));
-        assert!(agent.contains("PromptMediaOptions {"));
-        assert!(start.contains("PromptMediaOptions {"));
-        assert!(agent.contains("display_path: media_display_path(entry)"));
-        assert!(start.contains("display_path: media_display_path(entry)"));
-        assert!(media_options.contains("{item.display_path}"));
-        assert!(start.contains("PromptPopupPlacement::Downward"));
-        assert!(agent.contains("PromptPopup {"));
-    }
-
-    #[test]
     fn composer_slash_items_support_mouse_selection() {
         let source = include_str!("chat_page/page.rs");
         assert!(source.contains("onclick: move |_| run_slash_command"));

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -2118,10 +2118,11 @@ mod native_tests {
     #[test]
     fn installing_chat_uses_matrix_loading_composer() {
         let source = include_str!("chat_page/page.rs");
+        let composer = include_str!("../../vmux_ui/src/components/prompt_composer.rs");
         assert!(source.contains("let installing_splash = installing && items.read().is_empty();"));
         assert!(source.contains("MatrixRain {"));
-        assert!(source.contains("PromptGhost {"));
-        assert!(source.contains("terminal: false"));
+        assert!(source.contains("PromptComposer {"));
+        assert!(composer.contains("PromptGhost {"));
         assert!(source.contains("id: \"chat-scroll\""));
         assert!(source.contains("bg-gradient-to-t from-background via-background/95"));
         assert!(!source.contains("absolute inset-0 z-20 flex items-center justify-center"));
@@ -2131,48 +2132,48 @@ mod native_tests {
     fn composer_auto_grows_and_contains_action_button() {
         let source = include_str!("chat_page/page.rs");
         let prompt_box = include_str!("../../vmux_ui/src/components/prompt_box.rs");
-        assert!(source.contains("fn resize_prompt_textarea()"));
-        assert!(source.contains("textarea.scroll_height().clamp(40, 160)"));
-        assert!(source.contains("max-h-40 min-h-10"));
-        assert!(source.contains("PromptBox {"));
+        let composer = include_str!("../../vmux_ui/src/components/prompt_composer.rs");
+        assert!(composer.contains("fn resize_prompt_textarea"));
+        assert!(composer.contains("textarea.scroll_height().clamp(40, 160)"));
+        assert!(composer.contains("max-h-40 min-h-10"));
+        assert!(source.contains("PromptComposer {"));
+        assert!(composer.contains("PromptBox {"));
         assert!(source.contains("PromptPopup {"));
         assert!(prompt_box.contains("rounded-2xl"));
         assert!(prompt_box.contains("backdrop-blur-3xl backdrop-saturate-150"));
-        assert!(source.contains("h-8 w-8 shrink-0 self-center items-center justify-center"));
-        assert!(source.contains("if draft.read().is_empty()"));
+        assert!(composer.contains("h-8 w-8 shrink-0 self-center items-center justify-center"));
         assert!(source.contains("show_capability_examples"));
         assert!(source.contains("attachments.read().is_empty()"));
-        assert!(source.contains("if show_capability_examples"));
         assert!(source.contains("Type / for commands or @ for media"));
-        assert!(!source.contains("agent-chat-caret relative top-px ml-px h-4 w-1.5 shrink-0"));
-        assert!(source.contains("prompt_prefix_at_utf16"));
-        assert!(source.contains("agent-chat-caret"));
-        assert!(source.contains("caret-color:transparent"));
-        assert!(source.contains("install_prompt_page_focus_tracking"));
-        assert!(source.contains("document.has_focus().unwrap_or(false)"));
-        assert!(source.contains("add_event_listener_with_callback(\"focus\""));
-        assert!(source.contains("add_event_listener_with_callback(\"blur\""));
-        assert!(source.contains("if prompt_caret().is_some()"));
-        assert!(source.contains("onkeyup"));
-        assert!(source.contains("onscroll"));
-        assert!(source.contains("placeholder:text-transparent"));
+        assert!(composer.contains("prompt_prefix_at_utf16"));
+        assert!(composer.contains("vmux-prompt-caret"));
+        assert!(composer.contains("caret-color:transparent"));
+        assert!(composer.contains("install_prompt_focus_tracking"));
+        assert!(composer.contains("document.has_focus().unwrap_or(false)"));
+        assert!(composer.contains("add_event_listener_with_callback(\"focus\""));
+        assert!(composer.contains("add_event_listener_with_callback(\"blur\""));
+        assert!(composer.contains("if caret().is_some()"));
+        assert!(composer.contains("onkeyup"));
+        assert!(composer.contains("onscroll"));
+        assert!(composer.contains("placeholder:text-transparent"));
     }
 
     #[test]
     fn composer_supports_history_uploads_and_clipboard_media() {
         let source = include_str!("chat_page/page.rs");
+        let composer = include_str!("../../vmux_ui/src/components/prompt_composer.rs");
         assert!(source.contains("prompt_history_direction"));
         assert!(source.contains("move_prompt_history"));
         assert!(source.contains("ChatPickFiles"));
         assert!(source.contains("ChatPasteMedia"));
         assert!(source.contains("preview_data_url"));
-        assert!(source.contains("Remove attachment"));
+        assert!(composer.contains("Remove attachment"));
         assert!(source.contains("attachments_to_submit"));
         assert!(source.contains("ChatMediaListRequest"));
         assert!(source.contains("select_media_entry"));
         assert!(source.contains("entry.preview_data_url"));
         assert!(source.contains("h-12 w-16"));
-        assert!(source.contains("attachment-pill-{attachment.path}"));
+        assert!(source.contains("attachment-pill-{}"));
         assert!(source.contains("String::new()"));
         assert!(source.contains("CHAT_ATTACHMENT_PREVIEWS_EVENT"));
         assert!(source.contains("render_user_attachment"));
@@ -2185,13 +2186,24 @@ mod native_tests {
         let card = page
             .find("if workspace_selection_pending()")
             .expect("workspace card");
-        let composer = page.find("PromptBox {").expect("composer");
+        let composer = page.find("PromptComposer {").expect("composer");
 
         assert!(card < composer);
         assert!(page.contains("Choose a workspace"));
         assert!(page.contains("Choose folder"));
         assert!(page.contains("try_cef_bin_emit_rkyv(&ChatChooseWorkspace)"));
         assert!(include_str!("chat_page.rs").contains("WorkspacePickerStartRequest"));
+    }
+
+    #[test]
+    fn start_and_agent_share_prompt_composer() {
+        let agent = include_str!("chat_page/page.rs");
+        let start = include_str!("../../vmux_layout/src/command_bar/palette.rs");
+
+        assert!(agent.contains("PromptComposer {"));
+        assert!(start.contains("PromptComposer {"));
+        assert!(start.contains("PromptPopupPlacement::Downward"));
+        assert!(agent.contains("PromptPopup {"));
     }
 
     #[test]
@@ -2211,14 +2223,15 @@ mod native_tests {
     #[test]
     fn queued_flush_controls_repurpose_composer_button() {
         let source = include_str!("chat_page/page.rs");
+        let composer = include_str!("../../vmux_ui/src/components/prompt_composer.rs");
         assert!(source.contains("kbd {"));
-        assert!(source.contains("if queued.read().is_empty()"));
+        assert!(source.contains("prompt_streaming && queued.read().is_empty()"));
         assert!(source.contains("ChatCancelQueuedPrompt"));
         assert!(source.contains("title: \"Cancel queued prompt\""));
-        assert!(source.contains("title: \"Stop\""));
-        assert!(source.contains("rect { x: \"6\", y: \"6\""));
+        assert!(source.contains("\"Stop\""));
+        assert!(composer.contains("rect { x: \"6\", y: \"6\""));
         assert!(source.contains("\"Send all queued prompts now (Esc)\""));
-        assert!(source.contains("path { d: \"M12 19V5\" }"));
+        assert!(composer.contains("path { d: \"M12 19V5\" }"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -2148,6 +2148,11 @@ mod native_tests {
         assert!(source.contains("prompt_prefix_at_utf16"));
         assert!(source.contains("agent-chat-caret"));
         assert!(source.contains("caret-color:transparent"));
+        assert!(source.contains("install_prompt_page_focus_tracking"));
+        assert!(source.contains("document.has_focus().unwrap_or(false)"));
+        assert!(source.contains("add_event_listener_with_callback(\"focus\""));
+        assert!(source.contains("add_event_listener_with_callback(\"blur\""));
+        assert!(source.contains("if prompt_caret().is_some()"));
         assert!(source.contains("onkeyup"));
         assert!(source.contains("onscroll"));
         assert!(source.contains("placeholder:text-transparent"));

--- a/crates/vmux_agent/src/chat_page/composer.rs
+++ b/crates/vmux_agent/src/chat_page/composer.rs
@@ -375,10 +375,6 @@ pub(crate) fn edit_prompt(
     (updated, caret_utf16)
 }
 
-pub(crate) fn prompt_prefix_at_utf16(value: &str, offset: u32) -> &str {
-    &value[..utf16_to_byte(value, offset)]
-}
-
 fn utf16_to_byte(value: &str, offset: u32) -> usize {
     let mut units = 0u32;
     for (byte, character) in value.char_indices() {
@@ -728,11 +724,5 @@ mod tests {
         assert!(is_handoff_boundary(1, 2));
         assert!(!is_handoff_boundary(2, 2));
         assert!(!is_handoff_boundary(0, 0));
-    }
-
-    #[test]
-    fn prompt_prefix_uses_utf16_caret_offsets() {
-        assert_eq!(prompt_prefix_at_utf16("a🙂b", 3), "a🙂");
-        assert_eq!(prompt_prefix_at_utf16("a🙂b", 4), "a🙂b");
     }
 }

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -96,6 +96,13 @@ fn resize_prompt_textarea() {
 }
 
 fn sync_prompt_caret(mut caret: Signal<Option<u32>>, mut scroll_top: Signal<i32>) {
+    let page_active = web_sys::window()
+        .and_then(|window| window.document())
+        .is_some_and(|document| document.has_focus().unwrap_or(false));
+    if !page_active {
+        caret.set(None);
+        return;
+    }
     let Some(textarea) = prompt_textarea() else {
         return;
     };
@@ -103,6 +110,25 @@ fn sync_prompt_caret(mut caret: Signal<Option<u32>>, mut scroll_top: Signal<i32>
     let end = textarea.selection_end().ok().flatten().unwrap_or(start);
     caret.set((start == end).then_some(start));
     scroll_top.set(textarea.scroll_top());
+}
+
+fn install_prompt_page_focus_tracking(caret: Signal<Option<u32>>, scroll_top: Signal<i32>) {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+
+    let focus = Closure::wrap(Box::new(move || {
+        sync_prompt_caret(caret, scroll_top);
+    }) as Box<dyn FnMut()>);
+    let _ = window.add_event_listener_with_callback("focus", focus.as_ref().unchecked_ref());
+    focus.forget();
+
+    let mut blur_caret = caret;
+    let blur = Closure::wrap(Box::new(move || {
+        blur_caret.set(None);
+    }) as Box<dyn FnMut()>);
+    let _ = window.add_event_listener_with_callback("blur", blur.as_ref().unchecked_ref());
+    blur.forget();
 }
 
 fn focus_prompt_end() {
@@ -312,7 +338,7 @@ pub fn Page(
     let mut attachment_preview_requests = use_signal(HashSet::<String>::new);
     let mut history_cursor = use_signal(|| None::<usize>);
     let mut history_scratch = use_signal(String::new);
-    let prompt_caret = use_signal(|| Some(0u32));
+    let prompt_caret = use_signal(|| None::<u32>);
     let prompt_scroll_top = use_signal(|| 0i32);
     let mut elapsed = use_signal(|| 0u32);
     let mut at_bottom = use_signal(|| true);
@@ -334,6 +360,7 @@ pub fn Page(
     let mut verb = use_signal(|| "Working".to_string());
 
     use_effect(move || install_global_prompt_input(draft, slash_cmds));
+    use_effect(move || install_prompt_page_focus_tracking(prompt_caret, prompt_scroll_top));
     use_effect(focus_prompt_end);
     use_effect(move || {
         let _ = draft.read();
@@ -1146,7 +1173,12 @@ pub fn Page(
                                                 terminal: false,
                                             }
                                         } else {
-                                            div { class: "max-w-full truncate whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50", "Type / for commands or @ for media" }
+                                            div { class: "flex max-w-full items-center whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50",
+                                                if prompt_caret().is_some() {
+                                                    span { class: "agent-chat-caret relative top-px mr-px h-4 w-1.5 shrink-0" }
+                                                }
+                                                span { class: "min-w-0 truncate", "Type / for commands or @ for media" }
+                                            }
                                         }
                                     }
                                 }

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -31,6 +31,7 @@ use vmux_ui::components::prompt_composer::{
     PROMPT_INPUT_ID, PromptComposer, PromptComposerAction, PromptComposerAttachment,
     focus_prompt_end, prompt_textarea,
 };
+use vmux_ui::components::prompt_media_options::{PromptMediaOption, PromptMediaOptions};
 use vmux_ui::favicon::favicon_src_for_url;
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_theme};
 use wasm_bindgen::{JsCast, closure::Closure};
@@ -560,6 +561,18 @@ pub fn Page(
             filtered_sessions.len(),
         )
     });
+    let prompt_media_options = media_entries
+        .read()
+        .iter()
+        .map(|entry| PromptMediaOption {
+            key: format!("media-{}", entry.path),
+            name: entry.name.clone(),
+            display_path: media_display_path(entry),
+            preview_data_url: entry.preview_data_url.clone(),
+            label: file_extension_label(&entry.name),
+            is_dir: entry.is_dir,
+        })
+        .collect::<Vec<_>>();
     let prompt_attachments = transition_attachments
         .read()
         .iter()
@@ -773,15 +786,21 @@ pub fn Page(
 
     use_effect(move || {
         let selected = menu_sel();
-        let _ = draft.read();
+        let media_open = {
+            let draft = draft.read();
+            inline_media_query(&draft).is_some()
+        };
         let _ = sessions.read().len();
         let _ = models.read().len();
         let _ = media_entries.read().len();
+        let item_id = if media_open {
+            format!("prompt-media-item-{selected}")
+        } else {
+            format!("agent-selector-item-{selected}")
+        };
         if let Some(element) = web_sys::window()
             .and_then(|window| window.document())
-            .and_then(|document| {
-                document.get_element_by_id(&format!("agent-selector-item-{selected}"))
-            })
+            .and_then(|document| document.get_element_by_id(&item_id))
         {
             let options = web_sys::ScrollIntoViewOptions::new();
             options.set_block(web_sys::ScrollLogicalPosition::Nearest);
@@ -956,51 +975,16 @@ pub fn Page(
                     class: "agent-chat-prompt-shell vmux-agent-prompt-dock-enter relative mx-auto flex max-w-3xl flex-col gap-2",
                     if media_menu_open {
                         PromptPopup {
-                            if media_loading() {
-                                div { class: "px-3.5 py-2 text-sm text-muted-foreground", "Loading media…" }
-                            } else if media_entries.read().is_empty() {
-                                div { class: "px-3.5 py-2 text-sm text-muted-foreground", "No matching media" }
-                            } else {
-                                for (i , entry) in media_entries.read().iter().cloned().enumerate() {
-                                    {
-                                        let entry = entry.clone();
-                                        let display_path = media_display_path(&entry);
-                                        rsx! {
-                                            div {
-                                                key: "media-{entry.path}",
-                                                id: "agent-selector-item-{i}",
-                                                class: if i == menu_sel() { "flex cursor-pointer items-center gap-3 bg-foreground/10 px-3.5 py-2" } else { "flex cursor-pointer items-center gap-3 px-3.5 py-2" },
-                                                onclick: move |_| select_media_entry(&entry, draft, menu_sel),
-                                                div { class: "flex h-12 w-16 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-foreground/[0.06] text-muted-foreground ring-1 ring-inset ring-foreground/10",
-                                                    if entry.is_dir {
-                                                        svg {
-                                                            class: "h-4 w-4",
-                                                            view_box: "0 0 24 24",
-                                                            fill: "none",
-                                                            stroke: "currentColor",
-                                                            stroke_width: "2",
-                                                            stroke_linecap: "round",
-                                                            stroke_linejoin: "round",
-                                                            path { d: "M3 6h6l2 2h10v10H3z" }
-                                                        }
-                                                    } else if !entry.preview_data_url.is_empty() {
-                                                        img {
-                                                            src: "{entry.preview_data_url}",
-                                                            alt: "{entry.name}",
-                                                            class: "h-full w-full object-contain",
-                                                        }
-                                                    } else {
-                                                        span { class: "font-mono text-[9px] font-semibold", "{file_extension_label(&entry.name)}" }
-                                                    }
-                                                }
-                                                div { class: "min-w-0 flex-1",
-                                                    div { class: "truncate text-sm text-foreground", "{entry.name}" }
-                                                    div { class: "truncate text-xs text-muted-foreground", "{display_path}" }
-                                                }
-                                            }
-                                        }
+                            PromptMediaOptions {
+                                items: prompt_media_options,
+                                selected: menu_sel(),
+                                loading: media_loading(),
+                                on_hover: move |index| menu_sel.set(index),
+                                on_select: move |index| {
+                                    if let Some(entry) = media_entries.peek().get(index).cloned() {
+                                        select_media_entry(&entry, draft, menu_sel);
                                     }
-                                }
+                                },
                             }
                         }
                     }

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -4,8 +4,8 @@ use crate::chat_page::composer::{
     PromptEdit, PromptHistoryDirection, ResumeMenuState, SelectorMode, ToolActivity,
     chat_page_title, edit_prompt, filter_models, filter_sessions, is_handoff_boundary,
     menu_direction, move_prompt_history, move_selection, prompt_history_direction,
-    prompt_prefix_at_utf16, resume_menu_state, selector_mode, should_clear_draft_on_escape,
-    should_expand_thinking, should_fetch_resume, tool_activity,
+    resume_menu_state, selector_mode, should_clear_draft_on_escape, should_expand_thinking,
+    should_fetch_resume, tool_activity,
 };
 use crate::chat_page::event::{
     CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT,
@@ -26,13 +26,14 @@ use vmux_command::prompt_media::{
 };
 use vmux_terminal::matrix_rain::MatrixRain;
 use vmux_ui::agent_accent::agent_accent;
-use vmux_ui::components::prompt_box::{PromptBox, PromptPopup};
+use vmux_ui::components::prompt_box::PromptPopup;
+use vmux_ui::components::prompt_composer::{
+    PROMPT_INPUT_ID, PromptComposer, PromptComposerAction, PromptComposerAttachment,
+    focus_prompt_end, prompt_textarea,
+};
 use vmux_ui::favicon::favicon_src_for_url;
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_theme};
-use vmux_ui::prompt_ghost::PromptGhost;
 use wasm_bindgen::{JsCast, closure::Closure};
-
-const PROMPT_ID: &str = "agent-chat-prompt";
 
 /// True when the page has a non-collapsed text selection — so Ctrl+C should copy, not interrupt.
 fn has_text_selection() -> bool {
@@ -75,78 +76,6 @@ fn accent_rgb(color: &str, fallback_rgb: &str) -> String {
     hex_accent_rgb(color)
         .map(|(red, green, blue)| format!("{red} {green} {blue}"))
         .unwrap_or_else(|| fallback_rgb.to_string())
-}
-
-fn prompt_textarea() -> Option<web_sys::HtmlTextAreaElement> {
-    web_sys::window()?
-        .document()?
-        .get_element_by_id(PROMPT_ID)?
-        .dyn_into()
-        .ok()
-}
-
-fn resize_prompt_textarea() {
-    let Some(textarea) = prompt_textarea() else {
-        return;
-    };
-    let _ = textarea.set_attribute("style", "height:auto;overflow-y:hidden");
-    let height = textarea.scroll_height().clamp(40, 160);
-    let overflow = if height == 160 { "auto" } else { "hidden" };
-    let _ = textarea.set_attribute("style", &format!("height:{height}px;overflow-y:{overflow}"));
-}
-
-fn sync_prompt_caret(mut caret: Signal<Option<u32>>, mut scroll_top: Signal<i32>) {
-    let page_active = web_sys::window()
-        .and_then(|window| window.document())
-        .is_some_and(|document| document.has_focus().unwrap_or(false));
-    if !page_active {
-        caret.set(None);
-        return;
-    }
-    let Some(textarea) = prompt_textarea() else {
-        return;
-    };
-    let start = textarea.selection_start().ok().flatten().unwrap_or(0);
-    let end = textarea.selection_end().ok().flatten().unwrap_or(start);
-    caret.set((start == end).then_some(start));
-    scroll_top.set(textarea.scroll_top());
-}
-
-fn install_prompt_page_focus_tracking(caret: Signal<Option<u32>>, scroll_top: Signal<i32>) {
-    let Some(window) = web_sys::window() else {
-        return;
-    };
-
-    let focus = Closure::wrap(Box::new(move || {
-        sync_prompt_caret(caret, scroll_top);
-    }) as Box<dyn FnMut()>);
-    let _ = window.add_event_listener_with_callback("focus", focus.as_ref().unchecked_ref());
-    focus.forget();
-
-    let mut blur_caret = caret;
-    let blur = Closure::wrap(Box::new(move || {
-        blur_caret.set(None);
-    }) as Box<dyn FnMut()>);
-    let _ = window.add_event_listener_with_callback("blur", blur.as_ref().unchecked_ref());
-    blur.forget();
-}
-
-fn focus_prompt_end() {
-    let closure = Closure::once(move || {
-        let Some(textarea) = prompt_textarea() else {
-            return;
-        };
-        let end = textarea.value().encode_utf16().count() as u32;
-        let _ = textarea.focus();
-        let _ = textarea.set_selection_range(end, end);
-    });
-    if let Some(window) = web_sys::window() {
-        let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(
-            closure.as_ref().unchecked_ref(),
-            0,
-        );
-    }
-    closure.forget();
 }
 
 fn prompt_history(items: &[ChatItem], queued: &[QueuedPromptSnapshot]) -> Vec<String> {
@@ -203,7 +132,7 @@ fn select_media_entry(
     };
     draft.set(replace_inline_media_query(&value, query, &replacement));
     menu_sel.set(0);
-    focus_prompt_end();
+    focus_prompt_end(PROMPT_INPUT_ID);
 }
 
 fn dispatch_input_event(textarea: &web_sys::HtmlTextAreaElement) {
@@ -233,13 +162,13 @@ fn dispatch_keyboard_event(
 
 fn install_global_prompt_input(draft: Signal<String>, slash_cmds: Signal<Vec<SlashCommandEntry>>) {
     let closure = Closure::wrap(Box::new(move |event: web_sys::KeyboardEvent| {
-        let Some(textarea) = prompt_textarea() else {
+        let Some(textarea) = prompt_textarea(PROMPT_INPUT_ID) else {
             return;
         };
         let prompt_focused = web_sys::window()
             .and_then(|window| window.document())
             .and_then(|document| document.active_element())
-            .is_some_and(|element| element.id() == PROMPT_ID);
+            .is_some_and(|element| element.id() == PROMPT_INPUT_ID);
         if prompt_focused {
             return;
         }
@@ -338,8 +267,6 @@ pub fn Page(
     let mut attachment_preview_requests = use_signal(HashSet::<String>::new);
     let mut history_cursor = use_signal(|| None::<usize>);
     let mut history_scratch = use_signal(String::new);
-    let prompt_caret = use_signal(|| None::<u32>);
-    let prompt_scroll_top = use_signal(|| 0i32);
     let mut elapsed = use_signal(|| 0u32);
     let mut at_bottom = use_signal(|| true);
     let mut last_top = use_signal(|| 0i32);
@@ -360,12 +287,7 @@ pub fn Page(
     let mut verb = use_signal(|| "Working".to_string());
 
     use_effect(move || install_global_prompt_input(draft, slash_cmds));
-    use_effect(move || install_prompt_page_focus_tracking(prompt_caret, prompt_scroll_top));
-    use_effect(focus_prompt_end);
-    use_effect(move || {
-        let _ = draft.read();
-        resize_prompt_textarea();
-    });
+    use_effect(move || focus_prompt_end(PROMPT_INPUT_ID));
 
     use_future(move || async move {
         loop {
@@ -471,7 +393,7 @@ pub fn Page(
             }
             attachment_previews.set(previews);
             attachments.set(next);
-            focus_prompt_end();
+            focus_prompt_end(PROMPT_INPUT_ID);
         });
     let _attachment_previews = use_bin_event_listener::<ChatAttachments, _>(
         CHAT_ATTACHMENT_PREVIEWS_EVENT,
@@ -595,10 +517,6 @@ pub fn Page(
         }
     };
     let draft_val = draft();
-    let prompt_caret_prefix = prompt_caret()
-        .filter(|_| !draft_val.is_empty())
-        .map(|offset| prompt_prefix_at_utf16(&draft_val, offset).to_string());
-    let prompt_scroll_offset = prompt_scroll_top();
     let selector = selector_mode(&draft_val);
     let command_query = match selector {
         SelectorMode::Commands(query) => Some(query),
@@ -642,6 +560,216 @@ pub fn Page(
             filtered_sessions.len(),
         )
     });
+    let prompt_attachments = transition_attachments
+        .read()
+        .iter()
+        .map(|attachment| PromptComposerAttachment {
+            key: format!("transition-attachment-{}", attachment.path),
+            name: attachment.name.clone(),
+            label: attachment_label(attachment),
+            preview_data_url: attachment.preview_data_url.clone(),
+            remove_index: None,
+        })
+        .chain(
+            attachments
+                .read()
+                .iter()
+                .enumerate()
+                .map(|(index, attachment)| PromptComposerAttachment {
+                    key: format!("attachment-pill-{}", attachment.path),
+                    name: attachment.name.clone(),
+                    label: attachment_label(attachment),
+                    preview_data_url: attachment.preview_data_url.clone(),
+                    remove_index: Some(index),
+                }),
+        )
+        .collect::<Vec<_>>();
+    let prompt_streaming = matches!(status().as_str(), "streaming" | "awaiting");
+    let prompt_action = if prompt_streaming && queued.read().is_empty() {
+        PromptComposerAction::Stop
+    } else {
+        PromptComposerAction::Send
+    };
+    let prompt_action_title = if prompt_streaming && !queued.read().is_empty() {
+        "Send all queued prompts now (Esc)"
+    } else if prompt_streaming {
+        "Stop"
+    } else {
+        "Send (Enter)"
+    };
+    let prompt_action_enabled =
+        prompt_streaming || !draft_val.trim().is_empty() || !attachments.read().is_empty();
+    let prompt_keydown = move |e: KeyboardEvent| {
+        let streaming = matches!(status().as_str(), "streaming" | "awaiting");
+        let draft_now = draft.peek().clone();
+        let (cmd_items, sess_items, model_items, session_selector_open, model_selector_open) =
+            match selector_mode(&draft_now) {
+                SelectorMode::Commands(query) => {
+                    let query = query.to_lowercase();
+                    (
+                        slash_cmds
+                            .peek()
+                            .iter()
+                            .filter(|command| command.name.starts_with(&query))
+                            .cloned()
+                            .collect::<Vec<_>>(),
+                        Vec::new(),
+                        Vec::new(),
+                        false,
+                        false,
+                    )
+                }
+                SelectorMode::Resume(query) => (
+                    Vec::new(),
+                    filter_sessions(&sessions.peek(), query),
+                    Vec::new(),
+                    true,
+                    false,
+                ),
+                SelectorMode::Models(query) => (
+                    Vec::new(),
+                    Vec::new(),
+                    filter_models(&models.peek(), query),
+                    false,
+                    true,
+                ),
+                SelectorMode::None => (Vec::new(), Vec::new(), Vec::new(), false, false),
+            };
+        let media_selector_open = inline_media_query(&draft_now).is_some();
+        let media_items = if media_selector_open {
+            media_entries.peek().clone()
+        } else {
+            Vec::new()
+        };
+        let selector_open = media_selector_open
+            || session_selector_open
+            || model_selector_open
+            || !cmd_items.is_empty();
+        let selector_len = if media_selector_open {
+            media_items.len()
+        } else if session_selector_open {
+            sess_items.len()
+        } else if model_selector_open {
+            model_items.len()
+        } else {
+            cmd_items.len()
+        };
+        let key = e.key().to_string();
+        let command_modifier = e.modifiers().meta() || e.modifiers().ctrl() || e.modifiers().alt();
+        let direction = if e.modifiers().meta() || e.modifiers().alt() {
+            None
+        } else {
+            menu_direction(&key, e.modifiers().ctrl())
+        };
+
+        if selector_open && let Some(direction) = direction {
+            e.prevent_default();
+            let selected = *menu_sel.peek();
+            menu_sel.set(move_selection(selected, selector_len, direction));
+            return;
+        }
+        if selector_open && e.key() == Key::Enter && !e.modifiers().shift() && !command_modifier {
+            e.prevent_default();
+            let selected = *menu_sel.peek();
+            if media_selector_open {
+                if let Some(entry) = media_items.get(selected) {
+                    select_media_entry(entry, draft, menu_sel);
+                }
+            } else if session_selector_open {
+                if let Some(session) = sess_items.get(selected) {
+                    select_resume_session(session, draft);
+                }
+            } else if model_selector_open {
+                if let Some(model) = model_items.get(selected) {
+                    select_model(model, draft);
+                }
+            } else if let Some(command) = cmd_items.get(selected) {
+                run_slash_command(&command.name, draft, menu_sel);
+            }
+            return;
+        }
+        if selector_open && e.key() == Key::Escape && !command_modifier {
+            e.prevent_default();
+            if let Some(query) = inline_media_query(&draft_now) {
+                draft.set(replace_inline_media_query(&draft_now, query, ""));
+                focus_prompt_end(PROMPT_INPUT_ID);
+            } else {
+                draft.set(String::new());
+            }
+            menu_sel.set(0);
+            return;
+        }
+        if (media_selector_open || session_selector_open || model_selector_open)
+            && matches!(e.key(), Key::Enter | Key::Escape)
+        {
+            return;
+        }
+
+        if !selector_open
+            && !e.modifiers().meta()
+            && !e.modifiers().alt()
+            && let Some(textarea) = prompt_textarea(PROMPT_INPUT_ID)
+        {
+            let start = textarea
+                .selection_start()
+                .ok()
+                .flatten()
+                .unwrap_or_default();
+            let end = textarea.selection_end().ok().flatten().unwrap_or(start);
+            if let Some(direction) =
+                prompt_history_direction(&key, e.modifiers().ctrl(), &draft_now, start, end)
+            {
+                let history = prompt_history(&items.peek(), &queued.peek());
+                let current_cursor = *history_cursor.peek();
+                let should_handle = match direction {
+                    PromptHistoryDirection::Older => !history.is_empty(),
+                    PromptHistoryDirection::Newer => current_cursor.is_some(),
+                };
+                if should_handle {
+                    e.prevent_default();
+                    let (value, cursor, scratch) = move_prompt_history(
+                        &history,
+                        current_cursor,
+                        &history_scratch.peek(),
+                        &draft_now,
+                        direction,
+                    );
+                    draft.set(value);
+                    history_cursor.set(cursor);
+                    history_scratch.set(scratch);
+                    focus_prompt_end(PROMPT_INPUT_ID);
+                    return;
+                }
+            }
+        }
+
+        if e.key() == Key::Enter && !e.modifiers().shift() {
+            e.prevent_default();
+            do_submit(
+                draft,
+                attachments,
+                history_cursor,
+                history_scratch,
+                at_bottom,
+            );
+        } else if e.key() == Key::Escape {
+            e.prevent_default();
+            let _ = try_cef_bin_emit_rkyv(&ChatEscape);
+            if should_clear_draft_on_escape(
+                streaming,
+                queued.peek().is_empty(),
+                draft.peek().is_empty(),
+            ) {
+                draft.set(String::new());
+            }
+        } else if e.modifiers().ctrl()
+            && matches!(e.key(), Key::Character(c) if c == "c")
+            && !has_text_selection()
+        {
+            e.prevent_default();
+            let _ = try_cef_bin_emit_rkyv(&ChatCancel);
+        }
+    };
 
     use_effect(move || {
         let selected = menu_sel();
@@ -1087,382 +1215,55 @@ pub fn Page(
                             }
                         }
                     }
-                    PromptBox { class: "agent-chat-prompt-box",
-                        button {
-                            class: "relative z-10 ml-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg text-foreground/45 transition hover:bg-foreground/10 hover:text-foreground",
-                            title: "Attach files (/upload)",
-                            onclick: move |_| {
-                                let _ = try_cef_bin_emit_rkyv(&ChatPickFiles);
-                            },
-                            svg {
-                                class: "h-4 w-4",
-                                view_box: "0 0 24 24",
-                                fill: "none",
-                                stroke: "currentColor",
-                                stroke_width: "2",
-                                stroke_linecap: "round",
-                                stroke_linejoin: "round",
-                                path { d: "M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48" }
+                    PromptComposer {
+                        value: draft_val.clone(),
+                        preview: transition_preview(),
+                        attachments: prompt_attachments,
+                        show_examples: show_capability_examples,
+                        placeholder: "Type / for commands or @ for media".to_string(),
+                        accent_bg: agent_accent.accent_bg.to_string(),
+                        accent_color: theme_accent.clone(),
+                        accent_gradient: agent_accent.grad.to_string(),
+                        action: prompt_action,
+                        action_title: prompt_action_title.to_string(),
+                        action_enabled: prompt_action_enabled,
+                        on_input: move |value| {
+                            draft.set(value);
+                            history_cursor.set(None);
+                            history_scratch.set(String::new());
+                            menu_sel.set(0);
+                        },
+                        on_keydown: prompt_keydown,
+                        on_paste: move |_| {
+                            let _ = try_cef_bin_emit_rkyv(&ChatPasteMedia);
+                        },
+                        on_attach: move |_| {
+                            let _ = try_cef_bin_emit_rkyv(&ChatPickFiles);
+                        },
+                        on_remove_attachment: move |index| {
+                            let mut next = attachments.peek().clone();
+                            if index < next.len() {
+                                next.remove(index);
+                                attachments.set(next);
                             }
-                        }
-                        div { class: "relative z-10 flex min-w-0 flex-1 flex-wrap items-center gap-1 px-2",
-                            for attachment in transition_attachments.read().iter() {
-                                div {
-                                    key: "transition-attachment-{attachment.path}",
-                                    class: "flex h-7 max-w-56 shrink-0 items-center gap-1.5 rounded-full bg-foreground/[0.08] pl-1 pr-2 text-xs text-foreground/80 ring-1 ring-inset ring-foreground/10",
-                                    if attachment.preview_data_url.is_empty() {
-                                        span { class: "flex h-5 min-w-5 items-center justify-center rounded-full bg-foreground/[0.08] px-1 font-mono text-[8px] font-semibold text-muted-foreground",
-                                            "{attachment_label(attachment)}"
-                                        }
-                                    } else {
-                                        img {
-                                            src: "{attachment.preview_data_url}",
-                                            alt: "{attachment.name}",
-                                            class: "h-5 w-5 rounded-full object-cover",
-                                        }
-                                    }
-                                    span { class: "min-w-0 max-w-40 truncate", "{attachment.name}" }
-                                }
-                            }
-                            for (i , attachment) in attachments.read().iter().cloned().enumerate() {
-                                div {
-                                    key: "attachment-pill-{attachment.path}",
-                                    class: "group flex h-7 max-w-56 shrink-0 items-center gap-1.5 rounded-full bg-foreground/[0.08] pl-1 pr-1.5 text-xs text-foreground/80 ring-1 ring-inset ring-foreground/10",
-                                    if attachment.preview_data_url.is_empty() {
-                                        span { class: "flex h-5 min-w-5 items-center justify-center rounded-full bg-foreground/[0.08] px-1 font-mono text-[8px] font-semibold text-muted-foreground",
-                                            "{attachment_label(&attachment)}"
-                                        }
-                                    } else {
-                                        img {
-                                            src: "{attachment.preview_data_url}",
-                                            alt: "{attachment.name}",
-                                            class: "h-5 w-5 rounded-full object-cover",
-                                        }
-                                    }
-                                    span { class: "min-w-0 max-w-40 truncate", "{attachment.name}" }
-                                    button {
-                                        class: "flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-foreground/45 transition hover:bg-foreground/10 hover:text-foreground",
-                                        title: "Remove attachment",
-                                        onclick: move |_| {
-                                            let mut next = attachments.peek().clone();
-                                            if i < next.len() {
-                                                next.remove(i);
-                                                attachments.set(next);
-                                            }
-                                        },
-                                        svg {
-                                            class: "h-3 w-3",
-                                            view_box: "0 0 24 24",
-                                            fill: "none",
-                                            stroke: "currentColor",
-                                            stroke_width: "2.5",
-                                            stroke_linecap: "round",
-                                            path { d: "M6 6l12 12M18 6L6 18" }
-                                        }
-                                    }
-                                }
-                            }
-                            div { class: "relative min-w-32 flex-1 overflow-hidden",
-                                if draft.read().is_empty() {
-                                    div { class: "pointer-events-none absolute inset-0 flex -translate-y-px items-center overflow-hidden px-1.5",
-                                        if !transition_preview.read().is_empty() {
-                                            div { class: "max-w-full truncate whitespace-nowrap text-[15px] leading-6 text-foreground", "{transition_preview}" }
-                                        } else if show_capability_examples {
-                                            PromptGhost {
-                                                accent_bg: agent_accent.accent_bg.to_string(),
-                                                terminal: false,
-                                            }
-                                        } else {
-                                            div { class: "flex max-w-full items-center whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50",
-                                                if prompt_caret().is_some() {
-                                                    span { class: "agent-chat-caret relative top-px mr-px h-4 w-1.5 shrink-0" }
-                                                }
-                                                span { class: "min-w-0 truncate", "Type / for commands or @ for media" }
-                                            }
-                                        }
-                                    }
-                                }
-                                if let Some(prefix) = prompt_caret_prefix.as_ref() {
-                                    div { class: "pointer-events-none absolute inset-0 z-20 overflow-hidden",
-                                        div {
-                                            class: "min-h-10 w-full whitespace-pre-wrap break-words px-1.5 py-2 text-[15px] leading-6 text-transparent",
-                                            style: "transform:translateY(-{prompt_scroll_offset}px);",
-                                            span { "{prefix}" }
-                                            span { class: "agent-chat-caret relative top-px ml-px inline-block h-4 w-1.5 align-middle" }
-                                        }
-                                    }
-                                }
-                                textarea {
-                                id: PROMPT_ID,
-                                class: "agent-chat-prompt relative z-10 max-h-40 min-h-10 w-full resize-none bg-transparent px-1.5 py-2 text-[15px] leading-6 placeholder:text-transparent focus:outline-none",
-                                autofocus: true,
-                                rows: "1",
-                                placeholder: "Message the agent…",
-                                value: "{draft}",
-                                oninput: move |e| {
-                                    draft.set(e.value());
-                                    history_cursor.set(None);
-                                    history_scratch.set(String::new());
-                                    menu_sel.set(0);
-                                    sync_prompt_caret(prompt_caret, prompt_scroll_top);
-                                },
-                                onpaste: move |_| {
-                                    let _ = try_cef_bin_emit_rkyv(&ChatPasteMedia);
-                                },
-                                onfocus: move |_| sync_prompt_caret(prompt_caret, prompt_scroll_top),
-                                onblur: move |_| sync_prompt_caret(prompt_caret, prompt_scroll_top),
-                                onkeyup: move |_| sync_prompt_caret(prompt_caret, prompt_scroll_top),
-                                onmouseup: move |_| sync_prompt_caret(prompt_caret, prompt_scroll_top),
-                                onscroll: move |_| sync_prompt_caret(prompt_caret, prompt_scroll_top),
-                                onkeydown: move |e| {
-                                    let streaming = matches!(status().as_str(), "streaming" | "awaiting");
-                                    let draft_now = draft.peek().clone();
-                                    let (cmd_items, sess_items, model_items, session_selector_open, model_selector_open) = match selector_mode(&draft_now) {
-                                        SelectorMode::Commands(query) => {
-                                            let query = query.to_lowercase();
-                                            (
-                                                slash_cmds
-                                                    .peek()
-                                                    .iter()
-                                                    .filter(|command| command.name.starts_with(&query))
-                                                    .cloned()
-                                                    .collect::<Vec<_>>(),
-                                                Vec::new(),
-                                                Vec::new(),
-                                                false,
-                                                false,
-                                            )
-                                        }
-                                        SelectorMode::Resume(query) => (
-                                            Vec::new(),
-                                            filter_sessions(&sessions.peek(), query),
-                                            Vec::new(),
-                                            true,
-                                            false,
-                                        ),
-                                        SelectorMode::Models(query) => (
-                                            Vec::new(),
-                                            Vec::new(),
-                                            filter_models(&models.peek(), query),
-                                            false,
-                                            true,
-                                        ),
-                                        SelectorMode::None => (Vec::new(), Vec::new(), Vec::new(), false, false),
-                                    };
-                                    let media_selector_open = inline_media_query(&draft_now).is_some();
-                                    let media_items = if media_selector_open {
-                                        media_entries.peek().clone()
-                                    } else {
-                                        Vec::new()
-                                    };
-                                    let selector_open = media_selector_open
-                                        || session_selector_open
-                                        || model_selector_open
-                                        || !cmd_items.is_empty();
-                                    let selector_len = if media_selector_open {
-                                        media_items.len()
-                                    } else if session_selector_open {
-                                        sess_items.len()
-                                    } else if model_selector_open {
-                                        model_items.len()
-                                    } else {
-                                        cmd_items.len()
-                                    };
-                                    let key = e.key().to_string();
-                                    let command_modifier = e.modifiers().meta()
-                                        || e.modifiers().ctrl()
-                                        || e.modifiers().alt();
-                                    let direction = if e.modifiers().meta() || e.modifiers().alt() {
-                                        None
-                                    } else {
-                                        menu_direction(&key, e.modifiers().ctrl())
-                                    };
-
-                                    if selector_open && let Some(direction) = direction {
-                                        e.prevent_default();
-                                        let selected = *menu_sel.peek();
-                                        menu_sel.set(move_selection(selected, selector_len, direction));
-                                        return;
-                                    }
-                                    if selector_open
-                                        && e.key() == Key::Enter
-                                        && !e.modifiers().shift()
-                                        && !command_modifier
-                                    {
-                                        e.prevent_default();
-                                        let selected = *menu_sel.peek();
-                                        if media_selector_open {
-                                            if let Some(entry) = media_items.get(selected) {
-                                                select_media_entry(entry, draft, menu_sel);
-                                            }
-                                        } else if session_selector_open {
-                                            if let Some(session) = sess_items.get(selected) {
-                                                select_resume_session(session, draft);
-                                            }
-                                        } else if model_selector_open {
-                                            if let Some(model) = model_items.get(selected) {
-                                                select_model(model, draft);
-                                            }
-                                        } else if let Some(command) = cmd_items.get(selected) {
-                                            run_slash_command(&command.name, draft, menu_sel);
-                                        }
-                                        return;
-                                    }
-                                    if selector_open && e.key() == Key::Escape && !command_modifier {
-                                        e.prevent_default();
-                                        if let Some(query) = inline_media_query(&draft_now) {
-                                            draft.set(replace_inline_media_query(&draft_now, query, ""));
-                                            focus_prompt_end();
-                                        } else {
-                                            draft.set(String::new());
-                                        }
-                                        menu_sel.set(0);
-                                        return;
-                                    }
-                                    if (media_selector_open || session_selector_open || model_selector_open)
-                                        && matches!(e.key(), Key::Enter | Key::Escape)
-                                    {
-                                        return;
-                                    }
-
-                                    if !selector_open
-                                        && !e.modifiers().meta()
-                                        && !e.modifiers().alt()
-                                        && let Some(textarea) = prompt_textarea()
-                                    {
-                                        let start = textarea
-                                            .selection_start()
-                                            .ok()
-                                            .flatten()
-                                            .unwrap_or_default();
-                                        let end = textarea
-                                            .selection_end()
-                                            .ok()
-                                            .flatten()
-                                            .unwrap_or(start);
-                                        if let Some(direction) = prompt_history_direction(
-                                            &key,
-                                            e.modifiers().ctrl(),
-                                            &draft_now,
-                                            start,
-                                            end,
-                                        ) {
-                                            let history = prompt_history(&items.peek(), &queued.peek());
-                                            let current_cursor = *history_cursor.peek();
-                                            let should_handle = match direction {
-                                                PromptHistoryDirection::Older => !history.is_empty(),
-                                                PromptHistoryDirection::Newer => current_cursor.is_some(),
-                                            };
-                                            if should_handle {
-                                                e.prevent_default();
-                                                let (value, cursor, scratch) = move_prompt_history(
-                                                    &history,
-                                                    current_cursor,
-                                                    &history_scratch.peek(),
-                                                    &draft_now,
-                                                    direction,
-                                                );
-                                                draft.set(value);
-                                                history_cursor.set(cursor);
-                                                history_scratch.set(scratch);
-                                                focus_prompt_end();
-                                                return;
-                                            }
-                                        }
-                                    }
-
-                                    if e.key() == Key::Enter && !e.modifiers().shift() {
-                                        e.prevent_default();
-                                        do_submit(
-                                            draft,
-                                            attachments,
-                                            history_cursor,
-                                            history_scratch,
-                                            at_bottom,
-                                        );
-                                    } else if e.key() == Key::Escape {
-                                        e.prevent_default();
-                                        let _ = try_cef_bin_emit_rkyv(&ChatEscape);
-                                        if should_clear_draft_on_escape(
-                                            streaming,
-                                            queued.peek().is_empty(),
-                                            draft.peek().is_empty(),
-                                        ) {
-                                            draft.set(String::new());
-                                        }
-                                    } else if e.modifiers().ctrl()
-                                        && matches!(e.key(), Key::Character(c) if c == "c")
-                                        && !has_text_selection()
-                                    {
-                                        e.prevent_default();
-                                        let _ = try_cef_bin_emit_rkyv(&ChatCancel);
-                                    }
-                                },
-                                }
-                            }
-                        }
-                        if matches!(status().as_str(), "streaming" | "awaiting") {
-                            if queued.read().is_empty() {
-                                button {
-                                    class: "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg bg-white/40 text-foreground/70 shadow-sm ring-1 ring-inset ring-black/10 transition hover:bg-white/60 hover:text-foreground active:scale-95 dark:bg-white/[0.08] dark:ring-white/10 dark:hover:bg-white/[0.14]",
-                                    title: "Stop",
-                                    onclick: move |_| {
-                                        let _ = try_cef_bin_emit_rkyv(&ChatCancel);
-                                    },
-                                    svg {
-                                        class: "h-4 w-4",
-                                        view_box: "0 0 24 24",
-                                        fill: "currentColor",
-                                        rect { x: "6", y: "6", width: "12", height: "12", rx: "2.5" }
-                                    }
+                        },
+                        on_action: move |_| {
+                            if prompt_streaming {
+                                if queued.peek().is_empty() {
+                                    let _ = try_cef_bin_emit_rkyv(&ChatCancel);
+                                } else {
+                                    let _ = try_cef_bin_emit_rkyv(&ChatEscape);
                                 }
                             } else {
-                                button {
-                                    class: "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg bg-gradient-to-br text-white shadow-lg transition hover:brightness-110 active:scale-95 {agent_accent.grad}",
-                                    title: "Send all queued prompts now (Esc)",
-                                    onclick: move |_| {
-                                        let _ = try_cef_bin_emit_rkyv(&ChatEscape);
-                                    },
-                                    svg {
-                                        class: "h-4 w-4",
-                                        view_box: "0 0 24 24",
-                                        fill: "none",
-                                        stroke: "currentColor",
-                                        stroke_width: "2",
-                                        stroke_linecap: "round",
-                                        stroke_linejoin: "round",
-                                        path { d: "M12 19V5" }
-                                        path { d: "M5 12l7-7 7 7" }
-                                    }
-                                }
+                                do_submit(
+                                    draft,
+                                    attachments,
+                                    history_cursor,
+                                    history_scratch,
+                                    at_bottom,
+                                );
                             }
-                        } else {
-                            button {
-                                class: if draft.read().trim().is_empty() && attachments.read().is_empty() { "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 cursor-default self-center items-center justify-center rounded-lg bg-white/25 text-muted-foreground/35 shadow-sm ring-1 ring-inset ring-black/[0.06] dark:bg-white/[0.055] dark:ring-white/[0.08]" } else { "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg bg-gradient-to-br text-white shadow-lg transition hover:brightness-110 active:scale-95 {agent_accent.grad}" },
-                                disabled: draft.read().trim().is_empty() && attachments.read().is_empty(),
-                                title: "Send (Enter)",
-                                onclick: move |_| {
-                                    do_submit(
-                                        draft,
-                                        attachments,
-                                        history_cursor,
-                                        history_scratch,
-                                        at_bottom,
-                                    )
-                                },
-                                svg {
-                                    class: "h-4 w-4",
-                                    view_box: "0 0 24 24",
-                                    fill: "none",
-                                    stroke: "currentColor",
-                                    stroke_width: "2",
-                                    stroke_linecap: "round",
-                                    stroke_linejoin: "round",
-                                    path { d: "M12 19V5" }
-                                    path { d: "M5 12l7-7 7 7" }
-                                }
-                            }
-                        }
+                        },
                     }
                 }
             }
@@ -2326,12 +2127,7 @@ fn md_to_html(src: &str) -> String {
 /// HTML, and its preflight strips heading/list defaults). Theme-neutral rgba so it works in both
 /// light and dark.
 const MD_CSS: &str = r#"
-.agent-chat-prompt{caret-color:transparent}
-.agent-chat-caret{animation:agent-chat-caret-blink 1s step-end infinite;background:var(--agent-accent)}
-@keyframes agent-chat-caret-blink{0%,49%{opacity:1}50%,100%{opacity:0}}
 .agent-chat-prompt-shell::before{content:"";position:absolute;inset:-28px -42px;z-index:-1;border-radius:2.5rem;background:radial-gradient(60% 90% at 50% 75%,rgba(255,255,255,0.1),transparent 72%);filter:blur(16px);pointer-events:none}
-.agent-chat-prompt-box{border-color:rgba(255,255,255,0.18);box-shadow:0 22px 70px -28px rgba(255,255,255,0.2),inset 0 1px 0 rgba(255,255,255,0.16),inset 0 -1px 0 rgba(255,255,255,0.04)}
-.agent-chat-prompt-box:focus-within{border-color:rgba(255,255,255,0.28);box-shadow:0 26px 78px -26px rgba(255,255,255,0.28),inset 0 1px 0 rgba(255,255,255,0.2)}
 .agent-chat-page{background-image:radial-gradient(80% 55% at 15% 0%,color-mix(in srgb,var(--agent-accent) 9%,transparent),transparent 65%),radial-gradient(75% 55% at 90% 10%,color-mix(in srgb,var(--agent-accent) 7%,transparent),transparent 62%),radial-gradient(65% 45% at 55% 100%,color-mix(in srgb,var(--agent-accent) 5%,transparent),transparent 70%)}
 .agent-chat-glow-primary{background:color-mix(in srgb,var(--agent-accent) 8%,transparent)}
 .agent-chat-glow-secondary{background:color-mix(in srgb,var(--agent-accent) 6%,transparent)}

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -26,7 +26,8 @@ use vmux_command::open_target::OpenTarget;
 use vmux_command::prompt_media::{
     CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT, ChatAttachPaths, ChatAttachment,
     ChatAttachments, ChatMediaEntries, ChatMediaEntry, ChatMediaListRequest, ChatPasteMedia,
-    ChatPickFiles, inline_media_query, media_reference, replace_inline_media_query,
+    ChatPickFiles, inline_media_query, media_display_path, media_reference,
+    replace_inline_media_query,
 };
 use vmux_ui::agent_accent::agent_accent;
 use vmux_ui::components::icon::Icon;
@@ -34,6 +35,7 @@ use vmux_ui::components::prompt_box::{PromptBox, PromptPopup, PromptPopupPlaceme
 use vmux_ui::components::prompt_composer::{
     PROMPT_INPUT_ID, PromptComposer, PromptComposerAttachment, focus_prompt_end,
 };
+use vmux_ui::components::prompt_media_options::{PromptMediaOption, PromptMediaOptions};
 use vmux_ui::favicon::Favicon;
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener};
 use vmux_ui::icon::PageIconView;
@@ -267,6 +269,18 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let media_query = is_start.then(|| inline_media_query(&q)).flatten();
     let media_menu_open = media_query.is_some();
     let media_sel = media_selected().min(media_entries.read().len().saturating_sub(1));
+    let prompt_media_options = media_entries
+        .read()
+        .iter()
+        .map(|entry| PromptMediaOption {
+            key: format!("media-{}", entry.path),
+            name: entry.name.clone(),
+            display_path: media_display_path(entry),
+            preview_data_url: entry.preview_data_url.clone(),
+            label: file_extension_label(&entry.name),
+            is_dir: entry.is_dir,
+        })
+        .collect::<Vec<_>>();
     let start_prompt_mode = is_start && is_start_prompt_query(&q);
     let results: Vec<ResultItem> = if space_switch {
         space_switch_results(&spaces, &pages, &q)
@@ -403,7 +417,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
         if let Some(element) = web_sys::window()
             .and_then(|window| window.document())
             .and_then(|document| {
-                document.get_element_by_id(&format!("command-bar-media-item-{selected}"))
+                document.get_element_by_id(&format!("prompt-media-item-{selected}"))
             })
         {
             let options = web_sys::ScrollIntoViewOptions::new();
@@ -933,48 +947,16 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                 PromptPopup {
                     placement: PromptPopupPlacement::Downward,
                     id: "command-bar-results",
-                    if media_loading() {
-                        div { class: "px-3.5 py-2 text-sm text-muted-foreground", "Loading media…" }
-                    } else if media_entries.read().is_empty() {
-                        div { class: "px-3.5 py-2 text-sm text-muted-foreground", "No matching media" }
-                    } else {
-                        for (i, entry) in media_entries.read().iter().cloned().enumerate() {
-                            {
-                                let entry = entry.clone();
-                                rsx! {
-                                    div {
-                                        key: "start-media-{entry.path}",
-                                        id: "command-bar-media-item-{i}",
-                                        class: if i == media_sel { "flex cursor-pointer items-center gap-3 bg-foreground/10 px-3.5 py-2" } else { "flex cursor-pointer items-center gap-3 px-3.5 py-2" },
-                                        onmouseenter: move |_| media_selected.set(i),
-                                        onclick: move |_| select_start_media_entry(
-                                            &entry,
-                                            query,
-                                            media_selected,
-                                        ),
-                                        div { class: "flex h-12 w-16 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-foreground/[0.06] text-muted-foreground ring-1 ring-inset ring-foreground/10",
-                                            if entry.is_dir {
-                                                Icon { class: "h-4 w-4",
-                                                    path { d: "M3 6h6l2 2h10v10H3z" }
-                                                }
-                                            } else if !entry.preview_data_url.is_empty() {
-                                                img {
-                                                    src: "{entry.preview_data_url}",
-                                                    alt: "{entry.name}",
-                                                    class: "h-full w-full object-contain",
-                                                }
-                                            } else {
-                                                span { class: "font-mono text-[9px] font-semibold", "{file_extension_label(&entry.name)}" }
-                                            }
-                                        }
-                                        div { class: "min-w-0 flex-1",
-                                            div { class: "truncate text-sm text-foreground", "{entry.name}" }
-                                            div { class: "truncate text-xs text-muted-foreground", "{entry.parent}" }
-                                        }
-                                    }
-                                }
+                    PromptMediaOptions {
+                        items: prompt_media_options,
+                        selected: media_sel,
+                        loading: media_loading(),
+                        on_hover: move |index| media_selected.set(index),
+                        on_select: move |index| {
+                            if let Some(entry) = media_entries.peek().get(index).cloned() {
+                                select_start_media_entry(&entry, query, media_selected);
                             }
-                        }
+                        },
                     }
                 }
             }

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -31,10 +31,12 @@ use vmux_command::prompt_media::{
 use vmux_ui::agent_accent::agent_accent;
 use vmux_ui::components::icon::Icon;
 use vmux_ui::components::prompt_box::{PromptBox, PromptPopup, PromptPopupPlacement};
+use vmux_ui::components::prompt_composer::{
+    PROMPT_INPUT_ID, PromptComposer, PromptComposerAttachment, focus_prompt_end,
+};
 use vmux_ui::favicon::Favicon;
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener};
 use vmux_ui::icon::PageIconView;
-use vmux_ui::prompt_ghost::PromptGhost;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 
@@ -158,7 +160,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                 }
             }
             attachments.set(next);
-            focus_command_input_end();
+            focus_prompt_end(PROMPT_INPUT_ID);
         });
 
     let _media_entries_listener =
@@ -232,7 +234,11 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
         let open_id = state().open_id;
         if command_bar_should_refocus(last_focus_open_id(), open_id) {
             last_focus_open_id.set(open_id);
-            focus_and_install_ctrl_bindings();
+            if is_start {
+                focus_prompt_end(PROMPT_INPUT_ID);
+            } else {
+                focus_and_install_ctrl_bindings();
+            }
         }
     });
 
@@ -500,6 +506,245 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
             }
         }
     };
+    let start_accent = active_agent_accent.unwrap_or_else(|| agent_accent("vibe"));
+    let start_prompt_attachments = attachments
+        .read()
+        .iter()
+        .enumerate()
+        .map(|(index, attachment)| PromptComposerAttachment {
+            key: format!("start-attachment-{}", attachment.path),
+            name: attachment.name.clone(),
+            label: file_extension_label(&attachment.name),
+            preview_data_url: attachment.preview_data_url.clone(),
+            remove_index: Some(index),
+        })
+        .collect::<Vec<_>>();
+    let start_action_enabled = !q.trim().is_empty() || !attachments.read().is_empty();
+    let start_keydown_q = q.clone();
+    let start_keydown_results = results.clone();
+    let start_keydown_default_agent = default_agent_item.clone();
+    let start_keydown_ghost = ghost_text.clone();
+    let start_keydown = move |e: KeyboardEvent| {
+        if e.key() == Key::Tab {
+            e.prevent_default();
+            if !start_keydown_ghost.is_empty() {
+                query.set(format!("{}{}", start_keydown_q, start_keydown_ghost));
+                selected.set(0);
+                focus_prompt_end(PROMPT_INPUT_ID);
+            }
+            return;
+        }
+
+        let ctrl = e.modifiers().contains(Modifiers::CONTROL);
+        if space_switch
+            && !ctrl
+            && start_keydown_q.trim().is_empty()
+            && let Key::Character(s) = e.key()
+            && let Some(idx) = s
+                .chars()
+                .next()
+                .filter(|c| c.is_ascii_digit())
+                .and_then(|c| c.to_digit(10))
+        {
+            let space_count = start_keydown_results
+                .iter()
+                .filter(|result| matches!(result, ResultItem::Space { .. }))
+                .count();
+            if (idx as usize) < space_count {
+                e.prevent_default();
+                selected.set(idx as usize);
+                nav_mode.set(true);
+                return;
+            }
+        }
+        let go_down = (e.key() == Key::ArrowDown && !ctrl)
+            || (ctrl && matches!(e.code(), Code::KeyN | Code::KeyJ));
+        let go_up = (e.key() == Key::ArrowUp && !ctrl)
+            || (ctrl && matches!(e.code(), Code::KeyP | Code::KeyK));
+
+        if media_menu_open {
+            if go_down {
+                e.prevent_default();
+                let max = media_entries.read().len().saturating_sub(1);
+                media_selected.set((media_sel + 1).min(max));
+                return;
+            }
+            if go_up {
+                e.prevent_default();
+                media_selected.set(media_sel.saturating_sub(1));
+                return;
+            }
+            if e.key() == Key::Enter && !e.modifiers().shift() {
+                e.prevent_default();
+                if let Some(entry) = media_entries.read().get(media_sel).cloned() {
+                    select_start_media_entry(&entry, query, media_selected);
+                }
+                return;
+            }
+            if e.key() == Key::Escape {
+                e.prevent_default();
+                if let Some(media_query) = inline_media_query(&start_keydown_q) {
+                    query.set(replace_inline_media_query(
+                        &start_keydown_q,
+                        media_query,
+                        "",
+                    ));
+                }
+                media_selected.set(0);
+                return;
+            }
+        }
+
+        if go_down {
+            e.prevent_default();
+            let max = start_keydown_results.len().saturating_sub(1);
+            selected.set((sel + 1).min(max));
+            nav_mode.set(true);
+        } else if go_up {
+            e.prevent_default();
+            selected.set(sel.saturating_sub(1));
+            nav_mode.set(true);
+        } else if e.key() == Key::Escape || (ctrl && e.code() == Code::KeyC) {
+            on_dismiss.call(());
+        } else if e.key() == Key::Enter && !e.modifiers().shift() {
+            e.prevent_default();
+            if start_keydown_q.trim().is_empty() && !attachments.peek().is_empty() {
+                if let Some(item) = start_keydown_default_agent.as_ref() {
+                    execute(item);
+                } else {
+                    let selected_attachments = attachments.peek().clone();
+                    emit_prompt_action("", open_target, "", &selected_attachments);
+                }
+                return;
+            }
+            if space_switch {
+                if let Some(item) = start_keydown_results.get(sel) {
+                    execute(item);
+                }
+            } else if start_prompt_mode {
+                if let Some(item) = start_keydown_results.get(sel) {
+                    execute(item);
+                } else {
+                    on_close.call(());
+                    let selected_attachments = attachments.peek().clone();
+                    emit_prompt_action(
+                        start_keydown_q.trim(),
+                        open_target,
+                        "",
+                        &selected_attachments,
+                    );
+                }
+            } else {
+                let prefer_page = matches!(
+                    start_keydown_results.get(sel),
+                    Some(ResultItem::Page { url, .. })
+                        if start_keydown_q.trim().starts_with("vmux://")
+                            && url.starts_with(start_keydown_q.trim())
+                );
+                if !prefer_page
+                    && should_open_typed_query_on_enter(open_target, nav_mode(), &start_keydown_q)
+                {
+                    on_close.call(());
+                    emit_action_with_target("open", &start_keydown_q, open_target);
+                } else if let Some(item) = start_keydown_results.get(sel) {
+                    execute(item);
+                } else if !start_keydown_q.is_empty() {
+                    emit_action_with_target("open", &start_keydown_q, open_target);
+                }
+            }
+        }
+    };
+    let modal_keydown_q = q.clone();
+    let modal_keydown_results = results.clone();
+    let modal_keydown_ghost = ghost_text.clone();
+    let modal_keydown = move |e: KeyboardEvent| {
+        if e.key() == Key::Tab {
+            e.prevent_default();
+            if !modal_keydown_ghost.is_empty() {
+                let new_value = format!("{}{}", modal_keydown_q, modal_keydown_ghost);
+                query.set(new_value.clone());
+                selected.set(0);
+                if let Some(element) = web_sys::window()
+                    .and_then(|window| window.document())
+                    .and_then(|document| document.get_element_by_id("command-bar-input"))
+                {
+                    let input: web_sys::HtmlInputElement = element.unchecked_into();
+                    input.set_value(&new_value);
+                    let len = new_value.len() as u32;
+                    let _ = input.set_selection_range(len, len);
+                    ensure_caret_visible(&input, new_value.len());
+                }
+            }
+            return;
+        }
+
+        let ctrl = e.modifiers().contains(Modifiers::CONTROL);
+        let vmux_synthetic = is_vmux_synthetic_dioxus_keydown(&e);
+        if ctrl && ignore_physical_rerouted_ctrl_keydown(&e.code().to_string(), vmux_synthetic) {
+            e.prevent_default();
+            return;
+        }
+        if space_switch
+            && !ctrl
+            && modal_keydown_q.trim().is_empty()
+            && let Key::Character(s) = e.key()
+            && let Some(index) = s
+                .chars()
+                .next()
+                .filter(|character| character.is_ascii_digit())
+                .and_then(|character| character.to_digit(10))
+        {
+            let space_count = modal_keydown_results
+                .iter()
+                .filter(|result| matches!(result, ResultItem::Space { .. }))
+                .count();
+            if (index as usize) < space_count {
+                e.prevent_default();
+                selected.set(index as usize);
+                nav_mode.set(true);
+                return;
+            }
+        }
+        let go_down = (e.key() == Key::ArrowDown && !ctrl)
+            || (ctrl && matches!(e.code(), Code::KeyN | Code::KeyJ));
+        let go_up = (e.key() == Key::ArrowUp && !ctrl)
+            || (ctrl && matches!(e.code(), Code::KeyP | Code::KeyK));
+        if go_down {
+            e.prevent_default();
+            let max = modal_keydown_results.len().saturating_sub(1);
+            selected.set((sel + 1).min(max));
+            nav_mode.set(true);
+        } else if go_up {
+            e.prevent_default();
+            selected.set(sel.saturating_sub(1));
+            nav_mode.set(true);
+        } else if e.key() == Key::Escape || (ctrl && e.code() == Code::KeyC) {
+            on_dismiss.call(());
+        } else if e.key() == Key::Enter {
+            if space_switch {
+                if let Some(item) = modal_keydown_results.get(sel) {
+                    execute(item);
+                }
+            } else {
+                let prefer_page = matches!(
+                    modal_keydown_results.get(sel),
+                    Some(ResultItem::Page { url, .. })
+                        if modal_keydown_q.trim().starts_with("vmux://")
+                            && url.starts_with(modal_keydown_q.trim())
+                );
+                if !prefer_page
+                    && should_open_typed_query_on_enter(open_target, nav_mode(), &modal_keydown_q)
+                {
+                    on_close.call(());
+                    emit_action_with_target("open", &modal_keydown_q, open_target);
+                } else if let Some(item) = modal_keydown_results.get(sel) {
+                    execute(item);
+                } else if !modal_keydown_q.is_empty() {
+                    emit_action_with_target("open", &modal_keydown_q, open_target);
+                }
+            }
+        }
+    };
 
     rsx! {
         div { class: "relative",
@@ -509,377 +754,180 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                     div { class: "{accent.glow_bottom} transition-all duration-500 ease-out" }
                 }
             }
-            PromptBox {
-                glass: is_start,
-                class: if is_start { "" } else { "p-2" },
-                div { class: if is_start { "relative z-10 flex min-w-0 w-full flex-wrap items-center gap-2 overflow-hidden px-2 py-1" } else { command_bar_input_row_class() },
-                if !is_start && !space_name.is_empty() {
-                    span {
-                        title: "{space_name}",
-                        class: "max-w-36 shrink-0 truncate rounded-md bg-glass-hover px-2 py-1 text-ui-xs font-medium text-muted-foreground",
-                        "{space_name}"
-                    }
-                }
-                if is_start {
-                    button {
-                        class: "relative z-10 ml-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg text-foreground/45 transition hover:bg-foreground/10 hover:text-foreground",
-                        title: "Attach files",
-                        onmousedown: move |event| event.prevent_default(),
-                        onclick: move |_| {
-                            let _ = try_cef_bin_emit_rkyv(&ChatPickFiles);
-                        },
-                        Icon { class: "h-4 w-4",
-                            path { d: "M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48" }
+            if is_start {
+                PromptComposer {
+                    value: display_text.clone(),
+                    completion: ghost_text.clone(),
+                    attachments: start_prompt_attachments,
+                    show_examples: q.is_empty() && ghost_text.is_empty(),
+                    placeholder: "Type / for commands or @ for media".to_string(),
+                    accent_bg: start_accent.accent_bg.to_string(),
+                    accent_color: format!("rgb({})", start_accent.rain_rgb),
+                    accent_gradient: start_accent.grad.to_string(),
+                    action_title: "Send (Enter)".to_string(),
+                    action_enabled: start_action_enabled,
+                    on_input: move |value| {
+                        query.set(value);
+                        selected.set(0);
+                        nav_mode.set(false);
+                    },
+                    on_keydown: start_keydown,
+                    on_paste: move |_| {
+                        let _ = try_cef_bin_emit_rkyv(&ChatPasteMedia);
+                    },
+                    on_attach: move |_| {
+                        let _ = try_cef_bin_emit_rkyv(&ChatPickFiles);
+                    },
+                    on_remove_attachment: move |index| {
+                        let mut next = attachments.peek().clone();
+                        if index < next.len() {
+                            next.remove(index);
+                            attachments.set(next);
                         }
-                    }
-                    for (i, attachment) in attachments.read().iter().cloned().enumerate() {
-                        div {
-                            key: "start-attachment-{attachment.path}",
-                            class: "group relative z-10 flex h-7 max-w-48 shrink-0 items-center gap-1.5 rounded-full bg-foreground/[0.08] pl-1 pr-1.5 text-xs text-foreground/80 ring-1 ring-inset ring-foreground/10",
-                            if attachment.preview_data_url.is_empty() {
-                                span { class: "flex h-5 min-w-5 items-center justify-center rounded-full bg-foreground/[0.08] px-1 font-mono text-[8px] font-semibold text-muted-foreground",
-                                    "{file_extension_label(&attachment.name)}"
+                    },
+                    on_action: {
+                        let action_results = results.clone();
+                        let action_query = q.clone();
+                        let action_default_agent = default_agent_item.clone();
+                        move |_| {
+                            if let Some(item) = action_results.get(sel) {
+                                execute(item);
+                            } else if !action_query.trim().is_empty()
+                                || !attachments.peek().is_empty()
+                            {
+                                if action_query.trim().is_empty()
+                                    && let Some(item) = action_default_agent.as_ref()
+                                {
+                                    execute(item);
+                                } else {
+                                    on_close.call(());
+                                    let selected_attachments = attachments.peek().clone();
+                                    emit_prompt_action(
+                                        action_query.trim(),
+                                        open_target,
+                                        "",
+                                        &selected_attachments,
+                                    );
+                                }
+                            }
+                        }
+                    },
+                }
+            } else {
+                PromptBox {
+                    glass: false,
+                    class: "p-2",
+                    div { class: command_bar_input_row_class(),
+                        if !space_name.is_empty() {
+                            span {
+                                title: "{space_name}",
+                                class: "max-w-36 shrink-0 truncate rounded-md bg-glass-hover px-2 py-1 text-ui-xs font-medium text-muted-foreground",
+                                "{space_name}"
+                            }
+                        }
+                        {
+                            let icon_class = "h-4 w-4 shrink-0 text-muted-foreground";
+                            let (is_command, is_path, is_url) = if nav {
+                                match &active_item {
+                                    Some(ResultItem::Command { .. }) => (true, false, false),
+                                    Some(ResultItem::Terminal { path }) if path.is_empty() => (true, false, false),
+                                    Some(ResultItem::Terminal { .. }) => (false, true, false),
+                                    Some(ResultItem::Stack { .. }) => (false, false, true),
+                                    Some(ResultItem::Space { .. }) => (false, false, false),
+                                    Some(ResultItem::Page { .. }) => (false, false, false),
+                                    Some(ResultItem::Navigate { url }) => {
+                                        let is_url = url.contains("://")
+                                            || (url.contains('.') && !url.contains(' '));
+                                        (false, false, is_url)
+                                    }
+                                    Some(ResultItem::History { .. }) => (false, false, true),
+                                    Some(ResultItem::File { .. }) => (false, true, false),
+                                    Some(ResultItem::WorkDir { .. }) => (false, true, false),
+                                    Some(ResultItem::RecentFile { .. }) => (false, true, false),
+                                    None => (false, false, false),
                                 }
                             } else {
-                                img {
-                                    src: "{attachment.preview_data_url}",
-                                    alt: "{attachment.name}",
-                                    class: "h-5 w-5 rounded-full object-cover",
+                                let trimmed = q.trim();
+                                let command = trimmed.starts_with('>');
+                                let path = !command
+                                    && (trimmed.starts_with('/') || trimmed.starts_with('~'));
+                                let url = !command
+                                    && !path
+                                    && (trimmed.contains("://")
+                                        || (trimmed.contains('.') && !trimmed.contains(' ')));
+                                (command, path, url)
+                            };
+                            if is_command {
+                                rsx! { span { class: "select-none font-mono text-base text-muted-foreground", ">_" } }
+                            } else if is_path {
+                                rsx! { Icon { class: icon_class,
+                                    path { d: "M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" }
+                                    path { d: "M14 2v4a2 2 0 0 0 2 2h4" }
+                                } }
+                            } else if is_url {
+                                rsx! { Icon { class: icon_class,
+                                    path { d: "M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Z" }
+                                    path { d: "M2 12h20" }
+                                    path { d: "M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10Z" }
+                                } }
+                            } else {
+                                rsx! { Icon { class: icon_class,
+                                    circle { cx: "11", cy: "11", r: "8" }
+                                    path { d: "m21 21-4.3-4.3" }
+                                } }
+                            }
+                        }
+                        div { class: command_bar_input_wrap_class(),
+                            if !ghost_text.is_empty() {
+                                div {
+                                    class: "pointer-events-none absolute inset-0 flex items-center",
+                                    span { class: "invisible text-base", "{q}" }
+                                    span { class: "text-base text-muted-foreground/40", "{ghost_text}" }
                                 }
                             }
-                            span { class: "min-w-0 max-w-28 truncate", "{attachment.name}" }
-                            button {
-                                class: "flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-foreground/45 transition hover:bg-foreground/10 hover:text-foreground",
-                                title: "Remove attachment",
-                                onmousedown: move |event| event.prevent_default(),
-                                onclick: move |_| {
-                                    let mut next = attachments.peek().clone();
-                                    if i < next.len() {
-                                        next.remove(i);
-                                        attachments.set(next);
-                                    }
-                                    focus_command_input_end();
-                                },
-                                Icon { class: "h-3 w-3",
-                                    path { d: "M6 6l12 12M18 6L6 18" }
-                                }
-                            }
-                        }
-                    }
-                }
-                if !is_start {
-                {
-                    let icon_class = "h-4 w-4 shrink-0 text-muted-foreground";
-                    let (is_command, is_path, is_url) = if nav {
-                        match &active_item {
-                            Some(ResultItem::Command { .. }) => (true, false, false),
-                            Some(ResultItem::Terminal { path }) if path.is_empty() => (true, false, false),
-                            Some(ResultItem::Terminal { .. }) => (false, true, false),
-                            Some(ResultItem::Stack { .. }) => (false, false, true),
-                            Some(ResultItem::Space { .. }) => (false, false, false),
-                            Some(ResultItem::Page { .. }) => (false, false, false),
-                            Some(ResultItem::Navigate { url }) => {
-                                let is_u = url.contains("://") || (url.contains('.') && !url.contains(' '));
-                                (false, false, is_u)
-                            }
-                            Some(ResultItem::History { .. }) => (false, false, true),
-                            Some(ResultItem::File { .. }) => (false, true, false),
-                            Some(ResultItem::WorkDir { .. }) => (false, true, false),
-                            Some(ResultItem::RecentFile { .. }) => (false, true, false),
-                            None => (false, false, false),
-                        }
-                    } else {
-                        let trimmed = q.trim();
-                        let cmd = trimmed.starts_with('>');
-                        let pth = !cmd && (trimmed.starts_with('/') || trimmed.starts_with('~'));
-                        let url = !cmd && !pth && (trimmed.contains("://") || (trimmed.contains('.') && !trimmed.contains(' ')));
-                        (cmd, pth, url)
-                    };
-                    if is_command {
-                        rsx! { span { class: "select-none font-mono text-base text-muted-foreground", ">_" } }
-                    } else if is_path {
-                        rsx! { Icon { class: icon_class,
-                            path { d: "M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" }
-                            path { d: "M14 2v4a2 2 0 0 0 2 2h4" }
-                        } }
-                    } else if is_url {
-                        rsx! { Icon { class: icon_class,
-                            path { d: "M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Z" }
-                            path { d: "M2 12h20" }
-                            path { d: "M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10Z" }
-                        } }
-                    } else {
-                        rsx! { Icon { class: icon_class,
-                            circle { cx: "11", cy: "11", r: "8" }
-                            path { d: "m21 21-4.3-4.3" }
-                        } }
-                    }
-                }
-                }
-                div { class: if is_start { "relative min-w-48 flex-1 overflow-hidden" } else { command_bar_input_wrap_class() },
-                    if is_start && q.is_empty() && ghost_text.is_empty() {
-                        div { class: "pointer-events-none absolute inset-0 flex -translate-y-px items-center overflow-hidden px-1.5",
-                            PromptGhost {
-                                accent_bg: "bg-foreground/70".to_string(),
-                                terminal: false,
-                            }
-                        }
-                    }
-                    if !ghost_text.is_empty() {
-                        div {
-                            class: "pointer-events-none absolute inset-0 flex items-center",
-                            span { class: "invisible text-base", "{q}" }
-                            span { class: "text-base text-muted-foreground/40", "{ghost_text}" }
-                        }
-                    }
-                    input {
-                        id: "command-bar-input",
-                        r#type: "text",
-                        "data-ghost": "{ghost_text}",
-                        class: if is_start { "relative z-10 w-full min-w-0 cursor-text bg-transparent px-1.5 py-2 text-[15px] leading-6 text-foreground caret-foreground outline-none placeholder:text-transparent" } else { command_bar_input_class() },
-                        placeholder: if is_start { "Ask anything…" } else { placeholder },
-                        value: "{display_text}",
-                        autofocus: true,
-                        oninput: move |e| {
-                            query.set(e.value());
-                            selected.set(0);
-                            nav_mode.set(false);
-                        },
-                        onpaste: move |_| {
-                            if is_start {
-                                let _ = try_cef_bin_emit_rkyv(&ChatPasteMedia);
-                            }
-                        },
-                        onkeydown: {
-                            let q = q.clone();
-                            let results = results.clone();
-                            let default_agent_item = default_agent_item.clone();
-                            move |e| {
-                            if e.key() == Key::Tab {
-                                e.prevent_default();
-                                let gt = ghost_text.clone();
-                                if !gt.is_empty() {
-                                    let new_val = format!("{}{}", q, gt);
-                                    query.set(new_val.clone());
+                            input {
+                                id: "command-bar-input",
+                                r#type: "text",
+                                "data-ghost": "{ghost_text}",
+                                class: command_bar_input_class(),
+                                placeholder,
+                                value: "{display_text}",
+                                autofocus: true,
+                                oninput: move |event| {
+                                    query.set(event.value());
                                     selected.set(0);
-                                    if let Some(el) = web_sys::window()
-                                        .and_then(|w| w.document())
-                                        .and_then(|d| d.get_element_by_id("command-bar-input"))
-                                    {
-                                        let input: web_sys::HtmlInputElement = el.unchecked_into();
-                                        input.set_value(&new_val);
-                                        let len = new_val.len() as u32;
-                                        let _ = input.set_selection_range(len, len);
-                                        ensure_caret_visible(&input, new_val.len());
-                                    }
-                                }
-                                return;
+                                    nav_mode.set(false);
+                                },
+                                onkeydown: modal_keydown,
                             }
-
-                            let ctrl = e.modifiers().contains(Modifiers::CONTROL);
-                            let vmux_synthetic = is_vmux_synthetic_dioxus_keydown(&e);
-                            if ctrl
-                                && ignore_physical_rerouted_ctrl_keydown(
-                                    &e.code().to_string(),
-                                    vmux_synthetic,
-                                )
-                            {
-                                e.prevent_default();
-                                return;
+                        }
+                        button {
+                            r#type: "button",
+                            aria_label: "Bookmark this page",
+                            title: "Bookmark this page (⌘D)",
+                            class: "flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-foreground/10 hover:text-foreground",
+                            onmousedown: move |event| {
+                                event.prevent_default();
+                                event.stop_propagation();
+                            },
+                            onclick: move |event| {
+                                event.prevent_default();
+                                event.stop_propagation();
+                                let _ = try_cef_bin_emit_rkyv(&crate::event::BookmarksCommandEvent {
+                                    command: "toggle_active".into(),
+                                    uuid: None,
+                                    name: None,
+                                    url: None,
+                                    metadata: None,
+                                    folder: None,
+                                });
+                            },
+                            Icon { class: "h-4 w-4",
+                                path { d: "M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" }
                             }
-                            if space_switch
-                                && !ctrl
-                                && q.trim().is_empty()
-                                && let Key::Character(s) = e.key()
-                                && let Some(idx) = s
-                                    .chars()
-                                    .next()
-                                    .filter(|c| c.is_ascii_digit())
-                                    .and_then(|c| c.to_digit(10))
-                            {
-                                let space_count = results
-                                    .iter()
-                                    .filter(|r| matches!(r, ResultItem::Space { .. }))
-                                    .count();
-                                if (idx as usize) < space_count {
-                                    e.prevent_default();
-                                    selected.set(idx as usize);
-                                    nav_mode.set(true);
-                                    return;
-                                }
-                            }
-                            let go_down = (e.key() == Key::ArrowDown && !ctrl)
-                                || (ctrl && matches!(e.code(), Code::KeyN | Code::KeyJ));
-                            let go_up = (e.key() == Key::ArrowUp && !ctrl)
-                                || (ctrl && matches!(e.code(), Code::KeyP | Code::KeyK));
-
-                            if media_menu_open {
-                                if go_down {
-                                    e.prevent_default();
-                                    let max = media_entries.read().len().saturating_sub(1);
-                                    media_selected.set((media_sel + 1).min(max));
-                                    return;
-                                }
-                                if go_up {
-                                    e.prevent_default();
-                                    media_selected.set(media_sel.saturating_sub(1));
-                                    return;
-                                }
-                                if e.key() == Key::Enter {
-                                    e.prevent_default();
-                                    if let Some(entry) = media_entries.read().get(media_sel).cloned() {
-                                        select_start_media_entry(
-                                            &entry,
-                                            query,
-                                            media_selected,
-                                        );
-                                    }
-                                    return;
-                                }
-                                if e.key() == Key::Escape {
-                                    e.prevent_default();
-                                    if let Some(media_query) = inline_media_query(&q) {
-                                        query.set(replace_inline_media_query(&q, media_query, ""));
-                                    }
-                                    media_selected.set(0);
-                                    return;
-                                }
-                            }
-
-                            if go_down {
-                                e.prevent_default();
-                                let max = results.len().saturating_sub(1);
-                                selected.set((sel + 1).min(max));
-                                nav_mode.set(true);
-                            } else if go_up {
-                                e.prevent_default();
-                                selected.set(sel.saturating_sub(1));
-                                nav_mode.set(true);
-                            } else if e.key() == Key::Escape
-                                || (ctrl && e.code() == Code::KeyC)
-                            {
-                                on_dismiss.call(());
-                            } else if e.key() == Key::Enter {
-                                if is_start
-                                    && q.trim().is_empty()
-                                    && !attachments.peek().is_empty()
-                                {
-                                    if let Some(item) = default_agent_item.as_ref() {
-                                        execute(item);
-                                    } else {
-                                        let selected_attachments = attachments.peek().clone();
-                                        emit_prompt_action(
-                                            "",
-                                            open_target,
-                                            "",
-                                            &selected_attachments,
-                                        );
-                                    }
-                                    return;
-                                }
-                                if space_switch {
-                                    if let Some(item) = results.get(sel) {
-                                        execute(item);
-                                    }
-                                } else {
-                                    if start_prompt_mode {
-                                        if let Some(item) = results.get(sel) {
-                                            execute(item);
-                                        } else {
-                                            on_close.call(());
-                                            let selected_attachments = attachments.peek().clone();
-                                            emit_prompt_action(
-                                                q.trim(),
-                                                open_target,
-                                                "",
-                                                &selected_attachments,
-                                            );
-                                        }
-                                        return;
-                                    }
-                                    let prefer_page = matches!(
-                                        results.get(sel),
-                                        Some(ResultItem::Page { url, .. })
-                                            if q.trim().starts_with("vmux://")
-                                                && url.starts_with(q.trim())
-                                    );
-                                    if !prefer_page
-                                        && should_open_typed_query_on_enter(open_target, nav_mode(), &q)
-                                    {
-                                        on_close.call(());
-                                        emit_action_with_target("open", &q, open_target);
-                                    } else if let Some(item) = results.get(sel) {
-                                        execute(item);
-                                    } else if !q.is_empty() {
-                                        emit_action_with_target("open", &q, open_target);
-                                    }
-                                }
-                            }
-                            }
-                        },
-                    }
-                }
-                if is_start {
-                    button {
-                        class: if q.trim().is_empty() && attachments.read().is_empty() { "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 cursor-default self-center items-center justify-center rounded-lg bg-white/25 text-muted-foreground/35 shadow-sm ring-1 ring-inset ring-black/[0.06] dark:bg-white/[0.055] dark:ring-white/[0.08]" } else { "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg bg-foreground text-background shadow-lg transition hover:brightness-110 active:scale-95" },
-                        disabled: q.trim().is_empty() && attachments.read().is_empty(),
-                        title: "Send (Enter)",
-                        onclick: {
-                            let results = results.clone();
-                            let q = q.clone();
-                            let default_agent_item = default_agent_item.clone();
-                            move |_| {
-                                if let Some(item) = results.get(sel) {
-                                    execute(item);
-                                } else if !q.trim().is_empty() || !attachments.peek().is_empty() {
-                                    if q.trim().is_empty()
-                                        && let Some(item) = default_agent_item.as_ref()
-                                    {
-                                        execute(item);
-                                    } else {
-                                        on_close.call(());
-                                        let selected_attachments = attachments.peek().clone();
-                                        emit_prompt_action(
-                                            q.trim(),
-                                            open_target,
-                                            "",
-                                            &selected_attachments,
-                                        );
-                                    }
-                                }
-                            }
-                        },
-                        Icon { class: "h-4 w-4",
-                            path { d: "M12 19V5" }
-                            path { d: "M5 12l7-7 7 7" }
                         }
                     }
                 }
-                if matches!(variant, PaletteVariant::Modal) {
-                    button {
-                        r#type: "button",
-                        aria_label: "Bookmark this page",
-                        title: "Bookmark this page (\u{2318}D)",
-                        class: "flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-foreground/10 hover:text-foreground",
-                        onmousedown: move |e| { e.prevent_default(); e.stop_propagation(); },
-                        onclick: move |e| {
-                            e.prevent_default();
-                            e.stop_propagation();
-                            let _ = try_cef_bin_emit_rkyv(&crate::event::BookmarksCommandEvent {
-                                command: "toggle_active".into(),
-                                uuid: None,
-                                name: None,
-                                url: None,
-                                metadata: None,
-                                folder: None,
-                            });
-                        },
-                        Icon { class: "h-4 w-4",
-                            path { d: "M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" }
-                        }
-                    }
-                }
-            }
             }
             if media_menu_open {
                 PromptPopup {
@@ -1197,28 +1245,6 @@ fn file_extension_label(name: &str) -> String {
         .unwrap_or_else(|| "FILE".to_string())
 }
 
-fn focus_command_input_end() {
-    let closure = Closure::once(move || {
-        let Some(input) = web_sys::window()
-            .and_then(|window| window.document())
-            .and_then(|document| document.get_element_by_id("command-bar-input"))
-            .and_then(|element| element.dyn_into::<web_sys::HtmlInputElement>().ok())
-        else {
-            return;
-        };
-        let end = input.value().encode_utf16().count() as u32;
-        let _ = input.focus();
-        let _ = input.set_selection_range(end, end);
-    });
-    if let Some(window) = web_sys::window() {
-        let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(
-            closure.as_ref().unchecked_ref(),
-            0,
-        );
-    }
-    closure.forget();
-}
-
 fn select_start_media_entry(
     entry: &ChatMediaEntry,
     mut query: Signal<String>,
@@ -1247,7 +1273,7 @@ fn select_start_media_entry(
         &replacement,
     ));
     selected.set(0);
-    focus_command_input_end();
+    focus_prompt_end(PROMPT_INPUT_ID);
 }
 
 /// Emit a command-bar action to the host with no explicit open target.

--- a/crates/vmux_layout/src/command_bar/style.rs
+++ b/crates/vmux_layout/src/command_bar/style.rs
@@ -283,7 +283,7 @@ mod tests {
         let source = include_str!("palette.rs");
 
         assert!(source.contains("should_open_typed_query_on_enter("));
-        assert!(source.contains("emit_action_with_target(\"open\", &q, open_target)"));
+        assert!(source.contains("emit_action_with_target(\"open\""));
     }
 
     #[test]

--- a/crates/vmux_layout/src/start/page.rs
+++ b/crates/vmux_layout/src/start/page.rs
@@ -2,6 +2,7 @@
 
 use dioxus::prelude::*;
 use vmux_command::event::{COMMAND_BAR_OPEN_EVENT, CommandBarOpenEvent};
+use vmux_ui::components::prompt_composer::{PROMPT_INPUT_ID, prompt_textarea};
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_event, use_theme};
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
@@ -153,13 +154,12 @@ fn try_focus_command_input_once() -> bool {
     let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
         return true;
     };
-    let Some(el) = doc.get_element_by_id("command-bar-input") else {
+    let Some(input) = prompt_textarea(PROMPT_INPUT_ID) else {
         return false;
     };
-    let input: web_sys::HtmlInputElement = el.unchecked_into();
     let active_is_input = doc
         .active_element()
-        .map(|a| a.id() == "command-bar-input")
+        .map(|a| a.id() == PROMPT_INPUT_ID)
         .unwrap_or(false);
     if !active_is_input {
         let _ = input.focus();
@@ -231,24 +231,24 @@ fn install_keep_input_focused_on_click() {
         if start_transitioned(&window) {
             return;
         }
-        let Some(document) = window.document() else {
-            return;
-        };
-        let Some(input) = document.get_element_by_id("command-bar-input") else {
+        let Some(input) = prompt_textarea(PROMPT_INPUT_ID) else {
             return;
         };
         if let Some(el) = e
             .target()
             .and_then(|t| t.dyn_into::<web_sys::Element>().ok())
         {
-            let on_input = el.closest("#command-bar-input").ok().flatten().is_some();
+            let on_input = el
+                .closest(&format!("#{PROMPT_INPUT_ID}"))
+                .ok()
+                .flatten()
+                .is_some();
             let on_results = el.closest("#command-bar-results").ok().flatten().is_some();
             if on_input || on_results {
                 return;
             }
         }
         e.prevent_default();
-        let input: web_sys::HtmlInputElement = input.unchecked_into();
         let _ = input.focus();
     }) as Box<dyn FnMut(web_sys::Event)>);
     let target: &web_sys::EventTarget = document.as_ref();

--- a/crates/vmux_ui/Cargo.toml
+++ b/crates/vmux_ui/Cargo.toml
@@ -31,7 +31,7 @@ js-sys = "0.3"
 web-sys = { version = "0.3", features = [
     "Window", "Document", "Element", "HtmlElement", "Node",
     "CssStyleDeclaration", "DomRect",
-    "EventTarget", "Event", "KeyboardEvent",
+    "EventTarget", "Event", "HtmlTextAreaElement", "KeyboardEvent",
 ] }
 dioxus = { workspace = true }
 time = { version = "0.3", default-features = false, features = [

--- a/crates/vmux_ui/src/agent_accent.rs
+++ b/crates/vmux_ui/src/agent_accent.rs
@@ -1,3 +1,4 @@
+#[derive(Clone, Copy)]
 pub struct AgentAccent {
     pub glow_top: &'static str,
     pub glow_bottom: &'static str,

--- a/crates/vmux_ui/src/components.rs
+++ b/crates/vmux_ui/src/components.rs
@@ -28,6 +28,7 @@ pub mod popover;
 pub mod progress;
 pub mod prompt_box;
 pub mod prompt_composer;
+pub mod prompt_media_options;
 pub mod radio_group;
 pub mod scroll_area;
 pub mod select;

--- a/crates/vmux_ui/src/components.rs
+++ b/crates/vmux_ui/src/components.rs
@@ -27,6 +27,7 @@ pub mod pagination;
 pub mod popover;
 pub mod progress;
 pub mod prompt_box;
+pub mod prompt_composer;
 pub mod radio_group;
 pub mod scroll_area;
 pub mod select;

--- a/crates/vmux_ui/src/components/prompt_composer.rs
+++ b/crates/vmux_ui/src/components/prompt_composer.rs
@@ -1,0 +1,338 @@
+use dioxus::prelude::*;
+use wasm_bindgen::{JsCast, closure::Closure};
+
+use crate::listener_guard::GuardedListener;
+use crate::prompt_ghost::PromptGhost;
+
+use super::prompt_box::PromptBox;
+
+pub const PROMPT_INPUT_ID: &str = "vmux-prompt-input";
+
+const PROMPT_COMPOSER_CSS: &str = r#"
+.vmux-prompt-input{caret-color:transparent}
+.vmux-prompt-caret{animation:vmux-prompt-caret-blink 1s step-end infinite;background:var(--vmux-prompt-accent)}
+@keyframes vmux-prompt-caret-blink{0%,49%{opacity:1}50%,100%{opacity:0}}
+.vmux-prompt-composer{border-color:rgba(255,255,255,0.18);box-shadow:0 22px 70px -28px rgba(255,255,255,0.2),inset 0 1px 0 rgba(255,255,255,0.16),inset 0 -1px 0 rgba(255,255,255,0.04)}
+.vmux-prompt-composer:focus-within{border-color:rgba(255,255,255,0.28);box-shadow:0 26px 78px -26px rgba(255,255,255,0.28),inset 0 1px 0 rgba(255,255,255,0.2)}
+"#;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PromptComposerAttachment {
+    pub key: String,
+    pub name: String,
+    pub label: String,
+    pub preview_data_url: String,
+    pub remove_index: Option<usize>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PromptComposerAction {
+    #[default]
+    Send,
+    Stop,
+}
+
+#[component]
+pub fn PromptComposer(
+    value: String,
+    #[props(default)] preview: String,
+    #[props(default)] completion: String,
+    #[props(default)] attachments: Vec<PromptComposerAttachment>,
+    #[props(default)] show_examples: bool,
+    placeholder: String,
+    accent_bg: String,
+    accent_color: String,
+    accent_gradient: String,
+    #[props(default)] action: PromptComposerAction,
+    action_title: String,
+    action_enabled: bool,
+    on_input: EventHandler<String>,
+    on_keydown: EventHandler<KeyboardEvent>,
+    on_paste: EventHandler<()>,
+    on_attach: EventHandler<()>,
+    on_remove_attachment: EventHandler<usize>,
+    on_action: EventHandler<()>,
+) -> Element {
+    let mut caret = use_signal(|| None::<u32>);
+    let scroll_top = use_signal(|| 0i32);
+
+    let focus_listener = use_hook(|| {
+        GuardedListener::new(Box::new(move |_: ()| {
+            sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top);
+        }) as Box<dyn FnMut(())>)
+    });
+    let blur_listener = use_hook(|| {
+        GuardedListener::new(Box::new(move |_: ()| {
+            caret.set(None);
+        }) as Box<dyn FnMut(())>)
+    });
+    use_effect({
+        let focus_listener = focus_listener.clone();
+        let blur_listener = blur_listener.clone();
+        move || install_prompt_focus_tracking(focus_listener.clone(), blur_listener.clone())
+    });
+    let focus_guard = focus_listener.guard();
+    let blur_guard = blur_listener.guard();
+    use_drop(move || {
+        focus_guard.deactivate();
+        blur_guard.deactivate();
+    });
+
+    use_effect(use_reactive((&value,), move |_| {
+        resize_prompt_textarea(PROMPT_INPUT_ID);
+        sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top);
+    }));
+
+    let caret_prefix = caret()
+        .filter(|_| !value.is_empty())
+        .map(|offset| prompt_prefix_at_utf16(&value, offset).to_string());
+    let prompt_scroll_offset = scroll_top();
+    let action_class = if action_enabled {
+        match action {
+            PromptComposerAction::Send => format!(
+                "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg bg-gradient-to-br text-white shadow-lg transition hover:brightness-110 active:scale-95 {accent_gradient}"
+            ),
+            PromptComposerAction::Stop => "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg bg-white/40 text-foreground/70 shadow-sm ring-1 ring-inset ring-black/10 transition hover:bg-white/60 hover:text-foreground active:scale-95 dark:bg-white/[0.08] dark:ring-white/10 dark:hover:bg-white/[0.14]".to_string(),
+        }
+    } else {
+        "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 cursor-default self-center items-center justify-center rounded-lg bg-white/25 text-muted-foreground/35 shadow-sm ring-1 ring-inset ring-black/[0.06] dark:bg-white/[0.055] dark:ring-white/[0.08]".to_string()
+    };
+
+    rsx! {
+        style { dangerous_inner_html: PROMPT_COMPOSER_CSS }
+        PromptBox {
+            class: "vmux-prompt-composer",
+            style: "--vmux-prompt-accent:{accent_color};",
+            button {
+                class: "relative z-10 ml-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg text-foreground/45 transition hover:bg-foreground/10 hover:text-foreground",
+                title: "Attach files (/upload)",
+                onmousedown: move |event| event.prevent_default(),
+                onclick: move |_| on_attach.call(()),
+                svg {
+                    class: "h-4 w-4",
+                    view_box: "0 0 24 24",
+                    fill: "none",
+                    stroke: "currentColor",
+                    stroke_width: "2",
+                    stroke_linecap: "round",
+                    stroke_linejoin: "round",
+                    path { d: "M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48" }
+                }
+            }
+            div { class: "relative z-10 flex min-w-0 flex-1 flex-wrap items-center gap-1 px-2",
+                for attachment in attachments.iter().cloned() {
+                    div {
+                        key: "{attachment.key}",
+                        class: if attachment.remove_index.is_some() { "group flex h-7 max-w-56 shrink-0 items-center gap-1.5 rounded-full bg-foreground/[0.08] pl-1 pr-1.5 text-xs text-foreground/80 ring-1 ring-inset ring-foreground/10" } else { "flex h-7 max-w-56 shrink-0 items-center gap-1.5 rounded-full bg-foreground/[0.08] pl-1 pr-2 text-xs text-foreground/80 ring-1 ring-inset ring-foreground/10" },
+                        if attachment.preview_data_url.is_empty() {
+                            span { class: "flex h-5 min-w-5 items-center justify-center rounded-full bg-foreground/[0.08] px-1 font-mono text-[8px] font-semibold text-muted-foreground",
+                                "{attachment.label}"
+                            }
+                        } else {
+                            img {
+                                src: "{attachment.preview_data_url}",
+                                alt: "{attachment.name}",
+                                class: "h-5 w-5 rounded-full object-cover",
+                            }
+                        }
+                        span { class: "min-w-0 max-w-40 truncate", "{attachment.name}" }
+                        if let Some(remove_index) = attachment.remove_index {
+                            button {
+                                class: "flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-foreground/45 transition hover:bg-foreground/10 hover:text-foreground",
+                                title: "Remove attachment",
+                                onmousedown: move |event| event.prevent_default(),
+                                onclick: move |_| {
+                                    on_remove_attachment.call(remove_index);
+                                    focus_prompt_end(PROMPT_INPUT_ID);
+                                },
+                                svg {
+                                    class: "h-3 w-3",
+                                    view_box: "0 0 24 24",
+                                    fill: "none",
+                                    stroke: "currentColor",
+                                    stroke_width: "2.5",
+                                    stroke_linecap: "round",
+                                    path { d: "M6 6l12 12M18 6L6 18" }
+                                }
+                            }
+                        }
+                    }
+                }
+                div { class: "relative min-w-32 flex-1 overflow-hidden",
+                    if value.is_empty() {
+                        div { class: "pointer-events-none absolute inset-0 flex -translate-y-px items-center overflow-hidden px-1.5",
+                            if !preview.is_empty() {
+                                div { class: "max-w-full truncate whitespace-nowrap text-[15px] leading-6 text-foreground", "{preview}" }
+                            } else if show_examples {
+                                PromptGhost {
+                                    accent_bg,
+                                    terminal: false,
+                                }
+                            } else {
+                                div { class: "flex max-w-full items-center whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50",
+                                    if caret().is_some() {
+                                        span { class: "vmux-prompt-caret relative top-px mr-px h-4 w-1.5 shrink-0" }
+                                    }
+                                    span { class: "min-w-0 truncate", "{placeholder}" }
+                                }
+                            }
+                        }
+                    }
+                    if !completion.is_empty() {
+                        div {
+                            class: "pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words px-1.5 py-2 text-[15px] leading-6",
+                            span { class: "text-transparent", "{value}" }
+                            span { class: "text-muted-foreground/40", "{completion}" }
+                        }
+                    }
+                    if let Some(prefix) = caret_prefix.as_ref() {
+                        div { class: "pointer-events-none absolute inset-0 z-20 overflow-hidden",
+                            div {
+                                class: "min-h-10 w-full whitespace-pre-wrap break-words px-1.5 py-2 text-[15px] leading-6 text-transparent",
+                                style: "transform:translateY(-{prompt_scroll_offset}px);",
+                                span { "{prefix}" }
+                                span { class: "vmux-prompt-caret relative top-px ml-px inline-block h-4 w-1.5 align-middle" }
+                            }
+                        }
+                    }
+                    textarea {
+                        id: PROMPT_INPUT_ID,
+                        class: "vmux-prompt-input relative z-10 max-h-40 min-h-10 w-full resize-none bg-transparent px-1.5 py-2 text-[15px] leading-6 placeholder:text-transparent focus:outline-none",
+                        autofocus: true,
+                        rows: "1",
+                        placeholder: "{placeholder}",
+                        value: "{value}",
+                        oninput: move |event| {
+                            on_input.call(event.value());
+                            resize_prompt_textarea(PROMPT_INPUT_ID);
+                            sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top);
+                        },
+                        onpaste: move |_| on_paste.call(()),
+                        onfocus: move |_| sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top),
+                        onblur: move |_| sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top),
+                        onkeyup: move |_| sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top),
+                        onmouseup: move |_| sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top),
+                        onscroll: move |_| sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top),
+                        onkeydown: move |event| on_keydown.call(event),
+                    }
+                }
+            }
+            button {
+                class: "{action_class}",
+                disabled: !action_enabled,
+                title: "{action_title}",
+                onmousedown: move |event| event.prevent_default(),
+                onclick: move |_| {
+                    if action_enabled {
+                        on_action.call(());
+                    }
+                },
+                if action == PromptComposerAction::Stop {
+                    svg {
+                        class: "h-4 w-4",
+                        view_box: "0 0 24 24",
+                        fill: "currentColor",
+                        rect { x: "6", y: "6", width: "12", height: "12", rx: "2.5" }
+                    }
+                } else {
+                    svg {
+                        class: "h-4 w-4",
+                        view_box: "0 0 24 24",
+                        fill: "none",
+                        stroke: "currentColor",
+                        stroke_width: "2",
+                        stroke_linecap: "round",
+                        stroke_linejoin: "round",
+                        path { d: "M12 19V5" }
+                        path { d: "M5 12l7-7 7 7" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub fn prompt_textarea(input_id: &str) -> Option<web_sys::HtmlTextAreaElement> {
+    web_sys::window()?
+        .document()?
+        .get_element_by_id(input_id)?
+        .dyn_into()
+        .ok()
+}
+
+pub fn focus_prompt_end(input_id: &str) {
+    let input_id = input_id.to_string();
+    let closure = Closure::once(move || {
+        let Some(textarea) = prompt_textarea(&input_id) else {
+            return;
+        };
+        let end = textarea.value().encode_utf16().count() as u32;
+        let _ = textarea.focus();
+        let _ = textarea.set_selection_range(end, end);
+    });
+    if let Some(window) = web_sys::window() {
+        let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(
+            closure.as_ref().unchecked_ref(),
+            0,
+        );
+    }
+    closure.forget();
+}
+
+fn resize_prompt_textarea(input_id: &str) {
+    let Some(textarea) = prompt_textarea(input_id) else {
+        return;
+    };
+    let _ = textarea.set_attribute("style", "height:auto;overflow-y:hidden");
+    let height = textarea.scroll_height().clamp(40, 160);
+    let overflow = if height == 160 { "auto" } else { "hidden" };
+    let _ = textarea.set_attribute("style", &format!("height:{height}px;overflow-y:{overflow}"));
+}
+
+fn sync_prompt_caret(input_id: &str, mut caret: Signal<Option<u32>>, mut scroll_top: Signal<i32>) {
+    let page_active = web_sys::window()
+        .and_then(|window| window.document())
+        .is_some_and(|document| document.has_focus().unwrap_or(false));
+    if !page_active {
+        caret.set(None);
+        return;
+    }
+    let Some(textarea) = prompt_textarea(input_id) else {
+        return;
+    };
+    let start = textarea.selection_start().ok().flatten().unwrap_or(0);
+    let end = textarea.selection_end().ok().flatten().unwrap_or(start);
+    caret.set((start == end).then_some(start));
+    scroll_top.set(textarea.scroll_top());
+}
+
+fn install_prompt_focus_tracking(
+    focus_listener: GuardedListener<Box<dyn FnMut(())>>,
+    blur_listener: GuardedListener<Box<dyn FnMut(())>>,
+) {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let focus = Closure::wrap(Box::new(move || {
+        focus_listener.call(());
+    }) as Box<dyn FnMut()>);
+    let _ = window.add_event_listener_with_callback("focus", focus.as_ref().unchecked_ref());
+    focus.forget();
+
+    let blur = Closure::wrap(Box::new(move || {
+        blur_listener.call(());
+    }) as Box<dyn FnMut()>);
+    let _ = window.add_event_listener_with_callback("blur", blur.as_ref().unchecked_ref());
+    blur.forget();
+}
+
+fn prompt_prefix_at_utf16(value: &str, offset: u32) -> &str {
+    let mut units = 0u32;
+    for (byte, character) in value.char_indices() {
+        if units >= offset {
+            return &value[..byte];
+        }
+        units += character.len_utf16() as u32;
+    }
+    value
+}

--- a/crates/vmux_ui/src/components/prompt_composer.rs
+++ b/crates/vmux_ui/src/components/prompt_composer.rs
@@ -1,3 +1,6 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use dioxus::prelude::*;
 use wasm_bindgen::{JsCast, closure::Closure};
 
@@ -30,6 +33,23 @@ pub enum PromptComposerAction {
     #[default]
     Send,
     Stop,
+}
+
+struct PromptFocusTracking {
+    window: web_sys::Window,
+    focus: Closure<dyn FnMut()>,
+    blur: Closure<dyn FnMut()>,
+}
+
+impl Drop for PromptFocusTracking {
+    fn drop(&mut self) {
+        let _ = self
+            .window
+            .remove_event_listener_with_callback("focus", self.focus.as_ref().unchecked_ref());
+        let _ = self
+            .window
+            .remove_event_listener_with_callback("blur", self.blur.as_ref().unchecked_ref());
+    }
 }
 
 #[component]
@@ -66,16 +86,22 @@ pub fn PromptComposer(
             caret.set(None);
         }) as Box<dyn FnMut(())>)
     });
+    let focus_tracking = use_hook(|| Rc::new(RefCell::new(None::<PromptFocusTracking>)));
     use_effect({
         let focus_listener = focus_listener.clone();
         let blur_listener = blur_listener.clone();
-        move || install_prompt_focus_tracking(focus_listener.clone(), blur_listener.clone())
+        let focus_tracking = focus_tracking.clone();
+        move || {
+            *focus_tracking.borrow_mut() =
+                install_prompt_focus_tracking(focus_listener.clone(), blur_listener.clone());
+        }
     });
     let focus_guard = focus_listener.guard();
     let blur_guard = blur_listener.guard();
     use_drop(move || {
         focus_guard.deactivate();
         blur_guard.deactivate();
+        focus_tracking.borrow_mut().take();
     });
 
     use_effect(use_reactive((&value,), move |_| {
@@ -309,21 +335,23 @@ fn sync_prompt_caret(input_id: &str, mut caret: Signal<Option<u32>>, mut scroll_
 fn install_prompt_focus_tracking(
     focus_listener: GuardedListener<Box<dyn FnMut(())>>,
     blur_listener: GuardedListener<Box<dyn FnMut(())>>,
-) {
-    let Some(window) = web_sys::window() else {
-        return;
-    };
+) -> Option<PromptFocusTracking> {
+    let window = web_sys::window()?;
     let focus = Closure::wrap(Box::new(move || {
         focus_listener.call(());
     }) as Box<dyn FnMut()>);
     let _ = window.add_event_listener_with_callback("focus", focus.as_ref().unchecked_ref());
-    focus.forget();
 
     let blur = Closure::wrap(Box::new(move || {
         blur_listener.call(());
     }) as Box<dyn FnMut()>);
     let _ = window.add_event_listener_with_callback("blur", blur.as_ref().unchecked_ref());
-    blur.forget();
+
+    Some(PromptFocusTracking {
+        window,
+        focus,
+        blur,
+    })
 }
 
 fn prompt_prefix_at_utf16(value: &str, offset: u32) -> &str {

--- a/crates/vmux_ui/src/components/prompt_media_options.rs
+++ b/crates/vmux_ui/src/components/prompt_media_options.rs
@@ -1,0 +1,71 @@
+use dioxus::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PromptMediaOption {
+    pub key: String,
+    pub name: String,
+    pub display_path: String,
+    pub preview_data_url: String,
+    pub label: String,
+    pub is_dir: bool,
+}
+
+#[component]
+pub fn PromptMediaOptions(
+    items: Vec<PromptMediaOption>,
+    selected: usize,
+    loading: bool,
+    #[props(default = "Loading media…".to_string())] loading_label: String,
+    #[props(default = "No matching media".to_string())] empty_label: String,
+    on_select: EventHandler<usize>,
+    on_hover: EventHandler<usize>,
+) -> Element {
+    if loading {
+        return rsx! {
+            div { class: "px-3.5 py-2 text-sm text-muted-foreground", "{loading_label}" }
+        };
+    }
+    if items.is_empty() {
+        return rsx! {
+            div { class: "px-3.5 py-2 text-sm text-muted-foreground", "{empty_label}" }
+        };
+    }
+
+    rsx! {
+        for (index, item) in items.iter().cloned().enumerate() {
+            div {
+                key: "{item.key}",
+                id: "prompt-media-item-{index}",
+                class: if index == selected { "flex cursor-pointer items-center gap-3 bg-foreground/10 px-3.5 py-2" } else { "flex cursor-pointer items-center gap-3 px-3.5 py-2" },
+                onmouseenter: move |_| on_hover.call(index),
+                onclick: move |_| on_select.call(index),
+                div { class: "flex h-12 w-16 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-foreground/[0.06] text-muted-foreground ring-1 ring-inset ring-foreground/10",
+                    if item.is_dir {
+                        svg {
+                            class: "h-4 w-4",
+                            view_box: "0 0 24 24",
+                            fill: "none",
+                            stroke: "currentColor",
+                            stroke_width: "2",
+                            stroke_linecap: "round",
+                            stroke_linejoin: "round",
+                            path { d: "M3 6h6l2 2h10v10H3z" }
+                        }
+                    } else if !item.preview_data_url.is_empty() {
+                        img {
+                            src: "{item.preview_data_url}",
+                            alt: "{item.name}",
+                            class: "h-full w-full object-contain",
+                        }
+                    } else {
+                        span { class: "font-mono text-[9px] font-semibold", "{item.label}" }
+                    }
+                }
+                div { class: "min-w-0 flex-1",
+                    div { class: "truncate text-sm text-foreground", "{item.name}" }
+                    div { class: "truncate text-xs text-muted-foreground", "{item.display_path}" }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Context
The start launcher and agent chat used separate prompt implementations, so caret, layout, attachment, media option, and input behavior could drift. They should share prompt UI so changes apply to both pages automatically.

## Implementation
Move the prompt shell, multiline textarea, custom caret and page-focus tracking, auto-grow behavior, attachment pills, and send/stop controls into a shared vmux_ui composer. Move media result rows into a shared component too, including previews, hover/selection behavior, labels, and full display paths. Both vmux://start/ and vmux://agent/* now use these components. Only popup placement remains page-owned: start opens options downward and agent chat opens them upward.

## Checks / QA
1. Open vmux://start/ and confirm the prompt caret blinks, multiline input grows, attachments render, and Enter sends while Shift+Enter inserts a newline.
2. Type a media query on vmux://start/ and confirm rows match agent chat and show full paths such as `~/Downloads`.
3. Open vmux://agent/* and confirm the same prompt visuals, media rows, paths, and input behavior.
4. Confirm start option rows open below the composer and agent option rows open above it.
5. Switch away from and back to either page and confirm the caret focus state updates correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared prompt composer with auto-resizing input, caret tracking, completion previews, attachments, and thumbnail support.
  * Added attachment removal controls and unified Send/Stop actions.
  * Updated chat, start, and command palette inputs to use the shared composer.
  * Improved prompt focus behavior and keyboard navigation across chat and launcher views.

* **Bug Fixes**
  * Improved handling of prompt history, media selection, cancellation, queued actions, and focus transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
