### PR TITLE
feat(acp): add first-run authentication flow

### DIFF
--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -23,12 +23,12 @@ use bevy_cef::prelude::{BinEventEmitterPlugin, BinHostEmitEvent, BinReceive, Bro
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::chat_page::event::{
-    CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT,
-    CHAT_SNAPSHOT_EVENT, ChatApproval, ChatAttachPaths, ChatAttachment,
-    ChatAttachmentPreviewRequest, ChatAttachments, ChatCancel, ChatCancelQueuedPrompt,
-    ChatChooseWorkspace, ChatClearQueue, ChatEscape, ChatMediaEntries, ChatMediaEntry,
-    ChatMediaListRequest, ChatPasteMedia, ChatPickFiles, ChatResume, ChatSnapshot, ChatSubmit,
-    MODEL_STATE_EVENT, ModelOptionEntry, ModelState, QueuedPromptSnapshot,
+    AuthMethodEntry, CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT,
+    CHAT_MEDIA_ENTRIES_EVENT, CHAT_SNAPSHOT_EVENT, ChatApproval, ChatAttachPaths, ChatAttachment,
+    ChatAttachmentPreviewRequest, ChatAttachments, ChatAuthenticate, ChatCancel,
+    ChatCancelQueuedPrompt, ChatChooseWorkspace, ChatClearQueue, ChatEscape, ChatMediaEntries,
+    ChatMediaEntry, ChatMediaListRequest, ChatPasteMedia, ChatPickFiles, ChatResume, ChatSnapshot,
+    ChatSubmit, MODEL_STATE_EVENT, ModelOptionEntry, ModelState, QueuedPromptSnapshot,
     RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions, ResumeListRequest,
     ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry,
     SlashCommands,
@@ -182,12 +182,14 @@ impl Plugin for AgentChatPagePlugin {
             )>::for_hosts(&["agent", "start"]))
             .add_plugins(BinEventEmitterPlugin::<(
                 ChatPickFiles,
+                ChatAuthenticate,
                 ChatPasteMedia,
                 ChatMediaListRequest,
                 ChatAttachPaths,
                 ChatAttachmentPreviewRequest,
             )>::for_hosts(&["agent", "start"]))
             .add_observer(on_chat_submit)
+            .add_observer(on_chat_authenticate)
             .add_observer(on_chat_approval)
             .add_observer(on_chat_cancel)
             .add_observer(on_chat_resume)
@@ -243,7 +245,9 @@ fn track_turn_duration(
                         .push(time.elapsed().saturating_sub(start).as_secs() as u32);
                 }
             }
-            AgentRunState::AwaitingApproval { .. } | AgentRunState::Installing { .. } => {}
+            AgentRunState::AwaitingApproval { .. }
+            | AgentRunState::AwaitingAuthentication { .. }
+            | AgentRunState::Installing { .. } => {}
         }
     }
 }
@@ -923,6 +927,18 @@ fn snapshot_of(
         }
         AgentRunState::Streaming => ("streaming", String::new()),
         AgentRunState::AwaitingApproval { .. } => ("awaiting", String::new()),
