### PR TITLE
feat(agent): extend run timeout for Codex and Claude

### DIFF
--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -587,8 +587,18 @@ fn apply_agent_compatibility_env(
     match crate::acp_install::registry_id_alias(agent_id) {
         "mistral-vibe" => apply_vibe_compatibility_env(env),
         "codex-acp" => apply_codex_compatibility_env(env),
+        "claude-acp" => apply_claude_compatibility_env(env),
         _ => env,
     }
+}
+
+fn apply_claude_compatibility_env(mut env: Vec<(String, String)>) -> Vec<(String, String)> {
+    env.retain(|(key, _)| key != "MCP_TOOL_TIMEOUT");
+    env.push((
+        "MCP_TOOL_TIMEOUT".to_string(),
+        (crate::mcp::LONG_MCP_TOOL_TIMEOUT_SECS * 1_000).to_string(),
+    ));
+    env
 }
 
 fn apply_vibe_compatibility_env(mut env: Vec<(String, String)>) -> Vec<(String, String)> {
@@ -699,6 +709,25 @@ fn apply_codex_compatibility_env(mut env: Vec<(String, String)>) -> Vec<(String,
         .as_object_mut()
         .unwrap()
         .insert("web_search".to_string(), serde_json::Value::Bool(false));
+
+    let mcp_servers = config
+        .entry("mcp_servers")
+        .or_insert_with(|| serde_json::json!({}));
+    if !mcp_servers.is_object() {
+        *mcp_servers = serde_json::json!({});
+    }
+    let vmux = mcp_servers
+        .as_object_mut()
+        .unwrap()
+        .entry("vmux")
+        .or_insert_with(|| serde_json::json!({}));
+    if !vmux.is_object() {
+        *vmux = serde_json::json!({});
+    }
+    vmux.as_object_mut().unwrap().insert(
+        "tool_timeout_sec".to_string(),
+        serde_json::json!(crate::mcp::LONG_MCP_TOOL_TIMEOUT_SECS),
+    );
 
     let instructions = config
         .get("developer_instructions")
@@ -1586,6 +1615,7 @@ mod tests {
             assert_eq!(config["features"]["unified_exec"], false);
             assert_eq!(config["tools"]["web_search"], false);
             assert_eq!(config["approvals_reviewer"], "user");
+            assert_eq!(config["mcp_servers"]["vmux"]["tool_timeout_sec"], 660);
             assert_eq!(
                 config["features"]["code_mode"]["direct_only_tool_namespaces"],
                 serde_json::json!([crate::client::cli::codex::DIRECT_ONLY_NAMESPACE])
@@ -1595,6 +1625,19 @@ mod tests {
                     .as_str()
                     .unwrap()
                     .contains("mcp__vmux__run")
+            );
+        }
+    }
+
+    #[test]
+    fn claude_acp_extends_mcp_tool_timeout() {
+        for agent_id in ["claude", "claude-acp"] {
+            let env = apply_agent_compatibility_env(agent_id, vec![s("MCP_TOOL_TIMEOUT", "60000")]);
+            assert_eq!(
+                env.iter()
+                    .find(|(key, _)| key == "MCP_TOOL_TIMEOUT")
+                    .map(|(_, value)| value.as_str()),
+                Some("660000")
             );
         }
     }

--- a/crates/vmux_agent/src/client/cli/claude.rs
+++ b/crates/vmux_agent/src/client/cli/claude.rs
@@ -15,7 +15,8 @@ const ALLOWED_TOOLS: &str = "mcp__vmux__run,mcp__vmux__read_terminal,\
 mcp__vmux__browser_navigate,mcp__vmux__browser_snapshot,mcp__vmux__browser_scroll";
 const RUN_STEER_PROMPT: &str = "The native Bash, WebSearch, and WebFetch tools are disabled. Run \
 ALL shell commands via the mcp__vmux__run tool (a visible terminal the user can watch and take \
-over). Do ALL web access via the vmux browser tools in the user's visible browser: \
+over). Use the output returned by run directly; call read_terminal only when run says the command \
+is still running. Do ALL web access via the vmux browser tools in the user's visible browser: \
 mcp__vmux__browser_navigate (it returns the page snapshot on load), then mcp__vmux__browser_scroll \
 to read more. Omit the pane argument - it targets your own browser pane. Do not look for a \
 built-in web search.";
@@ -60,7 +61,10 @@ impl CliAgentStrategy for ClaudeStrategy {
     }
 
     fn build_env(&self, _mcp: &McpServerConfig) -> Vec<(String, String)> {
-        vec![]
+        vec![(
+            "MCP_TOOL_TIMEOUT".to_string(),
+            (crate::mcp::LONG_MCP_TOOL_TIMEOUT_SECS * 1_000).to_string(),
+        )]
     }
 
     fn discover_session(
@@ -521,6 +525,20 @@ mod tests {
         assert!(json.contains("\"cwd\":\"/work\""));
         assert!(json.contains("\"vmux\""));
         assert!(json.contains("\"mcpServers\""));
+    }
+
+    #[test]
+    fn build_env_extends_mcp_tool_timeout() {
+        let mcp = McpServerConfig {
+            command: "/bin/vmux".into(),
+            args: vec!["mcp".into()],
+            cwd: None,
+        };
+
+        assert_eq!(
+            ClaudeStrategy.build_env(&mcp),
+            vec![("MCP_TOOL_TIMEOUT".into(), "660000".into())]
+        );
     }
 
     #[test]

--- a/crates/vmux_agent/src/client/cli/codex.rs
+++ b/crates/vmux_agent/src/client/cli/codex.rs
@@ -11,7 +11,8 @@ use crate::{AgentKind, AgentVariant, AssistantBlock, McpServerConfig, Message};
 const DISABLED_FEATURES: &[&str] = &["shell_tool", "unified_exec"];
 pub(crate) const DIRECT_ONLY_NAMESPACE: &str = "mcp__vmux";
 pub(crate) const RUN_STEER_PROMPT: &str = "The native shell and web search tools are disabled. Run ALL shell \
-commands via the mcp__vmux__run tool (a visible terminal the user can watch and take over). To READ \
+commands via the mcp__vmux__run tool (a visible terminal the user can watch and take over). Use the \
+output returned by run directly; call read_terminal only when run says the command is still running. To READ \
 a file, use the mcp__vmux__read_file tool (it shows the file in a pane beside you and returns its \
 text) - do NOT cat/sed/head/tail a file via run. To SEARCH code, use the mcp__vmux__grep tool (it \
 opens each matching file in a pane and returns the matches) - do NOT run rg/grep/ag via run. Do ALL web access via the vmux browser tools in the \
@@ -44,6 +45,11 @@ impl CliAgentStrategy for CodexStrategy {
             format!("mcp_servers.vmux.command={}", quote_toml(&mcp.command)),
             "-c".into(),
             format!("mcp_servers.vmux.args={}", toml_array(&mcp.args)),
+            "-c".into(),
+            format!(
+                "mcp_servers.vmux.tool_timeout_sec={}",
+                crate::mcp::LONG_MCP_TOOL_TIMEOUT_SECS
+            ),
         ];
         if let Some(cwd) = &mcp.cwd {
             args.push("-c".into());
@@ -402,6 +408,10 @@ mod tests {
                 .any(|a| a == "mcp_servers.vmux.command=\"/bin/vmux\"")
         );
         assert!(args.iter().any(|a| a == "mcp_servers.vmux.args=[\"mcp\"]"));
+        assert!(
+            args.iter()
+                .any(|a| a == "mcp_servers.vmux.tool_timeout_sec=660")
+        );
     }
 
     #[test]

--- a/crates/vmux_agent/src/launch.rs
+++ b/crates/vmux_agent/src/launch.rs
@@ -14,7 +14,7 @@ pub fn build_agent_launch(
     let strategy = strategies
         .get_cli(kind)
         .ok_or_else(|| format!("CLI strategy not registered for {:?}", kind))?;
-    let mcp_cfg = mcp::resolve(cwd, anchor)?;
+    let mcp_cfg = mcp::resolve(cwd, anchor, kind)?;
     strategy.prepare_launch(&mcp_cfg);
     let args = strategy.build_args(&mcp_cfg, session_id);
     let mut env: Vec<(String, String)> = std::env::vars().collect();

--- a/crates/vmux_agent/src/mcp.rs
+++ b/crates/vmux_agent/src/mcp.rs
@@ -3,10 +3,14 @@ use std::path::{Path, PathBuf};
 use vmux_core::ProcessId;
 pub use vmux_core::agent::McpServerConfig;
 
-use crate::exec;
+use crate::{AgentKind, exec};
 
-pub fn resolve(cwd: &Path, anchor: ProcessId) -> Result<McpServerConfig, String> {
-    resolve_inner(cwd, anchor, false, false)
+const DEFAULT_RUN_TIMEOUT_SECS: u64 = 50;
+pub(crate) const LONG_RUN_TIMEOUT_SECS: u64 = 600;
+pub(crate) const LONG_MCP_TOOL_TIMEOUT_SECS: u64 = LONG_RUN_TIMEOUT_SECS + 60;
+
+pub fn resolve(cwd: &Path, anchor: ProcessId, kind: AgentKind) -> Result<McpServerConfig, String> {
+    resolve_inner(cwd, anchor, false, false, run_timeout_secs_for_kind(kind))
 }
 
 /// Resolve the MCP sidecar for an ACP agent. Agents that use ACP client terminals hide the
@@ -16,7 +20,27 @@ pub fn resolve_acp(
     anchor: ProcessId,
     agent_id: &str,
 ) -> Result<McpServerConfig, String> {
-    resolve_inner(cwd, anchor, true, acp_uses_native_terminals(agent_id))
+    resolve_inner(
+        cwd,
+        anchor,
+        true,
+        acp_uses_native_terminals(agent_id),
+        run_timeout_secs_for_agent_id(agent_id),
+    )
+}
+
+fn run_timeout_secs_for_kind(kind: AgentKind) -> u64 {
+    match kind {
+        AgentKind::Vibe => DEFAULT_RUN_TIMEOUT_SECS,
+        AgentKind::Claude | AgentKind::Codex => LONG_RUN_TIMEOUT_SECS,
+    }
+}
+
+fn run_timeout_secs_for_agent_id(agent_id: &str) -> u64 {
+    match crate::acp_install::registry_id_alias(agent_id) {
+        "claude-acp" | "codex-acp" => LONG_RUN_TIMEOUT_SECS,
+        _ => DEFAULT_RUN_TIMEOUT_SECS,
+    }
 }
 
 fn acp_uses_native_terminals(agent_id: &str) -> bool {
@@ -31,10 +55,19 @@ fn resolve_inner(
     anchor: ProcessId,
     acp_session: bool,
     acp_terminals: bool,
+    run_timeout_secs: u64,
 ) -> Result<McpServerConfig, String> {
     let sidecar = vmux_sidecar_path()?;
     let profile = vmux_core::profile::active_profile_name();
-    resolve_with_sidecar(&sidecar, cwd, anchor, &profile, acp_session, acp_terminals)
+    resolve_with_sidecar(
+        &sidecar,
+        cwd,
+        anchor,
+        &profile,
+        acp_session,
+        acp_terminals,
+        run_timeout_secs,
+    )
 }
 
 fn resolve_with_sidecar(
@@ -44,11 +77,18 @@ fn resolve_with_sidecar(
     profile: &str,
     acp_session: bool,
     acp_terminals: bool,
+    run_timeout_secs: u64,
 ) -> Result<McpServerConfig, String> {
     if exec::is_executable_path(sidecar) {
         return Ok(McpServerConfig {
             command: sidecar.to_string_lossy().to_string(),
-            args: mcp_subcommand_args(anchor, profile, acp_session, acp_terminals),
+            args: mcp_subcommand_args(
+                anchor,
+                profile,
+                acp_session,
+                acp_terminals,
+                run_timeout_secs,
+            ),
             cwd: None,
         });
     }
@@ -63,6 +103,7 @@ fn resolve_with_sidecar(
         profile,
         acp_session,
         acp_terminals,
+        run_timeout_secs,
     ));
     Ok(McpServerConfig {
         command: "cargo".to_string(),
@@ -76,6 +117,7 @@ fn mcp_subcommand_args(
     profile: &str,
     acp_session: bool,
     acp_terminals: bool,
+    run_timeout_secs: u64,
 ) -> Vec<String> {
     let mut args = vec![
         "mcp".to_string(),
@@ -83,6 +125,8 @@ fn mcp_subcommand_args(
         anchor.to_string(),
         "--profile".to_string(),
         profile.to_string(),
+        "--run-timeout-secs".to_string(),
+        run_timeout_secs.to_string(),
     ];
     if acp_session {
         args.push("--acp-session".to_string());
@@ -120,7 +164,7 @@ mod tests {
     fn mcp_args_always_append_profile() {
         let anchor = ProcessId::new();
         for profile in ["personal", "gregor"] {
-            let args = mcp_subcommand_args(anchor, profile, false, false);
+            let args = mcp_subcommand_args(anchor, profile, false, false, DEFAULT_RUN_TIMEOUT_SECS);
             assert!(
                 args.windows(2)
                     .any(|w| w[0] == "--profile" && w[1] == profile)
@@ -131,8 +175,8 @@ mod tests {
     #[test]
     fn acp_args_append_acp_terminals_flag() {
         let anchor = ProcessId::new();
-        let plain = mcp_subcommand_args(anchor, "personal", false, false);
-        let acp = mcp_subcommand_args(anchor, "personal", true, true);
+        let plain = mcp_subcommand_args(anchor, "personal", false, false, DEFAULT_RUN_TIMEOUT_SECS);
+        let acp = mcp_subcommand_args(anchor, "personal", true, true, DEFAULT_RUN_TIMEOUT_SECS);
         assert!(!plain.iter().any(|a| a == "--acp-session"));
         assert!(acp.iter().any(|a| a == "--acp-session"));
         assert!(!plain.iter().any(|a| a == "--acp-terminals"));
@@ -151,6 +195,38 @@ mod tests {
     }
 
     #[test]
+    fn codex_and_claude_use_long_run_timeout() {
+        assert_eq!(
+            run_timeout_secs_for_kind(AgentKind::Codex),
+            LONG_RUN_TIMEOUT_SECS
+        );
+        assert_eq!(
+            run_timeout_secs_for_kind(AgentKind::Claude),
+            LONG_RUN_TIMEOUT_SECS
+        );
+        assert_eq!(
+            run_timeout_secs_for_agent_id("codex"),
+            LONG_RUN_TIMEOUT_SECS
+        );
+        assert_eq!(
+            run_timeout_secs_for_agent_id("claude"),
+            LONG_RUN_TIMEOUT_SECS
+        );
+    }
+
+    #[test]
+    fn vibe_keeps_default_run_timeout() {
+        assert_eq!(
+            run_timeout_secs_for_kind(AgentKind::Vibe),
+            DEFAULT_RUN_TIMEOUT_SECS
+        );
+        assert_eq!(
+            run_timeout_secs_for_agent_id("mistral-vibe"),
+            DEFAULT_RUN_TIMEOUT_SECS
+        );
+    }
+
+    #[test]
     fn falls_back_to_cargo_run_when_sidecar_is_missing() {
         let temp = std::env::temp_dir().join(format!("vmux-agent-mcp-{}", std::process::id()));
         let workspace = temp.join("workspace");
@@ -165,6 +241,7 @@ mod tests {
             "personal",
             false,
             false,
+            DEFAULT_RUN_TIMEOUT_SECS,
         )
         .unwrap();
         let _ = std::fs::remove_dir_all(&temp);
@@ -184,7 +261,9 @@ mod tests {
                 "--anchor",
                 &anchor.to_string(),
                 "--profile",
-                "personal"
+                "personal",
+                "--run-timeout-secs",
+                "50"
             ]
         );
         assert_eq!(config.cwd, Some(workspace));
@@ -205,6 +284,7 @@ mod tests {
             "personal",
             false,
             false,
+            DEFAULT_RUN_TIMEOUT_SECS,
         )
         .unwrap();
         let _ = std::fs::remove_dir_all(&temp);

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -5047,7 +5047,9 @@ fn rebuilt_args_env_for_restart(
     session_id: Option<&str>,
     new_id: ProcessId,
 ) -> (Vec<String>, Vec<(String, String)>) {
-    let Ok(mcp_cfg) = crate::mcp::resolve(std::path::Path::new(&launch.cwd), new_id) else {
+    let Ok(mcp_cfg) =
+        crate::mcp::resolve(std::path::Path::new(&launch.cwd), new_id, strategy.kind())
+    else {
         return (launch.args.clone(), launch.env.clone());
     };
     let args = strategy.build_args(&mcp_cfg, session_id);

--- a/crates/vmux_cli/src/commands.rs
+++ b/crates/vmux_cli/src/commands.rs
@@ -28,6 +28,8 @@ pub enum Command {
         /// terminals instead); `terminal_send` stays.
         #[arg(long)]
         acp_terminals: bool,
+        #[arg(long, default_value_t = 50)]
+        run_timeout_secs: u64,
     },
     Notify {
         #[arg(long)]

--- a/crates/vmux_cli/src/commands/mcp.rs
+++ b/crates/vmux_cli/src/commands/mcp.rs
@@ -5,6 +5,7 @@ pub async fn run(
     profile: Option<String>,
     acp_session: bool,
     acp_terminals: bool,
+    run_timeout_secs: u64,
 ) -> io::Result<()> {
     if let Some(p) = profile
         .map(|p| p.trim().to_string())
@@ -13,5 +14,11 @@ pub async fn run(
         unsafe { std::env::set_var("VMUX_PROFILE", p) };
     }
     let anchor = anchor.and_then(|s| s.parse::<vmux_service::protocol::ProcessId>().ok());
-    vmux_mcp::protocol::run_stdio(anchor, acp_session, acp_terminals).await
+    vmux_mcp::protocol::run_stdio(
+        anchor,
+        acp_session,
+        acp_terminals,
+        std::time::Duration::from_secs(run_timeout_secs),
+    )
+    .await
 }

--- a/crates/vmux_cli/src/main.rs
+++ b/crates/vmux_cli/src/main.rs
@@ -16,7 +16,17 @@ async fn main() -> std::io::Result<()> {
             profile,
             acp_session,
             acp_terminals,
-        }) => commands::mcp::run(anchor, profile, acp_session, acp_terminals).await,
+            run_timeout_secs,
+        }) => {
+            commands::mcp::run(
+                anchor,
+                profile,
+                acp_session,
+                acp_terminals,
+                run_timeout_secs,
+            )
+            .await
+        }
         Some(Command::Notify {
             title,
             body,

--- a/crates/vmux_mcp/src/protocol.rs
+++ b/crates/vmux_mcp/src/protocol.rs
@@ -6,9 +6,6 @@ use vmux_service::protocol::{
     ServiceMessage,
 };
 
-/// How long `run` waits for a command to finish before returning a partial
-/// result. Kept under vibe's 60s default MCP tool timeout.
-const RUN_BLOCK_TIMEOUT: Duration = Duration::from_secs(50);
 const RUN_PROCESS_MATERIALIZE_TIMEOUT: Duration = Duration::from_secs(2);
 /// Interval between terminal reads while waiting for the completion marker.
 const RUN_POLL_INTERVAL: Duration = Duration::from_millis(200);
@@ -28,6 +25,7 @@ pub async fn run_stdio(
     anchor: Option<vmux_service::protocol::ProcessId>,
     acp_session: bool,
     acp_terminals: bool,
+    run_block_timeout: Duration,
 ) -> io::Result<()> {
     let stdin = io::stdin();
     let mut reader = stdin.lock();
@@ -35,7 +33,15 @@ pub async fn run_stdio(
     let mut writer = stdout.lock();
 
     while let Some(message) = read_json_line(&mut reader)? {
-        if let Some(response) = handle_message(message, anchor, acp_session, acp_terminals).await {
+        if let Some(response) = handle_message(
+            message,
+            anchor,
+            acp_session,
+            acp_terminals,
+            run_block_timeout,
+        )
+        .await
+        {
             serde_json::to_writer(&mut writer, &response)?;
             writer.write_all(b"\n")?;
             writer.flush()?;
@@ -49,6 +55,7 @@ async fn handle_message(
     anchor: Option<vmux_service::protocol::ProcessId>,
     acp_session: bool,
     acp_terminals: bool,
+    run_block_timeout: Duration,
 ) -> Option<Value> {
     let id = message.get("id").cloned()?;
     let method = message.get("method").and_then(Value::as_str).unwrap_or("");
@@ -59,7 +66,16 @@ async fn handle_message(
         "tools/list" => Ok(json!({
             "tools": crate::tools::tool_definitions_filtered(acp_session, acp_terminals)
         })),
-        "tools/call" => tool_call_result(&params, anchor, acp_session, acp_terminals).await,
+        "tools/call" => {
+            tool_call_result(
+                &params,
+                anchor,
+                acp_session,
+                acp_terminals,
+                run_block_timeout,
+            )
+            .await
+        }
         _ => {
             return Some(json!({
                 "jsonrpc": "2.0",
@@ -108,6 +124,7 @@ async fn tool_call_result(
     anchor: Option<vmux_service::protocol::ProcessId>,
     acp_session: bool,
     acp_terminals: bool,
+    run_block_timeout: Duration,
 ) -> Result<Value, String> {
     let name = params
         .get("name")
@@ -139,7 +156,7 @@ async fn tool_call_result(
         crate::tools::DispatchTarget::Command(command @ AgentCommand::Run { .. })
         | crate::tools::DispatchTarget::Command(
             command @ AgentCommand::RunWithPlacementOverride { .. },
-        ) => run_blocking(command).await,
+        ) => run_blocking(command, run_block_timeout).await,
         crate::tools::DispatchTarget::Command(command) => run_agent_command(command, anchor).await,
         crate::tools::DispatchTarget::Query(query) => run_agent_query(query).await,
     }
@@ -411,13 +428,19 @@ fn blocking_run_with_marker(mut run: AgentCommand, request_id: AgentRequestId) -
     run
 }
 
-fn run_result(pid: &str, exit: Option<i32>, output: &str, timed_out: bool) -> Value {
+fn run_result(
+    pid: &str,
+    exit: Option<i32>,
+    output: &str,
+    timed_out: bool,
+    run_block_timeout: Duration,
+) -> Value {
     let mut text = format!("terminal: {pid}\n");
     match exit {
         Some(code) => text.push_str(&format!("exit: {code}\n")),
         None if timed_out => text.push_str(&format!(
             "note: still running after {}s; call read_terminal({pid}) to read more\n",
-            RUN_BLOCK_TIMEOUT.as_secs()
+            run_block_timeout.as_secs()
         )),
         None => {}
     }
@@ -453,7 +476,7 @@ fn run_completion_exit(
 /// Send `run`, then block (polling `RunCompletion`) until the invisible OSC
 /// completion escape for this run's token is seen, returning the output + exit
 /// code in one response.
-async fn run_blocking(run: AgentCommand) -> Result<Value, String> {
+async fn run_blocking(run: AgentCommand, run_block_timeout: Duration) -> Result<Value, String> {
     let connection = vmux_service::client::ServiceConnection::connect()
         .await
         .map_err(|error| format!("cannot connect to vmux_service: {error}"))?;
@@ -501,7 +524,7 @@ async fn run_blocking(run: AgentCommand) -> Result<Value, String> {
 
     let start = Instant::now();
     let baseline_text = read_full_text(&connection, process_id).await;
-    let deadline = start + RUN_BLOCK_TIMEOUT;
+    let deadline = start + run_block_timeout;
     let materialize_deadline = start + RUN_PROCESS_MATERIALIZE_TIMEOUT;
     let mut process_materialized = false;
     loop {
@@ -513,12 +536,18 @@ async fn run_blocking(run: AgentCommand) -> Result<Value, String> {
         if let Some(exit) = exit {
             let final_text = read_full_text(&connection, process_id).await;
             let output = output_since(&baseline_text, &final_text);
-            return Ok(run_result(&pid, Some(exit), &output, false));
+            return Ok(run_result(
+                &pid,
+                Some(exit),
+                &output,
+                false,
+                run_block_timeout,
+            ));
         }
         if Instant::now() >= deadline {
             let final_text = read_full_text(&connection, process_id).await;
             let output = output_since(&baseline_text, &final_text);
-            return Ok(run_result(&pid, None, &output, true));
+            return Ok(run_result(&pid, None, &output, true, run_block_timeout));
         }
         tokio::time::sleep(RUN_POLL_INTERVAL).await;
     }
@@ -811,6 +840,7 @@ mod tests {
                 None,
                 true,
                 true,
+                Duration::from_secs(50),
             )
             .await
             .unwrap();
@@ -835,6 +865,7 @@ mod tests {
             None,
             true,
             false,
+            Duration::from_secs(50),
         )
         .await
         .unwrap();
@@ -906,15 +937,17 @@ mod tests {
 
     #[test]
     fn run_result_shapes_text() {
-        let done = run_result("pid7", Some(1), "boom", false);
+        let timeout = Duration::from_secs(600);
+        let done = run_result("pid7", Some(1), "boom", false, timeout);
         let text = done["content"][0]["text"].as_str().unwrap();
         assert!(text.contains("terminal: pid7"));
         assert!(text.contains("exit: 1"));
         assert!(text.contains("output:\nboom"));
 
-        let timeout = run_result("pid7", None, "partial", true);
-        let text = timeout["content"][0]["text"].as_str().unwrap();
+        let timed_out = run_result("pid7", None, "partial", true, timeout);
+        let text = timed_out["content"][0]["text"].as_str().unwrap();
         assert!(text.contains("still running"));
+        assert!(text.contains("600s"));
         assert!(text.contains("read_terminal(pid7)"));
     }
 

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -403,8 +403,8 @@ fn run_definition() -> ToolDefinition {
         description:
             "Run a shell command in a visible terminal pane the user can watch live and take over. \
 Blocks until the command finishes and returns its full output plus the exit code \
-(`terminal: <id>`, `exit: <code>`, `output: ...`). If it has not finished within ~50s, returns the \
-output so far with a note to call read_terminal for the rest. \
+(`terminal: <id>`, `exit: <code>`, `output: ...`). If it reaches the configured wait limit, returns \
+the output so far with a note to call read_terminal for the rest. \
 \
 PLACEMENT — by DEFAULT you don't need to think about this: a bare `run` reuses ONE persistent terminal \
 beside you — the SAME shell across calls, so its working directory and environment persist. Do NOT `cd` \


### PR DESCRIPTION
## Context
Codex and Claude terminal runs inherited Vibe's 50-second MCP limit. Longer jobs returned early and forced avoidable read_terminal follow-up calls.

## Implementation
Use per-agent run limits: Vibe stays at 50 seconds, while Codex and Claude wait up to 10 minutes. Their MCP caller deadlines are raised to 11 minutes, and steering tells them to consume run output before polling the terminal.

## Checks / QA
- Run a 50-600 second command from Codex or Claude and verify the original run call returns final output and exit code.
- Run a command longer than 50 seconds from Vibe and verify it returns partial output plus the terminal ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable MCP execution timeouts for agent commands.
  - Claude and Codex commands now allow longer-running operations, up to 660 seconds.
  - Added the `--run-timeout-secs` option to configure MCP command wait limits.

- **Improvements**
  - Timeout settings now apply consistently across direct and ACP agent sessions.
  - MCP tool messaging reflects the configured wait limit instead of a fixed duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->