### PR TITLE
feat(acp): surface subagent activity

### DIFF
--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -1815,6 +1815,7 @@ mod native_tests {
                         call_id: "call-1".into(),
                         name: "run".into(),
                         args: "{}".into(),
+                        parent_call_id: None,
                     }],
                 },
                 crate::Message::ToolResult {

--- a/crates/vmux_agent/src/chat_page/composer.rs
+++ b/crates/vmux_agent/src/chat_page/composer.rs
@@ -630,6 +630,7 @@ mod tests {
                 call_id: "1".into(),
                 name: "functions.exec_command".into(),
                 args: "{}".into(),
+                parent_call_id: None,
             }),
             "Ship dynamic titles"
         );
@@ -638,6 +639,7 @@ mod tests {
                 call_id: "2".into(),
                 name: "search_files".into(),
                 args: "{}".into(),
+                parent_call_id: None,
             }),
             "Ship dynamic titles"
         );

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -361,7 +361,9 @@ pub enum ChatBlock {
         call_id: String,
         name: String,
         args: String,
+        parent_call_id: Option<String>,
     },
+    Subagent(Box<ChatSubagent>),
     Diff {
         call_id: String,
         path: String,
@@ -380,6 +382,25 @@ pub enum ChatBlock {
         attempt: u32,
         total: u32,
     },
+}
+
+/// Page representation of `vmux_service::message::SubagentBlock`.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct ChatSubagent {
+    pub call_id: String,
+    pub provider: String,
+    pub title: String,
+    pub status: String,
+    pub action: String,
+    pub agent_name: Option<String>,
+    pub thread_id: Option<String>,
+    pub parent_thread_id: Option<String>,
+    pub child_thread_ids: Vec<String>,
+    pub parent_call_id: Option<String>,
+    pub prompt: Option<String>,
+    pub model: Option<String>,
+    pub reasoning_effort: Option<String>,
+    pub raw_input: String,
 }
 
 /// Mirror of `vmux_service::message::PlanStep`.
