### PR TITLE
perf(git): coalesce repository status refreshes

### DIFF
--- a/.agents/skills/cleanup/SKILL.md
+++ b/.agents/skills/cleanup/SKILL.md
@@ -40,6 +40,9 @@ bash -c '
 pkill -f vmux_desktop 2>/dev/null; pkill -f "Vmux.app" 2>/dev/null; pkill -f vmux_service 2>/dev/null; sleep 1
 launchctl bootout "gui/$(id -u)/ai.vmux.service" 2>/dev/null
 launchctl bootout "gui/$(id -u)/ai.vmux.service.dev" 2>/dev/null
+launchctl list 2>/dev/null | awk '$3 ~ /^ai\.vmux\.service\./ {print $3}' | while IFS= read -r label; do
+  launchctl bootout "gui/$(id -u)/$label" 2>/dev/null
+done
 rm -rf ~/Library/"Application Support/Vmux"
 echo "full reset (first-run)"
 '

--- a/.agents/skills/cleanup/SKILL.md
+++ b/.agents/skills/cleanup/SKILL.md
@@ -1,35 +1,39 @@
 ---
 name: cleanup
-description: "Use when testing vmux (vmux_desktop / Vmux.app) from a clean slate. Wipes local profile data so it starts at first-run. Fixes startup crashes or blank/dark windows caused by stale space.ron, dead agent sessions, or old type paths from a different build sharing the same profile dir."
+description: "Use when testing vmux (vmux_desktop / Vmux.app) from a clean slate. Resets saved layout state that can restore dead sessions, missing files, or stale component types."
 ---
 
 # Cleanup
 
-Reset vmux's local state. All builds (released `Vmux.app` **and** `make dev`) share one data dir — `~/Library/Application Support/Vmux/` — so a space saved by one build can crash/blank another (stale type paths, dead agent sessions). These commands clear that.
+Local and release builds share `~/Library/Application Support/Vmux/`. Dev builds use `~/Library/Application Support/Vmux/dev/`.
 
 Data layout:
-- `profiles/personal/` — Chromium/CEF profile: cookies, login, caches, **`spaces/`** (the tab/pane/stack layout)
-- `spaces.ron` — space index · `settings.ron` — app settings · `services/` — vmux_service state
-- launchd daemons: `ai.vmux.service` (prod) + `ai.vmux.service.dev` (dev)
 
-## Space reset (keep login + settings) — the common one
+- `store.ron` — local/release tab, pane, stack, history, and window state
+- `dev/store.ron` — dev tab, pane, stack, history, and window state
+- `profiles/personal/` and `dev/profiles/personal/` — Chromium/CEF cookies, login, and caches
+- `~/.vmux/settings.ron` — shared app settings
+- `services/` — vmux_service state
 
-Use when the window starts **blank/dark** or **crashes on load** with `no registration found for …` or `Path not found: agent/…`. Clears only the saved layout; keeps cookies/login/settings.
+## Layout reset
+
+For `make dev`:
 
 ```bash
-bash -c '
-pkill -f vmux_desktop 2>/dev/null; sleep 1
-rm -rf ~/Library/"Application Support/Vmux"/profiles/*/spaces \
-       ~/Library/"Application Support/Vmux"/spaces.ron
-echo "spaces reset (login kept)"
-'
+make cleanup
 ```
 
-Relaunch (`make dev`) → fresh default space, still logged in.
+For `make local` or installed/released Vmux:
 
-## Full fresh (first-run: logged out, default settings)
+```bash
+make cleanup-local
+```
 
-Quit everything, stop both daemons, wipe the whole data dir.
+Both keep browser profiles and settings. `cleanup-local` backs up the old layout as `store.ron.cleanup-<timestamp>`.
+
+## Full fresh
+
+Quit everything, stop daemons, and wipe all Vmux application data:
 
 ```bash
 bash -c '
@@ -41,11 +45,9 @@ echo "full reset (first-run)"
 '
 ```
 
-Relaunch → first-run: fresh CEF profile (logged out), default settings, empty space. The app re-registers its launchd service on launch.
+Relaunch to create a fresh profile and default layout.
 
 ## Notes
 
-- **Quit vmux first** — `pkill -f vmux_desktop` catches both the dev binary (`target/debug/vmux_desktop`) and the released `Vmux.app`. The space reset includes it.
-- **Backups vs delete:** to keep a recovery copy instead of deleting, `mv` the file aside: `mv .../spaces/space-1/space.ron space.ron.bak`.
-- **Mixed builds clobber each other:** running released `Vmux.app` and `make dev` against the shared dir is what produces stale-space crashes — full reset clears it.
-- **CEF single-instance lock:** only one vmux can run per data dir; a second instance logs "Opening in existing browser session" and won't render. Quit the first.
+- Use the matching target. `make cleanup` resets dev only. `make cleanup-local` resets the store shared by local and release builds.
+- A second app instance using the same CEF profile will not render. Stop the first instance before relaunching.

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ build: ensure-mac-deps
 -include .env
 export
 
-build-local: ensure-mac-deps ensure-package-deps
+build-local: ensure-mac-deps ensure-package-deps ensure-codesign-deps
 	./scripts/build-mac-release.sh local
 
 local: build-local

--- a/Makefile
+++ b/Makefile
@@ -151,18 +151,47 @@ cleanup:
 	echo "cleanup: reset vmux dev storage (kept ~/.vmux settings + spaces + dev browser profiles)"
 
 cleanup-local:
-	@pkill -f "/Applications/Vmux.app/Contents/MacOS/vmux_desktop" 2>/dev/null || true
-	@pkill -f "target/release/Vmux .*app/Contents/MacOS/vmux_desktop" 2>/dev/null || true
-	@sleep 1
-	@case "$$(uname -s)" in \
+	@set -eu; \
+	pkill -f "/Applications/Vmux.app/Contents/MacOS/vmux_desktop" 2>/dev/null || true; \
+	pkill -f "target/release/Vmux .*app/Contents/MacOS/vmux_desktop" 2>/dev/null || true; \
+	pkill -x "Vmux Service" 2>/dev/null || true; \
+	if [ "$$(uname -s)" = Darwin ]; then \
+		uid="$$(id -u)"; \
+		launchctl bootout "gui/$$uid/ai.vmux.service" 2>/dev/null || true; \
+		launchctl list 2>/dev/null | awk '{print $$3}' | while IFS= read -r label; do \
+			case "$$label" in \
+				ai.vmux.service.dev|ai.vmux.service) ;; \
+				ai.vmux.service.*) launchctl bootout "gui/$$uid/$$label" 2>/dev/null || true ;; \
+			esac; \
+		done; \
+	fi; \
+	for _ in 1 2 3 4 5; do \
+		if ! pgrep -x "Vmux Service" >/dev/null 2>&1; then break; fi; \
+		sleep 1; \
+	done; \
+	if pgrep -x "Vmux Service" >/dev/null 2>&1; then \
+		echo "cleanup-local: vmux service is still running" >&2; \
+		exit 1; \
+	fi; \
+	case "$$(uname -s)" in \
 		Darwin) base="$$HOME/Library/Application Support/Vmux" ;; \
 		*) base="$${TMPDIR:-/tmp}/Vmux" ;; \
 	esac; stamp="$$(date +%Y%m%d-%H%M%S)"; \
 	if [ -f "$$base/store.ron" ]; then \
-		mv "$$base/store.ron" "$$base/store.ron.cleanup-$$stamp"; \
+		store_backup="$$base/store.ron.cleanup-$$stamp"; \
+		version_backup="$$base/store.version.cleanup-$$stamp"; \
+		cp -p "$$base/store.ron" "$$store_backup"; \
+		if [ -f "$$base/store.version" ]; then \
+			if ! cp -p "$$base/store.version" "$$version_backup"; then \
+				rm -f "$$store_backup"; \
+				exit 1; \
+			fi; \
+		fi; \
+		rm -f "$$base/store.ron" "$$base/store.version"; \
 		echo "cleanup-local: backed up layout to $$base/store.ron.cleanup-$$stamp"; \
+	else \
+		rm -f "$$base/store.version"; \
 	fi; \
-	rm -f "$$base/store.version"; \
 	rm -f "$$base/profiles/"*/session.ron; \
 	rm -f "$$base/services/"vmux-local.* "$$base/services/"vmux-local-*; \
 	echo "cleanup-local: reset local/release layout (kept settings and browser profiles)"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev dev-full dev-player dev-rust web-bundle test-app local release build-local build-release build setup-cef install-debug-render-process seed-target doctor ensure-mac-deps ensure-native-deps ensure-web-deps ensure-package-deps ensure-codesign-deps website build-website-release build-website-css api-docs lint lint-fix test setup-hooks cleanup
+.PHONY: dev dev-full dev-player dev-rust web-bundle test-app local release build-local build-release build setup-cef install-debug-render-process seed-target doctor ensure-mac-deps ensure-native-deps ensure-web-deps ensure-package-deps ensure-codesign-deps website build-website-release build-website-css api-docs lint lint-fix test setup-hooks cleanup cleanup-local
 
 .DEFAULT_GOAL := dev
 
@@ -149,6 +149,23 @@ cleanup:
 	rm -rf "$$dev/logs"; \
 	rm -f "$$base/services/"vmux-dev.* "$$base/services/"vmux-dev-*; \
 	echo "cleanup: reset vmux dev storage (kept ~/.vmux settings + spaces + dev browser profiles)"
+
+cleanup-local:
+	@pkill -f "/Applications/Vmux.app/Contents/MacOS/vmux_desktop" 2>/dev/null || true
+	@pkill -f "target/release/Vmux .*app/Contents/MacOS/vmux_desktop" 2>/dev/null || true
+	@sleep 1
+	@case "$$(uname -s)" in \
+		Darwin) base="$$HOME/Library/Application Support/Vmux" ;; \
+		*) base="$${TMPDIR:-/tmp}/Vmux" ;; \
+	esac; stamp="$$(date +%Y%m%d-%H%M%S)"; \
+	if [ -f "$$base/store.ron" ]; then \
+		mv "$$base/store.ron" "$$base/store.ron.cleanup-$$stamp"; \
+		echo "cleanup-local: backed up layout to $$base/store.ron.cleanup-$$stamp"; \
+	fi; \
+	rm -f "$$base/store.version"; \
+	rm -f "$$base/profiles/"*/session.ron; \
+	rm -f "$$base/services/"vmux-local.* "$$base/services/"vmux-local-*; \
+	echo "cleanup-local: reset local/release layout (kept settings and browser profiles)"
 
 # Website
 build-website-css:

--- a/crates/vmux_desktop/tests/release_invariants.rs
+++ b/crates/vmux_desktop/tests/release_invariants.rs
@@ -75,6 +75,95 @@ fn local_cargo_builds_share_cef_sdk_and_sccache() {
     assert!(wrapper.contains("CMAKE_CXX_COMPILER_LAUNCHER"));
 }
 
+#[cfg(unix)]
+#[test]
+fn cargo_cache_wrapper_allows_nested_package_builds() {
+    use std::{
+        fs,
+        os::unix::{fs::PermissionsExt, process::CommandExt},
+        process::Command,
+        thread,
+        time::{Duration, Instant},
+    };
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let target = temp.path().join("target");
+    let locks = temp.path().join("locks");
+    let cache = temp.path().join("cef-cache");
+    let cargo = temp.path().join("cargo");
+    let rustc = temp.path().join("rustc");
+    let log = temp.path().join("cargo.log");
+    fs::create_dir_all(&target).expect("create target");
+    fs::write(
+        &cargo,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "-V" ]]; then
+    echo "cargo 1.0.0"
+    exit 0
+fi
+printf '%s\n' "$*" >> "$FAKE_CARGO_LOG"
+if [[ "${1:-}" == "packager" ]]; then
+    "$CARGO_WRAPPER" build -p nested-package-build
+fi
+"#,
+    )
+    .expect("write fake cargo");
+    fs::write(
+        &rustc,
+        "#!/usr/bin/env bash\necho 'rustc 1.0.0'\necho 'host: test-host'\n",
+    )
+    .expect("write fake rustc");
+    for executable in [&cargo, &rustc] {
+        let mut permissions = fs::metadata(executable)
+            .expect("fake executable metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(executable, permissions).expect("make fake executable runnable");
+    }
+
+    let wrapper = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../scripts/cargo-with-cef-cache.sh");
+    let mut command = Command::new("bash");
+    command
+        .arg(&wrapper)
+        .arg("packager")
+        .env_remove("CI")
+        .env_remove("VMUX_TARGET_LOCK_TARGET")
+        .env_remove("VMUX_TARGET_LOCK_OWNER_PID")
+        .env("CARGO_BIN", &cargo)
+        .env("RUSTC", &rustc)
+        .env("CARGO_TARGET_DIR", &target)
+        .env("VMUX_TARGET_LOCK_ROOT", &locks)
+        .env("VMUX_CEF_SDK_CACHE", &cache)
+        .env("VMUX_DISABLE_SCCACHE", "1")
+        .env("CARGO_WRAPPER", &wrapper)
+        .env("FAKE_CARGO_LOG", &log)
+        .process_group(0);
+    let mut child = command.spawn().expect("run nested cargo wrapper");
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let status = loop {
+        if let Some(status) = child.try_wait().expect("poll nested cargo wrapper") {
+            break status;
+        }
+        if Instant::now() >= deadline {
+            let _ = Command::new("kill")
+                .arg("-TERM")
+                .arg(format!("-{}", child.id()))
+                .status();
+            let _ = child.wait();
+            panic!("nested cargo wrapper deadlocked on the target cache lock");
+        }
+        thread::sleep(Duration::from_millis(100));
+    };
+
+    assert!(status.success());
+    assert_eq!(
+        fs::read_to_string(log).expect("read fake cargo log"),
+        "packager\nbuild -p nested-package-build\n"
+    );
+}
+
 #[test]
 fn cef_wheel_forwarding_rejects_invalid_events() {
     let source =
@@ -297,6 +386,8 @@ fn cef_injection_uses_ci_cached_framework_path() {
 #[test]
 fn local_signing_uses_stable_codesigning_identity() {
     let signing_script = include_str!("../../../scripts/ensure-local-codesign-identity.sh");
+    let build_script = include_str!("../../../scripts/build-mac-release.sh");
+    let makefile = include_str!("../../../Makefile");
 
     assert!(signing_script.contains("Vmux Dev"));
     assert!(!signing_script.contains("Vmux Development"));
@@ -311,6 +402,11 @@ fn local_signing_uses_stable_codesigning_identity() {
     assert!(signing_script.contains("security set-key-partition-list"));
     assert!(signing_script.contains("could not pre-authorize codesign key access"));
     assert!(signing_script.contains("security find-identity -v -p codesigning"));
+    assert!(build_script.contains("ensure-local-codesign-identity.sh"));
+    assert!(build_script.contains("SKIP_NOTARIZE=\"${SKIP_NOTARIZE:-1}\""));
+    assert!(
+        makefile.contains("build-local: ensure-mac-deps ensure-package-deps ensure-codesign-deps")
+    );
 }
 
 #[test]

--- a/crates/vmux_editor/src/page.rs
+++ b/crates/vmux_editor/src/page.rs
@@ -622,6 +622,7 @@ pub fn Page() -> Element {
         });
 
     let _meta = use_bin_event_listener::<FileMetaEvent, _>(FILE_META_EVENT, move |m| {
+        error.set(String::new());
         clear_blob_state(preview, thumbs);
         media.set(None);
         reset_file_scroll();
@@ -740,6 +741,7 @@ pub fn Page() -> Element {
     });
 
     let _dir = use_bin_event_listener::<FileDirEvent, _>(FILE_DIR_EVENT, move |d| {
+        error.set(String::new());
         clear_blob_state(preview, thumbs);
         media.set(None);
         if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
@@ -780,6 +782,7 @@ pub fn Page() -> Element {
     });
 
     let _media = use_bin_event_listener::<FileMediaEvent, _>(FILE_MEDIA_EVENT, move |e| {
+        error.set(String::new());
         clear_blob_state(preview, thumbs);
         let kind = e.kind;
         media.set(Some(e));

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -362,7 +362,10 @@ fn load_file_buffers(
     for (entity, fv) in &q {
         if fv.path.is_dir() {
             let entries = list_dir(&fv.path);
-            commands.entity(entity).insert(FileDir { entries });
+            commands
+                .entity(entity)
+                .remove::<MissingFileView>()
+                .insert(FileDir { entries });
             continue;
         }
         let path_str = fv.path.to_string_lossy();
@@ -370,22 +373,34 @@ fn load_file_buffers(
             let mime = vmux_core::media::media_mime(&path_str)
                 .unwrap_or("application/octet-stream")
                 .to_string();
-            commands.entity(entity).insert(FileMedia { kind, mime });
+            commands
+                .entity(entity)
+                .remove::<MissingFileView>()
+                .insert(FileMedia { kind, mime });
             continue;
         }
         match std::fs::metadata(&fv.path).map(|m| m.len()) {
             Ok(len) if len > crate::highlight::FILE_VIEW_MAX_BYTES => {
-                commands.entity(entity).insert(FileBuffer::error(format!(
-                    "__error__:file too large ({len} bytes, max {})",
-                    crate::highlight::FILE_VIEW_MAX_BYTES
-                )));
+                commands
+                    .entity(entity)
+                    .remove::<MissingFileView>()
+                    .insert(FileBuffer::error(format!(
+                        "__error__:file too large ({len} bytes, max {})",
+                        crate::highlight::FILE_VIEW_MAX_BYTES
+                    )));
                 continue;
             }
             Err(e) => {
-                commands.entity(entity).insert(FileBuffer::error(format!(
+                let mut entity_commands = commands.entity(entity);
+                entity_commands.insert(FileBuffer::error(format!(
                     "__error__:cannot open {}: {e}",
                     fv.path.display()
                 )));
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    entity_commands.insert(MissingFileView);
+                } else {
+                    entity_commands.remove::<MissingFileView>();
+                }
                 continue;
             }
             _ => {}
@@ -394,18 +409,27 @@ fn load_file_buffers(
             Ok(bytes) => match String::from_utf8(bytes) {
                 Ok(t) => t,
                 Err(_) => {
-                    commands.entity(entity).insert(FileBuffer::error(format!(
-                        "__error__:not a UTF-8 text file: {}",
-                        fv.path.display()
-                    )));
+                    commands
+                        .entity(entity)
+                        .remove::<MissingFileView>()
+                        .insert(FileBuffer::error(format!(
+                            "__error__:not a UTF-8 text file: {}",
+                            fv.path.display()
+                        )));
                     continue;
                 }
             },
             Err(e) => {
-                commands.entity(entity).insert(FileBuffer::error(format!(
+                let mut entity_commands = commands.entity(entity);
+                entity_commands.insert(FileBuffer::error(format!(
                     "__error__:cannot read {}: {e}",
                     fv.path.display()
                 )));
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    entity_commands.insert(MissingFileView);
+                } else {
+                    entity_commands.remove::<MissingFileView>();
+                }
                 continue;
             }
         };
@@ -432,6 +456,7 @@ fn load_file_buffers(
                 dirty: false,
             },
         ));
+        commands.entity(entity).remove::<MissingFileView>();
     }
 }
 
@@ -1227,6 +1252,9 @@ fn on_file_open(
 #[derive(Component)]
 struct FileReloadRequested;
 
+#[derive(Component)]
+struct MissingFileView;
+
 struct FileWatch {
     watcher: RecommendedWatcher,
     rx: mpsc::Receiver<notify::Result<notify::Event>>,
@@ -1238,30 +1266,42 @@ fn canon(p: &Path) -> PathBuf {
 }
 
 fn watch_dir_for(path: &Path) -> Option<PathBuf> {
-    if path.is_dir() {
-        Some(path.to_path_buf())
-    } else {
-        path.parent().map(Path::to_path_buf)
+    let mut dir = if path.is_dir() { path } else { path.parent()? };
+    loop {
+        if dir.is_dir() {
+            return Some(dir.to_path_buf());
+        }
+        dir = dir.parent()?;
+    }
+}
+
+fn ensure_file_watch(watch: &mut FileWatch, dir: PathBuf) {
+    if !watch.dirs.contains(&dir)
+        && watch
+            .watcher
+            .watch(&dir, RecursiveMode::NonRecursive)
+            .is_ok()
+    {
+        watch.dirs.insert(dir);
     }
 }
 
 fn reconcile_file_watches(
-    q: Query<(&FileView, &ExplorerState)>,
+    views: Query<&FileView>,
+    explorers: Query<&ExplorerState>,
     watch: Option<NonSendMut<FileWatch>>,
 ) {
     let Some(mut watch) = watch else {
         return;
     };
-    for (fv, st) in &q {
-        if let Some(dir) = watch_dir_for(&fv.path)
-            && watch.dirs.insert(dir.clone())
-        {
-            let _ = watch.watcher.watch(&dir, RecursiveMode::NonRecursive);
+    for fv in &views {
+        if let Some(dir) = watch_dir_for(&fv.path) {
+            ensure_file_watch(&mut watch, dir);
         }
+    }
+    for st in &explorers {
         for dir in st.expanded.iter() {
-            if watch.dirs.insert(dir.clone()) {
-                let _ = watch.watcher.watch(dir, RecursiveMode::NonRecursive);
-            }
+            ensure_file_watch(&mut watch, dir.clone());
         }
     }
 }
@@ -1269,7 +1309,8 @@ fn reconcile_file_watches(
 fn drain_file_changes(
     watch: Option<NonSend<FileWatch>>,
     self_writes: Option<NonSendMut<SelfWrites>>,
-    mut q: Query<(Entity, &FileView, &mut ExplorerState)>,
+    views: Query<(Entity, &FileView, Has<MissingFileView>)>,
+    mut explorers: Query<(Entity, &mut ExplorerState)>,
     mut commands: Commands,
 ) {
     let Some(watch) = watch else {
@@ -1290,15 +1331,18 @@ fn drain_file_changes(
     if let Some(sw) = sw.as_mut() {
         sw.0.retain(|_, t| t.elapsed() < std::time::Duration::from_secs(2));
     }
-    for (entity, fv, mut st) in &mut q {
+    for (entity, fv, missing) in &views {
         let cp = canon(&fv.path);
         let self_written = sw
             .as_ref()
             .map(|sw| sw.0.contains_key(&cp))
             .unwrap_or(false);
-        if changed.contains(&cp) && !self_written {
+        let ancestor_changed = missing && changed.iter().any(|path| cp.starts_with(path));
+        if (changed.contains(&cp) || ancestor_changed) && !self_written {
             commands.entity(entity).insert(FileReloadRequested);
         }
+    }
+    for (entity, mut st) in &mut explorers {
         let cached: Vec<PathBuf> = st.children.keys().cloned().collect();
         for d in cached {
             let dc = canon(&d);
@@ -2821,8 +2865,18 @@ impl Plugin for EditorPlugin {
     fn build(&self, app: &mut App) {
         app.world_mut().spawn(PAGE_MANIFEST);
         let (tx, rx) = mpsc::channel();
-        match notify::recommended_watcher(move |res| {
+        let proxy = app
+            .world()
+            .get_resource::<bevy::winit::EventLoopProxyWrapper>()
+            .map(|wrapper| (**wrapper).clone());
+        match notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+            let wake = res
+                .as_ref()
+                .is_ok_and(|event| !matches!(event.kind, notify::EventKind::Access(_)));
             let _ = tx.send(res);
+            if wake && let Some(proxy) = proxy.as_ref() {
+                let _ = proxy.send_event(bevy::winit::WinitUserEvent::WakeUp);
+            }
         }) {
             Ok(watcher) => {
                 app.insert_non_send(FileWatch {
@@ -2888,6 +2942,7 @@ impl Plugin for EditorPlugin {
             .add_systems(
                 Update,
                 (
+                    reconcile_file_watches.before(load_file_buffers),
                     load_file_buffers,
                     send_initial_meta,
                     send_initial_text_meta,
@@ -2900,7 +2955,6 @@ impl Plugin for EditorPlugin {
                     send_file_view_mode,
                     rehighlight_on_color_scheme,
                     drain_thumb_tasks,
-                    reconcile_file_watches,
                     flush_lsp_changes,
                     apply_goto,
                     apply_pending_goto,
@@ -2994,6 +3048,77 @@ mod edit_flow_tests {
             FileViewMode::Diff
         );
         assert!(app.world().get::<FileView>(second).is_some());
+    }
+
+    #[test]
+    fn missing_file_view_loads_when_file_is_created() {
+        let temp = tempfile::tempdir().unwrap();
+        let parent = temp.path().join("created-after-open");
+        let path = parent.join("file.txt");
+        let (tx, rx) = mpsc::channel();
+        let watcher = notify::recommended_watcher(|_| {}).unwrap();
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins).add_systems(
+            Update,
+            (
+                reconcile_file_watches,
+                load_file_buffers,
+                drain_file_changes,
+                reload_changed_files,
+            )
+                .chain(),
+        );
+        app.world_mut().insert_non_send(FileWatch {
+            watcher,
+            rx,
+            dirs: HashSet::new(),
+        });
+        app.world_mut().insert_non_send(SelfWrites::default());
+        app.world_mut().insert_non_send(Browsers::default());
+        app.world_mut()
+            .insert_non_send(crate::lsp::manager::LspManager::default());
+        let entity = app
+            .world_mut()
+            .spawn((
+                FileView { path: path.clone() },
+                FileViewport {
+                    top_row: 0,
+                    rows: 0,
+                },
+            ))
+            .id();
+
+        app.update();
+        assert!(
+            app.world()
+                .get::<FileBuffer>(entity)
+                .unwrap()
+                .language
+                .starts_with("__error__:cannot open")
+        );
+
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::write(&path, "created\n").unwrap();
+        tx.send(Ok(
+            notify::Event::new(notify::EventKind::Any).add_path(parent)
+        ))
+        .unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while app.world().get::<EditState>(entity).is_none() && std::time::Instant::now() < deadline
+        {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            app.update();
+        }
+
+        assert_eq!(
+            app.world()
+                .get::<EditState>(entity)
+                .unwrap()
+                .core
+                .buffer
+                .text(),
+            "created\n"
+        );
     }
 
     #[test]

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -2942,13 +2942,20 @@ impl Plugin for EditorPlugin {
             .add_systems(
                 Update,
                 (
-                    reconcile_file_watches.before(load_file_buffers),
-                    load_file_buffers,
-                    send_initial_meta,
-                    send_initial_text_meta,
-                    send_initial_dir,
-                    sync_media_allowlist,
-                    send_initial_media.after(sync_media_allowlist),
+                    (
+                        reconcile_file_watches,
+                        drain_file_changes,
+                        reload_changed_files,
+                        load_file_buffers,
+                    )
+                        .chain(),
+                    send_initial_meta.after(load_file_buffers),
+                    send_initial_text_meta.after(load_file_buffers),
+                    send_initial_dir.after(load_file_buffers),
+                    sync_media_allowlist.after(load_file_buffers),
+                    send_initial_media
+                        .after(load_file_buffers)
+                        .after(sync_media_allowlist),
                     (detach_video_overlays, attach_video_overlays).chain(),
                     send_file_theme,
                     apply_file_view_mode_requests.before(send_file_view_mode),
@@ -2961,7 +2968,6 @@ impl Plugin for EditorPlugin {
                     reapply_keymap_on_change,
                     apply_lsp_folds,
                     persist_folds,
-                    (drain_file_changes, reload_changed_files).chain(),
                 ),
             )
             .add_systems(Update, (mark_note_dirty, send_note.after(mark_note_dirty)))
@@ -3062,9 +3068,9 @@ mod edit_flow_tests {
             Update,
             (
                 reconcile_file_watches,
-                load_file_buffers,
                 drain_file_changes,
                 reload_changed_files,
+                load_file_buffers,
             )
                 .chain(),
         );
@@ -3103,12 +3109,7 @@ mod edit_flow_tests {
             notify::Event::new(notify::EventKind::Any).add_path(parent)
         ))
         .unwrap();
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-        while app.world().get::<EditState>(entity).is_none() && std::time::Instant::now() < deadline
-        {
-            std::thread::sleep(std::time::Duration::from_millis(20));
-            app.update();
-        }
+        app.update();
 
         assert_eq!(
             app.world()

--- a/crates/vmux_git/src/parse.rs
+++ b/crates/vmux_git/src/parse.rs
@@ -1,3 +1,5 @@
+use std::collections::{HashMap, HashSet};
+
 use crate::event::{DiffKind, DiffLine, FileStatus, StyledSpan};
 
 pub struct ParsedStatus {
@@ -7,6 +9,24 @@ pub struct ParsedStatus {
     pub has_upstream: bool,
     pub file_status: FileStatus,
     pub staged_count: u32,
+}
+
+pub struct ParsedStatuses {
+    pub branch: String,
+    pub ahead: u32,
+    pub behind: u32,
+    pub has_upstream: bool,
+    pub staged_count: u32,
+    file_statuses: HashMap<String, FileStatus>,
+}
+
+impl ParsedStatuses {
+    pub fn file_status(&self, target_rel: &str) -> FileStatus {
+        self.file_statuses
+            .get(target_rel)
+            .copied()
+            .unwrap_or(FileStatus::Clean)
+    }
 }
 
 fn entry_path(line: &str, kind_tokens: usize) -> &str {
@@ -29,13 +49,13 @@ fn xy_status(xy: &str) -> FileStatus {
     }
 }
 
-pub fn parse_porcelain_v2(out: &str, target_rel: &str) -> ParsedStatus {
+pub fn parse_porcelain_v2_statuses(out: &str) -> ParsedStatuses {
     let mut branch = String::new();
     let mut ahead = 0u32;
     let mut behind = 0u32;
     let mut has_upstream = false;
     let mut staged_count = 0u32;
-    let mut file_status = FileStatus::Clean;
+    let mut file_statuses = HashMap::new();
 
     for line in out.lines() {
         if let Some(rest) = line.strip_prefix("# branch.head ") {
@@ -60,36 +80,50 @@ pub fn parse_porcelain_v2(out: &str, target_rel: &str) -> ParsedStatus {
                 .split('\t')
                 .next()
                 .unwrap_or("");
-            if path == target_rel {
-                file_status = xy_status(xy);
+            if !path.is_empty() {
+                file_statuses.insert(path.to_string(), xy_status(xy));
             }
         } else if let Some(rest) = line.strip_prefix("u ") {
             let _ = rest;
             let path = entry_path(line, 10);
-            if path == target_rel {
-                file_status = FileStatus::Conflicted;
+            if !path.is_empty() {
+                file_statuses.insert(path.to_string(), FileStatus::Conflicted);
             }
-        } else if let Some(path) = line.strip_prefix("? ")
-            && path.trim() == target_rel
-        {
-            file_status = FileStatus::Untracked;
+        } else if let Some(path) = line.strip_prefix("? ") {
+            let path = path.trim();
+            if !path.is_empty() {
+                file_statuses.insert(path.to_string(), FileStatus::Untracked);
+            }
         }
     }
 
-    ParsedStatus {
+    ParsedStatuses {
         branch,
         ahead,
         behind,
         has_upstream,
-        file_status,
         staged_count,
+        file_statuses,
+    }
+}
+
+pub fn parse_porcelain_v2(out: &str, target_rel: &str) -> ParsedStatus {
+    let parsed = parse_porcelain_v2_statuses(out);
+    let file_status = parsed.file_status(target_rel);
+    ParsedStatus {
+        branch: parsed.branch,
+        ahead: parsed.ahead,
+        behind: parsed.behind,
+        has_upstream: parsed.has_upstream,
+        file_status,
+        staged_count: parsed.staged_count,
     }
 }
 
 /// Repo-relative paths of every changed entry in `git status --porcelain=v2`
 /// output — one per `1 `/`2 `/`u `/`? ` line (untracked files included).
-pub fn changed_paths(out: &str) -> std::collections::HashSet<String> {
-    let mut set = std::collections::HashSet::new();
+pub fn changed_paths(out: &str) -> HashSet<String> {
+    let mut set = HashSet::new();
     for line in out.lines() {
         let path = if line.starts_with("1 ") || line.starts_with("2 ") {
             let kind_tokens = if line.starts_with("2 ") { 9 } else { 8 };

--- a/crates/vmux_git/src/plugin.rs
+++ b/crates/vmux_git/src/plugin.rs
@@ -11,10 +11,64 @@ use crate::event::{
 };
 use crate::job::{Emit, JobKind, emit_event_name, run_job};
 
-pub type OutboxQueue = Vec<(Entity, Vec<Emit>)>;
+pub enum GitOutboxItem {
+    Events {
+        webview: Entity,
+        emits: Vec<Emit>,
+    },
+    StatusBatch {
+        repo_root: PathBuf,
+        results: Vec<(Entity, Vec<Emit>)>,
+    },
+}
+
+pub type OutboxQueue = Vec<GitOutboxItem>;
 
 #[derive(Resource, Clone, Default)]
 pub struct GitOutbox(pub Arc<Mutex<OutboxQueue>>);
+
+#[derive(Clone, Debug)]
+struct PendingStatusRequest {
+    webview: Entity,
+    path: PathBuf,
+    dirty: bool,
+}
+
+#[derive(Resource, Default)]
+struct GitStatusJobs {
+    pending: HashMap<PathBuf, HashMap<Entity, PendingStatusRequest>>,
+    in_flight: HashSet<PathBuf>,
+}
+
+impl GitStatusJobs {
+    fn queue(&mut self, repo_root: PathBuf, request: PendingStatusRequest) {
+        self.pending
+            .entry(repo_root)
+            .or_default()
+            .insert(request.webview, request);
+    }
+
+    fn take_ready(&mut self) -> Vec<(PathBuf, Vec<PendingStatusRequest>)> {
+        let roots: Vec<PathBuf> = self
+            .pending
+            .keys()
+            .filter(|root| !self.in_flight.contains(*root))
+            .cloned()
+            .collect();
+        roots
+            .into_iter()
+            .filter_map(|root| {
+                let requests = self.pending.remove(&root)?;
+                self.in_flight.insert(root.clone());
+                Some((root, requests.into_values().collect()))
+            })
+            .collect()
+    }
+
+    fn complete(&mut self, repo_root: &Path) {
+        self.in_flight.remove(repo_root);
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct GitWatchTarget {
@@ -24,6 +78,7 @@ struct GitWatchTarget {
 
 struct GitSubscription {
     path: PathBuf,
+    repo_root: PathBuf,
     targets: Vec<GitWatchTarget>,
     complete: bool,
 }
@@ -56,7 +111,9 @@ fn resolve_git_path(root: &Path, value: &str) -> PathBuf {
     canon(&path)
 }
 
-fn git_watch_targets(file: &Path) -> Result<Vec<GitWatchTarget>, crate::runner::GitError> {
+fn git_watch_targets(
+    file: &Path,
+) -> Result<(PathBuf, Vec<GitWatchTarget>), crate::runner::GitError> {
     let root = crate::runner::repo_root(file)?;
     let (stdout, stderr, ok) = crate::runner::git(
         &root,
@@ -88,10 +145,18 @@ fn git_watch_targets(file: &Path) -> Result<Vec<GitWatchTarget>, crate::runner::
         path: common_dir.join("refs"),
         recursive: true,
     });
-    Ok(targets)
+    Ok((root, targets))
+}
+
+fn is_git_lock_path(path: &Path) -> bool {
+    path.file_name()
+        .is_some_and(|name| name.to_string_lossy().ends_with(".lock"))
 }
 
 fn target_matches(target: &GitWatchTarget, changed: &Path) -> bool {
+    if is_git_lock_path(changed) {
+        return false;
+    }
     let changed = canon(changed);
     changed == target.path
         || if target.recursive {
@@ -102,19 +167,22 @@ fn target_matches(target: &GitWatchTarget, changed: &Path) -> bool {
 }
 
 impl GitWatch {
-    fn subscribe(&mut self, entity: Entity, path: &Path) {
+    fn subscribe(
+        &mut self,
+        entity: Entity,
+        path: &Path,
+    ) -> Result<PathBuf, crate::runner::GitError> {
         let path = canon(path);
-        if self
+        if let Some(subscription) = self
             .subscriptions
             .get(&entity)
-            .is_some_and(|subscription| subscription.path == path && subscription.complete)
+            .filter(|subscription| subscription.path == path && subscription.complete)
         {
-            return;
+            return Ok(subscription.repo_root.clone());
         }
-        let Ok(targets) = git_watch_targets(&path) else {
+        let (repo_root, targets) = git_watch_targets(&path).inspect_err(|_| {
             self.subscriptions.remove(&entity);
-            return;
-        };
+        })?;
         let mut complete = true;
         for target in &targets {
             if self.watched.contains(target) {
@@ -135,10 +203,12 @@ impl GitWatch {
             entity,
             GitSubscription {
                 path,
+                repo_root: repo_root.clone(),
                 targets,
                 complete,
             },
         );
+        Ok(repo_root)
     }
 }
 
@@ -154,9 +224,10 @@ impl Plugin for GitPlugin {
             .get_resource::<bevy::winit::EventLoopProxyWrapper>()
             .map(|wrapper| (**wrapper).clone());
         match notify::recommended_watcher(move |result: notify::Result<notify::Event>| {
-            let wake = result
-                .as_ref()
-                .is_ok_and(|event| !matches!(event.kind, EventKind::Access(_)));
+            let wake = result.as_ref().is_ok_and(|event| {
+                !matches!(event.kind, EventKind::Access(_))
+                    && event.paths.iter().any(|path| !is_git_lock_path(path))
+            });
             let _ = tx.send(result);
             if wake && let Some(proxy) = proxy.as_ref() {
                 let _ = proxy.send_event(bevy::winit::WinitUserEvent::WakeUp);
@@ -173,6 +244,7 @@ impl Plugin for GitPlugin {
             Err(error) => bevy::log::warn!("git watcher init failed: {error}"),
         }
         app.init_resource::<GitOutbox>()
+            .init_resource::<GitStatusJobs>()
             .add_plugins(BinEventEmitterPlugin::<(
                 GitStatusRequest,
                 GitDiffRequest,
@@ -191,7 +263,10 @@ impl Plugin for GitPlugin {
             .add_observer(on_commit_request)
             .add_observer(on_push_request)
             .add_observer(on_hunk_request)
-            .add_systems(Update, (drain_git_watch, drain_git_outbox));
+            .add_systems(
+                Update,
+                (drain_git_watch, drain_git_outbox, dispatch_status_jobs).chain(),
+            );
     }
 }
 
@@ -201,7 +276,50 @@ fn spawn_job(outbox: &GitOutbox, webview: Entity, job: JobKind) {
         let emits = run_job(job);
         sink.lock()
             .unwrap_or_else(|p| p.into_inner())
-            .push((webview, emits));
+            .push(GitOutboxItem::Events { webview, emits });
+    });
+}
+
+fn spawn_status_batch(
+    outbox: &GitOutbox,
+    repo_root: PathBuf,
+    requests: Vec<PendingStatusRequest>,
+) {
+    let sink = outbox.0.clone();
+    std::thread::spawn(move || {
+        let paths: Vec<PathBuf> = requests.iter().map(|request| request.path.clone()).collect();
+        let results = match crate::runner::statuses(&repo_root, &paths) {
+            Ok(events) => requests
+                .into_iter()
+                .zip(events)
+                .map(|(request, mut event)| {
+                    if request.dirty {
+                        event.file_status = match event.file_status {
+                            crate::event::FileStatus::Clean => crate::event::FileStatus::Modified,
+                            crate::event::FileStatus::Staged => {
+                                crate::event::FileStatus::StagedModified
+                            }
+                            status => status,
+                        };
+                    }
+                    (request.webview, vec![Emit::Status(event)])
+                })
+                .collect(),
+            Err(error) => requests
+                .into_iter()
+                .map(|request| {
+                    (
+                        request.webview,
+                        vec![Emit::Error(crate::event::GitErrorEvent {
+                            message: error.0.clone(),
+                        })],
+                    )
+                })
+                .collect(),
+        };
+        sink.lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(GitOutboxItem::StatusBatch { repo_root, results });
     });
 }
 
@@ -210,19 +328,43 @@ fn on_status_request(
     sources: Query<&GitDiffSource>,
     outbox: Res<GitOutbox>,
     watch: Option<NonSendMut<GitWatch>>,
+    mut jobs: ResMut<GitStatusJobs>,
 ) {
-    if let Some(mut watch) = watch {
-        watch.subscribe(
-            trigger.event().webview,
-            Path::new(&trigger.event().payload.path),
-        );
+    let webview = trigger.event().webview;
+    let path: PathBuf = trigger.event().payload.path.clone().into();
+    let repo_root = if let Some(mut watch) = watch {
+        watch.subscribe(webview, &path)
+    } else {
+        crate::runner::repo_root(&path)
+    };
+    match repo_root {
+        Ok(repo_root) => jobs.queue(
+            repo_root,
+            PendingStatusRequest {
+                webview,
+                path,
+                dirty: sources
+                    .get(webview)
+                    .is_ok_and(|source| source.dirty),
+            },
+        ),
+        Err(error) => outbox
+            .0
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(GitOutboxItem::Events {
+                webview,
+                emits: vec![Emit::Error(crate::event::GitErrorEvent {
+                    message: error.0,
+                })],
+            }),
     }
-    spawn_job(&outbox, trigger.event().webview, JobKind::Status {
-        path: trigger.event().payload.path.clone().into(),
-        dirty: sources
-            .get(trigger.event().webview)
-            .is_ok_and(|source| source.dirty),
-    });
+}
+
+fn dispatch_status_jobs(mut jobs: ResMut<GitStatusJobs>, outbox: Res<GitOutbox>) {
+    for (repo_root, requests) in jobs.take_ready() {
+        spawn_status_batch(&outbox, repo_root, requests);
+    }
 }
 
 fn drain_git_watch(watch: Option<NonSendMut<GitWatch>>, mut commands: Commands) {
@@ -321,20 +463,40 @@ fn on_hunk_request(trigger: On<BinReceive<GitHunkRequest>>, outbox: Res<GitOutbo
     });
 }
 
-fn drain_git_outbox(outbox: Res<GitOutbox>, mut commands: Commands) {
+fn emit_events(commands: &mut Commands, webview: Entity, emits: Vec<Emit>) {
+    for emit in emits {
+        let name = emit_event_name(&emit);
+        match emit {
+            Emit::Status(ev) => commands.trigger(BinHostEmitEvent::from_rkyv(webview, name, &ev)),
+            Emit::DiffMeta(ev) => commands.trigger(BinHostEmitEvent::from_rkyv(webview, name, &ev)),
+            Emit::DiffViewport(ev) => {
+                commands.trigger(BinHostEmitEvent::from_rkyv(webview, name, &ev))
+            }
+            Emit::Result(ev) => commands.trigger(BinHostEmitEvent::from_rkyv(webview, name, &ev)),
+            Emit::Error(ev) => commands.trigger(BinHostEmitEvent::from_rkyv(webview, name, &ev)),
+        }
+    }
+}
+
+fn drain_git_outbox(
+    outbox: Res<GitOutbox>,
+    mut jobs: ResMut<GitStatusJobs>,
+    mut commands: Commands,
+) {
     let drained: OutboxQueue = {
         let mut q = outbox.0.lock().unwrap_or_else(|p| p.into_inner());
         q.drain(..).collect()
     };
-    for (webview, emits) in drained {
-        for emit in emits {
-            let name = emit_event_name(&emit);
-            match emit {
-                Emit::Status(ev) => commands.trigger(BinHostEmitEvent::from_rkyv(webview, name, &ev)),
-                Emit::DiffMeta(ev) => commands.trigger(BinHostEmitEvent::from_rkyv(webview, name, &ev)),
-                Emit::DiffViewport(ev) => commands.trigger(BinHostEmitEvent::from_rkyv(webview, name, &ev)),
-                Emit::Result(ev) => commands.trigger(BinHostEmitEvent::from_rkyv(webview, name, &ev)),
-                Emit::Error(ev) => commands.trigger(BinHostEmitEvent::from_rkyv(webview, name, &ev)),
+    for item in drained {
+        match item {
+            GitOutboxItem::Events { webview, emits } => {
+                emit_events(&mut commands, webview, emits);
+            }
+            GitOutboxItem::StatusBatch { repo_root, results } => {
+                jobs.complete(&repo_root);
+                for (webview, emits) in results {
+                    emit_events(&mut commands, webview, emits);
+                }
             }
         }
     }
@@ -351,13 +513,21 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .init_resource::<GitOutbox>()
+            .init_resource::<GitStatusJobs>()
             .add_systems(Update, drain_git_outbox);
 
         let webview = app.world_mut().spawn_empty().id();
-        app.world().resource::<GitOutbox>().0.lock().unwrap().push((
-            webview,
-            vec![Emit::Error(GitErrorEvent { message: "boom".into() })],
-        ));
+        app.world()
+            .resource::<GitOutbox>()
+            .0
+            .lock()
+            .unwrap()
+            .push(GitOutboxItem::Events {
+                webview,
+                emits: vec![Emit::Error(GitErrorEvent {
+                    message: "boom".into(),
+                })],
+            });
 
         app.update();
 
@@ -368,7 +538,7 @@ mod tests {
     fn git_watch_targets_cover_index_and_refs() {
         let repo = test_repo::init();
         let file = test_repo::write(repo.path(), "a.txt", "one\n");
-        let targets = git_watch_targets(&file).unwrap();
+        let (_, targets) = git_watch_targets(&file).unwrap();
         let git_dir = canon(&repo.path().join(".git"));
 
         assert!(targets.contains(&GitWatchTarget {
@@ -401,7 +571,7 @@ mod tests {
             ],
         );
 
-        let targets = git_watch_targets(&worktree.join("a.txt")).unwrap();
+        let (_, targets) = git_watch_targets(&worktree.join("a.txt")).unwrap();
         let common = canon(&repo.path().join(".git"));
 
         assert!(targets.iter().any(|target| {
@@ -432,7 +602,83 @@ mod tests {
         };
 
         assert!(target_matches(&direct, &root.join("index")));
+        assert!(!target_matches(&direct, &root.join("index.lock")));
         assert!(!target_matches(&direct, &root.join("refs/heads/main")));
         assert!(target_matches(&recursive, &root.join("refs/heads/main")));
+        assert!(!target_matches(
+            &recursive,
+            &root.join("refs/heads/main.lock")
+        ));
+    }
+
+    #[test]
+    fn status_jobs_batch_by_repo_and_keep_one_batch_in_flight() {
+        let root = PathBuf::from("/repo");
+        let other_root = PathBuf::from("/other");
+        let first = Entity::from_bits(1);
+        let second = Entity::from_bits(2);
+        let mut jobs = GitStatusJobs::default();
+
+        jobs.queue(
+            root.clone(),
+            PendingStatusRequest {
+                webview: first,
+                path: root.join("a.txt"),
+                dirty: false,
+            },
+        );
+        jobs.queue(
+            root.clone(),
+            PendingStatusRequest {
+                webview: first,
+                path: root.join("a.txt"),
+                dirty: true,
+            },
+        );
+        jobs.queue(
+            root.clone(),
+            PendingStatusRequest {
+                webview: second,
+                path: root.join("b.txt"),
+                dirty: false,
+            },
+        );
+        jobs.queue(
+            other_root.clone(),
+            PendingStatusRequest {
+                webview: first,
+                path: other_root.join("c.txt"),
+                dirty: false,
+            },
+        );
+
+        let batches = jobs.take_ready();
+        assert_eq!(batches.len(), 2);
+        let (_, requests) = batches
+            .iter()
+            .find(|(batch_root, _)| batch_root == &root)
+            .unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(
+            requests
+                .iter()
+                .any(|request| request.webview == first && request.dirty)
+        );
+
+        jobs.queue(
+            root.clone(),
+            PendingStatusRequest {
+                webview: first,
+                path: root.join("a.txt"),
+                dirty: false,
+            },
+        );
+        assert!(jobs.take_ready().is_empty());
+
+        jobs.complete(&root);
+        let batches = jobs.take_ready();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].0, root);
+        assert_eq!(batches[0].1.len(), 1);
     }
 }

--- a/crates/vmux_git/src/runner.rs
+++ b/crates/vmux_git/src/runner.rs
@@ -174,18 +174,18 @@ pub(crate) fn statuses(root: &Path, files: &[PathBuf]) -> Result<Vec<GitStatusEv
         return Err(GitError(stderr.trim().to_string()));
     }
     let repo_root = root.to_string_lossy().into_owned();
+    let parsed = parse::parse_porcelain_v2_statuses(&stdout);
     Ok(files
         .iter()
         .map(|file| {
             let target = rel(root, file);
-            let p = parse::parse_porcelain_v2(&stdout, &target);
             GitStatusEvent {
-                branch: p.branch,
-                ahead: p.ahead,
-                behind: p.behind,
-                has_upstream: p.has_upstream,
-                file_status: p.file_status,
-                staged_count: p.staged_count,
+                branch: parsed.branch.clone(),
+                ahead: parsed.ahead,
+                behind: parsed.behind,
+                has_upstream: parsed.has_upstream,
+                file_status: parsed.file_status(&target),
+                staged_count: parsed.staged_count,
                 repo_root: repo_root.clone(),
             }
         })

--- a/crates/vmux_git/src/runner.rs
+++ b/crates/vmux_git/src/runner.rs
@@ -161,7 +161,15 @@ pub fn status(file: &Path) -> Result<GitStatusEvent, GitError> {
 }
 
 pub(crate) fn statuses(root: &Path, files: &[PathBuf]) -> Result<Vec<GitStatusEvent>, GitError> {
-    let (stdout, stderr, ok) = git_read(root, &["status", "--porcelain=v2", "--branch"])?;
+    let (stdout, stderr, ok) = git_read(
+        root,
+        &[
+            "status",
+            "--porcelain=v2",
+            "--branch",
+            "--untracked-files=all",
+        ],
+    )?;
     if !ok {
         return Err(GitError(stderr.trim().to_string()));
     }
@@ -188,7 +196,10 @@ pub(crate) fn statuses(root: &Path, files: &[PathBuf]) -> Result<Vec<GitStatusEv
 /// reports as changed (modified/staged/untracked/renamed/deleted/conflicted).
 pub fn dirty_set(file: &Path) -> Result<(PathBuf, std::collections::HashSet<String>), GitError> {
     let root = repo_root(file)?;
-    let (stdout, stderr, ok) = git_read(&root, &["status", "--porcelain=v2"])?;
+    let (stdout, stderr, ok) = git_read(
+        &root,
+        &["status", "--porcelain=v2", "--untracked-files=all"],
+    )?;
     if !ok {
         return Err(GitError(stderr.trim().to_string()));
     }
@@ -589,6 +600,15 @@ mod tests {
         assert_eq!(status(&file).unwrap().file_status, FileStatus::Modified);
         stage(&file).unwrap();
         assert_eq!(status(&file).unwrap().file_status, FileStatus::Staged);
+    }
+
+    #[test]
+    fn status_reports_nested_untracked_file() {
+        let repo = test_repo::init();
+        std::fs::create_dir(repo.path().join("nested")).unwrap();
+        let file = test_repo::write(repo.path(), "nested/new.txt", "new\n");
+
+        assert_eq!(status(&file).unwrap().file_status, FileStatus::Untracked);
     }
 
     #[test]

--- a/crates/vmux_git/src/runner.rs
+++ b/crates/vmux_git/src/runner.rs
@@ -93,6 +93,19 @@ pub(crate) fn git(root: &Path, args: &[&str]) -> Result<(String, String, bool), 
     ))
 }
 
+fn git_read(root: &Path, args: &[&str]) -> Result<(String, String, bool), GitError> {
+    let out = git_command(root)
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .args(args)
+        .output()
+        .map_err(|e| GitError(format!("failed to run git: {e}")))?;
+    Ok((
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.success(),
+    ))
+}
+
 pub(crate) fn git_err(stdout: &str, stderr: &str) -> GitError {
     let s = stderr.trim();
     GitError(if s.is_empty() {
@@ -142,28 +155,40 @@ fn rel(root: &Path, file: &Path) -> String {
 
 pub fn status(file: &Path) -> Result<GitStatusEvent, GitError> {
     let root = repo_root(file)?;
-    let target = rel(&root, file);
-    let (stdout, stderr, ok) = git(&root, &["status", "--porcelain=v2", "--branch"])?;
+    statuses(&root, &[file.to_path_buf()])?
+        .pop()
+        .ok_or_else(|| GitError("missing git status result".into()))
+}
+
+pub(crate) fn statuses(root: &Path, files: &[PathBuf]) -> Result<Vec<GitStatusEvent>, GitError> {
+    let (stdout, stderr, ok) = git_read(root, &["status", "--porcelain=v2", "--branch"])?;
     if !ok {
         return Err(GitError(stderr.trim().to_string()));
     }
-    let p = parse::parse_porcelain_v2(&stdout, &target);
-    Ok(GitStatusEvent {
-        branch: p.branch,
-        ahead: p.ahead,
-        behind: p.behind,
-        has_upstream: p.has_upstream,
-        file_status: p.file_status,
-        staged_count: p.staged_count,
-        repo_root: root.to_string_lossy().into_owned(),
-    })
+    let repo_root = root.to_string_lossy().into_owned();
+    Ok(files
+        .iter()
+        .map(|file| {
+            let target = rel(root, file);
+            let p = parse::parse_porcelain_v2(&stdout, &target);
+            GitStatusEvent {
+                branch: p.branch,
+                ahead: p.ahead,
+                behind: p.behind,
+                has_upstream: p.has_upstream,
+                file_status: p.file_status,
+                staged_count: p.staged_count,
+                repo_root: repo_root.clone(),
+            }
+        })
+        .collect())
 }
 
 /// Repo root plus the set of repo-relative paths `git status --porcelain=v2`
 /// reports as changed (modified/staged/untracked/renamed/deleted/conflicted).
 pub fn dirty_set(file: &Path) -> Result<(PathBuf, std::collections::HashSet<String>), GitError> {
     let root = repo_root(file)?;
-    let (stdout, stderr, ok) = git(&root, &["status", "--porcelain=v2"])?;
+    let (stdout, stderr, ok) = git_read(&root, &["status", "--porcelain=v2"])?;
     if !ok {
         return Err(GitError(stderr.trim().to_string()));
     }
@@ -564,6 +589,47 @@ mod tests {
         assert_eq!(status(&file).unwrap().file_status, FileStatus::Modified);
         stage(&file).unwrap();
         assert_eq!(status(&file).unwrap().file_status, FileStatus::Staged);
+    }
+
+    #[test]
+    fn status_batch_reports_each_requested_path() {
+        let repo = test_repo::init();
+        let modified = test_repo::write(repo.path(), "modified.txt", "one\n");
+        let staged = test_repo::write(repo.path(), "staged.txt", "one\n");
+        test_repo::run(repo.path(), &["add", "."]);
+        test_repo::run(repo.path(), &["commit", "-qm", "init"]);
+        test_repo::write(repo.path(), "modified.txt", "two\n");
+        test_repo::write(repo.path(), "staged.txt", "two\n");
+        test_repo::run(repo.path(), &["add", "staged.txt"]);
+
+        let events = statuses(repo.path(), &[modified, staged]).unwrap();
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].file_status, FileStatus::Modified);
+        assert_eq!(events[1].file_status, FileStatus::Staged);
+    }
+
+    #[test]
+    fn background_status_does_not_refresh_index() {
+        use std::fs::{FileTimes, OpenOptions};
+        use std::time::{Duration, SystemTime};
+
+        let repo = test_repo::init();
+        let file = test_repo::write(repo.path(), "a.txt", "one\n");
+        test_repo::run(repo.path(), &["add", "a.txt"]);
+        test_repo::run(repo.path(), &["commit", "-qm", "init"]);
+        let index = repo.path().join(".git/index");
+        let before = std::fs::read(&index).unwrap();
+        OpenOptions::new()
+            .write(true)
+            .open(&file)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(SystemTime::now() + Duration::from_secs(3600)))
+            .unwrap();
+
+        assert_eq!(status(&file).unwrap().file_status, FileStatus::Clean);
+
+        assert_eq!(std::fs::read(index).unwrap(), before);
     }
 
     #[test]

--- a/crates/vmux_layout/src/stack.rs
+++ b/crates/vmux_layout/src/stack.rs
@@ -3,7 +3,7 @@ use crate::{
     NewStackContext,
     pane::{Pane, PaneSplit, PendingCursorWarp, first_leaf_descendant, first_stack_in_pane},
     swap::{find_kind_index, resolve_next, resolve_prev, swap_siblings},
-    tab::Tab,
+    tab::{CloseTabRequest, Tab},
 };
 use bevy::{
     ecs::{relationship::Relationship, system::SystemParam},
@@ -251,7 +251,6 @@ pub fn stack_bundle() -> impl Bundle {
 
 fn handle_stack_commands(
     mut reader: MessageReader<AppCommand>,
-    tabs: Query<(Entity, &LastActivatedAt), With<Tab>>,
     active_tab_param: ActiveTabParam,
     all_children: Query<&Children>,
     leaf_panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
@@ -264,6 +263,7 @@ fn handle_stack_commands(
     effective_startup_url: Option<Res<crate::settings::EffectiveStartupUrl>>,
 
     mut new_stack_ctx: ResMut<NewStackContext>,
+    mut close_tab_requests: MessageWriter<CloseTabRequest>,
     mut page_open_requests: MessageWriter<PageOpenRequest>,
     mut commands: Commands,
     mut pending_cursor_warp: ResMut<PendingCursorWarp>,
@@ -361,11 +361,9 @@ fn handle_stack_commands(
                         && close_tab_if_only_closing_stack(
                             tab,
                             active,
-                            &tabs,
-                            &child_of_q,
                             &all_children,
                             &stack_q,
-                            &mut commands,
+                            &mut close_tab_requests,
                         )
                     {
                         if new_stack_ctx.stack == Some(active) {
@@ -594,23 +592,14 @@ fn handle_stack_commands(
 fn close_tab_if_only_closing_stack(
     tab: Entity,
     closing_stack: Entity,
-    tabs: &Query<(Entity, &LastActivatedAt), With<Tab>>,
-    child_of_q: &Query<&ChildOf>,
     all_children: &Query<&Children>,
     stack_q: &Query<Entity, With<Stack>>,
-    commands: &mut Commands,
+    close_tab_requests: &mut MessageWriter<CloseTabRequest>,
 ) -> bool {
     if entity_tree_contains_stack_other_than(tab, closing_stack, all_children, stack_q) {
         return false;
     }
-    let siblings = sibling_tabs(tab, tabs, child_of_q, all_children);
-    if siblings.len() <= 1 {
-        return false;
-    }
-    if let Some(next) = crate::tab::pick_after_close(tab, &siblings) {
-        commands.entity(next).insert(LastActivatedAt::now());
-    }
-    commands.entity(tab).despawn();
+    close_tab_requests.write(CloseTabRequest { tab });
     true
 }
 
@@ -626,21 +615,6 @@ fn entity_tree_contains_stack_other_than(
                 entity_tree_contains_stack_other_than(child, ignored_stack, all_children, stack_q)
             })
         })
-}
-
-fn sibling_tabs(
-    tab: Entity,
-    tabs: &Query<(Entity, &LastActivatedAt), With<Tab>>,
-    child_of_q: &Query<&ChildOf>,
-    all_children: &Query<&Children>,
-) -> Vec<Entity> {
-    let Ok(parent) = child_of_q.get(tab).map(Relationship::get) else {
-        return vec![tab];
-    };
-    let Ok(children) = all_children.get(parent) else {
-        return vec![tab];
-    };
-    children.iter().filter(|e| tabs.get(*e).is_ok()).collect()
 }
 
 fn sync_stack_picking(
@@ -739,7 +713,6 @@ mod tests {
         FocusRingSettings, LayoutSettings, PaneSettings, SideSheetSettings, WindowSettings,
     };
     use bevy::ecs::relationship::Relationship;
-    use bevy::window::ClosingWindow;
     use bevy_cef::prelude::WebviewExtendStandardMaterial;
     use vmux_command::{CommandPlugin, WriteAppCommands};
 
@@ -865,21 +838,62 @@ mod tests {
     }
 
     #[test]
-    fn closing_last_stack_without_startup_url_opens_command_bar_with_replacement_stack() {
+    fn closing_last_stack_replaces_only_tab_with_fresh_tab() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, CommandPlugin))
+            .add_message::<CloseTabRequest>()
+            .add_message::<crate::TabLayoutSpawnRequest>()
             .add_message::<PageOpenRequest>()
             .init_resource::<NewStackContext>()
             .init_resource::<PendingCursorWarp>()
+            .init_resource::<crate::tab::LastTabCloseAt>()
+            .init_resource::<FocusedStack>()
             .insert_resource(test_settings())
             .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
-            .add_systems(Update, handle_stack_commands.in_set(WriteAppCommands));
+            .add_systems(
+                Update,
+                (
+                    handle_stack_commands.in_set(WriteAppCommands),
+                    crate::archive::handle_close_tab_requests,
+                    crate::window::spawn_requested_tab_layouts,
+                )
+                    .chain(),
+            );
 
-        let window = app.world_mut().spawn(PrimaryWindow).id();
+        app.world_mut()
+            .spawn((bevy::window::Window::default(), PrimaryWindow));
+        let space = app
+            .world_mut()
+            .spawn((
+                crate::space::Space,
+                crate::space::SpaceId("s1".to_string()),
+                vmux_core::Active,
+            ))
+            .id();
+        let startup = tempfile::tempdir().unwrap();
+        let worktree = tempfile::tempdir().unwrap();
+        app.insert_resource(crate::settings::EffectiveStartupDir(Some((
+            space,
+            Some(startup.path().to_path_buf()),
+        ))));
         let tab_e = app
             .world_mut()
-            .spawn((Tab::default(), LastActivatedAt::now()))
+            .spawn((
+                Tab {
+                    name: "Worktree".to_string(),
+                    startup_dir: Some(worktree.path().to_string_lossy().into_owned()),
+                },
+                crate::tab::TabWorktree {
+                    repo_root: worktree.path().to_string_lossy().into_owned(),
+                    checkout_dir: worktree.path().to_string_lossy().into_owned(),
+                    branch: "test".to_string(),
+                    base_ref: "main".to_string(),
+                },
+                vmux_core::Active,
+                LastActivatedAt::now(),
+                ChildOf(space),
+            ))
             .id();
         let pane = app
             .world_mut()
@@ -887,7 +901,7 @@ mod tests {
             .id();
         let original_stack = app
             .world_mut()
-            .spawn((Stack::default(), LastActivatedAt::now(), ChildOf(pane)))
+            .spawn((stack_bundle(), LastActivatedAt::now(), ChildOf(pane)))
             .id();
         app.world_mut()
             .resource_mut::<Messages<AppCommand>>()
@@ -897,35 +911,56 @@ mod tests {
 
         app.update();
 
-        assert!(!app.world().entity(window).contains::<ClosingWindow>());
+        assert!(app.world().get_entity(tab_e).is_err());
         assert!(app.world().get_entity(original_stack).is_err());
-
-        let ctx = app.world().resource::<NewStackContext>();
-        let Some(replacement_stack) = ctx.stack else {
-            panic!("expected replacement stack to open command bar");
-        };
-        assert!(ctx.needs_open);
-        assert_eq!(ctx.previous_stack, None);
+        let fresh_tab = app
+            .world_mut()
+            .query_filtered::<Entity, With<Tab>>()
+            .single(app.world())
+            .unwrap();
+        assert_ne!(fresh_tab, tab_e);
+        assert!(
+            app.world()
+                .get::<crate::tab::TabWorktree>(fresh_tab)
+                .is_none()
+        );
         assert_eq!(
             app.world()
-                .get::<ChildOf>(replacement_stack)
-                .map(Relationship::get),
-            Some(pane)
+                .get::<Tab>(fresh_tab)
+                .unwrap()
+                .startup_dir
+                .as_deref(),
+            startup.path().canonicalize().unwrap().to_str()
         );
+        let ctx = app.world().resource::<NewStackContext>();
+        assert!(ctx.needs_open);
+        assert!(ctx.stack.is_some());
+        assert_eq!(ctx.previous_stack, None);
     }
 
     #[test]
     fn closing_last_stack_in_tab_closes_the_tab_when_another_tab_exists() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, CommandPlugin))
+            .add_message::<CloseTabRequest>()
+            .add_message::<crate::TabLayoutSpawnRequest>()
             .add_message::<PageOpenRequest>()
             .init_resource::<NewStackContext>()
             .init_resource::<PendingCursorWarp>()
+            .init_resource::<crate::tab::LastTabCloseAt>()
             .insert_resource(test_settings())
             .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
-            .add_systems(Update, handle_stack_commands.in_set(WriteAppCommands));
+            .add_systems(
+                Update,
+                (
+                    handle_stack_commands.in_set(WriteAppCommands),
+                    crate::archive::handle_close_tab_requests,
+                )
+                    .chain(),
+            );
 
+        app.world_mut().spawn(PrimaryWindow);
         let root = app.world_mut().spawn_empty().id();
         let remaining_tab = app
             .world_mut()
@@ -976,14 +1011,25 @@ mod tests {
     fn closing_last_stack_in_active_rightmost_tab_activates_left_neighbor_not_first() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, CommandPlugin))
+            .add_message::<CloseTabRequest>()
+            .add_message::<crate::TabLayoutSpawnRequest>()
             .add_message::<PageOpenRequest>()
             .init_resource::<NewStackContext>()
             .init_resource::<PendingCursorWarp>()
+            .init_resource::<crate::tab::LastTabCloseAt>()
             .insert_resource(test_settings())
             .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
-            .add_systems(Update, handle_stack_commands.in_set(WriteAppCommands));
+            .add_systems(
+                Update,
+                (
+                    handle_stack_commands.in_set(WriteAppCommands),
+                    crate::archive::handle_close_tab_requests,
+                )
+                    .chain(),
+            );
 
+        app.world_mut().spawn(PrimaryWindow);
         let root = app.world_mut().spawn_empty().id();
         let make_tab = |app: &mut App, ts: i64| -> Entity {
             let tab = app
@@ -1024,6 +1070,7 @@ mod tests {
     fn closing_only_stack_in_split_pane_closes_pane() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, CommandPlugin))
+            .add_message::<CloseTabRequest>()
             .add_message::<PageOpenRequest>()
             .init_resource::<NewStackContext>()
             .init_resource::<PendingCursorWarp>()
@@ -1088,6 +1135,7 @@ mod tests {
     fn closing_stack_in_three_way_split_keeps_split_and_does_not_respawn_startup() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, CommandPlugin))
+            .add_message::<CloseTabRequest>()
             .add_message::<PageOpenRequest>()
             .init_resource::<NewStackContext>()
             .init_resource::<PendingCursorWarp>()
@@ -1294,6 +1342,7 @@ mod tests {
     fn build_app_with_collector() -> App {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, CommandPlugin))
+            .add_message::<CloseTabRequest>()
             .add_message::<PageOpenRequest>()
             .init_resource::<NewStackContext>()
             .init_resource::<PendingCursorWarp>()
@@ -1327,12 +1376,12 @@ mod tests {
     }
 
     #[test]
-    fn closing_last_stack_uses_startup_url_for_replacement_stack() {
+    fn closing_last_stack_requests_tab_close_instead_of_reusing_pane() {
         let mut app = build_app_with_collector();
         app.insert_resource(crate::settings::EffectiveStartupUrl(
             "https://startup.test".into(),
         ));
-        let (_tab, pane, original_stack) = build_hierarchy(&mut app);
+        let (tab, _pane, original_stack) = build_hierarchy(&mut app);
 
         app.world_mut()
             .resource_mut::<Messages<AppCommand>>()
@@ -1342,26 +1391,20 @@ mod tests {
 
         app.update();
 
-        assert!(app.world().get_entity(original_stack).is_err());
+        assert!(app.world().get_entity(original_stack).is_ok());
         let ctx = app.world().resource::<NewStackContext>();
         assert_eq!(ctx.stack, None);
         assert!(!ctx.needs_open);
 
         let collected = app.world().resource::<CollectedSpawns>();
-        assert_eq!(collected.0.len(), 1);
-        assert_eq!(collected.0[0].url, "https://startup.test");
-        match collected.0[0].target {
-            PageOpenTarget::Stack(replacement_stack) => {
-                assert_ne!(replacement_stack, original_stack);
-                assert_eq!(
-                    app.world()
-                        .get::<ChildOf>(replacement_stack)
-                        .map(Relationship::get),
-                    Some(pane)
-                );
-            }
-            _ => panic!("expected stack target"),
-        }
+        assert!(collected.0.is_empty());
+        let close_requests: Vec<_> = app
+            .world_mut()
+            .resource_mut::<Messages<CloseTabRequest>>()
+            .drain()
+            .collect();
+        assert_eq!(close_requests.len(), 1);
+        assert_eq!(close_requests[0].tab, tab);
     }
 
     #[test]

--- a/crates/vmux_layout/src/tab.rs
+++ b/crates/vmux_layout/src/tab.rs
@@ -51,7 +51,8 @@ impl Plugin for TabPlugin {
                 Update,
                 crate::archive::handle_close_tab_requests
                     .in_set(ReadAppCommands)
-                    .after(TabCommandSet),
+                    .after(TabCommandSet)
+                    .after(crate::stack::StackCommandSet),
             )
             .add_systems(PostUpdate, sync_tab_visibility.before(UiSystems::Layout))
             .add_systems(PostUpdate, sync_tab_order);

--- a/crates/vmux_terminal/src/matrix_rain.rs
+++ b/crates/vmux_terminal/src/matrix_rain.rs
@@ -232,8 +232,9 @@ fn start_rain(
             let head_row = *drop;
             let y = head_row * FONT_PX;
             if y >= 0.0 {
-                let ch = pick_glyph(&glyphs, &word_chars, i, head_row).to_string();
-                let _ = ctx.fill_text(&ch, x, y);
+                let mut buffer = [0; 4];
+                let ch = pick_glyph(&glyphs, &word_chars, i, head_row);
+                let _ = ctx.fill_text(ch.encode_utf8(&mut buffer), x, y);
             }
             if y > h && js_sys::Math::random() < reset_chance {
                 *drop = 0.0;

--- a/crates/vmux_terminal/src/matrix_rain.rs
+++ b/crates/vmux_terminal/src/matrix_rain.rs
@@ -8,6 +8,8 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 
 const FONT_PX: f64 = 16.0;
+const DROP_ROWS_PER_SECOND: f64 = 60.0;
+const RESET_RATE_PER_SECOND: f64 = 1.5;
 const GLYPHS: &str = "ｱｲｳｴｵｶｷｸｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝ0123456789";
 
 /// Full-bleed Matrix rain. `accent_rgb` is a `"r g b"` triple (from
@@ -17,7 +19,8 @@ const GLYPHS: &str = "ｱｲｳｴｵｶｷｸｹｺｻｼｽｾｿﾀﾁﾂﾃ�
 pub fn MatrixRain(accent_rgb: String, words: Vec<String>) -> Element {
     let canvas_id = use_hook(|| format!("matrix-rain-{}", (js_sys::Math::random() * 1.0e9) as u64));
     let running: Rc<RefCell<bool>> = use_hook(|| Rc::new(RefCell::new(true)));
-    let raf: Rc<RefCell<Option<Closure<dyn FnMut()>>>> = use_hook(|| Rc::new(RefCell::new(None)));
+    let raf: Rc<RefCell<Option<Closure<dyn FnMut(f64)>>>> =
+        use_hook(|| Rc::new(RefCell::new(None)));
     let handle: Rc<RefCell<Option<i32>>> = use_hook(|| Rc::new(RefCell::new(None)));
 
     use_effect({
@@ -103,7 +106,7 @@ fn start_rain(
     accent_rgb: String,
     words: Vec<String>,
     running: Rc<RefCell<bool>>,
-    raf: Rc<RefCell<Option<Closure<dyn FnMut()>>>>,
+    raf: Rc<RefCell<Option<Closure<dyn FnMut(f64)>>>>,
     handle: Rc<RefCell<Option<i32>>>,
 ) {
     let Some(window) = web_sys::window() else {
@@ -176,11 +179,9 @@ fn start_rain(
     } else {
         format!("rgb({})", darken(&accent_rgb, 42))
     };
-    let trail_color = if dark {
-        format!("rgb({accent_rgb} / 0.85)")
-    } else {
-        format!("rgb({} / 0.8)", darken(&accent_rgb, 62))
-    };
+    let font = format!("{FONT_PX}px monospace");
+    ctx.set_font(&font);
+    ctx.set_text_baseline("top");
 
     let mut cols = (canvas.client_width().max(1) as f64 / FONT_PX)
         .floor()
@@ -194,18 +195,16 @@ fn start_rain(
     let running_inner = running.clone();
     let handle_inner = handle.clone();
     let mut last_frame_ms = 0.0;
-    let closure = Closure::wrap(Box::new(move || {
-        let now = js_sys::Date::now();
-        if now - last_frame_ms < 33.0 {
-            if *running_inner.borrow()
-                && let Some(cb) = raf_inner.borrow().as_ref()
-                && let Ok(id) = win.request_animation_frame(cb.as_ref().unchecked_ref())
-            {
-                *handle_inner.borrow_mut() = Some(id);
-            }
-            return;
-        }
+    let closure = Closure::wrap(Box::new(move |now: f64| {
+        let delta_ms = if last_frame_ms == 0.0 {
+            1000.0 / 60.0
+        } else {
+            (now - last_frame_ms).clamp(0.0, 50.0)
+        };
         last_frame_ms = now;
+        let delta_seconds = delta_ms / 1000.0;
+        let drop_step = DROP_ROWS_PER_SECOND * delta_seconds;
+        let reset_chance = 1.0 - (-RESET_RATE_PER_SECOND * delta_seconds).exp();
         let w = canvas.client_width().max(1) as f64;
         let h = canvas.client_height().max(1) as f64;
         let want_w = (w * dpr) as u32;
@@ -215,6 +214,8 @@ fn start_rain(
             canvas.set_height(want_h);
             let _ = ctx.reset_transform();
             let _ = ctx.scale(dpr, dpr);
+            ctx.set_font(&font);
+            ctx.set_text_baseline("top");
             let new_cols = (w / FONT_PX).floor().max(1.0) as usize;
             if new_cols != cols {
                 drops.resize_with(new_cols, || -(js_sys::Math::random() * 40.0));
@@ -222,11 +223,9 @@ fn start_rain(
             }
         }
 
-        ctx.set_font(&format!("{FONT_PX}px monospace"));
-        ctx.set_text_baseline("top");
-
         ctx.set_fill_style_str(fade);
         ctx.fill_rect(0.0, 0.0, w, h);
+        ctx.set_fill_style_str(&head_color);
 
         for (i, drop) in drops.iter_mut().enumerate().take(cols) {
             let x = i as f64 * FONT_PX;
@@ -234,15 +233,12 @@ fn start_rain(
             let y = head_row * FONT_PX;
             if y >= 0.0 {
                 let ch = pick_glyph(&glyphs, &word_chars, i, head_row).to_string();
-                ctx.set_fill_style_str(&trail_color);
-                let _ = ctx.fill_text(&ch, x, y);
-                ctx.set_fill_style_str(&head_color);
                 let _ = ctx.fill_text(&ch, x, y);
             }
-            if y > h && js_sys::Math::random() > 0.975 {
+            if y > h && js_sys::Math::random() < reset_chance {
                 *drop = 0.0;
             } else {
-                *drop += 1.0;
+                *drop += drop_step;
             }
         }
 
@@ -252,7 +248,7 @@ fn start_rain(
         {
             *handle_inner.borrow_mut() = Some(id);
         }
-    }) as Box<dyn FnMut()>);
+    }) as Box<dyn FnMut(f64)>);
 
     *raf.borrow_mut() = Some(closure);
     if let Some(cb) = raf.borrow().as_ref()

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -4684,7 +4684,6 @@ mod tests {
         assert!(rain.contains("use_drop"));
         assert!(rain.contains("prefers-reduced-motion"));
         assert!(rain.contains("device_pixel_ratio().clamp(1.0, 1.5)"));
-        assert!(rain.contains("now - last_frame_ms < 33.0"));
     }
 
     #[test]

--- a/scripts/build-mac-release.sh
+++ b/scripts/build-mac-release.sh
@@ -25,6 +25,16 @@ if [[ -f "$ROOT/.env" ]]; then
     done < "$ROOT/.env"
 fi
 
+if [[ "$PROFILE" == "local" ]]; then
+    export SKIP_NOTARIZE="${SKIP_NOTARIZE:-1}"
+    if [[ -z "${APPLE_CERTIFICATE:-}" \
+        && -z "${APPLE_CERTIFICATE_PASSWORD:-}" \
+        && -z "${APPLE_SIGNING_IDENTITY:-}" ]]; then
+        APPLE_SIGNING_IDENTITY="$("$ROOT/scripts/ensure-local-codesign-identity.sh")"
+        export APPLE_SIGNING_IDENTITY
+    fi
+fi
+
 TMP_DIR=""
 KEYCHAIN=""
 ORIGINAL_KEYCHAINS=()

--- a/scripts/cargo-with-cef-cache.sh
+++ b/scripts/cargo-with-cef-cache.sh
@@ -60,9 +60,20 @@ if [[ "${CI:-}" != "true" ]]; then
     target_parent="$(cd "$target_parent" && pwd)"
     target_dir="$target_parent/$(basename "$target_dir")"
     export VMUX_TARGET_DESTINATION="$target_dir"
-    "$root/scripts/seed-worktree-target.sh" --if-needed "$root"
-    vmux_target_lock_acquire "$target_dir" "$root" 8
-    trap cleanup EXIT
+    inherited_target_lock=0
+    if [[ "${VMUX_TARGET_LOCK_TARGET:-}" == "$target_dir" \
+        && "${VMUX_TARGET_LOCK_OWNER_PID:-}" =~ ^[0-9]+$ \
+        && "${VMUX_TARGET_LOCK_OWNER_PID}" != "$$" ]] \
+        && kill -0 "$VMUX_TARGET_LOCK_OWNER_PID" 2>/dev/null; then
+        inherited_target_lock=1
+    fi
+    if [[ "$inherited_target_lock" == "0" ]]; then
+        "$root/scripts/seed-worktree-target.sh" --if-needed "$root"
+        vmux_target_lock_acquire "$target_dir" "$root" 8
+        export VMUX_TARGET_LOCK_TARGET="$target_dir"
+        export VMUX_TARGET_LOCK_OWNER_PID="$$"
+        trap cleanup EXIT
+    fi
 fi
 
 trap 'forward_signal HUP' HUP


### PR DESCRIPTION
## Context

Opening several file previews for one repository made every Git metadata event launch a separate status scan. Git optional index locks then retriggered the watcher, producing a persistent high-CPU feedback loop on large repositories.

Local release packaging also deadlocked because the outer cargo-packager wrapper held the target-cache lock while its nested before-package build tried to acquire the same lock.

Agent-follow could open a new file before the agent created it. The editor cached the initial `NotFound` result and never retried, leaving the preview stuck on the error.

Closing the last page reused the existing tab entity, preserving worktree metadata and making the replacement start page inherit stale tab configuration.

## Implementation

- Batch pending status requests by repository and share one porcelain snapshot across subscribed editor views.
- Keep at most one status batch in flight per repository.
- Suppress optional Git locks for background reads and ignore transient lock-file watcher events.
- Let nested package builds inherit a live target-cache lock from their parent.
- Default local packages to the stable Vmux Dev identity and skip notarization unless explicitly requested.
- Add `make cleanup-local` for the layout store shared by local/release builds; preserve the previous store as a timestamped backup.
- Register file watches before initial editor loading and independently of explorer state.
- Track missing file views, watch their nearest existing ancestor, and reload them when the agent creates the missing path.
- Wake Bevy's reactive event loop when filesystem changes arrive.
- Route last-page closure through normal tab closure, then create a fresh tab from configured startup settings without inherited worktree metadata.

## Checks / QA

- vmux_git: 68 tests passed.
- vmux_editor: 189 tests passed, including missing nested path creation regression coverage.
- vmux_layout: 477 tests passed, including fresh-tab replacement coverage.
- release invariants: 30 tests passed, including nested-lock regression coverage.
- Targeted clippy passed.
- Full pre-push fmt, clippy, tests, and doctests passed.
- make build-local completed, produced a signed app, and passed deep signature verification.
- make cleanup-local reset the current local/release layout and preserved its backup.

Open an agent session that touches several files in a large repository. Confirm file Git indicators still update after staging or committing, while Activity Monitor no longer shows a continuous fan-out of git status processes.

Ask the agent to create a file inside a new nested directory. Confirm the followed editor automatically replaces the initial missing-file error with the created contents without switching tabs or reopening the file.

Open a worktree-backed tab, then close its only page. Confirm the old tab disappears and a fresh start-page tab opens using configured startup settings without the old worktree context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `cleanup-local` command that stops local services, optionally backs up saved layout state, and resets the local/release layout while preserving settings and browser profiles.
  * Missing files now automatically reload when the file (or its parent directory) is created or restored.
* **Bug Fixes**
  * Improved Git status responsiveness via batched updates.
  * Background Git status checks no longer refresh the repository index.
  * Improved tab/stack closing behavior and cleared stale page error messages on new backend state.
* **Build Improvements**
  * Local macOS release builds now automatically prepare code-signing requirements and default to skipping notarization; nested build execution avoids lock-related hangs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