+        AgentRunState::AwaitingAuthentication {
+            pending_method_id,
+            error,
+            ..
+        } => (
+            if pending_method_id.is_some() {
+                "authenticating"
+            } else {
+                "auth_required"
+            },
+            error.clone(),
+        ),
         AgentRunState::Errored(message) => ("errored", message.clone()),
     };
     let (call_id, name, args_json) = match state {
@@ -936,6 +952,24 @@ fn snapshot_of(
     let (agent_name, accent_color) = profile
         .map(|p| (p.name.clone(), p.avatar.color.clone()))
         .unwrap_or_default();
+    let (auth_methods, auth_pending_method_id) = match state {
+        AgentRunState::AwaitingAuthentication {
+            methods,
+            pending_method_id,
+            ..
+        } => (
+            methods
+                .iter()
+                .map(|method| AuthMethodEntry {
+                    id: method.id.clone(),
+                    name: method.name.clone(),
+                    description: method.description.clone().unwrap_or_default(),
+                })
+                .collect(),
+            pending_method_id.clone().unwrap_or_default(),
+        ),
+        _ => (Vec::new(), String::new()),
+    };
     let agent_icon = meta
         .map(|m| m.icon.favicon_url().to_string())
         .unwrap_or_default();
@@ -946,6 +980,8 @@ fn snapshot_of(
         approval_call_id: call_id,
         approval_name: name,
         approval_args_json: args_json,
+        auth_methods,
+        auth_pending_method_id,
         agent_name,
         agent_icon,
         accent_color,
@@ -974,6 +1010,42 @@ fn snapshot_of(
             .collect(),
         paused: queue.paused,
     }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn on_chat_authenticate(
+    trigger: On<BinReceive<ChatAuthenticate>>,
+    child_of: Query<&ChildOf>,
+    mut sessions: Query<(&AcpSession, &mut AgentRunState)>,
+    service: Option<Res<ServiceClient>>,
+) {
+    let Some(service) = service else {
+        return;
+    };
+    let Ok(parent) = child_of.get(trigger.event().webview) else {
+        return;
+    };
+    let Ok((session, mut state)) = sessions.get_mut(parent.parent()) else {
+        return;
+    };
+    let method_id = trigger.event().payload.method_id.clone();
+    let AgentRunState::AwaitingAuthentication {
+        methods,
+        pending_method_id,
+        error,
+    } = &mut *state
+    else {
+        return;
+    };
+    if pending_method_id.is_some() || !methods.iter().any(|method| method.id == method_id) {
+        return;
+    }
+    *pending_method_id = Some(method_id.clone());
+    error.clear();
+    service.0.send(ClientMessage::AcpAuthenticate {
+        sid: session.sid.clone(),
+        method_id,
+    });
 }
 
 /// Push each changed session's conversation + run-state to its pane webview (the child
@@ -1863,6 +1935,32 @@ mod native_tests {
             snapshot.approval_args_json,
             r#"{"command":"echo hi","focus":true}"#
         );
+    }
+
+    #[test]
+    fn snapshot_includes_acp_authentication_choices() {
+        let snapshot = snapshot_of(
+            &AgentMessages::default(),
+            &AgentRunState::AwaitingAuthentication {
+                methods: vec![vmux_service::protocol::AcpAuthMethod {
+                    id: "browser".into(),
+                    name: "Browser login".into(),
+                    description: Some("Use your existing account".into()),
+                }],
+                pending_method_id: Some("browser".into()),
+                error: String::new(),
+            },
+            None,
+            None,
+            None,
+            &PromptQueue::default(),
+            None,
+            false,
+        );
+
+        assert_eq!(snapshot.status, "authenticating");
+        assert_eq!(snapshot.auth_methods[0].id, "browser");
+        assert_eq!(snapshot.auth_pending_method_id, "browser");
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -49,6 +49,8 @@ pub struct ChatSnapshot {
     pub approval_call_id: String,
     pub approval_name: String,
     pub approval_args_json: String,
+    pub auth_methods: Vec<AuthMethodEntry>,
+    pub auth_pending_method_id: String,
     /// Prompts queued behind the running turn (FIFO), oldest first.
     pub queued: Vec<QueuedPromptSnapshot>,
     /// True after an interrupt: the queue is held (not auto-advancing) until resume/clear/submit.
@@ -64,6 +66,37 @@ pub struct ChatSnapshot {
     /// Number of rendered [`ChatItem`] entries originating from the imported conversation.
     pub handoff_message_count: u32,
     pub workspace_selection_pending: bool,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct AuthMethodEntry {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+}
+
+/// Page → native: start an authentication method advertised by the ACP agent.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatAuthenticate {
+    pub method_id: String,
 }
 
 /// Page → native: the user submitted a prompt.

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -8,15 +8,16 @@ use crate::chat_page::composer::{
     should_expand_thinking, should_fetch_resume, tool_activity,
 };
 use crate::chat_page::event::{
-    CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT,
-    CHAT_SNAPSHOT_EVENT, ChatApproval, ChatAttachPaths, ChatAttachment,
-    ChatAttachmentPreviewRequest, ChatAttachments, ChatBlock, ChatCancel, ChatCancelQueuedPrompt,
-    ChatChooseWorkspace, ChatClearQueue, ChatEscape, ChatItem, ChatMediaEntries, ChatMediaEntry,
-    ChatMediaListRequest, ChatPasteMedia, ChatPickFiles, ChatResume, ChatSnapshot, ChatSubmit,
-    ChatSubmitAttachment, ChatTurn, MODEL_STATE_EVENT, ModelOptionEntry, ModelState,
-    QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions,
-    ResumeListRequest, ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel,
-    SlashCommandEntry, SlashCommands, WORKING_VERBS,
+    AuthMethodEntry, CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT,
+    CHAT_MEDIA_ENTRIES_EVENT, CHAT_SNAPSHOT_EVENT, ChatApproval, ChatAttachPaths, ChatAttachment,
+    ChatAttachmentPreviewRequest, ChatAttachments, ChatAuthenticate, ChatBlock, ChatCancel,
+    ChatCancelQueuedPrompt, ChatChooseWorkspace, ChatClearQueue, ChatEscape, ChatItem,
+    ChatMediaEntries, ChatMediaEntry, ChatMediaListRequest, ChatPasteMedia, ChatPickFiles,
+    ChatResume, ChatSnapshot, ChatSubmit, ChatSubmitAttachment, ChatTurn, MODEL_STATE_EVENT,
+    ModelOptionEntry, ModelState, QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT,
+    ResumableSessionEntry, ResumableSessions, ResumeListRequest, ResumeSession,
+    RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry, SlashCommands,
+    WORKING_VERBS,
 };
 use dioxus::prelude::*;
 use std::borrow::Cow;
@@ -297,6 +298,8 @@ pub fn Page(
     let mut items = use_signal(Vec::<ChatItem>::new);
     let mut status = use_signal(|| "installing".to_string());
     let mut error = use_signal(String::new);
+    let mut auth_methods = use_signal(Vec::<AuthMethodEntry>::new);
+    let mut auth_pending_method_id = use_signal(String::new);
     let mut approval = use_signal(|| Option::<(String, String, String)>::None);
     let mut agent_name = use_signal(String::new);
     let mut agent_icon = use_signal(String::new);
@@ -408,6 +411,8 @@ pub fn Page(
         }
         status.set(snap.status.clone());
         error.set(snap.error.clone());
+        auth_methods.set(snap.auth_methods.clone());
+        auth_pending_method_id.set(snap.auth_pending_method_id.clone());
         queued.set(snap.queued.clone());
         transition_preview.set(String::new());
         transition_attachments.set(Vec::new());
@@ -706,6 +711,52 @@ pub fn Page(
                                 "{header_name}"
                             }
                             p { class: "text-sm text-muted-foreground", "Ready when you are." }
+                        }
+                    } else if matches!(status().as_str(), "auth_required" | "authenticating") {
+                        div { class: "my-auto flex justify-center py-16",
+                            div { class: "w-full max-w-lg rounded-2xl bg-background/80 p-5 shadow-xl ring-1 ring-inset ring-foreground/10 backdrop-blur-xl",
+                                div { class: "flex items-start gap-3",
+                                    {avatar_node(&agent_icon(), &accent(), &agent, &header_name, "h-10 w-10 text-base")}
+                                    div { class: "min-w-0 flex-1",
+                                        h2 { class: "text-base font-semibold text-foreground", "Connect {header_name}" }
+                                        p { class: "mt-1 text-sm leading-relaxed text-muted-foreground",
+                                            "Sign in once. The agent keeps the credentials in its normal account storage."
+                                        }
+                                    }
+                                }
+                                if !error().is_empty() {
+                                    div { class: "mt-4 rounded-lg bg-red-500/10 px-3 py-2 text-xs text-red-600 ring-1 ring-inset ring-red-500/20 dark:text-red-300",
+                                        "{error}"
+                                    }
+                                }
+                                div { class: "mt-4 flex flex-col gap-2",
+                                    for method in auth_methods.read().iter().cloned() {
+                                        {
+                                            let method_id = method.id.clone();
+                                            let pending = auth_pending_method_id() == method.id;
+                                            rsx! {
+                                                button {
+                                                    key: "auth-{method.id}",
+                                                    class: "flex w-full items-center justify-between gap-3 rounded-xl bg-foreground/[0.06] px-4 py-3 text-left ring-1 ring-inset ring-foreground/10 transition hover:bg-foreground/10 disabled:cursor-wait disabled:opacity-60",
+                                                    disabled: !auth_pending_method_id().is_empty(),
+                                                    onclick: move |_| send_authenticate(method_id.clone()),
+                                                    div { class: "min-w-0",
+                                                        div { class: "text-sm font-medium text-foreground", "{method.name}" }
+                                                        if !method.description.is_empty() {
+                                                            div { class: "mt-0.5 text-xs leading-relaxed text-muted-foreground", "{method.description}" }
+                                                        }
+                                                    }
+                                                    if pending {
+                                                        span { class: "h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-foreground/20 border-t-foreground/70" }
+                                                    } else {
+                                                        span { class: "shrink-0 text-sm text-muted-foreground", "Continue →" }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                     for (i , item) in items.read().iter().enumerate() {
@@ -1525,6 +1576,10 @@ fn send_approval(call_id: String, decision: u8) {
     let _ = try_cef_bin_emit_rkyv(&ChatApproval { call_id, decision });
 }
 
+fn send_authenticate(method_id: String) {
+    let _ = try_cef_bin_emit_rkyv(&ChatAuthenticate { method_id });
+}
+
 fn render_item(
     key: usize,
     item: &ChatItem,
@@ -1887,7 +1942,8 @@ fn tool_activity_icon_for(name: &str, args: &str) -> ActivityIcon {
 
 fn current_activity_icon(items: &[ChatItem], status: &str) -> Option<ActivityIcon> {
     match status {
-        "installing" => Some(ActivityIcon::Installing),
+        "installing" | "authenticating" => Some(ActivityIcon::Installing),
+        "auth_required" => Some(ActivityIcon::Awaiting),
         "awaiting" => Some(ActivityIcon::Awaiting),
         "errored" => Some(ActivityIcon::Error),
         "streaming" => {
@@ -2210,6 +2266,8 @@ fn status_dot_class(status: &str) -> &'static str {
     match status {
         "streaming" => "bg-amber-400 animate-pulse shadow-[0_0_8px_rgba(251,191,36,0.65)]",
         "installing" => "bg-sky-400 animate-pulse shadow-[0_0_8px_rgba(56,189,248,0.65)]",
+        "authenticating" => "bg-sky-400 animate-pulse shadow-[0_0_8px_rgba(56,189,248,0.65)]",
+        "auth_required" => "bg-violet-400 animate-pulse shadow-[0_0_8px_rgba(167,139,250,0.65)]",
         "awaiting" => "bg-violet-400 animate-pulse shadow-[0_0_8px_rgba(167,139,250,0.65)]",
         "errored" => "bg-red-500 shadow-[0_0_8px_rgba(239,68,68,0.65)]",
         _ => "bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.65)]",

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -226,6 +226,7 @@ impl Plugin for AcpAgentPlugin {
             .init_resource::<AcpCatalog>()
             .init_resource::<AcpInstallGeneration>()
             .add_message::<vmux_service::agent_events::PageAgentInfo>()
+            .add_message::<vmux_service::agent_events::PageAgentAuthRequired>()
             .add_message::<vmux_service::agent_events::PageAgentWorkspaceChanged>()
             .add_message::<vmux_service::agent_events::PageAgentModelInfo>()
             .add_message::<vmux_service::agent_events::PageAgentModelSelectionResult>()
@@ -240,6 +241,7 @@ impl Plugin for AcpAgentPlugin {
                     drain_acp_installs,
                     receive_catalog,
                     apply_acp_agent_info,
+                    apply_acp_auth_required,
                     apply_acp_workspace_changed,
                     (apply_acp_model_info, apply_acp_model_selection_result).chain(),
                     apply_acp_session_created,
@@ -248,6 +250,23 @@ impl Plugin for AcpAgentPlugin {
             )
             .add_observer(close_acp_session_on_remove)
             .add_observer(auto_allow_acp_approval);
+    }
+}
+
+fn apply_acp_auth_required(
+    mut reader: MessageReader<vmux_service::agent_events::PageAgentAuthRequired>,
+    mut sessions: Query<(&AcpSession, &mut AgentRunState)>,
+) {
+    for event in reader.read() {
+        for (session, mut state) in &mut sessions {
+            if session.sid == event.sid {
+                *state = AgentRunState::AwaitingAuthentication {
+                    methods: event.methods.clone(),
+                    pending_method_id: None,
+                    error: event.error.clone(),
+                };
+            }
+        }
     }
 }
 

--- a/crates/vmux_agent/src/run_state.rs
+++ b/crates/vmux_agent/src/run_state.rs
@@ -17,6 +17,11 @@ pub enum AgentRunState {
         name: String,
         args: serde_json::Value,
     },
+    AwaitingAuthentication {
+        methods: Vec<vmux_service::protocol::AcpAuthMethod>,
+        pending_method_id: Option<String>,
+        error: String,
+    },
     Errored(String),
 }
 

--- a/crates/vmux_agent/src/run_state_kind.rs
+++ b/crates/vmux_agent/src/run_state_kind.rs
@@ -18,6 +18,7 @@ impl From<&AgentRunState> for AgentRunStateKind {
             AgentRunState::Installing { .. } => AgentRunStateKind::Idle,
             AgentRunState::Streaming => AgentRunStateKind::Streaming,
             AgentRunState::AwaitingApproval { .. } => AgentRunStateKind::AwaitingApproval,
+            AgentRunState::AwaitingAuthentication { .. } => AgentRunStateKind::Idle,
             AgentRunState::Errored(_) => AgentRunStateKind::Errored,
         }
     }

--- a/crates/vmux_service/src/acp.rs
+++ b/crates/vmux_service/src/acp.rs
@@ -103,6 +103,12 @@ impl AcpSessionManager {
             .and_then(|handle| handle.shared.model_info_message())
     }
 
+    pub fn auth_required(&self, sid: &str) -> Option<ServiceMessage> {
+        self.sessions
+            .get(sid)
+            .and_then(|handle| handle.shared.auth_required_message())
+    }
+
     pub fn contains(&self, sid: &str) -> bool {
         self.sessions.contains_key(sid)
     }

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -11,19 +11,19 @@ use std::sync::{Arc, Mutex};
 
 use agent_client_protocol::schema::ProtocolVersion;
 use agent_client_protocol::schema::v1::{
-    AudioContent, CancelNotification, ContentBlock, CreateTerminalRequest, CreateTerminalResponse,
-    ImageContent, Implementation, InitializeRequest, KillTerminalRequest, KillTerminalResponse,
-    LoadSessionRequest, McpServer, NewSessionRequest, PermissionOption, PermissionOptionId,
-    PromptCapabilities, PromptRequest, ReadTextFileRequest, ReadTextFileResponse,
-    ReleaseTerminalRequest, ReleaseTerminalResponse, RequestPermissionOutcome,
-    RequestPermissionRequest, RequestPermissionResponse, ResourceLink, SelectedPermissionOutcome,
-    SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory,
+    AudioContent, AuthMethod, AuthenticateRequest, CancelNotification, ContentBlock,
+    CreateTerminalRequest, CreateTerminalResponse, ImageContent, Implementation, InitializeRequest,
+    KillTerminalRequest, KillTerminalResponse, LoadSessionRequest, McpServer, NewSessionRequest,
+    PermissionOption, PermissionOptionId, PromptCapabilities, PromptRequest, ReadTextFileRequest,
+    ReadTextFileResponse, ReleaseTerminalRequest, ReleaseTerminalResponse,
+    RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse, ResourceLink,
+    SelectedPermissionOutcome, SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory,
     SessionConfigSelectOptions, SessionId, SessionNotification, SessionUpdate,
     SetSessionConfigOptionRequest, TerminalExitStatus, TerminalId, TerminalOutputRequest,
     TerminalOutputResponse, TextContent, WaitForTerminalExitRequest, WaitForTerminalExitResponse,
     WriteTextFileRequest, WriteTextFileResponse,
 };
-use agent_client_protocol::{Client, Responder};
+use agent_client_protocol::{Client, ErrorCode, Responder};
 use base64::Engine;
 use tokio::process::Command;
 use tokio::sync::{broadcast, mpsc, oneshot, watch};
@@ -33,7 +33,7 @@ use vmux_core::ProcessId;
 use super::projector::{AcpProjector, Intent};
 use crate::process::{ProcessManager, PtyInputWriter};
 use crate::protocol::{
-    AgentAttachment, AgentCommand, AgentRequestId, AgentRunStatus, ApprovalDecision,
+    AcpAuthMethod, AgentAttachment, AgentCommand, AgentRequestId, AgentRunStatus, ApprovalDecision,
     ServiceMessage, compose_agent_prompt,
 };
 
@@ -57,6 +57,9 @@ pub enum AcpInput {
         config_id: String,
         model_id: String,
     },
+    Authenticate {
+        method_id: String,
+    },
     /// Interrupt the in-flight prompt (ACP `session/cancel`); keep the session alive.
     Cancel,
     Close,
@@ -74,6 +77,12 @@ pub struct AcpTerminal {
     pub process_id: ProcessId,
     pub exit_rx: watch::Receiver<AcpTerminalExit>,
     pub output_byte_limit: Option<u64>,
+}
+
+#[derive(Clone)]
+struct AcpAuthRequiredState {
+    methods: Vec<AcpAuthMethod>,
+    error: String,
 }
 
 #[derive(Clone)]
@@ -133,6 +142,7 @@ pub struct AcpShared {
     pub input_writers: Arc<tokio::sync::Mutex<HashMap<ProcessId, PtyInputWriter>>>,
     agent_name: Mutex<Option<String>>,
     model_info: Mutex<Option<AcpModelInfoState>>,
+    auth_required: Mutex<Option<AcpAuthRequiredState>>,
     history_replay: AtomicBool,
     history_replay_updates: AtomicUsize,
     /// Set by `AcpInput::Cancel`; read (and reset) when the in-flight prompt resolves so it
@@ -161,6 +171,7 @@ impl AcpShared {
             input_writers,
             agent_name: Mutex::new(None),
             model_info: Mutex::new(None),
+            auth_required: Mutex::new(None),
             history_replay: AtomicBool::new(false),
             history_replay_updates: AtomicUsize::new(0),
             cancel_requested: AtomicBool::new(false),
@@ -228,6 +239,35 @@ impl AcpShared {
             .unwrap()
             .as_ref()
             .map(|state| state.message(&self.sid))
+    }
+
+    pub fn auth_required_message(&self) -> Option<ServiceMessage> {
+        self.auth_required
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|state| ServiceMessage::AcpAuthRequired {
+                sid: self.sid.clone(),
+                methods: state.methods.clone(),
+                error: state.error.clone(),
+            })
+    }
+
+    fn publish_auth_required(&self, methods: &[AcpAuthMethod], error: String) {
+        let state = AcpAuthRequiredState {
+            methods: methods.to_vec(),
+            error,
+        };
+        *self.auth_required.lock().unwrap() = Some(state.clone());
+        self.emit(ServiceMessage::AcpAuthRequired {
+            sid: self.sid.clone(),
+            methods: state.methods,
+            error: state.error,
+        });
+    }
+
+    fn clear_auth_required(&self) {
+        self.auth_required.lock().unwrap().take();
     }
 
     fn publish_agent_info(&self, name: String) {
@@ -748,6 +788,7 @@ pub async fn run(
             init.client_capabilities.terminal = true;
             let init_resp = cx.send_request(init).block_task().await?;
             let prompt_capabilities = init_resp.agent_capabilities.prompt_capabilities.clone();
+            let auth_methods = acp_auth_methods(&init_resp.auth_methods);
 
             if let Some(name) = acp_display_name(init_resp.agent_info.as_ref()) {
                 main_shared.publish_agent_info(name);
@@ -812,14 +853,21 @@ pub async fn run(
                         }
                     }
                     Err(err) => {
-                        main_shared.emit_status(AgentRunStatus::Errored(format!(
-                            "acp session/new failed: {err}"
-                        )));
-                        return Ok(());
+                        if err.code == ErrorCode::AuthRequired {
+                            request_authentication(&main_shared, &auth_methods, &err);
+                        } else {
+                            main_shared.emit_status(AgentRunStatus::Errored(format!(
+                                "acp session/new failed: {err}"
+                            )));
+                            return Ok(());
+                        }
                     }
                 }
             }
-            main_shared.emit_status(AgentRunStatus::Idle);
+            if session_id.is_some() {
+                main_shared.clear_auth_required();
+                main_shared.emit_status(AgentRunStatus::Idle);
+            }
 
             while let Some(input) = input_rx.recv().await {
                 match input {
@@ -857,6 +905,10 @@ pub async fn run(
                         .await;
                         let (active_session_id, created) = match ensured {
                             Ok(value) => value,
+                            Err(err) if err.code == ErrorCode::AuthRequired => {
+                                request_authentication(&main_shared, &auth_methods, &err);
+                                continue;
+                            }
                             Err(err) => {
                                 main_shared.emit_status(AgentRunStatus::Errored(format!(
                                     "acp session/new failed: {err}"
@@ -898,6 +950,71 @@ pub async fn run(
                         if let Some(tx) = main_shared.pending_perms.lock().unwrap().remove(&call_id)
                         {
                             let _ = tx.send(decision);
+                        }
+                    }
+                    AcpInput::Authenticate { method_id } => {
+                        if !auth_methods.iter().any(|method| method.id == method_id) {
+                            main_shared.publish_auth_required(
+                                &auth_methods,
+                                "The agent no longer offers that login method".to_string(),
+                            );
+                            continue;
+                        }
+                        match cx
+                            .send_request(AuthenticateRequest::new(method_id))
+                            .block_task()
+                            .await
+                        {
+                            Ok(_) => {
+                                let ensured = ensure_session(&mut session_id, || {
+                                    let mut new_session = NewSessionRequest::new(main_shared.cwd());
+                                    new_session.mcp_servers = mcp_servers.clone();
+                                    new_session.meta = session_meta.clone();
+                                    let shared = main_shared.clone();
+                                    let cx = cx.clone();
+                                    async move {
+                                        cx.send_request(new_session).block_task().await.map(
+                                            |response| {
+                                                shared.publish_model_info(
+                                                    response
+                                                        .config_options
+                                                        .as_deref()
+                                                        .unwrap_or_default(),
+                                                );
+                                                response.session_id
+                                            },
+                                        )
+                                    }
+                                })
+                                .await;
+                                match ensured {
+                                    Ok((sid, created)) => {
+                                        main_shared.clear_auth_required();
+                                        if created {
+                                            main_shared.emit(ServiceMessage::AcpSessionCreated {
+                                                sid: main_shared.sid.clone(),
+                                                acp_session_id: sid.to_string(),
+                                            });
+                                        }
+                                        main_shared.emit_status(AgentRunStatus::Idle);
+                                    }
+                                    Err(err) if err.code == ErrorCode::AuthRequired => {
+                                        request_authentication(&main_shared, &auth_methods, &err);
+                                    }
+                                    Err(err) => {
+                                        main_shared.publish_auth_required(
+                                            &auth_methods,
+                                            format!("Sign-in completed, but startup failed: {err}"),
+                                        );
+                                    }
+                                }
+                            }
+                            Err(err) => {
+                                main_shared.publish_auth_required(
+                                    &auth_methods,
+                                    format!("Sign-in failed: {err}"),
+                                );
+                            }
                         }
                     }
                     AcpInput::SetModel {
@@ -1044,6 +1161,37 @@ fn acp_display_name(info: Option<&Implementation>) -> Option<String> {
             (!name.is_empty()).then_some(name)
         })
         .map(str::to_string)
+}
+
+fn acp_auth_methods(methods: &[AuthMethod]) -> Vec<AcpAuthMethod> {
+    methods
+        .iter()
+        .map(|method| AcpAuthMethod {
+            id: method.id().to_string(),
+            name: method.name().to_string(),
+            description: method.description().map(str::to_string),
+        })
+        .collect()
+}
+
+fn request_authentication(
+    shared: &AcpShared,
+    methods: &[AcpAuthMethod],
+    error: &agent_client_protocol::Error,
+) {
+    if methods.is_empty() {
+        shared.emit_status(AgentRunStatus::Errored(
+            "Authentication required, but the agent did not advertise a login method. Run its CLI once or export its API key, then reopen this chat"
+                .to_string(),
+        ));
+        return;
+    }
+    let detail = if error.code == ErrorCode::AuthRequired {
+        String::new()
+    } else {
+        error.message.clone()
+    };
+    shared.publish_auth_required(methods, detail);
 }
 
 fn publish_model_selection_result(
@@ -2264,6 +2412,50 @@ mod tests {
             Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         ));
         (shared, stream_rx)
+    }
+
+    #[test]
+    fn auth_methods_preserve_agent_metadata() {
+        let methods = acp_auth_methods(&[AuthMethod::Agent(
+            agent_client_protocol::schema::v1::AuthMethodAgent::new("browser", "Browser login")
+                .description("Use your existing account"),
+        )]);
+
+        assert_eq!(
+            methods,
+            vec![AcpAuthMethod {
+                id: "browser".into(),
+                name: "Browser login".into(),
+                description: Some("Use your existing account".into()),
+            }]
+        );
+    }
+
+    #[test]
+    fn auth_required_is_emitted_and_replayable() {
+        let (shared, mut stream_rx) =
+            test_shared(Arc::new(tokio::sync::Mutex::new(ProcessManager::default())));
+        let methods = vec![AcpAuthMethod {
+            id: "browser".into(),
+            name: "Browser login".into(),
+            description: None,
+        }];
+
+        request_authentication(
+            &shared,
+            &methods,
+            &agent_client_protocol::Error::auth_required(),
+        );
+
+        assert!(matches!(
+            stream_rx.try_recv().unwrap(),
+            ServiceMessage::AcpAuthRequired { methods: emitted, error, .. }
+                if emitted == methods && error.is_empty()
+        ));
+        assert!(matches!(
+            shared.auth_required_message(),
+            Some(ServiceMessage::AcpAuthRequired { methods: emitted, .. }) if emitted == methods
+        ));
     }
 
     #[test]

--- a/crates/vmux_service/src/agent_events.rs
+++ b/crates/vmux_service/src/agent_events.rs
@@ -86,6 +86,13 @@ pub struct PageAgentInfo {
 }
 
 #[derive(Message)]
+pub struct PageAgentAuthRequired {
+    pub sid: String,
+    pub methods: Vec<crate::protocol::AcpAuthMethod>,
+    pub error: String,
+}
+
+#[derive(Message)]
 pub struct PageAgentWorkspaceChanged {
     pub sid: String,
     pub name: String,

--- a/crates/vmux_service/src/server.rs
+++ b/crates/vmux_service/src/server.rs
@@ -907,6 +907,13 @@ async fn handle_client(
                 }
             }
 
+            ClientMessage::AcpAuthenticate { sid, method_id } => {
+                acp_manager
+                    .lock()
+                    .await
+                    .input(&sid, crate::acp::AcpInput::Authenticate { method_id });
+            }
+
             ClientMessage::ClosePageAgent { sid } => {
                 if acp_manager.lock().await.contains(&sid) {
                     acp_manager.lock().await.close(&sid);
@@ -976,6 +983,10 @@ async fn handle_client(
                     if let Some(model_info) = acp_manager.lock().await.model_info(&sid) {
                         let mut w = writer.lock().await;
                         write_message!(&mut *w, &model_info)?;
+                    }
+                    if let Some(auth_required) = acp_manager.lock().await.auth_required(&sid) {
+                        let mut w = writer.lock().await;
+                        write_message!(&mut *w, &auth_required)?;
                     }
                     if let Some(old) = page_agent_forwarders.remove(&sid) {
                         old.abort();

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -1169,6 +1169,7 @@ struct PollServiceWriters<'w> {
     page_agent_awaiting: MessageWriter<'w, vmux_service::agent_events::PageAgentAwaitingApproval>,
     page_agent_snapshot: MessageWriter<'w, vmux_service::agent_events::PageAgentSnapshot>,
     page_agent_info: MessageWriter<'w, vmux_service::agent_events::PageAgentInfo>,
+    page_agent_auth_required: MessageWriter<'w, vmux_service::agent_events::PageAgentAuthRequired>,
     page_agent_workspace_changed:
         MessageWriter<'w, vmux_service::agent_events::PageAgentWorkspaceChanged>,
     page_agent_model_info: MessageWriter<'w, vmux_service::agent_events::PageAgentModelInfo>,
@@ -1674,6 +1675,19 @@ fn poll_service_messages(
                 writers
                     .page_agent_info
                     .write(vmux_service::agent_events::PageAgentInfo { sid, name });
+            }
+            ServiceMessage::AcpAuthRequired {
+                sid,
+                methods,
+                error,
+            } => {
+                writers.page_agent_auth_required.write(
+                    vmux_service::agent_events::PageAgentAuthRequired {
+                        sid,
+                        methods,
+                        error,
+                    },
+                );
             }
             ServiceMessage::AcpWorkspaceChanged {
                 sid,
@@ -3914,6 +3928,8 @@ mod tests {
             .expect("service handler body");
         assert!(handler.contains("ServiceMessage::AcpAgentInfo"));
         assert!(handler.contains(".page_agent_info"));
+        assert!(handler.contains("ServiceMessage::AcpAuthRequired"));
+        assert!(handler.contains(".page_agent_auth_required"));
     }
 
     #[test]

--- a/crates/vmux_wire/src/protocol.rs
+++ b/crates/vmux_wire/src/protocol.rs
@@ -522,6 +522,11 @@ pub enum ClientMessage {
         config_id: String,
         model_id: String,
     },
+    /// Start one authentication method advertised by the ACP agent during initialization.
+    AcpAuthenticate {
+        sid: String,
+        method_id: String,
+    },
     /// Interrupt the session's in-flight turn without tearing the session down.
     AgentCancel {
         sid: String,
@@ -878,6 +883,12 @@ pub enum ServiceMessage {
         sid: String,
         name: String,
     },
+    /// The agent rejected session creation until the user completes one advertised login method.
+    AcpAuthRequired {
+        sid: String,
+        methods: Vec<AcpAuthMethod>,
+        error: String,
+    },
     AcpWorkspaceChanged {
         sid: String,
         name: String,
@@ -904,6 +915,14 @@ pub enum ServiceMessage {
 /// One model exposed by an ACP session configuration selector.
 #[derive(Debug, Clone, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct AcpModelOption {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
+}
+
+/// One authentication choice advertised by an ACP agent during initialization.
+#[derive(Debug, Clone, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub struct AcpAuthMethod {
     pub id: String,
     pub name: String,
     pub description: Option<String>,
@@ -1509,6 +1528,10 @@ mod tests {
                 sid: "s".into(),
                 cwd: "/tmp/worktree".into(),
             },
+            ClientMessage::AcpAuthenticate {
+                sid: "s".into(),
+                method_id: "browser".into(),
+            },
         ];
         for msg in messages {
             let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&msg).unwrap();
@@ -1580,6 +1603,15 @@ mod tests {
             ServiceMessage::AcpAgentInfo {
                 sid: "s".into(),
                 name: "Antigravity".into(),
+            },
+            ServiceMessage::AcpAuthRequired {
+                sid: "s".into(),
+                methods: vec![AcpAuthMethod {
+                    id: "browser".into(),
+                    name: "Continue in browser".into(),
+                    description: Some("Sign in to your account".into()),
+                }],
+                error: String::new(),
             },
             ServiceMessage::AcpModelInfo {
                 sid: "s".into(),

--- a/docs/specs/2026-07-01-acp-runtime-bootstrap-design.md
+++ b/docs/specs/2026-07-01-acp-runtime-bootstrap-design.md
@@ -87,9 +87,14 @@ auth, version pin, plus a `System` escape hatch for custom agents not in the reg
 Re-fetch `registry.json` on the TTL; compare installed `Receipt.version` vs registry `version`;
 surface an update in the manager page (and refresh on next launch). No manual version bumps.
 
-### 8. Auth (unchanged, agent-handled)
-Each agent does Agent Auth (OAuth, opens browser) or Terminal Auth on first prompt; vmux passes env
-from settings overrides. Not vmux's concern beyond env plumbing.
+### 8. Auth
+vmux optimistically creates the session so existing CLI credentials and login-shell API keys remain
+zero-click. On ACP `auth_required`, it keeps the adapter alive, shows the advertised Agent Auth
+methods in the chat page, sends `authenticate` after the user chooses one, then retries session
+creation. Authentication errors return to the same card for retry.
+
+Unstable ACP environment-variable and terminal-auth methods remain separate follow-up work. Their
+credentials must be collected securely and applied before restarting the adapter process.
 
 ## Scope / sequencing (this is large — flagged)
 


### PR DESCRIPTION
## Context
Fresh users without existing agent credentials hit ACP auth_required and only see a raw error. This blocks the first agent connection even when the adapter advertises a supported browser or account login flow.

## Implementation
- Optimistically create sessions so existing CLI credentials and login-shell API keys stay zero-click.
- Keep the ACP adapter alive on auth_required, surface advertised login methods in the chat page, call authenticate after selection, and retry session creation.
- Preserve pending authentication state across service attachment and return failed attempts to the same retryable card.
- Document unstable environment-variable and terminal authentication as follow-up work.

## Checks / QA
1. With no saved credentials, open a Codex or Vibe ACP chat and confirm the connection card lists the advertised login methods.
2. Select browser login, complete authentication, and confirm the chat becomes ready without reopening the pane.
3. Open an agent with existing credentials and confirm no authentication card appears.
4. Cancel or fail authentication and confirm the card returns with an actionable error and can be retried.