### PR TITLE
perf(ui): reduce start-page typing CPU

### DIFF
--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -23,18 +23,19 @@ use bevy_cef::prelude::{BinEventEmitterPlugin, BinHostEmitEvent, BinReceive, Bro
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::chat_page::event::{
-    CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT,
+    CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_HISTORY_MAX_PAGE_SIZE,
+    CHAT_HISTORY_PAGE_EVENT, CHAT_INITIAL_ITEM_LIMIT, CHAT_MEDIA_ENTRIES_EVENT,
     CHAT_SNAPSHOT_EVENT, ChatApproval, ChatAttachPaths, ChatAttachment,
     ChatAttachmentPreviewRequest, ChatAttachments, ChatCancel, ChatCancelQueuedPrompt,
-    ChatChoiceSelected, ChatChooseWorkspace, ChatClearQueue, ChatEscape, ChatMediaEntries,
-    ChatMediaEntry, ChatMediaListRequest, ChatPasteMedia, ChatPickFiles, ChatResume, ChatSnapshot,
-    ChatSubmit, MODEL_STATE_EVENT, ModelOptionEntry, ModelState, QueuedPromptSnapshot,
-    RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions, ResumeListRequest,
-    ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry,
-    SlashCommands,
+    ChatChoiceSelected, ChatChooseWorkspace, ChatClearQueue, ChatEscape, ChatHistoryPage,
+    ChatHistoryRequest, ChatMediaEntries, ChatMediaEntry, ChatMediaListRequest, ChatPasteMedia,
+    ChatPickFiles, ChatResume, ChatSnapshot, ChatSubmit, MODEL_STATE_EVENT, ModelOptionEntry,
+    ModelState, QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry,
+    ResumableSessions, ResumeListRequest, ResumeSession, RuntimeSwitchRequest,
+    SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry, SlashCommands,
 };
 #[cfg(not(target_arch = "wasm32"))]
-use crate::chat_page::turns::group_turns;
+use crate::chat_page::turns::{group_turns_before, group_turns_tail, grouped_item_count};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::client::acp::{AcpModelState, AcpSession};
 #[cfg(not(target_arch = "wasm32"))]
@@ -44,9 +45,7 @@ use crate::events::{
     AgentApprovalReply, AgentChoiceSelected, ApprovalDecision, WorkspacePickerStartRequest,
 };
 #[cfg(not(target_arch = "wasm32"))]
-use crate::handoff::{
-    DEFAULT_CONTEXT_LIMIT, ImportedConversation, build_context, visible_messages,
-};
+use crate::handoff::{DEFAULT_CONTEXT_LIMIT, ImportedConversation, build_context};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::run_state::{AgentRunState, AgentTurnMeta};
 #[cfg(not(target_arch = "wasm32"))]
@@ -189,6 +188,7 @@ impl Plugin for AgentChatPagePlugin {
                 ChatAttachPaths,
                 ChatAttachmentPreviewRequest,
                 ChatChoiceSelected,
+                ChatHistoryRequest,
             )>::for_hosts(&["agent", "start"]))
             .add_observer(on_chat_submit)
             .add_observer(on_chat_approval)
