### PR TITLE
chore(release): v0.0.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9471,7 +9471,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "base64 0.22.1",
  "bevy",
@@ -9520,7 +9520,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_browser"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -9557,7 +9557,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -9570,7 +9570,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9586,7 +9586,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command_mcp"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "serde_json",
  "vmux_command",
@@ -9595,7 +9595,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9617,7 +9617,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9680,7 +9680,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_editor"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "arboard",
  "bevy",
@@ -9724,7 +9724,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_git"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9744,7 +9744,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9765,7 +9765,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_knowledge"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9780,7 +9780,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -9816,7 +9816,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "muda",
  "proc-macro2",
@@ -9826,7 +9826,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -9839,14 +9839,14 @@ dependencies = [
 
 [[package]]
 name = "vmux_profile"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "vmux_server"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "dioxus",
  "regex",
@@ -9866,7 +9866,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "agent-client-protocol",
  "alacritty_terminal",
@@ -9906,7 +9906,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service_client"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "chrono",
  "libc",
@@ -9919,7 +9919,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9942,7 +9942,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9967,7 +9967,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_team"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9988,7 +9988,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10021,7 +10021,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "dioxus",
  "dioxus-primitives",
@@ -10040,7 +10040,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_wire"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "bevy_ecs",
  "bevy_reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.26"
+version = "0.0.27"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "GPL-3.0-or-later"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.26"
-  sha256 "67f53918e3e527b7b85e5ef33d2208b55234b6b73ff39f3794c6cd58a3c667bc"
+  version "0.0.27"
+  sha256 "673d1aea2df23a45dc1d8bf807ad899b4925abad759a2433f226052a9fa3b28d"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.26/Vmux_0.0.26_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.27/Vmux_0.0.27_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai/"

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.26",
-  "pub_date": "2026-07-20T12:46:25Z",
+  "version": "v0.0.27",
+  "pub_date": "2026-07-21T00:01:35Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.26/Vmux-v0.0.26-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HT3oySWZEbWwxWWp1Q3RmZXoxMGhnNHhiV3crSHAwUkczQ0IxbGpXeFJNemJHVTJzTDBNbDlJMlZjMU9OK3A2USt1NHhZeUE0VzBQQ0NTd1lIbmNBc3dNPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg0NTUxMzMxCWZpbGU6Vm11eC12MC4wLjI2LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKT1kyVUpwSktvNXV2R0JuVVFiUHR4VUloL25RRGE1cGdWdnRtdWVtTjhva1ZzcnZzVUlCWnp5bEJkV1d5MXdocEx1eUNBUjB2Rm9lMGMwRHdpYXpaREE9PQo=",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.27/Vmux-v0.0.27-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HT3lQS0thR1habWVjZE9sWEJ2VlY5YlJqSzU0dldxSUZVQjJNQVk5QXBwdzF4TW4yQ2h1Vnhra2RwMzQ2NFRvL1ZpbUh2UEhROE5OcDVpd0RmYWU5U0FjPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg0NTkyMDkzCWZpbGU6Vm11eC12MC4wLjI3LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKeXVrRnNHS3JuRW5OTEIwSXNaOFdFNndBRVhYQUowaTNHejlSSUNWeG5vdW1YN0w5ZlYzZWR4NEthSjdBQ1NGaHlNNUxxOXQzeHEzaU9WWGtxeXBnQnc9PQo=",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.26/Vmux_0.0.26_aarch64.dmg",
-      "filename": "Vmux_0.0.26_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.27/Vmux_0.0.27_aarch64.dmg",
+      "filename": "Vmux_0.0.27_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
Release v0.0.27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Published version 0.0.27.
  * Updated macOS Apple Silicon downloads and signatures.
  * Updated the Homebrew installation package to the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->