@@ -438,36 +459,55 @@ pub(crate) fn is_guardian_tool(name: &str) -> bool {
 
 impl ChatTurn {
     pub(crate) fn parent_tool_index(&self, index: usize) -> Option<usize> {
+        let mut parent = self.direct_parent_index(index)?;
+        for _ in 0..self.blocks.len() {
+            let Some(next) = self.direct_parent_index(parent) else {
+                break;
+            };
+            if next == parent {
+                break;
+            }
+            parent = next;
+        }
+        Some(parent)
+    }
+
+    fn direct_parent_index(&self, index: usize) -> Option<usize> {
         match self.blocks.get(index)? {
+            ChatBlock::ToolUse {
+                parent_call_id: Some(parent_call_id),
+                ..
+            } => self.call_index(parent_call_id),
+            ChatBlock::Subagent(subagent) => subagent
+                .parent_call_id
+                .as_deref()
+                .and_then(|parent_call_id| self.call_index(parent_call_id)),
             ChatBlock::ToolUse { name, .. } if is_guardian_tool(name) => {
                 self.guardian_parent_index(index)
             }
             ChatBlock::ToolResult { call_id, .. } if !call_id.is_empty() => {
-                let tool_index = self.blocks.iter().position(|block| {
-                    matches!(
-                        block,
-                        ChatBlock::ToolUse {
-                            call_id: tool_call_id,
-                            ..
-                        } if tool_call_id == call_id
-                    )
-                })?;
-                match &self.blocks[tool_index] {
-                    ChatBlock::ToolUse { name, .. } if is_guardian_tool(name) => {
-                        self.guardian_parent_index(tool_index).or(Some(tool_index))
-                    }
-                    _ => Some(tool_index),
-                }
+                self.call_index(call_id)
             }
             _ => None,
         }
+    }
+
+    fn call_index(&self, call_id: &str) -> Option<usize> {
+        self.blocks.iter().position(|block| match block {
+            ChatBlock::ToolUse {
+                call_id: block_call_id,
+                ..
+            } => block_call_id == call_id,
+            ChatBlock::Subagent(subagent) => subagent.call_id == call_id,
+            _ => false,
+        })
     }
 
     fn guardian_parent_index(&self, index: usize) -> Option<usize> {
         for (candidate, block) in self.blocks[..index].iter().enumerate().rev() {
             match block {
                 ChatBlock::ToolUse { name, .. } if is_guardian_tool(name) => {}
-                ChatBlock::ToolUse { .. } => return Some(candidate),
+                ChatBlock::ToolUse { .. } | ChatBlock::Subagent(_) => return Some(candidate),
                 _ => return None,
             }
         }
@@ -633,11 +673,13 @@ mod tests {
                     call_id: "read-1".into(),
                     name: "read_file".into(),
                     args: "{}".into(),
+                    parent_call_id: None,
                 },
                 ChatBlock::ToolUse {
                     call_id: "review-1".into(),
                     name: "guardian_review".into(),
                     args: "{}".into(),
+                    parent_call_id: None,
                 },
                 ChatBlock::ToolResult {
                     call_id: "read-1".into(),
@@ -667,6 +709,7 @@ mod tests {
                     call_id: String::new(),
                     name: "read_file".into(),
                     args: "{}".into(),
+                    parent_call_id: None,
                 },
                 ChatBlock::ToolResult {
                     call_id: String::new(),
@@ -689,6 +732,7 @@ mod tests {
                     call_id: "review-1".into(),
                     name: "guardian_review".into(),
                     args: "{}".into(),
+                    parent_call_id: None,
                 },
                 ChatBlock::ToolResult {
                     call_id: "review-1".into(),

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -1706,6 +1706,7 @@ enum ActivityIcon {
     Command,
     Browser,
     Guardian,
+    Subagent,
     Tool,
     Output,
     Error,
@@ -1755,6 +1756,12 @@ fn activity_icon_paths(kind: ActivityIcon) -> &'static [&'static str] {
         ActivityIcon::Guardian => &[
             "M20 13c0 5-3.5 7.5-8 9-4.5-1.5-8-4-8-9V5l8-3 8 3v8Z",
             "m9 12 2 2 4-4",
+        ],
+        ActivityIcon::Subagent => &[
+            "M12 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z",
+            "M5 21v-2a7 7 0 0 1 14 0v2",
+            "M5.5 11a2.5 2.5 0 1 0 0-5",
+            "M18.5 11a2.5 2.5 0 1 1 0-5",
         ],
         ActivityIcon::Tool => &[
             "M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76Z",
@@ -1828,6 +1835,9 @@ fn render_activity_icon(kind: ActivityIcon) -> Element {
         ActivityIcon::Guardian => {
             "bg-emerald-500/10 text-emerald-600 ring-emerald-500/20 dark:text-emerald-300"
         }
+        ActivityIcon::Subagent => {
+            "bg-violet-500/10 text-violet-600 ring-violet-500/20 dark:text-violet-300"
+        }
         ActivityIcon::Tool => {
             "bg-orange-500/10 text-orange-600 ring-orange-500/20 dark:text-orange-300"
         }
@@ -1899,6 +1909,7 @@ fn current_activity_icon(items: &[ChatItem], status: &str) -> Option<ActivityIco
                 Some(ChatBlock::Text(_)) => ActivityIcon::Writing,
                 Some(ChatBlock::Thinking(_)) | None => ActivityIcon::Thinking,
                 Some(ChatBlock::ToolUse { name, args, .. }) => tool_activity_icon_for(name, args),
+                Some(ChatBlock::Subagent(_)) => ActivityIcon::Subagent,
                 Some(ChatBlock::Diff { path, .. }) => {
                     language_activity_icon(path).unwrap_or(ActivityIcon::Diff)
                 }
@@ -2044,6 +2055,80 @@ fn render_block(
                 }
             }
         }
+        ChatBlock::Subagent(subagent) => {
+            let status_label = subagent_status_label(&subagent.status);
+            let status_class = subagent_status_class(&subagent.status);
+            let title = if subagent.title.is_empty() {
+                "Subagent".to_string()
+            } else {
+                subagent.title.replace('_', " ")
+            };
+            let action = subagent.action.replace('_', " ");
+            let child_threads = subagent.child_thread_ids.join(", ");
+            rsx! {
+                div { key: "{key}", class: "grid grid-cols-[1.5rem_minmax(0,1fr)] items-start gap-2.5 rounded-xl bg-violet-500/[0.025] px-2 py-1.5 ring-1 ring-inset ring-violet-500/10 transition-colors hover:bg-violet-500/[0.05]",
+                    {render_activity_icon(ActivityIcon::Subagent)}
+                    div { class: "min-w-0",
+                        details { open: subagent.status == "in_progress", class: "disclosure text-sm text-muted-foreground",
+                            summary { class: "flex cursor-pointer select-none flex-wrap items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
+                                span { class: "font-medium text-foreground/85", "{title}" }
+                                span { class: "rounded-full px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide {status_class}", "{status_label}" }
+                                {render_disclosure_icon()}
+                            }
+                            div { class: "mt-2 flex flex-wrap gap-1.5 text-[10px]",
+                                span { class: "rounded-full bg-violet-500/10 px-2 py-0.5 font-semibold text-violet-700 dark:text-violet-300", "{subagent.provider}" }
+                                if !subagent.action.is_empty() {
+                                    span { class: "rounded-full bg-foreground/[0.055] px-2 py-0.5 text-foreground/60", "{action}" }
+                                }
+                                if let Some(agent_name) = &subagent.agent_name {
+                                    span { class: "rounded-full bg-foreground/[0.055] px-2 py-0.5 text-foreground/60", "{agent_name}" }
+                                }
+                                if let Some(model) = &subagent.model {
+                                    span { class: "rounded-full bg-foreground/[0.055] px-2 py-0.5 font-mono text-foreground/60", "{model}" }
+                                }
+                                if let Some(effort) = &subagent.reasoning_effort {
+                                    span { class: "rounded-full bg-foreground/[0.055] px-2 py-0.5 text-foreground/60", "{effort}" }
+                                }
+                            }
+                            if let Some(prompt) = &subagent.prompt {
+                                div { class: "mt-2 rounded-lg bg-foreground/[0.025] p-2 text-xs leading-relaxed text-foreground/75 ring-1 ring-inset ring-foreground/10",
+                                    div { class: "mb-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/70", "Prompt" }
+                                    div { class: "whitespace-pre-wrap", "{prompt}" }
+                                }
+                            }
+                            div { class: "mt-2 grid gap-1 text-[10px] text-muted-foreground/75",
+                                if let Some(thread_id) = &subagent.thread_id {
+                                    div { span { class: "font-semibold", "Thread " } code { class: "font-mono", "{thread_id}" } }
+                                }
+                                if let Some(parent_thread_id) = &subagent.parent_thread_id {
+                                    div { span { class: "font-semibold", "Parent " } code { class: "font-mono", "{parent_thread_id}" } }
+                                }
+                                if !child_threads.is_empty() {
+                                    div { span { class: "font-semibold", "Children " } code { class: "break-all font-mono", "{child_threads}" } }
+                                }
+                                div { span { class: "font-semibold", "Call " } code { class: "font-mono", "{subagent.call_id}" } }
+                            }
+                            if !subagent.raw_input.is_empty() && subagent.raw_input != "{}" {
+                                details { class: "disclosure mt-2 text-[11px] text-muted-foreground",
+                                    summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
+                                        span { class: "font-medium", "Raw event" }
+                                        {render_disclosure_icon()}
+                                    }
+                                    pre { class: "agent-code-panel mt-1.5 max-h-56 overflow-auto whitespace-pre-wrap rounded-lg p-2 font-mono text-[11px] text-muted-foreground", "{subagent.raw_input}" }
+                                }
+                            }
+                        }
+                        if !children.is_empty() {
+                            div { class: "agent-context-tree ml-0.5 mt-2 flex flex-col gap-1 border-l border-violet-500/25 pl-3",
+                                for (child_key , child) in children {
+                                    {render_tool_child(*child_key, child)}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
         ChatBlock::Plan { steps } => {
             let n = steps.len();
             rsx! {
@@ -2140,10 +2225,50 @@ fn render_tool_child(key: usize, block: &ChatBlock) -> Element {
                 }
             }
         }
+        ChatBlock::Subagent(subagent) => {
+            let status_label = subagent_status_label(&subagent.status);
+            let status_class = subagent_status_class(&subagent.status);
+            rsx! {
+                details { key: "{key}", class: "disclosure text-xs text-muted-foreground",
+                    summary { class: "flex cursor-pointer select-none flex-wrap items-center gap-2 py-0.5 list-none [&::-webkit-details-marker]:hidden",
+                        span { class: "font-medium", "{subagent.title}" }
+                        span { class: "rounded-full px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide {status_class}", "{status_label}" }
+                        {render_disclosure_icon()}
+                    }
+                    div { class: "mt-1 flex flex-wrap gap-1 text-[10px]",
+                        span { class: "rounded-full bg-violet-500/10 px-1.5 py-0.5 text-violet-700 dark:text-violet-300", "{subagent.provider}" }
+                        if let Some(agent_name) = &subagent.agent_name {
+                            span { class: "rounded-full bg-foreground/[0.055] px-1.5 py-0.5", "{agent_name}" }
+                        }
+                    }
+                    if let Some(prompt) = &subagent.prompt {
+                        div { class: "mt-1.5 whitespace-pre-wrap rounded-lg bg-foreground/[0.025] p-2 text-[11px] leading-relaxed ring-1 ring-inset ring-foreground/10", "{prompt}" }
+                    }
+                }
+            }
+        }
         ChatBlock::ToolResult {
             content, is_error, ..
         } => render_nested_tool_result(key, content, *is_error),
         _ => rsx! {},
+    }
+}
+
+fn subagent_status_label(status: &str) -> &'static str {
+    match status {
+        "in_progress" => "Running",
+        "completed" => "Done",
+        "failed" => "Failed",
+        _ => "Pending",
+    }
+}
+
+fn subagent_status_class(status: &str) -> &'static str {
+    match status {
+        "in_progress" => "bg-violet-500/10 text-violet-700 dark:text-violet-300",
+        "completed" => "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+        "failed" => "bg-red-500/10 text-red-700 dark:text-red-300",
+        _ => "bg-amber-500/10 text-amber-700 dark:text-amber-300",
     }
 }
 

--- a/crates/vmux_agent/src/chat_page/turns.rs
+++ b/crates/vmux_agent/src/chat_page/turns.rs
@@ -2,8 +2,10 @@
 //! user bubbles and grouped assistant turns. Pure + unit-tested — the brain for the dumb chat
 //! page (see the context-collapse design).
 
-use crate::chat_page::event::{ChatBlock, ChatItem, ChatPlanStep, ChatSubmitAttachment, ChatTurn};
-use vmux_service::message::{AssistantBlock, Message, PlanStep};
+use crate::chat_page::event::{
+    ChatBlock, ChatItem, ChatPlanStep, ChatSubagent, ChatSubmitAttachment, ChatTurn,
+};
+use vmux_service::message::{AssistantBlock, Message, PlanStep, SubagentBlock};
 
 /// Group `messages` into `ChatItem`s: one `ChatItem::User` per user message, followed by one
 /// `ChatItem::Turn` per started turn. `durations[i]` is the finished seconds of the `i`-th
@@ -52,11 +54,16 @@ pub fn group_turns(messages: &[Message], durations: &[u32], running: bool) -> Ve
                             call_id,
                             name,
                             args,
+                            parent_call_id,
                         } => turn.blocks.push(ChatBlock::ToolUse {
                             call_id: call_id.clone(),
                             name: name.clone(),
                             args: args.clone(),
+                            parent_call_id: parent_call_id.clone(),
                         }),
+                        AssistantBlock::Subagent(subagent) => turn
+                            .blocks
+                            .push(ChatBlock::Subagent(Box::new(map_subagent(subagent)))),
                         AssistantBlock::Diff {
                             call_id,
                             path,
@@ -163,6 +170,25 @@ fn map_plan_step(step: &PlanStep) -> ChatPlanStep {
     }
 }
 
+fn map_subagent(subagent: &SubagentBlock) -> ChatSubagent {
+    ChatSubagent {
+        call_id: subagent.call_id.clone(),
+        provider: subagent.provider.clone(),
+        title: subagent.title.clone(),
+        status: subagent.status.clone(),
+        action: subagent.action.clone(),
+        agent_name: subagent.agent_name.clone(),
+        thread_id: subagent.thread_id.clone(),
+        parent_thread_id: subagent.parent_thread_id.clone(),
+        child_thread_ids: subagent.child_thread_ids.clone(),
+        parent_call_id: subagent.parent_call_id.clone(),
+        prompt: subagent.prompt.clone(),
+        model: subagent.model.clone(),
+        reasoning_effort: subagent.reasoning_effort.clone(),
+        raw_input: subagent.raw_input.clone(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -175,7 +201,27 @@ mod tests {
             call_id: id.into(),
             name: "run".into(),
             args: "{}".into(),
+            parent_call_id: None,
         }
+    }
+
+    fn subagent(id: &str) -> AssistantBlock {
+        AssistantBlock::Subagent(Box::new(SubagentBlock {
+            call_id: id.into(),
+            provider: "Claude".into(),
+            title: "Inspect ACP support".into(),
+            status: "in_progress".into(),
+            action: "delegate".into(),
+            agent_name: Some("Explore".into()),
+            thread_id: None,
+            parent_thread_id: None,
+            child_thread_ids: Vec::new(),
+            parent_call_id: None,
+            prompt: Some("Trace metadata".into()),
+            model: Some("sonnet".into()),
+            reasoning_effort: None,
+            raw_input: "{}".into(),
+        }))
     }
 
     #[test]
@@ -382,11 +428,13 @@ mod tests {
                     call_id: "read-1".into(),
                     name: "read_file".into(),
                     args: "{}".into(),
+                    parent_call_id: None,
                 },
                 AssistantBlock::ToolUse {
                     call_id: "review-1".into(),
                     name: "guardian_review".into(),
                     args: "{}".into(),
+                    parent_call_id: None,
                 },
             ]),
             Message::ToolResult {
@@ -400,6 +448,42 @@ mod tests {
             panic!()
         };
         assert_eq!(turn.step_count, 1);
+    }
+
+    #[test]
+    fn subagent_children_and_results_fold_into_one_visible_step() {
+        let msgs = vec![
+            Message::user("a"),
+            assistant(vec![
+                subagent("agent-1"),
+                AssistantBlock::ToolUse {
+                    call_id: "read-1".into(),
+                    name: "read_file".into(),
+                    args: "{}".into(),
+                    parent_call_id: Some("agent-1".into()),
+                },
+            ]),
+            Message::ToolResult {
+                call_id: "read-1".into(),
+                content: "file contents".into(),
+                is_error: false,
+            },
+            Message::ToolResult {
+                call_id: "agent-1".into(),
+                content: "done".into(),
+                is_error: false,
+            },
+        ];
+
+        let items = group_turns(&msgs, &[], false);
+        let ChatItem::Turn(turn) = &items[1] else {
+            panic!()
+        };
+        assert_eq!(turn.step_count, 1);
+        assert!(matches!(&turn.blocks[0], ChatBlock::Subagent(_)));
+        assert_eq!(turn.parent_tool_index(1), Some(0));
+        assert_eq!(turn.parent_tool_index(2), Some(0));
+        assert_eq!(turn.parent_tool_index(3), Some(0));
     }
 
     #[test]

--- a/crates/vmux_agent/src/handoff.rs
+++ b/crates/vmux_agent/src/handoff.rs
@@ -250,6 +250,7 @@ mod tests {
                         call_id: "c".into(),
                         name: "run".into(),
                         args: "{}".into(),
+                        parent_call_id: None,
                     },
                 ],
             },

--- a/crates/vmux_service/src/acp/projector.rs
+++ b/crates/vmux_service/src/acp/projector.rs
@@ -4,7 +4,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::Path;
 
-use crate::message::{AssistantBlock, Message, PlanStep};
+use crate::message::{AssistantBlock, Message, PlanStep, SubagentBlock};
 use crate::protocol::AgentAttachment;
 use agent_client_protocol::schema::v1::{
     ContentBlock, Plan, PlanEntryStatus, SessionUpdate, ToolCall, ToolCallContent,
@@ -205,8 +205,13 @@ impl AcpProjector {
                     call_id: existing,
                     name,
                     args,
+                    ..
                 } = block
                 else {
+                    if let AssistantBlock::Subagent(subagent) = block {
+                        return (subagent.call_id == call_id)
+                            .then(|| (subagent.title.clone(), subagent.raw_input.clone()));
+                    }
                     return None;
                 };
                 (existing == call_id).then(|| (name.clone(), args.clone()))
@@ -394,7 +399,24 @@ impl AcpProjector {
 
     fn apply_tool_call(&mut self, tc: ToolCall) -> Vec<Intent> {
         let call_id = tc.tool_call_id.to_string();
-        self.upsert_tool_use(&call_id, &tc.title, &raw_input_json(tc.raw_input.as_ref()));
+        let subagent = subagent_block(
+            &call_id,
+            &tc.title,
+            Some(&tc.status),
+            tc.raw_input.as_ref(),
+            tc.meta.as_ref(),
+        );
+        let is_subagent = subagent.is_some();
+        if let Some(subagent) = subagent {
+            self.upsert_subagent(subagent);
+        } else {
+            self.upsert_tool_use(
+                &call_id,
+                &tc.title,
+                &raw_input_json(tc.raw_input.as_ref()),
+                parent_call_id(tc.meta.as_ref()),
+            );
+        }
         let diff_locations = tc
             .locations
             .is_empty()
@@ -408,22 +430,57 @@ impl AcpProjector {
             Some(tc.status),
             true,
         ));
-        intents.extend(self.record_tool_content(
-            &call_id,
-            &tc.content,
-            matches!(tc.status, ToolCallStatus::Failed),
-        ));
+        if !is_subagent
+            || matches!(
+                tc.status,
+                ToolCallStatus::Completed | ToolCallStatus::Failed
+            )
+        {
+            intents.extend(self.record_tool_content(
+                &call_id,
+                &tc.content,
+                matches!(tc.status, ToolCallStatus::Failed),
+            ));
+            if is_subagent && tool_output_text(&tc.content).is_empty() {
+                self.record_raw_output(
+                    &call_id,
+                    tc.raw_output.as_ref(),
+                    matches!(tc.status, ToolCallStatus::Failed),
+                );
+            }
+        }
         intents
     }
 
     fn apply_tool_call_update(&mut self, update: ToolCallUpdate) -> Vec<Intent> {
         let call_id = update.tool_call_id.to_string();
         let title = update.fields.title.clone().unwrap_or_default();
-        self.upsert_tool_use(
+        let subagent = subagent_block(
             &call_id,
             &title,
-            &raw_input_json(update.fields.raw_input.as_ref()),
+            update.fields.status.as_ref(),
+            update.fields.raw_input.as_ref(),
+            update.meta.as_ref(),
         );
+        let is_subagent = if let Some(subagent) = subagent {
+            self.upsert_subagent(subagent);
+            true
+        } else if self.update_subagent(
+            &call_id,
+            &title,
+            update.fields.status.as_ref(),
+            update.fields.raw_input.as_ref(),
+        ) {
+            true
+        } else {
+            self.upsert_tool_use(
+                &call_id,
+                &title,
+                &raw_input_json(update.fields.raw_input.as_ref()),
+                parent_call_id(update.meta.as_ref()),
+            );
+            false
+        };
         let diff_locations = update
             .fields
             .content
@@ -446,9 +503,24 @@ impl AcpProjector {
             update.fields.status,
             false,
         ));
-        if let Some(content) = &update.fields.content {
+        let terminal_status = matches!(
+            update.fields.status,
+            Some(ToolCallStatus::Completed | ToolCallStatus::Failed)
+        );
+        if let Some(content) = &update.fields.content
+            && (!is_subagent || terminal_status)
+        {
             let failed = matches!(update.fields.status, Some(ToolCallStatus::Failed));
             intents.extend(self.record_tool_content(&call_id, content, failed));
+            if is_subagent && tool_output_text(content).is_empty() {
+                self.record_raw_output(&call_id, update.fields.raw_output.as_ref(), failed);
+            }
+        } else if is_subagent && terminal_status {
+            self.record_raw_output(
+                &call_id,
+                update.fields.raw_output.as_ref(),
+                matches!(update.fields.status, Some(ToolCallStatus::Failed)),
+            );
         }
         intents
     }
@@ -516,7 +588,91 @@ impl AcpProjector {
         });
     }
 
-    fn upsert_tool_use(&mut self, call_id: &str, name: &str, args: &str) {
+    fn record_raw_output(
+        &mut self,
+        call_id: &str,
+        raw_output: Option<&serde_json::Value>,
+        is_error: bool,
+    ) {
+        let Some(raw_output) = raw_output.filter(|value| !value.is_null()) else {
+            return;
+        };
+        self.upsert_tool_result(call_id, pretty_json(raw_output), is_error);
+    }
+
+    fn update_subagent(
+        &mut self,
+        call_id: &str,
+        title: &str,
+        status: Option<&ToolCallStatus>,
+        raw_input: Option<&serde_json::Value>,
+    ) -> bool {
+        for message in self.messages.iter_mut() {
+            let Message::Assistant { blocks } = message else {
+                continue;
+            };
+            for block in blocks.iter_mut() {
+                let AssistantBlock::Subagent(subagent) = block else {
+                    continue;
+                };
+                if subagent.call_id != call_id {
+                    continue;
+                }
+                if !title.is_empty() {
+                    subagent.title = title.to_string();
+                }
+                if let Some(status) = status {
+                    subagent.status = tool_call_status(status).to_string();
+                }
+                if let Some(raw_input) = raw_input {
+                    subagent.raw_input = pretty_json(raw_input);
+                    merge_subagent_input(subagent, raw_input);
+                }
+                return true;
+            }
+        }
+        false
+    }
+
+    fn upsert_subagent(&mut self, subagent: SubagentBlock) {
+        for message in self.messages.iter_mut() {
+            let Message::Assistant { blocks } = message else {
+                continue;
+            };
+            for block in blocks.iter_mut() {
+                let same_call = match block {
+                    AssistantBlock::ToolUse {
+                        call_id: existing, ..
+                    } => existing == &subagent.call_id,
+                    AssistantBlock::Subagent(existing) => existing.call_id == subagent.call_id,
+                    _ => false,
+                };
+                if !same_call {
+                    continue;
+                }
+                match block {
+                    AssistantBlock::Subagent(existing) => merge_subagent(existing, subagent),
+                    _ => *block = AssistantBlock::Subagent(Box::new(subagent)),
+                }
+                return;
+            }
+        }
+        let block = AssistantBlock::Subagent(Box::new(subagent));
+        match self.messages.last_mut() {
+            Some(Message::Assistant { blocks }) => blocks.push(block),
+            _ => self.messages.push(Message::Assistant {
+                blocks: vec![block],
+            }),
+        }
+    }
+
+    fn upsert_tool_use(
+        &mut self,
+        call_id: &str,
+        name: &str,
+        args: &str,
+        parent_call_id: Option<String>,
+    ) {
         for message in self.messages.iter_mut() {
             if let Message::Assistant { blocks } = message {
                 for block in blocks.iter_mut() {
@@ -524,6 +680,7 @@ impl AcpProjector {
                         call_id: existing,
                         name: existing_name,
                         args: existing_args,
+                        parent_call_id: existing_parent_call_id,
                     } = block
                         && existing == call_id
                     {
@@ -532,6 +689,9 @@ impl AcpProjector {
                         }
                         if args != "{}" {
                             *existing_args = args.to_string();
+                        }
+                        if parent_call_id.is_some() {
+                            *existing_parent_call_id = parent_call_id;
                         }
                         return;
                     }
@@ -542,6 +702,7 @@ impl AcpProjector {
             call_id: call_id.to_string(),
             name: name.to_string(),
             args: args.to_string(),
+            parent_call_id,
         };
         match self.messages.last_mut() {
             Some(Message::Assistant { blocks }) => blocks.push(block),
@@ -591,6 +752,211 @@ impl AcpProjector {
     }
 }
 
+fn subagent_block(
+    call_id: &str,
+    title: &str,
+    status: Option<&ToolCallStatus>,
+    raw_input: Option<&serde_json::Value>,
+    meta: Option<&serde_json::Map<String, serde_json::Value>>,
+) -> Option<SubagentBlock> {
+    codex_subagent_block(call_id, title, status, raw_input, meta)
+        .or_else(|| claude_subagent_block(call_id, title, status, raw_input, meta))
+}
+
+fn codex_subagent_block(
+    call_id: &str,
+    title: &str,
+    status: Option<&ToolCallStatus>,
+    raw_input: Option<&serde_json::Value>,
+    meta: Option<&serde_json::Map<String, serde_json::Value>>,
+) -> Option<SubagentBlock> {
+    let codex = meta?.get("codex")?.as_object()?;
+    let input = raw_input.and_then(serde_json::Value::as_object);
+    if let Some(subagent) = codex.get("subagent").and_then(serde_json::Value::as_object) {
+        let path = string_field(subagent, "path");
+        return Some(SubagentBlock {
+            call_id: call_id.to_string(),
+            provider: "Codex".to_string(),
+            title: title.to_string(),
+            status: status.map(tool_call_status).unwrap_or_default().to_string(),
+            action: string_field(subagent, "activity").unwrap_or_default(),
+            agent_name: path.as_deref().and_then(agent_name_from_path),
+            thread_id: string_field(subagent, "threadId")
+                .or_else(|| input.and_then(|input| string_field(input, "agentThreadId"))),
+            parent_thread_id: None,
+            child_thread_ids: Vec::new(),
+            parent_call_id: None,
+            prompt: input.and_then(|input| string_field(input, "prompt")),
+            model: input.and_then(|input| string_field(input, "model")),
+            reasoning_effort: input.and_then(|input| string_field(input, "reasoningEffort")),
+            raw_input: raw_input.map(pretty_json).unwrap_or_default(),
+        });
+    }
+    let collaboration = codex
+        .get("collaboration")
+        .and_then(serde_json::Value::as_object)?;
+    let child_thread_ids = string_list_field(collaboration, "receiverThreadIds");
+    Some(SubagentBlock {
+        call_id: call_id.to_string(),
+        provider: "Codex".to_string(),
+        title: title.to_string(),
+        status: status.map(tool_call_status).unwrap_or_default().to_string(),
+        action: string_field(collaboration, "tool").unwrap_or_default(),
+        agent_name: None,
+        thread_id: None,
+        parent_thread_id: string_field(collaboration, "senderThreadId")
+            .or_else(|| input.and_then(|input| string_field(input, "senderThreadId"))),
+        child_thread_ids: if child_thread_ids.is_empty() {
+            input
+                .map(|input| string_list_field(input, "receiverThreadIds"))
+                .unwrap_or_default()
+        } else {
+            child_thread_ids
+        },
+        parent_call_id: None,
+        prompt: input.and_then(|input| string_field(input, "prompt")),
+        model: input.and_then(|input| string_field(input, "model")),
+        reasoning_effort: input.and_then(|input| string_field(input, "reasoningEffort")),
+        raw_input: raw_input.map(pretty_json).unwrap_or_default(),
+    })
+}
+
+fn claude_subagent_block(
+    call_id: &str,
+    title: &str,
+    status: Option<&ToolCallStatus>,
+    raw_input: Option<&serde_json::Value>,
+    meta: Option<&serde_json::Map<String, serde_json::Value>>,
+) -> Option<SubagentBlock> {
+    let claude = meta?.get("claudeCode")?.as_object()?;
+    let tool_name = claude.get("toolName")?.as_str()?;
+    if !matches!(tool_name, "Agent" | "Task") {
+        return None;
+    }
+    let input = raw_input.and_then(serde_json::Value::as_object);
+    let action = if input.is_some_and(|input| input.get("resume").is_some()) {
+        "resume"
+    } else if input
+        .and_then(|input| input.get("run_in_background"))
+        .and_then(serde_json::Value::as_bool)
+        == Some(true)
+    {
+        "background"
+    } else {
+        "delegate"
+    };
+    Some(SubagentBlock {
+        call_id: call_id.to_string(),
+        provider: "Claude".to_string(),
+        title: title.to_string(),
+        status: status.map(tool_call_status).unwrap_or_default().to_string(),
+        action: action.to_string(),
+        agent_name: input.and_then(|input| {
+            string_field(input, "name").or_else(|| string_field(input, "subagent_type"))
+        }),
+        thread_id: input.and_then(|input| string_field(input, "resume")),
+        parent_thread_id: None,
+        child_thread_ids: Vec::new(),
+        parent_call_id: string_field(claude, "parentToolUseId"),
+        prompt: input.and_then(|input| string_field(input, "prompt")),
+        model: input.and_then(|input| string_field(input, "model")),
+        reasoning_effort: None,
+        raw_input: raw_input.map(pretty_json).unwrap_or_default(),
+    })
+}
+
+fn parent_call_id(meta: Option<&serde_json::Map<String, serde_json::Value>>) -> Option<String> {
+    meta?
+        .get("claudeCode")?
+        .as_object()
+        .and_then(|claude| string_field(claude, "parentToolUseId"))
+}
+
+fn merge_subagent(existing: &mut SubagentBlock, update: SubagentBlock) {
+    if !update.provider.is_empty() {
+        existing.provider = update.provider;
+    }
+    if !update.title.is_empty() {
+        existing.title = update.title;
+    }
+    if !update.status.is_empty() {
+        existing.status = update.status;
+    }
+    if !update.action.is_empty() {
+        existing.action = update.action;
+    }
+    existing.agent_name = update.agent_name.or(existing.agent_name.take());
+    existing.thread_id = update.thread_id.or(existing.thread_id.take());
+    existing.parent_thread_id = update.parent_thread_id.or(existing.parent_thread_id.take());
+    if !update.child_thread_ids.is_empty() {
+        existing.child_thread_ids = update.child_thread_ids;
+    }
+    existing.parent_call_id = update.parent_call_id.or(existing.parent_call_id.take());
+    existing.prompt = update.prompt.or(existing.prompt.take());
+    existing.model = update.model.or(existing.model.take());
+    existing.reasoning_effort = update.reasoning_effort.or(existing.reasoning_effort.take());
+    if !update.raw_input.is_empty() {
+        existing.raw_input = update.raw_input;
+    }
+}
+
+fn merge_subagent_input(subagent: &mut SubagentBlock, raw_input: &serde_json::Value) {
+    let Some(input) = raw_input.as_object() else {
+        return;
+    };
+    subagent.prompt = string_field(input, "prompt").or(subagent.prompt.take());
+    subagent.model = string_field(input, "model").or(subagent.model.take());
+    subagent.reasoning_effort =
+        string_field(input, "reasoningEffort").or(subagent.reasoning_effort.take());
+    let child_thread_ids = string_list_field(input, "receiverThreadIds");
+    if !child_thread_ids.is_empty() {
+        subagent.child_thread_ids = child_thread_ids;
+    }
+}
+
+fn string_field(
+    object: &serde_json::Map<String, serde_json::Value>,
+    field: &str,
+) -> Option<String> {
+    let value = object.get(field)?;
+    value.as_str().map(ToString::to_string).or_else(|| {
+        (!value.is_null() && !value.is_object() && !value.is_array()).then(|| value.to_string())
+    })
+}
+
+fn string_list_field(
+    object: &serde_json::Map<String, serde_json::Value>,
+    field: &str,
+) -> Vec<String> {
+    object
+        .get(field)
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|value| value.as_str().map(ToString::to_string))
+        .collect()
+}
+
+fn agent_name_from_path(path: &str) -> Option<String> {
+    path.rsplit('/')
+        .find(|part| !part.is_empty())
+        .map(|part| part.trim_end_matches(".toml").to_string())
+}
+
+fn tool_call_status(status: &ToolCallStatus) -> &'static str {
+    match status {
+        ToolCallStatus::Pending => "pending",
+        ToolCallStatus::InProgress => "in_progress",
+        ToolCallStatus::Completed => "completed",
+        ToolCallStatus::Failed => "failed",
+        _ => "pending",
+    }
+}
+
+fn pretty_json(value: &serde_json::Value) -> String {
+    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+}
+
 fn raw_input_json(raw: Option<&serde_json::Value>) -> String {
     raw.map(|v| v.to_string())
         .unwrap_or_else(|| "{}".to_string())
@@ -624,6 +990,13 @@ mod tests {
         SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(TextContent::new(
             text,
         ))))
+    }
+
+    fn meta(value: serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+        let serde_json::Value::Object(meta) = value else {
+            panic!("expected metadata object")
+        };
+        meta
     }
 
     #[test]
@@ -749,6 +1122,164 @@ mod tests {
             )),
             other => panic!("expected assistant message, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn codex_subagent_metadata_projects_first_class_block() {
+        let mut p = AcpProjector::new();
+        let tc = ToolCall::new("sub-1", "Start subagent explorer")
+            .status(ToolCallStatus::InProgress)
+            .raw_input(serde_json::json!({
+                "agentThreadId": "thread-child",
+                "agentPath": ".codex/agents/explorer.toml",
+                "activityKind": "started",
+                "prompt": "Inspect ACP projection",
+                "model": "gpt-5.4",
+                "reasoningEffort": "high"
+            }))
+            .meta(meta(serde_json::json!({
+                "codex": {
+                    "subagent": {
+                        "threadId": "thread-child",
+                        "path": ".codex/agents/explorer.toml",
+                        "activity": "started"
+                    }
+                }
+            })));
+
+        p.apply(SessionUpdate::ToolCall(tc));
+
+        let Message::Assistant { blocks } = &p.messages()[0] else {
+            panic!("expected assistant message")
+        };
+        let AssistantBlock::Subagent(subagent) = &blocks[0] else {
+            panic!("expected subagent block")
+        };
+        assert_eq!(subagent.provider, "Codex");
+        assert_eq!(subagent.status, "in_progress");
+        assert_eq!(subagent.action, "started");
+        assert_eq!(subagent.agent_name.as_deref(), Some("explorer"));
+        assert_eq!(subagent.thread_id.as_deref(), Some("thread-child"));
+        assert_eq!(subagent.prompt.as_deref(), Some("Inspect ACP projection"));
+        assert_eq!(subagent.model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(subagent.reasoning_effort.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn codex_collaboration_metadata_projects_child_threads() {
+        let mut p = AcpProjector::new();
+        p.apply(SessionUpdate::ToolCall(
+            ToolCall::new("spawn-1", "spawn_agent")
+                .status(ToolCallStatus::InProgress)
+                .raw_input(serde_json::json!({
+                    "prompt": "Inspect two subsystems",
+                    "receiverThreadIds": ["thread-a", "thread-b"],
+                    "model": "gpt-5.4",
+                    "reasoningEffort": "medium"
+                }))
+                .meta(meta(serde_json::json!({
+                    "codex": {
+                        "collaboration": {
+                            "tool": "spawn_agent",
+                            "senderThreadId": "thread-root",
+                            "receiverThreadIds": ["thread-a", "thread-b"]
+                        }
+                    }
+                }))),
+        ));
+
+        let Message::Assistant { blocks } = &p.messages()[0] else {
+            panic!("expected assistant message")
+        };
+        let AssistantBlock::Subagent(subagent) = &blocks[0] else {
+            panic!("expected subagent block")
+        };
+        assert_eq!(subagent.action, "spawn_agent");
+        assert_eq!(subagent.parent_thread_id.as_deref(), Some("thread-root"));
+        assert_eq!(subagent.child_thread_ids, ["thread-a", "thread-b"]);
+        assert_eq!(subagent.prompt.as_deref(), Some("Inspect two subsystems"));
+    }
+
+    #[test]
+    fn subagent_update_without_metadata_preserves_identity_and_records_output() {
+        use agent_client_protocol::schema::v1::{ToolCallUpdate, ToolCallUpdateFields};
+
+        let mut p = AcpProjector::new();
+        p.apply(SessionUpdate::ToolCall(
+            ToolCall::new("sub-1", "Start subagent explorer")
+                .status(ToolCallStatus::InProgress)
+                .meta(meta(serde_json::json!({
+                    "codex": {
+                        "subagent": {
+                            "threadId": "thread-child",
+                            "path": "explorer",
+                            "activity": "started"
+                        }
+                    }
+                }))),
+        ));
+
+        p.apply(SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+            "sub-1",
+            ToolCallUpdateFields::new()
+                .status(ToolCallStatus::Completed)
+                .raw_output(serde_json::json!({"summary": "inspection complete"})),
+        )));
+
+        let Message::Assistant { blocks } = &p.messages()[0] else {
+            panic!("expected assistant message")
+        };
+        assert!(matches!(
+            &blocks[0],
+            AssistantBlock::Subagent(subagent) if subagent.status == "completed"
+        ));
+        assert!(p.messages().iter().any(|message| matches!(
+            message,
+            Message::ToolResult { call_id, content, is_error: false }
+                if call_id == "sub-1" && content.contains("inspection complete")
+        )));
+    }
+
+    #[test]
+    fn claude_agent_and_child_tool_preserve_parent_relationship() {
+        let mut p = AcpProjector::new();
+        p.apply(SessionUpdate::ToolCall(
+            ToolCall::new("agent-1", "Inspect ACP support")
+                .status(ToolCallStatus::InProgress)
+                .raw_input(serde_json::json!({
+                    "description": "Inspect ACP support",
+                    "prompt": "Trace subagent metadata",
+                    "subagent_type": "Explore",
+                    "model": "sonnet"
+                }))
+                .meta(meta(serde_json::json!({
+                    "claudeCode": {"toolName": "Agent"}
+                }))),
+        ));
+        p.apply(SessionUpdate::ToolCall(
+            ToolCall::new("read-1", "Read files").meta(meta(serde_json::json!({
+                "claudeCode": {
+                    "toolName": "Read",
+                    "parentToolUseId": "agent-1"
+                }
+            }))),
+        ));
+
+        let Message::Assistant { blocks } = &p.messages()[0] else {
+            panic!("expected assistant message")
+        };
+        assert!(matches!(
+            &blocks[0],
+            AssistantBlock::Subagent(subagent)
+                if subagent.provider == "Claude"
+                    && subagent.agent_name.as_deref() == Some("Explore")
+                    && subagent.prompt.as_deref() == Some("Trace subagent metadata")
+        ));
+        assert!(matches!(
+            &blocks[1],
+            AssistantBlock::ToolUse { parent_call_id, .. }
+                if parent_call_id.as_deref() == Some("agent-1")
+        ));
     }
 
     #[test]

--- a/crates/vmux_service/src/agent.rs
+++ b/crates/vmux_service/src/agent.rs
@@ -311,6 +311,7 @@ async fn run_session(
                                         call_id: cid.clone(),
                                         name: name.clone(),
                                         args: args.clone(),
+                                        parent_call_id: None,
                                     });
                                     pending_tool = Some((cid, name, args));
                                 }

--- a/crates/vmux_service/src/message.rs
+++ b/crates/vmux_service/src/message.rs
@@ -48,7 +48,10 @@ pub enum AssistantBlock {
         call_id: String,
         name: String,
         args: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_call_id: Option<String>,
     },
+    Subagent(Box<SubagentBlock>),
     /// A proposed file edit (ACP `ToolCallContent::Diff`), rendered as an inline diff in the chat.
     Diff {
         call_id: String,
@@ -61,6 +64,25 @@ pub enum AssistantBlock {
     Plan {
         steps: Vec<PlanStep>,
     },
+}
+
+/// A delegated agent operation surfaced by an ACP adapter.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct SubagentBlock {
+    pub call_id: String,
+    pub provider: String,
+    pub title: String,
+    pub status: String,
+    pub action: String,
+    pub agent_name: Option<String>,
+    pub thread_id: Option<String>,
+    pub parent_thread_id: Option<String>,
+    pub child_thread_ids: Vec<String>,
+    pub parent_call_id: Option<String>,
+    pub prompt: Option<String>,
+    pub model: Option<String>,
+    pub reasoning_effort: Option<String>,
+    pub raw_input: String,
 }
 
 /// One entry in an agent [`AssistantBlock::Plan`]. `status` is `pending` | `in_progress` |
@@ -99,12 +121,43 @@ mod tests {
                     call_id: "abc".into(),
                     name: "list_spaces".into(),
                     args: "{}".to_string(),
+                    parent_call_id: None,
                 },
+                AssistantBlock::Subagent(Box::new(SubagentBlock {
+                    call_id: "agent-1".into(),
+                    provider: "Codex".into(),
+                    title: "Start subagent explorer".into(),
+                    status: "in_progress".into(),
+                    action: "started".into(),
+                    agent_name: Some("explorer".into()),
+                    thread_id: Some("thread-1".into()),
+                    parent_thread_id: Some("thread-root".into()),
+                    child_thread_ids: vec!["thread-1".into()],
+                    parent_call_id: None,
+                    prompt: Some("Inspect ACP support".into()),
+                    model: Some("gpt-5.4".into()),
+                    reasoning_effort: Some("high".into()),
+                    raw_input: "{}".into(),
+                })),
             ],
         };
         let json = serde_json::to_string(&m).unwrap();
         let back: Message = serde_json::from_str(&json).unwrap();
         assert_eq!(m, back);
+    }
+
+    #[test]
+    fn tool_use_deserializes_without_parent_call_id() {
+        let block: AssistantBlock =
+            serde_json::from_str(r#"{"ToolUse":{"call_id":"abc","name":"run","args":"{}"}}"#)
+                .unwrap();
+        assert!(matches!(
+            block,
+            AssistantBlock::ToolUse {
+                parent_call_id: None,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/vmux_service/src/providers/anthropic.rs
+++ b/crates/vmux_service/src/providers/anthropic.rs
@@ -56,11 +56,19 @@ fn messages_to_anthropic_blocks(messages: &[Message]) -> Vec<Value> {
                             call_id,
                             name,
                             args,
+                            ..
                         } => json!({
                             "type":"tool_use",
                             "id":call_id,
                             "name":name,
                             "input": serde_json::from_str::<Value>(args).unwrap_or(json!({}))
+                        }),
+                        AssistantBlock::Subagent(subagent) => json!({
+                            "type":"tool_use",
+                            "id":subagent.call_id,
+                            "name":"subagent",
+                            "input": serde_json::from_str::<Value>(&subagent.raw_input)
+                                .unwrap_or(json!({}))
                         }),
                         AssistantBlock::Diff { .. }
                         | AssistantBlock::Thinking(_)

--- a/crates/vmux_service/src/providers/openai.rs
+++ b/crates/vmux_service/src/providers/openai.rs
@@ -56,8 +56,15 @@ fn messages_to_responses_input(messages: &[Message]) -> Vec<Value> {
                             call_id,
                             name,
                             args,
+                            ..
                         } => out.push(json!({
                             "type":"function_call","call_id":call_id,"name":name,"arguments":args
+                        })),
+                        AssistantBlock::Subagent(subagent) => out.push(json!({
+                            "type":"function_call",
+                            "call_id":subagent.call_id,
+                            "name":"subagent",
+                            "arguments":subagent.raw_input
                         })),
                         AssistantBlock::Diff { .. }
                         | AssistantBlock::Thinking(_)

--- a/crates/vmux_service/src/providers/openai_shared.rs
+++ b/crates/vmux_service/src/providers/openai_shared.rs
@@ -104,10 +104,16 @@ pub fn messages_to_chat_completions(messages: &[Message]) -> Vec<Value> {
                             call_id,
                             name,
                             args,
+                            ..
                         } => tool_calls.push(json!({
                             "id": call_id,
                             "type":"function",
                             "function": {"name": name, "arguments": args}
+                        })),
+                        AssistantBlock::Subagent(subagent) => tool_calls.push(json!({
+                            "id": subagent.call_id,
+                            "type":"function",
+                            "function": {"name": "subagent", "arguments": subagent.raw_input}
                         })),
                         AssistantBlock::Diff { .. }
                         | AssistantBlock::Thinking(_)


### PR DESCRIPTION
## Context

ACP adapters now expose Codex and Claude subagent activity, but vmux rendered it as generic tool calls and discarded the relationships needed to understand delegated work.

## Implementation

Preserve provider subagent metadata in the transcript, model parent/child tool relationships, and render dedicated lifecycle cards with prompts, models, thread IDs, raw events, nested child tools, and results. Keep subagent history compatible with direct-provider message conversion.

## Checks / QA

1. Start a Codex ACP session, request parallel subagents, and verify live status, thread IDs, prompts, and results appear in dedicated cards.
2. Start a Claude ACP session that uses an Agent task and verify child tool activity and results appear nested under the delegated agent.