### PR TITLE
fix(agent): open all ACP-edited files

### DIFF
--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -1351,23 +1351,24 @@ fn handle_agent_file_touch(
         ));
     }
     for previews in previews.into_values() {
-        let mut deduped: Vec<PendingFilePreview> = Vec::new();
-        for preview in previews {
-            if let Some(existing) = deduped.iter_mut().find(|existing| {
-                vmux_layout::placement::reusable_page_match(&preview.url, &existing.url)
-            }) {
-                *existing = preview;
-            } else {
-                deduped.push(preview);
-            }
-        }
-        if deduped
+        let all_reads = previews
             .iter()
-            .all(|preview| preview.kind == vmux_service::protocol::FileTouchKind::Read)
-        {
-            let drop_count = deduped.len().saturating_sub(1);
-            deduped.drain(..drop_count);
-        }
+            .all(|preview| preview.kind == vmux_service::protocol::FileTouchKind::Read);
+        let deduped = if all_reads {
+            previews.into_iter().last().into_iter().collect()
+        } else {
+            let mut deduped: Vec<PendingFilePreview> = Vec::new();
+            for preview in previews {
+                if let Some(existing) = deduped.iter_mut().find(|existing| {
+                    vmux_layout::placement::reusable_page_match(&preview.url, &existing.url)
+                }) {
+                    *existing = preview;
+                } else {
+                    deduped.push(preview);
+                }
+            }
+            deduped
+        };
         let open_as_tabs = deduped.len() > 1;
         for preview in deduped {
             let anchor = preview.anchor;
@@ -5948,11 +5949,12 @@ mod tests {
     }
 
     #[test]
-    fn same_frame_file_reads_replace_once_with_latest() {
+    fn same_frame_file_reads_replace_once_with_last_touch() {
         let mut app = file_touch_test_app();
         let (anchor, file_stack) = spawn_file_touch_layout(&mut app, "file:///repo/old.rs", false);
         send_file_read(&mut app, anchor, "/repo/first.rs");
-        send_file_read(&mut app, anchor, "/repo/latest.rs");
+        send_file_read(&mut app, anchor, "/repo/second.rs");
+        send_file_read(&mut app, anchor, "/repo/first.rs");
 
         app.update();
 
@@ -5966,7 +5968,7 @@ mod tests {
             opens[0].target,
             vmux_core::PageOpenTarget::Stack(stack) if stack == file_stack
         ));
-        assert_eq!(opens[0].url, "file:///repo/latest.rs");
+        assert_eq!(opens[0].url, "file:///repo/first.rs");
         let view_modes = app
             .world_mut()
             .resource_mut::<Messages<vmux_editor::FileViewModeRequest>>()

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -1122,6 +1122,7 @@ struct PendingFilePreview {
     url: String,
     request_id: [u8; 16],
     user_origin: bool,
+    kind: vmux_service::protocol::FileTouchKind,
 }
 
 impl AgentFileResolve<'_, '_> {
@@ -1279,7 +1280,8 @@ fn handle_agent_file_touch(
     mut resolve: AgentFileResolve,
     settings: Res<AppSettings>,
 ) {
-    let mut previews = std::collections::HashMap::new();
+    let mut previews: std::collections::HashMap<Entity, Vec<PendingFilePreview>> =
+        std::collections::HashMap::new();
     for request in reader.read() {
         let ServiceAgentCommand::FileTouched {
             anchor,
@@ -1328,54 +1330,77 @@ fn handle_agent_file_touch(
         if !settings.agent.follow_files {
             continue;
         }
-        previews.insert(
-            agent_pane,
-            PendingFilePreview {
+        previews
+            .entry(agent_pane)
+            .or_default()
+            .push(PendingFilePreview {
                 anchor: *anchor,
                 agent_pane,
                 url: file_touch_url(path, *line, *col, *end_col),
                 request_id: request.request_id.0,
                 user_origin: !origin_is_agent(&request.origin),
-            },
-        );
+                kind: *kind,
+            });
     }
-    for preview in previews.into_values() {
-        let anchor = preview.anchor;
-        let existing = resolve.file_page_for(preview.agent_pane);
-        let target = resolve.file_page_target(preview.agent_pane, &preview.url);
-        if let Some(target) = target {
-            if target.navigate {
-                resolve.page_open.write(vmux_core::PageOpenRequest {
-                    target: vmux_core::PageOpenTarget::Stack(target.stack),
+    for previews in previews.into_values() {
+        let mut deduped: Vec<PendingFilePreview> = Vec::new();
+        for preview in previews {
+            if let Some(existing) = deduped.iter_mut().find(|existing| {
+                vmux_layout::placement::reusable_page_match(&preview.url, &existing.url)
+            }) {
+                *existing = preview;
+            } else {
+                deduped.push(preview);
+            }
+        }
+        if deduped
+            .iter()
+            .all(|preview| preview.kind == vmux_service::protocol::FileTouchKind::Read)
+        {
+            let drop_count = deduped.len().saturating_sub(1);
+            deduped.drain(..drop_count);
+        }
+        let open_as_tabs = deduped.len() > 1;
+        for preview in deduped {
+            let anchor = preview.anchor;
+            let existing = resolve.file_page_for(preview.agent_pane);
+            let target = (!open_as_tabs)
+                .then(|| resolve.file_page_target(preview.agent_pane, &preview.url))
+                .flatten();
+            if let Some(target) = target {
+                if target.navigate {
+                    resolve.page_open.write(vmux_core::PageOpenRequest {
+                        target: vmux_core::PageOpenTarget::Stack(target.stack),
+                        url: preview.url,
+                        request_id: None,
+                    });
+                }
+            } else {
+                resolve.open_beside.write(vmux_layout::OpenBesideRequest {
+                    pane: preview.agent_pane,
+                    direction: None,
                     url: preview.url,
-                    request_id: None,
+                    request_id: preview.request_id,
+                    focus: preview.user_origin && existing.is_some(),
                 });
             }
-        } else {
-            resolve.open_beside.write(vmux_layout::OpenBesideRequest {
-                pane: preview.agent_pane,
-                direction: None,
-                url: preview.url,
-                request_id: preview.request_id,
-                focus: preview.user_origin && existing.is_some(),
-            });
-        }
-        if let Some(pane) = target
-            .map(|target| target.pane)
-            .or(existing.map(|(_, pane)| pane))
-        {
-            let kind = resolve.agent_kind(anchor);
-            resolve
-                .activate
-                .write(vmux_layout::active_panes::ActivatePane {
-                    profile: vmux_layout::active_panes::ProfileId::Agent(format!("{anchor:?}")),
-                    active: vmux_layout::active_panes::ActiveStack {
-                        tab: None,
-                        pane: Some(pane),
-                        stack: None,
-                        kind,
-                    },
-                });
+            if let Some(pane) = target
+                .map(|target| target.pane)
+                .or(existing.map(|(_, pane)| pane))
+            {
+                let kind = resolve.agent_kind(anchor);
+                resolve
+                    .activate
+                    .write(vmux_layout::active_panes::ActivatePane {
+                        profile: vmux_layout::active_panes::ProfileId::Agent(format!("{anchor:?}")),
+                        active: vmux_layout::active_panes::ActiveStack {
+                            tab: None,
+                            pane: Some(pane),
+                            stack: None,
+                            kind,
+                        },
+                    });
+            }
         }
     }
 }
@@ -5843,7 +5868,12 @@ mod tests {
         (anchor, file_stack)
     }
 
-    fn send_file_read(app: &mut App, anchor: ProcessId, path: &str) {
+    fn send_file_touch(
+        app: &mut App,
+        anchor: ProcessId,
+        path: &str,
+        kind: vmux_service::protocol::FileTouchKind,
+    ) {
         app.world_mut()
             .resource_mut::<Messages<AgentCommandRequest>>()
             .write(AgentCommandRequest {
@@ -5858,9 +5888,27 @@ mod tests {
                     line: None,
                     col: None,
                     end_col: None,
-                    kind: vmux_service::protocol::FileTouchKind::Read,
+                    kind,
                 },
             });
+    }
+
+    fn send_file_read(app: &mut App, anchor: ProcessId, path: &str) {
+        send_file_touch(
+            app,
+            anchor,
+            path,
+            vmux_service::protocol::FileTouchKind::Read,
+        );
+    }
+
+    fn send_file_edit(app: &mut App, anchor: ProcessId, path: &str) {
+        send_file_touch(
+            app,
+            anchor,
+            path,
+            vmux_service::protocol::FileTouchKind::Edit,
+        );
     }
 
     #[test]
@@ -5910,6 +5958,32 @@ mod tests {
             vmux_core::PageOpenTarget::Stack(stack) if stack == file_stack
         ));
         assert_eq!(opens[0].url, "file:///repo/latest.rs");
+    }
+
+    #[test]
+    fn same_frame_file_edits_open_each_distinct_file_as_tabs() {
+        let mut app = file_touch_test_app();
+        let (anchor, _) = spawn_file_touch_layout(&mut app, "file:///repo/old.rs", false);
+        send_file_edit(&mut app, anchor, "/repo/first.rs");
+        send_file_edit(&mut app, anchor, "/repo/second.rs");
+        send_file_edit(&mut app, anchor, "/repo/first.rs");
+
+        app.update();
+
+        let opens = app
+            .world_mut()
+            .resource_mut::<Messages<vmux_core::PageOpenRequest>>()
+            .drain()
+            .count();
+        assert_eq!(opens, 0);
+        let beside: Vec<_> = app
+            .world_mut()
+            .resource_mut::<Messages<vmux_layout::OpenBesideRequest>>()
+            .drain()
+            .collect();
+        assert_eq!(beside.len(), 2);
+        assert_eq!(beside[0].url, "file:///repo/first.rs");
+        assert_eq!(beside[1].url, "file:///repo/second.rs");
     }
 
     #[test]

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -1279,9 +1279,11 @@ fn handle_agent_file_touch(
     mut reader: MessageReader<AgentCommandRequest>,
     mut resolve: AgentFileResolve,
     settings: Res<AppSettings>,
+    mut file_view_mode: Option<ResMut<Messages<vmux_editor::FileViewModeRequest>>>,
 ) {
     let mut previews: std::collections::HashMap<Entity, Vec<PendingFilePreview>> =
         std::collections::HashMap::new();
+    let mut request_diff_mode = false;
     for request in reader.read() {
         let ServiceAgentCommand::FileTouched {
             anchor,
@@ -1330,6 +1332,7 @@ fn handle_agent_file_touch(
         if !settings.agent.follow_files {
             continue;
         }
+        request_diff_mode |= *kind == vmux_service::protocol::FileTouchKind::Edit;
         previews
             .entry(agent_pane)
             .or_default()
@@ -1341,6 +1344,11 @@ fn handle_agent_file_touch(
                 user_origin: !origin_is_agent(&request.origin),
                 kind: *kind,
             });
+    }
+    if request_diff_mode && let Some(file_view_mode) = file_view_mode.as_mut() {
+        file_view_mode.write(vmux_editor::FileViewModeRequest(
+            vmux_core::event::FileViewMode::Diff,
+        ));
     }
     for previews in previews.into_values() {
         let mut deduped: Vec<PendingFilePreview> = Vec::new();
@@ -5837,6 +5845,7 @@ mod tests {
             .add_message::<vmux_core::PageOpenRequest>()
             .add_message::<vmux_layout::OpenBesideRequest>()
             .add_message::<vmux_layout::active_panes::ActivatePane>()
+            .add_message::<vmux_editor::FileViewModeRequest>()
             .add_message::<vmux_layout::worktree::TabDirectoryObserved>()
             .insert_resource(test_settings())
             .add_systems(Update, handle_agent_file_touch);
@@ -5958,6 +5967,12 @@ mod tests {
             vmux_core::PageOpenTarget::Stack(stack) if stack == file_stack
         ));
         assert_eq!(opens[0].url, "file:///repo/latest.rs");
+        let view_modes = app
+            .world_mut()
+            .resource_mut::<Messages<vmux_editor::FileViewModeRequest>>()
+            .drain()
+            .count();
+        assert_eq!(view_modes, 0);
     }
 
     #[test]
@@ -5984,6 +5999,17 @@ mod tests {
         assert_eq!(beside.len(), 2);
         assert_eq!(beside[0].url, "file:///repo/first.rs");
         assert_eq!(beside[1].url, "file:///repo/second.rs");
+        let view_modes: Vec<_> = app
+            .world_mut()
+            .resource_mut::<Messages<vmux_editor::FileViewModeRequest>>()
+            .drain()
+            .collect();
+        assert_eq!(
+            view_modes,
+            vec![vmux_editor::FileViewModeRequest(
+                vmux_core::event::FileViewMode::Diff
+            )]
+        );
     }
 
     #[test]
@@ -6038,6 +6064,7 @@ mod tests {
             .add_message::<vmux_core::PageOpenRequest>()
             .add_message::<vmux_layout::OpenBesideRequest>()
             .add_message::<vmux_layout::active_panes::ActivatePane>()
+            .add_message::<vmux_editor::FileViewModeRequest>()
             .add_message::<vmux_layout::worktree::TabDirectoryObserved>()
             .insert_resource(test_settings())
             .add_systems(Update, handle_agent_file_touch);
@@ -6093,6 +6120,7 @@ mod tests {
             .add_message::<vmux_core::PageOpenRequest>()
             .add_message::<vmux_layout::OpenBesideRequest>()
             .add_message::<vmux_layout::active_panes::ActivatePane>()
+            .add_message::<vmux_editor::FileViewModeRequest>()
             .add_message::<vmux_layout::worktree::TabDirectoryObserved>()
             .insert_resource(settings)
             .add_systems(Update, handle_agent_file_touch);
@@ -6161,6 +6189,7 @@ mod tests {
             .add_message::<vmux_core::PageOpenRequest>()
             .add_message::<vmux_layout::OpenBesideRequest>()
             .add_message::<vmux_layout::active_panes::ActivatePane>()
+            .add_message::<vmux_editor::FileViewModeRequest>()
             .add_message::<vmux_layout::worktree::TabDirectoryObserved>()
             .insert_resource(settings)
             .add_systems(Update, handle_agent_file_touch);
@@ -6289,6 +6318,7 @@ mod tests {
             .add_message::<vmux_core::PageOpenRequest>()
             .add_message::<vmux_layout::OpenBesideRequest>()
             .add_message::<vmux_layout::active_panes::ActivatePane>()
+            .add_message::<vmux_editor::FileViewModeRequest>()
             .init_resource::<CapturedRunCwd>()
             .insert_resource(settings)
             .add_systems(

--- a/crates/vmux_editor/src/lib.rs
+++ b/crates/vmux_editor/src/lib.rs
@@ -29,7 +29,7 @@ mod preview;
 #[cfg(not(target_arch = "wasm32"))]
 mod plugin;
 #[cfg(not(target_arch = "wasm32"))]
-pub use plugin::{EditorPlugin, FileView, restore_file_view_bundle};
+pub use plugin::{EditorPlugin, FileView, FileViewModeRequest, restore_file_view_bundle};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod lsp;

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -166,6 +166,10 @@ impl Default for SharedFileViewMode {
     }
 }
 
+/// Requests a shared rendering mode for all open file editors.
+#[derive(Message, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FileViewModeRequest(pub FileViewMode);
+
 #[derive(Component)]
 struct FileViewModeSent;
 
@@ -595,6 +599,15 @@ fn send_file_view_mode(
                 &event,
             ));
         }
+    }
+}
+
+fn apply_file_view_mode_requests(
+    mut reader: MessageReader<FileViewModeRequest>,
+    mut mode: ResMut<SharedFileViewMode>,
+) {
+    if let Some(request) = reader.read().last() {
+        mode.0 = request.0;
     }
 }
 
@@ -2832,6 +2845,7 @@ impl Plugin for EditorPlugin {
             .init_resource::<ExplorerChromeSynced>()
             .init_resource::<SharedFileViewMode>()
             .add_message::<vmux_core::event::RecordVisitRequest>()
+            .add_message::<FileViewModeRequest>()
             .add_plugins(crate::lsp::LspPlugin)
             .add_plugins(BinEventEmitterPlugin::<(
                 FileResizeEvent,
@@ -2882,6 +2896,7 @@ impl Plugin for EditorPlugin {
                     send_initial_media.after(sync_media_allowlist),
                     (detach_video_overlays, attach_video_overlays).chain(),
                     send_file_theme,
+                    apply_file_view_mode_requests.before(send_file_view_mode),
                     send_file_view_mode,
                     rehighlight_on_color_scheme,
                     drain_thumb_tasks,
@@ -2979,6 +2994,25 @@ mod edit_flow_tests {
             FileViewMode::Diff
         );
         assert!(app.world().get::<FileView>(second).is_some());
+    }
+
+    #[test]
+    fn file_view_mode_request_updates_shared_mode() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<SharedFileViewMode>()
+            .add_message::<FileViewModeRequest>()
+            .add_systems(Update, apply_file_view_mode_requests);
+
+        app.world_mut()
+            .resource_mut::<Messages<FileViewModeRequest>>()
+            .write(FileViewModeRequest(FileViewMode::Diff));
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<SharedFileViewMode>().0,
+            FileViewMode::Diff
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Context

ACP agents can report several edited files in one update, but vmux collapsed same-frame file touches to one preview. The transcript showed every diff while the editor opened only one file, and edits opened in the regular file view instead of the review-oriented diff view.

## Implementation

Keep distinct edit touches for an agent and open them as tabs in the file follow pane. Duplicate start/completion touches are deduplicated by file, while read-only bursts retain the existing latest-file behavior. Edit touches also request the shared file editor diff mode before the previews render.

## Checks / QA

Run a Codex ACP task that edits multiple files in one tool call. Confirm each edited file opens as a tab in the file follow pane, the files display in diff mode, and repeated updates do not create duplicate tabs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File edits now automatically open affected files in Diff view.
  * Multiple distinct files touched in the same update can open as separate tabs.
  * File previews are deduplicated to reduce redundant navigation and duplicate views.

* **Bug Fixes**
  * Improved handling of multiple read and edit events received together.
  * Preserved the appropriate file-pane focus and activation after navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->