### PR TITLE
feat(agent): stage repository and worktree setup

### DIFF
--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -26,9 +26,9 @@ use crate::chat_page::event::{
     CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT,
     CHAT_SNAPSHOT_EVENT, ChatApproval, ChatAttachPaths, ChatAttachment,
     ChatAttachmentPreviewRequest, ChatAttachments, ChatCancel, ChatCancelQueuedPrompt,
-    ChatChooseWorkspace, ChatClearQueue, ChatEscape, ChatMediaEntries, ChatMediaEntry,
-    ChatMediaListRequest, ChatPasteMedia, ChatPickFiles, ChatResume, ChatSnapshot, ChatSubmit,
-    MODEL_STATE_EVENT, ModelOptionEntry, ModelState, QueuedPromptSnapshot,
+    ChatChoiceSelected, ChatChooseWorkspace, ChatClearQueue, ChatEscape, ChatMediaEntries,
+    ChatMediaEntry, ChatMediaListRequest, ChatPasteMedia, ChatPickFiles, ChatResume, ChatSnapshot,
+    ChatSubmit, MODEL_STATE_EVENT, ModelOptionEntry, ModelState, QueuedPromptSnapshot,
     RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions, ResumeListRequest,
     ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry,
     SlashCommands,
@@ -40,7 +40,9 @@ use crate::client::acp::{AcpModelState, AcpSession};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::components::{AgentMessages, AgentSession, PromptQueue};
 #[cfg(not(target_arch = "wasm32"))]
-use crate::events::{AgentApprovalReply, ApprovalDecision, WorkspacePickerStartRequest};
+use crate::events::{
+    AgentApprovalReply, AgentChoiceSelected, ApprovalDecision, WorkspacePickerStartRequest,
+};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::handoff::{
     DEFAULT_CONTEXT_LIMIT, ImportedConversation, build_context, visible_messages,
@@ -186,6 +188,7 @@ impl Plugin for AgentChatPagePlugin {
                 ChatMediaListRequest,
                 ChatAttachPaths,
                 ChatAttachmentPreviewRequest,
+                ChatChoiceSelected,
             )>::for_hosts(&["agent", "start"]))
             .add_observer(on_chat_submit)
             .add_observer(on_chat_approval)
@@ -195,6 +198,7 @@ impl Plugin for AgentChatPagePlugin {
             .add_observer(on_chat_cancel_queued_prompt)
             .add_observer(on_chat_escape)
             .add_observer(on_chat_choose_workspace)
+            .add_observer(on_chat_choice_selected)
             .add_observer(on_chat_pick_files)
             .add_observer(on_chat_paste_media)
             .add_observer(on_chat_media_list_request)
@@ -636,6 +640,14 @@ fn on_chat_choose_workspace(trigger: On<BinReceive<ChatChooseWorkspace>>, mut co
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+fn on_chat_choice_selected(trigger: On<BinReceive<ChatChoiceSelected>>, mut commands: Commands) {
+    commands.trigger(AgentChoiceSelected {
+        webview: trigger.event().webview,
+        index: trigger.event().payload.index as usize,
+    });
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 fn on_chat_pick_files(trigger: On<BinReceive<ChatPickFiles>>, mut commands: Commands) {
     let mut dialog = rfd::FileDialog::new();
     if let Some(home) = std::env::var_os("HOME") {
@@ -741,6 +753,7 @@ fn sync_chat_to_ready_views(
     )>,
     acp_sessions: Query<(&AcpSession, Option<&AcpModelState>)>,
     workspace_selections: Query<(), With<crate::plugin::PendingWorkspaceSelection>>,
+    choices: Query<&crate::plugin::PendingAgentChoice>,
     browsers: NonSend<Browsers>,
     mut commands: Commands,
 ) {
@@ -768,6 +781,7 @@ fn sync_chat_to_ready_views(
                 queue,
                 imported,
                 workspace_selections.contains(webview),
+                choices.get(webview).ok(),
             ),
         ));
         let (cross, model_state) = acp_sessions
@@ -906,6 +920,7 @@ fn snapshot_of(
     queue: &PromptQueue,
     imported: Option<&ImportedConversation>,
     workspace_selection_pending: bool,
+    choice: Option<&crate::plugin::PendingAgentChoice>,
 ) -> ChatSnapshot {
     let display_messages = visible_messages(imported, &messages.0);
     let durations: &[u32] = turn_meta.map(|m| m.durations.as_slice()).unwrap_or(&[]);
@@ -959,6 +974,12 @@ fn snapshot_of(
             })
             .unwrap_or_default(),
         workspace_selection_pending,
+        choice_question: choice
+            .map(|choice| choice.question.clone())
+            .unwrap_or_default(),
+        choice_options: choice
+            .map(|choice| choice.options.clone())
+            .unwrap_or_default(),
         queued: queue
             .items
             .iter()
@@ -1003,6 +1024,7 @@ fn push_chat_to_page(
     children: Query<&Children>,
     is_browser: Query<(), With<vmux_layout::Browser>>,
     workspace_selections: Query<(), With<crate::plugin::PendingWorkspaceSelection>>,
+    choices: Query<&crate::plugin::PendingAgentChoice>,
     browsers: NonSend<Browsers>,
     mut commands: Commands,
 ) {
@@ -1028,6 +1050,7 @@ fn push_chat_to_page(
                 queue,
                 imported,
                 workspace_selections.contains(webview),
+                choices.get(webview).ok(),
             ),
         ));
     }
@@ -1836,6 +1859,7 @@ mod native_tests {
             &PromptQueue::default(),
             Some(&imported),
             true,
+            None,
         );
 
         assert_eq!(snapshot.handoff_message_count, 2);
@@ -1857,6 +1881,7 @@ mod native_tests {
             &PromptQueue::default(),
             None,
             false,
+            None,
         );
 
         assert_eq!(snapshot.approval_name, "vmux.run");
@@ -2191,10 +2216,25 @@ mod native_tests {
         let composer = page.find("PromptComposer {").expect("composer");
 
         assert!(card < composer);
-        assert!(page.contains("Choose a workspace"));
+        assert!(page.contains("Choose repository folder"));
         assert!(page.contains("Choose folder"));
         assert!(page.contains("try_cef_bin_emit_rkyv(&ChatChooseWorkspace)"));
         assert!(include_str!("chat_page.rs").contains("WorkspacePickerStartRequest"));
+    }
+
+    #[test]
+    fn agent_choice_prompt_precedes_composer_and_supports_keyboard_selection() {
+        let page = include_str!("chat_page/page.rs");
+        let choice = page
+            .find("if !choice_options.read().is_empty()")
+            .expect("choice card");
+        let composer = page.find("PromptComposer {").expect("composer");
+
+        assert!(choice < composer);
+        assert!(page.contains("Ctrl+N/Ctrl+P"));
+        assert!(page.contains("choice_number_index"));
+        assert!(page.contains("ChatChoiceSelected"));
+        assert!(page.contains("agent-choice-item-{index}"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/composer.rs
+++ b/crates/vmux_agent/src/chat_page/composer.rs
@@ -158,6 +158,15 @@ pub(crate) fn menu_direction(key: &str, ctrl: bool) -> Option<MenuDirection> {
     }
 }
 
+pub(crate) fn choice_number_index(key: &str, len: usize) -> Option<usize> {
+    let number = key.parse::<usize>().ok()?;
+    if number == 0 || number > len {
+        None
+    } else {
+        Some(number - 1)
+    }
+}
+
 pub(crate) fn move_selection(current: usize, len: usize, direction: MenuDirection) -> usize {
     if len == 0 {
         return 0;
@@ -502,6 +511,10 @@ mod tests {
         assert_eq!(menu_direction("p", true), Some(MenuDirection::Previous));
         assert_eq!(menu_direction("n", false), None);
         assert_eq!(menu_direction("ArrowDown", true), None);
+        assert_eq!(choice_number_index("1", 3), Some(0));
+        assert_eq!(choice_number_index("3", 3), Some(2));
+        assert_eq!(choice_number_index("0", 3), None);
+        assert_eq!(choice_number_index("4", 3), None);
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -64,6 +64,8 @@ pub struct ChatSnapshot {
     /// Number of rendered [`ChatItem`] entries originating from the imported conversation.
     pub handoff_message_count: u32,
     pub workspace_selection_pending: bool,
+    pub choice_question: String,
+    pub choice_options: Vec<String>,
 }
 
 /// Page → native: the user submitted a prompt.
@@ -94,6 +96,21 @@ pub struct ChatSubmit {
     rkyv::Deserialize,
 )]
 pub struct ChatChooseWorkspace;
+
+/// Page → native: answer the active agent-authored multiple-choice prompt.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatChoiceSelected {
+    pub index: u32,
+}
 
 /// Page → native: the user answered a permission prompt. `decision`: 0 = deny, 1 = allow,
 /// 2 = allow-always.
@@ -553,6 +570,8 @@ mod tests {
             handoff_truncated: true,
             handoff_message_count: 2,
             workspace_selection_pending: true,
+            choice_question: "Repository?".into(),
+            choice_options: vec!["Local".into(), "Remote".into(), "Create".into()],
             queued: vec![
                 QueuedPromptSnapshot {
                     id: 4,
@@ -581,6 +600,8 @@ mod tests {
         assert!(back.handoff_truncated);
         assert_eq!(back.handoff_message_count, 2);
         assert!(back.workspace_selection_pending);
+        assert_eq!(back.choice_question, "Repository?");
+        assert_eq!(back.choice_options.len(), 3);
     }
 
     #[test]
@@ -606,6 +627,15 @@ mod tests {
                 .preview_data_url
                 .starts_with("data:image/png")
         );
+    }
+
+    #[test]
+    fn chat_choice_selected_rkyv_roundtrip() {
+        let value = ChatChoiceSelected { index: 2 };
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&value).unwrap();
+        let back = rkyv::from_bytes::<ChatChoiceSelected, rkyv::rancor::Error>(&bytes).unwrap();
+
+        assert_eq!(back.index, 2);
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -2,21 +2,22 @@
 
 use crate::chat_page::composer::{
     PromptEdit, PromptHistoryDirection, ResumeMenuState, SelectorMode, ToolActivity,
-    chat_page_title, edit_prompt, filter_models, filter_sessions, is_handoff_boundary,
-    menu_direction, move_prompt_history, move_selection, prompt_history_direction,
-    resume_menu_state, selector_mode, should_clear_draft_on_escape, should_expand_thinking,
-    should_fetch_resume, tool_activity,
+    chat_page_title, choice_number_index, edit_prompt, filter_models, filter_sessions,
+    is_handoff_boundary, menu_direction, move_prompt_history, move_selection,
+    prompt_history_direction, resume_menu_state, selector_mode, should_clear_draft_on_escape,
+    should_expand_thinking, should_fetch_resume, tool_activity,
 };
 use crate::chat_page::event::{
     CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT,
     CHAT_SNAPSHOT_EVENT, ChatApproval, ChatAttachPaths, ChatAttachment,
     ChatAttachmentPreviewRequest, ChatAttachments, ChatBlock, ChatCancel, ChatCancelQueuedPrompt,
-    ChatChooseWorkspace, ChatClearQueue, ChatEscape, ChatItem, ChatMediaEntries, ChatMediaEntry,
-    ChatMediaListRequest, ChatPasteMedia, ChatPickFiles, ChatResume, ChatSnapshot, ChatSubmit,
-    ChatSubmitAttachment, ChatTurn, MODEL_STATE_EVENT, ModelOptionEntry, ModelState,
-    QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions,
-    ResumeListRequest, ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel,
-    SlashCommandEntry, SlashCommands, WORKING_VERBS,
+    ChatChoiceSelected, ChatChooseWorkspace, ChatClearQueue, ChatEscape, ChatItem,
+    ChatMediaEntries, ChatMediaEntry, ChatMediaListRequest, ChatPasteMedia, ChatPickFiles,
+    ChatResume, ChatSnapshot, ChatSubmit, ChatSubmitAttachment, ChatTurn, MODEL_STATE_EVENT,
+    ModelOptionEntry, ModelState, QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT,
+    ResumableSessionEntry, ResumableSessions, ResumeListRequest, ResumeSession,
+    RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry, SlashCommands,
+    WORKING_VERBS,
 };
 use dioxus::prelude::*;
 use std::borrow::Cow;
@@ -161,7 +162,11 @@ fn dispatch_keyboard_event(
     }
 }
 
-fn install_global_prompt_input(draft: Signal<String>, slash_cmds: Signal<Vec<SlashCommandEntry>>) {
+fn install_global_prompt_input(
+    draft: Signal<String>,
+    slash_cmds: Signal<Vec<SlashCommandEntry>>,
+    choice_options: Signal<Vec<String>>,
+) {
     let closure = Closure::wrap(Box::new(move |event: web_sys::KeyboardEvent| {
         let Some(textarea) = prompt_textarea(PROMPT_INPUT_ID) else {
             return;
@@ -191,6 +196,8 @@ fn install_global_prompt_input(draft: Signal<String>, slash_cmds: Signal<Vec<Sla
                 }
         };
         let key = event.key();
+        let choice_len = choice_options.peek().len();
+        let choice_open = choice_len > 0;
         let direction = if event.meta_key() || event.alt_key() {
             None
         } else {
@@ -201,7 +208,12 @@ fn install_global_prompt_input(draft: Signal<String>, slash_cmds: Signal<Vec<Sla
             && !event.alt_key()
             && matches!(key.as_str(), "Enter" | "Escape");
         let selector_key = direction.is_some() || plain_invoke_or_close;
-        if direction.is_some() || (selector_open && selector_key) {
+        let choice_key = direction.is_some()
+            || (!event.meta_key()
+                && !event.ctrl_key()
+                && !event.alt_key()
+                && (key == "Enter" || choice_number_index(&key, choice_len).is_some()));
+        if (choice_open && choice_key) || direction.is_some() || (selector_open && selector_key) {
             event.prevent_default();
             event.stop_propagation();
             let _ = textarea.focus();
@@ -262,6 +274,8 @@ pub fn Page(
     let mut handoff_message_count = use_signal(|| 0u32);
     let mut workspace_selection_pending = use_signal(|| false);
     let mut workspace_picker_open = use_signal(|| false);
+    let mut choice_question = use_signal(String::new);
+    let mut choice_options = use_signal(Vec::<String>::new);
     let mut draft = use_signal(String::new);
     let mut attachments = use_signal(Vec::<ChatAttachment>::new);
     let mut attachment_previews = use_signal(HashMap::<String, ChatAttachment>::new);
@@ -287,7 +301,7 @@ pub fn Page(
     let mut resume_loading = use_signal(|| false);
     let mut verb = use_signal(|| "Working".to_string());
 
-    use_effect(move || install_global_prompt_input(draft, slash_cmds));
+    use_effect(move || install_global_prompt_input(draft, slash_cmds, choice_options));
     use_effect(move || focus_prompt_end(PROMPT_INPUT_ID));
 
     use_future(move || async move {
@@ -369,6 +383,11 @@ pub fn Page(
         handoff_truncated.set(snap.handoff_truncated);
         handoff_message_count.set(snap.handoff_message_count);
         workspace_selection_pending.set(snap.workspace_selection_pending);
+        if choice_options.peek().as_slice() != snap.choice_options.as_slice() {
+            menu_sel.set(0);
+        }
+        choice_question.set(snap.choice_question.clone());
+        choice_options.set(snap.choice_options.clone());
         if !snap.workspace_selection_pending {
             workspace_picker_open.set(false);
         }
@@ -610,9 +629,47 @@ pub fn Page(
     } else {
         "Send (Enter)"
     };
-    let prompt_action_enabled =
-        prompt_streaming || !draft_val.trim().is_empty() || !attachments.read().is_empty();
+    let choice_pending = !choice_options.read().is_empty();
+    let prompt_action_enabled = !choice_pending
+        && (prompt_streaming || !draft_val.trim().is_empty() || !attachments.read().is_empty());
     let prompt_keydown = move |e: KeyboardEvent| {
+        let pending_choices = choice_options.peek().clone();
+        if !pending_choices.is_empty() {
+            let key = e.key().to_string();
+            if !e.modifiers().meta()
+                && !e.modifiers().alt()
+                && let Some(direction) = menu_direction(&key, e.modifiers().ctrl())
+            {
+                e.prevent_default();
+                let selected = *menu_sel.peek();
+                menu_sel.set(move_selection(selected, pending_choices.len(), direction));
+                return;
+            }
+            let numbered = !e.modifiers().meta()
+                && !e.modifiers().ctrl()
+                && !e.modifiers().alt()
+                && choice_number_index(&key, pending_choices.len()).is_some();
+            let entered = e.key() == Key::Enter
+                && !e.modifiers().shift()
+                && !e.modifiers().meta()
+                && !e.modifiers().ctrl()
+                && !e.modifiers().alt();
+            if numbered || entered {
+                e.prevent_default();
+                let selected = *menu_sel.peek();
+                let index = choice_number_index(&key, pending_choices.len()).unwrap_or(selected);
+                if try_cef_bin_emit_rkyv(&ChatChoiceSelected {
+                    index: index as u32,
+                })
+                .is_ok()
+                {
+                    choice_question.set(String::new());
+                    choice_options.set(Vec::new());
+                    menu_sel.set(0);
+                }
+                return;
+            }
+        }
         let streaming = matches!(status().as_str(), "streaming" | "awaiting");
         let draft_now = draft.peek().clone();
         let (cmd_items, sess_items, model_items, session_selector_open, model_selector_open) =
@@ -793,7 +850,10 @@ pub fn Page(
         let _ = sessions.read().len();
         let _ = models.read().len();
         let _ = media_entries.read().len();
-        let item_id = if media_open {
+        let choice_open = !choice_options.read().is_empty();
+        let item_id = if choice_open {
+            format!("agent-choice-item-{selected}")
+        } else if media_open {
             format!("prompt-media-item-{selected}")
         } else {
             format!("agent-selector-item-{selected}")
@@ -1070,6 +1130,30 @@ pub fn Page(
                             }
                         }
                     }
+                    if !choice_options.read().is_empty() {
+                        div { class: "rounded-2xl border border-foreground/10 bg-foreground/[0.045] p-3.5 shadow-sm backdrop-blur-xl",
+                            div { class: "mb-3 text-sm font-medium text-foreground", "{choice_question}" }
+                            div { class: "flex flex-col gap-1.5",
+                                for (index, option) in choice_options.read().iter().cloned().enumerate() {
+                                    button {
+                                        key: "choice-{index}",
+                                        id: "agent-choice-item-{index}",
+                                        class: if index == menu_sel() { "flex items-center gap-3 rounded-xl bg-foreground px-3 py-2 text-left text-sm text-background" } else { "flex items-center gap-3 rounded-xl bg-foreground/[0.045] px-3 py-2 text-left text-sm text-foreground hover:bg-foreground/[0.08]" },
+                                        onclick: move |_| {
+                                            if try_cef_bin_emit_rkyv(&ChatChoiceSelected { index: index as u32 }).is_ok() {
+                                                choice_question.set(String::new());
+                                                choice_options.set(Vec::new());
+                                                menu_sel.set(0);
+                                            }
+                                        },
+                                        span { class: "flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-current/20 font-mono text-[10px]", "{index + 1}" }
+                                        span { class: "min-w-0 flex-1", "{option}" }
+                                    }
+                                }
+                            }
+                            div { class: "mt-2.5 text-[11px] text-muted-foreground", "↑/↓ or Ctrl+N/Ctrl+P · 1–9 · Enter" }
+                        }
+                    }
                     if workspace_selection_pending() {
                         div { class: "flex items-center gap-3 rounded-2xl border border-foreground/10 bg-foreground/[0.045] p-2.5 pl-3.5 shadow-sm backdrop-blur-xl",
                             div { class: "flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-foreground/[0.07] text-foreground/55 ring-1 ring-inset ring-foreground/10",
@@ -1085,8 +1169,8 @@ pub fn Page(
                                 }
                             }
                             div { class: "min-w-0 flex-1",
-                                div { class: "text-sm font-medium text-foreground", "Choose a workspace" }
-                                div { class: "truncate text-xs text-muted-foreground", "Select the project folder the agent should work in." }
+                                div { class: "text-sm font-medium text-foreground", "Choose repository folder" }
+                                div { class: "truncate text-xs text-muted-foreground", "Select the local Git repository the agent should use." }
                             }
                             button {
                                 class: if workspace_picker_open() { "flex h-8 shrink-0 cursor-default items-center gap-1.5 rounded-lg bg-foreground/[0.06] px-2.5 text-xs font-medium text-muted-foreground/60" } else { "flex h-8 shrink-0 items-center gap-1.5 rounded-lg bg-foreground px-2.5 text-xs font-medium text-background transition hover:opacity-85 active:scale-[0.98]" },
@@ -1204,7 +1288,7 @@ pub fn Page(
                         preview: transition_preview(),
                         attachments: prompt_attachments,
                         show_examples: show_capability_examples,
-                        placeholder: "Type / for commands or @ for media".to_string(),
+                        placeholder: if choice_pending { "Choose an option above".to_string() } else { "Type / for commands or @ for media".to_string() },
                         accent_bg: agent_accent.accent_bg.to_string(),
                         accent_color: theme_accent.clone(),
                         accent_gradient: agent_accent.grad.to_string(),

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -38,15 +38,13 @@ fn ancestor_acp_workspace_state(
     tabs: &Query<&vmux_layout::tab::Tab>,
     workspaces: &Query<(), With<vmux_layout::tab::TabWorkspace>>,
     pending_projects: &Query<(), With<crate::plugin::PendingAgentProject>>,
+    repositories_needing_worktrees: &Query<(), With<crate::plugin::RepositoryNeedsWorktree>>,
 ) -> Option<AcpWorkspaceState> {
     let mut current = entity;
     loop {
         if let Ok(tab) = tabs.get(current) {
             let state = match tab.startup_dir.as_deref() {
-                Some(path)
-                    if vmux_git::worktree::checkout_info(std::path::Path::new(path)).is_ok()
-                        && !vmux_git::worktree::is_linked_worktree(std::path::Path::new(path)) =>
-                {
+                Some(_) if repositories_needing_worktrees.contains(current) => {
                     AcpWorkspaceState::RepositoryNeedsWorktree
                 }
                 Some(_) => AcpWorkspaceState::Bound,
@@ -976,6 +974,7 @@ fn send_acp_input(
     tabs: Query<&vmux_layout::tab::Tab>,
     workspaces: Query<(), With<vmux_layout::tab::TabWorkspace>>,
     pending_projects: Query<(), With<crate::plugin::PendingAgentProject>>,
+    repositories_needing_worktrees: Query<(), With<crate::plugin::RepositoryNeedsWorktree>>,
     service: Option<Res<ServiceClient>>,
 ) {
     let Some(service) = service else {
@@ -1000,8 +999,14 @@ fn send_acp_input(
         {
             imported.first_prompt = Some(text.clone());
         }
-        let workspace_state =
-            ancestor_acp_workspace_state(entity, &child_of, &tabs, &workspaces, &pending_projects);
+        let workspace_state = ancestor_acp_workspace_state(
+            entity,
+            &child_of,
+            &tabs,
+            &workspaces,
+            &pending_projects,
+            &repositories_needing_worktrees,
+        );
         let context = acp_prompt_context(handoff, workspace_state);
         service.0.send(ClientMessage::agent_input(
             session.sid.clone(),
@@ -1139,13 +1144,18 @@ mod tests {
                     move |child_of: Query<&ChildOf>,
                           tabs: Query<&vmux_layout::tab::Tab>,
                           workspaces: Query<(), With<vmux_layout::tab::TabWorkspace>>,
-                          pending: Query<(), With<crate::plugin::PendingAgentProject>>| {
+                          pending: Query<(), With<crate::plugin::PendingAgentProject>>,
+                          needs_worktree: Query<
+                        (),
+                        With<crate::plugin::RepositoryNeedsWorktree>,
+                    >| {
                         ancestor_acp_workspace_state(
                             stack,
                             &child_of,
                             &tabs,
                             &workspaces,
                             &pending,
+                            &needs_worktree,
                         )
                     },
                 )
@@ -1160,11 +1170,23 @@ mod tests {
             state(app.world_mut()),
             Some(AcpWorkspaceState::PendingWorktree)
         );
+        app.world_mut().entity_mut(tab).insert((
+            vmux_layout::tab::Tab {
+                name: "Tab 1".into(),
+                startup_dir: Some("/repo".into()),
+            },
+            crate::plugin::RepositoryNeedsWorktree,
+        ));
+        assert_eq!(
+            state(app.world_mut()),
+            Some(AcpWorkspaceState::RepositoryNeedsWorktree)
+        );
         app.world_mut()
             .entity_mut(tab)
             .insert(vmux_layout::tab::TabWorkspace {
                 project_dir: "/repo".into(),
-            });
+            })
+            .remove::<crate::plugin::RepositoryNeedsWorktree>();
         assert_eq!(state(app.world_mut()), Some(AcpWorkspaceState::Bound));
     }
 

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -20,14 +20,16 @@ use crate::events::{AgentApprovalReply, AgentApprovalRequest, ApprovalDecision};
 use crate::handoff::{ImportedConversation, PendingHandoff};
 use crate::run_state::AgentRunState;
 
-const UNBOUND_WORKSPACE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): This tab has no selected workspace. If the user's request requires inspecting, searching, editing, testing, or running an existing project, your first project action must be to call the vmux choose_workspace tool. Do not search the user's home directory for repositories, do not access project paths directly, and never run git worktree add yourself. General questions and self-contained terminal demonstrations may run in the temporary current directory. vmux uses a selected linked worktree directly and creates an isolated managed worktree when the user selects a normal Git checkout.";
+const UNBOUND_WORKSPACE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): This tab has no selected repository. For development work, first call request_user_choice with these options in this order: Local repository, Remote repository, Create repository. Only after the user answers, bind the resulting local checkout with choose_workspace. Pass a path when the conversation identifies one; vmux opens the folder picker only when it cannot resolve that path. Remote repositories must be cloned and new repositories initialized before choose_workspace. Do not search the user's home directory. General questions and self-contained terminal demonstrations may run in the temporary current directory.";
 const PENDING_WORKTREE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): Workspace activation is pending. Do not access project paths directly or run git worktree add yourself. Wait for vmux to finish preparing the selected workspace before inspecting, editing, testing, or running the project.";
+const REPOSITORY_WORKTREE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): The repository is selected, but this tab is not isolated. Reading and inspection are allowed. Immediately before the first edit, write, test, build, or other mutation, call create_worktree. It reuses a known linked worktree, automatically uses one unambiguous existing worktree, or creates one when none exists. If it reports multiple candidates, ask the user with request_user_choice to choose an existing path or Create new worktree, then call create_worktree again with path or create=true. Never run git worktree add yourself.";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum AcpWorkspaceState {
     Bound,
     Unbound,
     PendingWorktree,
+    RepositoryNeedsWorktree,
 }
 
 fn ancestor_acp_workspace_state(
@@ -40,15 +42,19 @@ fn ancestor_acp_workspace_state(
     let mut current = entity;
     loop {
         if let Ok(tab) = tabs.get(current) {
-            return Some(
-                if workspaces.contains(current) || tab.startup_dir.is_some() {
-                    AcpWorkspaceState::Bound
-                } else if pending_projects.contains(current) {
-                    AcpWorkspaceState::PendingWorktree
-                } else {
-                    AcpWorkspaceState::Unbound
-                },
-            );
+            let state = match tab.startup_dir.as_deref() {
+                Some(path)
+                    if vmux_git::worktree::checkout_info(std::path::Path::new(path)).is_ok()
+                        && !vmux_git::worktree::is_linked_worktree(std::path::Path::new(path)) =>
+                {
+                    AcpWorkspaceState::RepositoryNeedsWorktree
+                }
+                Some(_) => AcpWorkspaceState::Bound,
+                None if workspaces.contains(current) => AcpWorkspaceState::Bound,
+                None if pending_projects.contains(current) => AcpWorkspaceState::PendingWorktree,
+                None => AcpWorkspaceState::Unbound,
+            };
+            return Some(state);
         }
         current = child_of.get(current).ok()?.parent();
     }
@@ -61,6 +67,7 @@ fn acp_prompt_context(
     let policy = match workspace_state {
         Some(AcpWorkspaceState::Unbound) => Some(UNBOUND_WORKSPACE_CONTEXT),
         Some(AcpWorkspaceState::PendingWorktree) => Some(PENDING_WORKTREE_CONTEXT),
+        Some(AcpWorkspaceState::RepositoryNeedsWorktree) => Some(REPOSITORY_WORKTREE_CONTEXT),
         Some(AcpWorkspaceState::Bound) | None => None,
     };
     match (handoff, policy) {
@@ -1067,12 +1074,24 @@ mod tests {
     fn unbound_workspace_context_requires_picker_before_project_work() {
         let context = acp_prompt_context(None, Some(AcpWorkspaceState::Unbound)).unwrap();
 
-        assert!(context.contains("first project action"));
+        assert!(context.contains("Local repository, Remote repository, Create repository"));
+        assert!(context.contains("request_user_choice"));
         assert!(context.contains("choose_workspace"));
         assert!(context.contains("Do not search the user's home directory"));
-        assert!(context.contains("never run git worktree add"));
-        assert!(context.contains("selected linked worktree directly"));
-        assert!(context.contains("creates an isolated managed worktree"));
+        assert!(context.contains("folder picker"));
+        assert!(context.contains("Remote repositories must be cloned"));
+    }
+
+    #[test]
+    fn repository_context_defers_worktree_until_mutation() {
+        let context =
+            acp_prompt_context(None, Some(AcpWorkspaceState::RepositoryNeedsWorktree)).unwrap();
+
+        assert!(context.contains("Reading and inspection are allowed"));
+        assert!(context.contains("Immediately before the first edit"));
+        assert!(context.contains("create_worktree"));
+        assert!(context.contains("request_user_choice"));
+        assert!(context.contains("Never run git worktree add"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/client/cli/claude.rs
+++ b/crates/vmux_agent/src/client/cli/claude.rs
@@ -12,14 +12,22 @@ use crate::{AgentKind, AgentVariant, AssistantBlock, McpServerConfig, Message};
 
 const DISALLOWED_TOOLS: &str = "Bash,Monitor,WebSearch,WebFetch";
 const ALLOWED_TOOLS: &str = "mcp__vmux__run,mcp__vmux__read_terminal,\
-mcp__vmux__browser_navigate,mcp__vmux__browser_snapshot,mcp__vmux__browser_scroll";
+mcp__vmux__browser_navigate,mcp__vmux__browser_snapshot,mcp__vmux__browser_scroll,\
+mcp__vmux__request_user_choice,mcp__vmux__choose_workspace,mcp__vmux__create_worktree";
 const RUN_STEER_PROMPT: &str = "The native Bash, WebSearch, and WebFetch tools are disabled. Run \
 ALL shell commands via the mcp__vmux__run tool (a visible terminal the user can watch and take \
 over). Use the output returned by run directly; call read_terminal only when run says the command \
 is still running. Do ALL web access via the vmux browser tools in the user's visible browser: \
 mcp__vmux__browser_navigate (it returns the page snapshot on load), then mcp__vmux__browser_scroll \
 to read more. Omit the pane argument - it targets your own browser pane. Do not look for a \
-built-in web search.";
+built-in web search. For development work without a selected repository, first call \
+mcp__vmux__request_user_choice with options Local repository, Remote repository, Create repository \
+in that order, then call mcp__vmux__choose_workspace after the answer. Pass a known path so vmux \
+only opens the folder picker when path resolution fails. Immediately before the first edit, write, \
+test, build, or mutation, call mcp__vmux__create_worktree. If it reports ambiguous existing \
+worktrees, ask whether to create or choose an existing path, then call create_worktree with \
+create=true or the selected path. Never \
+run git worktree add yourself.";
 const FILE_TOUCH_MATCHER: &str = "Read|Edit|Write|MultiEdit";
 
 pub struct ClaudeStrategy;
@@ -439,6 +447,9 @@ mod tests {
         let allowed = args.iter().position(|a| a == "--allowedTools").unwrap();
         assert!(args[allowed + 1].contains("mcp__vmux__run"));
         assert!(args[allowed + 1].contains("mcp__vmux__read_terminal"));
+        assert!(args[allowed + 1].contains("mcp__vmux__request_user_choice"));
+        assert!(args[allowed + 1].contains("mcp__vmux__choose_workspace"));
+        assert!(args[allowed + 1].contains("mcp__vmux__create_worktree"));
 
         let steer = args
             .iter()
@@ -446,6 +457,10 @@ mod tests {
             .unwrap();
         assert!(args[steer + 1].contains("mcp__vmux__run"));
         assert!(args[steer + 1].contains("browser_navigate"));
+        let repository = args[steer + 1].find("Local repository").unwrap();
+        let workspace = args[steer + 1].find("mcp__vmux__choose_workspace").unwrap();
+        let worktree = args[steer + 1].find("mcp__vmux__create_worktree").unwrap();
+        assert!(repository < workspace && workspace < worktree);
     }
 
     #[test]

--- a/crates/vmux_agent/src/client/cli/codex.rs
+++ b/crates/vmux_agent/src/client/cli/codex.rs
@@ -18,7 +18,14 @@ text) - do NOT cat/sed/head/tail a file via run. To SEARCH code, use the mcp__vm
 opens each matching file in a pane and returns the matches) - do NOT run rg/grep/ag via run. Do ALL web access via the vmux browser tools in the \
 user's visible browser: mcp__vmux__browser_navigate (it returns the page snapshot on load), then \
 mcp__vmux__browser_scroll to read more. Omit the pane argument - it targets your own browser pane. \
-Do not look for a built-in web search.";
+Do not look for a built-in web search. For development work without a selected repository, first \
+call mcp__vmux__request_user_choice with options Local repository, Remote repository, Create \
+repository in that order, then call mcp__vmux__choose_workspace after the answer. Pass a known path \
+so vmux only opens the folder picker when path resolution fails. Immediately before the first edit, \
+write, test, build, or mutation, call mcp__vmux__create_worktree. If it reports ambiguous existing \
+worktrees, ask whether to create or choose an existing path, then call create_worktree with \
+create=true or the selected path. Never \
+run git worktree add yourself.";
 const FILE_TOUCH_MATCHER: &str = "apply_patch|Edit|Write";
 
 pub struct CodexStrategy;
@@ -533,6 +540,11 @@ mod tests {
             .expect("developer_instructions override present");
         assert!(steer.contains("mcp__vmux__run"));
         assert!(steer.contains("browser_navigate"));
+        let repository = steer.find("Local repository").unwrap();
+        let workspace = steer.find("mcp__vmux__choose_workspace").unwrap();
+        let worktree = steer.find("mcp__vmux__create_worktree").unwrap();
+        assert!(repository < workspace && workspace < worktree);
+        assert!(steer.contains("create=true"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/client/cli/codex.rs
+++ b/crates/vmux_agent/src/client/cli/codex.rs
@@ -23,7 +23,7 @@ call mcp__vmux__request_user_choice with options Local repository, Remote reposi
 repository in that order, then call mcp__vmux__choose_workspace after the answer. Pass a known path \
 so vmux only opens the folder picker when path resolution fails. Immediately before the first edit, \
 write, test, build, or mutation, call mcp__vmux__create_worktree. If it reports ambiguous existing \
-worktrees, ask whether to create or choose an existing path, then call create_worktree with \
+worktrees, ask whether to create or choose an existing path, then call mcp__vmux__create_worktree with \
 create=true or the selected path. Never \
 run git worktree add yourself.";
 const FILE_TOUCH_MATCHER: &str = "apply_patch|Edit|Write";
@@ -540,11 +540,6 @@ mod tests {
             .expect("developer_instructions override present");
         assert!(steer.contains("mcp__vmux__run"));
         assert!(steer.contains("browser_navigate"));
-        let repository = steer.find("Local repository").unwrap();
-        let workspace = steer.find("mcp__vmux__choose_workspace").unwrap();
-        let worktree = steer.find("mcp__vmux__create_worktree").unwrap();
-        assert!(repository < workspace && workspace < worktree);
-        assert!(steer.contains("create=true"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/events.rs
+++ b/crates/vmux_agent/src/events.rs
@@ -11,6 +11,12 @@ pub struct WorkspacePickerStartRequest {
     pub webview: Entity,
 }
 
+#[derive(Event, Clone, Copy)]
+pub struct AgentChoiceSelected {
+    pub webview: Entity,
+    pub index: usize,
+}
+
 #[derive(Event, Clone, Debug)]
 pub struct AgentInput {
     pub session: Entity,

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -36,11 +36,11 @@ use crate::client::cli::claude::ClaudeStrategy;
 use crate::client::cli::codex::CodexStrategy;
 use crate::client::cli::vibe::VibeStrategy;
 use crate::events::{
-    AgentCommandRequest, AgentQueryRequest, AgentToolCallRequest, BrowserScrollRequest,
-    BrowserSnapshotRequest, BrowserSnapshotResponse, CommandOrigin, NavAwaitingSnapshot,
-    RecordStartRequest, RecordStartResponse, RecordStopRequest, RecordStopResponse, RecordingInfo,
-    ScreenshotImage, ScreenshotRequest, ScreenshotResponse, WorkspacePickerStartRequest,
-    snapshot_response_to_query_result,
+    AgentChoiceSelected, AgentCommandRequest, AgentQueryRequest, AgentToolCallRequest,
+    BrowserScrollRequest, BrowserSnapshotRequest, BrowserSnapshotResponse, CommandOrigin,
+    NavAwaitingSnapshot, RecordStartRequest, RecordStartResponse, RecordStopRequest,
+    RecordStopResponse, RecordingInfo, ScreenshotImage, ScreenshotRequest, ScreenshotResponse,
+    WorkspacePickerStartRequest, snapshot_response_to_query_result,
 };
 use crate::session::{
     self, AgentSession, AgentSessionDirty, AgentSessionExited, AgentSessionToEntity,
@@ -53,7 +53,11 @@ pub use vmux_space::cwd::valid_cwd;
 const BUILTIN_AGENT_PROVIDERS: &[AgentKind] =
     &[AgentKind::Vibe, AgentKind::Claude, AgentKind::Codex];
 const WORKSPACE_SELECTION_REQUESTED: &str = "Workspace selection requested. Stop this turn and wait. vmux will resume this same conversation after the user chooses or cancels.";
+const USER_CHOICE_REQUESTED: &str = "User choice requested. Stop this turn and wait. vmux will resume this same conversation with the selected option.";
 const WORKSPACE_SELECTION_PENDING: &str = "Workspace selection is already pending. Stop this turn and wait. vmux will resume this same conversation after the user chooses or cancels.";
+const REPOSITORY_SOURCE_QUESTION: &str = "Which repository should this task use?";
+const REPOSITORY_SOURCE_OPTIONS: [&str; 3] =
+    ["Local repository", "Remote repository", "Create repository"];
 
 /// Per-[`AgentKind`] override for CLI executable resolution: `true` forces present, `false` forces
 /// missing, absent falls back to a real `PATH` lookup. Lets tests drive the spawn/setup-page flow
@@ -204,6 +208,7 @@ impl Plugin for AgentPlugin {
             .add_message::<vmux_core::notify::AgentAttention>()
             .add_message::<vmux_core::notify::OsNotify>()
             .add_observer(start_workspace_picker)
+            .add_observer(handle_agent_choice_selected)
             .init_resource::<bevy::ecs::message::Messages<vmux_core::PageOpenRequest>>()
             .init_resource::<bevy::ecs::message::Messages<vmux_layout::OpenBesideRequest>>()
             .init_resource::<bevy::ecs::message::Messages<vmux_layout::CloseStackRequest>>()
@@ -2002,6 +2007,9 @@ fn handle_agent_commands(
             | ServiceAgentCommand::RunWithPlacementOverride { .. }
             | ServiceAgentCommand::CreateWorktree { .. }
             | ServiceAgentCommand::ChooseWorkspace { .. }
+            | ServiceAgentCommand::ChooseWorkspaceAtPath { .. }
+            | ServiceAgentCommand::PrepareWorktree { .. }
+            | ServiceAgentCommand::RequestUserChoice { .. }
             | ServiceAgentCommand::CreateWorktreeOnBranch { .. }
             | ServiceAgentCommand::ResumeInAcp { .. } => {
                 continue;
@@ -2102,6 +2110,9 @@ fn self_command_anchor(command: &ServiceAgentCommand) -> Option<ProcessId> {
         | ServiceAgentCommand::RunWithPlacementOverride { anchor, .. }
         | ServiceAgentCommand::CreateWorktree { anchor }
         | ServiceAgentCommand::ChooseWorkspace { anchor }
+        | ServiceAgentCommand::ChooseWorkspaceAtPath { anchor, .. }
+        | ServiceAgentCommand::PrepareWorktree { anchor, .. }
+        | ServiceAgentCommand::RequestUserChoice { anchor, .. }
         | ServiceAgentCommand::CreateWorktreeOnBranch { anchor, .. } => Some(*anchor),
         _ => None,
     }
@@ -2112,6 +2123,9 @@ fn self_command_priority(command: &ServiceAgentCommand) -> u8 {
         command,
         ServiceAgentCommand::CreateWorktree { .. }
             | ServiceAgentCommand::ChooseWorkspace { .. }
+            | ServiceAgentCommand::ChooseWorkspaceAtPath { .. }
+            | ServiceAgentCommand::PrepareWorktree { .. }
+            | ServiceAgentCommand::RequestUserChoice { .. }
             | ServiceAgentCommand::CreateWorktreeOnBranch { .. }
     ) {
         0
@@ -2128,6 +2142,9 @@ fn self_command_blocked_by_worktree_failure(
         command,
         ServiceAgentCommand::CreateWorktree { .. }
             | ServiceAgentCommand::ChooseWorkspace { .. }
+            | ServiceAgentCommand::ChooseWorkspaceAtPath { .. }
+            | ServiceAgentCommand::PrepareWorktree { .. }
+            | ServiceAgentCommand::RequestUserChoice { .. }
             | ServiceAgentCommand::CreateWorktreeOnBranch { .. }
     ) && self_command_anchor(command).is_some_and(|anchor| failed.contains(&anchor))
 }
@@ -2572,7 +2589,18 @@ struct AgentSelfCommandWriters<'w> {
 pub(crate) struct PendingAgentProject(pub(crate) PathBuf);
 
 #[derive(Component, Clone, Debug, PartialEq, Eq)]
-struct PendingAgentContinuation(String);
+pub(crate) struct PendingAgentContinuation(String);
+
+#[derive(Component, Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PendingAgentChoice {
+    session_entity: Entity,
+    tab_entity: Option<Entity>,
+    pub(crate) question: String,
+    pub(crate) options: Vec<String>,
+}
+
+#[derive(Component, Clone, Copy)]
+struct RepositorySourceSelected;
 
 #[derive(Component, Clone, Copy)]
 pub(crate) struct PendingWorkspaceSelection {
@@ -2594,10 +2622,53 @@ struct PendingWorkspacePicker {
 struct WorkspacePickerContext<'w, 's> {
     selections: Query<'w, 's, &'static PendingWorkspaceSelection>,
     pickers: Query<'w, 's, &'static PendingWorkspacePicker>,
+    choices: Query<'w, 's, &'static PendingAgentChoice>,
+    repository_sources: Query<'w, 's, (), With<RepositorySourceSelected>>,
     chat_views: Query<'w, 's, (), With<crate::chat_page::AgentChatView>>,
     page_sessions: Query<'w, 's, &'static crate::components::AgentSession>,
     cli_sessions: Query<'w, 's, &'static AgentSession>,
     proxy: Option<Res<'w, bevy::winit::EventLoopProxyWrapper>>,
+}
+
+fn handle_agent_choice_selected(
+    trigger: On<AgentChoiceSelected>,
+    choices: Query<&PendingAgentChoice>,
+    mut commands: Commands,
+) {
+    let event = trigger.event();
+    let Ok(choice) = choices.get(event.webview) else {
+        return;
+    };
+    let Some(selected) = choice.options.get(event.index) else {
+        return;
+    };
+    let continuation = if choice.tab_entity.is_some() {
+        format!(
+            "VMUX REPOSITORY SOURCE SELECTED: The user selected \"{selected}\". Continue repository setup in this same conversation. Obtain or create the local checkout, then call choose_workspace before project work."
+        )
+    } else {
+        format!(
+            "VMUX USER CHOICE: For \"{}\", the user selected \"{}\". Continue the original request in this same conversation.",
+            choice.question, selected
+        )
+    };
+    commands
+        .entity(choice.session_entity)
+        .insert(PendingAgentContinuation(continuation));
+    if let Some(tab_entity) = choice.tab_entity {
+        commands.entity(tab_entity).insert(RepositorySourceSelected);
+    }
+    commands
+        .entity(event.webview)
+        .remove::<PendingAgentChoice>()
+        .remove::<crate::chat_page::ChatSynced>();
+}
+
+fn repository_source_choice(options: &[String]) -> bool {
+    options
+        .iter()
+        .map(String::as_str)
+        .eq(REPOSITORY_SOURCE_OPTIONS)
 }
 
 fn workspace_picker_task(
@@ -2620,6 +2691,19 @@ fn workspace_picker_task(
             let _ = wake.send_event(bevy::winit::WinitUserEvent::WakeUp);
         }
         selected
+    })
+}
+
+fn workspace_path_task(
+    path: PathBuf,
+    proxy: Option<&bevy::winit::EventLoopProxyWrapper>,
+) -> Task<Option<PathBuf>> {
+    let wake = proxy.map(|proxy| (**proxy).clone());
+    IoTaskPool::get().spawn(async move {
+        if let Some(wake) = wake {
+            let _ = wake.send_event(bevy::winit::WinitUserEvent::WakeUp);
+        }
+        Some(path)
     })
 }
 
@@ -2657,7 +2741,7 @@ fn bind_tab_workspace(tab: &mut vmux_layout::tab::Tab, project_dir: &Path, execu
 
 fn workspace_ready_continuation(path: &Path) -> String {
     format!(
-        "VMUX WORKSPACE SELECTION COMPLETED: Workspace {} is ready. Continue the original user request in this same conversation using this directory.",
+        "VMUX REPOSITORY SELECTION COMPLETED: Repository {} is ready for reading and inspection. Continue the original user request in this same conversation. Immediately before the first edit, write, test, build, or other mutation, call create_worktree; if it reports multiple candidates, ask the user whether to create or choose an existing worktree.",
         path.display()
     )
 }
@@ -2758,45 +2842,110 @@ fn activate_selected_workspace(
     tab_entity: Entity,
     agent_entity: Entity,
     selected: &Path,
-    managed_root: &Path,
+    _managed_root: &Path,
     tabs: &mut Query<&mut vmux_layout::tab::Tab>,
     acp_sessions: &mut Query<&mut crate::client::acp::AcpSession>,
     child_of: &Query<&ChildOf>,
     commands: &mut Commands,
 ) -> Result<(PathBuf, Option<ClientMessage>), String> {
-    if vmux_git::worktree::checkout_info(selected).is_ok()
-        && !vmux_git::worktree::is_linked_worktree(selected)
-    {
-        let name = tabs
-            .get(tab_entity)
-            .map(|tab| tab.name.clone())
-            .map_err(|_| "tab not found".to_string())?;
-        let slug_hint = vmux_layout::worktree::tab_worktree_slug_hint(&name, selected);
-        let activation =
-            vmux_layout::worktree::create_worktree_blocking(selected, &slug_hint, managed_root)?;
-        activate_agent_worktree(
-            tab_entity,
-            agent_entity,
-            selected,
-            activation,
-            tabs,
-            acp_sessions,
-            child_of,
-            commands,
-        )
-    } else {
-        let rebind = activate_agent_directory(
-            tab_entity,
-            agent_entity,
-            selected,
-            selected,
-            tabs,
-            acp_sessions,
-            child_of,
-            commands,
-        )?;
-        Ok((selected.to_path_buf(), rebind))
-    }
+    vmux_git::worktree::checkout_info(selected).map_err(|_| {
+        "selected directory is not a Git repository; initialize it before choosing it".to_string()
+    })?;
+    let rebind = activate_agent_directory(
+        tab_entity,
+        agent_entity,
+        selected,
+        selected,
+        tabs,
+        acp_sessions,
+        child_of,
+        commands,
+    )?;
+    Ok((selected.to_path_buf(), rebind))
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ExistingWorktreeCandidate {
+    checkout_dir: PathBuf,
+    execution_dir: PathBuf,
+    branch: String,
+}
+
+fn existing_worktree_candidates(
+    project_dir: &Path,
+) -> Result<Vec<ExistingWorktreeCandidate>, String> {
+    let project_dir = project_dir
+        .canonicalize()
+        .map_err(|error| format!("invalid project directory: {error}"))?;
+    let project_checkout =
+        vmux_git::worktree::checkout_info(&project_dir).map_err(|error| error.0)?;
+    let relative_dir = project_dir
+        .strip_prefix(&project_checkout.root)
+        .map_err(|_| "project directory is outside its checkout".to_string())?;
+    let mut candidates = vmux_git::worktree::worktree_registrations(&project_checkout.root)
+        .map_err(|error| error.0)?
+        .into_iter()
+        .filter_map(|registration| {
+            let branch = registration.branch?;
+            let checkout = vmux_git::worktree::checkout_info(&registration.path).ok()?;
+            if checkout.common_dir != project_checkout.common_dir
+                || !vmux_git::worktree::is_linked_worktree(&checkout.root)
+            {
+                return None;
+            }
+            let execution_dir = checkout.root.join(relative_dir).canonicalize().ok()?;
+            execution_dir.is_dir().then_some(ExistingWorktreeCandidate {
+                checkout_dir: checkout.root,
+                execution_dir,
+                branch,
+            })
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by(|left, right| left.execution_dir.cmp(&right.execution_dir));
+    candidates.dedup_by(|left, right| left.execution_dir == right.execution_dir);
+    Ok(candidates)
+}
+
+fn resolve_requested_worktree(
+    project_dir: &Path,
+    requested: &Path,
+) -> Result<ExistingWorktreeCandidate, String> {
+    let requested = requested
+        .canonicalize()
+        .map_err(|error| format!("invalid worktree path: {error}"))?;
+    existing_worktree_candidates(project_dir)?
+        .into_iter()
+        .find(|candidate| {
+            requested == candidate.execution_dir
+                || requested.starts_with(&candidate.execution_dir)
+                || requested == candidate.checkout_dir
+                || requested.starts_with(&candidate.checkout_dir)
+        })
+        .ok_or_else(|| {
+            format!(
+                "{} is not an existing linked worktree for this repository",
+                requested.display()
+            )
+        })
+}
+
+fn ambiguous_worktree_message(candidates: &[ExistingWorktreeCandidate]) -> String {
+    let existing = candidates
+        .iter()
+        .enumerate()
+        .map(|(index, candidate)| {
+            format!(
+                "{}. {} — {}",
+                index + 2,
+                candidate.branch,
+                candidate.execution_dir.display()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "Multiple existing worktrees match this repository. Ask the user with request_user_choice using these options, then call create_worktree again with create=true or the selected path:\n1. Create new worktree\n{existing}"
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -3146,7 +3295,53 @@ fn handle_agent_self_commands(
                     }
                 }
             }
-            ServiceAgentCommand::ChooseWorkspace { anchor } => {
+            ServiceAgentCommand::RequestUserChoice {
+                anchor,
+                question,
+                options,
+            } => match resolve_self_pane(*anchor, &agent_terms, &ctx.child_of_q) {
+                None => AgentCommandResult::Error("agent pane not found".to_string()),
+                Some((agent_entity, pane)) => {
+                    let Some(session_entity) = ancestor_agent_session(
+                        agent_entity,
+                        &acp_sessions,
+                        &workspace_picker.page_sessions,
+                        &workspace_picker.cli_sessions,
+                        &ctx.child_of_q,
+                    ) else {
+                        service.0.send(ClientMessage::AgentCommandResponse {
+                            request_id: request.request_id,
+                            result: AgentCommandResult::Error(
+                                "agent session not found".to_string(),
+                            ),
+                        });
+                        continue;
+                    };
+                    if workspace_picker.choices.get(agent_entity).is_ok() {
+                        AgentCommandResult::Text(USER_CHOICE_REQUESTED.to_string())
+                    } else if workspace_picker.chat_views.contains(agent_entity) {
+                        let tab_entity = repository_source_choice(options)
+                            .then(|| ancestor_self_tab(pane, &tab_worktree.tabs, &ctx.child_of_q));
+                        commands
+                            .entity(agent_entity)
+                            .insert(PendingAgentChoice {
+                                session_entity,
+                                tab_entity: tab_entity.flatten(),
+                                question: question.clone(),
+                                options: options.clone(),
+                            })
+                            .remove::<crate::chat_page::ChatSynced>();
+                        AgentCommandResult::Text(USER_CHOICE_REQUESTED.to_string())
+                    } else {
+                        AgentCommandResult::Error(
+                            "Native choice prompts require the chat agent view; ask the user with the same numbered options in the current terminal session."
+                                .to_string(),
+                        )
+                    }
+                }
+            },
+            ServiceAgentCommand::ChooseWorkspace { anchor }
+            | ServiceAgentCommand::ChooseWorkspaceAtPath { anchor, .. } => {
                 match resolve_self_pane(*anchor, &agent_terms, &ctx.child_of_q) {
                     None => AgentCommandResult::Error("agent pane not found".to_string()),
                     Some((agent_entity, pane)) => {
@@ -3174,8 +3369,42 @@ fn handle_agent_self_commands(
                             });
                             continue;
                         };
-                        if !workspace_picker_tabs.insert(tab_entity) {
+                        if tab_worktree.workspaces.get(tab_entity).is_err()
+                            && !workspace_picker.repository_sources.contains(tab_entity)
+                            && workspace_picker.chat_views.contains(agent_entity)
+                        {
+                            if workspace_picker.choices.get(agent_entity).is_err() {
+                                commands
+                                    .entity(agent_entity)
+                                    .insert(PendingAgentChoice {
+                                        session_entity,
+                                        tab_entity: Some(tab_entity),
+                                        question: REPOSITORY_SOURCE_QUESTION.to_string(),
+                                        options: REPOSITORY_SOURCE_OPTIONS
+                                            .into_iter()
+                                            .map(str::to_string)
+                                            .collect(),
+                                    })
+                                    .remove::<crate::chat_page::ChatSynced>();
+                            }
+                            AgentCommandResult::Text(USER_CHOICE_REQUESTED.to_string())
+                        } else if !workspace_picker_tabs.insert(tab_entity) {
                             AgentCommandResult::Text(WORKSPACE_SELECTION_PENDING.to_string())
+                        } else if let ServiceAgentCommand::ChooseWorkspaceAtPath { path, .. } =
+                            &request.command
+                            && let Ok(selected) = Path::new(path).canonicalize()
+                            && selected.is_dir()
+                        {
+                            commands.spawn(PendingWorkspacePicker {
+                                tab_entity,
+                                agent_entity,
+                                session_entity,
+                                task: workspace_path_task(
+                                    selected,
+                                    workspace_picker.proxy.as_deref(),
+                                ),
+                            });
+                            AgentCommandResult::Text(WORKSPACE_SELECTION_REQUESTED.to_string())
                         } else if workspace_picker.chat_views.contains(agent_entity) {
                             commands
                                 .entity(agent_entity)
@@ -3199,6 +3428,159 @@ fn handle_agent_self_commands(
                     }
                 }
             }
+            ServiceAgentCommand::PrepareWorktree {
+                anchor,
+                path,
+                task,
+                create,
+            } => match resolve_self_pane(*anchor, &agent_terms, &ctx.child_of_q) {
+                None => AgentCommandResult::Error("agent pane not found".to_string()),
+                Some((agent_entity, pane)) => {
+                    let Some(tab_entity) =
+                        ancestor_self_tab(pane, &tab_worktree.tabs, &ctx.child_of_q)
+                    else {
+                        service.0.send(ClientMessage::AgentCommandResponse {
+                            request_id: request.request_id,
+                            result: AgentCommandResult::Error("no tab for agent".to_string()),
+                        });
+                        continue;
+                    };
+                    let current_dir =
+                        tab_worktree.tabs.get(tab_entity).ok().and_then(|tab| {
+                            stored_tab_cwd(tab.startup_dir.as_deref()).ok().flatten()
+                        });
+                    if let Some(current_dir) = current_dir.as_deref()
+                        && vmux_git::worktree::is_linked_worktree(current_dir)
+                    {
+                        AgentCommandResult::Text(current_dir.to_string_lossy().into_owned())
+                    } else {
+                        let project_dir = tab_worktree
+                            .workspaces
+                            .get(tab_entity)
+                            .ok()
+                            .and_then(|workspace| {
+                                stored_tab_cwd(Some(&workspace.project_dir)).ok().flatten()
+                            })
+                            .or_else(|| {
+                                tab_worktree
+                                    .pending_projects
+                                    .get(tab_entity)
+                                    .ok()
+                                    .map(|project| project.0.clone())
+                            })
+                            .or(current_dir);
+                        let Some(project_dir) = project_dir else {
+                            service.0.send(ClientMessage::AgentCommandResponse {
+                                request_id: request.request_id,
+                                result: AgentCommandResult::Error(
+                                    "No repository selected. Complete choose_workspace first."
+                                        .to_string(),
+                                ),
+                            });
+                            continue;
+                        };
+                        if vmux_git::worktree::checkout_info(&project_dir).is_err() {
+                            AgentCommandResult::Text(project_dir.to_string_lossy().into_owned())
+                        } else {
+                            let candidate = if *create {
+                                Ok(None)
+                            } else {
+                                match path.as_deref() {
+                                    Some(path) => {
+                                        resolve_requested_worktree(&project_dir, Path::new(path))
+                                            .map(Some)
+                                    }
+                                    None => match existing_worktree_candidates(&project_dir) {
+                                        Ok(candidates) if candidates.is_empty() => Ok(None),
+                                        Ok(candidates) if candidates.len() == 1 => {
+                                            Ok(candidates.into_iter().next())
+                                        }
+                                        Ok(candidates) => {
+                                            Err(ambiguous_worktree_message(&candidates))
+                                        }
+                                        Err(error) => Err(error),
+                                    },
+                                }
+                            };
+                            match candidate {
+                                Err(error) => AgentCommandResult::Error(error),
+                                Ok(Some(candidate)) => match activate_agent_directory(
+                                    tab_entity,
+                                    agent_entity,
+                                    &project_dir,
+                                    &candidate.execution_dir,
+                                    &mut tab_worktree.tabs,
+                                    &mut acp_sessions,
+                                    &ctx.child_of_q,
+                                    &mut commands,
+                                ) {
+                                    Ok(rebind) => {
+                                        if let Some(message) = rebind {
+                                            service.0.send(message);
+                                        }
+                                        AgentCommandResult::Text(format!(
+                                            "Worktree ready: {}\nContinue the user's request in this directory.",
+                                            candidate.execution_dir.display()
+                                        ))
+                                    }
+                                    Err(error) => AgentCommandResult::Error(error),
+                                },
+                                Ok(None) => {
+                                    let name = task
+                                        .as_deref()
+                                        .filter(|task| !task.trim().is_empty())
+                                        .map(str::to_string)
+                                        .or_else(|| {
+                                            tab_worktree
+                                                .tabs
+                                                .get(tab_entity)
+                                                .ok()
+                                                .map(|tab| tab.name.clone())
+                                        })
+                                        .unwrap_or_else(|| "task".to_string());
+                                    let slug_hint = vmux_layout::worktree::tab_worktree_slug_hint(
+                                        &name,
+                                        &project_dir,
+                                    );
+                                    match vmux_layout::worktree::create_worktree_blocking(
+                                        &project_dir,
+                                        &slug_hint,
+                                        &managed_root,
+                                    ) {
+                                        Ok(activation) => match activate_agent_worktree(
+                                            tab_entity,
+                                            agent_entity,
+                                            &project_dir,
+                                            activation,
+                                            &mut tab_worktree.tabs,
+                                            &mut acp_sessions,
+                                            &ctx.child_of_q,
+                                            &mut commands,
+                                        ) {
+                                            Ok((execution_dir, rebind)) => {
+                                                if let Some(message) = rebind {
+                                                    service.0.send(message);
+                                                }
+                                                worktree_created_this_batch.insert(
+                                                    tab_entity,
+                                                    vmux_git::worktree::head_ref(&execution_dir)
+                                                        .unwrap_or_default(),
+                                                );
+                                                AgentCommandResult::Text(format!(
+                                                    "Worktree ready: {}\nContinue the user's request in this directory.",
+                                                    execution_dir.display()
+                                                ))
+                                            }
+                                            Err(error) => AgentCommandResult::Error(error),
+                                        },
+                                        Err(error) => AgentCommandResult::Error(error),
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             ServiceAgentCommand::CreateWorktree { anchor } => {
                 match resolve_self_pane(*anchor, &agent_terms, &ctx.child_of_q) {
                     None => AgentCommandResult::Error("agent pane not found".to_string()),
@@ -3434,7 +3816,8 @@ fn handle_agent_self_commands(
             (&request.command, &result),
             (
                 ServiceAgentCommand::CreateWorktree { .. }
-                    | ServiceAgentCommand::CreateWorktreeOnBranch { .. },
+                    | ServiceAgentCommand::CreateWorktreeOnBranch { .. }
+                    | ServiceAgentCommand::PrepareWorktree { .. },
                 AgentCommandResult::Error(_)
             )
         ) && let Some(anchor) = request_anchor
@@ -5216,9 +5599,58 @@ mod tests {
         let cancelled = failed_workspace_continuation("The user cancelled workspace selection");
 
         assert!(ready.contains("same conversation"));
-        assert!(ready.contains("Workspace /repo/dashboard is ready"));
-        assert!(!ready.contains("create_worktree"));
+        assert!(ready.contains("Repository /repo/dashboard is ready"));
+        assert!(ready.contains("Immediately before the first edit"));
+        assert!(ready.contains("create_worktree"));
         assert!(cancelled.contains("Do not retry automatically"));
+    }
+
+    #[test]
+    fn repository_source_choice_requires_exact_order() {
+        let ordered = REPOSITORY_SOURCE_OPTIONS
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        let reordered = [
+            "Remote repository".to_string(),
+            "Local repository".to_string(),
+            "Create repository".to_string(),
+        ];
+
+        assert!(repository_source_choice(&ordered));
+        assert!(!repository_source_choice(&reordered));
+    }
+
+    #[test]
+    fn selected_agent_choice_resumes_session_and_unlocks_repository_selection() {
+        let mut app = App::new();
+        app.add_observer(handle_agent_choice_selected);
+        let session = app.world_mut().spawn_empty().id();
+        let tab = app.world_mut().spawn_empty().id();
+        let webview = app
+            .world_mut()
+            .spawn(PendingAgentChoice {
+                session_entity: session,
+                tab_entity: Some(tab),
+                question: REPOSITORY_SOURCE_QUESTION.into(),
+                options: REPOSITORY_SOURCE_OPTIONS
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect(),
+            })
+            .id();
+
+        app.world_mut()
+            .trigger(AgentChoiceSelected { webview, index: 1 });
+        app.update();
+
+        let continuation = app
+            .world()
+            .get::<PendingAgentContinuation>(session)
+            .unwrap();
+        assert!(continuation.0.contains("Remote repository"));
+        assert!(app.world().get::<RepositorySourceSelected>(tab).is_some());
+        assert!(app.world().get::<PendingAgentChoice>(webview).is_none());
     }
 
     #[test]
@@ -5390,7 +5822,7 @@ mod tests {
     }
 
     #[test]
-    fn selected_workspace_reuses_linked_worktree_or_creates_managed_checkout() {
+    fn selected_workspace_binds_repository_without_eager_worktree_creation() {
         use bevy::ecs::system::RunSystemOnce;
 
         let repo = init_worktree_test_repo();
@@ -5490,11 +5922,11 @@ mod tests {
             .unwrap()
             .0;
 
-        assert!(managed_execution.starts_with(managed_root.path().canonicalize().unwrap()));
+        assert_eq!(managed_execution, project_dir);
         assert!(
             app.world()
                 .get::<vmux_layout::tab::TabWorktree>(managed_tab)
-                .is_some()
+                .is_none()
         );
         assert_eq!(
             app.world()
@@ -5507,8 +5939,73 @@ mod tests {
             vmux_git::worktree::worktree_list(&project_dir)
                 .unwrap()
                 .len(),
-            3
+            2
         );
+    }
+
+    #[test]
+    fn selected_workspace_rejects_non_git_directory() {
+        use bevy::ecs::system::RunSystemOnce;
+
+        let directory = tempfile::tempdir().unwrap();
+        let selected = directory.path().canonicalize().unwrap();
+        let managed_root = tempfile::tempdir().unwrap();
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        let tab = app
+            .world_mut()
+            .spawn(vmux_layout::tab::Tab {
+                name: "Create".into(),
+                startup_dir: None,
+            })
+            .id();
+        let agent = app.world_mut().spawn(ChildOf(tab)).id();
+
+        let error = app
+            .world_mut()
+            .run_system_once(
+                move |mut tabs: Query<&mut vmux_layout::tab::Tab>,
+                      mut sessions: Query<&mut crate::client::acp::AcpSession>,
+                      child_of: Query<&ChildOf>,
+                      mut commands: Commands| {
+                    activate_selected_workspace(
+                        tab,
+                        agent,
+                        &selected,
+                        managed_root.path(),
+                        &mut tabs,
+                        &mut sessions,
+                        &child_of,
+                        &mut commands,
+                    )
+                },
+            )
+            .unwrap()
+            .unwrap_err();
+
+        assert!(error.contains("not a Git repository"));
+    }
+
+    #[test]
+    fn worktree_candidates_resolve_known_path_and_offer_create_when_ambiguous() {
+        let repo = init_worktree_test_repo();
+        let project_dir = repo.path().canonicalize().unwrap();
+        let roots = tempfile::tempdir().unwrap();
+        let first = roots.path().join("first");
+        let second = roots.path().join("second");
+        vmux_git::worktree::worktree_add(&project_dir, &first, "feature/first", "main").unwrap();
+        vmux_git::worktree::worktree_add(&project_dir, &second, "feature/second", "main").unwrap();
+
+        let candidates = existing_worktree_candidates(&project_dir).unwrap();
+        let resolved = resolve_requested_worktree(&project_dir, &first).unwrap();
+        let message = ambiguous_worktree_message(&candidates);
+
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(resolved.branch, "feature/first");
+        assert!(message.contains("1. Create new worktree"));
+        assert!(message.contains("feature/first"));
+        assert!(message.contains("feature/second"));
+        assert!(message.contains("create=true"));
     }
 
     fn swap_test_app() -> App {

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -2603,6 +2603,9 @@ pub(crate) struct PendingAgentChoice {
 struct RepositorySourceSelected;
 
 #[derive(Component, Clone, Copy)]
+pub(crate) struct RepositoryNeedsWorktree;
+
+#[derive(Component, Clone, Copy)]
 pub(crate) struct PendingWorkspaceSelection {
     tab_entity: Entity,
     agent_entity: Entity,
@@ -2798,6 +2801,7 @@ fn activate_agent_worktree(
             vmux_layout::tab::TabDirDecided,
         ))
         .remove::<PendingAgentProject>()
+        .remove::<RepositoryNeedsWorktree>()
         .remove::<vmux_layout::tab::TabWorktreeUnavailable>();
     let rebind = ancestor_acp_stack(agent_entity, acp_sessions, child_of)
         .and_then(|stack| rebind_acp_workspace(stack, &execution_dir, acp_sessions, commands));
@@ -2830,6 +2834,7 @@ fn activate_agent_directory(
             vmux_layout::tab::TabDirDecided,
         ))
         .remove::<PendingAgentProject>()
+        .remove::<RepositoryNeedsWorktree>()
         .remove::<vmux_layout::tab::TabWorktree>()
         .remove::<vmux_layout::worktree::TabWorktreeReady>()
         .remove::<vmux_layout::tab::TabWorktreeUnavailable>();
@@ -2851,6 +2856,7 @@ fn activate_selected_workspace(
     vmux_git::worktree::checkout_info(selected).map_err(|_| {
         "selected directory is not a Git repository; initialize it before choosing it".to_string()
     })?;
+    let needs_worktree = !vmux_git::worktree::is_linked_worktree(selected);
     let rebind = activate_agent_directory(
         tab_entity,
         agent_entity,
@@ -2861,6 +2867,9 @@ fn activate_selected_workspace(
         child_of,
         commands,
     )?;
+    if needs_worktree {
+        commands.entity(tab_entity).insert(RepositoryNeedsWorktree);
+    }
     Ok((selected.to_path_buf(), rebind))
 }
 
@@ -5875,6 +5884,11 @@ mod tests {
                 .get::<vmux_layout::tab::TabWorktree>(linked_tab)
                 .is_none()
         );
+        assert!(
+            app.world()
+                .get::<RepositoryNeedsWorktree>(linked_tab)
+                .is_none()
+        );
         assert_eq!(
             app.world()
                 .get::<vmux_layout::tab::TabWorkspace>(linked_tab)
@@ -5927,6 +5941,11 @@ mod tests {
             app.world()
                 .get::<vmux_layout::tab::TabWorktree>(managed_tab)
                 .is_none()
+        );
+        assert!(
+            app.world()
+                .get::<RepositoryNeedsWorktree>(managed_tab)
+                .is_some()
         );
         assert_eq!(
             app.world()

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -444,14 +444,16 @@ is typed into an interactive shell, so the terminal stays usable afterwards."
 fn create_worktree_definition() -> ToolDefinition {
     ToolDefinition {
         name: "create_worktree".into(),
-        description: "Create vmux's isolated worktree on an exact user-specified branch for the current project. Use only when the user explicitly asks for that branch; normal workspace selection and automatic isolation are handled by choose_workspace. Never run git worktree add manually. Returns the absolute worktree path."
+        description: "Call immediately before the first edit, write, test, build, or other project mutation, after repository selection is complete. vmux reuses the current linked worktree, accepts a known existing worktree path, automatically uses a single unambiguous existing worktree, or creates a managed worktree when none exists. If multiple existing worktrees are returned as ambiguous, ask the user with request_user_choice to choose an existing path or Create new worktree; call again with path or create=true. Never run git worktree add manually. Returns the absolute worktree path."
             .into(),
         input_schema: serde_json::json!({
             "type": "object",
-            "required": ["branch"],
             "additionalProperties": false,
             "properties": {
-                "branch": {"type": "string"}
+                "path": {"type": "string"},
+                "branch": {"type": "string"},
+                "task": {"type": "string"},
+                "create": {"type": "boolean"}
             }
         }),
     }
@@ -460,12 +462,36 @@ fn create_worktree_definition() -> ToolDefinition {
 fn choose_workspace_definition() -> ToolDefinition {
     ToolDefinition {
         name: "choose_workspace".into(),
-        description: "Request the native workspace chooser before inspecting, searching, editing, testing, or running an existing project when this conversation has no project yet. vmux uses a selected linked worktree directly, creates an isolated managed worktree for a normal Git checkout, or binds a non-Git directory. The request returns immediately: stop the current turn and do not call this tool again while selection is pending. vmux resumes this same conversation after the workspace is ready or selection is cancelled. Do not search the user's home directory for repositories or create a worktree manually. Do not call for general questions or self-contained terminal demonstrations."
+        description: "Bind the repository selected by the user after request_user_choice has asked, in order: Local repository, Remote repository, or Create repository. Pass path when the conversation already identifies a valid local checkout; vmux tries it first and opens the native folder picker only when the path is absent or invalid. Remote repositories must be cloned and new repositories initialized before calling this tool. This binds the repository only; call create_worktree later, immediately before the first mutation. The request returns immediately when user selection is needed: stop the current turn and do not call again while pending. Do not search the user's home directory for repositories. Do not call for general questions or self-contained terminal demonstrations."
             .into(),
         input_schema: serde_json::json!({
             "type": "object",
             "additionalProperties": false,
-            "properties": {}
+            "properties": {
+                "path": {"type": "string"}
+            }
+        }),
+    }
+}
+
+fn request_user_choice_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "request_user_choice".into(),
+        description: "Show a native multiple-choice question in the agent conversation. Use this for the required repository-source question before choose_workspace and for ambiguous worktree selection. The user can choose with arrow keys, Ctrl+N/Ctrl+P, number keys, mouse, or Enter. The request returns immediately: stop the current turn; vmux resumes the same conversation with the selected option."
+            .into(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "required": ["question", "options"],
+            "additionalProperties": false,
+            "properties": {
+                "question": {"type": "string"},
+                "options": {
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 9,
+                    "items": {"type": "string"}
+                }
+            }
         }),
     }
 }
@@ -730,6 +756,7 @@ pub fn tool_definitions_filtered(acp_session: bool, acp_terminals: bool) -> Vec<
     if !acp_terminals {
         defs.push(run_definition());
     }
+    defs.push(request_user_choice_definition());
     defs.push(choose_workspace_definition());
     defs.push(create_worktree_definition());
     if !acp_terminals {
@@ -903,18 +930,83 @@ pub fn dispatch_with_anchor(
             .get("branch")
             .and_then(Value::as_str)
             .map(str::trim)
-            .filter(|branch| !branch.is_empty())
-            .ok_or("create_worktree.branch is empty")?;
-        return Ok(DispatchTarget::Command(
-            AgentCommand::CreateWorktreeOnBranch {
-                anchor,
-                branch: branch.to_string(),
-            },
-        ));
+            .filter(|branch| !branch.is_empty());
+        if let Some(branch) = branch {
+            return Ok(DispatchTarget::Command(
+                AgentCommand::CreateWorktreeOnBranch {
+                    anchor,
+                    branch: branch.to_string(),
+                },
+            ));
+        }
+        let string_arg = |name: &str| {
+            arguments
+                .get(name)
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+        };
+        return Ok(DispatchTarget::Command(AgentCommand::PrepareWorktree {
+            anchor,
+            path: string_arg("path"),
+            task: string_arg("task"),
+            create: arguments
+                .get("create")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+        }));
+    }
+    if name == "request_user_choice" {
+        let anchor = anchor
+            .ok_or("request_user_choice requires an agent anchor (not available to this client)")?;
+        let question = arguments
+            .get("question")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|question| !question.is_empty())
+            .ok_or("request_user_choice.question is empty")?;
+        let options = arguments
+            .get("options")
+            .and_then(Value::as_array)
+            .ok_or("request_user_choice.options must be an array")?
+            .iter()
+            .map(|option| {
+                option
+                    .as_str()
+                    .map(str::trim)
+                    .filter(|option| !option.is_empty())
+                    .map(str::to_string)
+                    .ok_or_else(|| {
+                        "request_user_choice options must be non-empty strings".to_string()
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if !(2..=9).contains(&options.len()) {
+            return Err("request_user_choice requires 2 to 9 options".to_string());
+        }
+        return Ok(DispatchTarget::Command(AgentCommand::RequestUserChoice {
+            anchor,
+            question: question.to_string(),
+            options,
+        }));
     }
     if name == "choose_workspace" {
         let anchor = anchor
             .ok_or("choose_workspace requires an agent anchor (not available to this client)")?;
+        if let Some(path) = arguments
+            .get("path")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+        {
+            return Ok(DispatchTarget::Command(
+                AgentCommand::ChooseWorkspaceAtPath {
+                    anchor,
+                    path: path.to_string(),
+                },
+            ));
+        }
         return Ok(DispatchTarget::Command(AgentCommand::ChooseWorkspace {
             anchor,
         }));
@@ -1360,6 +1452,7 @@ mod tests {
             "open_page",
             "run",
             "read_terminal",
+            "request_user_choice",
             "choose_workspace",
             "create_worktree",
         ] {
@@ -1537,6 +1630,7 @@ mod tests {
     fn workspace_tools_dispatch_with_anchor_and_branch() {
         let anchor = vmux_service::protocol::ProcessId::new();
         let choose_definition = choose_workspace_definition();
+        let choice_definition = request_user_choice_definition();
         assert!(
             choose_definition
                 .description
@@ -1547,24 +1641,45 @@ mod tests {
                 .description
                 .contains("Do not search the user's home directory")
         );
+        assert!(choose_definition.description.contains("Local repository"));
+        assert!(choose_definition.description.contains("folder picker"));
         assert!(
             choose_definition
                 .description
-                .contains("linked worktree directly")
+                .contains("binds the repository only")
         );
-        assert!(choose_definition.description.contains("managed worktree"));
-        assert!(choose_definition.description.contains("workspace is ready"));
         assert!(
             choose_definition
                 .description
                 .contains("returns immediately")
         );
-        assert!(choose_definition.description.contains("same conversation"));
+        assert!(choice_definition.description.contains("Ctrl+N/Ctrl+P"));
         let choose =
             dispatch_with_anchor("choose_workspace", serde_json::json!({}), Some(anchor)).unwrap();
+        let choose_path = dispatch_with_anchor(
+            "choose_workspace",
+            serde_json::json!({"path": "/repo"}),
+            Some(anchor),
+        )
+        .unwrap();
         let create = dispatch_with_anchor(
             "create_worktree",
             serde_json::json!({"branch": "feature/fun-terminal"}),
+            Some(anchor),
+        )
+        .unwrap();
+        let prepare = dispatch_with_anchor(
+            "create_worktree",
+            serde_json::json!({"path": "/repo-wt", "task": "fun terminal", "create": false}),
+            Some(anchor),
+        )
+        .unwrap();
+        let choice = dispatch_with_anchor(
+            "request_user_choice",
+            serde_json::json!({
+                "question": "Repository?",
+                "options": ["Local repository", "Remote repository", "Create repository"]
+            }),
             Some(anchor),
         )
         .unwrap();
@@ -1574,13 +1689,28 @@ mod tests {
             DispatchTarget::Command(AgentCommand::ChooseWorkspace { anchor: got }) if got == anchor
         ));
         assert!(matches!(
+            choose_path,
+            DispatchTarget::Command(AgentCommand::ChooseWorkspaceAtPath { anchor: got, path })
+                if got == anchor && path == "/repo"
+        ));
+        assert!(matches!(
             create,
             DispatchTarget::Command(AgentCommand::CreateWorktreeOnBranch { anchor: got, branch })
                 if got == anchor && branch == "feature/fun-terminal"
         ));
-        assert!(
-            dispatch_with_anchor("create_worktree", serde_json::json!({}), Some(anchor)).is_err()
-        );
+        assert!(matches!(
+            prepare,
+            DispatchTarget::Command(AgentCommand::PrepareWorktree { anchor: got, path, task, create })
+                if got == anchor
+                    && path.as_deref() == Some("/repo-wt")
+                    && task.as_deref() == Some("fun terminal")
+                    && !create
+        ));
+        assert!(matches!(
+            choice,
+            DispatchTarget::Command(AgentCommand::RequestUserChoice { anchor: got, question, options })
+                if got == anchor && question == "Repository?" && options.len() == 3
+        ));
     }
 
     #[test]

--- a/crates/vmux_wire/src/protocol.rs
+++ b/crates/vmux_wire/src/protocol.rs
@@ -208,6 +208,27 @@ pub enum AgentCommand {
         title: Option<String>,
         favicon_url: Option<String>,
     },
+    /// Show a native multiple-choice prompt and resume the same agent session with the answer.
+    /// Appended to preserve existing positional enum discriminants.
+    RequestUserChoice {
+        anchor: ProcessId,
+        question: String,
+        options: Vec<String>,
+    },
+    /// Select a known project path, falling back to the native folder picker when it is invalid.
+    /// Appended to preserve existing positional enum discriminants.
+    ChooseWorkspaceAtPath {
+        anchor: ProcessId,
+        path: String,
+    },
+    /// Prepare a worktree immediately before mutation, reusing a known checkout when possible.
+    /// Appended to preserve existing positional enum discriminants.
+    PrepareWorktree {
+        anchor: ProcessId,
+        path: Option<String>,
+        task: Option<String>,
+        create: bool,
+    },
 }
 
 pub const AGENT_QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
@@ -376,6 +397,18 @@ pub fn validate_agent_command(command: &AgentCommand) -> Result<(), &'static str
         }
         AgentCommand::CreateWorktreeOnBranch { branch, .. } if branch.trim().is_empty() => {
             Err("create_worktree.branch is empty")
+        }
+        AgentCommand::RequestUserChoice {
+            question, options, ..
+        } if question.trim().is_empty()
+            || options.len() < 2
+            || options.len() > 9
+            || options.iter().any(|option| option.trim().is_empty()) =>
+        {
+            Err("request_user_choice requires a question and 2 to 9 non-empty options")
+        }
+        AgentCommand::ChooseWorkspaceAtPath { path, .. } if path.trim().is_empty() => {
+            Err("choose_workspace.path is empty")
         }
         _ => Ok(()),
     }
@@ -1450,6 +1483,21 @@ mod tests {
             AgentCommand::CreateWorktreeOnBranch {
                 anchor: ProcessId::new(),
                 branch: "feature/fun-terminal".into(),
+            },
+            AgentCommand::RequestUserChoice {
+                anchor: ProcessId::new(),
+                question: "Repository?".into(),
+                options: vec!["Local".into(), "Remote".into(), "Create".into()],
+            },
+            AgentCommand::ChooseWorkspaceAtPath {
+                anchor: ProcessId::new(),
+                path: "/repo".into(),
+            },
+            AgentCommand::PrepareWorktree {
+                anchor: ProcessId::new(),
+                path: Some("/repo-wt".into()),
+                task: Some("feature".into()),
+                create: false,
             },
         ];
         for command in commands {


### PR DESCRIPTION
## Context
Development agents need repository selection and worktree isolation to happen as explicit, ordered setup stages. Users also need a keyboard-driven way to answer agent choices without unnecessary folder prompts.

## Implementation
Adds native agent-authored choice prompts, enforces repository-source selection before binding, and defers worktree preparation until the first mutation. Known paths and unambiguous worktrees resolve automatically; ambiguous worktrees offer existing checkouts or a new managed worktree.

## Checks / QA
Start a development request in an unbound agent tab. Verify repository-source options appear in order and support arrows, Ctrl+N/P, number keys, Enter, and mouse. Select a repository with multiple worktrees, begin an edit, and verify the worktree choice appears before mutation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive multiple-choice prompts in the agent chat, with clickable options and numeric keyboard shortcuts.
  * Added guided repository selection and worktree preparation for agent tasks.
  * Added support for creating or selecting existing worktrees through the agent workflow.
* **Bug Fixes**
  * Improved handling of repository, workspace, and worktree states to prevent actions in unprepared locations.
  * Enhanced validation for choice prompts and workspace-related selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->