@@ -199,6 +199,7 @@ impl Plugin for AgentChatPagePlugin {
             .add_observer(on_chat_escape)
             .add_observer(on_chat_choose_workspace)
             .add_observer(on_chat_choice_selected)
+            .add_observer(on_chat_history_request)
             .add_observer(on_chat_pick_files)
             .add_observer(on_chat_paste_media)
             .add_observer(on_chat_media_list_request)
@@ -922,11 +923,19 @@ fn snapshot_of(
     workspace_selection_pending: bool,
     choice: Option<&crate::plugin::PendingAgentChoice>,
 ) -> ChatSnapshot {
-    let display_messages = visible_messages(imported, &messages.0);
     let durations: &[u32] = turn_meta.map(|m| m.durations.as_slice()).unwrap_or(&[]);
     let running = matches!(state, AgentRunState::Streaming);
-    let items = group_turns(&display_messages, durations, running);
-    let messages_json = serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string());
+    let imported_messages = imported
+        .map(|conversation| conversation.messages.as_slice())
+        .unwrap_or_default();
+    let page = group_turns_tail(
+        imported_messages,
+        &messages.0,
+        durations,
+        running,
+        CHAT_INITIAL_ITEM_LIMIT as usize,
+    );
+    let messages_json = serde_json::to_string(&page.items).unwrap_or_else(|_| "[]".to_string());
     let (status, error) = match state {
         AgentRunState::Idle => ("idle", String::new()),
         AgentRunState::Installing { pct, message } => {
@@ -956,6 +965,8 @@ fn snapshot_of(
         .unwrap_or_default();
     ChatSnapshot {
         messages_json,
+        messages_start: u32::try_from(page.start).unwrap_or(u32::MAX),
+        messages_total: u32::try_from(page.total).unwrap_or(u32::MAX),
         status: status.to_string(),
         error,
         approval_call_id: call_id,
@@ -970,7 +981,7 @@ fn snapshot_of(
         handoff_truncated: imported.is_some_and(|imported| imported.truncated),
         handoff_message_count: imported
             .map(|imported| {
-                u32::try_from(group_turns(&imported.messages, &[], false).len()).unwrap_or(u32::MAX)
+                u32::try_from(grouped_item_count(&imported.messages, &[])).unwrap_or(u32::MAX)
             })
             .unwrap_or_default(),
         workspace_selection_pending,
@@ -1054,6 +1065,59 @@ fn push_chat_to_page(
             ),
         ));
     }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn on_chat_history_request(
+    trigger: On<BinReceive<ChatHistoryRequest>>,
+    child_of: Query<&ChildOf>,
+    sessions: Query<(
+        &AgentMessages,
+        &AgentRunState,
+        Option<&AgentTurnMeta>,
+        Option<&ImportedConversation>,
+    )>,
+    browsers: NonSend<Browsers>,
+    mut commands: Commands,
+) {
+    let webview = trigger.event().webview;
+    let Ok(parent) = child_of.get(webview) else {
+        return;
+    };
+    let Ok((messages, state, turn_meta, imported)) = sessions.get(parent.parent()) else {
+        return;
+    };
+    if !browsers.has_browser(webview) || !browsers.host_emit_ready(&webview) {
+        return;
+    }
+    let request = &trigger.event().payload;
+    if request.before == 0 || request.limit == 0 {
+        return;
+    }
+    let imported_messages = imported
+        .map(|conversation| conversation.messages.as_slice())
+        .unwrap_or_default();
+    let durations = turn_meta
+        .map(|meta| meta.durations.as_slice())
+        .unwrap_or(&[]);
+    let page = group_turns_before(
+        imported_messages,
+        &messages.0,
+        durations,
+        matches!(state, AgentRunState::Streaming),
+        request.before as usize,
+        request.limit.clamp(1, CHAT_HISTORY_MAX_PAGE_SIZE) as usize,
+    );
+    commands.trigger(BinHostEmitEvent::from_rkyv(
+        webview,
+        CHAT_HISTORY_PAGE_EVENT,
+        &ChatHistoryPage {
+            items_json: serde_json::to_string(&page.items).unwrap_or_else(|_| "[]".to_string()),
+            start: u32::try_from(page.start).unwrap_or(u32::MAX),
+            end: u32::try_from(page.end).unwrap_or(u32::MAX),
+            total: u32::try_from(page.total).unwrap_or(u32::MAX),
+        },
+    ));
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -1947,6 +2011,21 @@ mod native_tests {
         assert!(page.contains("current_activity_icon(&items, &status)"));
         assert!(page.contains("ActivityIcon::Python"));
         assert!(page.contains("language_activity_icon(path)"));
+    }
+
+    #[test]
+    fn chat_page_bounds_gpu_work_without_losing_motion() {
+        let page = include_str!("chat_page/page.rs");
+        assert!(!page.contains("agent-chat-glow"));
+        assert!(!page.contains("backdrop-blur"));
+        assert!(!page.contains("blur-["));
+        assert!(page.contains("content-visibility:auto"));
+        assert!(page.contains("PromptComposer {"));
+        assert!(page.contains("agent-working-hop"));
+        assert!(page.contains("prefers-reduced-motion:reduce"));
+        assert!(page.contains("CHAT_HISTORY_PAGE_EVENT"));
+        assert!(page.contains("request_chat_history"));
+        assert!(page.contains("WorkingIndicator {}"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -4,6 +4,10 @@
 
 /// Bin-event id: native → page conversation/run-state snapshot.
 pub const CHAT_SNAPSHOT_EVENT: &str = "chat_snapshot";
+pub const CHAT_HISTORY_PAGE_EVENT: &str = "chat_history_page";
+pub const CHAT_INITIAL_ITEM_LIMIT: u32 = 48;
+pub const CHAT_HISTORY_PAGE_SIZE: u32 = 40;
+pub const CHAT_HISTORY_MAX_PAGE_SIZE: u32 = 80;
 pub use vmux_command::prompt_media::{
     CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT,
     ChatAttachPaths, ChatAttachment, ChatAttachmentPreviewRequest, ChatAttachments,
@@ -27,7 +31,7 @@ pub struct QueuedPromptSnapshot {
     pub attachment_names: Vec<String>,
 }
 
-/// Native → page: the full conversation plus run-state, pushed on every change.
+/// Native → page: the recent conversation page plus run-state, pushed on every change.
 #[derive(
     Clone,
     Debug,
@@ -39,8 +43,10 @@ pub struct QueuedPromptSnapshot {
     rkyv::Deserialize,
 )]
 pub struct ChatSnapshot {
-    /// `serde_json` of `Vec<ChatItem>` (user bubbles + grouped assistant turns).
+    /// `serde_json` of the recent `Vec<ChatItem>` page.
     pub messages_json: String,
+    pub messages_start: u32,
+    pub messages_total: u32,
     /// `idle` | `streaming` | `awaiting` | `errored`.
     pub status: String,
     /// Populated when `status == "errored"`.
@@ -66,6 +72,38 @@ pub struct ChatSnapshot {
     pub workspace_selection_pending: bool,
     pub choice_question: String,
     pub choice_options: Vec<String>,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatHistoryRequest {
+    pub before: u32,
+    pub limit: u32,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatHistoryPage {
+    pub items_json: String,
+    pub start: u32,
+    pub end: u32,
+    pub total: u32,
 }
 
 /// Page → native: the user submitted a prompt.
@@ -565,6 +603,8 @@ mod tests {
     fn chat_snapshot_rkyv_roundtrip() {
         let v = ChatSnapshot {
             messages_json: "[]".to_string(),
+            messages_start: 12,
+            messages_total: 60,
             status: "streaming".to_string(),
             handoff_source: "Codex".to_string(),
             handoff_truncated: true,
@@ -590,6 +630,8 @@ mod tests {
         let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&v).unwrap();
         let back = rkyv::from_bytes::<ChatSnapshot, rkyv::rancor::Error>(&bytes).unwrap();
         assert_eq!(back.status, "streaming");
+        assert_eq!(back.messages_start, 12);
+        assert_eq!(back.messages_total, 60);
         assert_eq!(back.queued.len(), 2);
         assert_eq!(back.queued[0].id, 4);
         assert_eq!(back.queued[0].text, "a");
@@ -602,6 +644,19 @@ mod tests {
         assert!(back.workspace_selection_pending);
         assert_eq!(back.choice_question, "Repository?");
         assert_eq!(back.choice_options.len(), 3);
+    }
+
+    #[test]
+    fn chat_history_page_rkyv_roundtrip() {
+        let value = ChatHistoryPage {
+            items_json: "[]".into(),
+            start: 4,
+            end: 44,
+            total: 92,
+        };
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&value).unwrap();
+        let back = rkyv::from_bytes::<ChatHistoryPage, rkyv::rancor::Error>(&bytes).unwrap();
+        assert_eq!((back.start, back.end, back.total), (4, 44, 92));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -8,19 +8,20 @@ use crate::chat_page::composer::{
     should_expand_thinking, should_fetch_resume, tool_activity,
 };
 use crate::chat_page::event::{
-    CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT,
-    CHAT_SNAPSHOT_EVENT, ChatApproval, ChatAttachPaths, ChatAttachment,
-    ChatAttachmentPreviewRequest, ChatAttachments, ChatBlock, ChatCancel, ChatCancelQueuedPrompt,
-    ChatChoiceSelected, ChatChooseWorkspace, ChatClearQueue, ChatEscape, ChatItem,
-    ChatMediaEntries, ChatMediaEntry, ChatMediaListRequest, ChatPasteMedia, ChatPickFiles,
-    ChatResume, ChatSnapshot, ChatSubmit, ChatSubmitAttachment, ChatTurn, MODEL_STATE_EVENT,
-    ModelOptionEntry, ModelState, QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT,
-    ResumableSessionEntry, ResumableSessions, ResumeListRequest, ResumeSession,
-    RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry, SlashCommands,
-    WORKING_VERBS,
+    CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_HISTORY_PAGE_EVENT,
+    CHAT_HISTORY_PAGE_SIZE, CHAT_MEDIA_ENTRIES_EVENT, CHAT_SNAPSHOT_EVENT, ChatApproval,
+    ChatAttachPaths, ChatAttachment, ChatAttachmentPreviewRequest, ChatAttachments, ChatBlock,
+    ChatCancel, ChatCancelQueuedPrompt, ChatChoiceSelected, ChatChooseWorkspace, ChatClearQueue,
+    ChatEscape, ChatHistoryPage, ChatHistoryRequest, ChatItem, ChatMediaEntries, ChatMediaEntry,
+    ChatMediaListRequest, ChatPasteMedia, ChatPickFiles, ChatResume, ChatSnapshot, ChatSubmit,
+    ChatSubmitAttachment, ChatTurn, MODEL_STATE_EVENT, ModelOptionEntry, ModelState,
+    QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions,
+    ResumeListRequest, ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel,
+    SlashCommandEntry, SlashCommands, WORKING_VERBS,
 };
 use dioxus::prelude::*;
 use std::borrow::Cow;
+use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 use vmux_command::prompt_media::{
     inline_media_query, media_display_path, media_reference, replace_inline_media_query,
@@ -35,7 +36,7 @@ use vmux_ui::components::prompt_composer::{
 use vmux_ui::components::prompt_media_options::{PromptMediaOption, PromptMediaOptions};
 use vmux_ui::favicon::favicon_src_for_url;
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_theme};
-use wasm_bindgen::{JsCast, closure::Closure};
+use wasm_bindgen::{JsCast, JsValue, closure::Closure};
 
 /// True when the page has a non-collapsed text selection — so Ctrl+C should copy, not interrupt.
 fn has_text_selection() -> bool {
@@ -80,6 +81,109 @@ fn accent_rgb(color: &str, fallback_rgb: &str) -> String {
         .unwrap_or_else(|| fallback_rgb.to_string())
 }
 
+fn chat_scroll_element() -> Option<web_sys::Element> {
+    web_sys::window()?
+        .document()?
+        .get_element_by_id("chat-scroll")
+}
+
+thread_local! {
+    static SCROLL_TO_BOTTOM_PENDING: Cell<bool> = const { Cell::new(false) };
+}
+
+fn request_chat_history(before: u32, mut loading: Signal<bool>) {
+    if before == 0 || *loading.peek() {
+        return;
+    }
+    if try_cef_bin_emit_rkyv(&ChatHistoryRequest {
+        before,
+        limit: CHAT_HISTORY_PAGE_SIZE,
+    })
+    .is_ok()
+    {
+        loading.set(true);
+    }
+}
+
+fn schedule_scroll_to_bottom() {
+    if SCROLL_TO_BOTTOM_PENDING.replace(true) {
+        return;
+    }
+    let callback = Closure::once_into_js(move || {
+        SCROLL_TO_BOTTOM_PENDING.set(false);
+        if let Some(element) = chat_scroll_element() {
+            element.set_scroll_top(element.scroll_height());
+        }
+    })
+    .unchecked_into::<js_sys::Function>();
+    if let Some(window) = web_sys::window()
+        && window.request_animation_frame(&callback).is_ok()
+    {
+        return;
+    }
+    let _ = callback.call0(&JsValue::NULL);
+}
+
+fn schedule_scroll_restore(previous_height: i32, previous_top: i32) {
+    let callback = Closure::once_into_js(move || {
+        if let Some(element) = chat_scroll_element() {
+            let added_height = element.scroll_height().saturating_sub(previous_height);
+            element.set_scroll_top(previous_top.saturating_add(added_height));
+        }
+    })
+    .unchecked_into::<js_sys::Function>();
+    if let Some(window) = web_sys::window()
+        && window
+            .set_timeout_with_callback_and_timeout_and_arguments_0(&callback, 0)
+            .is_ok()
+    {
+        return;
+    }
+    let _ = callback.call0(&JsValue::NULL);
+}
+
+fn merge_transcript_page(
+    current: &mut Vec<ChatItem>,
+    current_start: u32,
+    incoming: Vec<ChatItem>,
+    incoming_start: u32,
+) -> u32 {
+    if current_start <= incoming_start {
+        let keep = incoming_start.saturating_sub(current_start) as usize;
+        if keep <= current.len() {
+            current.truncate(keep);
+            current.extend(incoming);
+            return current_start;
+        }
+    }
+    *current = incoming;
+    incoming_start
+}
+
+fn request_attachment_previews(
+    items: &[ChatItem],
+    previews: Signal<HashMap<String, ChatAttachment>>,
+    mut requests: Signal<HashSet<String>>,
+) {
+    let known = previews.peek().keys().cloned().collect::<HashSet<_>>();
+    let mut requested = requests.peek().clone();
+    let paths = items
+        .iter()
+        .filter_map(|item| match item {
+            ChatItem::User { attachments, .. } => Some(attachments),
+            _ => None,
+        })
+        .flatten()
+        .filter(|attachment| attachment.mime_type.starts_with("image/"))
+        .filter(|attachment| {
+            !known.contains(&attachment.path) && requested.insert(attachment.path.clone())
+        })
+        .map(|attachment| attachment.path.clone())
+        .collect::<Vec<_>>();
+    if !paths.is_empty() && try_cef_bin_emit_rkyv(&ChatAttachmentPreviewRequest { paths }).is_ok() {
+        requests.set(requested);
+    }
+}
 fn prompt_history(items: &[ChatItem], queued: &[QueuedPromptSnapshot]) -> Vec<String> {
     let mut history = items
         .iter()
@@ -263,6 +367,11 @@ pub fn Page(
     let mut transition_preview = use_signal(|| transition_prompt.unwrap_or_default());
     let mut transition_attachments = use_signal(|| transition_attachments.unwrap_or_default());
     let mut items = use_signal(Vec::<ChatItem>::new);
+    let mut loaded_start = use_signal(|| 0u32);
+    let mut messages_total = use_signal(|| 0u32);
+    let mut history_loading = use_signal(|| false);
+    let mut recent_messages_json = use_signal(String::new);
+    let mut recent_messages_start = use_signal(|| u32::MAX);
     let mut status = use_signal(|| "installing".to_string());
     let mut error = use_signal(String::new);
     let mut approval = use_signal(|| Option::<(String, String, String)>::None);
@@ -279,10 +388,9 @@ pub fn Page(
     let mut draft = use_signal(String::new);
     let mut attachments = use_signal(Vec::<ChatAttachment>::new);
     let mut attachment_previews = use_signal(HashMap::<String, ChatAttachment>::new);
-    let mut attachment_preview_requests = use_signal(HashSet::<String>::new);
+    let attachment_preview_requests = use_signal(HashSet::<String>::new);
     let mut history_cursor = use_signal(|| None::<usize>);
     let mut history_scratch = use_signal(String::new);
-    let mut elapsed = use_signal(|| 0u32);
     let mut at_bottom = use_signal(|| true);
     let mut last_top = use_signal(|| 0i32);
     let mut queued = use_signal(Vec::<QueuedPromptSnapshot>::new);
@@ -299,32 +407,9 @@ pub fn Page(
     let mut menu_sel = use_signal(|| 0usize);
     let mut resume_requested = use_signal(|| false);
     let mut resume_loading = use_signal(|| false);
-    let mut verb = use_signal(|| "Working".to_string());
 
     use_effect(move || install_global_prompt_input(draft, slash_cmds, choice_options));
     use_effect(move || focus_prompt_end(PROMPT_INPUT_ID));
-
-    use_future(move || async move {
-        loop {
-            gloo_timers::future::TimeoutFuture::new(1000).await;
-            if matches!(status().as_str(), "streaming" | "installing") {
-                elapsed.set(elapsed() + 1);
-            } else if elapsed() != 0 {
-                elapsed.set(0);
-            }
-        }
-    });
-
-    use_future(move || async move {
-        loop {
-            gloo_timers::future::TimeoutFuture::new(2500).await;
-            if status() == "streaming" {
-                let n = WORKING_VERBS.len();
-                let idx = ((js_sys::Math::random() * n as f64) as usize).min(n - 1);
-                verb.set(WORKING_VERBS[idx].to_string());
-            }
-        }
-    });
 
     use_effect(move || {
         // Subscribe to any transcript/status change (each snapshot is a fresh `set`). Only pin to
@@ -334,42 +419,30 @@ pub fn Page(
         if !*at_bottom.peek() {
             return;
         }
-        if let Some(el) = web_sys::window()
-            .and_then(|w| w.document())
-            .and_then(|d| d.get_element_by_id("chat-scroll"))
-        {
-            el.set_scroll_top(el.scroll_height());
-        }
+        schedule_scroll_to_bottom();
     });
 
     let _listener = use_bin_event_listener::<ChatSnapshot, _>(CHAT_SNAPSHOT_EVENT, move |snap| {
-        if let Ok(parsed) = serde_json::from_str::<Vec<ChatItem>>(&snap.messages_json) {
-            let known = attachment_previews
-                .peek()
-                .keys()
-                .cloned()
-                .collect::<HashSet<_>>();
-            let mut requested = attachment_preview_requests.peek().clone();
-            let paths = parsed
-                .iter()
-                .filter_map(|item| match item {
-                    ChatItem::User { attachments, .. } => Some(attachments),
-                    _ => None,
-                })
-                .flatten()
-                .filter(|attachment| attachment.mime_type.starts_with("image/"))
-                .filter(|attachment| {
-                    !known.contains(&attachment.path) && requested.insert(attachment.path.clone())
-                })
-                .map(|attachment| attachment.path.clone())
-                .collect::<Vec<_>>();
-            if !paths.is_empty()
-                && try_cef_bin_emit_rkyv(&ChatAttachmentPreviewRequest { paths }).is_ok()
-            {
-                attachment_preview_requests.set(requested);
+        let messages_changed = recent_messages_start() != snap.messages_start
+            || *recent_messages_json.peek() != snap.messages_json;
+        if messages_changed
+            && let Ok(parsed) = serde_json::from_str::<Vec<ChatItem>>(&snap.messages_json)
+        {
+            request_attachment_previews(&parsed, attachment_previews, attachment_preview_requests);
+            let start = merge_transcript_page(
+                &mut items.write(),
+                loaded_start(),
+                parsed,
+                snap.messages_start,
+            );
+            loaded_start.set(start);
+            recent_messages_json.set(snap.messages_json.clone());
+            recent_messages_start.set(snap.messages_start);
+            if start == 0 {
+                history_loading.set(false);
             }
-            items.set(parsed);
         }
+        messages_total.set(snap.messages_total);
         status.set(snap.status.clone());
         error.set(snap.error.clone());
         queued.set(snap.queued.clone());
@@ -401,6 +474,25 @@ pub fn Page(
             approval.set(None);
         }
     });
+    let _history =
+        use_bin_event_listener::<ChatHistoryPage, _>(CHAT_HISTORY_PAGE_EVENT, move |page| {
+            history_loading.set(false);
+            if page.end != loaded_start() {
+                return;
+            }
+            let Ok(older) = serde_json::from_str::<Vec<ChatItem>>(&page.items_json) else {
+                return;
+            };
+            request_attachment_previews(&older, attachment_previews, attachment_preview_requests);
+            let metrics = chat_scroll_element()
+                .map(|element| (element.scroll_height(), element.scroll_top()));
+            drop(items.write().splice(0..0, older));
+            loaded_start.set(page.start);
+            messages_total.set(page.total);
+            if let Some((height, top)) = metrics {
+                schedule_scroll_restore(height, top);
+            }
+        });
     let _attachments =
         use_bin_event_listener::<ChatAttachments, _>(CHAT_ATTACHMENTS_EVENT, move |selected| {
             let mut next = attachments.peek().clone();
@@ -880,14 +972,8 @@ pub fn Page(
                         words: vec![header_name.to_uppercase()],
                     }
                 }
-            } else {
-                div { class: "pointer-events-none absolute inset-0 -z-10 overflow-hidden",
-                    div { class: "agent-chat-glow agent-chat-glow-primary absolute -left-32 top-16 h-80 w-80 rounded-full blur-[110px]" }
-                    div { class: "agent-chat-glow agent-chat-glow-secondary absolute -right-24 top-1/3 h-72 w-72 rounded-full blur-[110px]" }
-                    div { class: "agent-chat-glow agent-chat-glow-tertiary absolute bottom-[-12rem] left-1/3 h-96 w-96 rounded-full blur-[140px]" }
-                }
             }
-            header { class: "agent-chat-header vmux-agent-surface-enter relative z-10 flex items-center gap-2.5 border-b bg-background/55 px-5 py-3 shadow-[0_1px_0_rgba(255,255,255,0.02)] backdrop-blur-xl",
+            header { class: "agent-chat-header vmux-agent-surface-enter relative z-10 flex items-center gap-2.5 border-b bg-background/95 px-5 py-3 shadow-[0_1px_0_rgba(255,255,255,0.02)]",
                 {avatar_node(&agent_icon(), &accent(), &agent, &header_name, "h-6 w-6 text-[11px]")}
                 span { class: "h-2.5 w-2.5 rounded-full {status_dot_class(&status())}" }
                 span { class: "bg-gradient-to-b from-foreground to-foreground/60 bg-clip-text text-sm font-semibold capitalize text-transparent",
@@ -901,12 +987,9 @@ pub fn Page(
             }
             div {
                 id: "chat-scroll",
-                class: "vmux-agent-surface-enter vmux-agent-surface-enter-delayed relative z-10 flex-1 overflow-y-auto px-4 py-6",
+                class: "vmux-agent-surface-enter vmux-agent-surface-enter-delayed relative z-10 flex-1 overflow-y-auto overscroll-contain px-4 py-6",
                 onscroll: move |_| {
-                    if let Some(el) = web_sys::window()
-                        .and_then(|w| w.document())
-                        .and_then(|d| d.get_element_by_id("chat-scroll"))
-                    {
+                    if let Some(el) = chat_scroll_element() {
                         let top = el.scroll_top();
                         let dist = el.scroll_height() - top - el.client_height();
                         // Re-pin once the user reaches the bottom; unpin only when they scroll UP
@@ -919,17 +1002,29 @@ pub fn Page(
                             at_bottom.set(false);
                         }
                         last_top.set(top);
+                        if top <= 160 {
+                            request_chat_history(loaded_start(), history_loading);
+                        }
                     }
                 },
                 div { class: "mx-auto flex min-h-full max-w-3xl flex-col gap-5",
+                    if loaded_start() > 0 {
+                        button {
+                            id: "chat-load-older",
+                            class: "mx-auto rounded-full border border-foreground/10 bg-background/90 px-3 py-1.5 text-xs text-muted-foreground shadow-sm transition-colors hover:bg-foreground/[0.06] hover:text-foreground disabled:opacity-50",
+                            disabled: history_loading(),
+                            onclick: move |_| request_chat_history(loaded_start(), history_loading),
+                            if history_loading() { "Loading older messages…" } else { "Load older messages" }
+                        }
+                    }
                     if installing_splash {
                         div { class: "my-auto flex flex-col items-center gap-3 py-16 text-center",
                             {avatar_node(&agent_icon(), &accent(), &agent, &header_name, "h-14 w-14 text-xl")}
                             h2 { class: "bg-gradient-to-b from-foreground to-foreground/50 bg-clip-text text-3xl font-semibold capitalize tracking-tight text-transparent",
                                 "{header_name}"
                             }
-                            div { class: "flex max-w-sm items-center gap-2 rounded-full bg-background/70 px-3 py-1.5 text-xs text-muted-foreground ring-1 ring-inset ring-foreground/10 backdrop-blur-xl",
-                                span { class: "h-1.5 w-1.5 shrink-0 animate-pulse rounded-full {agent_accent.accent_bg}" }
+                            div { class: "flex max-w-sm items-center gap-2 rounded-full bg-background/90 px-3 py-1.5 text-xs text-muted-foreground ring-1 ring-inset ring-foreground/10",
+                                span { class: "h-1.5 w-1.5 shrink-0 rounded-full {agent_accent.accent_bg}" }
                                 span { class: "truncate", "{install_detail}" }
                             }
                         }
@@ -943,9 +1038,12 @@ pub fn Page(
                         }
                     }
                     for (i , item) in items.read().iter().enumerate() {
-                        {render_item(i, item, &verb(), elapsed(), attachment_previews)}
+                        {render_item(loaded_start() as usize + i, item, attachment_previews)}
                         if !handoff_source().is_empty()
-                            && is_handoff_boundary(i, handoff_message_count())
+                            && is_handoff_boundary(
+                                loaded_start() as usize + i,
+                                handoff_message_count(),
+                            )
                         {
                             div { class: "flex items-center gap-2 py-1 text-xs text-muted-foreground",
                                 span { class: "h-px flex-1 bg-foreground/10" }
@@ -1131,7 +1229,7 @@ pub fn Page(
                         }
                     }
                     if !choice_options.read().is_empty() {
-                        div { class: "rounded-2xl border border-foreground/10 bg-foreground/[0.045] p-3.5 shadow-sm backdrop-blur-xl",
+                        div { class: "rounded-2xl border border-foreground/10 bg-foreground/[0.045] p-3.5 shadow-sm",
                             div { class: "mb-3 text-sm font-medium text-foreground", "{choice_question}" }
                             div { class: "flex flex-col gap-1.5",
                                 for (index, option) in choice_options.read().iter().cloned().enumerate() {
@@ -1155,7 +1253,7 @@ pub fn Page(
                         }
                     }
                     if workspace_selection_pending() {
-                        div { class: "flex items-center gap-3 rounded-2xl border border-foreground/10 bg-foreground/[0.045] p-2.5 pl-3.5 shadow-sm backdrop-blur-xl",
+                        div { class: "flex items-center gap-3 rounded-2xl border border-foreground/10 bg-background/95 p-2.5 pl-3.5 shadow-sm",
                             div { class: "flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-foreground/[0.07] text-foreground/55 ring-1 ring-inset ring-foreground/10",
                                 svg {
                                     class: "h-4 w-4",
@@ -1429,8 +1527,6 @@ fn send_approval(call_id: String, decision: u8) {
 fn render_item(
     key: usize,
     item: &ChatItem,
-    verb: &str,
-    elapsed: u32,
     attachment_previews: Signal<HashMap<String, ChatAttachment>>,
 ) -> Element {
     match item {
@@ -1441,7 +1537,7 @@ fn render_item(
         } => rsx! {
             div {
                 key: "{key}",
-                class: "chat-user-bubble flex max-w-[80%] self-end flex-col gap-2 rounded-[1.35rem] rounded-tr-md border p-2.5 text-sm backdrop-blur-sm",
+                class: "chat-user-bubble flex max-w-[80%] self-end flex-col gap-2 rounded-[1.35rem] rounded-tr-md border p-2.5 text-sm",
                 if let Some(context) = context {
                     details { class: "disclosure user-context-panel rounded-xl border",
                         summary { class: "flex cursor-pointer select-none items-center gap-2 px-2.5 py-2 text-xs list-none [&::-webkit-details-marker]:hidden",
@@ -1476,7 +1572,7 @@ fn render_item(
                 }
             }
         },
-        ChatItem::Turn(turn) => render_turn(key, turn, verb, elapsed),
+        ChatItem::Turn(turn) => render_turn(key, turn),
     }
 }
 
@@ -1497,6 +1593,8 @@ fn render_user_attachment(
                 img {
                     src: "{preview_data_url}",
                     alt: "{attachment.name}",
+                    loading: "lazy",
+                    decoding: "async",
                     class: "max-h-80 max-w-full object-contain",
                 }
                 figcaption { class: "max-w-72 truncate px-2.5 py-1.5 text-[10px] text-muted-foreground", "{attachment.name}" }
@@ -1513,7 +1611,7 @@ fn render_user_attachment(
     }
 }
 
-fn render_turn(key: usize, turn: &ChatTurn, verb: &str, elapsed: u32) -> Element {
+fn render_turn(key: usize, turn: &ChatTurn) -> Element {
     let reconnecting = matches!(turn.blocks.last(), Some(ChatBlock::Reconnect { .. }));
     let block_count = turn.blocks.len();
     let blocks = turn
@@ -1547,12 +1645,12 @@ fn render_turn(key: usize, turn: &ChatTurn, verb: &str, elapsed: u32) -> Element
         }
     });
     rsx! {
-        div { key: "{key}", class: "chat-assistant-turn relative flex max-w-[92%] flex-col gap-2.5 self-start overflow-hidden rounded-2xl border px-3.5 py-3 backdrop-blur-sm",
+        div { key: "{key}", class: "chat-assistant-turn relative flex max-w-[92%] flex-col gap-2.5 self-start overflow-hidden rounded-2xl border px-3.5 py-3",
             for (j , block , children) in blocks {
                 {render_block(j, block, &children, should_expand_thinking(j, block_count))}
             }
             if turn.running && !reconnecting {
-                {render_working(verb, elapsed)}
+                WorkingIndicator {}
             }
             if !turn.running && let Some(label) = duration_label {
                 div { class: "grid grid-cols-[1.5rem_minmax(0,1fr)] gap-2.5 pt-0.5 text-[11px] text-muted-foreground/70",
@@ -1576,19 +1674,38 @@ fn render_disclosure_icon() -> Element {
     }
 }
 
-fn render_working(verb: &str, elapsed: u32) -> Element {
+#[component]
+fn WorkingIndicator() -> Element {
+    let mut elapsed = use_signal(|| 0u32);
+    let mut verb = use_signal(|| "Working".to_string());
+    use_future(move || async move {
+        loop {
+            gloo_timers::future::TimeoutFuture::new(1000).await;
+            elapsed.set(elapsed() + 1);
+        }
+    });
+    use_future(move || async move {
+        loop {
+            gloo_timers::future::TimeoutFuture::new(2500).await;
+            let count = WORKING_VERBS.len();
+            let index = ((js_sys::Math::random() * count as f64) as usize).min(count - 1);
+            verb.set(WORKING_VERBS[index].to_string());
+        }
+    });
+    let verb_text = verb();
+    let elapsed_text = fmt_elapsed(elapsed());
     rsx! {
         div { class: "grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2.5 py-1 text-sm text-muted-foreground",
             span { class: "agent-themed-activity flex h-6 w-6 items-center justify-center rounded-lg",
                 span { class: "flex items-end gap-0.5",
-                    span { class: "h-1 w-1 animate-bounce rounded-full bg-current [animation-delay:-0.32s]" }
-                    span { class: "h-1 w-1 animate-bounce rounded-full bg-current [animation-delay:-0.16s]" }
-                    span { class: "h-1 w-1 animate-bounce rounded-full bg-current" }
+                    span { class: "agent-working-dot h-1 w-1 rounded-full bg-current" }
+                    span { class: "agent-working-dot h-1 w-1 rounded-full [animation-delay:120ms]" }
+                    span { class: "agent-working-dot h-1 w-1 rounded-full [animation-delay:240ms]" }
                 }
             }
             div { class: "flex items-baseline gap-2",
-                span { class: "agent-working-label animate-pulse font-medium", "{verb}" }
-                span { class: "tabular-nums text-xs", "{fmt_elapsed(elapsed)}" }
+                span { class: "agent-working-label font-medium", "{verb_text}" }
+                span { class: "tabular-nums text-xs", "{elapsed_text}" }
             }
         }
     }
@@ -2234,9 +2351,9 @@ fn render_standalone_tool_result(key: usize, content: &str, is_error: bool) -> E
 
 fn status_dot_class(status: &str) -> &'static str {
     match status {
-        "streaming" => "bg-amber-400 animate-pulse shadow-[0_0_8px_rgba(251,191,36,0.65)]",
-        "installing" => "bg-sky-400 animate-pulse shadow-[0_0_8px_rgba(56,189,248,0.65)]",
-        "awaiting" => "bg-violet-400 animate-pulse shadow-[0_0_8px_rgba(167,139,250,0.65)]",
+        "streaming" => "agent-status-dot bg-amber-400 shadow-[0_0_8px_rgba(251,191,36,0.65)]",
+        "installing" => "agent-status-dot bg-sky-400 shadow-[0_0_8px_rgba(56,189,248,0.65)]",
+        "awaiting" => "agent-status-dot bg-violet-400 shadow-[0_0_8px_rgba(167,139,250,0.65)]",
         "errored" => "bg-red-500 shadow-[0_0_8px_rgba(239,68,68,0.65)]",
         _ => "bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.65)]",
     }
@@ -2320,13 +2437,14 @@ fn md_to_html(src: &str) -> String {
 /// HTML, and its preflight strips heading/list defaults). Theme-neutral rgba so it works in both
 /// light and dark.
 const MD_CSS: &str = r#"
-.agent-chat-prompt-shell::before{content:"";position:absolute;inset:-28px -42px;z-index:-1;border-radius:2.5rem;background:radial-gradient(60% 90% at 50% 75%,rgba(255,255,255,0.1),transparent 72%);filter:blur(16px);pointer-events:none}
+@keyframes agent-status-breathe{0%,100%{opacity:0.58;transform:scale(0.82)}50%{opacity:1;transform:scale(1)}}
+@keyframes agent-working-hop{0%,60%,100%{opacity:0.42;transform:translateY(0)}30%{opacity:1;transform:translateY(-3px)}}
+.agent-status-dot{animation:agent-status-breathe 1.8s ease-in-out infinite;will-change:opacity,transform}
+.agent-working-dot{animation:agent-working-hop 900ms ease-in-out infinite;will-change:opacity,transform}
+.agent-chat-prompt-shell::before{content:"";position:absolute;inset:-28px -42px;z-index:-1;border-radius:2.5rem;background:radial-gradient(60% 90% at 50% 75%,rgba(255,255,255,0.1),transparent 72%);pointer-events:none}
 .agent-chat-page{background-image:radial-gradient(80% 55% at 15% 0%,color-mix(in srgb,var(--agent-accent) 9%,transparent),transparent 65%),radial-gradient(75% 55% at 90% 10%,color-mix(in srgb,var(--agent-accent) 7%,transparent),transparent 62%),radial-gradient(65% 45% at 55% 100%,color-mix(in srgb,var(--agent-accent) 5%,transparent),transparent 70%)}
-.agent-chat-glow-primary{background:color-mix(in srgb,var(--agent-accent) 8%,transparent)}
-.agent-chat-glow-secondary{background:color-mix(in srgb,var(--agent-accent) 6%,transparent)}
-.agent-chat-glow-tertiary{background:color-mix(in srgb,var(--agent-accent) 4%,transparent)}
 .agent-chat-header{border-color:color-mix(in srgb,var(--agent-accent) 12%,transparent)}
-.chat-user-bubble,.chat-assistant-turn{transition:border-color 180ms ease,box-shadow 180ms ease,transform 180ms ease}
+.chat-user-bubble,.chat-assistant-turn{content-visibility:auto;contain-intrinsic-size:auto 160px;contain:layout paint style;transition:border-color 180ms ease,box-shadow 180ms ease,transform 180ms ease}
 .chat-user-bubble{border-color:color-mix(in srgb,var(--agent-accent) 18%,transparent);background:linear-gradient(135deg,color-mix(in srgb,var(--agent-accent) 19%,transparent),color-mix(in srgb,var(--agent-accent) 9%,transparent) 58%,color-mix(in srgb,var(--agent-accent) 4%,transparent));box-shadow:0 10px 32px color-mix(in srgb,var(--agent-accent) 9%,transparent)}
 .chat-user-bubble:hover{border-color:color-mix(in srgb,var(--agent-accent) 30%,transparent);box-shadow:0 14px 38px color-mix(in srgb,var(--agent-accent) 14%,transparent);transform:translateY(-1px)}
 .chat-assistant-turn{border-color:color-mix(in srgb,var(--agent-accent) 9%,rgba(127,127,127,0.08));background:linear-gradient(135deg,color-mix(in srgb,var(--agent-accent) 5%,transparent),rgba(127,127,127,0.025) 55%,transparent);box-shadow:0 10px 35px rgba(0,0,0,0.035)}
@@ -2368,5 +2486,5 @@ const MD_CSS: &str = r#"
 .chat-md hr{border:0;border-top:1px solid rgba(127,127,127,0.25);margin:0.9em 0}
 .chat-md table{border-collapse:collapse;margin:0.5em 0;font-size:0.95em}
 .chat-md th,.chat-md td{border:1px solid rgba(127,127,127,0.3);padding:0.3em 0.6em;text-align:left}
-@media (prefers-reduced-motion:reduce){.chat-user-bubble,.chat-assistant-turn{transition:none}.chat-user-bubble:hover{transform:none}}
+@media (prefers-reduced-motion:reduce){.agent-chat-caret,.agent-status-dot,.agent-working-dot{animation:none}.chat-user-bubble,.chat-assistant-turn{transition:none}.chat-user-bubble:hover{transform:none}}
 "#;

--- a/crates/vmux_agent/src/chat_page/turns.rs
+++ b/crates/vmux_agent/src/chat_page/turns.rs
@@ -11,74 +11,124 @@ use vmux_service::message::{AssistantBlock, Message, PlanStep, SubagentBlock};
 /// `ChatItem::Turn` per started turn. `durations[i]` is the finished seconds of the `i`-th
 /// emitted turn (by ordinal); out-of-range → `None`. When `running`, the last turn is marked
 /// live and forced to `duration_secs = None`.
+#[cfg(test)]
 pub fn group_turns(messages: &[Message], durations: &[u32], running: bool) -> Vec<ChatItem> {
-    let mut items: Vec<ChatItem> = Vec::new();
-    let mut current: Option<ChatTurn> = None;
-    let mut ordinal: usize = 0;
+    group_turns_page(&[], messages, durations, running, 0, usize::MAX).items
+}
 
-    for msg in messages {
-        match msg {
+pub struct ChatItemPage {
+    pub items: Vec<ChatItem>,
+    pub start: usize,
+    pub end: usize,
+    pub total: usize,
+}
+
+pub fn grouped_item_count(imported: &[Message], live: &[Message]) -> usize {
+    let mut count = 0usize;
+    let mut current_turn = false;
+    for message in imported.iter().chain(live) {
+        match message {
             Message::User { text, attachments } => {
-                flush(&mut items, &mut current, &mut ordinal, durations);
-                let (context, text) = vmux_service::protocol::split_private_context_prompt(text)
-                    .map(|(context, display)| (Some(context.to_string()), display))
-                    .unwrap_or((None, text));
-                if text.trim().is_empty() && attachments.is_empty() {
-                    current = Some(ChatTurn::default());
-                    continue;
+                if current_turn {
+                    count += 1;
                 }
-                items.push(ChatItem::User {
-                    text: text.to_string(),
-                    context,
-                    attachments: attachments
-                        .iter()
-                        .map(|attachment| ChatSubmitAttachment {
-                            path: attachment.path.clone(),
-                            name: attachment.name.clone(),
-                            mime_type: attachment.mime_type.clone(),
-                            size: attachment.size,
-                        })
-                        .collect(),
-                });
-                current = Some(ChatTurn::default());
+                let text = vmux_service::protocol::extract_display_prompt(text).unwrap_or(text);
+                if !text.trim().is_empty() || !attachments.is_empty() {
+                    count += 1;
+                }
+                current_turn = true;
+            }
+            Message::Assistant { .. } | Message::ToolResult { .. } => current_turn = true,
+        }
+    }
+    if current_turn {
+        count += 1;
+    }
+    count
+}
+
+pub fn group_turns_tail(
+    imported: &[Message],
+    live: &[Message],
+    durations: &[u32],
+    running: bool,
+    limit: usize,
+) -> ChatItemPage {
+    let total = grouped_item_count(imported, live);
+    group_turns_page_with_total(
+        imported,
+        live,
+        durations,
+        running,
+        total.saturating_sub(limit),
+        total,
+        total,
+    )
+}
+
+pub fn group_turns_before(
+    imported: &[Message],
+    live: &[Message],
+    durations: &[u32],
+    running: bool,
+    before: usize,
+    limit: usize,
+) -> ChatItemPage {
+    let total = grouped_item_count(imported, live);
+    let end = before.min(total);
+    group_turns_page_with_total(
+        imported,
+        live,
+        durations,
+        running,
+        end.saturating_sub(limit),
+        end,
+        total,
+    )
+}
+
+#[cfg(test)]
+fn group_turns_page(
+    imported: &[Message],
+    live: &[Message],
+    durations: &[u32],
+    running: bool,
+    start: usize,
+    end: usize,
+) -> ChatItemPage {
+    let total = grouped_item_count(imported, live);
+    group_turns_page_with_total(imported, live, durations, running, start, end, total)
+}
+
+fn group_turns_page_with_total(
+    imported: &[Message],
+    live: &[Message],
+    durations: &[u32],
+    running: bool,
+    start: usize,
+    end: usize,
+    total: usize,
+) -> ChatItemPage {
+    let start = start.min(total);
+    let end = end.min(total).max(start);
+    let mut builder = PageBuilder::new(start, end, durations);
+
+    for message in imported.iter().chain(live) {
+        match message {
+            Message::User { text, attachments } => {
+                builder.flush_turn();
+                let (context, text) = vmux_service::protocol::split_private_context_prompt(text)
+                    .map(|(context, display)| (Some(context), display))
+                    .unwrap_or((None, text));
+                if !text.trim().is_empty() || !attachments.is_empty() {
+                    builder.push_user(text, context, attachments);
+                }
+                builder.start_turn();
             }
             Message::Assistant { blocks } => {
-                let turn = current.get_or_insert_with(ChatTurn::default);
-                for block in blocks {
-                    match block {
-                        AssistantBlock::Text(t) => push_assistant_text(turn, t),
-                        AssistantBlock::Thinking(t) => {
-                            turn.blocks.push(ChatBlock::Thinking(t.clone()))
-                        }
-                        AssistantBlock::ToolUse {
-                            call_id,
-                            name,
-                            args,
-                            parent_call_id,
-                        } => turn.blocks.push(ChatBlock::ToolUse {
-                            call_id: call_id.clone(),
-                            name: name.clone(),
-                            args: args.clone(),
-                            parent_call_id: parent_call_id.clone(),
-                        }),
-                        AssistantBlock::Subagent(subagent) => turn
-                            .blocks
-                            .push(ChatBlock::Subagent(Box::new(map_subagent(subagent)))),
-                        AssistantBlock::Diff {
-                            call_id,
-                            path,
-                            old_text,
-                            new_text,
-                        } => turn.blocks.push(ChatBlock::Diff {
-                            call_id: call_id.clone(),
-                            path: path.clone(),
-                            old_text: old_text.clone(),
-                            new_text: new_text.clone(),
-                        }),
-                        AssistantBlock::Plan { steps } => turn.blocks.push(ChatBlock::Plan {
-                            steps: steps.iter().map(map_plan_step).collect(),
-                        }),
-                    }
+                builder.start_turn();
+                if let Some(turn) = builder.current.as_mut() {
+                    push_assistant_blocks(turn, blocks);
                 }
             }
             Message::ToolResult {
@@ -86,42 +136,152 @@ pub fn group_turns(messages: &[Message], durations: &[u32], running: bool) -> Ve
                 content,
                 is_error,
             } => {
-                let turn = current.get_or_insert_with(ChatTurn::default);
-                turn.blocks.push(ChatBlock::ToolResult {
-                    call_id: call_id.clone(),
-                    content: content.clone(),
-                    is_error: *is_error,
-                });
+                builder.start_turn();
+                if let Some(turn) = builder.current.as_mut() {
+                    turn.blocks.push(ChatBlock::ToolResult {
+                        call_id: call_id.clone(),
+                        content: content.clone(),
+                        is_error: *is_error,
+                    });
+                }
             }
         }
     }
-    flush(&mut items, &mut current, &mut ordinal, durations);
-
-    if running && let Some(ChatItem::Turn(last)) = items.last_mut() {
+    builder.flush_turn();
+    if running
+        && end == total
+        && let Some(ChatItem::Turn(last)) = builder.items.last_mut()
+    {
         last.running = true;
         last.duration_secs = None;
     }
-    items
+    ChatItemPage {
+        items: builder.items,
+        start,
+        end,
+        total,
+    }
 }
 
-fn flush(
-    items: &mut Vec<ChatItem>,
-    current: &mut Option<ChatTurn>,
-    ordinal: &mut usize,
-    durations: &[u32],
-) {
-    if let Some(mut turn) = current.take() {
-        turn.step_count = turn
-            .blocks
-            .iter()
-            .enumerate()
-            .filter(|(index, block)| {
-                !matches!(block, ChatBlock::Text(_)) && turn.parent_tool_index(*index).is_none()
-            })
-            .count() as u32;
-        turn.duration_secs = durations.get(*ordinal).copied();
-        *ordinal += 1;
-        items.push(ChatItem::Turn(turn));
+struct PageBuilder<'a> {
+    items: Vec<ChatItem>,
+    start: usize,
+    end: usize,
+    item_index: usize,
+    turn_ordinal: usize,
+    durations: &'a [u32],
+    current_exists: bool,
+    current: Option<ChatTurn>,
+}
+
+impl<'a> PageBuilder<'a> {
+    fn new(start: usize, end: usize, durations: &'a [u32]) -> Self {
+        Self {
+            items: Vec::with_capacity(end.saturating_sub(start)),
+            start,
+            end,
+            item_index: 0,
+            turn_ordinal: 0,
+            durations,
+            current_exists: false,
+            current: None,
+        }
+    }
+
+    fn captures(&self) -> bool {
+        self.item_index >= self.start && self.item_index < self.end
+    }
+
+    fn start_turn(&mut self) {
+        if self.current_exists {
+            return;
+        }
+        self.current_exists = true;
+        if self.captures() {
+            self.current = Some(ChatTurn::default());
+        }
+    }
+
+    fn push_user(
+        &mut self,
+        text: &str,
+        context: Option<&str>,
+        attachments: &[vmux_service::protocol::AgentAttachment],
+    ) {
+        if self.captures() {
+            self.items.push(ChatItem::User {
+                text: text.to_string(),
+                context: context.map(str::to_string),
+                attachments: attachments
+                    .iter()
+                    .map(|attachment| ChatSubmitAttachment {
+                        path: attachment.path.clone(),
+                        name: attachment.name.clone(),
+                        mime_type: attachment.mime_type.clone(),
+                        size: attachment.size,
+                    })
+                    .collect(),
+            });
+        }
+        self.item_index += 1;
+    }
+
+    fn flush_turn(&mut self) {
+        if !self.current_exists {
+            return;
+        }
+        if let Some(mut turn) = self.current.take() {
+            turn.step_count = turn
+                .blocks
+                .iter()
+                .enumerate()
+                .filter(|(index, block)| {
+                    !matches!(block, ChatBlock::Text(_)) && turn.parent_tool_index(*index).is_none()
+                })
+                .count() as u32;
+            turn.duration_secs = self.durations.get(self.turn_ordinal).copied();
+            self.items.push(ChatItem::Turn(turn));
+        }
+        self.current_exists = false;
+        self.turn_ordinal += 1;
+        self.item_index += 1;
+    }
+}
+
+fn push_assistant_blocks(turn: &mut ChatTurn, blocks: &[AssistantBlock]) {
+    for block in blocks {
+        match block {
+            AssistantBlock::Text(text) => push_assistant_text(turn, text),
+            AssistantBlock::Thinking(text) => turn.blocks.push(ChatBlock::Thinking(text.clone())),
+            AssistantBlock::ToolUse {
+                call_id,
+                name,
+                args,
+                parent_call_id,
+            } => turn.blocks.push(ChatBlock::ToolUse {
+                call_id: call_id.clone(),
+                name: name.clone(),
+                args: args.clone(),
+                parent_call_id: parent_call_id.clone(),
+            }),
+            AssistantBlock::Subagent(subagent) => turn
+                .blocks
+                .push(ChatBlock::Subagent(Box::new(map_subagent(subagent)))),
+            AssistantBlock::Diff {
+                call_id,
+                path,
+                old_text,
+                new_text,
+            } => turn.blocks.push(ChatBlock::Diff {
+                call_id: call_id.clone(),
+                path: path.clone(),
+                old_text: old_text.clone(),
+                new_text: new_text.clone(),
+            }),
+            AssistantBlock::Plan { steps } => turn.blocks.push(ChatBlock::Plan {
+                steps: steps.iter().map(map_plan_step).collect(),
+            }),
+        }
     }
 }
 
@@ -292,6 +452,41 @@ mod tests {
         };
         assert_eq!(t0.duration_secs, Some(5));
         assert_eq!(t1.duration_secs, Some(9));
+    }
+
+    #[test]
+    fn tail_page_only_clones_recent_items() {
+        let messages = vec![
+            Message::user("a"),
+            assistant(vec![AssistantBlock::Text("one".into())]),
+            Message::user("b"),
+            assistant(vec![AssistantBlock::Text("two".into())]),
+            Message::user("c"),
+            assistant(vec![AssistantBlock::Text("three".into())]),
+        ];
+
+        let page = group_turns_tail(&[], &messages, &[1, 2, 3], false, 3);
+
+        assert_eq!((page.start, page.end, page.total), (3, 6, 6));
+        assert_eq!(page.items.len(), 3);
+        assert!(matches!(&page.items[0], ChatItem::Turn(turn) if turn.duration_secs == Some(2)));
+        assert!(matches!(&page.items[1], ChatItem::User { text, .. } if text == "c"));
+    }
+
+    #[test]
+    fn older_page_ends_at_requested_cursor() {
+        let messages = vec![
+            Message::user("a"),
+            assistant(vec![AssistantBlock::Text("one".into())]),
+            Message::user("b"),
+            assistant(vec![AssistantBlock::Text("two".into())]),
+        ];
+
+        let page = group_turns_before(&[], &messages, &[1, 2], false, 3, 2);
+
+        assert_eq!((page.start, page.end, page.total), (1, 3, 4));
+        assert!(matches!(&page.items[0], ChatItem::Turn(turn) if turn.duration_secs == Some(1)));
+        assert!(matches!(&page.items[1], ChatItem::User { text, .. } if text == "b"));
     }
 
     #[test]

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -1537,6 +1537,7 @@ fn sync_windowed_frames(
     mut last_raised_frame: Local<std::collections::HashMap<Entity, (i32, i32, i32, i32)>>,
     mut last_visible_pages: Local<Vec<Entity>>,
     mut last_windowed_pages: Local<Vec<Entity>>,
+    mut visible_frames: Local<Vec<WindowedFrameRect>>,
 ) {
     let visible_pane_count =
         visible_pane_count_for_windowed_sync(focus.tab, &all_children, &leaf_panes);
@@ -1546,6 +1547,7 @@ fn sync_windowed_frames(
     let force_raise = layout_hidden.is_changed();
     let mut hidden = Vec::new();
     let mut visible = Vec::new();
+    visible_frames.clear();
     for (entity, tf, self_computed, self_ui_gt, child_of) in &browser_q {
         if tf.scale.x <= 1.0e-3 {
             hidden.push(entity);
@@ -1617,6 +1619,7 @@ fn sync_windowed_frames(
             [cover_rgb.red, cover_rgb.green, cover_rgb.blue],
         );
         if browsers.has_browser(entity) {
+            visible_frames.push(frame);
             let key = (
                 frame.left.round() as i32,
                 frame.top.round() as i32,
@@ -1642,6 +1645,7 @@ fn sync_windowed_frames(
     }
     *last_visible_pages = visible;
     *last_windowed_pages = current_windowed;
+    *visible_frames = set_native_windowed_page_frames(std::mem::take(&mut *visible_frames));
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1660,6 +1664,52 @@ impl WindowedFrameRect {
     fn bottom(self) -> f32 {
         self.top + self.height
     }
+}
+
+#[cfg(target_os = "macos")]
+static NATIVE_WINDOWED_PAGE_FRAMES: LazyLock<Mutex<Vec<WindowedFrameRect>>> =
+    LazyLock::new(|| Mutex::new(Vec::new()));
+
+#[cfg(any(target_os = "macos", test))]
+fn windowed_frame_contains(frame: WindowedFrameRect, point: Vec2) -> bool {
+    point.x >= frame.left
+        && point.x <= frame.right()
+        && point.y >= frame.top
+        && point.y <= frame.bottom()
+}
+
+#[cfg(target_os = "macos")]
+fn set_native_windowed_page_frames(mut frames: Vec<WindowedFrameRect>) -> Vec<WindowedFrameRect> {
+    let mut published = NATIVE_WINDOWED_PAGE_FRAMES
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    std::mem::swap(&mut *published, &mut frames);
+    frames.clear();
+    frames
+}
+
+#[cfg(not(target_os = "macos"))]
+fn set_native_windowed_page_frames(mut frames: Vec<WindowedFrameRect>) -> Vec<WindowedFrameRect> {
+    frames.clear();
+    frames
+}
+
+/// Returns whether a physical window coordinate is inside a visible native page.
+#[cfg(target_os = "macos")]
+pub fn native_windowed_page_contains_point(x_px: f32, y_px: f32) -> bool {
+    let point = Vec2::new(x_px, y_px);
+    NATIVE_WINDOWED_PAGE_FRAMES
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .iter()
+        .copied()
+        .any(|frame| windowed_frame_contains(frame, point))
+}
+
+/// Returns whether a physical window coordinate is inside a visible native page.
+#[cfg(not(target_os = "macos"))]
+pub fn native_windowed_page_contains_point(_: f32, _: f32) -> bool {
+    false
 }
 
 fn windowed_frame_rect_from_computed(
@@ -5618,6 +5668,21 @@ mod tests {
                 height: 299.0,
             }
         );
+    }
+
+    #[test]
+    fn windowed_frame_hit_test_uses_physical_page_bounds() {
+        let frame = WindowedFrameRect {
+            left: 100.0,
+            top: 50.0,
+            width: 400.0,
+            height: 300.0,
+        };
+
+        assert!(windowed_frame_contains(frame, Vec2::new(100.0, 50.0)));
+        assert!(windowed_frame_contains(frame, Vec2::new(500.0, 350.0)));
+        assert!(!windowed_frame_contains(frame, Vec2::new(99.0, 200.0)));
+        assert!(!windowed_frame_contains(frame, Vec2::new(300.0, 351.0)));
     }
 
     #[test]

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -73,6 +73,8 @@ static IN_LIVE_RESIZE: AtomicBool = AtomicBool::new(false);
 static LIVE_RESIZE_MONITOR_INSTALLED: AtomicBool = AtomicBool::new(false);
 #[cfg(target_os = "macos")]
 static HOVER_OVER_PANE: AtomicBool = AtomicBool::new(false);
+#[cfg(target_os = "macos")]
+static NATIVE_WINDOWED_POINTER_INSIDE: AtomicBool = AtomicBool::new(false);
 
 #[cfg(target_os = "macos")]
 fn activate_primary_window_on_startup(
@@ -344,12 +346,17 @@ fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) 
                 | NSEventType::OtherMouseDown
                 | NSEventType::OtherMouseUp
         );
+        let scroll = event_type == NSEventType::ScrollWheel;
         let location = event_location_in_window_physical_px(ev);
+        let over_windowed_page =
+            location.is_some_and(|(x, y)| vmux_browser::native_windowed_page_contains_point(x, y));
+        let was_over_windowed_page =
+            NATIVE_WINDOWED_POINTER_INSIDE.swap(over_windowed_page, Ordering::Relaxed);
         let buttons = native_mouse_buttons();
         if let Some((x, y)) = location {
             vmux_layout::native_pointer::publish(Vec2::new(x, y), buttons, motion);
         }
-        let layout_pointer = (motion || button_event)
+        let layout_pointer = (motion || button_event || scroll)
             .then(|| {
                 location.map(|(x, y)| vmux_browser::queue_native_layout_pointer_move(x, y, buttons))
             })
@@ -375,9 +382,13 @@ fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) 
                 } else if result.pending {
                     flush_layout(interval);
                 }
-            } else {
+            } else if !over_windowed_page || !was_over_windowed_page || !event_window_is_key(ev) {
                 HOVER_OVER_PANE.store(true, Ordering::Relaxed);
                 local_wake(interval);
+            }
+        } else if scroll {
+            if layout_pointer.is_some_and(|result| result.owns_pointer) || !over_windowed_page {
+                local_wake(NATIVE_MOUSE_DRAG_WAKE_INTERVAL);
             }
         } else {
             if layout_pointer.is_some_and(|result| {
@@ -504,6 +515,14 @@ fn event_location_in_window_physical_px(event: &objc2_app_kit::NSEvent) -> Optio
 }
 
 #[cfg(target_os = "macos")]
+fn event_window_is_key(event: &objc2_app_kit::NSEvent) -> bool {
+    let Some(mtm) = objc2::MainThreadMarker::new() else {
+        return false;
+    };
+    event.window(mtm).is_some_and(|window| window.isKeyWindow())
+}
+
+#[cfg(target_os = "macos")]
 fn native_mouse_buttons() -> bevy_cef_core::prelude::NativeMouseButtons {
     let pressed = objc2_app_kit::NSEvent::pressedMouseButtons();
     bevy_cef_core::prelude::NativeMouseButtons {
@@ -516,13 +535,13 @@ fn native_mouse_buttons() -> bevy_cef_core::prelude::NativeMouseButtons {
 /// `react_to_device_events` is off in browse (User) mode: native CEF views own scroll/input, so only
 /// Player mode's free camera consumes `AccumulatedMouseMotion`.
 ///
-/// At rest window events wake rendering except while native layout chrome owns the pointer. Layout
-/// hover and scroll then use the explicit 30Hz native monitor wake instead of rendering once per
-/// raw macOS pointer event. During live resize the 16ms timer caps rendering near 60Hz.
+/// At rest window events wake rendering except while native CEF content owns the pointer. Native
+/// hover and scroll then use explicit monitor wakes instead of rendering once per raw macOS pointer
+/// event. During live resize the 16ms timer caps rendering near 60Hz.
 pub(crate) fn foreground_winit_settings(
     player: bool,
     live_resize: bool,
-    layout_pointer_inside: bool,
+    native_pointer_inside: bool,
 ) -> WinitSettings {
     let focused_mode = if live_resize {
         UpdateMode::Reactive {
@@ -536,7 +555,7 @@ pub(crate) fn foreground_winit_settings(
             wait: FOCUSED_FRAME_INTERVAL,
             react_to_device_events: player,
             react_to_user_events: true,
-            react_to_window_events: player || !layout_pointer_inside,
+            react_to_window_events: player || !native_pointer_inside,
         }
     };
     WinitSettings {
@@ -567,16 +586,17 @@ fn sync_winit_power_mode(
     #[cfg(not(target_os = "macos"))]
     let live_resize = false;
     #[cfg(target_os = "macos")]
-    let layout_pointer_inside = vmux_browser::native_layout_pointer_is_inside();
+    let native_pointer_inside = vmux_browser::native_layout_pointer_is_inside()
+        || NATIVE_WINDOWED_POINTER_INSIDE.load(Ordering::Relaxed);
     #[cfg(not(target_os = "macos"))]
-    let layout_pointer_inside = false;
+    let native_pointer_inside = false;
     let next = if all_hidden {
         hidden_winit_settings()
     } else {
         foreground_winit_settings(
             *mode == InteractionMode::Player,
             live_resize,
-            layout_pointer_inside,
+            native_pointer_inside,
         )
     };
     if settings.focused_mode != next.focused_mode || settings.unfocused_mode != next.unfocused_mode
@@ -987,6 +1007,7 @@ mod tests {
 
         assert!(monitor.contains("addLocalMonitorForEventsMatchingMask_handler"));
         assert!(monitor.contains("addGlobalMonitorForEventsMatchingMask_handler"));
+        assert!(monitor.contains("!event_window_is_key(ev)"));
     }
 
     #[test]
@@ -1003,7 +1024,7 @@ mod tests {
     }
 
     #[test]
-    fn native_layout_scroll_wakes_reactive_loop() {
+    fn native_layout_scroll_only_wakes_for_layout_regions() {
         let source = include_str!("background_lifecycle.rs");
         let monitor = source
             .split("fn install_native_mouse_wake_monitor")
@@ -1012,6 +1033,9 @@ mod tests {
             .unwrap_or_default();
 
         assert!(monitor.contains("NSEventMask::ScrollWheel"));
+        assert!(monitor.contains("else if scroll"));
+        assert!(monitor.contains("layout_pointer.is_some_and(|result| result.owns_pointer)"));
+        assert!(monitor.contains("|| !over_windowed_page"));
     }
 
     #[test]

--- a/crates/vmux_desktop/src/event_tap.rs
+++ b/crates/vmux_desktop/src/event_tap.rs
@@ -84,12 +84,6 @@ unsafe extern "C-unwind" fn tap_callback(
         return event.as_ptr();
     }
 
-    TAP_STATE.with(|s| {
-        if let Some(state) = s.borrow().as_ref() {
-            (state.wake)();
-        }
-    });
-
     if event_type != CGEventType::KeyDown {
         return event.as_ptr();
     }
@@ -103,6 +97,11 @@ unsafe extern "C-unwind" fn tap_callback(
 
     match gate(app_is_frontmost(), || classify(combo)) {
         TapOutcome::Consume(cmd) => {
+            TAP_STATE.with(|s| {
+                if let Some(state) = s.borrow().as_ref() {
+                    (state.wake)();
+                }
+            });
             if let Some(cmd) = cmd {
                 push_command(cmd);
             }

--- a/crates/vmux_desktop/src/native_keyboard.rs
+++ b/crates/vmux_desktop/src/native_keyboard.rs
@@ -49,6 +49,12 @@ pub(crate) enum KeyAction {
     PassThrough,
 }
 
+impl KeyAction {
+    fn is_consumed(&self) -> bool {
+        matches!(self, Self::Consume(_))
+    }
+}
+
 pub(crate) fn decide(
     map: &ShortcutMap,
     pending: &mut Option<(KeyCombo, Instant)>,
@@ -195,7 +201,6 @@ pub(crate) fn key_code_from_vk(vk: u16) -> Option<KeyCode> {
 fn install(wake: impl Fn() + Send + Sync + 'static) {
     let block = block2::RcBlock::new(move |event: NonNull<NSEvent>| -> *mut NSEvent {
         let ev = unsafe { event.as_ref() };
-        wake();
         if ev.r#type() != NSEventType::KeyDown {
             return event.as_ptr();
         }
@@ -204,7 +209,11 @@ fn install(wake: impl Fn() + Send + Sync + 'static) {
         let Some(combo) = translate(key_code, flags) else {
             return event.as_ptr();
         };
-        match classify(combo) {
+        let action = classify(combo);
+        if action.is_consumed() {
+            wake();
+        }
+        match action {
             KeyAction::Consume(cmd) => {
                 if let Some(cmd) = cmd {
                     PENDING_COMMANDS.lock().push(cmd);
@@ -319,6 +328,18 @@ mod tests {
             Instant::now(),
         );
         assert!(matches!(action, KeyAction::PassThrough));
+        assert!(!action.is_consumed());
+    }
+
+    #[test]
+    fn consumed_shortcut_requires_host_wake() {
+        assert!(KeyAction::Consume(None).is_consumed());
+        assert!(
+            KeyAction::Consume(Some(AppCommand::Layout(LayoutCommand::Pane(
+                PaneCommand::SelectLeft
+            ),)))
+            .is_consumed()
+        );
     }
 
     #[test]

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -1,5 +1,8 @@
 #![allow(non_snake_case)]
 
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
 use crate::command_bar::keyboard::{
     CtrlEditAction, CtrlKeyCapture, caret_scroll_left, ctrl_key_capture_for_code,
     ignore_physical_rerouted_ctrl_keydown, utf16_offset_to_byte,
@@ -41,6 +44,46 @@ use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener};
 use vmux_ui::icon::PageIconView;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
+
+const HOST_SEARCH_DEBOUNCE_MS: i32 = 150;
+
+type HostSearchTimer = Rc<RefCell<Option<(i32, js_sys::Function, Rc<Cell<bool>>)>>>;
+
+fn cancel_host_search(timer: &HostSearchTimer) {
+    let Some((id, callback, cancelled)) = timer.borrow_mut().take() else {
+        return;
+    };
+    cancelled.set(true);
+    if let Some(window) = web_sys::window() {
+        window.clear_timeout_with_handle(id);
+    }
+    let _ = callback.call0(&JsValue::NULL);
+}
+
+fn schedule_host_search(timer: HostSearchTimer, callback: impl FnOnce() + 'static) {
+    cancel_host_search(&timer);
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let cancelled = Rc::new(Cell::new(false));
+    let callback_timer = timer.clone();
+    let callback_cancelled = cancelled.clone();
+    let callback = Closure::once_into_js(move || {
+        callback_timer.borrow_mut().take();
+        if !callback_cancelled.get() {
+            callback();
+        }
+    })
+    .unchecked_into::<js_sys::Function>();
+    match window
+        .set_timeout_with_callback_and_timeout_and_arguments_0(&callback, HOST_SEARCH_DEBOUNCE_MS)
+    {
+        Ok(id) => *timer.borrow_mut() = Some((id, callback, cancelled)),
+        Err(_) => {
+            let _ = callback.call0(&JsValue::NULL);
+        }
+    }
+}
 
 /// Where a [`CommandPalette`] is rendered: the Cmd+K modal or the `vmux://start/` page.
 #[derive(Clone, Copy, PartialEq)]
@@ -92,17 +135,22 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let mut selected = use_signal(|| 0usize);
     let mut nav_mode = use_signal(|| false);
     let mut path_completions = use_signal(Vec::<PathEntry>::new);
+    let mut path_request_id = use_signal(|| 0u64);
+    let path_search_timer: HostSearchTimer = use_hook(|| Rc::new(RefCell::new(None)));
     let mut history_suggestions = use_signal(Vec::<HistoryEntry>::new);
     let mut suggestions_request_id = use_signal(|| 0u64);
+    let suggestions_search_timer: HostSearchTimer = use_hook(|| Rc::new(RefCell::new(None)));
     let mut last_open_id = use_signal(|| u64::MAX);
     let mut last_focus_open_id = use_signal(|| u64::MAX);
     let mut attachments = use_signal(Vec::<ChatAttachment>::new);
     let mut media_entries = use_signal(Vec::<ChatMediaEntry>::new);
     let mut media_request_id = use_signal(|| 0u64);
     let mut media_requested_query = use_signal(|| None::<String>);
+    let media_search_timer: HostSearchTimer = use_hook(|| Rc::new(RefCell::new(None)));
     let mut media_loading = use_signal(|| false);
     let mut media_selected = use_signal(|| 0usize);
 
+    let path_search_effect_timer = path_search_timer.clone();
     use_effect(move || {
         let s = state();
         if last_open_id() != s.open_id {
@@ -133,11 +181,19 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
 
     use_effect(move || {
         let q = query();
+        let request_id = (*path_request_id.peek()).wrapping_add(1).max(1);
+        path_request_id.set(request_id);
         let Some(path_query) = completion_query(&q) else {
+            cancel_host_search(&path_search_effect_timer);
             path_completions.set(Vec::new());
             return;
         };
-        let _ = try_cef_bin_emit_rkyv(&PathCompleteRequest { query: path_query });
+        schedule_host_search(path_search_effect_timer.clone(), move || {
+            if *path_request_id.peek() != request_id {
+                return;
+            }
+            let _ = try_cef_bin_emit_rkyv(&PathCompleteRequest { query: path_query });
+        });
     });
 
     let _history_listener = use_bin_event_listener::<HistorySuggestionsResponse, _>(
@@ -175,9 +231,12 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
             media_selected.set(0);
         });
 
+    let suggestions_search_effect_timer = suggestions_search_timer.clone();
     use_effect(move || {
         let q = query();
         let trimmed = q.trim();
+        let id = (*suggestions_request_id.peek()).wrapping_add(1).max(1);
+        suggestions_request_id.set(id);
         if trimmed.is_empty()
             || trimmed.starts_with('>')
             || trimmed.starts_with('/')
@@ -185,18 +244,24 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
             || trimmed.starts_with("vmux://")
             || trimmed.starts_with("file:")
         {
+            cancel_host_search(&suggestions_search_effect_timer);
             history_suggestions.set(Vec::new());
             return;
         }
-        let id = *suggestions_request_id.peek() + 1;
-        suggestions_request_id.set(id);
-        let _ = try_cef_bin_emit_rkyv(&HistorySuggestionsRequest {
-            query: trimmed.to_string(),
-            limit: 5,
-            request_id: id,
+        let query = trimmed.to_string();
+        schedule_host_search(suggestions_search_effect_timer.clone(), move || {
+            if *suggestions_request_id.peek() != id {
+                return;
+            }
+            let _ = try_cef_bin_emit_rkyv(&HistorySuggestionsRequest {
+                query,
+                limit: 5,
+                request_id: id,
+            });
         });
     });
 
+    let media_search_effect_timer = media_search_timer.clone();
     use_effect(move || {
         if !is_start {
             return;
@@ -204,32 +269,45 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
         let value = query();
         let Some(media_query) = inline_media_query(&value).map(|query| query.query.to_string())
         else {
+            let request_id = (*media_request_id.peek()).wrapping_add(1).max(1);
+            media_request_id.set(request_id);
+            cancel_host_search(&media_search_effect_timer);
             media_entries.set(Vec::new());
-            if media_requested_query.peek().is_some() {
-                media_request_id.set(media_request_id().wrapping_add(1).max(1));
-            }
             media_requested_query.set(None);
             media_loading.set(false);
             media_selected.set(0);
             return;
         };
-        if media_requested_query().as_deref() == Some(media_query.as_str()) {
+        if media_requested_query.peek().as_deref() == Some(media_query.as_str()) {
             return;
         }
-        let request_id = media_request_id().wrapping_add(1).max(1);
+        let request_id = (*media_request_id.peek()).wrapping_add(1).max(1);
         media_request_id.set(request_id);
         media_requested_query.set(Some(media_query.clone()));
         media_entries.set(Vec::new());
         media_loading.set(true);
         media_selected.set(0);
-        if try_cef_bin_emit_rkyv(&ChatMediaListRequest {
-            request_id,
-            query: media_query,
-        })
-        .is_err()
-        {
-            media_loading.set(false);
-        }
+        schedule_host_search(media_search_effect_timer.clone(), move || {
+            if *media_request_id.peek() != request_id
+                || media_requested_query.peek().as_deref() != Some(media_query.as_str())
+            {
+                return;
+            }
+            if try_cef_bin_emit_rkyv(&ChatMediaListRequest {
+                request_id,
+                query: media_query,
+            })
+            .is_err()
+            {
+                media_loading.set(false);
+            }
+        });
+    });
+
+    use_drop(move || {
+        cancel_host_search(&path_search_timer);
+        cancel_host_search(&suggestions_search_timer);
+        cancel_host_search(&media_search_timer);
     });
 
     use_effect(move || {

--- a/crates/vmux_terminal/src/matrix_rain.rs
+++ b/crates/vmux_terminal/src/matrix_rain.rs
@@ -125,7 +125,7 @@ fn start_rain(
         return;
     };
 
-    let dpr = window.device_pixel_ratio().max(1.0);
+    let dpr = window.device_pixel_ratio().clamp(1.0, 1.5);
 
     let reduced = window
         .match_media("(prefers-reduced-motion: reduce)")
@@ -193,7 +193,19 @@ fn start_rain(
     let raf_inner = raf.clone();
     let running_inner = running.clone();
     let handle_inner = handle.clone();
+    let mut last_frame_ms = 0.0;
     let closure = Closure::wrap(Box::new(move || {
+        let now = js_sys::Date::now();
+        if now - last_frame_ms < 33.0 {
+            if *running_inner.borrow()
+                && let Some(cb) = raf_inner.borrow().as_ref()
+                && let Ok(id) = win.request_animation_frame(cb.as_ref().unchecked_ref())
+            {
+                *handle_inner.borrow_mut() = Some(id);
+            }
+            return;
+        }
+        last_frame_ms = now;
         let w = canvas.client_width().max(1) as f64;
         let h = canvas.client_height().max(1) as f64;
         let want_w = (w * dpr) as u32;

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -4683,6 +4683,8 @@ mod tests {
         assert!(rain.contains("request_animation_frame"));
         assert!(rain.contains("use_drop"));
         assert!(rain.contains("prefers-reduced-motion"));
+        assert!(rain.contains("device_pixel_ratio().clamp(1.0, 1.5)"));
+        assert!(rain.contains("now - last_frame_ms < 33.0"));
     }
 
     #[test]


### PR DESCRIPTION
## Context

Typing on the start page issued history, path, and media searches on every keystroke. Each IPC message woke Bevy for another render update, letting release builds approach 100% CPU and making input laggy.

## Implementation

- Debounce history, path, and media searches with cancellable timers.
- Wake the native event loop only for consumed shortcuts and suppress redundant pointer-region wakes over CEF surfaces.
- Paginate chat history, contain transcript rendering to the viewport, update turns in place, and coalesce scroll state updates.
- Reduce blur and animation GPU work while preserving motion; cap Matrix rain near 30 FPS and DPR 1.5.
- Reuse native frame storage.

## Validation

- Full pre-push test suite.
- Targeted Clippy, chat, keyboard, event-tap, browser hit-test, and no-continuous-update checks.
- wasm checks for `vmux_agent` and `vmux_layout`.
- Release bundle build and signature verification.
- Manual release-build test: typing produced 0–14 user events/sec and main-process CPU stayed around 5% instead of approaching 100%.

## QA

- Type continuously on the start page and confirm input stays responsive and CPU remains low.
- Load older messages in a long chat and confirm pagination preserves scroll position.
- Verify native page hover, scroll, command shortcuts, animations, and reduced-motion behavior.
