### PR TITLE
feat(agent): refine tool activity and browser flow

### DIFF
--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -27,12 +27,12 @@ use crate::chat_page::event::{
     CHAT_HISTORY_PAGE_EVENT, CHAT_INITIAL_ITEM_LIMIT, CHAT_MEDIA_ENTRIES_EVENT,
     CHAT_SNAPSHOT_EVENT, ChatApproval, ChatAttachPaths, ChatAttachment,
     ChatAttachmentPreviewRequest, ChatAttachments, ChatCancel, ChatCancelQueuedPrompt,
-    ChatChoiceSelected, ChatChooseWorkspace, ChatClearQueue, ChatEscape, ChatHistoryPage,
-    ChatHistoryRequest, ChatMediaEntries, ChatMediaEntry, ChatMediaListRequest, ChatPasteMedia,
-    ChatPickFiles, ChatResume, ChatSnapshot, ChatSubmit, MODEL_STATE_EVENT, ModelOptionEntry,
-    ModelState, QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry,
-    ResumableSessions, ResumeListRequest, ResumeSession, RuntimeSwitchRequest,
-    SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry, SlashCommands,
+    ChatChoiceSelected, ChatClearQueue, ChatEscape, ChatHistoryPage, ChatHistoryRequest,
+    ChatMediaEntries, ChatMediaEntry, ChatMediaListRequest, ChatPasteMedia, ChatPickFiles,
+    ChatResume, ChatSnapshot, ChatSubmit, MODEL_STATE_EVENT, ModelOptionEntry, ModelState,
+    QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions,
+    ResumeListRequest, ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel,
+    SlashCommandEntry, SlashCommands,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use crate::chat_page::turns::{group_turns_before, group_turns_tail, grouped_item_count};
@@ -41,9 +41,7 @@ use crate::client::acp::{AcpModelState, AcpSession};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::components::{AgentMessages, AgentSession, PromptQueue};
 #[cfg(not(target_arch = "wasm32"))]
-use crate::events::{
-    AgentApprovalReply, AgentChoiceSelected, ApprovalDecision, WorkspacePickerStartRequest,
-};
+use crate::events::{AgentApprovalReply, AgentChoiceSelected, ApprovalDecision};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::handoff::{DEFAULT_CONTEXT_LIMIT, ImportedConversation, build_context};
 #[cfg(not(target_arch = "wasm32"))]
@@ -179,7 +177,6 @@ impl Plugin for AgentChatPagePlugin {
                 ResumeSession,
                 RuntimeSwitchRequest,
                 SelectModel,
-                ChatChooseWorkspace,
             )>::for_hosts(&["agent", "start"]))
             .add_plugins(BinEventEmitterPlugin::<(
                 ChatPickFiles,
@@ -197,7 +194,6 @@ impl Plugin for AgentChatPagePlugin {
             .add_observer(on_chat_clear_queue)
             .add_observer(on_chat_cancel_queued_prompt)
             .add_observer(on_chat_escape)
-            .add_observer(on_chat_choose_workspace)
             .add_observer(on_chat_choice_selected)
             .add_observer(on_chat_history_request)
             .add_observer(on_chat_pick_files)
@@ -634,13 +630,6 @@ fn on_chat_attachment_preview_request(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn on_chat_choose_workspace(trigger: On<BinReceive<ChatChooseWorkspace>>, mut commands: Commands) {
-    commands.trigger(WorkspacePickerStartRequest {
-        webview: trigger.event().webview,
-    });
-}
-
-#[cfg(not(target_arch = "wasm32"))]
 fn on_chat_choice_selected(trigger: On<BinReceive<ChatChoiceSelected>>, mut commands: Commands) {
     commands.trigger(AgentChoiceSelected {
         webview: trigger.event().webview,
@@ -753,7 +742,6 @@ fn sync_chat_to_ready_views(
         Option<&ImportedConversation>,
     )>,
     acp_sessions: Query<(&AcpSession, Option<&AcpModelState>)>,
-    workspace_selections: Query<(), With<crate::plugin::PendingWorkspaceSelection>>,
     choices: Query<&crate::plugin::PendingAgentChoice>,
     browsers: NonSend<Browsers>,
     mut commands: Commands,
@@ -781,7 +769,6 @@ fn sync_chat_to_ready_views(
                 meta,
                 queue,
                 imported,
-                workspace_selections.contains(webview),
                 choices.get(webview).ok(),
             ),
         ));
@@ -920,7 +907,6 @@ fn snapshot_of(
     meta: Option<&PageMetadata>,
     queue: &PromptQueue,
     imported: Option<&ImportedConversation>,
-    workspace_selection_pending: bool,
     choice: Option<&crate::plugin::PendingAgentChoice>,
 ) -> ChatSnapshot {
     let durations: &[u32] = turn_meta.map(|m| m.durations.as_slice()).unwrap_or(&[]);
@@ -984,7 +970,6 @@ fn snapshot_of(
                 u32::try_from(grouped_item_count(&imported.messages, &[])).unwrap_or(u32::MAX)
             })
             .unwrap_or_default(),
-        workspace_selection_pending,
         choice_question: choice
             .map(|choice| choice.question.clone())
             .unwrap_or_default(),
@@ -1034,7 +1019,6 @@ fn push_chat_to_page(
     >,
     children: Query<&Children>,
     is_browser: Query<(), With<vmux_layout::Browser>>,
-    workspace_selections: Query<(), With<crate::plugin::PendingWorkspaceSelection>>,
     choices: Query<&crate::plugin::PendingAgentChoice>,
     browsers: NonSend<Browsers>,
     mut commands: Commands,
@@ -1060,7 +1044,6 @@ fn push_chat_to_page(
                 meta,
                 queue,
                 imported,
-                workspace_selections.contains(webview),
                 choices.get(webview).ok(),
             ),
         ));
@@ -1922,12 +1905,10 @@ mod native_tests {
             None,
             &PromptQueue::default(),
             Some(&imported),
-            true,
             None,
         );
 
         assert_eq!(snapshot.handoff_message_count, 2);
-        assert!(snapshot.workspace_selection_pending);
     }
 
     #[test]
@@ -1944,7 +1925,6 @@ mod native_tests {
             None,
             &PromptQueue::default(),
             None,
-            false,
             None,
         );
 
@@ -2284,21 +2264,6 @@ mod native_tests {
         assert!(source.contains("CHAT_ATTACHMENT_PREVIEWS_EVENT"));
         assert!(source.contains("render_user_attachment"));
         assert!(source.contains("max-h-80 max-w-full object-contain"));
-    }
-
-    #[test]
-    fn workspace_selection_waits_for_inline_user_action() {
-        let page = include_str!("chat_page/page.rs");
-        let card = page
-            .find("if workspace_selection_pending()")
-            .expect("workspace card");
-        let composer = page.find("PromptComposer {").expect("composer");
-
-        assert!(card < composer);
-        assert!(page.contains("Choose repository folder"));
-        assert!(page.contains("Choose folder"));
-        assert!(page.contains("try_cef_bin_emit_rkyv(&ChatChooseWorkspace)"));
-        assert!(include_str!("chat_page.rs").contains("WorkspacePickerStartRequest"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -25,23 +25,26 @@ use bevy_cef::prelude::{BinEventEmitterPlugin, BinHostEmitEvent, BinReceive, Bro
 use crate::chat_page::event::{
     CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_HISTORY_MAX_PAGE_SIZE,
     CHAT_HISTORY_PAGE_EVENT, CHAT_INITIAL_ITEM_LIMIT, CHAT_MEDIA_ENTRIES_EVENT,
-    CHAT_SNAPSHOT_EVENT, ChatApproval, ChatAttachPaths, ChatAttachment,
+    CHAT_SNAPSHOT_EVENT, COMPOSER_CONTEXT_EVENT, ChatApproval, ChatAttachPaths, ChatAttachment,
     ChatAttachmentPreviewRequest, ChatAttachments, ChatCancel, ChatCancelQueuedPrompt,
-    ChatChoiceSelected, ChatClearQueue, ChatEscape, ChatHistoryPage, ChatHistoryRequest,
-    ChatMediaEntries, ChatMediaEntry, ChatMediaListRequest, ChatPasteMedia, ChatPickFiles,
-    ChatResume, ChatSnapshot, ChatSubmit, MODEL_STATE_EVENT, ModelOptionEntry, ModelState,
-    QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions,
-    ResumeListRequest, ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel,
-    SlashCommandEntry, SlashCommands,
+    ChatChoiceSelected, ChatClearQueue, ChatCreateWorktree, ChatEscape, ChatHistoryPage,
+    ChatHistoryRequest, ChatMediaEntries, ChatMediaEntry, ChatMediaListRequest, ChatPasteMedia,
+    ChatPickFiles, ChatResume, ChatSelectWorkspace, ChatSnapshot, ChatSubmit, ComposerContext,
+    MODEL_STATE_EVENT, ModelOptionEntry, ModelState, QueuedPromptSnapshot,
+    RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions, ResumeListRequest,
+    ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry,
+    SlashCommands,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use crate::chat_page::turns::{group_turns_before, group_turns_tail, grouped_item_count};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::client::acp::{AcpModelState, AcpSession};
 #[cfg(not(target_arch = "wasm32"))]
-use crate::components::{AgentMessages, AgentSession, PromptQueue};
+use crate::components::{AgentApprovalPolicy, AgentMessages, AgentSession, PromptQueue};
 #[cfg(not(target_arch = "wasm32"))]
-use crate::events::{AgentApprovalReply, AgentChoiceSelected, ApprovalDecision};
+use crate::events::{
+    AgentApprovalReply, AgentChoiceSelected, AgentCommandRequest, ApprovalDecision, CommandOrigin,
+};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::handoff::{DEFAULT_CONTEXT_LIMIT, ImportedConversation, build_context};
 #[cfg(not(target_arch = "wasm32"))]
@@ -57,7 +60,9 @@ use vmux_core::team::Profile;
 #[cfg(not(target_arch = "wasm32"))]
 use vmux_service::client::ServiceClient;
 #[cfg(not(target_arch = "wasm32"))]
-use vmux_service::protocol::{AgentAttachment, ClientMessage};
+use vmux_service::protocol::{
+    AgentAttachment, AgentCommand as ServiceAgentCommand, AgentRequestId, ClientMessage,
+};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
@@ -186,6 +191,8 @@ impl Plugin for AgentChatPagePlugin {
                 ChatAttachmentPreviewRequest,
                 ChatChoiceSelected,
                 ChatHistoryRequest,
+                ChatSelectWorkspace,
+                ChatCreateWorktree,
             )>::for_hosts(&["agent", "start"]))
             .add_observer(on_chat_submit)
             .add_observer(on_chat_approval)
@@ -205,6 +212,8 @@ impl Plugin for AgentChatPagePlugin {
             .add_observer(on_resume_session)
             .add_observer(on_runtime_switch_request)
             .add_observer(on_select_model)
+            .add_observer(on_chat_select_workspace)
+            .add_observer(on_chat_create_worktree)
             .add_observer(reset_chat_synced_on_page_ready)
             .add_systems(
                 Update,
@@ -213,6 +222,7 @@ impl Plugin for AgentChatPagePlugin {
                     sync_chat_to_ready_views,
                     push_acp_model_state_to_page,
                     push_removed_acp_model_state_to_page,
+                    push_composer_context_to_page,
                     send_acp_model_requests,
                     drain_chat_attachment_tasks,
                     drain_chat_media_list_tasks,
@@ -831,6 +841,180 @@ fn emit_model_state(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ComposerContextInput {
+    cwd: std::path::PathBuf,
+    workspace_selected: bool,
+    worktree: Option<vmux_layout::tab::TabWorktree>,
+    can_manage_workspace: bool,
+    auto_allow_count: u32,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Default)]
+struct ComposerContextCache {
+    entries: std::collections::HashMap<Entity, ComposerContextCacheEntry>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+struct ComposerContextCacheEntry {
+    input: ComposerContextInput,
+    context: ComposerContext,
+    refreshed_at: f32,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn composer_context_input(
+    stack: Entity,
+    acp: Option<&AcpSession>,
+    policy: Option<&AgentApprovalPolicy>,
+    child_of: &Query<&ChildOf>,
+    tabs: &Query<(
+        &vmux_layout::tab::Tab,
+        Option<&vmux_layout::tab::TabWorkspace>,
+        Option<&vmux_layout::tab::TabWorktree>,
+    )>,
+) -> ComposerContextInput {
+    let mut current = stack;
+    let mut tab_dir = None;
+    let mut workspace_selected = false;
+    let mut worktree = None;
+    loop {
+        if let Ok((tab, workspace, managed)) = tabs.get(current) {
+            tab_dir = tab.startup_dir.as_ref().map(std::path::PathBuf::from);
+            workspace_selected = workspace.is_some() || tab.startup_dir.is_some();
+            worktree = managed.cloned();
+            break;
+        }
+        let Ok(parent) = child_of.get(current) else {
+            break;
+        };
+        current = parent.parent();
+    }
+    ComposerContextInput {
+        cwd: tab_dir
+            .or_else(|| acp.map(|session| session.cwd.clone()))
+            .unwrap_or_default(),
+        workspace_selected,
+        worktree,
+        can_manage_workspace: acp.is_some(),
+        auto_allow_count: policy
+            .map(|policy| u32::try_from(policy.auto.len()).unwrap_or(u32::MAX))
+            .unwrap_or_default(),
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn composer_context_from_input(input: &ComposerContextInput) -> ComposerContext {
+    let info = (!input.cwd.as_os_str().is_empty())
+        .then(|| vmux_git::worktree::repo_info(&input.cwd))
+        .flatten();
+    let is_git_repo = info.is_some() || input.cwd.join(".git").exists();
+    let branch = info
+        .as_ref()
+        .map(|info| info.branch.clone())
+        .filter(|branch| !branch.is_empty())
+        .or_else(|| {
+            input
+                .worktree
+                .as_ref()
+                .map(|worktree| worktree.branch.clone())
+        })
+        .or_else(|| {
+            is_git_repo
+                .then(|| vmux_git::worktree::head_ref(&input.cwd).ok())
+                .flatten()
+        })
+        .unwrap_or_default();
+    let workspace_name = input
+        .cwd
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| input.cwd.to_string_lossy().into_owned());
+    ComposerContext {
+        cwd: input.cwd.to_string_lossy().into_owned(),
+        workspace_name,
+        workspace_selected: input.workspace_selected,
+        is_git_repo,
+        is_worktree: info.as_ref().is_some_and(|info| info.is_worktree) || input.worktree.is_some(),
+        branch,
+        base_ref: input
+            .worktree
+            .as_ref()
+            .map(|worktree| worktree.base_ref.clone())
+            .unwrap_or_default(),
+        uncommitted: info
+            .as_ref()
+            .map(|info| info.uncommitted)
+            .unwrap_or_default(),
+        ahead: info.as_ref().map(|info| info.ahead).unwrap_or_default(),
+        can_manage_workspace: input.can_manage_workspace,
+        auto_allow_count: input.auto_allow_count,
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(clippy::too_many_arguments)]
+fn push_composer_context_to_page(
+    views: Query<(Entity, &ChildOf, Ref<vmux_core::page::PageReady>), With<AgentChatView>>,
+    sessions: Query<(Option<&AcpSession>, Option<&AgentApprovalPolicy>)>,
+    child_of: Query<&ChildOf>,
+    tabs: Query<(
+        &vmux_layout::tab::Tab,
+        Option<&vmux_layout::tab::TabWorkspace>,
+        Option<&vmux_layout::tab::TabWorktree>,
+    )>,
+    browsers: NonSend<Browsers>,
+    time: Res<Time>,
+    mut cache: Local<ComposerContextCache>,
+    mut commands: Commands,
+) {
+    let now = time.elapsed_secs();
+    for (webview, parent, ready) in &views {
+        if !browsers.has_browser(webview) || !browsers.host_emit_ready(&webview) {
+            continue;
+        }
+        let stack = parent.parent();
+        let Ok((acp, policy)) = sessions.get(stack) else {
+            continue;
+        };
+        let input = composer_context_input(stack, acp, policy, &child_of, &tabs);
+        let refresh = cache
+            .entries
+            .get(&webview)
+            .is_none_or(|entry| entry.input != input || now - entry.refreshed_at >= 3.0);
+        if !refresh && !ready.is_changed() {
+            continue;
+        }
+        let context = if refresh {
+            composer_context_from_input(&input)
+        } else {
+            cache.entries.get(&webview).unwrap().context.clone()
+        };
+        let changed = cache
+            .entries
+            .get(&webview)
+            .is_none_or(|entry| entry.context != context);
+        if changed || ready.is_changed() {
+            commands.trigger(BinHostEmitEvent::from_rkyv(
+                webview,
+                COMPOSER_CONTEXT_EVENT,
+                &context,
+            ));
+        }
+        cache.entries.insert(
+            webview,
+            ComposerContextCacheEntry {
+                input,
+                context,
+                refreshed_at: now,
+            },
+        );
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 fn push_acp_model_state_to_page(
     sessions: Query<(Entity, &AcpSession, &AcpModelState), Changed<AcpModelState>>,
     children: Query<&Children>,
@@ -1364,6 +1548,50 @@ fn on_select_model(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+fn on_chat_select_workspace(
+    trigger: On<BinReceive<ChatSelectWorkspace>>,
+    child_of: Query<&ChildOf>,
+    sessions: Query<&AcpSession>,
+    mut requests: MessageWriter<AgentCommandRequest>,
+) {
+    let Ok(parent) = child_of.get(trigger.event().webview) else {
+        return;
+    };
+    let Ok(session) = sessions.get(parent.parent()) else {
+        return;
+    };
+    requests.write(AgentCommandRequest {
+        request_id: AgentRequestId::new(),
+        origin: CommandOrigin::User,
+        command: ServiceAgentCommand::ChooseWorkspace {
+            anchor: session.anchor,
+        },
+    });
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn on_chat_create_worktree(
+    trigger: On<BinReceive<ChatCreateWorktree>>,
+    child_of: Query<&ChildOf>,
+    sessions: Query<&AcpSession>,
+    mut requests: MessageWriter<AgentCommandRequest>,
+) {
+    let Ok(parent) = child_of.get(trigger.event().webview) else {
+        return;
+    };
+    let Ok(session) = sessions.get(parent.parent()) else {
+        return;
+    };
+    requests.write(AgentCommandRequest {
+        request_id: AgentRequestId::new(),
+        origin: CommandOrigin::User,
+        command: ServiceAgentCommand::CreateWorktree {
+            anchor: session.anchor,
+        },
+    });
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 fn send_acp_model_requests(
     mut requests: MessageReader<AcpSetModelRequest>,
     service: Option<Res<ServiceClient>>,
@@ -1828,6 +2056,51 @@ mod native_tests {
                 .count(),
             0
         );
+    }
+
+    #[test]
+    fn composer_workspace_controls_dispatch_for_current_session() {
+        let mut app = App::new();
+        app.add_message::<AgentCommandRequest>()
+            .add_observer(on_chat_select_workspace)
+            .add_observer(on_chat_create_worktree);
+        let anchor = vmux_core::ProcessId::new();
+        let stack = app
+            .world_mut()
+            .spawn(AcpSession {
+                agent_id: "claude".into(),
+                sid: "s1".into(),
+                cwd: "/tmp".into(),
+                anchor,
+                resume: None,
+            })
+            .id();
+        let webview = app.world_mut().spawn(ChildOf(stack)).id();
+
+        app.world_mut().trigger(BinReceive {
+            webview,
+            payload: ChatSelectWorkspace,
+        });
+        app.world_mut().trigger(BinReceive {
+            webview,
+            payload: ChatCreateWorktree,
+        });
+
+        let requests = app
+            .world_mut()
+            .resource_mut::<Messages<AgentCommandRequest>>()
+            .drain()
+            .collect::<Vec<_>>();
+        assert_eq!(requests.len(), 2);
+        assert!(matches!(requests[0].origin, CommandOrigin::User));
+        assert!(matches!(
+            requests[0].command,
+            ServiceAgentCommand::ChooseWorkspace { anchor: got } if got == anchor
+        ));
+        assert!(matches!(
+            requests[1].command,
+            ServiceAgentCommand::CreateWorktree { anchor: got } if got == anchor
+        ));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -40,7 +40,9 @@ use crate::chat_page::turns::{group_turns_before, group_turns_tail, grouped_item
 #[cfg(not(target_arch = "wasm32"))]
 use crate::client::acp::{AcpModelState, AcpSession};
 #[cfg(not(target_arch = "wasm32"))]
-use crate::components::{AgentApprovalPolicy, AgentMessages, AgentSession, PromptQueue};
+use crate::components::{
+    AgentApprovalPolicy, AgentConversationTitle, AgentMessages, AgentSession, PromptQueue,
+};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::events::{
     AgentApprovalReply, AgentChoiceSelected, AgentCommandRequest, ApprovalDecision, CommandOrigin,
@@ -750,6 +752,7 @@ fn sync_chat_to_ready_views(
         Option<&PageMetadata>,
         &PromptQueue,
         Option<&ImportedConversation>,
+        Option<&AgentConversationTitle>,
     )>,
     acp_sessions: Query<(&AcpSession, Option<&AcpModelState>)>,
     choices: Query<&crate::plugin::PendingAgentChoice>,
@@ -761,7 +764,8 @@ fn sync_chat_to_ready_views(
             continue;
         };
         let stack = parent.parent();
-        let Ok((messages, state, turn_meta, profile, meta, queue, imported)) = sessions.get(stack)
+        let Ok((messages, state, turn_meta, profile, meta, queue, imported, title)) =
+            sessions.get(stack)
         else {
             continue;
         };
@@ -779,6 +783,7 @@ fn sync_chat_to_ready_views(
                 meta,
                 queue,
                 imported,
+                title,
                 choices.get(webview).ok(),
             ),
         ));
@@ -971,6 +976,13 @@ fn push_composer_context_to_page(
     mut commands: Commands,
 ) {
     let now = time.elapsed_secs();
+    let live_views = views
+        .iter()
+        .map(|(webview, _, _)| webview)
+        .collect::<std::collections::HashSet<_>>();
+    cache
+        .entries
+        .retain(|webview, _| live_views.contains(webview));
     for (webview, parent, ready) in &views {
         if !browsers.has_browser(webview) || !browsers.host_emit_ready(&webview) {
             continue;
@@ -1091,6 +1103,7 @@ fn snapshot_of(
     meta: Option<&PageMetadata>,
     queue: &PromptQueue,
     imported: Option<&ImportedConversation>,
+    conversation_title: Option<&AgentConversationTitle>,
     choice: Option<&crate::plugin::PendingAgentChoice>,
 ) -> ChatSnapshot {
     let durations: &[u32] = turn_meta.map(|m| m.durations.as_slice()).unwrap_or(&[]);
@@ -1143,6 +1156,9 @@ fn snapshot_of(
         approval_name: name,
         approval_args_json: args_json,
         agent_name,
+        conversation_title: conversation_title
+            .map(|title| title.0.clone())
+            .unwrap_or_default(),
         agent_icon,
         accent_color,
         handoff_source: imported
@@ -1191,6 +1207,7 @@ fn push_chat_to_page(
             Option<&PageMetadata>,
             &PromptQueue,
             Option<&ImportedConversation>,
+            Option<&AgentConversationTitle>,
         ),
         Or<(
             Changed<AgentMessages>,
@@ -1199,6 +1216,7 @@ fn push_chat_to_page(
             Changed<PromptQueue>,
             Changed<Profile>,
             Changed<ImportedConversation>,
+            Changed<AgentConversationTitle>,
         )>,
     >,
     children: Query<&Children>,
@@ -1207,7 +1225,7 @@ fn push_chat_to_page(
     browsers: NonSend<Browsers>,
     mut commands: Commands,
 ) {
-    for (stack, messages, state, turn_meta, profile, meta, queue, imported) in &sessions {
+    for (stack, messages, state, turn_meta, profile, meta, queue, imported, title) in &sessions {
         let Ok(kids) = children.get(stack) else {
             continue;
         };
@@ -1228,6 +1246,7 @@ fn push_chat_to_page(
                 meta,
                 queue,
                 imported,
+                title,
                 choices.get(webview).ok(),
             ),
         ));
@@ -2179,6 +2198,7 @@ mod native_tests {
             &PromptQueue::default(),
             Some(&imported),
             None,
+            None,
         );
 
         assert_eq!(snapshot.handoff_message_count, 2);
@@ -2199,12 +2219,34 @@ mod native_tests {
             &PromptQueue::default(),
             None,
             None,
+            None,
         );
 
         assert_eq!(snapshot.approval_name, "vmux.run");
         assert_eq!(
             snapshot.approval_args_json,
             r#"{"command":"echo hi","focus":true}"#
+        );
+    }
+
+    #[test]
+    fn snapshot_includes_model_written_conversation_title() {
+        let title = AgentConversationTitle("Refine generated chat summaries".into());
+        let snapshot = snapshot_of(
+            &AgentMessages::default(),
+            &AgentRunState::Idle,
+            None,
+            None,
+            None,
+            &PromptQueue::default(),
+            None,
+            Some(&title),
+            None,
+        );
+
+        assert_eq!(
+            snapshot.conversation_title,
+            "Refine generated chat summaries"
         );
     }
 
@@ -2484,36 +2526,6 @@ mod native_tests {
         assert!(source.contains("id: \"chat-scroll\""));
         assert!(source.contains("bg-gradient-to-t from-background via-background/95"));
         assert!(!source.contains("absolute inset-0 z-20 flex items-center justify-center"));
-    }
-
-    #[test]
-    fn composer_auto_grows_and_contains_action_button() {
-        let source = include_str!("chat_page/page.rs");
-        let prompt_box = include_str!("../../vmux_ui/src/components/prompt_box.rs");
-        let composer = include_str!("../../vmux_ui/src/components/prompt_composer.rs");
-        assert!(composer.contains("fn resize_prompt_textarea"));
-        assert!(composer.contains("textarea.scroll_height().clamp(40, 160)"));
-        assert!(composer.contains("max-h-40 min-h-10"));
-        assert!(source.contains("PromptComposer {"));
-        assert!(composer.contains("PromptBox {"));
-        assert!(source.contains("PromptPopup {"));
-        assert!(prompt_box.contains("rounded-2xl"));
-        assert!(prompt_box.contains("backdrop-blur-3xl backdrop-saturate-150"));
-        assert!(composer.contains("h-8 w-8 shrink-0 self-center items-center justify-center"));
-        assert!(source.contains("show_capability_examples"));
-        assert!(source.contains("attachments.read().is_empty()"));
-        assert!(source.contains("Type / for commands or @ for media"));
-        assert!(composer.contains("prompt_prefix_at_utf16"));
-        assert!(composer.contains("vmux-prompt-caret"));
-        assert!(composer.contains("caret-color:transparent"));
-        assert!(composer.contains("install_prompt_focus_tracking"));
-        assert!(composer.contains("document.has_focus().unwrap_or(false)"));
-        assert!(composer.contains("add_event_listener_with_callback(\"focus\""));
-        assert!(composer.contains("add_event_listener_with_callback(\"blur\""));
-        assert!(composer.contains("if caret().is_some()"));
-        assert!(composer.contains("onkeyup"));
-        assert!(composer.contains("onscroll"));
-        assert!(composer.contains("placeholder:text-transparent"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/composer.rs
+++ b/crates/vmux_agent/src/chat_page/composer.rs
@@ -50,6 +50,8 @@ pub(crate) enum ToolActivity {
     Layout,
     Worktree,
     Image,
+    Screenshot,
+    OpenPage,
     Browser,
     Search,
     Command,
@@ -270,7 +272,11 @@ pub(crate) fn tool_activity(name: &str) -> ToolActivity {
     let lower = name.to_ascii_lowercase();
     if is_guardian_tool(name) {
         ToolActivity::Guardian
-    } else if lower.contains("read_file") || lower.contains("read file") {
+    } else if lower.contains("read_file")
+        || lower.contains("read file")
+        || lower.contains("open_file")
+        || lower.contains("open file")
+    {
         ToolActivity::ReadFile
     } else if matches!(lower.as_str(), "edit" | "write")
         || lower.contains("editing file")
@@ -294,6 +300,10 @@ pub(crate) fn tool_activity(name: &str) -> ToolActivity {
         || lower.contains("delete_space")
     {
         ToolActivity::Layout
+    } else if lower.contains("screenshot") {
+        ToolActivity::Screenshot
+    } else if lower.contains("open_page") || lower.contains("open page") {
+        ToolActivity::OpenPage
     } else if lower.contains("view_image") || lower.contains("view image") {
         ToolActivity::Image
     } else if lower.contains("browser") || lower.contains("navigate") || lower.contains("web_") {
@@ -756,6 +766,9 @@ mod tests {
         assert_eq!(tool_activity("read_layout"), ToolActivity::Layout);
         assert_eq!(tool_activity("create_worktree"), ToolActivity::Worktree);
         assert_eq!(tool_activity("view_image"), ToolActivity::Image);
+        assert_eq!(tool_activity("vmux_screenshot"), ToolActivity::Screenshot);
+        assert_eq!(tool_activity("vmux_open_page"), ToolActivity::OpenPage);
+        assert_eq!(tool_activity("vmux_open_file"), ToolActivity::ReadFile);
         assert_eq!(tool_activity("browser_navigate"), ToolActivity::Browser);
         assert_eq!(tool_activity("search_files"), ToolActivity::Search);
         assert_eq!(tool_activity("exec_command"), ToolActivity::Command);

--- a/crates/vmux_agent/src/chat_page/composer.rs
+++ b/crates/vmux_agent/src/chat_page/composer.rs
@@ -1,8 +1,4 @@
-#[cfg(test)]
-use super::event::ChatBlock;
-use super::event::{
-    ChatItem, ModelOptionEntry, ResumableSessionEntry, SlashCommandEntry, is_guardian_tool,
-};
+use super::event::{ModelOptionEntry, ResumableSessionEntry, SlashCommandEntry, is_guardian_tool};
 use unicode_segmentation::UnicodeSegmentation;
 
 const CHAT_PAGE_TITLE_MAX_GRAPHEMES: usize = 64;
@@ -256,16 +252,13 @@ pub(crate) fn should_clear_draft_on_escape(
     !streaming && queue_empty && !draft_empty
 }
 
-pub(crate) fn chat_page_title(items: &[ChatItem], _status: &str, agent_name: &str) -> String {
-    items
-        .iter()
-        .filter_map(|item| match item {
-            ChatItem::User { text, .. } => Some(text.as_str()),
-            ChatItem::Turn(_) => None,
-        })
-        .map(normalize_chat_page_title)
-        .find(|title| !title.is_empty())
-        .unwrap_or_else(|| normalize_chat_page_title(agent_name))
+pub(crate) fn chat_page_title(generated_title: &str, agent_name: &str) -> String {
+    let title = normalize_chat_page_title(generated_title);
+    if title.is_empty() {
+        normalize_chat_page_title(agent_name)
+    } else {
+        title
+    }
 }
 
 pub(crate) fn tool_activity(name: &str) -> ToolActivity {
@@ -442,7 +435,7 @@ fn utf16_to_byte(value: &str, offset: u32) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::chat_page::event::{ChatTurn, SlashCommandEntry};
+    use crate::chat_page::event::SlashCommandEntry;
 
     fn session(sid: &str, title: &str, cwd: &str) -> ResumableSessionEntry {
         ResumableSessionEntry {
@@ -645,117 +638,30 @@ mod tests {
     }
 
     #[test]
-    fn chat_page_title_uses_first_prompt_as_stable_topic() {
-        let items = vec![
-            ChatItem::user("  Fix the\ndynamic   agent page title  "),
-            ChatItem::Turn(ChatTurn {
-                running: true,
-                ..Default::default()
-            }),
-            ChatItem::user("continue"),
-        ];
-
+    fn chat_page_title_uses_model_written_summary() {
         assert_eq!(
-            chat_page_title(&items, "streaming", "Codex"),
-            "Fix the dynamic agent page title"
+            chat_page_title("  Refine model-generated\n summaries  ", "Codex"),
+            "Refine model-generated summaries"
         );
-        assert_eq!(
-            chat_page_title(&items, "awaiting", "Codex"),
-            "Fix the dynamic agent page title"
-        );
-    }
-
-    #[test]
-    fn chat_page_title_does_not_include_activity_emoji() {
-        fn title(block: ChatBlock) -> String {
-            chat_page_title(
-                &[
-                    ChatItem::user("Ship dynamic titles"),
-                    ChatItem::Turn(ChatTurn {
-                        blocks: vec![block],
-                        running: true,
-                        ..Default::default()
-                    }),
-                ],
-                "streaming",
-                "Codex",
-            )
-        }
-
-        assert_eq!(
-            title(ChatBlock::Thinking("hmm".into())),
-            "Ship dynamic titles"
-        );
-        assert_eq!(
-            title(ChatBlock::ToolUse {
-                call_id: "1".into(),
-                name: "functions.exec_command".into(),
-                args: "{}".into(),
-                parent_call_id: None,
-            }),
-            "Ship dynamic titles"
-        );
-        assert_eq!(
-            title(ChatBlock::ToolUse {
-                call_id: "2".into(),
-                name: "search_files".into(),
-                args: "{}".into(),
-                parent_call_id: None,
-            }),
-            "Ship dynamic titles"
-        );
-        assert_eq!(
-            title(ChatBlock::Plan { steps: Vec::new() }),
-            "Ship dynamic titles"
-        );
-        assert_eq!(
-            title(ChatBlock::Diff {
-                call_id: "3".into(),
-                path: "page.rs".into(),
-                old_text: None,
-                new_text: String::new(),
-            }),
-            "Ship dynamic titles"
-        );
-        assert_eq!(
-            title(ChatBlock::Text("done soon".into())),
-            "Ship dynamic titles"
-        );
-        assert_eq!(
-            title(ChatBlock::Reconnect {
-                attempt: 2,
-                total: 5,
-            }),
-            "Ship dynamic titles"
-        );
+        assert_eq!(chat_page_title("", "Codex"), "Codex");
     }
 
     #[test]
     fn chat_page_title_falls_back_to_agent_and_truncates_topic() {
-        assert_eq!(chat_page_title(&[], "idle", "Codex"), "Codex");
+        assert_eq!(chat_page_title("", "Codex"), "Codex");
 
-        let items = vec![ChatItem::user(
-            "a".repeat(CHAT_PAGE_TITLE_MAX_GRAPHEMES + 10),
-        )];
-        let title = chat_page_title(&items, "idle", "Codex");
+        let generated = "a".repeat(CHAT_PAGE_TITLE_MAX_GRAPHEMES + 10);
+        let title = chat_page_title(&generated, "Codex");
         assert_eq!(title.graphemes(true).count(), CHAT_PAGE_TITLE_MAX_GRAPHEMES);
         assert!(title.ends_with('…'));
         assert_eq!(
-            chat_page_title(&[ChatItem::user("Fix \u{202E}\x1b title")], "idle", "Codex"),
+            chat_page_title("Fix \u{202E}\x1b title", "Codex"),
             "Fix title"
         );
         assert_eq!(
-            chat_page_title(
-                &[
-                    ChatItem::user("\u{202E}"),
-                    ChatItem::user("Keep 👩‍💻 and فارسی\u{200C}"),
-                ],
-                "errored",
-                "Codex"
-            ),
+            chat_page_title("Keep 👩‍💻 and فارسی\u{200C}", "Codex"),
             "Keep 👩‍💻 and فارسی\u{200C}"
         );
-        assert_eq!(chat_page_title(&[], "installing", "Codex"), "Codex");
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/composer.rs
+++ b/crates/vmux_agent/src/chat_page/composer.rs
@@ -60,6 +60,15 @@ pub(crate) fn should_expand_thinking(block_index: usize, block_count: usize) -> 
     block_index + 1 == block_count
 }
 
+pub(crate) fn approval_decision_for_index(index: usize) -> Option<u8> {
+    match index {
+        0 => Some(1),
+        1 => Some(2),
+        2 => Some(0),
+        _ => None,
+    }
+}
+
 pub(crate) fn selector_mode(draft: &str) -> SelectorMode<'_> {
     let Some(token) = draft.strip_prefix('/') else {
         return SelectorMode::None;
@@ -453,6 +462,14 @@ mod tests {
     fn thinking_expands_only_until_the_next_block() {
         assert!(should_expand_thinking(0, 1));
         assert!(!should_expand_thinking(0, 2));
+    }
+
+    #[test]
+    fn approval_selector_maps_allow_always_and_deny() {
+        assert_eq!(approval_decision_for_index(0), Some(1));
+        assert_eq!(approval_decision_for_index(1), Some(2));
+        assert_eq!(approval_decision_for_index(2), Some(0));
+        assert_eq!(approval_decision_for_index(3), None);
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/composer.rs
+++ b/crates/vmux_agent/src/chat_page/composer.rs
@@ -46,6 +46,9 @@ pub(crate) enum ResumeMenuState {
 pub(crate) enum ToolActivity {
     Guardian,
     ReadFile,
+    WriteFile,
+    Layout,
+    Worktree,
     Image,
     Browser,
     Search,
@@ -260,6 +263,28 @@ pub(crate) fn tool_activity(name: &str) -> ToolActivity {
         ToolActivity::Guardian
     } else if lower.contains("read_file") || lower.contains("read file") {
         ToolActivity::ReadFile
+    } else if matches!(lower.as_str(), "edit" | "write")
+        || lower.contains("editing file")
+        || lower.contains("edited file")
+        || lower.contains("write file")
+        || lower.contains("apply_patch")
+        || lower.contains("edit_file")
+        || lower.contains("write_file")
+        || lower.contains("multi_edit")
+    {
+        ToolActivity::WriteFile
+    } else if lower.contains("worktree")
+        || lower.contains("workspace")
+        || lower.contains("repository")
+    {
+        ToolActivity::Worktree
+    } else if lower.contains("layout")
+        || lower.contains("list_spaces")
+        || lower.contains("create_space")
+        || lower.contains("rename_space")
+        || lower.contains("delete_space")
+    {
+        ToolActivity::Layout
     } else if lower.contains("view_image") || lower.contains("view image") {
         ToolActivity::Image
     } else if lower.contains("browser") || lower.contains("navigate") || lower.contains("web_") {
@@ -710,6 +735,9 @@ mod tests {
     fn tool_activity_classifies_timeline_icons() {
         assert_eq!(tool_activity("guardian_review"), ToolActivity::Guardian);
         assert_eq!(tool_activity("read_file"), ToolActivity::ReadFile);
+        assert_eq!(tool_activity("apply_patch"), ToolActivity::WriteFile);
+        assert_eq!(tool_activity("read_layout"), ToolActivity::Layout);
+        assert_eq!(tool_activity("create_worktree"), ToolActivity::Worktree);
         assert_eq!(tool_activity("view_image"), ToolActivity::Image);
         assert_eq!(tool_activity("browser_navigate"), ToolActivity::Browser);
         assert_eq!(tool_activity("search_files"), ToolActivity::Search);

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -5,6 +5,7 @@
 /// Bin-event id: native → page conversation/run-state snapshot.
 pub const CHAT_SNAPSHOT_EVENT: &str = "chat_snapshot";
 pub const CHAT_HISTORY_PAGE_EVENT: &str = "chat_history_page";
+pub const COMPOSER_CONTEXT_EVENT: &str = "composer_context";
 pub const CHAT_INITIAL_ITEM_LIMIT: u32 = 48;
 pub const CHAT_HISTORY_PAGE_SIZE: u32 = 40;
 pub const CHAT_HISTORY_MAX_PAGE_SIZE: u32 = 80;
@@ -71,6 +72,32 @@ pub struct ChatSnapshot {
     pub handoff_message_count: u32,
     pub choice_question: String,
     pub choice_options: Vec<String>,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ComposerContext {
+    pub cwd: String,
+    pub workspace_name: String,
+    pub workspace_selected: bool,
+    pub is_git_repo: bool,
+    pub is_worktree: bool,
+    pub branch: String,
+    pub base_ref: String,
+    pub uncommitted: u32,
+    pub ahead: u32,
+    pub can_manage_workspace: bool,
+    pub auto_allow_count: u32,
 }
 
 #[derive(
@@ -219,6 +246,30 @@ pub struct ChatCancelQueuedPrompt {
     rkyv::Deserialize,
 )]
 pub struct ChatEscape;
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatSelectWorkspace;
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ChatCreateWorktree;
 
 /// Bin-event id: native → page, the resumable-session list (answer to [`ResumeListRequest`]).
 pub const RESUMABLE_SESSIONS_EVENT: &str = "resumable_sessions";

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -69,7 +69,6 @@ pub struct ChatSnapshot {
     pub handoff_truncated: bool,
     /// Number of rendered [`ChatItem`] entries originating from the imported conversation.
     pub handoff_message_count: u32,
-    pub workspace_selection_pending: bool,
     pub choice_question: String,
     pub choice_options: Vec<String>,
 }
@@ -121,19 +120,6 @@ pub struct ChatSubmit {
     pub text: String,
     pub attachments: Vec<ChatSubmitAttachment>,
 }
-
-/// Page → native: open the workspace folder picker requested by the agent.
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    serde::Serialize,
-    serde::Deserialize,
-    rkyv::Archive,
-    rkyv::Serialize,
-    rkyv::Deserialize,
-)]
-pub struct ChatChooseWorkspace;
 
 /// Page → native: answer the active agent-authored multiple-choice prompt.
 #[derive(
@@ -513,6 +499,18 @@ pub(crate) fn is_guardian_tool(name: &str) -> bool {
 }
 
 impl ChatTurn {
+    #[cfg(any(test, target_arch = "wasm32"))]
+    pub(crate) fn latest_top_level_tool_index(&self) -> Option<usize> {
+        self.blocks
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(index, block)| match block {
+                ChatBlock::ToolUse { .. } if self.parent_tool_index(index).is_none() => Some(index),
+                _ => None,
+            })
+    }
+
     pub(crate) fn parent_tool_index(&self, index: usize) -> Option<usize> {
         let mut parent = self.direct_parent_index(index)?;
         for _ in 0..self.blocks.len() {
@@ -570,6 +568,20 @@ impl ChatTurn {
     }
 }
 
+#[cfg(any(test, target_arch = "wasm32"))]
+pub(crate) fn latest_tool_location(items: &[ChatItem]) -> Option<(usize, usize)> {
+    items
+        .iter()
+        .enumerate()
+        .rev()
+        .find_map(|(item_index, item)| match item {
+            ChatItem::Turn(turn) => turn
+                .latest_top_level_tool_index()
+                .map(|block_index| (item_index, block_index)),
+            ChatItem::User { .. } => None,
+        })
+}
+
 /// The curated verbs the running-turn header cycles through (owned by the shared contract, not
 /// the view). The page picks one at random every few seconds while streaming.
 pub const WORKING_VERBS: &[&str] = &[
@@ -609,7 +621,6 @@ mod tests {
             handoff_source: "Codex".to_string(),
             handoff_truncated: true,
             handoff_message_count: 2,
-            workspace_selection_pending: true,
             choice_question: "Repository?".into(),
             choice_options: vec!["Local".into(), "Remote".into(), "Create".into()],
             queued: vec![
@@ -641,7 +652,6 @@ mod tests {
         assert_eq!(back.handoff_source, "Codex");
         assert!(back.handoff_truncated);
         assert_eq!(back.handoff_message_count, 2);
-        assert!(back.workspace_selection_pending);
         assert_eq!(back.choice_question, "Repository?");
         assert_eq!(back.choice_options.len(), 3);
     }
@@ -784,6 +794,67 @@ mod tests {
         assert_eq!(turn.parent_tool_index(1), Some(0));
         assert_eq!(turn.parent_tool_index(2), Some(0));
         assert_eq!(turn.parent_tool_index(3), Some(0));
+    }
+
+    #[test]
+    fn latest_top_level_tool_ignores_results_and_nested_tools() {
+        let turn = ChatTurn {
+            blocks: vec![
+                ChatBlock::ToolUse {
+                    call_id: "first".into(),
+                    name: "read_file".into(),
+                    args: "{}".into(),
+                    parent_call_id: None,
+                },
+                ChatBlock::ToolResult {
+                    call_id: "first".into(),
+                    content: "done".into(),
+                    is_error: false,
+                },
+                ChatBlock::ToolUse {
+                    call_id: "nested".into(),
+                    name: "guardian_review".into(),
+                    args: "{}".into(),
+                    parent_call_id: Some("first".into()),
+                },
+                ChatBlock::ToolUse {
+                    call_id: "second".into(),
+                    name: "run".into(),
+                    args: "{}".into(),
+                    parent_call_id: None,
+                },
+            ],
+            ..Default::default()
+        };
+
+        assert_eq!(turn.latest_top_level_tool_index(), Some(3));
+    }
+
+    #[test]
+    fn latest_tool_location_selects_only_the_newest_turn_tool() {
+        let tool = |call_id: &str| ChatBlock::ToolUse {
+            call_id: call_id.into(),
+            name: "run".into(),
+            args: "{}".into(),
+            parent_call_id: None,
+        };
+        let items = vec![
+            ChatItem::Turn(ChatTurn {
+                blocks: vec![tool("old")],
+                ..Default::default()
+            }),
+            ChatItem::User {
+                text: "next".into(),
+                context: None,
+                attachments: Vec::new(),
+            },
+            ChatItem::Turn(ChatTurn {
+                blocks: vec![ChatBlock::Text("working".into()), tool("new")],
+                ..Default::default()
+            }),
+        ];
+
+        assert_eq!(latest_tool_location(&items), Some((2, 1)));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -62,6 +62,8 @@ pub struct ChatSnapshot {
     pub paused: bool,
     /// Agent display name (from the session `Profile`), for the header/hero.
     pub agent_name: String,
+    /// Model-written summary used as the conversation header and page title.
+    pub conversation_title: String,
     /// Agent favicon URL (from `PageMetadata.icon`); may be empty (page falls back per url).
     pub agent_icon: String,
     /// Agent brand accent color (hex, from the avatar), for loading/status accents.
@@ -669,6 +671,7 @@ mod tests {
             messages_start: 12,
             messages_total: 60,
             status: "streaming".to_string(),
+            conversation_title: "Refine generated summaries".to_string(),
             handoff_source: "Codex".to_string(),
             handoff_truncated: true,
             handoff_message_count: 2,
@@ -692,6 +695,7 @@ mod tests {
         let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&v).unwrap();
         let back = rkyv::from_bytes::<ChatSnapshot, rkyv::rancor::Error>(&bytes).unwrap();
         assert_eq!(back.status, "streaming");
+        assert_eq!(back.conversation_title, "Refine generated summaries");
         assert_eq!(back.messages_start, 12);
         assert_eq!(back.messages_total, 60);
         assert_eq!(back.queued.len(), 2);

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -34,11 +34,14 @@ use vmux_ui::components::prompt_composer::{
     PROMPT_INPUT_ID, PromptComposer, PromptComposerAction, PromptComposerAttachment,
     focus_prompt_end, prompt_textarea,
 };
+
 use vmux_ui::components::prompt_media_options::{PromptMediaOption, PromptMediaOptions};
 use vmux_ui::favicon::favicon_src_for_url;
 use vmux_ui::file_icon::{FileIcon, file_icon_kind, type_icon};
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_theme};
 use wasm_bindgen::{JsCast, JsValue, closure::Closure};
+
+const APPROVAL_OPTION_COUNT: usize = 3;
 
 /// True when the page has a non-collapsed text selection — so Ctrl+C should copy, not interrupt.
 fn has_text_selection() -> bool {
@@ -352,14 +355,19 @@ fn install_global_prompt_input(
             || (!event.meta_key()
                 && !event.ctrl_key()
                 && !event.alt_key()
-                && (key == "Enter" || choice_number_index(&key, 3).is_some()));
+                && (key == "Enter" || choice_number_index(&key, APPROVAL_OPTION_COUNT).is_some()));
         if approval_open && approval_key {
             event.prevent_default();
             event.stop_propagation();
             if let Some(direction) = direction {
-                approval_sel.set(move_selection(approval_sel(), 3, direction));
+                approval_sel.set(move_selection(
+                    approval_sel(),
+                    APPROVAL_OPTION_COUNT,
+                    direction,
+                ));
             } else if let Some((call_id, _, _)) = active_approval {
-                let index = choice_number_index(&key, 3).unwrap_or(approval_sel());
+                let index =
+                    choice_number_index(&key, APPROVAL_OPTION_COUNT).unwrap_or(approval_sel());
                 if let Some(decision) = approval_decision_for_index(index)
                     && send_approval(call_id, decision)
                 {
@@ -429,6 +437,7 @@ pub fn Page(
     let mut approval = use_signal(|| Option::<(String, String, String)>::None);
     let mut approval_sel = use_signal(|| 0usize);
     let mut agent_name = use_signal(String::new);
+    let mut conversation_title = use_signal(String::new);
     let mut agent_icon = use_signal(String::new);
     let mut accent = use_signal(String::new);
     let mut handoff_source = use_signal(String::new);
@@ -504,6 +513,7 @@ pub fn Page(
         transition_attachments.set(Vec::new());
         paused.set(snap.paused);
         agent_name.set(snap.agent_name.clone());
+        conversation_title.set(snap.conversation_title.clone());
         agent_icon.set(snap.agent_icon.clone());
         accent.set(snap.accent_color.clone());
         handoff_source.set(snap.handoff_source.clone());
@@ -649,9 +659,9 @@ pub fn Page(
             let n = agent_name();
             if n.is_empty() { current_agent() } else { n }
         };
+        let title = chat_page_title(&conversation_title(), &name);
         let status = status();
         let items = items.read();
-        let title = chat_page_title(&items, &status, &name);
         if let Some(document) = web_sys::window().and_then(|window| window.document()) {
             if document.title() != title {
                 document.set_title(&title);
@@ -672,6 +682,7 @@ pub fn Page(
         let n = agent_name();
         if n.is_empty() { agent.clone() } else { n }
     };
+    let conversation_title = chat_page_title(&conversation_title(), &header_name);
     let agent_accent = agent_accent(&agent);
     let profile_accent = accent();
     let theme_accent = normalized_accent(&profile_accent, agent_accent.rain_rgb);
@@ -799,13 +810,17 @@ pub fn Page(
                 && let Some(direction) = menu_direction(&key, e.modifiers().ctrl())
             {
                 e.prevent_default();
-                approval_sel.set(move_selection(approval_sel(), 3, direction));
+                approval_sel.set(move_selection(
+                    approval_sel(),
+                    APPROVAL_OPTION_COUNT,
+                    direction,
+                ));
                 return;
             }
             let numbered = !e.modifiers().meta()
                 && !e.modifiers().ctrl()
                 && !e.modifiers().alt()
-                && choice_number_index(&key, 3).is_some();
+                && choice_number_index(&key, APPROVAL_OPTION_COUNT).is_some();
             let entered = e.key() == Key::Enter
                 && !e.modifiers().shift()
                 && !e.modifiers().meta()
@@ -813,7 +828,8 @@ pub fn Page(
                 && !e.modifiers().alt();
             if numbered || entered {
                 e.prevent_default();
-                let index = choice_number_index(&key, 3).unwrap_or(approval_sel());
+                let index =
+                    choice_number_index(&key, APPROVAL_OPTION_COUNT).unwrap_or(approval_sel());
                 if let Some(decision) = approval_decision_for_index(index)
                     && send_approval(call_id, decision)
                 {
@@ -1095,7 +1111,7 @@ pub fn Page(
         _ => "Ready",
     };
     let composer_footer = rsx! {
-        div { class: "flex min-w-0 items-center justify-between gap-2 border-t border-foreground/[0.08] px-1.5 pb-0.5 pt-1.5",
+        div { class: "flex min-w-0 items-center justify-between gap-1",
             div { class: "flex min-w-0 flex-1 items-center gap-1 overflow-x-auto",
                 if !model_name.is_empty() {
                     button {
@@ -1275,11 +1291,14 @@ pub fn Page(
                     }
                 }
             }
-            header { class: "agent-chat-header vmux-agent-surface-enter relative z-10 flex items-center gap-2.5 border-b bg-background/95 px-5 py-3 shadow-[0_1px_0_rgba(255,255,255,0.02)]",
+            header { class: "agent-chat-header vmux-agent-surface-enter relative z-10 flex min-w-0 items-center gap-2.5 border-b bg-background/95 px-5 py-3 shadow-[0_1px_0_rgba(255,255,255,0.02)]",
                 {avatar_node(&agent_icon(), &accent(), &agent, &header_name, "h-6 w-6 text-[11px]")}
                 span { class: "h-2.5 w-2.5 rounded-full {status_dot_class(&status())}" }
-                span { class: "bg-gradient-to-b from-foreground to-foreground/60 bg-clip-text text-sm font-semibold capitalize text-transparent",
-                    "{header_name}"
+                div { class: "min-w-0 flex-1",
+                    div { class: "truncate bg-gradient-to-b from-foreground to-foreground/60 bg-clip-text text-sm font-semibold text-transparent", title: "{conversation_title}",
+                        "{conversation_title}"
+                    }
+                    div { class: "truncate text-[10px] text-muted-foreground/60", "{header_name}" }
                 }
             }
             div {
@@ -1900,15 +1919,17 @@ fn render_turn(key: usize, turn: &ChatTurn, latest_tool_index: Option<usize>) ->
     });
     rsx! {
         div { key: "{key}", class: "flex max-w-[92%] flex-col gap-2 self-start",
-            div { class: "chat-assistant-turn relative flex flex-col gap-2.5 overflow-hidden rounded-2xl border px-3.5 py-3",
-                for (j , block , children) in blocks {
-                    {render_block(
-                        j,
-                        block,
-                        &children,
-                        should_expand_thinking(j, block_count),
-                        latest_tool_index == Some(j),
-                    )}
+            if !blocks.is_empty() {
+                div { class: "chat-assistant-turn relative flex flex-col gap-2.5 overflow-hidden rounded-2xl border px-3.5 py-3",
+                    for (j , block , children) in blocks {
+                        {render_block(
+                            j,
+                            block,
+                            &children,
+                            should_expand_thinking(j, block_count),
+                            latest_tool_index == Some(j),
+                        )}
+                    }
                 }
             }
             if turn.running && !reconnecting {

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -35,6 +35,7 @@ use vmux_ui::components::prompt_composer::{
 };
 use vmux_ui::components::prompt_media_options::{PromptMediaOption, PromptMediaOptions};
 use vmux_ui::favicon::favicon_src_for_url;
+use vmux_ui::file_icon::type_icon;
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_theme};
 use wasm_bindgen::{JsCast, JsValue, closure::Closure};
 
@@ -1719,6 +1720,9 @@ enum ActivityIcon {
     Awaiting,
     Python,
     ReadFile,
+    WriteFile,
+    Layout,
+    Worktree,
     Search,
     Image,
     Command,
@@ -1758,6 +1762,19 @@ fn activity_icon_paths(kind: ActivityIcon) -> &'static [&'static str] {
             "M12 7v14",
             "M3 18a1 1 0 0 1-1-1V5a2 2 0 0 1 2-2h5a3 3 0 0 1 3 3v15a3 3 0 0 0-3-3Z",
             "M21 18a1 1 0 0 0 1-1V5a2 2 0 0 0-2-2h-5a3 3 0 0 0-3 3v15a3 3 0 0 1 3-3Z",
+        ],
+        ActivityIcon::WriteFile => &["M12 20h9", "M16.5 3.5a2.12 2.12 0 0 1 3 3L8 18l-4 1 1-4Z"],
+        ActivityIcon::Layout => &[
+            "M4 4h6v6H4Z",
+            "M14 4h6v6h-6Z",
+            "M4 14h6v6H4Z",
+            "M14 14h6v6h-6Z",
+        ],
+        ActivityIcon::Worktree => &[
+            "M6 3v12",
+            "M18 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z",
+            "M6 6a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z",
+            "M6 15c0 3 2 5 5 5h4",
         ],
         ActivityIcon::Search => &["M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z", "m21 21-4.35-4.35"],
         ActivityIcon::Image => &[
@@ -1844,6 +1861,15 @@ fn render_activity_icon(kind: ActivityIcon) -> Element {
         | ActivityIcon::Awaiting => "agent-themed-activity",
         ActivityIcon::Python => unreachable!(),
         ActivityIcon::ReadFile => "bg-sky-500/10 text-sky-600 ring-sky-500/20 dark:text-sky-300",
+        ActivityIcon::WriteFile => {
+            "bg-green-500/10 text-green-600 ring-green-500/20 dark:text-green-300"
+        }
+        ActivityIcon::Layout => {
+            "bg-violet-500/10 text-violet-600 ring-violet-500/20 dark:text-violet-300"
+        }
+        ActivityIcon::Worktree => {
+            "bg-emerald-500/10 text-emerald-600 ring-emerald-500/20 dark:text-emerald-300"
+        }
         ActivityIcon::Search => "bg-cyan-500/10 text-cyan-600 ring-cyan-500/20 dark:text-cyan-300",
         ActivityIcon::Image => "bg-pink-500/10 text-pink-600 ring-pink-500/20 dark:text-pink-300",
         ActivityIcon::Command => {
@@ -1893,6 +1919,9 @@ fn tool_activity_icon(activity: ToolActivity) -> ActivityIcon {
     match activity {
         ToolActivity::Guardian => ActivityIcon::Guardian,
         ToolActivity::ReadFile => ActivityIcon::ReadFile,
+        ToolActivity::WriteFile => ActivityIcon::WriteFile,
+        ToolActivity::Layout => ActivityIcon::Layout,
+        ToolActivity::Worktree => ActivityIcon::Worktree,
         ToolActivity::Image => ActivityIcon::Image,
         ToolActivity::Browser => ActivityIcon::Browser,
         ToolActivity::Search => ActivityIcon::Search,
@@ -1905,6 +1934,70 @@ fn language_activity_icon(value: &str) -> Option<ActivityIcon> {
     let lower = value.to_ascii_lowercase();
     (lower.contains(".py") || lower == "py" || lower.contains("python"))
         .then_some(ActivityIcon::Python)
+}
+
+fn file_path_from_value(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::Object(map) => {
+            for key in ["path", "file_path", "filename", "file"] {
+                if let Some(path) = map.get(key).and_then(serde_json::Value::as_str)
+                    && !path.trim().is_empty()
+                {
+                    return Some(path.to_string());
+                }
+            }
+            map.values().find_map(file_path_from_value)
+        }
+        serde_json::Value::Array(values) => values.iter().find_map(file_path_from_value),
+        serde_json::Value::String(text) => file_path_from_text(text),
+        _ => None,
+    }
+}
+
+fn file_path_from_text(text: &str) -> Option<String> {
+    for marker in ["*** Update File: ", "*** Add File: ", "*** Delete File: "] {
+        if let Some(path) = text.lines().find_map(|line| line.strip_prefix(marker)) {
+            return Some(path.trim().to_string());
+        }
+    }
+    text.split_whitespace()
+        .map(|token| token.trim_matches(['"', '\'', ',', ':', ';', '(', ')']))
+        .find(|token| {
+            let name = token.rsplit('/').next().unwrap_or(token);
+            name.rsplit_once('.')
+                .is_some_and(|(_, ext)| !ext.is_empty() && ext.len() <= 12)
+        })
+        .map(ToOwned::to_owned)
+}
+
+fn tool_file_path(args: &str) -> Option<String> {
+    serde_json::from_str(args)
+        .ok()
+        .and_then(|value| file_path_from_value(&value))
+        .or_else(|| file_path_from_text(args))
+}
+
+fn render_file_activity_icon(path: &str, write: bool) -> Element {
+    let tone = if write {
+        "bg-green-500/10 text-green-600 ring-green-500/20 dark:text-green-300"
+    } else {
+        "bg-sky-500/10 text-sky-600 ring-sky-500/20 dark:text-sky-300"
+    };
+    rsx! {
+        span { class: "flex h-6 w-6 shrink-0 items-center justify-center rounded-lg ring-1 ring-inset {tone}", aria_hidden: "true",
+            {type_icon(path, false, "h-4 w-4")}
+        }
+    }
+}
+
+fn render_tool_activity_icon(name: &str, args: &str, fallback: ActivityIcon) -> Element {
+    let activity = tool_activity(name);
+    if matches!(activity, ToolActivity::ReadFile | ToolActivity::WriteFile)
+        && let Some(path) = tool_file_path(args)
+    {
+        return render_file_activity_icon(&path, activity == ToolActivity::WriteFile);
+    }
+    render_activity_icon(fallback)
 }
 
 fn tool_activity_icon_for(name: &str, args: &str) -> ActivityIcon {
@@ -2004,6 +2097,9 @@ fn tool_presentation(name: &str, args: &str) -> (ActivityIcon, Cow<'static, str>
     match activity {
         ToolActivity::Guardian => (icon, Cow::Borrowed("Guardian Review")),
         ToolActivity::ReadFile => (icon, Cow::Borrowed("Read files")),
+        ToolActivity::WriteFile => (icon, Cow::Borrowed("Editing files")),
+        ToolActivity::Layout => (icon, Cow::Borrowed("Managed layout")),
+        ToolActivity::Worktree => (icon, Cow::Borrowed("Managed workspace")),
         ToolActivity::Image => (icon, Cow::Borrowed("Viewed image")),
         ToolActivity::Browser => (icon, Cow::Borrowed("Used browser")),
         ToolActivity::Search => (icon, Cow::Borrowed("Searched files")),
@@ -2017,6 +2113,144 @@ fn tool_presentation(name: &str, args: &str) -> (ActivityIcon, Cow<'static, str>
                     .replace('_', " "),
             ),
         ),
+    }
+}
+
+fn normalized_tool_args(args: &str) -> Option<serde_json::Value> {
+    let mut value = serde_json::from_str::<serde_json::Value>(args).ok()?;
+    loop {
+        let serde_json::Value::Object(map) = &value else {
+            break;
+        };
+        let Some(arguments) = map.get("arguments") else {
+            break;
+        };
+        if map.contains_key("server") || map.contains_key("tool") || map.contains_key("name") {
+            value = arguments.clone();
+        } else {
+            break;
+        }
+    }
+    Some(value)
+}
+
+fn tool_arg_label(key: &str) -> String {
+    let mut label = key.replace('_', " ");
+    if let Some(first) = label.get_mut(0..1) {
+        first.make_ascii_uppercase();
+    }
+    label
+}
+
+fn tool_arg_is_path(key: &str, value: &str) -> bool {
+    matches!(
+        key,
+        "path" | "file" | "file_path" | "cwd" | "dir" | "directory" | "workdir"
+    ) || value.starts_with('/')
+}
+
+fn render_tool_arg(key: String, value: serde_json::Value) -> Element {
+    let label = tool_arg_label(&key);
+    match value {
+        serde_json::Value::String(text) if tool_arg_is_path(&key, &text) => rsx! {
+            div { class: "flex min-w-0 items-center gap-2 rounded-lg bg-foreground/[0.035] px-2.5 py-2 ring-1 ring-inset ring-foreground/[0.07]",
+                {type_icon(&text, false, "h-4 w-4 shrink-0 opacity-85")}
+                div { class: "min-w-0 flex-1",
+                    div { class: "mb-0.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/65", "{label}" }
+                    code { class: "block truncate font-mono text-[11px] text-foreground/80", title: "{text}", "{text}" }
+                }
+            }
+        },
+        serde_json::Value::String(text)
+            if matches!(
+                key.as_str(),
+                "cmd" | "command" | "script" | "patch" | "text" | "content"
+            ) || text.contains('\n') =>
+        {
+            rsx! {
+                div { class: "overflow-hidden rounded-lg bg-black/[0.18] ring-1 ring-inset ring-foreground/[0.09]",
+                    div { class: "flex items-center gap-1.5 border-b border-foreground/[0.07] px-2.5 py-1.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/65",
+                        span { class: "h-1.5 w-1.5 rounded-full bg-emerald-400/70" }
+                        "{label}"
+                    }
+                    pre { class: "max-h-56 overflow-auto whitespace-pre-wrap break-words px-3 py-2.5 font-mono text-[11px] leading-relaxed text-foreground/78", "{text}" }
+                }
+            }
+        }
+        serde_json::Value::String(text) => rsx! {
+            div { class: "flex min-w-0 items-baseline justify-between gap-3 rounded-lg bg-foreground/[0.03] px-2.5 py-2 ring-1 ring-inset ring-foreground/[0.06]",
+                span { class: "shrink-0 text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/65", "{label}" }
+                code { class: "min-w-0 truncate text-right font-mono text-[11px] text-foreground/78", title: "{text}", "{text}" }
+            }
+        },
+        serde_json::Value::Bool(value) => {
+            let tone = if value {
+                "bg-emerald-500/10 text-emerald-600 ring-emerald-500/20 dark:text-emerald-300"
+            } else {
+                "bg-foreground/[0.04] text-muted-foreground ring-foreground/10"
+            };
+            rsx! {
+                div { class: "flex items-center justify-between gap-3 rounded-lg bg-foreground/[0.03] px-2.5 py-2 ring-1 ring-inset ring-foreground/[0.06]",
+                    span { class: "text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/65", "{label}" }
+                    span { class: "rounded-full px-2 py-0.5 text-[10px] font-semibold ring-1 ring-inset {tone}", "{value}" }
+                }
+            }
+        }
+        serde_json::Value::Number(value) => rsx! {
+            div { class: "flex items-center justify-between gap-3 rounded-lg bg-foreground/[0.03] px-2.5 py-2 ring-1 ring-inset ring-foreground/[0.06]",
+                span { class: "text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/65", "{label}" }
+                code { class: "font-mono text-[11px] tabular-nums text-cyan-600 dark:text-cyan-300", "{value}" }
+            }
+        },
+        serde_json::Value::Array(values) => rsx! {
+            div { class: "rounded-lg bg-foreground/[0.025] p-2 ring-1 ring-inset ring-foreground/[0.06]",
+                div { class: "mb-1.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/65", "{label}" }
+                div { class: "flex flex-col gap-1.5",
+                    for (index , value) in values.into_iter().enumerate() {
+                        {render_tool_arg(format!("{}", index + 1), value)}
+                    }
+                }
+            }
+        },
+        serde_json::Value::Object(values) => rsx! {
+            div { class: "rounded-lg bg-foreground/[0.025] p-2 ring-1 ring-inset ring-foreground/[0.06]",
+                if !key.is_empty() {
+                    div { class: "mb-1.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/65", "{label}" }
+                }
+                div { class: "flex flex-col gap-1.5",
+                    for (child_key , child_value) in values {
+                        {render_tool_arg(child_key, child_value)}
+                    }
+                }
+            }
+        },
+        serde_json::Value::Null => rsx! {
+            div { class: "flex items-center justify-between gap-3 rounded-lg bg-foreground/[0.03] px-2.5 py-2 ring-1 ring-inset ring-foreground/[0.06]",
+                span { class: "text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/65", "{label}" }
+                span { class: "text-[10px] italic text-muted-foreground/60", "None" }
+            }
+        },
+    }
+}
+
+fn render_tool_args(args: &str) -> Element {
+    let Some(value) = normalized_tool_args(args) else {
+        return rsx! {
+            pre { class: "agent-code-panel mt-1.5 max-h-56 overflow-auto whitespace-pre-wrap rounded-lg p-2.5 font-mono text-[11px] leading-relaxed text-muted-foreground", "{args}" }
+        };
+    };
+    match value {
+        serde_json::Value::Object(map) if map.is_empty() => rsx! {},
+        serde_json::Value::Object(map) => rsx! {
+            div { class: "mt-2 flex flex-col gap-1.5", aria_label: "Tool arguments",
+                for (key , value) in map {
+                    {render_tool_arg(key, value)}
+                }
+            }
+        },
+        value => rsx! {
+            div { class: "mt-2", {render_tool_arg(String::new(), value)} }
+        },
     }
 }
 
@@ -2050,7 +2284,7 @@ fn render_block(
             let (icon, label) = tool_presentation(name, args);
             rsx! {
                 div { key: "{key}", class: "grid grid-cols-[1.5rem_minmax(0,1fr)] items-start gap-2.5 rounded-xl px-2 py-1.5 transition-colors hover:bg-foreground/[0.025]",
-                    {render_activity_icon(icon)}
+                    {render_tool_activity_icon(name, args, icon)}
                     div { class: "min-w-0",
                         details { class: "disclosure text-sm text-muted-foreground",
                             summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
@@ -2059,7 +2293,7 @@ fn render_block(
                             }
                             div { class: "mt-1 text-[11px] font-medium text-foreground/45", "{name}" }
                             if !args.is_empty() && args != "{}" {
-                                pre { class: "agent-code-panel mt-1.5 max-h-56 overflow-auto whitespace-pre-wrap rounded-lg p-2 font-mono text-[11px] text-muted-foreground", "{args}" }
+                                {render_tool_args(args)}
                             }
                         }
                         if !children.is_empty() {
@@ -2193,10 +2427,9 @@ fn render_block(
                     })
                     .collect();
             let fname = path.rsplit('/').next().unwrap_or(path.as_str()).to_string();
-            let icon = language_activity_icon(path).unwrap_or(ActivityIcon::Diff);
             rsx! {
                 div { key: "{key}", class: "grid grid-cols-[1.5rem_minmax(0,1fr)] items-start gap-2.5 rounded-xl px-2 py-1.5 transition-colors hover:bg-green-500/[0.035]",
-                    {render_activity_icon(icon)}
+                    {render_file_activity_icon(path, true)}
                     details { class: "disclosure min-w-0 text-sm text-muted-foreground",
                         summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
                             span { class: "font-medium", "Edited " }
@@ -2238,7 +2471,7 @@ fn render_tool_child(key: usize, block: &ChatBlock) -> Element {
                     }
                     div { class: "mt-1 text-[11px] font-medium text-foreground/45", "{name}" }
                     if !args.is_empty() && args != "{}" {
-                        pre { class: "agent-code-panel mt-1.5 max-h-56 overflow-auto whitespace-pre-wrap rounded-lg p-2 font-mono text-[11px] text-muted-foreground", "{args}" }
+                        {render_tool_args(args)}
                     }
                 }
             }

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -9,15 +9,16 @@ use crate::chat_page::composer::{
 };
 use crate::chat_page::event::{
     CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_HISTORY_PAGE_EVENT,
-    CHAT_HISTORY_PAGE_SIZE, CHAT_MEDIA_ENTRIES_EVENT, CHAT_SNAPSHOT_EVENT, ChatApproval,
-    ChatAttachPaths, ChatAttachment, ChatAttachmentPreviewRequest, ChatAttachments, ChatBlock,
-    ChatCancel, ChatCancelQueuedPrompt, ChatChoiceSelected, ChatClearQueue, ChatEscape,
-    ChatHistoryPage, ChatHistoryRequest, ChatItem, ChatMediaEntries, ChatMediaEntry,
-    ChatMediaListRequest, ChatPasteMedia, ChatPickFiles, ChatResume, ChatSnapshot, ChatSubmit,
-    ChatSubmitAttachment, ChatTurn, MODEL_STATE_EVENT, ModelOptionEntry, ModelState,
-    QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions,
-    ResumeListRequest, ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel,
-    SlashCommandEntry, SlashCommands, WORKING_VERBS, latest_tool_location,
+    CHAT_HISTORY_PAGE_SIZE, CHAT_MEDIA_ENTRIES_EVENT, CHAT_SNAPSHOT_EVENT, COMPOSER_CONTEXT_EVENT,
+    ChatApproval, ChatAttachPaths, ChatAttachment, ChatAttachmentPreviewRequest, ChatAttachments,
+    ChatBlock, ChatCancel, ChatCancelQueuedPrompt, ChatChoiceSelected, ChatClearQueue,
+    ChatCreateWorktree, ChatEscape, ChatHistoryPage, ChatHistoryRequest, ChatItem,
+    ChatMediaEntries, ChatMediaEntry, ChatMediaListRequest, ChatPasteMedia, ChatPickFiles,
+    ChatResume, ChatSelectWorkspace, ChatSnapshot, ChatSubmit, ChatSubmitAttachment, ChatTurn,
+    ComposerContext, MODEL_STATE_EVENT, ModelOptionEntry, ModelState, QueuedPromptSnapshot,
+    RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions, ResumeListRequest,
+    ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry,
+    SlashCommands, WORKING_VERBS, latest_tool_location,
 };
 use dioxus::prelude::*;
 use std::borrow::Cow;
@@ -35,7 +36,7 @@ use vmux_ui::components::prompt_composer::{
 };
 use vmux_ui::components::prompt_media_options::{PromptMediaOption, PromptMediaOptions};
 use vmux_ui::favicon::favicon_src_for_url;
-use vmux_ui::file_icon::type_icon;
+use vmux_ui::file_icon::{FileIcon, file_icon_kind, type_icon};
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_theme};
 use wasm_bindgen::{JsCast, JsValue, closure::Closure};
 
@@ -202,6 +203,31 @@ fn prompt_history(items: &[ChatItem], queued: &[QueuedPromptSnapshot]) -> Vec<St
     history
 }
 
+fn composer_activity_counts(items: &[ChatItem]) -> (usize, usize) {
+    let mut subagents = 0usize;
+    let mut tasks = 0usize;
+    for item in items {
+        let ChatItem::Turn(turn) = item else {
+            continue;
+        };
+        for block in &turn.blocks {
+            match block {
+                ChatBlock::Subagent(subagent) if subagent.status == "in_progress" => {
+                    subagents += 1;
+                }
+                ChatBlock::Plan { steps } => {
+                    tasks += steps
+                        .iter()
+                        .filter(|step| step.status != "completed")
+                        .count();
+                }
+                _ => {}
+            }
+        }
+    }
+    (subagents, tasks)
+}
+
 fn file_extension_label(name: &str) -> String {
     std::path::Path::new(name)
         .extension()
@@ -333,7 +359,7 @@ fn install_global_prompt_input(
             if let Some(direction) = direction {
                 approval_sel.set(move_selection(approval_sel(), 3, direction));
             } else if let Some((call_id, _, _)) = active_approval {
-                let index = choice_number_index(&key, 3).unwrap_or_else(|| approval_sel());
+                let index = choice_number_index(&key, 3).unwrap_or(approval_sel());
                 if let Some(decision) = approval_decision_for_index(index)
                     && send_approval(call_id, decision)
                 {
@@ -429,6 +455,7 @@ pub fn Page(
     let mut media_loading = use_signal(|| false);
     let mut current_model_id = use_signal(String::new);
     let mut current_model = use_signal(String::new);
+    let mut composer_context = use_signal(ComposerContext::default);
     let mut menu_sel = use_signal(|| 0usize);
     let mut resume_requested = use_signal(|| false);
     let mut resume_loading = use_signal(|| false);
@@ -567,6 +594,10 @@ pub fn Page(
         current_model.set(state.current_model_name.clone());
         menu_sel.set(0);
     });
+    let _composer_context =
+        use_bin_event_listener::<ComposerContext, _>(COMPOSER_CONTEXT_EVENT, move |context| {
+            composer_context.set(context.clone())
+        });
     let _sess =
         use_bin_event_listener::<ResumableSessions, _>(RESUMABLE_SESSIONS_EVENT, move |s| {
             sessions.set(s.sessions.clone());
@@ -782,7 +813,7 @@ pub fn Page(
                 && !e.modifiers().alt();
             if numbered || entered {
                 e.prevent_default();
-                let index = choice_number_index(&key, 3).unwrap_or_else(|| approval_sel());
+                let index = choice_number_index(&key, 3).unwrap_or(approval_sel());
                 if let Some(decision) = approval_decision_for_index(index)
                     && send_approval(call_id, decision)
                 {
@@ -1027,6 +1058,210 @@ pub fn Page(
         }
     });
 
+    let context = composer_context();
+    let model_name = current_model();
+    let (active_subagents, active_tasks) = composer_activity_counts(&items.read());
+    let queued_count = queued.read().len();
+    let workspace_label = if context.workspace_selected && !context.workspace_name.is_empty() {
+        context.workspace_name.clone()
+    } else {
+        "Select workspace".to_string()
+    };
+    let access_label = if context.auto_allow_count == 0 {
+        "Ask".to_string()
+    } else {
+        format!("Ask · {} allowed", context.auto_allow_count)
+    };
+    let workspace_title = if context.cwd.is_empty() {
+        "Create or select workspace".to_string()
+    } else {
+        format!("Create or select workspace · {}", context.cwd)
+    };
+    let branch_title = if context.branch.is_empty() {
+        "Git repository".to_string()
+    } else {
+        format!("Branch {}", context.branch)
+    };
+    let worktree_title = if context.base_ref.is_empty() {
+        "Linked worktree".to_string()
+    } else {
+        format!("Worktree from {}", context.base_ref)
+    };
+    let run_label = match status().as_str() {
+        "streaming" => "Running",
+        "awaiting" => "Approval",
+        "installing" => "Starting",
+        "errored" => "Error",
+        _ => "Ready",
+    };
+    let composer_footer = rsx! {
+        div { class: "flex min-w-0 items-center justify-between gap-2 border-t border-foreground/[0.08] px-1.5 pb-0.5 pt-1.5",
+            div { class: "flex min-w-0 flex-1 items-center gap-1 overflow-x-auto",
+                if !model_name.is_empty() {
+                    button {
+                        class: "flex h-7 max-w-44 shrink-0 items-center gap-1.5 rounded-lg px-2 text-[11px] font-medium text-foreground/70 transition hover:bg-foreground/[0.08] hover:text-foreground",
+                        title: "Change model",
+                        onmousedown: move |event| event.prevent_default(),
+                        onclick: move |_| {
+                            draft.set("/model ".to_string());
+                            menu_sel.set(0);
+                            focus_prompt_end(PROMPT_INPUT_ID);
+                        },
+                        svg {
+                            class: "h-3.5 w-3.5 shrink-0",
+                            view_box: "0 0 24 24",
+                            fill: "none",
+                            stroke: "currentColor",
+                            stroke_width: "1.8",
+                            stroke_linecap: "round",
+                            stroke_linejoin: "round",
+                            path { d: "M12 3l1.7 4.6L18 9.3l-4.3 1.7L12 16l-1.7-5L6 9.3l4.3-1.7L12 3Z" }
+                            path { d: "M19 15l.8 2.2L22 18l-2.2.8L19 21l-.8-2.2L16 18l2.2-.8L19 15Z" }
+                        }
+                        span { class: "truncate", "{model_name}" }
+                        svg {
+                            class: "h-3 w-3 shrink-0 opacity-50",
+                            view_box: "0 0 24 24",
+                            fill: "none",
+                            stroke: "currentColor",
+                            stroke_width: "2",
+                            path { d: "m8 10 4 4 4-4" }
+                        }
+                    }
+                }
+                span {
+                    class: "flex h-7 shrink-0 items-center gap-1.5 rounded-lg px-2 text-[11px] text-muted-foreground",
+                    title: "Tools ask before protected actions; Allow always is remembered per tool",
+                    svg {
+                        class: "h-3.5 w-3.5",
+                        view_box: "0 0 24 24",
+                        fill: "none",
+                        stroke: "currentColor",
+                        stroke_width: "1.8",
+                        stroke_linecap: "round",
+                        stroke_linejoin: "round",
+                        path { d: "M12 3 5 6v5c0 4.8 2.9 8.2 7 10 4.1-1.8 7-5.2 7-10V6l-7-3Z" }
+                        path { d: "m9 12 2 2 4-4" }
+                    }
+                    "{access_label}"
+                }
+                if context.can_manage_workspace {
+                    button {
+                        class: "flex h-7 max-w-44 shrink-0 items-center gap-1.5 rounded-lg px-2 text-[11px] text-muted-foreground transition hover:bg-foreground/[0.08] hover:text-foreground",
+                        title: "{workspace_title}",
+                        onmousedown: move |event| event.prevent_default(),
+                        onclick: move |_| {
+                            let _ = try_cef_bin_emit_rkyv(&ChatSelectWorkspace);
+                            focus_prompt_end(PROMPT_INPUT_ID);
+                        },
+                        svg {
+                            class: "h-3.5 w-3.5 shrink-0",
+                            view_box: "0 0 24 24",
+                            fill: "none",
+                            stroke: "currentColor",
+                            stroke_width: "1.8",
+                            stroke_linecap: "round",
+                            stroke_linejoin: "round",
+                            path { d: "M3 6.5h6l2 2h10v9.5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V6.5Z" }
+                        }
+                        span { class: "truncate", "{workspace_label}" }
+                    }
+                } else if !context.cwd.is_empty() {
+                    span {
+                        class: "flex h-7 max-w-44 shrink-0 items-center gap-1.5 rounded-lg px-2 text-[11px] text-muted-foreground",
+                        title: "{context.cwd}",
+                        svg {
+                            class: "h-3.5 w-3.5 shrink-0",
+                            view_box: "0 0 24 24",
+                            fill: "none",
+                            stroke: "currentColor",
+                            stroke_width: "1.8",
+                            path { d: "M3 6.5h6l2 2h10v9.5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V6.5Z" }
+                        }
+                        span { class: "truncate", "{workspace_label}" }
+                    }
+                }
+                if context.is_git_repo {
+                    span {
+                        class: "flex h-7 max-w-40 shrink-0 items-center gap-1.5 rounded-lg px-2 font-mono text-[10px] text-muted-foreground",
+                        title: "{branch_title}",
+                        svg {
+                            class: "h-3.5 w-3.5 shrink-0",
+                            view_box: "0 0 24 24",
+                            fill: "none",
+                            stroke: "currentColor",
+                            stroke_width: "1.8",
+                            stroke_linecap: "round",
+                            stroke_linejoin: "round",
+                            circle { cx: "6", cy: "5", r: "2" }
+                            circle { cx: "6", cy: "19", r: "2" }
+                            circle { cx: "18", cy: "12", r: "2" }
+                            path { d: "M8 5h3a3 3 0 0 1 3 3v1a3 3 0 0 0 3 3" }
+                            path { d: "M6 7v10" }
+                        }
+                        span { class: "truncate", if context.branch.is_empty() { "Git" } else { "{context.branch}" } }
+                    }
+                    if context.is_worktree {
+                        span {
+                            class: "flex h-7 shrink-0 items-center gap-1 rounded-lg bg-violet-500/[0.08] px-2 text-[10px] font-medium text-violet-600 ring-1 ring-inset ring-violet-500/15 dark:text-violet-300",
+                            title: "{worktree_title}",
+                            "Worktree"
+                        }
+                    } else if context.can_manage_workspace {
+                        button {
+                            class: "flex h-7 shrink-0 items-center gap-1 rounded-lg px-2 text-[10px] font-medium text-muted-foreground transition hover:bg-violet-500/[0.08] hover:text-violet-600 dark:hover:text-violet-300",
+                            title: "Create or select a worktree for this workspace",
+                            onmousedown: move |event| event.prevent_default(),
+                            onclick: move |_| {
+                                let _ = try_cef_bin_emit_rkyv(&ChatCreateWorktree);
+                                focus_prompt_end(PROMPT_INPUT_ID);
+                            },
+                            "+ Worktree"
+                        }
+                    }
+                    if context.uncommitted > 0 {
+                        span { class: "shrink-0 font-mono text-[10px] text-amber-500", title: "Uncommitted changes", "● {context.uncommitted}" }
+                    }
+                    if context.ahead > 0 {
+                        span { class: "shrink-0 font-mono text-[10px] text-sky-500", title: "Commits ahead of upstream", "↑{context.ahead}" }
+                    }
+                } else if context.workspace_selected {
+                    span { class: "h-7 shrink-0 content-center rounded-lg px-2 text-[10px] text-muted-foreground/70", "No Git" }
+                }
+            }
+            div { class: "flex shrink-0 items-center gap-1 text-[10px] text-muted-foreground",
+                span { class: "flex h-7 items-center gap-1.5 rounded-lg px-2",
+                    span { class: "h-1.5 w-1.5 rounded-full {status_dot_class(&status())}" }
+                    "{run_label}"
+                }
+                if active_subagents > 0 {
+                    span { class: "flex h-7 items-center gap-1 rounded-lg bg-violet-500/[0.07] px-2 text-violet-600 dark:text-violet-300", title: "Active subagents",
+                        svg {
+                            class: "h-3.5 w-3.5",
+                            view_box: "0 0 24 24",
+                            fill: "none",
+                            stroke: "currentColor",
+                            stroke_width: "1.8",
+                            stroke_linecap: "round",
+                            stroke_linejoin: "round",
+                            circle { cx: "9", cy: "8", r: "3" }
+                            path { d: "M3.5 19a5.5 5.5 0 0 1 11 0" }
+                            circle { cx: "17", cy: "9", r: "2.5" }
+                            path { d: "M15.5 14.5A4.5 4.5 0 0 1 21 19" }
+                        }
+                        "{active_subagents}"
+                    }
+                }
+                if active_tasks > 0 {
+                    span { class: "flex h-7 items-center gap-1 rounded-lg px-2", title: "Open plan tasks", "{active_tasks} tasks" }
+                }
+                if queued_count > 0 {
+                    span { class: "flex h-7 items-center gap-1 rounded-lg px-2", title: "Queued prompts", "{queued_count} queued" }
+                }
+            }
+        }
+    };
+
     rsx! {
         main {
             class: "agent-chat-page relative isolate flex h-screen flex-col overflow-hidden bg-background text-foreground",
@@ -1045,11 +1280,6 @@ pub fn Page(
                 span { class: "h-2.5 w-2.5 rounded-full {status_dot_class(&status())}" }
                 span { class: "bg-gradient-to-b from-foreground to-foreground/60 bg-clip-text text-sm font-semibold capitalize text-transparent",
                     "{header_name}"
-                }
-                if !current_model().is_empty() {
-                    span { class: "min-w-0 truncate rounded-md bg-foreground/[0.06] px-2 py-0.5 font-mono text-[10px] text-muted-foreground ring-1 ring-inset ring-foreground/10",
-                        "{current_model}"
-                    }
                 }
             }
             div {
@@ -1177,11 +1407,11 @@ pub fn Page(
                                             onclick: {
                                                 let call_id = call_id.clone();
                                                 move |_| {
-                                                    if let Some(decision) = approval_decision_for_index(index) {
-                                                        if send_approval(call_id.clone(), decision) {
-                                                            approval.set(None);
-                                                            approval_sel.set(0);
-                                                        }
+                                                    if let Some(decision) = approval_decision_for_index(index)
+                                                        && send_approval(call_id.clone(), decision)
+                                                    {
+                                                        approval.set(None);
+                                                        approval_sel.set(0);
                                                     }
                                                 }
                                             },
@@ -1412,6 +1642,7 @@ pub fn Page(
                         accent_bg: agent_accent.accent_bg.to_string(),
                         accent_color: theme_accent.clone(),
                         accent_gradient: agent_accent.grad.to_string(),
+                        footer: Some(composer_footer),
                         action: prompt_action,
                         action_title: prompt_action_title.to_string(),
                         action_enabled: prompt_action_enabled,
@@ -1668,26 +1899,24 @@ fn render_turn(key: usize, turn: &ChatTurn, latest_tool_index: Option<usize>) ->
         }
     });
     rsx! {
-        div { key: "{key}", class: "chat-assistant-turn relative flex max-w-[92%] flex-col gap-2.5 self-start overflow-hidden rounded-2xl border px-3.5 py-3",
-            for (j , block , children) in blocks {
-                {render_block(
-                    j,
-                    block,
-                    &children,
-                    should_expand_thinking(j, block_count),
-                    latest_tool_index == Some(j),
-                )}
+        div { key: "{key}", class: "flex max-w-[92%] flex-col gap-2 self-start",
+            div { class: "chat-assistant-turn relative flex flex-col gap-2.5 overflow-hidden rounded-2xl border px-3.5 py-3",
+                for (j , block , children) in blocks {
+                    {render_block(
+                        j,
+                        block,
+                        &children,
+                        should_expand_thinking(j, block_count),
+                        latest_tool_index == Some(j),
+                    )}
+                }
             }
             if turn.running && !reconnecting {
                 WorkingIndicator {}
-            }
-            if !turn.running && let Some(label) = duration_label {
-                div { class: "grid grid-cols-[1.5rem_minmax(0,1fr)] gap-2.5 pt-0.5 text-[11px] text-muted-foreground/70",
-                    span {}
-                    span { class: "agent-turn-meta inline-flex w-fit items-center gap-1.5 rounded-full border px-2 py-1 tabular-nums",
-                        span { class: "agent-turn-meta-dot h-1.5 w-1.5 rounded-full" }
-                        "{label}"
-                    }
+            } else if let Some(label) = duration_label {
+                div { class: "flex items-center gap-2 px-1 text-sm text-muted-foreground/70",
+                    span { class: "h-1.5 w-1.5 rounded-full bg-[color:var(--agent-accent)]" }
+                    span { class: "tabular-nums", "{label}" }
                 }
             }
         }
@@ -1724,18 +1953,14 @@ fn WorkingIndicator() -> Element {
     let verb_text = verb();
     let elapsed_text = fmt_elapsed(elapsed());
     rsx! {
-        div { class: "grid grid-cols-[1.5rem_minmax(0,1fr)] items-center gap-2.5 py-1 text-sm text-muted-foreground",
-            span { class: "agent-themed-activity flex h-6 w-6 items-center justify-center rounded-lg",
-                span { class: "flex items-end gap-0.5",
-                    span { class: "agent-working-dot h-1 w-1 rounded-full bg-current" }
-                    span { class: "agent-working-dot h-1 w-1 rounded-full [animation-delay:120ms]" }
-                    span { class: "agent-working-dot h-1 w-1 rounded-full [animation-delay:240ms]" }
-                }
+        div { class: "flex items-center gap-2 px-1 text-sm text-muted-foreground",
+            span { class: "agent-working-label font-medium", "{verb_text}" }
+            span { class: "flex items-end gap-0.5 text-[color:var(--agent-accent)]",
+                span { class: "agent-working-dot h-1 w-1 rounded-full bg-current" }
+                span { class: "agent-working-dot h-1 w-1 rounded-full bg-current [animation-delay:120ms]" }
+                span { class: "agent-working-dot h-1 w-1 rounded-full bg-current [animation-delay:240ms]" }
             }
-            div { class: "flex items-baseline gap-2",
-                span { class: "agent-working-label font-medium", "{verb_text}" }
-                span { class: "tabular-nums text-xs", "{elapsed_text}" }
-            }
+            span { class: "tabular-nums text-xs", "{elapsed_text}" }
         }
     }
 }
@@ -1753,6 +1978,8 @@ enum ActivityIcon {
     Worktree,
     Search,
     Image,
+    Screenshot,
+    OpenPage,
     Command,
     Browser,
     Guardian,
@@ -1792,12 +2019,7 @@ fn activity_icon_paths(kind: ActivityIcon) -> &'static [&'static str] {
             "M21 18a1 1 0 0 0 1-1V5a2 2 0 0 0-2-2h-5a3 3 0 0 0-3 3v15a3 3 0 0 1 3-3Z",
         ],
         ActivityIcon::WriteFile => &["M12 20h9", "M16.5 3.5a2.12 2.12 0 0 1 3 3L8 18l-4 1 1-4Z"],
-        ActivityIcon::Layout => &[
-            "M4 4h6v6H4Z",
-            "M14 4h6v6h-6Z",
-            "M4 14h6v6H4Z",
-            "M14 14h6v6h-6Z",
-        ],
+        ActivityIcon::Layout => &["M4 4h9v16H4Z", "M15 4h5v7h-5Z", "M15 13h5v7h-5Z"],
         ActivityIcon::Worktree => &[
             "M6 3v12",
             "M18 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z",
@@ -1809,6 +2031,15 @@ fn activity_icon_paths(kind: ActivityIcon) -> &'static [&'static str] {
             "M19 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2Z",
             "M10.5 8.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z",
             "m21 15-5-5L5 21",
+        ],
+        ActivityIcon::Screenshot => &[
+            "M9 4 7.5 6H5a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-2.5L15 4Z",
+            "M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z",
+        ],
+        ActivityIcon::OpenPage => &[
+            "M14 3h7v7",
+            "m21 3-9 9",
+            "M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6",
         ],
         ActivityIcon::Command => &["m4 17 6-6-6-6", "M12 19h8"],
         ActivityIcon::Browser => &[
@@ -1900,6 +2131,12 @@ fn render_activity_icon(kind: ActivityIcon) -> Element {
         }
         ActivityIcon::Search => "bg-cyan-500/10 text-cyan-600 ring-cyan-500/20 dark:text-cyan-300",
         ActivityIcon::Image => "bg-pink-500/10 text-pink-600 ring-pink-500/20 dark:text-pink-300",
+        ActivityIcon::Screenshot => {
+            "bg-fuchsia-500/10 text-fuchsia-600 ring-fuchsia-500/20 dark:text-fuchsia-300"
+        }
+        ActivityIcon::OpenPage => {
+            "bg-blue-500/10 text-blue-600 ring-blue-500/20 dark:text-blue-300"
+        }
         ActivityIcon::Command => {
             "bg-amber-500/10 text-amber-600 ring-amber-500/20 dark:text-amber-300"
         }
@@ -1951,6 +2188,8 @@ fn tool_activity_icon(activity: ToolActivity) -> ActivityIcon {
         ToolActivity::Layout => ActivityIcon::Layout,
         ToolActivity::Worktree => ActivityIcon::Worktree,
         ToolActivity::Image => ActivityIcon::Image,
+        ToolActivity::Screenshot => ActivityIcon::Screenshot,
+        ToolActivity::OpenPage => ActivityIcon::OpenPage,
         ToolActivity::Browser => ActivityIcon::Browser,
         ToolActivity::Search => ActivityIcon::Search,
         ToolActivity::Command => ActivityIcon::Command,
@@ -1991,6 +2230,9 @@ fn file_path_from_text(text: &str) -> Option<String> {
     text.split_whitespace()
         .map(|token| token.trim_matches(['"', '\'', ',', ':', ';', '(', ')']))
         .find(|token| {
+            if token.contains("://") {
+                return false;
+            }
             let name = token.rsplit('/').next().unwrap_or(token);
             name.rsplit_once('.')
                 .is_some_and(|(_, ext)| !ext.is_empty() && ext.len() <= 12)
@@ -2020,10 +2262,15 @@ fn render_file_activity_icon(path: &str, write: bool) -> Element {
 
 fn render_tool_activity_icon(name: &str, args: &str, fallback: ActivityIcon) -> Element {
     let activity = tool_activity(name);
-    if matches!(activity, ToolActivity::ReadFile | ToolActivity::WriteFile)
-        && let Some(path) = tool_file_path(args)
+    if matches!(
+        activity,
+        ToolActivity::ReadFile | ToolActivity::WriteFile | ToolActivity::Other
+    ) && let Some(path) = tool_file_path(args)
     {
         return render_file_activity_icon(&path, activity == ToolActivity::WriteFile);
+    }
+    if matches!(file_icon_kind(name, false), FileIcon::Logo(_)) {
+        return render_file_activity_icon(name, false);
     }
     render_activity_icon(fallback)
 }
@@ -2129,6 +2376,8 @@ fn tool_presentation(name: &str, args: &str) -> (ActivityIcon, Cow<'static, str>
         ToolActivity::Layout => (icon, Cow::Borrowed("Managed layout")),
         ToolActivity::Worktree => (icon, Cow::Borrowed("Managed workspace")),
         ToolActivity::Image => (icon, Cow::Borrowed("Viewed image")),
+        ToolActivity::Screenshot => (icon, Cow::Borrowed("Captured screenshot")),
+        ToolActivity::OpenPage => (icon, Cow::Borrowed("Opened page")),
         ToolActivity::Browser => (icon, Cow::Borrowed("Used browser")),
         ToolActivity::Search => (icon, Cow::Borrowed("Searched files")),
         ToolActivity::Command => (icon, Cow::Borrowed("Ran commands")),
@@ -2146,10 +2395,7 @@ fn tool_presentation(name: &str, args: &str) -> (ActivityIcon, Cow<'static, str>
 
 fn normalized_tool_args(args: &str) -> Option<serde_json::Value> {
     let mut value = serde_json::from_str::<serde_json::Value>(args).ok()?;
-    loop {
-        let serde_json::Value::Object(map) = &value else {
-            break;
-        };
+    while let serde_json::Value::Object(map) = &value {
         let Some(arguments) = map.get("arguments") else {
             break;
         };
@@ -2179,14 +2425,17 @@ fn tool_arg_is_path(key: &str, value: &str) -> bool {
 
 fn render_tool_arg(key: String, value: serde_json::Value) -> Element {
     let label = tool_arg_label(&key);
+    let row_class = "relative flex min-w-0 items-center gap-3 py-1.5 pl-1 before:absolute before:-left-3 before:top-1/2 before:h-px before:w-2 before:bg-foreground/20";
+    let label_class =
+        "shrink-0 text-[10px] font-medium uppercase tracking-[0.1em] text-muted-foreground/80";
     match value {
         serde_json::Value::String(text) if tool_arg_is_path(&key, &text) => rsx! {
-            div { class: "flex min-w-0 items-center gap-2 rounded-lg bg-foreground/[0.035] px-2.5 py-2 ring-1 ring-inset ring-foreground/[0.07]",
+            div { class: "{row_class}",
                 {type_icon(&text, false, "h-4 w-4 shrink-0 opacity-85")}
-                div { class: "min-w-0 flex-1",
-                    div { class: "mb-0.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/65", "{label}" }
-                    code { class: "block truncate font-mono text-[11px] text-foreground/80", title: "{text}", "{text}" }
+                if !key.is_empty() {
+                    span { class: "{label_class}", "{label}" }
                 }
+                code { class: "min-w-0 flex-1 truncate text-right font-mono text-[11px] text-foreground/80", title: "{text}", "{text}" }
             }
         },
         serde_json::Value::String(text)
@@ -2196,19 +2445,23 @@ fn render_tool_arg(key: String, value: serde_json::Value) -> Element {
             ) || text.contains('\n') =>
         {
             rsx! {
-                div { class: "overflow-hidden rounded-lg bg-black/[0.18] ring-1 ring-inset ring-foreground/[0.09]",
-                    div { class: "flex items-center gap-1.5 border-b border-foreground/[0.07] px-2.5 py-1.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/65",
-                        span { class: "h-1.5 w-1.5 rounded-full bg-emerald-400/70" }
-                        "{label}"
+                div { class: "relative py-1.5 pl-1 before:absolute before:-left-3 before:top-3 before:h-px before:w-2 before:bg-foreground/20",
+                    if !key.is_empty() {
+                        div { class: "mb-1.5 flex items-center gap-1.5 {label_class}",
+                            span { class: "h-1.5 w-1.5 rounded-full bg-emerald-400/70" }
+                            "{label}"
+                        }
                     }
-                    pre { class: "max-h-56 overflow-auto whitespace-pre-wrap break-words px-3 py-2.5 font-mono text-[11px] leading-relaxed text-foreground/78", "{text}" }
+                    pre { class: "max-h-56 overflow-auto whitespace-pre-wrap break-words border-l border-foreground/20 py-1 pl-3 font-mono text-[11px] leading-relaxed text-foreground/80", "{text}" }
                 }
             }
         }
         serde_json::Value::String(text) => rsx! {
-            div { class: "flex min-w-0 items-baseline justify-between gap-3 rounded-lg bg-foreground/[0.03] px-2.5 py-2 ring-1 ring-inset ring-foreground/[0.06]",
-                span { class: "shrink-0 text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/65", "{label}" }
-                code { class: "min-w-0 truncate text-right font-mono text-[11px] text-foreground/78", title: "{text}", "{text}" }
+            div { class: "{row_class}",
+                if !key.is_empty() {
+                    span { class: "{label_class}", "{label}" }
+                }
+                code { class: "min-w-0 flex-1 truncate text-right font-mono text-[11px] text-foreground/80", title: "{text}", "{text}" }
             }
         },
         serde_json::Value::Bool(value) => {
@@ -2218,22 +2471,28 @@ fn render_tool_arg(key: String, value: serde_json::Value) -> Element {
                 "bg-foreground/[0.04] text-muted-foreground ring-foreground/10"
             };
             rsx! {
-                div { class: "flex items-center justify-between gap-3 rounded-lg bg-foreground/[0.03] px-2.5 py-2 ring-1 ring-inset ring-foreground/[0.06]",
-                    span { class: "text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/65", "{label}" }
+                div { class: "{row_class}",
+                    if !key.is_empty() {
+                        span { class: "{label_class}", "{label}" }
+                    }
                     span { class: "rounded-full px-2 py-0.5 text-[10px] font-semibold ring-1 ring-inset {tone}", "{value}" }
                 }
             }
         }
         serde_json::Value::Number(value) => rsx! {
-            div { class: "flex items-center justify-between gap-3 rounded-lg bg-foreground/[0.03] px-2.5 py-2 ring-1 ring-inset ring-foreground/[0.06]",
-                span { class: "text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/65", "{label}" }
-                code { class: "font-mono text-[11px] tabular-nums text-cyan-600 dark:text-cyan-300", "{value}" }
+            div { class: "{row_class}",
+                if !key.is_empty() {
+                    span { class: "{label_class}", "{label}" }
+                }
+                code { class: "ml-auto font-mono text-[11px] tabular-nums text-cyan-600 dark:text-cyan-300", "{value}" }
             }
         },
         serde_json::Value::Array(values) => rsx! {
-            div { class: "rounded-lg bg-foreground/[0.025] p-2 ring-1 ring-inset ring-foreground/[0.06]",
-                div { class: "mb-1.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/65", "{label}" }
-                div { class: "flex flex-col gap-1.5",
+            div { class: "relative py-1 pl-1 before:absolute before:-left-3 before:top-3 before:h-px before:w-2 before:bg-foreground/20",
+                if !key.is_empty() {
+                    div { class: "mb-1 {label_class}", "{label}" }
+                }
+                div { class: "ml-1 flex flex-col border-l border-foreground/20 pl-3",
                     for (index , value) in values.into_iter().enumerate() {
                         {render_tool_arg(format!("{}", index + 1), value)}
                     }
@@ -2241,11 +2500,11 @@ fn render_tool_arg(key: String, value: serde_json::Value) -> Element {
             }
         },
         serde_json::Value::Object(values) => rsx! {
-            div { class: "rounded-lg bg-foreground/[0.025] p-2 ring-1 ring-inset ring-foreground/[0.06]",
+            div { class: "relative py-1 pl-1 before:absolute before:-left-3 before:top-3 before:h-px before:w-2 before:bg-foreground/20",
                 if !key.is_empty() {
-                    div { class: "mb-1.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/65", "{label}" }
+                    div { class: "mb-1 {label_class}", "{label}" }
                 }
-                div { class: "flex flex-col gap-1.5",
+                div { class: "ml-1 flex flex-col border-l border-foreground/20 pl-3",
                     for (child_key , child_value) in values {
                         {render_tool_arg(child_key, child_value)}
                     }
@@ -2253,9 +2512,11 @@ fn render_tool_arg(key: String, value: serde_json::Value) -> Element {
             }
         },
         serde_json::Value::Null => rsx! {
-            div { class: "flex items-center justify-between gap-3 rounded-lg bg-foreground/[0.03] px-2.5 py-2 ring-1 ring-inset ring-foreground/[0.06]",
-                span { class: "text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/65", "{label}" }
-                span { class: "text-[10px] italic text-muted-foreground/60", "None" }
+            div { class: "{row_class}",
+                if !key.is_empty() {
+                    span { class: "{label_class}", "{label}" }
+                }
+                span { class: "ml-auto text-[10px] italic text-muted-foreground/70", "None" }
             }
         },
     }
@@ -2270,14 +2531,14 @@ fn render_tool_args(args: &str) -> Element {
     match value {
         serde_json::Value::Object(map) if map.is_empty() => rsx! {},
         serde_json::Value::Object(map) => rsx! {
-            div { class: "mt-2 flex flex-col gap-1.5", aria_label: "Tool arguments",
+            div { class: "ml-1 mt-2 flex flex-col border-l border-foreground/20 pl-3", aria_label: "Tool arguments",
                 for (key , value) in map {
                     {render_tool_arg(key, value)}
                 }
             }
         },
         value => rsx! {
-            div { class: "mt-2", {render_tool_arg(String::new(), value)} }
+            div { class: "ml-1 mt-2 border-l border-foreground/20 pl-3", {render_tool_arg(String::new(), value)} }
         },
     }
 }

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -2,8 +2,8 @@
 
 use crate::chat_page::composer::{
     PromptEdit, PromptHistoryDirection, ResumeMenuState, SelectorMode, ToolActivity,
-    chat_page_title, choice_number_index, edit_prompt, filter_models, filter_sessions,
-    is_handoff_boundary, menu_direction, move_prompt_history, move_selection,
+    approval_decision_for_index, chat_page_title, choice_number_index, edit_prompt, filter_models,
+    filter_sessions, is_handoff_boundary, menu_direction, move_prompt_history, move_selection,
     prompt_history_direction, resume_menu_state, selector_mode, should_clear_draft_on_escape,
     should_expand_thinking, should_fetch_resume, tool_activity,
 };
@@ -11,13 +11,13 @@ use crate::chat_page::event::{
     CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_HISTORY_PAGE_EVENT,
     CHAT_HISTORY_PAGE_SIZE, CHAT_MEDIA_ENTRIES_EVENT, CHAT_SNAPSHOT_EVENT, ChatApproval,
     ChatAttachPaths, ChatAttachment, ChatAttachmentPreviewRequest, ChatAttachments, ChatBlock,
-    ChatCancel, ChatCancelQueuedPrompt, ChatChoiceSelected, ChatChooseWorkspace, ChatClearQueue,
-    ChatEscape, ChatHistoryPage, ChatHistoryRequest, ChatItem, ChatMediaEntries, ChatMediaEntry,
+    ChatCancel, ChatCancelQueuedPrompt, ChatChoiceSelected, ChatClearQueue, ChatEscape,
+    ChatHistoryPage, ChatHistoryRequest, ChatItem, ChatMediaEntries, ChatMediaEntry,
     ChatMediaListRequest, ChatPasteMedia, ChatPickFiles, ChatResume, ChatSnapshot, ChatSubmit,
     ChatSubmitAttachment, ChatTurn, MODEL_STATE_EVENT, ModelOptionEntry, ModelState,
     QueuedPromptSnapshot, RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions,
     ResumeListRequest, ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel,
-    SlashCommandEntry, SlashCommands, WORKING_VERBS,
+    SlashCommandEntry, SlashCommands, WORKING_VERBS, latest_tool_location,
 };
 use dioxus::prelude::*;
 use std::borrow::Cow;
@@ -271,6 +271,8 @@ fn install_global_prompt_input(
     draft: Signal<String>,
     slash_cmds: Signal<Vec<SlashCommandEntry>>,
     choice_options: Signal<Vec<String>>,
+    mut approval: Signal<Option<(String, String, String)>>,
+    mut approval_sel: Signal<usize>,
 ) {
     let closure = Closure::wrap(Box::new(move |event: web_sys::KeyboardEvent| {
         let Some(textarea) = prompt_textarea(PROMPT_INPUT_ID) else {
@@ -301,6 +303,8 @@ fn install_global_prompt_input(
                 }
         };
         let key = event.key();
+        let active_approval = approval.peek().clone();
+        let approval_open = active_approval.is_some();
         let choice_len = choice_options.peek().len();
         let choice_open = choice_len > 0;
         let direction = if event.meta_key() || event.alt_key() {
@@ -318,6 +322,27 @@ fn install_global_prompt_input(
                 && !event.ctrl_key()
                 && !event.alt_key()
                 && (key == "Enter" || choice_number_index(&key, choice_len).is_some()));
+        let approval_key = direction.is_some()
+            || (!event.meta_key()
+                && !event.ctrl_key()
+                && !event.alt_key()
+                && (key == "Enter" || choice_number_index(&key, 3).is_some()));
+        if approval_open && approval_key {
+            event.prevent_default();
+            event.stop_propagation();
+            if let Some(direction) = direction {
+                approval_sel.set(move_selection(approval_sel(), 3, direction));
+            } else if let Some((call_id, _, _)) = active_approval {
+                let index = choice_number_index(&key, 3).unwrap_or_else(|| approval_sel());
+                if let Some(decision) = approval_decision_for_index(index)
+                    && send_approval(call_id, decision)
+                {
+                    approval.set(None);
+                    approval_sel.set(0);
+                }
+            }
+            return;
+        }
         if (choice_open && choice_key) || direction.is_some() || (selector_open && selector_key) {
             event.prevent_default();
             event.stop_propagation();
@@ -376,14 +401,13 @@ pub fn Page(
     let mut status = use_signal(|| "installing".to_string());
     let mut error = use_signal(String::new);
     let mut approval = use_signal(|| Option::<(String, String, String)>::None);
+    let mut approval_sel = use_signal(|| 0usize);
     let mut agent_name = use_signal(String::new);
     let mut agent_icon = use_signal(String::new);
     let mut accent = use_signal(String::new);
     let mut handoff_source = use_signal(String::new);
     let mut handoff_truncated = use_signal(|| false);
     let mut handoff_message_count = use_signal(|| 0u32);
-    let mut workspace_selection_pending = use_signal(|| false);
-    let mut workspace_picker_open = use_signal(|| false);
     let mut choice_question = use_signal(String::new);
     let mut choice_options = use_signal(Vec::<String>::new);
     let mut draft = use_signal(String::new);
@@ -409,7 +433,9 @@ pub fn Page(
     let mut resume_requested = use_signal(|| false);
     let mut resume_loading = use_signal(|| false);
 
-    use_effect(move || install_global_prompt_input(draft, slash_cmds, choice_options));
+    use_effect(move || {
+        install_global_prompt_input(draft, slash_cmds, choice_options, approval, approval_sel)
+    });
     use_effect(move || focus_prompt_end(PROMPT_INPUT_ID));
 
     use_effect(move || {
@@ -456,23 +482,27 @@ pub fn Page(
         handoff_source.set(snap.handoff_source.clone());
         handoff_truncated.set(snap.handoff_truncated);
         handoff_message_count.set(snap.handoff_message_count);
-        workspace_selection_pending.set(snap.workspace_selection_pending);
         if choice_options.peek().as_slice() != snap.choice_options.as_slice() {
             menu_sel.set(0);
         }
         choice_question.set(snap.choice_question.clone());
         choice_options.set(snap.choice_options.clone());
-        if !snap.workspace_selection_pending {
-            workspace_picker_open.set(false);
-        }
         if snap.status == "awaiting" {
+            let changed = approval
+                .peek()
+                .as_ref()
+                .is_none_or(|(call_id, _, _)| call_id != &snap.approval_call_id);
             approval.set(Some((
                 snap.approval_call_id.clone(),
                 snap.approval_name.clone(),
                 snap.approval_args_json.clone(),
             )));
+            if changed {
+                approval_sel.set(0);
+            }
         } else {
             approval.set(None);
+            approval_sel.set(0);
         }
     });
     let _history =
@@ -665,6 +695,10 @@ pub fn Page(
     let session_menu_open = resume_query.is_some();
     let model_menu_open = model_query.is_some();
     let media_menu_open = media_query.is_some();
+    let latest_tool = {
+        let items = items.read();
+        latest_tool_location(&items)
+    };
     let resume_state = resume_query.map(|_| {
         resume_menu_state(
             resume_requested(),
@@ -722,10 +756,42 @@ pub fn Page(
     } else {
         "Send (Enter)"
     };
-    let choice_pending = !choice_options.read().is_empty();
+    let choice_pending = !choice_options.read().is_empty() || approval.read().is_some();
     let prompt_action_enabled = !choice_pending
         && (prompt_streaming || !draft_val.trim().is_empty() || !attachments.read().is_empty());
     let prompt_keydown = move |e: KeyboardEvent| {
+        let active_approval = { approval.peek().clone() };
+        if let Some((call_id, _, _)) = active_approval {
+            let key = e.key().to_string();
+            if !e.modifiers().meta()
+                && !e.modifiers().alt()
+                && let Some(direction) = menu_direction(&key, e.modifiers().ctrl())
+            {
+                e.prevent_default();
+                approval_sel.set(move_selection(approval_sel(), 3, direction));
+                return;
+            }
+            let numbered = !e.modifiers().meta()
+                && !e.modifiers().ctrl()
+                && !e.modifiers().alt()
+                && choice_number_index(&key, 3).is_some();
+            let entered = e.key() == Key::Enter
+                && !e.modifiers().shift()
+                && !e.modifiers().meta()
+                && !e.modifiers().ctrl()
+                && !e.modifiers().alt();
+            if numbered || entered {
+                e.prevent_default();
+                let index = choice_number_index(&key, 3).unwrap_or_else(|| approval_sel());
+                if let Some(decision) = approval_decision_for_index(index)
+                    && send_approval(call_id, decision)
+                {
+                    approval.set(None);
+                    approval_sel.set(0);
+                }
+                return;
+            }
+        }
         let pending_choices = choice_options.peek().clone();
         if !pending_choices.is_empty() {
             let key = e.key().to_string();
@@ -1039,7 +1105,14 @@ pub fn Page(
                         }
                     }
                     for (i , item) in items.read().iter().enumerate() {
-                        {render_item(loaded_start() as usize + i, item, attachment_previews)}
+                        {render_item(
+                            loaded_start() as usize + i,
+                            item,
+                            attachment_previews,
+                            latest_tool
+                                .filter(|(item_index, _)| *item_index == i)
+                                .map(|(_, block_index)| block_index),
+                        )}
                         if !handoff_source().is_empty()
                             && is_handoff_boundary(
                                 loaded_start() as usize + i,
@@ -1096,31 +1169,27 @@ pub fn Page(
                                         }
                                     }
                                 }
-                                div { class: "flex justify-end gap-2",
-                                    button {
-                                        class: "rounded-lg px-3 py-1.5 text-sm text-muted-foreground hover:bg-foreground/10",
-                                        onclick: {
-                                            let call_id = call_id.clone();
-                                            move |_| send_approval(call_id.clone(), 0)
-                                        },
-                                        "Deny"
+                                div { class: "flex flex-col gap-1.5",
+                                    for (index , label) in ["Allow", "Allow always", "Deny"].into_iter().enumerate() {
+                                        button {
+                                            key: "approval-option-{index}",
+                                            class: if approval_sel() == index { "flex items-center gap-3 rounded-xl bg-foreground px-3 py-2 text-left text-sm text-background" } else { "flex items-center gap-3 rounded-xl bg-foreground/[0.045] px-3 py-2 text-left text-sm text-foreground hover:bg-foreground/[0.08]" },
+                                            onclick: {
+                                                let call_id = call_id.clone();
+                                                move |_| {
+                                                    if let Some(decision) = approval_decision_for_index(index) {
+                                                        if send_approval(call_id.clone(), decision) {
+                                                            approval.set(None);
+                                                            approval_sel.set(0);
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            span { class: "flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-current/20 font-mono text-[10px]", "{index + 1}" }
+                                            span { class: "min-w-0 flex-1", "{label}" }
+                                        }
                                     }
-                                    button {
-                                        class: "rounded-lg bg-foreground/10 px-3 py-1.5 text-sm hover:bg-foreground/20",
-                                        onclick: {
-                                            let call_id = call_id.clone();
-                                            move |_| send_approval(call_id.clone(), 2)
-                                        },
-                                        "Allow always"
-                                    }
-                                    button {
-                                        class: "rounded-lg bg-foreground px-3 py-1.5 text-sm font-medium text-background",
-                                        onclick: {
-                                            let call_id = call_id.clone();
-                                            move |_| send_approval(call_id.clone(), 1)
-                                        },
-                                        "Allow"
-                                    }
+                                    div { class: "mt-1 text-[11px] text-muted-foreground", "↑/↓ or Ctrl+N/Ctrl+P · 1–3 · Enter" }
                                 }
                             }
                         }
@@ -1251,54 +1320,6 @@ pub fn Page(
                                 }
                             }
                             div { class: "mt-2.5 text-[11px] text-muted-foreground", "↑/↓ or Ctrl+N/Ctrl+P · 1–9 · Enter" }
-                        }
-                    }
-                    if workspace_selection_pending() {
-                        div { class: "flex items-center gap-3 rounded-2xl border border-foreground/10 bg-background/95 p-2.5 pl-3.5 shadow-sm",
-                            div { class: "flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-foreground/[0.07] text-foreground/55 ring-1 ring-inset ring-foreground/10",
-                                svg {
-                                    class: "h-4 w-4",
-                                    view_box: "0 0 24 24",
-                                    fill: "none",
-                                    stroke: "currentColor",
-                                    stroke_width: "2",
-                                    stroke_linecap: "round",
-                                    stroke_linejoin: "round",
-                                    path { d: "M3 6h6l2 2h10v10H3z" }
-                                }
-                            }
-                            div { class: "min-w-0 flex-1",
-                                div { class: "text-sm font-medium text-foreground", "Choose repository folder" }
-                                div { class: "truncate text-xs text-muted-foreground", "Select the local Git repository the agent should use." }
-                            }
-                            button {
-                                class: if workspace_picker_open() { "flex h-8 shrink-0 cursor-default items-center gap-1.5 rounded-lg bg-foreground/[0.06] px-2.5 text-xs font-medium text-muted-foreground/60" } else { "flex h-8 shrink-0 items-center gap-1.5 rounded-lg bg-foreground px-2.5 text-xs font-medium text-background transition hover:opacity-85 active:scale-[0.98]" },
-                                disabled: workspace_picker_open(),
-                                onclick: move |_| {
-                                    if workspace_picker_open() {
-                                        return;
-                                    }
-                                    workspace_picker_open.set(true);
-                                    if try_cef_bin_emit_rkyv(&ChatChooseWorkspace).is_err() {
-                                        workspace_picker_open.set(false);
-                                    }
-                                },
-                                svg {
-                                    class: "h-3.5 w-3.5",
-                                    view_box: "0 0 24 24",
-                                    fill: "none",
-                                    stroke: "currentColor",
-                                    stroke_width: "2",
-                                    stroke_linecap: "round",
-                                    stroke_linejoin: "round",
-                                    path { d: "M3 6h6l2 2h10v10H3z" }
-                                }
-                                if workspace_picker_open() {
-                                    span { "Choosing…" }
-                                } else {
-                                    span { "Choose folder" }
-                                }
-                            }
                         }
                     }
                     if transition_preview.read().is_empty() && !queued.read().is_empty() {
@@ -1521,14 +1542,15 @@ fn do_submit(
     history_scratch.set(String::new());
 }
 
-fn send_approval(call_id: String, decision: u8) {
-    let _ = try_cef_bin_emit_rkyv(&ChatApproval { call_id, decision });
+fn send_approval(call_id: String, decision: u8) -> bool {
+    try_cef_bin_emit_rkyv(&ChatApproval { call_id, decision }).is_ok()
 }
 
 fn render_item(
     key: usize,
     item: &ChatItem,
     attachment_previews: Signal<HashMap<String, ChatAttachment>>,
+    latest_tool_block: Option<usize>,
 ) -> Element {
     match item {
         ChatItem::User {
@@ -1573,7 +1595,7 @@ fn render_item(
                 }
             }
         },
-        ChatItem::Turn(turn) => render_turn(key, turn),
+        ChatItem::Turn(turn) => render_turn(key, turn, latest_tool_block),
     }
 }
 
@@ -1612,7 +1634,7 @@ fn render_user_attachment(
     }
 }
 
-fn render_turn(key: usize, turn: &ChatTurn) -> Element {
+fn render_turn(key: usize, turn: &ChatTurn, latest_tool_index: Option<usize>) -> Element {
     let reconnecting = matches!(turn.blocks.last(), Some(ChatBlock::Reconnect { .. }));
     let block_count = turn.blocks.len();
     let blocks = turn
@@ -1648,7 +1670,13 @@ fn render_turn(key: usize, turn: &ChatTurn) -> Element {
     rsx! {
         div { key: "{key}", class: "chat-assistant-turn relative flex max-w-[92%] flex-col gap-2.5 self-start overflow-hidden rounded-2xl border px-3.5 py-3",
             for (j , block , children) in blocks {
-                {render_block(j, block, &children, should_expand_thinking(j, block_count))}
+                {render_block(
+                    j,
+                    block,
+                    &children,
+                    should_expand_thinking(j, block_count),
+                    latest_tool_index == Some(j),
+                )}
             }
             if turn.running && !reconnecting {
                 WorkingIndicator {}
@@ -2258,7 +2286,8 @@ fn render_block(
     key: usize,
     block: &ChatBlock,
     children: &[(usize, &ChatBlock)],
-    latest: bool,
+    latest_thinking: bool,
+    latest_tool: bool,
 ) -> Element {
     match block {
         ChatBlock::Text(text) => rsx! {
@@ -2271,7 +2300,7 @@ fn render_block(
         ChatBlock::Thinking(text) => rsx! {
             div { key: "{key}", class: "agent-row-hover grid grid-cols-[1.5rem_minmax(0,1fr)] items-start gap-2.5 rounded-xl px-2 py-1.5 transition-colors",
                 {render_activity_icon(ActivityIcon::Thinking)}
-                details { open: latest, class: "disclosure min-w-0 text-sm text-muted-foreground",
+                details { open: latest_thinking, class: "disclosure min-w-0 text-sm text-muted-foreground",
                     summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
                         span { class: "font-medium", "Thinking" }
                         {render_disclosure_icon()}
@@ -2286,7 +2315,7 @@ fn render_block(
                 div { key: "{key}", class: "grid grid-cols-[1.5rem_minmax(0,1fr)] items-start gap-2.5 rounded-xl px-2 py-1.5 transition-colors hover:bg-foreground/[0.025]",
                     {render_tool_activity_icon(name, args, icon)}
                     div { class: "min-w-0",
-                        details { class: "disclosure text-sm text-muted-foreground",
+                        details { open: latest_tool, class: "disclosure text-sm text-muted-foreground",
                             summary { class: "flex cursor-pointer select-none items-center gap-2 list-none [&::-webkit-details-marker]:hidden",
                                 span { class: "font-medium", "{label}" }
                                 {render_disclosure_icon()}

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -20,6 +20,8 @@ use crate::events::{AgentApprovalReply, AgentApprovalRequest, ApprovalDecision};
 use crate::handoff::{ImportedConversation, PendingHandoff};
 use crate::run_state::AgentRunState;
 
+const CONVERSATION_TITLE_STEER_PROMPT: &str = "Immediately after every user message, call mcp__vmux__set_conversation_title as the first tool of the turn, before reading skills, calling any other tool, or answering. Write a concise 3 to 7 word model-generated summary of the whole conversation. Correct spelling and grammar. Never copy the user's prompt verbatim. Update the title even when the user sends a short follow-up.";
+
 const UNBOUND_WORKSPACE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): This tab has no selected workspace. For development work, first call select_workspace. Pass a path when the conversation identifies a local directory; otherwise vmux opens the native folder picker immediately after approval. Any directory can be a workspace. If it has no .git, vmux asks whether to initialize Git; declining keeps the plain workspace usable. Do not search the user's home directory. General questions and self-contained terminal demonstrations may run in the temporary current directory.";
 const PENDING_WORKTREE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): Workspace activation is pending. Do not access project paths directly or run git worktree add yourself. Wait for vmux to finish preparing the selected workspace before inspecting, editing, testing, or running the project.";
 const REPOSITORY_WORKTREE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): The selected workspace is a Git repository, but this tab is not isolated. Reading and inspection are allowed. Immediately before the first edit, write, test, build, or other mutation, call create_worktree. It reuses a known linked worktree, automatically uses one unambiguous existing worktree, or creates one when none exists. If it reports multiple candidates, ask the user with request_user_choice to choose an existing path or Create new worktree, then call create_worktree again with path or create=true. Never run git worktree add yourself.";
@@ -749,6 +751,11 @@ fn apply_codex_compatibility_env(mut env: Vec<(String, String)>) -> Vec<(String,
         )
     };
     let instructions = vmux_core::knowledge::append_agent_context(&instructions);
+    let instructions = if instructions.contains("mcp__vmux__set_conversation_title") {
+        instructions
+    } else {
+        format!("{instructions}\n\n{CONVERSATION_TITLE_STEER_PROMPT}")
+    };
     config.insert(
         "developer_instructions".to_string(),
         serde_json::Value::String(instructions),
@@ -1666,6 +1673,9 @@ mod tests {
                     .unwrap()
                     .contains("mcp__vmux__run")
             );
+            let instructions = config["developer_instructions"].as_str().unwrap();
+            assert!(instructions.contains("mcp__vmux__set_conversation_title"));
+            assert!(instructions.contains("first tool of the turn"));
         }
     }
 

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -20,9 +20,9 @@ use crate::events::{AgentApprovalReply, AgentApprovalRequest, ApprovalDecision};
 use crate::handoff::{ImportedConversation, PendingHandoff};
 use crate::run_state::AgentRunState;
 
-const UNBOUND_WORKSPACE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): This tab has no selected repository. For development work, first call request_user_choice with these options in this order: Local repository, Remote repository, Create repository. Only after the user answers, bind the resulting local checkout with choose_workspace. Pass a path when the conversation identifies one; vmux opens the folder picker only when it cannot resolve that path. Remote repositories must be cloned and new repositories initialized before choose_workspace. Do not search the user's home directory. General questions and self-contained terminal demonstrations may run in the temporary current directory.";
+const UNBOUND_WORKSPACE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): This tab has no selected workspace. For development work, first call select_workspace. Pass a path when the conversation identifies a local directory; otherwise vmux opens the native folder picker immediately after approval. Any directory can be a workspace. If it has no .git, vmux asks whether to initialize Git; declining keeps the plain workspace usable. Do not search the user's home directory. General questions and self-contained terminal demonstrations may run in the temporary current directory.";
 const PENDING_WORKTREE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): Workspace activation is pending. Do not access project paths directly or run git worktree add yourself. Wait for vmux to finish preparing the selected workspace before inspecting, editing, testing, or running the project.";
-const REPOSITORY_WORKTREE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): The repository is selected, but this tab is not isolated. Reading and inspection are allowed. Immediately before the first edit, write, test, build, or other mutation, call create_worktree. It reuses a known linked worktree, automatically uses one unambiguous existing worktree, or creates one when none exists. If it reports multiple candidates, ask the user with request_user_choice to choose an existing path or Create new worktree, then call create_worktree again with path or create=true. Never run git worktree add yourself.";
+const REPOSITORY_WORKTREE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): The selected workspace is a Git repository, but this tab is not isolated. Reading and inspection are allowed. Immediately before the first edit, write, test, build, or other mutation, call create_worktree. It reuses a known linked worktree, automatically uses one unambiguous existing worktree, or creates one when none exists. If it reports multiple candidates, ask the user with request_user_choice to choose an existing path or Create new worktree, then call create_worktree again with path or create=true. Never run git worktree add yourself.";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum AcpWorkspaceState {
@@ -1079,12 +1079,11 @@ mod tests {
     fn unbound_workspace_context_requires_picker_before_project_work() {
         let context = acp_prompt_context(None, Some(AcpWorkspaceState::Unbound)).unwrap();
 
-        assert!(context.contains("Local repository, Remote repository, Create repository"));
-        assert!(context.contains("request_user_choice"));
-        assert!(context.contains("choose_workspace"));
+        assert!(context.contains("select_workspace"));
+        assert!(context.contains("Any directory can be a workspace"));
+        assert!(context.contains("initialize Git"));
         assert!(context.contains("Do not search the user's home directory"));
         assert!(context.contains("folder picker"));
-        assert!(context.contains("Remote repositories must be cloned"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/client/cli/claude.rs
+++ b/crates/vmux_agent/src/client/cli/claude.rs
@@ -13,17 +13,17 @@ use crate::{AgentKind, AgentVariant, AssistantBlock, McpServerConfig, Message};
 const DISALLOWED_TOOLS: &str = "Bash,Monitor,WebSearch,WebFetch";
 const ALLOWED_TOOLS: &str = "mcp__vmux__run,mcp__vmux__read_terminal,\
 mcp__vmux__browser_navigate,mcp__vmux__browser_snapshot,mcp__vmux__browser_scroll,\
-mcp__vmux__request_user_choice,mcp__vmux__choose_workspace,mcp__vmux__create_worktree";
+mcp__vmux__request_user_choice,mcp__vmux__select_workspace,mcp__vmux__create_worktree";
 const RUN_STEER_PROMPT: &str = "The native Bash, WebSearch, and WebFetch tools are disabled. Run \
 ALL shell commands via the mcp__vmux__run tool (a visible terminal the user can watch and take \
 over). Use the output returned by run directly; call read_terminal only when run says the command \
 is still running. Do ALL web access via the vmux browser tools in the user's visible browser: \
 mcp__vmux__browser_navigate (it returns the page snapshot on load), then mcp__vmux__browser_scroll \
 to read more. Omit the pane argument - it targets your own browser pane. Do not look for a \
-built-in web search. For development work without a selected repository, first call \
-mcp__vmux__request_user_choice with options Local repository, Remote repository, Create repository \
-in that order, then call mcp__vmux__choose_workspace after the answer. Pass a known path so vmux \
-only opens the folder picker when path resolution fails. Immediately before the first edit, write, \
+built-in web search. For development work without a selected workspace, first call \
+mcp__vmux__select_workspace. Pass a known local directory or omit it so vmux opens the native folder \
+picker immediately after approval. Any directory can be a workspace; vmux asks whether to initialize \
+Git when .git is absent. Immediately before the first edit, write, \
 test, build, or mutation, call mcp__vmux__create_worktree. If it reports ambiguous existing \
 worktrees, ask whether to create or choose an existing path, then call create_worktree with \
 create=true or the selected path. Never \
@@ -448,7 +448,7 @@ mod tests {
         assert!(args[allowed + 1].contains("mcp__vmux__run"));
         assert!(args[allowed + 1].contains("mcp__vmux__read_terminal"));
         assert!(args[allowed + 1].contains("mcp__vmux__request_user_choice"));
-        assert!(args[allowed + 1].contains("mcp__vmux__choose_workspace"));
+        assert!(args[allowed + 1].contains("mcp__vmux__select_workspace"));
         assert!(args[allowed + 1].contains("mcp__vmux__create_worktree"));
 
         let steer = args
@@ -457,10 +457,9 @@ mod tests {
             .unwrap();
         assert!(args[steer + 1].contains("mcp__vmux__run"));
         assert!(args[steer + 1].contains("browser_navigate"));
-        let repository = args[steer + 1].find("Local repository").unwrap();
-        let workspace = args[steer + 1].find("mcp__vmux__choose_workspace").unwrap();
+        let workspace = args[steer + 1].find("mcp__vmux__select_workspace").unwrap();
         let worktree = args[steer + 1].find("mcp__vmux__create_worktree").unwrap();
-        assert!(repository < workspace && workspace < worktree);
+        assert!(workspace < worktree);
     }
 
     #[test]

--- a/crates/vmux_agent/src/client/cli/codex.rs
+++ b/crates/vmux_agent/src/client/cli/codex.rs
@@ -18,10 +18,10 @@ text) - do NOT cat/sed/head/tail a file via run. To SEARCH code, use the mcp__vm
 opens each matching file in a pane and returns the matches) - do NOT run rg/grep/ag via run. Do ALL web access via the vmux browser tools in the \
 user's visible browser: mcp__vmux__browser_navigate (it returns the page snapshot on load), then \
 mcp__vmux__browser_scroll to read more. Omit the pane argument - it targets your own browser pane. \
-Do not look for a built-in web search. For development work without a selected repository, first \
-call mcp__vmux__request_user_choice with options Local repository, Remote repository, Create \
-repository in that order, then call mcp__vmux__choose_workspace after the answer. Pass a known path \
-so vmux only opens the folder picker when path resolution fails. Immediately before the first edit, \
+Do not look for a built-in web search. For development work without a selected workspace, first \
+call mcp__vmux__select_workspace. Pass a known local directory or omit it so vmux opens the native \
+folder picker immediately after approval. Any directory can be a workspace; vmux asks whether to \
+initialize Git when .git is absent. Immediately before the first edit, \
 write, test, build, or mutation, call mcp__vmux__create_worktree. If it reports ambiguous existing \
 worktrees, ask whether to create or choose an existing path, then call mcp__vmux__create_worktree with \
 create=true or the selected path. Never \

--- a/crates/vmux_agent/src/components.rs
+++ b/crates/vmux_agent/src/components.rs
@@ -20,6 +20,9 @@ pub struct AgentSession {
 #[derive(Component, Clone, Debug, Default, Serialize, Deserialize)]
 pub struct AgentMessages(pub Vec<Message>);
 
+#[derive(Component, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentConversationTitle(pub String);
+
 #[derive(Component, Clone, Debug, Default, Serialize, Deserialize, Reflect)]
 #[reflect(Component)]
 pub struct AgentApprovalPolicy {

--- a/crates/vmux_agent/src/events.rs
+++ b/crates/vmux_agent/src/events.rs
@@ -7,11 +7,6 @@ pub use vmux_service::agent_events::{
 };
 
 #[derive(Event, Clone, Copy)]
-pub struct WorkspacePickerStartRequest {
-    pub webview: Entity,
-}
-
-#[derive(Event, Clone, Copy)]
 pub struct AgentChoiceSelected {
     pub webview: Entity,
     pub index: usize,

--- a/crates/vmux_agent/src/events.rs
+++ b/crates/vmux_agent/src/events.rs
@@ -89,6 +89,7 @@ pub struct ScreenshotResponse {
 pub struct BrowserSnapshotRequest {
     pub request_id: [u8; 16],
     pub pane: Option<String>,
+    pub webview: Option<Entity>,
 }
 
 #[derive(Message, Clone)]

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use bevy::ecs::relationship::Relationship;
 use bevy::prelude::*;
 use bevy::tasks::{IoTaskPool, Task, futures_lite::future};
 use bevy_cef::prelude::{CefKeyboardTarget, WebviewExtendStandardMaterial};
@@ -176,6 +177,7 @@ impl Plugin for AgentPlugin {
             .init_resource::<AgentTerminalRegions>()
             .init_resource::<AgentSessionDirty>()
             .init_resource::<NavAwaitingSnapshot>()
+            .init_resource::<vmux_layout::active_panes::ActivePanes>()
             .init_resource::<vmux_layout::pane::SpawnCounter>()
             .add_message::<AgentCommandRequest>()
             .add_message::<vmux_layout::bookmark::BookmarkOp>()
@@ -187,6 +189,7 @@ impl Plugin for AgentPlugin {
             .add_message::<BrowserSnapshotRequest>()
             .add_message::<BrowserSnapshotResponse>()
             .add_message::<BrowserScrollRequest>()
+            .add_message::<vmux_editor::GlobalSearchRequest>()
             .add_message::<vmux_layout::active_panes::ActivatePane>()
             .add_message::<RecordStartRequest>()
             .add_message::<RecordStartResponse>()
@@ -271,6 +274,7 @@ impl Plugin for AgentPlugin {
                     handle_resume_in_acp,
                     handle_agent_commands,
                     handle_agent_file_touch.before(vmux_layout::worktree::TabDirectoryRebindSet),
+                    handle_agent_file_search,
                 )
                     .chain()
                     .in_set(WriteAppCommands)
@@ -979,6 +983,7 @@ pub(crate) struct AgentBrowserResolve<'w, 's> {
     pane_children: Query<'w, 's, &'static Children, With<Pane>>,
     stack_q: Query<'w, 's, Entity, With<vmux_layout::stack::Stack>>,
     browser_stacks: Query<'w, 's, &'static ChildOf, With<vmux_layout::Browser>>,
+    active: Res<'w, vmux_layout::active_panes::ActivePanes>,
 }
 
 impl AgentBrowserResolve<'_, '_> {
@@ -1042,13 +1047,19 @@ impl AgentBrowserResolve<'_, '_> {
     fn claim_browser_pane(&mut self, anchor: vmux_service::protocol::ProcessId) -> Option<Entity> {
         let pane = self.browser_pane_for(self.agent_pane(anchor)?)?;
         let kind = self.agent_kind(anchor);
+        let profile = vmux_layout::active_panes::ProfileId::Agent(format!("{anchor:?}"));
+        let stack = self
+            .active
+            .get(&profile)
+            .filter(|active| active.pane == Some(pane))
+            .and_then(|active| active.stack);
         self.activate
             .write(vmux_layout::active_panes::ActivatePane {
-                profile: vmux_layout::active_panes::ProfileId::Agent(format!("{anchor:?}")),
+                profile,
                 active: vmux_layout::active_panes::ActiveStack {
                     tab: None,
                     pane: Some(pane),
-                    stack: None,
+                    stack,
                     kind,
                 },
             });
@@ -1068,8 +1079,23 @@ impl AgentBrowserResolve<'_, '_> {
             return pane.clone();
         }
         let anchor = (*anchor)?;
-        self.claim_browser_pane(anchor)
-            .map(|p| p.to_bits().to_string())
+        let pane = self.claim_browser_pane(anchor)?;
+        let profile = vmux_layout::active_panes::ProfileId::Agent(format!("{anchor:?}"));
+        if let Some(stack) = self
+            .active
+            .get(&profile)
+            .filter(|active| active.pane == Some(pane))
+            .and_then(|active| active.stack)
+        {
+            return Some(vmux_service::protocol::format_id(
+                vmux_service::protocol::NodeKind::Stack,
+                stack.to_bits(),
+            ));
+        }
+        Some(vmux_service::protocol::format_id(
+            vmux_service::protocol::NodeKind::Pane,
+            pane.to_bits(),
+        ))
     }
 
     /// Same as `resolve_pane` but reads the anchor from a command's origin, for
@@ -1111,6 +1137,8 @@ pub(crate) struct AgentFileResolve<'w, 's> {
             Option<&'static vmux_git::GitDiffSource>,
         ),
     >,
+    pane_children: Query<'w, 's, &'static Children, With<Pane>>,
+    stack_q: Query<'w, 's, Entity, With<vmux_layout::stack::Stack>>,
     tabs: Query<'w, 's, (), With<vmux_layout::tab::Tab>>,
 }
 
@@ -1161,12 +1189,66 @@ impl AgentFileResolve<'_, '_> {
         }
     }
 
+    fn stack_has_file_page(&self, stack: Entity) -> bool {
+        self.file_pages.iter().any(|(_, child_of, metadata, _)| {
+            child_of.get() == stack && metadata.url.starts_with("file:")
+        })
+    }
+
+    fn pane_has_only_file_stacks(&self, pane: Entity) -> bool {
+        let Ok(children) = self.pane_children.get(pane) else {
+            return false;
+        };
+        let mut found = false;
+        for stack in children
+            .iter()
+            .filter(|stack| self.stack_q.contains(*stack))
+        {
+            found = true;
+            if !self.stack_has_file_page(stack) {
+                return false;
+            }
+        }
+        found
+    }
+
+    fn file_panes_for(&self, agent_pane: Entity) -> Vec<Entity> {
+        use bevy::ecs::relationship::Relationship;
+        let Some(agent_tab) = self.ancestor_tab(agent_pane) else {
+            return Vec::new();
+        };
+        let agent_parent = self.child_of.get(agent_pane).ok().map(Relationship::get);
+        let mut panes = Vec::new();
+        for (_, page_child, metadata, _) in self.file_pages.iter() {
+            if !metadata.url.starts_with("file:") {
+                continue;
+            }
+            let stack = page_child.get();
+            let Ok(pane_child) = self.child_of.get(stack) else {
+                continue;
+            };
+            let pane = pane_child.get();
+            if pane == agent_pane
+                || self.ancestor_tab(pane) != Some(agent_tab)
+                || !self.pane_has_only_file_stacks(pane)
+                || panes.contains(&pane)
+            {
+                continue;
+            }
+            panes.push(pane);
+        }
+        panes.sort_by_key(|pane| {
+            let direct = self.child_of.get(*pane).ok().map(Relationship::get) == agent_parent;
+            !direct
+        });
+        panes
+    }
+
     /// The agent's existing `file://` follow-page (the page entity) and its leaf
     /// pane: a sibling pane (same parent split) hosting a file page. `None` if
     /// the agent has no file pane yet.
     fn file_page_for(&self, agent_pane: Entity) -> Option<(Entity, Entity)> {
-        use bevy::ecs::relationship::Relationship;
-        let agent_parent = self.child_of.get(agent_pane).ok()?.get();
+        let pane = self.file_panes_for(agent_pane).into_iter().next()?;
         for (page, page_co, meta, _) in self.file_pages.iter() {
             if !meta.url.starts_with("file:") {
                 continue;
@@ -1174,13 +1256,7 @@ impl AgentFileResolve<'_, '_> {
             let Ok(pane_co) = self.child_of.get(page_co.get()) else {
                 continue;
             };
-            let pane = pane_co.get();
-            if pane == agent_pane {
-                continue;
-            }
-            if let Ok(parent_co) = self.child_of.get(pane)
-                && parent_co.get() == agent_parent
-            {
+            if pane_co.get() == pane {
                 return Some((page, pane));
             }
         }
@@ -1188,8 +1264,7 @@ impl AgentFileResolve<'_, '_> {
     }
 
     fn file_page_target(&self, agent_pane: Entity, url: &str) -> Option<FilePageTarget> {
-        use bevy::ecs::relationship::Relationship;
-        let agent_parent = self.child_of.get(agent_pane).ok()?.get();
+        let panes = self.file_panes_for(agent_pane);
         let mut clean = None;
         for (_, page_co, meta, diff) in self.file_pages.iter() {
             if !meta.url.starts_with("file:") {
@@ -1200,9 +1275,7 @@ impl AgentFileResolve<'_, '_> {
                 continue;
             };
             let pane = pane_co.get();
-            if pane == agent_pane
-                || self.child_of.get(pane).ok().map(|c| c.get()) != Some(agent_parent)
-            {
+            if !panes.contains(&pane) {
                 continue;
             }
             let dirty = diff.is_some_and(|source| source.dirty);
@@ -1232,9 +1305,7 @@ impl AgentFileResolve<'_, '_> {
         &self,
         agent_pane: Entity,
     ) -> Option<(Entity, Vec<(Entity, Entity, String)>)> {
-        use bevy::ecs::relationship::Relationship;
-        let agent_parent = self.child_of.get(agent_pane).ok()?.get();
-        let mut follow_pane = None;
+        let follow_pane = self.file_panes_for(agent_pane).into_iter().next()?;
         let mut stacks = Vec::new();
         for (page, page_co, meta, _) in self.file_pages.iter() {
             if !meta.url.starts_with("file:") {
@@ -1245,16 +1316,12 @@ impl AgentFileResolve<'_, '_> {
                 continue;
             };
             let pane = pane_co.get();
-            if pane == agent_pane {
+            if pane != follow_pane {
                 continue;
             }
-            if self.child_of.get(pane).ok().map(|c| c.get()) != Some(agent_parent) {
-                continue;
-            }
-            follow_pane = Some(pane);
             stacks.push((stack, page, meta.url.clone()));
         }
-        follow_pane.map(|p| (p, stacks))
+        Some((follow_pane, stacks))
     }
 }
 
@@ -1416,6 +1483,41 @@ fn handle_agent_file_touch(
                     });
             }
         }
+    }
+}
+
+fn handle_agent_file_search(
+    mut reader: MessageReader<AgentCommandRequest>,
+    mut writer: MessageWriter<vmux_editor::GlobalSearchRequest>,
+) {
+    for request in reader.read() {
+        let ServiceAgentCommand::FileSearch {
+            root,
+            query,
+            matches,
+            ..
+        } = &request.command
+        else {
+            continue;
+        };
+        let Some(target_path) = matches.first().map(|result| PathBuf::from(&result.path)) else {
+            continue;
+        };
+        writer.write(vmux_editor::GlobalSearchRequest {
+            target_path,
+            root: root.clone(),
+            query: query.clone(),
+            matches: matches
+                .iter()
+                .map(|result| vmux_core::event::ExplorerSearchMatch {
+                    path: result.path.clone(),
+                    line: result.line,
+                    col: result.col,
+                    end_col: result.end_col,
+                    preview: result.preview.clone(),
+                })
+                .collect(),
+        });
     }
 }
 
@@ -1701,6 +1803,7 @@ fn handle_agent_commands(
         };
         let result = match &request.command {
             ServiceAgentCommand::FileTouched { .. } => AgentCommandResult::Ok,
+            ServiceAgentCommand::FileSearch { .. } => AgentCommandResult::Ok,
             ServiceAgentCommand::TurnEnded { .. } => AgentCommandResult::Ok,
             ServiceAgentCommand::AppCommand { id, args_json } => {
                 let args: serde_json::Value = if args_json.is_empty() {
@@ -1810,14 +1913,18 @@ fn handle_agent_commands(
             }
             ServiceAgentCommand::BrowserNavigate { url, pane } => {
                 let mut pane = pane.clone();
+                let mut new_stack = false;
+                let mut profile = None;
                 if pane.is_none()
                     && let CommandOrigin::Agent {
                         anchor: Some(anchor),
                         ..
                     } = &request.origin
                 {
+                    profile = Some(format!("{anchor:?}"));
                     if let Some(browser_pane) = writers.browse.claim_browser_pane(*anchor) {
                         pane = Some(browser_pane.to_bits().to_string());
+                        new_stack = true;
                     } else if let Some(agent_pane) = writers.browse.agent_pane(*anchor) {
                         writers.open_beside.write(vmux_layout::OpenBesideRequest {
                             pane: agent_pane,
@@ -1843,6 +1950,8 @@ fn handle_agent_commands(
                     url: url.clone(),
                     pane,
                     request_id: Some(request.request_id.0),
+                    new_stack,
+                    profile,
                 });
                 continue;
             }
@@ -4241,6 +4350,7 @@ fn handle_agent_queries(
                 browser_snapshot_writer.write(BrowserSnapshotRequest {
                     request_id: request.request_id.0,
                     pane: browse.resolve_pane(pane, anchor),
+                    webview: None,
                 });
             }
             AgentQuery::BrowserScroll {
@@ -6464,6 +6574,111 @@ mod tests {
             .drain()
             .count();
         assert_eq!(beside, 0);
+    }
+
+    #[test]
+    fn file_read_replaces_clean_follow_stack_across_nested_split() {
+        let mut app = file_touch_test_app();
+        let tab = app.world_mut().spawn(vmux_layout::tab::Tab::default()).id();
+        let root = app
+            .world_mut()
+            .spawn((
+                Pane,
+                PaneSplit {
+                    direction: vmux_layout::pane::PaneSplitDirection::Row,
+                },
+                ChildOf(tab),
+            ))
+            .id();
+        let agent_pane = app.world_mut().spawn((Pane, ChildOf(root))).id();
+        let agent_stack = app
+            .world_mut()
+            .spawn((vmux_layout::stack::stack_bundle(), ChildOf(agent_pane)))
+            .id();
+        let anchor = ProcessId::new();
+        app.world_mut().spawn((anchor, ChildOf(agent_stack)));
+        let nested = app
+            .world_mut()
+            .spawn((
+                Pane,
+                PaneSplit {
+                    direction: vmux_layout::pane::PaneSplitDirection::Column,
+                },
+                ChildOf(root),
+            ))
+            .id();
+        app.world_mut().spawn((Pane, ChildOf(nested)));
+        let file_pane = app.world_mut().spawn((Pane, ChildOf(nested))).id();
+        let file_stack = app
+            .world_mut()
+            .spawn((vmux_layout::stack::stack_bundle(), ChildOf(file_pane)))
+            .id();
+        app.world_mut().spawn((
+            vmux_core::PageMetadata {
+                url: "file:///repo/old.rs".into(),
+                ..default()
+            },
+            vmux_git::GitDiffSource::default(),
+            ChildOf(file_stack),
+        ));
+        send_file_read(&mut app, anchor, "/repo/new.rs");
+
+        app.update();
+
+        let opens: Vec<_> = app
+            .world_mut()
+            .resource_mut::<Messages<vmux_core::PageOpenRequest>>()
+            .drain()
+            .collect();
+        assert_eq!(opens.len(), 1);
+        assert!(matches!(
+            opens[0].target,
+            vmux_core::PageOpenTarget::Stack(stack) if stack == file_stack
+        ));
+        assert_eq!(opens[0].url, "file:///repo/new.rs");
+    }
+
+    #[test]
+    fn file_search_forwards_results_to_editor() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<AgentCommandRequest>()
+            .add_message::<vmux_editor::GlobalSearchRequest>()
+            .add_systems(Update, handle_agent_file_search);
+        let anchor = ProcessId::new();
+        app.world_mut()
+            .resource_mut::<Messages<AgentCommandRequest>>()
+            .write(AgentCommandRequest {
+                request_id: AgentRequestId::new(),
+                origin: CommandOrigin::Agent {
+                    sid: None,
+                    anchor: Some(anchor),
+                },
+                command: ServiceAgentCommand::FileSearch {
+                    anchor,
+                    root: "/repo".into(),
+                    query: "needle".into(),
+                    matches: vec![vmux_service::protocol::FileSearchMatch {
+                        path: "/repo/src/main.rs".into(),
+                        line: 9,
+                        col: 4,
+                        end_col: 10,
+                        preview: "let needle = true;".into(),
+                    }],
+                },
+            });
+
+        app.update();
+
+        let requests: Vec<_> = app
+            .world_mut()
+            .resource_mut::<Messages<vmux_editor::GlobalSearchRequest>>()
+            .drain()
+            .collect();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].target_path, PathBuf::from("/repo/src/main.rs"));
+        assert_eq!(requests[0].query, "needle");
+        assert_eq!(requests[0].matches[0].line, 9);
     }
 
     #[test]
@@ -9580,6 +9795,7 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .add_message::<vmux_layout::active_panes::ActivatePane>()
+            .init_resource::<vmux_layout::active_panes::ActivePanes>()
             .init_resource::<BrowserPaneClaimOutput>()
             .add_systems(Update, claim_browser_pane_test_system);
         let split = app

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -1042,7 +1042,10 @@ impl AgentBrowserResolve<'_, '_> {
     /// Resolve the agent's browser pane from its anchor, and record it as that
     /// agent's active pane (for its focus ring). Returns the pane entity, or
     /// `None` if the agent has no browser pane yet (caller keeps the default).
-    fn claim_browser_pane(&mut self, anchor: vmux_service::protocol::ProcessId) -> Option<Entity> {
+    fn claim_browser_pane(
+        &mut self,
+        anchor: vmux_service::protocol::ProcessId,
+    ) -> Option<(Entity, Option<Entity>)> {
         let pane = self.browser_pane_for(self.agent_pane(anchor)?)?;
         let kind = self.agent_kind(anchor);
         let profile = vmux_layout::active_panes::ProfileId::Agent(format!("{anchor:?}"));
@@ -1061,7 +1064,7 @@ impl AgentBrowserResolve<'_, '_> {
                     kind,
                 },
             });
-        Some(pane)
+        Some((pane, stack))
     }
 
     /// Returns the explicit pane if given, else the agent's resolved browser
@@ -1077,14 +1080,8 @@ impl AgentBrowserResolve<'_, '_> {
             return pane.clone();
         }
         let anchor = (*anchor)?;
-        let pane = self.claim_browser_pane(anchor)?;
-        let profile = vmux_layout::active_panes::ProfileId::Agent(format!("{anchor:?}"));
-        if let Some(stack) = self
-            .active
-            .get(&profile)
-            .filter(|active| active.pane == Some(pane))
-            .and_then(|active| active.stack)
-        {
+        let (pane, stack) = self.claim_browser_pane(anchor)?;
+        if let Some(stack) = stack {
             return Some(vmux_service::protocol::format_id(
                 vmux_service::protocol::NodeKind::Stack,
                 stack.to_bits(),
@@ -1263,36 +1260,40 @@ impl AgentFileResolve<'_, '_> {
 
     fn file_page_target(&self, agent_pane: Entity, url: &str) -> Option<FilePageTarget> {
         let panes = self.file_panes_for(agent_pane);
-        let mut clean = None;
-        for (_, page_co, meta, diff) in self.file_pages.iter() {
-            if !meta.url.starts_with("file:") {
-                continue;
-            }
-            let stack = page_co.get();
-            let Ok(pane_co) = self.child_of.get(stack) else {
-                continue;
-            };
-            let pane = pane_co.get();
-            if !panes.contains(&pane) {
-                continue;
-            }
-            let dirty = diff.is_some_and(|source| source.dirty);
-            if vmux_layout::placement::reusable_page_match(url, &meta.url) {
+        for pane in &panes {
+            for (_, page_co, meta, diff) in self.file_pages.iter() {
+                let stack = page_co.get();
+                if !meta.url.starts_with("file:")
+                    || self.child_of.get(stack).ok().map(Relationship::get) != Some(*pane)
+                    || !vmux_layout::placement::reusable_page_match(url, &meta.url)
+                {
+                    continue;
+                }
+                let dirty = diff.is_some_and(|source| source.dirty);
                 return Some(FilePageTarget {
                     stack,
-                    pane,
+                    pane: *pane,
                     navigate: !dirty && meta.url != url,
                 });
             }
-            if !dirty && clean.is_none() {
-                clean = Some(FilePageTarget {
+        }
+        for pane in panes {
+            for (_, page_co, meta, diff) in self.file_pages.iter() {
+                let stack = page_co.get();
+                if !meta.url.starts_with("file:")
+                    || self.child_of.get(stack).ok().map(Relationship::get) != Some(pane)
+                    || diff.is_some_and(|source| source.dirty)
+                {
+                    continue;
+                }
+                return Some(FilePageTarget {
                     stack,
                     pane,
                     navigate: true,
                 });
             }
         }
-        clean
+        None
     }
 
     /// The agent's follow-pane and every `file://` preview stack in it, with each
@@ -1920,7 +1921,7 @@ fn handle_agent_commands(
                     } = &request.origin
                 {
                     profile = Some(format!("{anchor:?}"));
-                    if let Some(browser_pane) = writers.browse.claim_browser_pane(*anchor) {
+                    if let Some((browser_pane, _)) = writers.browse.claim_browser_pane(*anchor) {
                         pane = Some(browser_pane.to_bits().to_string());
                         new_stack = true;
                     } else if let Some(agent_pane) = writers.browse.agent_pane(*anchor) {
@@ -2117,6 +2118,7 @@ fn handle_agent_commands(
             | ServiceAgentCommand::ChooseWorkspaceAtPath { .. }
             | ServiceAgentCommand::PrepareWorktree { .. }
             | ServiceAgentCommand::RequestUserChoice { .. }
+            | ServiceAgentCommand::SetConversationTitle { .. }
             | ServiceAgentCommand::CreateWorktreeOnBranch { .. }
             | ServiceAgentCommand::ResumeInAcp { .. } => {
                 continue;
@@ -2220,6 +2222,7 @@ fn self_command_anchor(command: &ServiceAgentCommand) -> Option<ProcessId> {
         | ServiceAgentCommand::ChooseWorkspaceAtPath { anchor, .. }
         | ServiceAgentCommand::PrepareWorktree { anchor, .. }
         | ServiceAgentCommand::RequestUserChoice { anchor, .. }
+        | ServiceAgentCommand::SetConversationTitle { anchor, .. }
         | ServiceAgentCommand::CreateWorktreeOnBranch { anchor, .. } => Some(*anchor),
         _ => None,
     }
@@ -2233,6 +2236,7 @@ fn self_command_priority(command: &ServiceAgentCommand) -> u8 {
             | ServiceAgentCommand::ChooseWorkspaceAtPath { .. }
             | ServiceAgentCommand::PrepareWorktree { .. }
             | ServiceAgentCommand::RequestUserChoice { .. }
+            | ServiceAgentCommand::SetConversationTitle { .. }
             | ServiceAgentCommand::CreateWorktreeOnBranch { .. }
     ) {
         0
@@ -2252,6 +2256,7 @@ fn self_command_blocked_by_worktree_failure(
             | ServiceAgentCommand::ChooseWorkspaceAtPath { .. }
             | ServiceAgentCommand::PrepareWorktree { .. }
             | ServiceAgentCommand::RequestUserChoice { .. }
+            | ServiceAgentCommand::SetConversationTitle { .. }
             | ServiceAgentCommand::CreateWorktreeOnBranch { .. }
     ) && self_command_anchor(command).is_some_and(|anchor| failed.contains(&anchor))
 }
@@ -2733,6 +2738,7 @@ struct WorkspacePickerContext<'w, 's> {
     chat_views: Query<'w, 's, (), With<crate::chat_page::AgentChatView>>,
     page_sessions: Query<'w, 's, &'static crate::components::AgentSession>,
     cli_sessions: Query<'w, 's, &'static AgentSession>,
+    conversation_titles: Query<'w, 's, &'static mut crate::components::AgentConversationTitle>,
     proxy: Option<Res<'w, bevy::winit::EventLoopProxyWrapper>>,
 }
 
@@ -3097,7 +3103,7 @@ fn handle_agent_self_commands(
     mut regions: ResMut<AgentTerminalRegions>,
     mut spawn_counter: ResMut<vmux_layout::pane::SpawnCounter>,
     mut tab_worktree: AgentTabWorktreeContext,
-    workspace_picker: WorkspacePickerContext,
+    mut workspace_picker: WorkspacePickerContext,
 ) {
     use vmux_service::protocol::{AgentCommandResult, ClientMessage};
     let Some(service) = service else {
@@ -3457,6 +3463,42 @@ fn handle_agent_self_commands(
                     }
                 }
             },
+            ServiceAgentCommand::SetConversationTitle { anchor, title } => {
+                match resolve_self_pane(*anchor, &agent_terms, &ctx.child_of_q) {
+                    None => AgentCommandResult::Error("agent pane not found".to_string()),
+                    Some((agent_entity, _)) => {
+                        let Some(session_entity) = ancestor_agent_session(
+                            agent_entity,
+                            &acp_sessions,
+                            &workspace_picker.page_sessions,
+                            &workspace_picker.cli_sessions,
+                            &ctx.child_of_q,
+                        ) else {
+                            service.0.send(ClientMessage::AgentCommandResponse {
+                                request_id: request.request_id,
+                                result: AgentCommandResult::Error(
+                                    "agent session not found".to_string(),
+                                ),
+                            });
+                            continue;
+                        };
+                        let title = title.trim().to_string();
+                        if title.is_empty() {
+                            AgentCommandResult::Error("conversation title is empty".to_string())
+                        } else if let Ok(mut current) =
+                            workspace_picker.conversation_titles.get_mut(session_entity)
+                        {
+                            current.0 = title;
+                            AgentCommandResult::Ok
+                        } else {
+                            commands
+                                .entity(session_entity)
+                                .insert(crate::components::AgentConversationTitle(title));
+                            AgentCommandResult::Ok
+                        }
+                    }
+                }
+            }
             ServiceAgentCommand::ChooseWorkspace { anchor }
             | ServiceAgentCommand::ChooseWorkspaceAtPath { anchor, .. } => {
                 match resolve_self_pane(*anchor, &agent_terms, &ctx.child_of_q) {
@@ -9675,7 +9717,9 @@ mod tests {
         mut resolve: AgentBrowserResolve,
         mut out: ResMut<BrowserPaneClaimOutput>,
     ) {
-        out.0 = resolve.claim_browser_pane(input.anchor);
+        out.0 = resolve
+            .claim_browser_pane(input.anchor)
+            .map(|(pane, _)| pane);
     }
 
     fn spawn_stack_in_pane(app: &mut App, pane: Entity, url: &str) -> Entity {

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -41,7 +41,7 @@ use crate::events::{
     BrowserScrollRequest, BrowserSnapshotRequest, BrowserSnapshotResponse, CommandOrigin,
     NavAwaitingSnapshot, RecordStartRequest, RecordStartResponse, RecordStopRequest,
     RecordStopResponse, RecordingInfo, ScreenshotImage, ScreenshotRequest, ScreenshotResponse,
-    WorkspacePickerStartRequest, snapshot_response_to_query_result,
+    snapshot_response_to_query_result,
 };
 use crate::session::{
     self, AgentSession, AgentSessionDirty, AgentSessionExited, AgentSessionToEntity,
@@ -56,9 +56,8 @@ const BUILTIN_AGENT_PROVIDERS: &[AgentKind] =
 const WORKSPACE_SELECTION_REQUESTED: &str = "Workspace selection requested. Stop this turn and wait. vmux will resume this same conversation after the user chooses or cancels.";
 const USER_CHOICE_REQUESTED: &str = "User choice requested. Stop this turn and wait. vmux will resume this same conversation with the selected option.";
 const WORKSPACE_SELECTION_PENDING: &str = "Workspace selection is already pending. Stop this turn and wait. vmux will resume this same conversation after the user chooses or cancels.";
-const REPOSITORY_SOURCE_QUESTION: &str = "Which repository should this task use?";
-const REPOSITORY_SOURCE_OPTIONS: [&str; 3] =
-    ["Local repository", "Remote repository", "Create repository"];
+const INITIALIZE_GIT_QUESTION: &str = "Initialize Git repository?";
+const INITIALIZE_GIT_OPTIONS: [&str; 2] = ["Initialize Git", "Not now"];
 
 /// Per-[`AgentKind`] override for CLI executable resolution: `true` forces present, `false` forces
 /// missing, absent falls back to a real `PATH` lookup. Lets tests drive the spawn/setup-page flow
@@ -210,7 +209,6 @@ impl Plugin for AgentPlugin {
             .add_message::<vmux_core::notify::BellReceived>()
             .add_message::<vmux_core::notify::AgentAttention>()
             .add_message::<vmux_core::notify::OsNotify>()
-            .add_observer(start_workspace_picker)
             .add_observer(handle_agent_choice_selected)
             .init_resource::<bevy::ecs::message::Messages<vmux_core::PageOpenRequest>>()
             .init_resource::<bevy::ecs::message::Messages<vmux_layout::OpenBesideRequest>>()
@@ -2703,24 +2701,22 @@ pub(crate) struct PendingAgentContinuation(String);
 #[derive(Component, Clone, Debug, PartialEq, Eq)]
 pub(crate) struct PendingAgentChoice {
     session_entity: Entity,
-    tab_entity: Option<Entity>,
+    action: PendingAgentChoiceAction,
     pub(crate) question: String,
     pub(crate) options: Vec<String>,
 }
 
-#[derive(Component, Clone, Copy)]
-struct RepositorySourceSelected;
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum PendingAgentChoiceAction {
+    Resume,
+    InitializeGit {
+        tab_entity: Entity,
+        workspace: PathBuf,
+    },
+}
 
 #[derive(Component, Clone, Copy)]
 pub(crate) struct RepositoryNeedsWorktree;
-
-#[derive(Component, Clone, Copy)]
-pub(crate) struct PendingWorkspaceSelection {
-    tab_entity: Entity,
-    agent_entity: Entity,
-    session_entity: Entity,
-    picker_started: bool,
-}
 
 #[derive(Component)]
 struct PendingWorkspacePicker {
@@ -2732,10 +2728,8 @@ struct PendingWorkspacePicker {
 
 #[derive(bevy::ecs::system::SystemParam)]
 struct WorkspacePickerContext<'w, 's> {
-    selections: Query<'w, 's, &'static PendingWorkspaceSelection>,
     pickers: Query<'w, 's, &'static PendingWorkspacePicker>,
     choices: Query<'w, 's, &'static PendingAgentChoice>,
-    repository_sources: Query<'w, 's, (), With<RepositorySourceSelected>>,
     chat_views: Query<'w, 's, (), With<crate::chat_page::AgentChatView>>,
     page_sessions: Query<'w, 's, &'static crate::components::AgentSession>,
     cli_sessions: Query<'w, 's, &'static AgentSession>,
@@ -2745,6 +2739,7 @@ struct WorkspacePickerContext<'w, 's> {
 fn handle_agent_choice_selected(
     trigger: On<AgentChoiceSelected>,
     choices: Query<&PendingAgentChoice>,
+    tabs: Query<(), With<vmux_layout::tab::Tab>>,
     mut commands: Commands,
 ) {
     let event = trigger.event();
@@ -2754,33 +2749,37 @@ fn handle_agent_choice_selected(
     let Some(selected) = choice.options.get(event.index) else {
         return;
     };
-    let continuation = if choice.tab_entity.is_some() {
-        format!(
-            "VMUX REPOSITORY SOURCE SELECTED: The user selected \"{selected}\". Continue repository setup in this same conversation. Obtain or create the local checkout, then call choose_workspace before project work."
-        )
-    } else {
-        format!(
+    let continuation = match &choice.action {
+        PendingAgentChoiceAction::Resume => format!(
             "VMUX USER CHOICE: For \"{}\", the user selected \"{}\". Continue the original request in this same conversation.",
             choice.question, selected
-        )
+        ),
+        PendingAgentChoiceAction::InitializeGit {
+            tab_entity,
+            workspace,
+        } => {
+            if !tabs.contains(*tab_entity) {
+                failed_workspace_continuation("The workspace tab no longer exists")
+            } else if event.index == 0 {
+                match vmux_git::worktree::repository_init(workspace) {
+                    Ok(root) => {
+                        commands.entity(*tab_entity).insert(RepositoryNeedsWorktree);
+                        git_workspace_ready_continuation(&root)
+                    }
+                    Err(error) => git_initialization_failed_continuation(workspace, &error.0),
+                }
+            } else {
+                plain_workspace_ready_continuation(workspace)
+            }
+        }
     };
     commands
         .entity(choice.session_entity)
         .insert(PendingAgentContinuation(continuation));
-    if let Some(tab_entity) = choice.tab_entity {
-        commands.entity(tab_entity).insert(RepositorySourceSelected);
-    }
     commands
         .entity(event.webview)
         .remove::<PendingAgentChoice>()
         .remove::<crate::chat_page::ChatSynced>();
-}
-
-fn repository_source_choice(options: &[String]) -> bool {
-    options
-        .iter()
-        .map(String::as_str)
-        .eq(REPOSITORY_SOURCE_OPTIONS)
 }
 
 fn workspace_picker_task(
@@ -2795,6 +2794,7 @@ fn workspace_picker_task(
         .unwrap_or_else(|| PathBuf::from("/"));
     IoTaskPool::get().spawn(async move {
         let selected = rfd::AsyncFileDialog::new()
+            .set_title("Create or select workspace")
             .set_directory(initial_dir)
             .pick_folder()
             .await
@@ -2819,28 +2819,6 @@ fn workspace_path_task(
     })
 }
 
-fn start_workspace_picker(
-    trigger: On<WorkspacePickerStartRequest>,
-    mut selections: Query<&mut PendingWorkspaceSelection>,
-    proxy: Option<Res<bevy::winit::EventLoopProxyWrapper>>,
-    mut commands: Commands,
-) {
-    let webview = trigger.event().webview;
-    let Ok(mut selection) = selections.get_mut(webview) else {
-        return;
-    };
-    if selection.picker_started {
-        return;
-    }
-    selection.picker_started = true;
-    commands.spawn(PendingWorkspacePicker {
-        tab_entity: selection.tab_entity,
-        agent_entity: selection.agent_entity,
-        session_entity: selection.session_entity,
-        task: workspace_picker_task(proxy.as_deref()),
-    });
-}
-
 fn bind_tab_workspace(tab: &mut vmux_layout::tab::Tab, project_dir: &Path, execution_dir: &Path) {
     tab.startup_dir = Some(execution_dir.to_string_lossy().into_owned());
     if vmux_layout::worktree::is_generated_tab_name(&tab.name)
@@ -2851,9 +2829,23 @@ fn bind_tab_workspace(tab: &mut vmux_layout::tab::Tab, project_dir: &Path, execu
     }
 }
 
-fn workspace_ready_continuation(path: &Path) -> String {
+fn git_workspace_ready_continuation(path: &Path) -> String {
     format!(
-        "VMUX REPOSITORY SELECTION COMPLETED: Repository {} is ready for reading and inspection. Continue the original user request in this same conversation. Immediately before the first edit, write, test, build, or other mutation, call create_worktree; if it reports multiple candidates, ask the user whether to create or choose an existing worktree.",
+        "VMUX WORKSPACE SELECTION COMPLETED: Git workspace {} is ready for reading and inspection. Continue the original user request in this same conversation. Immediately before the first edit, write, test, build, or other mutation, call create_worktree; if it reports multiple candidates, ask the user whether to create or choose an existing worktree.",
+        path.display()
+    )
+}
+
+fn plain_workspace_ready_continuation(path: &Path) -> String {
+    format!(
+        "VMUX WORKSPACE SELECTION COMPLETED: Workspace {} is ready without Git. Continue the original user request in this same conversation. Do not call create_worktree unless Git is initialized later.",
+        path.display()
+    )
+}
+
+fn git_initialization_failed_continuation(path: &Path, error: &str) -> String {
+    format!(
+        "VMUX GIT INITIALIZATION FAILED: {error}. Workspace {} remains selected and usable without Git. Continue the original user request in this same conversation. Do not call create_worktree.",
         path.display()
     )
 }
@@ -2956,16 +2948,20 @@ fn activate_selected_workspace(
     tab_entity: Entity,
     agent_entity: Entity,
     selected: &Path,
-    _managed_root: &Path,
     tabs: &mut Query<&mut vmux_layout::tab::Tab>,
     acp_sessions: &mut Query<&mut crate::client::acp::AcpSession>,
     child_of: &Query<&ChildOf>,
     commands: &mut Commands,
-) -> Result<(PathBuf, Option<ClientMessage>), String> {
-    vmux_git::worktree::checkout_info(selected).map_err(|_| {
-        "selected directory is not a Git repository; initialize it before choosing it".to_string()
-    })?;
-    let needs_worktree = !vmux_git::worktree::is_linked_worktree(selected);
+) -> Result<(PathBuf, Option<ClientMessage>, SelectedWorkspaceKind), String> {
+    let kind = if selected.join(".git").exists() {
+        vmux_git::worktree::checkout_info(selected)
+            .map_err(|error| format!("selected workspace has invalid Git metadata: {}", error.0))?;
+        SelectedWorkspaceKind::Git {
+            needs_worktree: !vmux_git::worktree::is_linked_worktree(selected),
+        }
+    } else {
+        SelectedWorkspaceKind::Plain
+    };
     let rebind = activate_agent_directory(
         tab_entity,
         agent_entity,
@@ -2976,10 +2972,21 @@ fn activate_selected_workspace(
         child_of,
         commands,
     )?;
-    if needs_worktree {
+    if matches!(
+        kind,
+        SelectedWorkspaceKind::Git {
+            needs_worktree: true
+        }
+    ) {
         commands.entity(tab_entity).insert(RepositoryNeedsWorktree);
     }
-    Ok((selected.to_path_buf(), rebind))
+    Ok((selected.to_path_buf(), rebind, kind))
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SelectedWorkspaceKind {
+    Plain,
+    Git { needs_worktree: bool },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -3114,16 +3121,10 @@ fn handle_agent_self_commands(
         std::collections::HashMap::new();
     let mut failed_worktree_anchors = std::collections::HashSet::new();
     let mut workspace_picker_tabs: std::collections::HashSet<Entity> = workspace_picker
-        .selections
+        .pickers
         .iter()
-        .map(|selection| selection.tab_entity)
+        .map(|picker| picker.tab_entity)
         .collect();
-    workspace_picker_tabs.extend(
-        workspace_picker
-            .pickers
-            .iter()
-            .map(|picker| picker.tab_entity),
-    );
     let mut requests: Vec<_> = reader.read().collect();
     requests.sort_by_key(|request| self_command_priority(&request.command));
     for request in requests {
@@ -3419,7 +3420,7 @@ fn handle_agent_self_commands(
                 options,
             } => match resolve_self_pane(*anchor, &agent_terms, &ctx.child_of_q) {
                 None => AgentCommandResult::Error("agent pane not found".to_string()),
-                Some((agent_entity, pane)) => {
+                Some((agent_entity, _)) => {
                     let Some(session_entity) = ancestor_agent_session(
                         agent_entity,
                         &acp_sessions,
@@ -3438,13 +3439,11 @@ fn handle_agent_self_commands(
                     if workspace_picker.choices.get(agent_entity).is_ok() {
                         AgentCommandResult::Text(USER_CHOICE_REQUESTED.to_string())
                     } else if workspace_picker.chat_views.contains(agent_entity) {
-                        let tab_entity = repository_source_choice(options)
-                            .then(|| ancestor_self_tab(pane, &tab_worktree.tabs, &ctx.child_of_q));
                         commands
                             .entity(agent_entity)
                             .insert(PendingAgentChoice {
                                 session_entity,
-                                tab_entity: tab_entity.flatten(),
+                                action: PendingAgentChoiceAction::Resume,
                                 question: question.clone(),
                                 options: options.clone(),
                             })
@@ -3487,24 +3486,7 @@ fn handle_agent_self_commands(
                             });
                             continue;
                         };
-                        if tab_worktree.workspaces.get(tab_entity).is_err()
-                            && !workspace_picker.repository_sources.contains(tab_entity)
-                            && workspace_picker.chat_views.contains(agent_entity)
-                        {
-                            if workspace_picker.choices.get(agent_entity).is_err() {
-                                commands
-                                    .entity(agent_entity)
-                                    .insert(PendingAgentChoice {
-                                        session_entity,
-                                        tab_entity: Some(tab_entity),
-                                        question: REPOSITORY_SOURCE_QUESTION.to_string(),
-                                        options: REPOSITORY_SOURCE_OPTIONS
-                                            .into_iter()
-                                            .map(str::to_string)
-                                            .collect(),
-                                    })
-                                    .remove::<crate::chat_page::ChatSynced>();
-                            }
+                        if workspace_picker.choices.get(agent_entity).is_ok() {
                             AgentCommandResult::Text(USER_CHOICE_REQUESTED.to_string())
                         } else if !workspace_picker_tabs.insert(tab_entity) {
                             AgentCommandResult::Text(WORKSPACE_SELECTION_PENDING.to_string())
@@ -3522,17 +3504,6 @@ fn handle_agent_self_commands(
                                     workspace_picker.proxy.as_deref(),
                                 ),
                             });
-                            AgentCommandResult::Text(WORKSPACE_SELECTION_REQUESTED.to_string())
-                        } else if workspace_picker.chat_views.contains(agent_entity) {
-                            commands
-                                .entity(agent_entity)
-                                .insert(PendingWorkspaceSelection {
-                                    tab_entity,
-                                    agent_entity,
-                                    session_entity,
-                                    picker_started: false,
-                                })
-                                .remove::<crate::chat_page::ChatSynced>();
                             AgentCommandResult::Text(WORKSPACE_SELECTION_REQUESTED.to_string())
                         } else {
                             commands.spawn(PendingWorkspacePicker {
@@ -3591,7 +3562,7 @@ fn handle_agent_self_commands(
                             service.0.send(ClientMessage::AgentCommandResponse {
                                 request_id: request.request_id,
                                 result: AgentCommandResult::Error(
-                                    "No repository selected. Complete choose_workspace first."
+                                    "No Git workspace selected. Complete select_workspace and initialize Git first."
                                         .to_string(),
                                 ),
                             });
@@ -3888,7 +3859,7 @@ fn handle_agent_self_commands(
                                 service.0.send(ClientMessage::AgentCommandResponse {
                                     request_id: request.request_id,
                                     result: AgentCommandResult::Error(
-                                        "No project selected. Call choose_workspace first."
+                                        "No workspace selected. Call select_workspace first."
                                             .to_string(),
                                     ),
                                 });
@@ -3954,65 +3925,92 @@ fn handle_agent_self_commands(
 
 fn drain_workspace_picker_tasks(
     mut pickers: Query<(Entity, &mut PendingWorkspacePicker)>,
-    workspace_selections: Query<(), With<PendingWorkspaceSelection>>,
+    chat_views: Query<(), With<crate::chat_page::AgentChatView>>,
     mut tabs: Query<&mut vmux_layout::tab::Tab>,
     mut acp_sessions: Query<&mut crate::client::acp::AcpSession>,
     child_of: Query<&ChildOf>,
-    managed_root: Option<Res<vmux_layout::worktree::ManagedWorktreeRoot>>,
     mut commands: Commands,
     service: Option<Res<ServiceClient>>,
 ) {
     let Some(service) = service else {
         return;
     };
-    let managed_root = managed_root.as_deref().cloned().unwrap_or_default().0;
     for (picker_entity, mut picker) in &mut pickers {
         let Some(selected) = future::block_on(future::poll_once(&mut picker.task)) else {
             continue;
         };
         let continuation = match selected {
-            None => failed_workspace_continuation("The user cancelled workspace selection"),
+            None => Some(failed_workspace_continuation(
+                "The user cancelled workspace selection",
+            )),
             Some(selected) => match selected.canonicalize() {
                 Ok(selected) if selected.is_dir() => {
                     if tabs.get(picker.tab_entity).is_err() {
-                        failed_workspace_continuation("The workspace tab no longer exists")
+                        Some(failed_workspace_continuation(
+                            "The workspace tab no longer exists",
+                        ))
                     } else {
                         match activate_selected_workspace(
                             picker.tab_entity,
                             picker.agent_entity,
                             &selected,
-                            &managed_root,
                             &mut tabs,
                             &mut acp_sessions,
                             &child_of,
                             &mut commands,
                         ) {
-                            Ok((execution_dir, rebind)) => {
+                            Ok((execution_dir, rebind, kind)) => {
                                 if let Some(message) = rebind {
                                     service.0.send(message);
                                 }
-                                workspace_ready_continuation(&execution_dir)
+                                match kind {
+                                    SelectedWorkspaceKind::Git { .. } => {
+                                        Some(git_workspace_ready_continuation(&execution_dir))
+                                    }
+                                    SelectedWorkspaceKind::Plain
+                                        if chat_views.contains(picker.agent_entity) =>
+                                    {
+                                        commands
+                                            .entity(picker.agent_entity)
+                                            .insert(PendingAgentChoice {
+                                                session_entity: picker.session_entity,
+                                                action: PendingAgentChoiceAction::InitializeGit {
+                                                    tab_entity: picker.tab_entity,
+                                                    workspace: execution_dir,
+                                                },
+                                                question: INITIALIZE_GIT_QUESTION.to_string(),
+                                                options: INITIALIZE_GIT_OPTIONS
+                                                    .into_iter()
+                                                    .map(str::to_string)
+                                                    .collect(),
+                                            })
+                                            .remove::<crate::chat_page::ChatSynced>();
+                                        None
+                                    }
+                                    SelectedWorkspaceKind::Plain => Some(format!(
+                                        "VMUX WORKSPACE SELECTION COMPLETED: Workspace {} is ready without Git. Ask the user: \"Initialize Git repository?\" If yes, initialize Git in this exact workspace, then call create_worktree before mutation. If no, continue the original request without a worktree.",
+                                        execution_dir.display()
+                                    )),
+                                }
                             }
-                            Err(error) => failed_workspace_continuation(&format!(
+                            Err(error) => Some(failed_workspace_continuation(&format!(
                                 "The selected workspace could not be prepared: {error}"
-                            )),
+                            ))),
                         }
                     }
                 }
-                Ok(_) => failed_workspace_continuation("The selected workspace is not a directory"),
-                Err(error) => failed_workspace_continuation(&format!(
-                    "The selected workspace directory is invalid: {error}"
+                Ok(_) => Some(failed_workspace_continuation(
+                    "The selected workspace is not a directory",
                 )),
+                Err(error) => Some(failed_workspace_continuation(&format!(
+                    "The selected workspace directory is invalid: {error}"
+                ))),
             },
         };
-        commands
-            .entity(picker.session_entity)
-            .insert(PendingAgentContinuation(continuation));
-        if workspace_selections.contains(picker.agent_entity) {
+        if let Some(continuation) = continuation {
             commands
-                .entity(picker.agent_entity)
-                .remove::<PendingWorkspaceSelection>()
-                .remove::<crate::chat_page::ChatSynced>();
+                .entity(picker.session_entity)
+                .insert(PendingAgentContinuation(continuation));
         }
         commands.entity(picker_entity).despawn();
     }
@@ -5714,48 +5712,31 @@ mod tests {
 
     #[test]
     fn workspace_selection_continuations_resume_original_request() {
-        let ready = workspace_ready_continuation(Path::new("/repo/dashboard"));
+        let ready = git_workspace_ready_continuation(Path::new("/repo/dashboard"));
+        let plain = plain_workspace_ready_continuation(Path::new("/tmp/demo"));
         let cancelled = failed_workspace_continuation("The user cancelled workspace selection");
 
         assert!(ready.contains("same conversation"));
-        assert!(ready.contains("Repository /repo/dashboard is ready"));
+        assert!(ready.contains("Git workspace /repo/dashboard is ready"));
         assert!(ready.contains("Immediately before the first edit"));
         assert!(ready.contains("create_worktree"));
+        assert!(plain.contains("Workspace /tmp/demo is ready without Git"));
+        assert!(plain.contains("Do not call create_worktree"));
         assert!(cancelled.contains("Do not retry automatically"));
     }
 
     #[test]
-    fn repository_source_choice_requires_exact_order() {
-        let ordered = REPOSITORY_SOURCE_OPTIONS
-            .into_iter()
-            .map(str::to_string)
-            .collect::<Vec<_>>();
-        let reordered = [
-            "Remote repository".to_string(),
-            "Local repository".to_string(),
-            "Create repository".to_string(),
-        ];
-
-        assert!(repository_source_choice(&ordered));
-        assert!(!repository_source_choice(&reordered));
-    }
-
-    #[test]
-    fn selected_agent_choice_resumes_session_and_unlocks_repository_selection() {
+    fn selected_agent_choice_resumes_session() {
         let mut app = App::new();
         app.add_observer(handle_agent_choice_selected);
         let session = app.world_mut().spawn_empty().id();
-        let tab = app.world_mut().spawn_empty().id();
         let webview = app
             .world_mut()
             .spawn(PendingAgentChoice {
                 session_entity: session,
-                tab_entity: Some(tab),
-                question: REPOSITORY_SOURCE_QUESTION.into(),
-                options: REPOSITORY_SOURCE_OPTIONS
-                    .into_iter()
-                    .map(str::to_string)
-                    .collect(),
+                action: PendingAgentChoiceAction::Resume,
+                question: "Mode?".into(),
+                options: vec!["Fast".into(), "Safe".into()],
             })
             .id();
 
@@ -5767,9 +5748,53 @@ mod tests {
             .world()
             .get::<PendingAgentContinuation>(session)
             .unwrap();
-        assert!(continuation.0.contains("Remote repository"));
-        assert!(app.world().get::<RepositorySourceSelected>(tab).is_some());
+        assert!(continuation.0.contains("Safe"));
         assert!(app.world().get::<PendingAgentChoice>(webview).is_none());
+    }
+
+    #[test]
+    fn initialize_git_choice_marks_workspace_for_worktree_creation() {
+        let workspace = tempfile::tempdir().unwrap();
+        let workspace_path = workspace.path().canonicalize().unwrap();
+        let mut app = App::new();
+        app.add_observer(handle_agent_choice_selected);
+        let session = app.world_mut().spawn_empty().id();
+        let tab = app
+            .world_mut()
+            .spawn(vmux_layout::tab::Tab {
+                name: "Workspace".into(),
+                startup_dir: Some(workspace_path.to_string_lossy().into_owned()),
+            })
+            .id();
+        let webview = app
+            .world_mut()
+            .spawn(PendingAgentChoice {
+                session_entity: session,
+                action: PendingAgentChoiceAction::InitializeGit {
+                    tab_entity: tab,
+                    workspace: workspace_path.clone(),
+                },
+                question: INITIALIZE_GIT_QUESTION.into(),
+                options: INITIALIZE_GIT_OPTIONS
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect(),
+            })
+            .id();
+
+        app.world_mut()
+            .trigger(AgentChoiceSelected { webview, index: 0 });
+        app.update();
+
+        assert!(workspace_path.join(".git").is_dir());
+        assert!(app.world().get::<RepositoryNeedsWorktree>(tab).is_some());
+        assert!(
+            app.world()
+                .get::<PendingAgentContinuation>(session)
+                .unwrap()
+                .0
+                .contains("call create_worktree")
+        );
     }
 
     #[test]
@@ -5951,7 +5976,6 @@ mod tests {
         vmux_git::worktree::worktree_add(&project_dir, &external, "feature/existing", "main")
             .unwrap();
         let external = external.canonicalize().unwrap();
-        let managed_root = tempfile::tempdir().unwrap();
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
 
@@ -5964,7 +5988,6 @@ mod tests {
             .id();
         let linked_agent = app.world_mut().spawn(ChildOf(linked_tab)).id();
         let external_for_system = external.clone();
-        let managed_root_for_system = managed_root.path().to_path_buf();
         let linked_execution = app
             .world_mut()
             .run_system_once(
@@ -5976,7 +5999,6 @@ mod tests {
                         linked_tab,
                         linked_agent,
                         &external_for_system,
-                        &managed_root_for_system,
                         &mut tabs,
                         &mut sessions,
                         &child_of,
@@ -6022,7 +6044,6 @@ mod tests {
             .id();
         let managed_agent = app.world_mut().spawn(ChildOf(managed_tab)).id();
         let project_for_system = project_dir.clone();
-        let managed_root_for_system = managed_root.path().to_path_buf();
         let managed_execution = app
             .world_mut()
             .run_system_once(
@@ -6034,7 +6055,6 @@ mod tests {
                         managed_tab,
                         managed_agent,
                         &project_for_system,
-                        &managed_root_for_system,
                         &mut tabs,
                         &mut sessions,
                         &child_of,
@@ -6073,12 +6093,11 @@ mod tests {
     }
 
     #[test]
-    fn selected_workspace_rejects_non_git_directory() {
+    fn selected_workspace_binds_non_git_directory_without_worktree() {
         use bevy::ecs::system::RunSystemOnce;
 
         let directory = tempfile::tempdir().unwrap();
         let selected = directory.path().canonicalize().unwrap();
-        let managed_root = tempfile::tempdir().unwrap();
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
         let tab = app
@@ -6089,8 +6108,9 @@ mod tests {
             })
             .id();
         let agent = app.world_mut().spawn(ChildOf(tab)).id();
+        let selected_for_system = selected.clone();
 
-        let error = app
+        let (execution_dir, _, kind) = app
             .world_mut()
             .run_system_once(
                 move |mut tabs: Query<&mut vmux_layout::tab::Tab>,
@@ -6100,8 +6120,7 @@ mod tests {
                     activate_selected_workspace(
                         tab,
                         agent,
-                        &selected,
-                        managed_root.path(),
+                        &selected_for_system,
                         &mut tabs,
                         &mut sessions,
                         &child_of,
@@ -6110,9 +6129,18 @@ mod tests {
                 },
             )
             .unwrap()
-            .unwrap_err();
+            .unwrap();
 
-        assert!(error.contains("not a Git repository"));
+        assert_eq!(execution_dir, selected);
+        assert_eq!(kind, SelectedWorkspaceKind::Plain);
+        assert_eq!(
+            app.world()
+                .get::<vmux_layout::tab::TabWorkspace>(tab)
+                .unwrap()
+                .project_dir,
+            selected.to_string_lossy()
+        );
+        assert!(app.world().get::<RepositoryNeedsWorktree>(tab).is_none());
     }
 
     #[test]
@@ -9139,44 +9167,6 @@ mod tests {
                 .contains(".before(vmux_terminal::plugin::respond_terminal_stack_spawn)"),
             "run terminal spawn requests must materialize before the next agent command frame"
         );
-    }
-
-    #[test]
-    fn workspace_picker_waits_for_inline_user_action_without_blocking() {
-        let source = include_str!("plugin.rs");
-        let start = source
-            .find("fn handle_agent_self_commands(")
-            .expect("agent command handler");
-        let end = source[start..]
-            .find("fn drain_workspace_picker_tasks(")
-            .expect("picker drain");
-        let handler = &source[start..start + end];
-        let task_start = source
-            .find("fn workspace_picker_task(")
-            .expect("picker task");
-        let task_end = source[task_start..]
-            .find("fn start_workspace_picker(")
-            .expect("picker start observer");
-        let task = &source[task_start..task_start + task_end];
-        let selection_start = source
-            .find("struct PendingWorkspaceSelection")
-            .expect("pending workspace selection");
-        let selection_end = source[selection_start..]
-            .find("struct PendingWorkspacePicker")
-            .expect("pending workspace picker");
-        let selection = &source[selection_start..selection_start + selection_end];
-
-        assert!(!handler.contains("rfd::FileDialog::new().pick_folder()"));
-        assert!(handler.contains("PendingWorkspaceSelection"));
-        assert!(handler.contains("workspace_picker.chat_views.contains(agent_entity)"));
-        assert!(handler.contains("WORKSPACE_SELECTION_REQUESTED"));
-        assert!(!selection.contains("request_id"));
-        assert!(selection.contains("session_entity"));
-        assert!(selection.contains("picker_started"));
-        assert!(task.contains("rfd::AsyncFileDialog::new()"));
-        assert!(task.contains(".set_directory(initial_dir)"));
-        assert!(task.contains("IoTaskPool::get().spawn"));
-        assert!(task.contains("WinitUserEvent::WakeUp"));
     }
 
     #[test]

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -4405,6 +4405,7 @@ fn handle_page_open_requests(
     stack_ts: Query<(Entity, &LastActivatedAt), With<Stack>>,
     stack_filter: Query<Entity, With<Stack>>,
     service: Option<Res<vmux_service::client::ServiceClient>>,
+    time: Res<Time>,
     mut commands: Commands,
 ) {
     for request in reader.read() {
@@ -4423,12 +4424,22 @@ fn handle_page_open_requests(
                 continue;
             }
         };
-        commands.spawn(PageOpenTask {
+        let task = PageOpenTask {
             id: PageOpenId::new(),
             stack,
             url: normalize_vmux_url(&request.url),
             request_id: request.request_id,
-        });
+        };
+        if request.request_id.is_some() {
+            commands.spawn((
+                task,
+                PageOpenAwaitSnapshot {
+                    started: time.elapsed(),
+                },
+            ));
+        } else {
+            commands.spawn(task);
+        }
     }
 }
 
@@ -4525,7 +4536,9 @@ fn attach_cef_page_requests(
 struct PageOpenFallbackDeferred;
 
 #[derive(Component, Clone, Debug)]
-struct PageOpenAwaitSnapshot;
+struct PageOpenAwaitSnapshot {
+    started: std::time::Duration,
+}
 
 fn handle_unclaimed_page_open_tasks(
     mut tasks: Query<
@@ -4541,9 +4554,6 @@ fn handle_unclaimed_page_open_tasks(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
-    child_of: Query<&ChildOf>,
-    time: Res<Time>,
-    mut pending_nav: ResMut<PendingNavSnapshots>,
 ) {
     for (entity, task, error, deferred_once) in &mut tasks {
         if let Some(error) = error {
@@ -4592,7 +4602,7 @@ fn handle_unclaimed_page_open_tasks(
                 },
             ));
         } else {
-            let browser = attach_cef_page_to_stack(
+            attach_cef_page_to_stack(
                 task.stack,
                 &task.url,
                 &task.url,
@@ -4602,26 +4612,7 @@ fn handle_unclaimed_page_open_tasks(
                 &mut meshes,
                 &mut webview_mt,
             );
-            if let Some(request_id) = task.request_id {
-                let pane = child_of
-                    .get(task.stack)
-                    .ok()
-                    .map(|child_of| child_of.get().to_bits().to_string());
-                pending_nav.0.insert(
-                    browser,
-                    NavPending {
-                        request_id,
-                        started: time.elapsed(),
-                        saw_loading: false,
-                        pane,
-                    },
-                );
-                commands
-                    .entity(entity)
-                    .insert((PageOpenHandled, PageOpenAwaitSnapshot));
-            } else {
-                commands.entity(entity).insert(PageOpenHandled);
-            }
+            commands.entity(entity).insert(PageOpenHandled);
         }
     }
 }
@@ -4632,22 +4623,61 @@ fn respond_page_open_tasks(
             Entity,
             &PageOpenTask,
             Option<&PageOpenError>,
-            Has<PageOpenAwaitSnapshot>,
+            Option<&PageOpenAwaitSnapshot>,
         ),
         With<PageOpenHandled>,
     >,
     service: Option<Res<vmux_service::client::ServiceClient>>,
+    time: Res<Time>,
+    children: Query<&Children>,
+    browsers: Query<(), With<Browser>>,
+    child_of: Query<&ChildOf>,
+    mut pending_nav: ResMut<PendingNavSnapshots>,
     mut commands: Commands,
 ) {
     for (entity, task, error, await_snapshot) in &tasks {
-        let result = match error {
-            Some(error) => Err(error.message.clone()),
-            None => Ok(()),
-        };
-        if !await_snapshot {
-            send_page_open_response(&service, task.request_id, result);
+        if let Some(error) = error {
+            send_page_open_response(&service, task.request_id, Err(error.message.clone()));
+            commands.entity(entity).despawn();
+            continue;
         }
-        commands.entity(entity).despawn();
+        let Some(await_snapshot) = await_snapshot else {
+            send_page_open_response(&service, task.request_id, Ok(()));
+            commands.entity(entity).despawn();
+            continue;
+        };
+        let webview = children
+            .get(task.stack)
+            .ok()
+            .and_then(|children| children.iter().find(|child| browsers.contains(*child)));
+        if let (Some(webview), Some(request_id)) = (webview, task.request_id) {
+            let pane = child_of
+                .get(task.stack)
+                .ok()
+                .map(|child_of| child_of.get().to_bits().to_string());
+            pending_nav.0.insert(
+                webview,
+                NavPending {
+                    request_id,
+                    started: await_snapshot.started,
+                    saw_loading: false,
+                    pane,
+                },
+            );
+            commands.entity(entity).despawn();
+        } else if time
+            .elapsed()
+            .saturating_sub(await_snapshot.started)
+            .as_secs_f32()
+            > 10.0
+        {
+            send_page_open_response(
+                &service,
+                task.request_id,
+                Err("page opened without a snapshot-capable webview".to_string()),
+            );
+            commands.entity(entity).despawn();
+        }
     }
 }
 
@@ -6801,7 +6831,7 @@ mod tests {
             for (entity, task) in &tasks {
                 if task.url.starts_with("vmux://terminal/") {
                     crate::clear_stack_children(task.stack, &children_q, &mut commands);
-                    commands.spawn((Terminal, ChildOf(task.stack)));
+                    commands.spawn((Browser, Terminal, ChildOf(task.stack)));
                     commands.entity(entity).insert(PageOpenHandled);
                 } else if task.url.starts_with("vmux://agent/") {
                     crate::clear_stack_children(task.stack, &children_q, &mut commands);
@@ -7088,11 +7118,12 @@ mod tests {
 
             let pane = app.world_mut().spawn(Pane).id();
             app.world_mut().resource_mut::<FocusedStack>().pane = Some(pane);
+            let request_id = AgentRequestId::new();
 
             app.world_mut()
                 .resource_mut::<Messages<AgentCommandRequest>>()
                 .write(AgentCommandRequest {
-                    request_id: AgentRequestId::new(),
+                    request_id,
                     origin: vmux_service::agent_events::CommandOrigin::User,
                     command: ServiceAgentCommand::BrowserNavigate {
                         url: "vmux://terminal/".to_string(),
@@ -7108,6 +7139,14 @@ mod tests {
             assert!(
                 terminal_count >= 1,
                 "terminal should be spawned in focused pane"
+            );
+            assert!(
+                world
+                    .resource::<PendingNavSnapshots>()
+                    .0
+                    .values()
+                    .any(|pending| pending.request_id == request_id.0),
+                "terminal navigation should wait for its snapshot"
             );
         }
 

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -11,6 +11,7 @@ use bevy::{
     ecs::{message::Messages, relationship::Relationship},
     input::{
         ButtonState, InputSystems,
+        keyboard::KeyboardInput,
         mouse::{MouseButton, MouseButtonInput, MouseWheel},
     },
     material::AlphaMode,
@@ -335,7 +336,9 @@ impl Plugin for BrowserPlugin {
             )
             .init_resource::<HostFocusIntent>()
             .init_resource::<PendingNavSnapshots>()
+            .init_resource::<RecentBrowserInteraction>()
             .init_resource::<HostSpawnRegistry>()
+            .add_systems(Update, track_browser_interaction)
             .add_systems(
                 PostUpdate,
                 (
@@ -4313,17 +4316,23 @@ pub fn handle_browser_go_back_requests(
     terminals: Query<(Entity, &ChildOf), (With<Terminal>, Without<terminal::ProcessExited>)>,
     browsers: Query<(Entity, &ChildOf), With<Browser>>,
     pane_children: Query<&Children, With<Pane>>,
+    stacks: Query<Entity, With<Stack>>,
     stack_ts: Query<(Entity, &LastActivatedAt), With<Stack>>,
     mut commands: Commands,
 ) {
     for request in reader.read() {
         let target = match request.pane.as_deref() {
-            Some(s) => vmux_layout::target::parse_pane_target(s, &panes),
-            None => focus.pane.filter(|p| panes.contains(*p)),
+            Some(s) => vmux_layout::target::parse_browser_target(s, &panes, &stacks),
+            None => focus
+                .pane
+                .filter(|p| panes.contains(*p))
+                .map(vmux_layout::target::BrowserTarget::Pane),
         };
-        let Some(pane_entity) = target else { continue };
-        let Some(webview) = vmux_layout::target::active_webview_for_tab(
-            active_stack_in_pane(pane_entity, &pane_children, &stack_ts),
+        let Some(target) = target else { continue };
+        let Some(webview) = vmux_layout::target::webview_for_target(
+            target,
+            &pane_children,
+            &stack_ts,
             &browsers,
             &terminals,
         ) else {
@@ -4340,17 +4349,23 @@ pub fn handle_browser_go_forward_requests(
     terminals: Query<(Entity, &ChildOf), (With<Terminal>, Without<terminal::ProcessExited>)>,
     browsers: Query<(Entity, &ChildOf), With<Browser>>,
     pane_children: Query<&Children, With<Pane>>,
+    stacks: Query<Entity, With<Stack>>,
     stack_ts: Query<(Entity, &LastActivatedAt), With<Stack>>,
     mut commands: Commands,
 ) {
     for request in reader.read() {
         let target = match request.pane.as_deref() {
-            Some(s) => vmux_layout::target::parse_pane_target(s, &panes),
-            None => focus.pane.filter(|p| panes.contains(*p)),
+            Some(s) => vmux_layout::target::parse_browser_target(s, &panes, &stacks),
+            None => focus
+                .pane
+                .filter(|p| panes.contains(*p))
+                .map(vmux_layout::target::BrowserTarget::Pane),
         };
-        let Some(pane_entity) = target else { continue };
-        let Some(webview) = vmux_layout::target::active_webview_for_tab(
-            active_stack_in_pane(pane_entity, &pane_children, &stack_ts),
+        let Some(target) = target else { continue };
+        let Some(webview) = vmux_layout::target::webview_for_target(
+            target,
+            &pane_children,
+            &stack_ts,
             &browsers,
             &terminals,
         ) else {
@@ -4509,6 +4524,9 @@ fn attach_cef_page_requests(
 #[derive(Component, Clone, Debug)]
 struct PageOpenFallbackDeferred;
 
+#[derive(Component, Clone, Debug)]
+struct PageOpenAwaitSnapshot;
+
 fn handle_unclaimed_page_open_tasks(
     mut tasks: Query<
         (
@@ -4523,6 +4541,9 @@ fn handle_unclaimed_page_open_tasks(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
+    child_of: Query<&ChildOf>,
+    time: Res<Time>,
+    mut pending_nav: ResMut<PendingNavSnapshots>,
 ) {
     for (entity, task, error, deferred_once) in &mut tasks {
         if let Some(error) = error {
@@ -4571,7 +4592,7 @@ fn handle_unclaimed_page_open_tasks(
                 },
             ));
         } else {
-            attach_cef_page_to_stack(
+            let browser = attach_cef_page_to_stack(
                 task.stack,
                 &task.url,
                 &task.url,
@@ -4581,22 +4602,51 @@ fn handle_unclaimed_page_open_tasks(
                 &mut meshes,
                 &mut webview_mt,
             );
-            commands.entity(entity).insert(PageOpenHandled);
+            if let Some(request_id) = task.request_id {
+                let pane = child_of
+                    .get(task.stack)
+                    .ok()
+                    .map(|child_of| child_of.get().to_bits().to_string());
+                pending_nav.0.insert(
+                    browser,
+                    NavPending {
+                        request_id,
+                        started: time.elapsed(),
+                        saw_loading: false,
+                        pane,
+                    },
+                );
+                commands
+                    .entity(entity)
+                    .insert((PageOpenHandled, PageOpenAwaitSnapshot));
+            } else {
+                commands.entity(entity).insert(PageOpenHandled);
+            }
         }
     }
 }
 
 fn respond_page_open_tasks(
-    tasks: Query<(Entity, &PageOpenTask, Option<&PageOpenError>), With<PageOpenHandled>>,
+    tasks: Query<
+        (
+            Entity,
+            &PageOpenTask,
+            Option<&PageOpenError>,
+            Has<PageOpenAwaitSnapshot>,
+        ),
+        With<PageOpenHandled>,
+    >,
     service: Option<Res<vmux_service::client::ServiceClient>>,
     mut commands: Commands,
 ) {
-    for (entity, task, error) in &tasks {
+    for (entity, task, error, await_snapshot) in &tasks {
         let result = match error {
             Some(error) => Err(error.message.clone()),
             None => Ok(()),
         };
-        send_page_open_response(&service, task.request_id, result);
+        if !await_snapshot {
+            send_page_open_response(&service, task.request_id, result);
+        }
         commands.entity(entity).despawn();
     }
 }
@@ -4629,7 +4679,7 @@ fn attach_cef_page_to_stack(
     commands: &mut Commands,
     meshes: &mut ResMut<Assets<Mesh>>,
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
-) {
+) -> Entity {
     clear_stack_children(stack, children_q, commands);
     commands.entity(stack).insert(PageMetadata {
         url: url.to_string(),
@@ -4644,6 +4694,7 @@ fn attach_cef_page_to_stack(
         ))
         .id();
     commands.entity(browser).insert(CefKeyboardTarget);
+    browser
 }
 
 fn attach_error_page_to_stack(
@@ -4734,6 +4785,46 @@ pub struct NavPending {
 #[derive(Resource, Default)]
 pub struct PendingNavSnapshots(pub std::collections::HashMap<Entity, NavPending>);
 
+#[derive(Resource, Default)]
+pub struct RecentBrowserInteraction {
+    stack: Option<Entity>,
+    at: Option<std::time::Instant>,
+}
+
+impl RecentBrowserInteraction {
+    fn active(&self, stack: Entity) -> bool {
+        self.stack == Some(stack)
+            && self
+                .at
+                .is_some_and(|at| at.elapsed() < std::time::Duration::from_secs(2))
+    }
+}
+
+fn track_browser_interaction(
+    mut mouse_buttons: MessageReader<MouseButtonInput>,
+    mut mouse_wheels: MessageReader<MouseWheel>,
+    mut keyboard: MessageReader<KeyboardInput>,
+    focus: Res<vmux_layout::stack::FocusedStack>,
+    browsers: Query<&ChildOf, With<Browser>>,
+    mut recent: ResMut<RecentBrowserInteraction>,
+) {
+    let interacted = mouse_buttons
+        .read()
+        .any(|event| event.state == ButtonState::Pressed)
+        || mouse_wheels.read().next().is_some()
+        || keyboard
+            .read()
+            .any(|event| event.state == ButtonState::Pressed);
+    if !interacted {
+        return;
+    }
+    let Some(stack) = focus.stack else { return };
+    if browsers.iter().any(|child_of| child_of.get() == stack) {
+        recent.stack = Some(stack);
+        recent.at = Some(std::time::Instant::now());
+    }
+}
+
 pub fn handle_browser_navigate_requests(
     mut reader: MessageReader<vmux_layout::BrowserNavigateRequest>,
     focus: Res<vmux_layout::stack::FocusedStack>,
@@ -4747,16 +4838,54 @@ pub fn handle_browser_navigate_requests(
     time: Res<Time>,
     pane_children: Query<&Children, With<Pane>>,
     stack_ts: Query<(Entity, &vmux_core::LastActivatedAt), With<vmux_layout::stack::Stack>>,
+    recent_interaction: Res<RecentBrowserInteraction>,
+    mut activate: MessageWriter<vmux_layout::active_panes::ActivatePane>,
 ) {
     for request in reader.read() {
         let vmux_layout::BrowserNavigateRequest {
             url,
             pane,
             request_id,
+            new_stack,
+            profile,
         } = request.clone();
 
         if let Some(s) = pane.as_deref() {
             if let Some(target) = vmux_layout::target::parse_pane_target(s, &panes) {
+                if new_stack && !url.starts_with("vmux://") && !url.starts_with("file:") {
+                    let active_stack =
+                        vmux_layout::stack::active_stack_in_pane(target, &pane_children, &stack_ts);
+                    let activate_new =
+                        active_stack.is_none_or(|stack| !recent_interaction.active(stack));
+                    let stack = commands
+                        .spawn((
+                            vmux_layout::stack::stack_bundle(),
+                            if activate_new {
+                                LastActivatedAt::now()
+                            } else {
+                                LastActivatedAt(0)
+                            },
+                            ChildOf(target),
+                        ))
+                        .id();
+                    if let Some(profile) = profile {
+                        activate.write(vmux_layout::active_panes::ActivatePane {
+                            profile: vmux_layout::active_panes::ProfileId::Agent(profile),
+                            active: vmux_layout::active_panes::ActiveStack {
+                                tab: None,
+                                pane: Some(target),
+                                stack: Some(stack),
+                                kind: None,
+                            },
+                        });
+                    }
+                    page_open_writer.write(PageOpenRequest {
+                        target: PageOpenTarget::Stack(stack),
+                        url,
+                        request_id,
+                    });
+                    continue;
+                }
                 let in_place = if url.starts_with("vmux://") || url.starts_with("file:") {
                     None
                 } else {
@@ -6573,6 +6702,7 @@ mod tests {
     }
 
     mod browser_navigate_flow {
+        use crate::{Browser, PendingNavSnapshots, RecentBrowserInteraction};
         use bevy::ecs::relationship::Relationship;
         use bevy::prelude::*;
         use bevy_cef::prelude::WebviewExtendStandardMaterial;
@@ -6580,8 +6710,8 @@ mod tests {
         use vmux_agent::plugin::AgentPlugin;
         use vmux_agent::strategy::AgentStrategies;
         use vmux_core::{
-            CefPageAttachRequest, PageMetadata, PageOpenError, PageOpenHandled, PageOpenId,
-            PageOpenRequest, PageOpenSet, PageOpenTask,
+            CefPageAttachRequest, LastActivatedAt, PageMetadata, PageOpenError, PageOpenHandled,
+            PageOpenId, PageOpenRequest, PageOpenSet, PageOpenTask,
         };
         use vmux_layout::pane::Pane;
         use vmux_layout::settings::{
@@ -6633,7 +6763,9 @@ mod tests {
                 .add_message::<vmux_setting::SettingsWriteRequest>()
                 .add_message::<vmux_space::SpaceCommandRequest>()
                 .add_message::<vmux_history::query::HistoryOpenIntent>()
+                .add_message::<vmux_layout::active_panes::ActivatePane>()
                 .init_resource::<crate::PendingNavSnapshots>()
+                .init_resource::<crate::RecentBrowserInteraction>()
                 .configure_sets(
                     Update,
                     (
@@ -6788,6 +6920,115 @@ mod tests {
                 urls.contains(&"https://example.com".to_string()),
                 "browser entity with the URL should exist; found {urls:?}"
             );
+        }
+
+        #[test]
+        fn agent_browser_navigate_stacks_new_page_and_waits_for_snapshot() {
+            let mut app = App::new();
+            app.add_plugins(MinimalPlugins);
+            add_consumer_systems(&mut app);
+            app.insert_resource(FocusedStack::default())
+                .insert_resource(test_settings())
+                .init_resource::<Assets<Mesh>>()
+                .init_resource::<Assets<WebviewExtendStandardMaterial>>();
+
+            let pane = app.world_mut().spawn(Pane).id();
+            let first_stack = app
+                .world_mut()
+                .spawn((
+                    vmux_layout::stack::stack_bundle(),
+                    LastActivatedAt(1),
+                    ChildOf(pane),
+                ))
+                .id();
+            app.world_mut().spawn((Browser, ChildOf(first_stack)));
+            let request_id = [7; 16];
+            app.world_mut()
+                .resource_mut::<Messages<vmux_layout::BrowserNavigateRequest>>()
+                .write(vmux_layout::BrowserNavigateRequest {
+                    url: "https://second.example".into(),
+                    pane: Some(pane.to_bits().to_string()),
+                    request_id: Some(request_id),
+                    new_stack: true,
+                    profile: Some("agent-1".into()),
+                });
+
+            app.update();
+            app.update();
+
+            let world = app.world_mut();
+            let mut stacks = world.query_filtered::<
+                (Entity, &PageMetadata, &LastActivatedAt),
+                With<vmux_layout::stack::Stack>,
+            >();
+            let second = stacks
+                .iter(world)
+                .find(|(_, metadata, _)| metadata.url == "https://second.example")
+                .map(|(entity, _, activated)| (entity, activated.0))
+                .expect("new browser stack");
+            assert_ne!(second.0, first_stack);
+            assert!(second.1 > 1);
+            assert_eq!(world.resource::<PendingNavSnapshots>().0.len(), 1);
+            assert_eq!(
+                world
+                    .resource::<PendingNavSnapshots>()
+                    .0
+                    .values()
+                    .next()
+                    .unwrap()
+                    .request_id,
+                request_id
+            );
+        }
+
+        #[test]
+        fn agent_browser_navigate_does_not_raise_new_stack_during_user_interaction() {
+            let mut app = App::new();
+            app.add_plugins(MinimalPlugins);
+            add_consumer_systems(&mut app);
+            app.insert_resource(FocusedStack::default())
+                .insert_resource(test_settings())
+                .init_resource::<Assets<Mesh>>()
+                .init_resource::<Assets<WebviewExtendStandardMaterial>>();
+
+            let pane = app.world_mut().spawn(Pane).id();
+            let first_stack = app
+                .world_mut()
+                .spawn((
+                    vmux_layout::stack::stack_bundle(),
+                    LastActivatedAt(10),
+                    ChildOf(pane),
+                ))
+                .id();
+            app.world_mut().spawn((Browser, ChildOf(first_stack)));
+            app.insert_resource(RecentBrowserInteraction {
+                stack: Some(first_stack),
+                at: Some(std::time::Instant::now()),
+            });
+            app.world_mut()
+                .resource_mut::<Messages<vmux_layout::BrowserNavigateRequest>>()
+                .write(vmux_layout::BrowserNavigateRequest {
+                    url: "https://second.example".into(),
+                    pane: Some(pane.to_bits().to_string()),
+                    request_id: None,
+                    new_stack: true,
+                    profile: Some("agent-1".into()),
+                });
+
+            app.update();
+            app.update();
+
+            let world = app.world_mut();
+            let mut stacks = world.query_filtered::<
+                (&PageMetadata, &LastActivatedAt),
+                With<vmux_layout::stack::Stack>,
+            >();
+            let activated = stacks
+                .iter(world)
+                .find(|(metadata, _)| metadata.url == "https://second.example")
+                .map(|(_, activated)| activated.0)
+                .expect("new browser stack");
+            assert_eq!(activated, 0);
         }
 
         #[test]

--- a/crates/vmux_command/src/event.rs
+++ b/crates/vmux_command/src/event.rs
@@ -31,6 +31,37 @@ pub enum SearchEngine {
 }
 
 impl SearchEngine {
+    pub const ALL: [Self; 5] = [
+        Self::Google,
+        Self::Bing,
+        Self::DuckDuckGo,
+        Self::Brave,
+        Self::Kagi,
+    ];
+
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Google => "Google",
+            Self::Bing => "Bing",
+            Self::DuckDuckGo => "DuckDuckGo",
+            Self::Brave => "Brave Search",
+            Self::Kagi => "Kagi",
+        }
+    }
+
+    pub fn from_url(url: &str) -> Option<Self> {
+        let parsed = url::Url::parse(url).ok()?;
+        let host = parsed.host_str()?.trim_start_matches("www.");
+        match host {
+            "google.com" => Some(Self::Google),
+            "bing.com" => Some(Self::Bing),
+            "duckduckgo.com" => Some(Self::DuckDuckGo),
+            "search.brave.com" => Some(Self::Brave),
+            "kagi.com" => Some(Self::Kagi),
+            _ => None,
+        }
+    }
+
     /// Build a search result URL for `query`.
     pub fn search_url(self, query: &str) -> String {
         let query: String = url::form_urlencoded::byte_serialize(query.trim().as_bytes()).collect();
@@ -72,9 +103,36 @@ pub struct CommandBarOpenEvent {
     pub work_dirs: Vec<CommandBarWorkDir>,
     #[serde(default)]
     pub recent_files: Vec<CommandBarRecentFile>,
+    #[serde(default)]
+    pub search_engines: Vec<SearchEngine>,
+    #[serde(default)]
+    pub prompt_context: CommandBarPromptContext,
     pub target: Option<crate::open_target::OpenTarget>,
     #[serde(default)]
     pub space_switch: bool,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct CommandBarPromptContext {
+    pub cwd: String,
+    pub workspace_name: String,
+    pub is_git_repo: bool,
+    pub is_worktree: bool,
+    pub branch: String,
+    pub base_ref: String,
+    pub uncommitted: u32,
+    pub ahead: u32,
 }
 
 #[derive(

--- a/crates/vmux_command/src/snapshot.rs
+++ b/crates/vmux_command/src/snapshot.rs
@@ -1,4 +1,4 @@
-use crate::event::{CommandBarPage, CommandBarRecentFile, CommandBarWorkDir};
+use crate::event::{CommandBarPage, CommandBarRecentFile, CommandBarWorkDir, SearchEngine};
 use bevy::prelude::*;
 use std::collections::HashMap;
 use vmux_core::agent::AgentKind;
@@ -74,6 +74,7 @@ pub struct CommandBarPagesSnapshot {
 pub struct CommandBarWorkSnapshot {
     pub work_dirs: Vec<CommandBarWorkDir>,
     pub recent_files: Vec<CommandBarRecentFile>,
+    pub search_engines: Vec<SearchEngine>,
 }
 
 pub fn update_pages_snapshot(

--- a/crates/vmux_core/src/event.rs
+++ b/crates/vmux_core/src/event.rs
@@ -86,6 +86,8 @@ pub const EXPLORER_CLOSE_EDITOR_EVENT: &str = "explorer_close_editor";
 pub const EXPLORER_PANEL_TOGGLE_EVENT: &str = "explorer_panel_toggle";
 pub const EXPLORER_PANEL_WIDTH_EVENT: &str = "explorer_panel_width";
 pub const EXPLORER_GOTO_EVENT: &str = "explorer_goto";
+pub const EXPLORER_SEARCH_EVENT: &str = "explorer_search";
+pub const EXPLORER_SEARCH_OPEN_EVENT: &str = "explorer_search_open";
 pub const TERMINAL_PAGE_URL: &str = "vmux://terminal/";
 
 #[derive(
@@ -1177,6 +1179,60 @@ pub struct ExplorerPanelWidth {
 pub struct ExplorerGoto {
     pub path: String,
     pub line: u32,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ExplorerSearchMatch {
+    pub path: String,
+    pub line: u32,
+    pub col: u32,
+    pub end_col: u32,
+    pub preview: String,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ExplorerSearchEvent {
+    pub root: String,
+    pub query: String,
+    pub matches: Vec<ExplorerSearchMatch>,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct ExplorerSearchOpen {
+    pub path: String,
+    pub line: u32,
+    pub col: u32,
+    pub end_col: u32,
 }
 
 #[cfg(test)]

--- a/crates/vmux_desktop/src/browser_scroll.rs
+++ b/crates/vmux_desktop/src/browser_scroll.rs
@@ -7,7 +7,7 @@ use vmux_layout::Browser;
 use vmux_layout::active_panes::ActivePanes;
 use vmux_layout::pane::{Pane, PaneSplit};
 use vmux_layout::stack::{Stack, active_stack_in_pane};
-use vmux_layout::target::{active_webview_for_tab, parse_pane_target};
+use vmux_layout::target::active_webview_for_tab;
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn run_scrolls(
@@ -18,21 +18,36 @@ pub(crate) fn run_scrolls(
     terminals: Query<(Entity, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
     browsers: Query<(Entity, &ChildOf), With<Browser>>,
     pane_children: Query<&Children, With<Pane>>,
+    stacks: Query<Entity, With<Stack>>,
     stack_ts: Query<(Entity, &LastActivatedAt), With<Stack>>,
     mut snap_writer: MessageWriter<BrowserSnapshotRequest>,
 ) {
     for request in reader.read() {
-        let target = match request.pane.as_deref() {
-            Some(s) => parse_pane_target(s, &panes),
-            None => active.local().pane.filter(|p| panes.contains(*p)),
-        };
-        let webview = target
-            .and_then(|pane| {
-                active_webview_for_tab(
-                    active_stack_in_pane(pane, &pane_children, &stack_ts),
+        let webview = request
+            .pane
+            .as_deref()
+            .and_then(|target| vmux_layout::target::parse_browser_target(target, &panes, &stacks))
+            .and_then(|target| {
+                vmux_layout::target::webview_for_target(
+                    target,
+                    &pane_children,
+                    &stack_ts,
                     &browsers,
                     &terminals,
                 )
+            })
+            .or_else(|| {
+                active
+                    .local()
+                    .pane
+                    .filter(|p| panes.contains(*p))
+                    .and_then(|pane| {
+                        active_webview_for_tab(
+                            active_stack_in_pane(pane, &pane_children, &stack_ts),
+                            &browsers,
+                            &terminals,
+                        )
+                    })
             })
             .or_else(|| {
                 crate::browser_snapshot::most_recent_browser(&browsers, &terminals, &stack_ts)
@@ -51,6 +66,7 @@ pub(crate) fn run_scrolls(
         snap_writer.write(BrowserSnapshotRequest {
             request_id: request.request_id,
             pane: request.pane.clone(),
+            webview,
         });
     }
 }

--- a/crates/vmux_desktop/src/browser_snapshot.rs
+++ b/crates/vmux_desktop/src/browser_snapshot.rs
@@ -9,7 +9,7 @@ use vmux_core::terminal::{ProcessExited, Terminal};
 use vmux_layout::active_panes::ActivePanes;
 use vmux_layout::pane::{Pane, PaneSplit};
 use vmux_layout::stack::{Stack, active_stack_in_pane};
-use vmux_layout::target::{active_webview_for_tab, parse_pane_target};
+use vmux_layout::target::active_webview_for_tab;
 use vmux_layout::{Browser, Loading};
 
 fn hex(id: &[u8; 16]) -> String {
@@ -40,21 +40,38 @@ pub(crate) fn start_snapshots(
     terminals: Query<(Entity, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
     browsers: Query<(Entity, &ChildOf), With<Browser>>,
     pane_children: Query<&Children, With<Pane>>,
+    stacks: Query<Entity, With<Stack>>,
     stack_ts: Query<(Entity, &LastActivatedAt), With<Stack>>,
     mut writer: MessageWriter<BrowserSnapshotResponse>,
 ) {
     for request in reader.read() {
-        let target = match request.pane.as_deref() {
-            Some(s) => parse_pane_target(s, &panes),
-            None => active.local().pane.filter(|p| panes.contains(*p)),
-        };
-        let webview = target
-            .and_then(|pane| {
-                active_webview_for_tab(
-                    active_stack_in_pane(pane, &pane_children, &stack_ts),
+        let webview = request
+            .webview
+            .filter(|webview| browsers.contains(*webview))
+            .or_else(|| {
+                let target = request.pane.as_deref().and_then(|target| {
+                    vmux_layout::target::parse_browser_target(target, &panes, &stacks)
+                })?;
+                vmux_layout::target::webview_for_target(
+                    target,
+                    &pane_children,
+                    &stack_ts,
                     &browsers,
                     &terminals,
                 )
+            })
+            .or_else(|| {
+                active
+                    .local()
+                    .pane
+                    .filter(|p| panes.contains(*p))
+                    .and_then(|pane| {
+                        active_webview_for_tab(
+                            active_stack_in_pane(pane, &pane_children, &stack_ts),
+                            &browsers,
+                            &terminals,
+                        )
+                    })
             })
             .or_else(|| most_recent_browser(&browsers, &terminals, &stack_ts));
         let sent = webview
@@ -96,6 +113,7 @@ pub(crate) fn drive_pending_nav_snapshots(
     mut pending: ResMut<PendingNavSnapshots>,
     loading_q: Query<(), With<Loading>>,
     alive_q: Query<(), With<Browser>>,
+    ready_q: Query<(), With<vmux_core::page::PageReady>>,
     mut nav_awaiting: ResMut<NavAwaitingSnapshot>,
     mut snapshot_writer: MessageWriter<BrowserSnapshotRequest>,
 ) {
@@ -106,6 +124,7 @@ pub(crate) fn drive_pending_nav_snapshots(
     let mut done: Vec<Entity> = Vec::new();
     for (webview, nav) in pending.0.iter_mut() {
         let alive = alive_q.contains(*webview);
+        let ready = ready_q.contains(*webview);
         let loading = loading_q.contains(*webview);
         if loading {
             nav.saw_loading = true;
@@ -114,11 +133,12 @@ pub(crate) fn drive_pending_nav_snapshots(
         let settled = nav.saw_loading && !loading;
         let assume_instant = !nav.saw_loading && elapsed > 2.0;
         let timed_out = elapsed > 10.0;
-        if !alive || settled || assume_instant || timed_out {
+        if !alive || ready && (settled || assume_instant) || timed_out {
             nav_awaiting.0.insert(nav.request_id);
             snapshot_writer.write(BrowserSnapshotRequest {
                 request_id: nav.request_id,
                 pane: nav.pane.clone(),
+                webview: Some(*webview),
             });
             done.push(*webview);
         }

--- a/crates/vmux_editor/src/explorer.rs
+++ b/crates/vmux_editor/src/explorer.rs
@@ -3,6 +3,7 @@
 //! Explorer panel rendering, motion, context menus, and user intents.
 
 use std::collections::HashSet;
+use std::path::Path;
 
 use crate::page_model::merge_tree_motion_rows;
 use dioxus::prelude::*;
@@ -76,6 +77,23 @@ fn goto_line(line: u32) {
         path: String::new(),
         line,
     });
+}
+
+fn open_search_match(result: ExplorerSearchMatch) {
+    let _ = try_cef_bin_emit_rkyv(&ExplorerSearchOpen {
+        path: result.path,
+        line: result.line,
+        col: result.col,
+        end_col: result.end_col,
+    });
+}
+
+fn search_result_path(root: &str, path: &str) -> String {
+    Path::new(path)
+        .strip_prefix(root)
+        .ok()
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.to_string())
 }
 
 fn create_entry(parent: String, name: String, is_dir: bool) {
@@ -305,7 +323,9 @@ pub fn ExplorerPanel(visible: Signal<bool>) -> Element {
     let focus_generation = use_signal(|| 0u32);
     let mut open_editors = use_signal(Vec::<OpenEditorItem>::new);
     let mut outline = use_signal(Vec::<OutlineRow>::new);
+    let mut search = use_signal(|| None::<ExplorerSearchEvent>);
     let mut show_open = use_signal(|| true);
+    let mut show_search = use_signal(|| true);
     let mut show_files = use_signal(|| true);
     let mut show_outline = use_signal(|| true);
     let mut menu = use_signal(|| None::<TreeMenu>);
@@ -345,6 +365,11 @@ pub fn ExplorerPanel(visible: Signal<bool>) -> Element {
     let _outline = use_bin_event_listener::<OutlineEvent, _>(EXPLORER_OUTLINE_EVENT, move |e| {
         outline.set(e.items);
     });
+    let _search =
+        use_bin_event_listener::<ExplorerSearchEvent, _>(EXPLORER_SEARCH_EVENT, move |e| {
+            search.set(Some(e));
+            show_search.set(true);
+        });
     let _fs_result =
         use_bin_event_listener::<ExplorerFsResult, _>(EXPLORER_FS_RESULT_EVENT, move |e| {
             if e.ok && !e.open_path.is_empty() {
@@ -366,6 +391,11 @@ pub fn ExplorerPanel(visible: Signal<bool>) -> Element {
         "grid grid-rows-[0fr] opacity-0 transition-[grid-template-rows,opacity] duration-200 ease-out"
     };
     let files_body = if show_files() {
+        "grid grid-rows-[1fr] opacity-100 transition-[grid-template-rows,opacity] duration-200 ease-out"
+    } else {
+        "grid grid-rows-[0fr] opacity-0 transition-[grid-template-rows,opacity] duration-200 ease-out"
+    };
+    let search_body = if show_search() {
         "grid grid-rows-[1fr] opacity-100 transition-[grid-template-rows,opacity] duration-200 ease-out"
     } else {
         "grid grid-rows-[0fr] opacity-0 transition-[grid-template-rows,opacity] duration-200 ease-out"
@@ -413,6 +443,48 @@ pub fn ExplorerPanel(visible: Signal<bool>) -> Element {
                                         span { class: "truncate", "{it.name}" }
                                         if dirty {
                                             span { class: "ml-auto h-1.5 w-1.5 shrink-0 rounded-full bg-cyan-300" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if let Some(results) = search() {
+                    {section_header("Search".to_string(), show_search, EventHandler::new(move |_| show_search.set(!show_search())))}
+                    div { class: "{search_body}",
+                        div { class: "min-h-0 overflow-hidden pb-1",
+                            div { class: "mx-2 mb-1 flex h-7 items-center gap-2 rounded-md bg-foreground/[0.06] px-2 text-foreground/85 ring-1 ring-inset ring-foreground/10",
+                                svg {
+                                    class: "h-3.5 w-3.5 shrink-0 text-cyan-400",
+                                    view_box: "0 0 24 24",
+                                    fill: "none",
+                                    stroke: "currentColor",
+                                    stroke_width: "1.8",
+                                    stroke_linecap: "round",
+                                    stroke_linejoin: "round",
+                                    circle { cx: "11", cy: "11", r: "8" }
+                                    path { d: "m21 21-4.35-4.35" }
+                                }
+                                span { class: "min-w-0 flex-1 truncate font-mono", "{results.query}" }
+                                span { class: "shrink-0 text-[10px] tabular-nums text-muted-foreground", "{results.matches.len()}" }
+                            }
+                            for result in results.matches.clone() {
+                                {
+                                    let display_path = search_result_path(&results.root, &result.path);
+                                    let open_result = result.clone();
+                                    rsx! {
+                                        button {
+                                            key: "{result.path}:{result.line}:{result.col}",
+                                            class: "flex w-full min-w-0 flex-col gap-0.5 px-3 py-1 text-left text-foreground/75 transition-colors hover:bg-foreground/[0.08] hover:text-foreground",
+                                            title: "{result.path}:{result.line}",
+                                            onclick: move |_| open_search_match(open_result.clone()),
+                                            span { class: "flex min-w-0 items-baseline gap-1.5",
+                                                span { class: "truncate text-[11px]", "{display_path}" }
+                                                span { class: "shrink-0 text-[10px] tabular-nums text-cyan-400/80", "{result.line}" }
+                                            }
+                                            span { class: "w-full truncate font-mono text-[10px] text-muted-foreground", "{result.preview}" }
                                         }
                                     }
                                 }

--- a/crates/vmux_editor/src/lib.rs
+++ b/crates/vmux_editor/src/lib.rs
@@ -29,7 +29,9 @@ mod preview;
 #[cfg(not(target_arch = "wasm32"))]
 mod plugin;
 #[cfg(not(target_arch = "wasm32"))]
-pub use plugin::{EditorPlugin, FileView, FileViewModeRequest, restore_file_view_bundle};
+pub use plugin::{
+    EditorPlugin, FileView, FileViewModeRequest, GlobalSearchRequest, restore_file_view_bundle,
+};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod lsp;

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -170,6 +170,23 @@ impl Default for SharedFileViewMode {
 #[derive(Message, Clone, Copy, Debug, PartialEq, Eq)]
 pub struct FileViewModeRequest(pub FileViewMode);
 
+#[derive(Message, Clone, Debug, PartialEq, Eq)]
+pub struct GlobalSearchRequest {
+    pub target_path: PathBuf,
+    pub root: String,
+    pub query: String,
+    pub matches: Vec<ExplorerSearchMatch>,
+}
+
+#[derive(Component, Clone)]
+struct GlobalSearchState(ExplorerSearchEvent);
+
+#[derive(Component)]
+struct GlobalSearchDirty;
+
+#[derive(Resource, Default)]
+struct PendingGlobalSearch(Vec<GlobalSearchRequest>);
+
 #[derive(Component)]
 struct FileViewModeSent;
 
@@ -207,6 +224,11 @@ type ChangedNoteEditor = (With<FileView>, With<EditState>, Changed<EditState>);
 type TreeDirtyReady = (With<ExplorerTreeDirty>, With<vmux_core::page::PageReady>);
 type OpenEditorsDirtyReady = (With<OpenEditorsDirty>, With<vmux_core::page::PageReady>);
 type OutlineDirtyReady = (With<OutlineDirty>, With<vmux_core::page::PageReady>);
+type GlobalSearchDirtyReady = (
+    With<GlobalSearchState>,
+    With<GlobalSearchDirty>,
+    With<vmux_core::page::PageReady>,
+);
 type ChromeUnsentReady = (
     With<FileView>,
     Without<ExplorerChromeSent>,
@@ -2849,6 +2871,87 @@ fn on_explorer_goto(
     });
 }
 
+fn apply_global_search_requests(
+    mut reader: MessageReader<GlobalSearchRequest>,
+    views: Query<(Entity, &FileView)>,
+    mut pending: ResMut<PendingGlobalSearch>,
+    mut chrome: ResMut<ExplorerChrome>,
+    mut commands: Commands,
+) {
+    pending.0.extend(reader.read().cloned());
+    if !pending.0.is_empty() && !chrome.visible {
+        chrome.visible = true;
+        for (entity, _) in &views {
+            commands.entity(entity).remove::<ExplorerChromeSent>();
+        }
+    }
+    let mut remaining = Vec::new();
+    for request in pending.0.drain(..) {
+        let Some((entity, _)) = views
+            .iter()
+            .find(|(_, view)| view.path == request.target_path)
+        else {
+            remaining.push(request);
+            continue;
+        };
+        commands.entity(entity).insert((
+            GlobalSearchState(ExplorerSearchEvent {
+                root: request.root,
+                query: request.query,
+                matches: request.matches,
+            }),
+            GlobalSearchDirty,
+        ));
+    }
+    pending.0 = remaining;
+}
+
+fn emit_global_search(
+    q: Query<(Entity, &GlobalSearchState), GlobalSearchDirtyReady>,
+    browsers: NonSend<Browsers>,
+    mut commands: Commands,
+) {
+    for (entity, search) in &q {
+        if !browsers.has_browser(entity) || !browsers.host_emit_ready(&entity) {
+            continue;
+        }
+        commands.trigger(BinHostEmitEvent::from_rkyv(
+            entity,
+            EXPLORER_SEARCH_EVENT,
+            &search.0,
+        ));
+        commands.entity(entity).remove::<GlobalSearchDirty>();
+    }
+}
+
+fn on_explorer_search_open(
+    trigger: On<BinReceive<ExplorerSearchOpen>>,
+    mut views: Query<(&mut FileView, &mut FileViewport, &mut PageMetadata)>,
+    mut manager: NonSendMut<crate::lsp::manager::LspManager>,
+    mut commands: Commands,
+) {
+    let entity = trigger.event().webview;
+    let request = &trigger.event().payload;
+    let Ok((mut view, mut viewport, mut metadata)) = views.get_mut(entity) else {
+        return;
+    };
+    navigate_file_view(
+        entity,
+        PathBuf::from(&request.path),
+        request.line.saturating_sub(1),
+        &mut view,
+        &mut viewport,
+        &mut metadata,
+        &mut manager,
+        &mut commands,
+    );
+    commands.entity(entity).insert(PendingGoto {
+        line: request.line.saturating_sub(1),
+        utf16_col: request.col,
+        select_end_col: Some(request.end_col),
+    });
+}
+
 pub const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
     host: "files",
     title: "Files",
@@ -2897,9 +3000,11 @@ impl Plugin for EditorPlugin {
                 request_id: 0,
             })
             .init_resource::<ExplorerChromeSynced>()
+            .init_resource::<PendingGlobalSearch>()
             .init_resource::<SharedFileViewMode>()
             .add_message::<vmux_core::event::RecordVisitRequest>()
             .add_message::<FileViewModeRequest>()
+            .add_message::<GlobalSearchRequest>()
             .add_plugins(crate::lsp::LspPlugin)
             .add_plugins(BinEventEmitterPlugin::<(
                 FileResizeEvent,
@@ -2934,6 +3039,7 @@ impl Plugin for EditorPlugin {
                 ExplorerPanelSetVisible,
                 ExplorerPanelWidth,
                 ExplorerGoto,
+                ExplorerSearchOpen,
             )>::default())
             .add_systems(
                 Update,
@@ -2984,6 +3090,8 @@ impl Plugin for EditorPlugin {
                     mark_outline_dirty,
                     emit_outline_markdown,
                     clear_outline_on_file_change,
+                    apply_global_search_requests,
+                    emit_global_search.after(apply_global_search_requests),
                 ),
             )
             .add_observer(reset_file_sent_markers_on_page_ready)
@@ -3014,7 +3122,8 @@ impl Plugin for EditorPlugin {
             .add_observer(on_explorer_panel_set_visible)
             .add_observer(on_explorer_panel_width)
             .add_observer(on_explorer_close_editor)
-            .add_observer(on_explorer_goto);
+            .add_observer(on_explorer_goto)
+            .add_observer(on_explorer_search_open);
     }
 }
 

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -185,7 +185,14 @@ struct GlobalSearchState(ExplorerSearchEvent);
 struct GlobalSearchDirty;
 
 #[derive(Resource, Default)]
-struct PendingGlobalSearch(Vec<GlobalSearchRequest>);
+struct PendingGlobalSearch(Vec<PendingGlobalSearchRequest>);
+
+struct PendingGlobalSearchRequest {
+    request: GlobalSearchRequest,
+    retries_left: u8,
+}
+
+const GLOBAL_SEARCH_RETRY_LIMIT: u8 = 120;
 
 #[derive(Component)]
 struct FileViewModeSent;
@@ -2878,7 +2885,15 @@ fn apply_global_search_requests(
     mut chrome: ResMut<ExplorerChrome>,
     mut commands: Commands,
 ) {
-    pending.0.extend(reader.read().cloned());
+    pending.0.extend(
+        reader
+            .read()
+            .cloned()
+            .map(|request| PendingGlobalSearchRequest {
+                request,
+                retries_left: GLOBAL_SEARCH_RETRY_LIMIT,
+            }),
+    );
     if !pending.0.is_empty() && !chrome.visible {
         chrome.visible = true;
         for (entity, _) in &views {
@@ -2886,14 +2901,19 @@ fn apply_global_search_requests(
         }
     }
     let mut remaining = Vec::new();
-    for request in pending.0.drain(..) {
+    for mut pending_request in pending.0.drain(..) {
+        let request = &pending_request.request;
         let Some((entity, _)) = views
             .iter()
             .find(|(_, view)| view.path == request.target_path)
         else {
-            remaining.push(request);
+            pending_request.retries_left = pending_request.retries_left.saturating_sub(1);
+            if pending_request.retries_left > 0 {
+                remaining.push(pending_request);
+            }
             continue;
         };
+        let request = pending_request.request;
         commands.entity(entity).insert((
             GlobalSearchState(ExplorerSearchEvent {
                 root: request.root,

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -2957,7 +2957,7 @@ pub const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageMa
     title: "Files",
     keywords: &["file", "open"],
     icon: Some(vmux_core::BuiltinIcon::Files),
-    command_bar: false,
+    command_bar: true,
 };
 
 /// Wires the file editor: buffer loading, filesystem watching, image and theme sends, LSP

--- a/crates/vmux_git/src/worktree.rs
+++ b/crates/vmux_git/src/worktree.rs
@@ -147,6 +147,21 @@ pub fn repo_root_of(dir: &Path) -> Result<PathBuf, GitError> {
     checkout_info(dir).map(|info| info.root)
 }
 
+/// Initialize a Git repository in an existing directory.
+pub fn repository_init(dir: &Path) -> Result<PathBuf, GitError> {
+    let dir = dir
+        .canonicalize()
+        .map_err(|error| GitError(format!("invalid workspace directory: {error}")))?;
+    if !dir.is_dir() {
+        return Err(GitError("workspace path is not a directory".to_string()));
+    }
+    let (stdout, stderr, ok) = git(&dir, &["init", "--quiet"])?;
+    if !ok {
+        return Err(git_err(&stdout, &stderr));
+    }
+    checkout_info(&dir).map(|info| info.root)
+}
+
 /// The absolute common Git directory shared by a repository's main and linked worktrees.
 pub fn common_dir_of(dir: &Path) -> Result<PathBuf, GitError> {
     checkout_info(dir).map(|info| info.common_dir)
@@ -564,6 +579,16 @@ mod tests {
         let wt_info = repo_info(&wt).expect("worktree is a repo");
         assert!(wt_info.is_worktree);
         assert_eq!(wt_info.branch, "vmux/feat");
+    }
+
+    #[test]
+    fn repository_init_makes_the_selected_directory_a_checkout() {
+        let workspace = tempfile::tempdir().unwrap();
+
+        let root = repository_init(workspace.path()).unwrap();
+
+        assert_eq!(root, workspace.path().canonicalize().unwrap());
+        assert!(workspace.path().join(".git").is_dir());
     }
 
     #[test]

--- a/crates/vmux_layout/src/active_panes.rs
+++ b/crates/vmux_layout/src/active_panes.rs
@@ -84,7 +84,11 @@ fn mirror_local_active_pane(focus: Res<FocusedStack>, mut active: ResMut<ActiveP
 
 fn apply_active_panes(mut reader: MessageReader<ActivatePane>, mut active: ResMut<ActivePanes>) {
     for ev in reader.read() {
-        active.0.insert(ev.profile.clone(), ev.active);
+        let mut next = ev.active;
+        if next.kind.is_none() {
+            next.kind = active.0.get(&ev.profile).and_then(|current| current.kind);
+        }
+        active.0.insert(ev.profile.clone(), next);
     }
 }
 

--- a/crates/vmux_layout/src/active_panes.rs
+++ b/crates/vmux_layout/src/active_panes.rs
@@ -185,4 +185,44 @@ mod tests {
             Some(agent_pane)
         );
     }
+
+    #[test]
+    fn activation_without_kind_preserves_profile_kind() {
+        let mut app = App::new();
+        app.init_resource::<ActivePanes>()
+            .add_message::<ActivatePane>()
+            .add_systems(Update, apply_active_panes);
+
+        let profile = ProfileId::Agent("a1".to_string());
+        let pane = app.world_mut().spawn_empty().id();
+        app.world_mut().resource_mut::<ActivePanes>().0.insert(
+            profile.clone(),
+            ActiveStack {
+                tab: None,
+                pane: Some(pane),
+                stack: None,
+                kind: Some(vmux_core::agent::AgentKind::Codex),
+            },
+        );
+        app.world_mut().write_message(ActivatePane {
+            profile: profile.clone(),
+            active: ActiveStack {
+                tab: None,
+                pane: Some(pane),
+                stack: None,
+                kind: None,
+            },
+        });
+
+        app.update();
+
+        assert_eq!(
+            app.world()
+                .resource::<ActivePanes>()
+                .get(&profile)
+                .unwrap()
+                .kind,
+            Some(vmux_core::agent::AgentKind::Codex)
+        );
+    }
 }

--- a/crates/vmux_layout/src/command_bar/handler.rs
+++ b/crates/vmux_layout/src/command_bar/handler.rs
@@ -1018,6 +1018,7 @@ fn command_bar_open_payload(
     pages: Vec<CommandBarPage>,
     work_dirs: Vec<vmux_command::event::CommandBarWorkDir>,
     recent_files: Vec<vmux_command::event::CommandBarRecentFile>,
+    search_engines: Vec<SearchEngine>,
 ) -> CommandBarOpenEvent {
     CommandBarOpenEvent {
         open_id,
@@ -1030,6 +1031,8 @@ fn command_bar_open_payload(
         pages,
         work_dirs,
         recent_files,
+        search_engines,
+        prompt_context: default(),
         target,
         space_switch: false,
     }
@@ -1189,6 +1192,7 @@ pub(crate) fn build_command_bar_open_payload(
         pages,
         work_snapshot.work_dirs.clone(),
         work_snapshot.recent_files.clone(),
+        work_snapshot.search_engines.clone(),
     )
 }
 
@@ -2526,6 +2530,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Vec::new(),
+            Vec::new(),
         );
 
         assert_eq!(payload.space_name, "Work");
@@ -2551,6 +2556,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             None,
+            Vec::new(),
             Vec::new(),
             Vec::new(),
             Vec::new(),

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -365,7 +365,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     } else if is_start && q.trim().is_empty() {
         Vec::new()
     } else if start_prompt_mode {
-        start_page_results(&pages, &q)
+        start_page_results(&pages, &work_dirs, &recent_files, &q)
     } else {
         let history = history_suggestions();
         let r = filter_results(

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -9,7 +9,8 @@ use crate::command_bar::keyboard::{
 };
 use crate::command_bar::results::{
     CommandBarResultItem as ResultItem, active_space_index, agent_page_matches_query,
-    agent_page_results, agent_page_url, filter_results, space_switch_results, start_page_results,
+    agent_page_results, agent_page_url, filter_results, prepend_prompt_agent, space_switch_results,
+    start_page_results,
 };
 use crate::command_bar::style::{
     command_bar_input_class, command_bar_input_row_class, command_bar_input_wrap_class,
@@ -18,6 +19,7 @@ use crate::command_bar::style::{
     result_secondary_text_class, result_shortcut_badge_class, result_terminal_path_class,
     result_trailing_slot_class,
 };
+use crate::start::event::StartSelectWorkspace;
 use dioxus::prelude::*;
 use vmux_command::event::{
     CommandBarActionEvent, CommandBarOpenEvent, HISTORY_SUGGESTIONS_RESPONSE_EVENT, HistoryEntry,
@@ -45,7 +47,7 @@ use vmux_ui::icon::PageIconView;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 
-const HOST_SEARCH_DEBOUNCE_MS: i32 = 150;
+const HOST_SEARCH_DEBOUNCE_MS: i32 = 300;
 
 type HostSearchTimer = Rc<RefCell<Option<(i32, js_sys::Function, Rc<Cell<bool>>)>>>;
 
@@ -149,6 +151,8 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let media_search_timer: HostSearchTimer = use_hook(|| Rc::new(RefCell::new(None)));
     let mut media_loading = use_signal(|| false);
     let mut media_selected = use_signal(|| 0usize);
+    let mut start_agent_url = use_signal(String::new);
+    let mut start_agent_menu_open = use_signal(|| false);
 
     let path_search_effect_timer = path_search_timer.clone();
     use_effect(move || {
@@ -233,6 +237,11 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
 
     let suggestions_search_effect_timer = suggestions_search_timer.clone();
     use_effect(move || {
+        if is_start {
+            cancel_host_search(&suggestions_search_effect_timer);
+            history_suggestions.set(Vec::new());
+            return;
+        }
         let q = query();
         let trimmed = q.trim();
         let id = (*suggestions_request_id.peek()).wrapping_add(1).max(1);
@@ -339,6 +348,8 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let pages = state_val.pages.clone();
     let work_dirs = state_val.work_dirs.clone();
     let recent_files = state_val.recent_files.clone();
+    let search_engines = state_val.search_engines.clone();
+    let prompt_context = state_val.prompt_context.clone();
     let open_target = state_val.target;
     let space_switch = state_val.space_switch;
     let is_new_tab = matches!(open_target, Some(OpenTarget::InNewStack));
@@ -360,12 +371,22 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
         })
         .collect::<Vec<_>>();
     let start_prompt_mode = is_start && is_start_prompt_query(&q);
-    let results: Vec<ResultItem> = if space_switch {
+    let start_agent_items = if is_start {
+        agent_page_results(&pages, "")
+    } else {
+        Vec::new()
+    };
+    let default_agent_item = start_agent_items
+        .iter()
+        .find(|item| agent_page_url(item) == Some(start_agent_url().as_str()))
+        .cloned()
+        .or_else(|| start_agent_items.first().cloned());
+    let mut results: Vec<ResultItem> = if space_switch {
         space_switch_results(&spaces, &pages, &q)
     } else if is_start && q.trim().is_empty() {
         Vec::new()
     } else if start_prompt_mode {
-        start_page_results(&pages, &work_dirs, &recent_files, &q)
+        start_page_results(&pages, &work_dirs, &recent_files, &search_engines, &q)
     } else {
         let history = history_suggestions();
         let r = filter_results(
@@ -412,23 +433,35 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
             r
         }
     };
-    let default_agent_item = is_start
-        .then(|| agent_page_results(&pages, "").into_iter().next())
-        .flatten();
+    if start_prompt_mode {
+        prepend_prompt_agent(&mut results, default_agent_item.as_ref(), &q);
+    }
     let sel = selected().min(results.len().saturating_sub(1));
     let active_item = results.get(sel).cloned();
-    let active_agent_accent = active_item
+    let nav = nav_mode();
+    let selected_agent_accent = default_agent_item
         .as_ref()
         .and_then(agent_page_url)
         .and_then(|url| url.strip_prefix("vmux://agent/"))
         .and_then(|path| path.split('/').next())
         .filter(|agent| !agent.is_empty())
         .map(agent_accent);
-    let nav = nav_mode();
+    let active_agent_accent = if nav {
+        active_item.as_ref()
+    } else {
+        default_agent_item.as_ref()
+    }
+    .and_then(agent_page_url)
+    .and_then(|url| url.strip_prefix("vmux://agent/"))
+    .and_then(|path| path.split('/').next())
+    .filter(|agent| !agent.is_empty())
+    .map(agent_accent)
+    .or(selected_agent_accent);
     let display_text = if nav && !start_prompt_mode {
         match &active_item {
             Some(ResultItem::Command { name, .. }) => format!("> {name}"),
             Some(ResultItem::Navigate { url }) => url.clone(),
+            Some(ResultItem::Search { query, .. }) => query.clone(),
             Some(ResultItem::Stack { url, .. }) => url.clone(),
             Some(ResultItem::Space { name, .. }) => name.clone(),
             Some(ResultItem::Page { title, .. }) => title.clone(),
@@ -564,6 +597,9 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                     emit_action_with_target("open", url, open_target);
                 }
             }
+            ResultItem::Search { engine, query } => {
+                emit_action_with_target("open", &engine.search_url(query), open_target);
+            }
             ResultItem::History { url, .. } => {
                 if !url.is_empty() {
                     emit_action_with_target("open", url, open_target);
@@ -612,9 +648,148 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
         })
         .collect::<Vec<_>>();
     let start_action_enabled = !q.trim().is_empty() || !attachments.read().is_empty();
+    let selected_agent_title = default_agent_item
+        .as_ref()
+        .and_then(|item| match item {
+            ResultItem::Page { title, .. } => Some(title.clone()),
+            _ => None,
+        })
+        .unwrap_or_else(|| "Agent".to_string());
+    let selected_agent_url_value = default_agent_item
+        .as_ref()
+        .and_then(agent_page_url)
+        .unwrap_or_default()
+        .to_string();
+    let workspace_label = if prompt_context.workspace_name.is_empty() {
+        "Select workspace".to_string()
+    } else {
+        prompt_context.workspace_name.clone()
+    };
+    let branch_title = if prompt_context.branch.is_empty() {
+        "Git repository".to_string()
+    } else {
+        format!("Branch {}", prompt_context.branch)
+    };
+    let worktree_title = if prompt_context.base_ref.is_empty() {
+        "Linked worktree".to_string()
+    } else {
+        format!("Worktree from {}", prompt_context.base_ref)
+    };
+    let start_composer_footer = rsx! {
+        div { class: "flex min-w-0 items-center justify-between gap-1",
+            div { class: "flex min-w-0 flex-1 items-center gap-1 overflow-x-auto",
+                button {
+                    class: "flex h-7 max-w-44 shrink-0 items-center gap-1.5 rounded-lg px-2 text-[11px] font-medium text-foreground/70 transition hover:bg-foreground/[0.08] hover:text-foreground",
+                    title: "Choose agent",
+                    onmousedown: move |event| event.prevent_default(),
+                    onclick: move |_| {
+                        start_agent_menu_open.set(!start_agent_menu_open());
+                        focus_prompt_end(PROMPT_INPUT_ID);
+                    },
+                    svg {
+                        class: "h-3.5 w-3.5 shrink-0",
+                        view_box: "0 0 24 24",
+                        fill: "none",
+                        stroke: "currentColor",
+                        stroke_width: "1.8",
+                        stroke_linecap: "round",
+                        stroke_linejoin: "round",
+                        path { d: "M12 3l1.7 4.6L18 9.3l-4.3 1.7L12 16l-1.7-5L6 9.3l4.3-1.7L12 3Z" }
+                        path { d: "M19 15l.8 2.2L22 18l-2.2.8L19 21l-.8-2.2L16 18l2.2-.8L19 15Z" }
+                    }
+                    span { class: "truncate", "{selected_agent_title}" }
+                    svg {
+                        class: "h-3 w-3 shrink-0 opacity-50",
+                        view_box: "0 0 24 24",
+                        fill: "none",
+                        stroke: "currentColor",
+                        stroke_width: "2",
+                        path { d: "m8 10 4 4 4-4" }
+                    }
+                }
+                span {
+                    class: "flex h-7 shrink-0 items-center gap-1.5 rounded-lg px-2 text-[11px] text-muted-foreground",
+                    title: "Tools ask before protected actions",
+                    svg {
+                        class: "h-3.5 w-3.5",
+                        view_box: "0 0 24 24",
+                        fill: "none",
+                        stroke: "currentColor",
+                        stroke_width: "1.8",
+                        stroke_linecap: "round",
+                        stroke_linejoin: "round",
+                        path { d: "M12 3 5 6v5c0 4.8 2.9 8.2 7 10 4.1-1.8 7-5.2 7-10V6l-7-3Z" }
+                        path { d: "m9 12 2 2 4-4" }
+                    }
+                    "Ask"
+                }
+                button {
+                        class: "flex h-7 max-w-44 shrink-0 items-center gap-1.5 rounded-lg px-2 text-[11px] text-muted-foreground transition hover:bg-foreground/[0.08] hover:text-foreground",
+                        title: if prompt_context.cwd.is_empty() { "Create or select workspace" } else { "{prompt_context.cwd}" },
+                        onmousedown: move |event| event.prevent_default(),
+                        onclick: move |_| {
+                            let _ = try_cef_bin_emit_rkyv(&StartSelectWorkspace {
+                                current_dir: prompt_context.cwd.clone(),
+                            });
+                            focus_prompt_end(PROMPT_INPUT_ID);
+                        },
+                        svg {
+                            class: "h-3.5 w-3.5 shrink-0",
+                            view_box: "0 0 24 24",
+                            fill: "none",
+                            stroke: "currentColor",
+                            stroke_width: "1.8",
+                            path { d: "M3 6.5h6l2 2h10v9.5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V6.5Z" }
+                        }
+                        span { class: "truncate", "{workspace_label}" }
+                }
+                if prompt_context.is_git_repo {
+                    span {
+                        class: "flex h-7 max-w-40 shrink-0 items-center gap-1.5 rounded-lg px-2 font-mono text-[10px] text-muted-foreground",
+                        title: "{branch_title}",
+                        svg {
+                            class: "h-3.5 w-3.5 shrink-0",
+                            view_box: "0 0 24 24",
+                            fill: "none",
+                            stroke: "currentColor",
+                            stroke_width: "1.8",
+                            stroke_linecap: "round",
+                            stroke_linejoin: "round",
+                            circle { cx: "6", cy: "5", r: "2" }
+                            circle { cx: "6", cy: "19", r: "2" }
+                            circle { cx: "18", cy: "12", r: "2" }
+                            path { d: "M8 5h3a3 3 0 0 1 3 3v1a3 3 0 0 0 3 3" }
+                            path { d: "M6 7v10" }
+                        }
+                        span { class: "truncate", if prompt_context.branch.is_empty() { "Git" } else { "{prompt_context.branch}" } }
+                    }
+                    if prompt_context.is_worktree {
+                        span {
+                            class: "flex h-7 shrink-0 items-center gap-1 rounded-lg bg-violet-500/[0.08] px-2 text-[10px] font-medium text-violet-600 ring-1 ring-inset ring-violet-500/15 dark:text-violet-300",
+                            title: "{worktree_title}",
+                            "Worktree"
+                        }
+                    }
+                    if prompt_context.uncommitted > 0 {
+                        span { class: "shrink-0 font-mono text-[10px] text-amber-500", title: "Uncommitted changes", "● {prompt_context.uncommitted}" }
+                    }
+                    if prompt_context.ahead > 0 {
+                        span { class: "shrink-0 font-mono text-[10px] text-sky-500", title: "Commits ahead of upstream", "↑{prompt_context.ahead}" }
+                    }
+                } else if !prompt_context.cwd.is_empty() {
+                    span { class: "h-7 shrink-0 content-center rounded-lg px-2 text-[10px] text-muted-foreground/70", "No Git" }
+                }
+            }
+            span { class: "flex h-7 shrink-0 items-center gap-1.5 rounded-lg px-2 text-[10px] text-muted-foreground",
+                span { class: "h-1.5 w-1.5 rounded-full bg-emerald-500" }
+                "Ready"
+            }
+        }
+    };
     let start_keydown_q = q.clone();
     let start_keydown_results = results.clone();
     let start_keydown_default_agent = default_agent_item.clone();
+    let start_keydown_nav = nav;
     let start_keydown_ghost = ghost_text.clone();
     let start_keydown = move |e: KeyboardEvent| {
         if e.key() == Key::Tab {
@@ -714,7 +889,14 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                     execute(item);
                 }
             } else if start_prompt_mode {
-                if let Some(item) = start_keydown_results.get(sel) {
+                if let Some(item) = start_keydown_results.get(sel).filter(|item| {
+                    start_keydown_nav
+                        || agent_page_matches_query(item, &start_keydown_q)
+                        || (matches!(item, ResultItem::Terminal { .. })
+                            && start_keydown_q.trim().eq_ignore_ascii_case("terminal"))
+                }) {
+                    execute(item);
+                } else if let Some(item) = start_keydown_default_agent.as_ref() {
                     execute(item);
                 } else {
                     on_close.call(());
@@ -847,6 +1029,51 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                 }
             }
             if is_start {
+                if start_agent_menu_open() {
+                    PromptPopup {
+                        placement: PromptPopupPlacement::Upward,
+                        id: "start-agent-selector",
+                        div { class: "p-1.5",
+                            div { class: "px-2 pb-1 pt-0.5 text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground/60", "Agent" }
+                            for item in start_agent_items.iter() {
+                                if let ResultItem::Page { url, title, .. } = item {
+                                    {
+                                        let option_url = url.clone();
+                                        let option_selected = url == &selected_agent_url_value;
+                                        rsx! {
+                                            button {
+                                                key: "{url}",
+                                                class: if option_selected { "flex w-full items-center gap-2 rounded-xl bg-foreground/[0.08] px-2.5 py-2 text-left text-sm text-foreground" } else { "flex w-full items-center gap-2 rounded-xl px-2.5 py-2 text-left text-sm text-foreground/75 transition hover:bg-foreground/[0.06] hover:text-foreground" },
+                                                onmousedown: move |event| event.prevent_default(),
+                                                onclick: move |_| {
+                                                    start_agent_url.set(option_url.clone());
+                                                    start_agent_menu_open.set(false);
+                                                    selected.set(0);
+                                                    nav_mode.set(false);
+                                                    focus_prompt_end(PROMPT_INPUT_ID);
+                                                },
+                                                span { class: "flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-foreground/[0.07] text-[10px] font-semibold uppercase", "{title.chars().next().unwrap_or('A')}" }
+                                                span { class: "min-w-0 flex-1 truncate", "{title}" }
+                                                if option_selected {
+                                                    svg {
+                                                        class: "h-3.5 w-3.5 shrink-0 text-emerald-500",
+                                                        view_box: "0 0 24 24",
+                                                        fill: "none",
+                                                        stroke: "currentColor",
+                                                        stroke_width: "2.2",
+                                                        stroke_linecap: "round",
+                                                        stroke_linejoin: "round",
+                                                        path { d: "m5 12 4 4L19 6" }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
                 PromptComposer {
                     value: display_text.clone(),
                     completion: ghost_text.clone(),
@@ -856,9 +1083,11 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                     accent_bg: start_accent.accent_bg.to_string(),
                     accent_color: format!("rgb({})", start_accent.rain_rgb),
                     accent_gradient: start_accent.grad.to_string(),
+                    footer: Some(start_composer_footer),
                     action_title: "Send (Enter)".to_string(),
                     action_enabled: start_action_enabled,
                     on_input: move |value| {
+                        start_agent_menu_open.set(false);
                         query.set(value);
                         selected.set(0);
                         nav_mode.set(false);
@@ -881,15 +1110,20 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                         let action_results = results.clone();
                         let action_query = q.clone();
                         let action_default_agent = default_agent_item.clone();
+                        let action_nav = nav;
                         move |_| {
-                            if let Some(item) = action_results.get(sel) {
+                            if let Some(item) = action_results.get(sel).filter(|item| {
+                                !start_prompt_mode
+                                    || action_nav
+                                    || agent_page_matches_query(item, &action_query)
+                                    || (matches!(item, ResultItem::Terminal { .. })
+                                        && action_query.trim().eq_ignore_ascii_case("terminal"))
+                            }) {
                                 execute(item);
                             } else if !action_query.trim().is_empty()
                                 || !attachments.peek().is_empty()
                             {
-                                if action_query.trim().is_empty()
-                                    && let Some(item) = action_default_agent.as_ref()
-                                {
+                                if let Some(item) = action_default_agent.as_ref() {
                                     execute(item);
                                 } else {
                                     on_close.call(());
@@ -932,6 +1166,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                                             || (url.contains('.') && !url.contains(' '));
                                         (false, false, is_url)
                                     }
+                                    Some(ResultItem::Search { .. }) => (false, false, false),
                                     Some(ResultItem::History { .. }) => (false, false, true),
                                     Some(ResultItem::File { .. }) => (false, true, false),
                                     Some(ResultItem::WorkDir { .. }) => (false, true, false),
@@ -1021,7 +1256,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                     }
                 }
             }
-            if media_menu_open {
+            if !start_agent_menu_open() && media_menu_open {
                 PromptPopup {
                     placement: PromptPopupPlacement::Downward,
                     id: "command-bar-results",
@@ -1038,7 +1273,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                     }
                 }
             }
-            if !media_menu_open && !results.is_empty() {
+            if !start_agent_menu_open() && !media_menu_open && !results.is_empty() {
                 PromptPopup {
                     placement: if is_start { PromptPopupPlacement::Downward } else { PromptPopupPlacement::Inline },
                     id: "command-bar-results",
@@ -1137,8 +1372,15 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                                         icon_class: result_leading_icon_class().to_string(),
                                     }
                                     div { class: "flex min-w-0 flex-1 flex-col overflow-hidden",
-                                        span { class: result_primary_text_class(), "{title}" }
-                                        span { class: result_secondary_text_class(), "{url}" }
+                                        if start_prompt_mode
+                                            && agent_page_url(item).is_some()
+                                            && !agent_page_matches_query(item, &q)
+                                        {
+                                            span { class: result_primary_text_class(), "Ask {title}" }
+                                        } else {
+                                            span { class: result_primary_text_class(), "{title}" }
+                                            span { class: result_secondary_text_class(), "{url}" }
+                                        }
                                     }
                                 }
                                 span { class: result_trailing_slot_class(),
@@ -1173,6 +1415,21 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                                 } else {
                                     span { class: result_trailing_slot_class() }
                                 }
+                            },
+                            ResultItem::Search { engine, query } => rsx! {
+                                div { class: result_content_row_class(),
+                                    Favicon {
+                                        favicon_url: String::new(),
+                                        url: engine.search_url(query),
+                                        class: result_favicon_class().to_string(),
+                                        globe_class: result_leading_icon_class().to_string(),
+                                    }
+                                    div { class: "flex min-w-0 flex-1 flex-col overflow-hidden",
+                                        span { class: result_primary_text_class(), "Search with {engine.name()}" }
+                                        span { class: result_secondary_text_class(), "{query}" }
+                                    }
+                                }
+                                span { class: result_trailing_slot_class(), "\u{21b5}" }
                             },
                             ResultItem::File { path, is_dir } => {
                                 let name = path

--- a/crates/vmux_layout/src/command_bar/results.rs
+++ b/crates/vmux_layout/src/command_bar/results.rs
@@ -1,6 +1,6 @@
 use vmux_command::event::{
     CommandBarCommandEntry, CommandBarPage, CommandBarRecentFile, CommandBarSpace, CommandBarTab,
-    CommandBarWorkDir, HistoryEntry,
+    CommandBarWorkDir, HistoryEntry, SearchEngine,
 };
 use vmux_core::PageIcon;
 
@@ -37,6 +37,10 @@ pub enum CommandBarResultItem {
     },
     Navigate {
         url: String,
+    },
+    Search {
+        engine: SearchEngine,
+        query: String,
     },
     File {
         path: String,
@@ -155,7 +159,6 @@ pub fn agent_page_url(item: &CommandBarResultItem) -> Option<&str> {
     }
 }
 
-#[cfg(any(target_arch = "wasm32", test))]
 pub(crate) fn agent_page_matches_query(item: &CommandBarResultItem, query: &str) -> bool {
     let CommandBarResultItem::Page { url, title, .. } = item else {
         return false;
@@ -169,22 +172,45 @@ pub(crate) fn agent_page_matches_query(item: &CommandBarResultItem, query: &str)
             || url.to_lowercase().contains(&search_lower))
 }
 
+#[cfg(any(target_arch = "wasm32", test))]
+pub(crate) fn prepend_prompt_agent(
+    results: &mut Vec<CommandBarResultItem>,
+    agent: Option<&CommandBarResultItem>,
+    query: &str,
+) {
+    if !vmux_command::event::is_start_prompt_query(query)
+        || results
+            .iter()
+            .any(|item| matches!(item, CommandBarResultItem::Terminal { .. }))
+        || results.iter().any(|item| agent_page_url(item).is_some())
+    {
+        return;
+    }
+    if let Some(agent) = agent {
+        results.insert(0, agent.clone());
+    }
+}
+
 pub fn start_page_results(
     pages: &[CommandBarPage],
     work_dirs: &[CommandBarWorkDir],
     recent_files: &[CommandBarRecentFile],
+    search_engines: &[SearchEngine],
     query: &str,
 ) -> Vec<CommandBarResultItem> {
     let search_lower = query.trim().to_lowercase();
-    let mut results = agent_page_results(pages, query);
-    if !search_lower.is_empty() && "terminal".contains(&search_lower) {
-        results.push(CommandBarResultItem::Terminal {
+    if !search_lower.is_empty() && "terminal".starts_with(&search_lower) {
+        return vec![CommandBarResultItem::Terminal {
             path: String::new(),
-        });
+        }];
     }
+    let mut results = agent_page_results(pages, query)
+        .into_iter()
+        .filter(|item| agent_page_matches_query(item, query))
+        .collect::<Vec<_>>();
     let mut app_pages: Vec<_> = pages
         .iter()
-        .filter(|page| page.host != "agent" && page.host != "start")
+        .filter(|page| page.host != "agent" && page.host != "start" && page.host != "terminal")
         .filter(|page| page_matches(page, &search_lower))
         .collect();
     app_pages.sort_by_cached_key(|page| page.url.to_lowercase());
@@ -201,7 +227,22 @@ pub fn start_page_results(
     results.extend(work_dir_results(work_dirs, &search_lower));
     results.extend(recent_file_results(recent_files, &search_lower));
     let trimmed = query.trim();
-    if !trimmed.is_empty() {
+    if vmux_command::event::is_start_prompt_query(trimmed) {
+        let engines = if search_engines.is_empty() {
+            SearchEngine::ALL.as_slice()
+        } else {
+            search_engines
+        };
+        results.extend(
+            engines
+                .iter()
+                .copied()
+                .map(|engine| CommandBarResultItem::Search {
+                    engine,
+                    query: trimmed.to_string(),
+                }),
+        );
+    } else if !trimmed.is_empty() {
         results.push(CommandBarResultItem::Navigate {
             url: trimmed.to_string(),
         });
@@ -782,8 +823,8 @@ mod tests {
     }
 
     #[test]
-    fn start_page_lists_agents_before_other_vmux_pages() {
-        let results = start_page_results(&sample_pages(), &[], &[], "");
+    fn start_page_does_not_show_unmatched_agents() {
+        let results = start_page_results(&sample_pages(), &[], &[], &[], "settings");
         let urls: Vec<_> = results
             .iter()
             .filter_map(|result| match result {
@@ -792,48 +833,75 @@ mod tests {
             })
             .collect();
 
+        assert_eq!(urls, vec!["vmux://settings/"]);
+    }
+
+    #[test]
+    fn start_page_offers_each_search_engine_in_supplied_order() {
+        let engines = [SearchEngine::Kagi, SearchEngine::Google, SearchEngine::Bing];
+        let results =
+            start_page_results(&sample_pages(), &[], &[], &engines, "fix the failing test");
+        let actual = results
+            .iter()
+            .filter_map(|result| match result {
+                CommandBarResultItem::Search { engine, .. } => Some(*engine),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(actual, engines);
+    }
+
+    #[test]
+    fn selected_agent_precedes_web_search_for_prompt_text() {
+        let agent = agent_page_results(&sample_pages(), "").remove(0);
+        let mut results = start_page_results(
+            &sample_pages(),
+            &[],
+            &[],
+            &[SearchEngine::Google, SearchEngine::Bing],
+            "show me something fun",
+        );
+
+        prepend_prompt_agent(&mut results, Some(&agent), "show me something fun");
+
+        assert_eq!(agent_page_url(&results[0]), Some("vmux://agent/vibe/"));
+        assert!(matches!(results[1], CommandBarResultItem::Search { .. }));
+    }
+
+    #[test]
+    fn terminal_stays_the_only_result() {
+        let agent = agent_page_results(&sample_pages(), "").remove(0);
+        let mut results = start_page_results(&sample_pages(), &[], &[], &[], "terminal");
+
+        prepend_prompt_agent(&mut results, Some(&agent), "terminal");
+
         assert_eq!(
-            urls,
-            vec![
-                "vmux://agent/vibe/",
-                "vmux://history/",
-                "vmux://settings/",
-                "vmux://spaces/"
-            ]
+            results,
+            vec![CommandBarResultItem::Terminal {
+                path: String::new()
+            }]
         );
     }
 
     #[test]
-    fn start_page_filters_vmux_pages_but_keeps_prompt_agents() {
-        let results = start_page_results(&sample_pages(), &[], &[], "settings");
-        let urls: Vec<_> = results
-            .iter()
-            .filter_map(|result| match result {
-                CommandBarResultItem::Page { url, .. } => Some(url.as_str()),
-                _ => None,
-            })
-            .collect();
-
-        assert_eq!(urls, vec!["vmux://agent/vibe/", "vmux://settings/"]);
-    }
-
-    #[test]
-    fn start_page_offers_web_search_for_prompt_text() {
-        let results = start_page_results(&sample_pages(), &[], &[], "fix the failing test");
-
-        assert!(matches!(
-            results.last(),
-            Some(CommandBarResultItem::Navigate { url }) if url == "fix the failing test"
-        ));
-    }
-
-    #[test]
     fn start_page_suggests_terminal_by_name() {
-        let results = start_page_results(&sample_pages(), &[], &[], "terminal");
-        assert!(matches!(
-            results.iter().find(|result| matches!(result, CommandBarResultItem::Terminal { .. })),
-            Some(CommandBarResultItem::Terminal { path }) if path.is_empty()
-        ));
+        let mut pages = sample_pages();
+        pages.push(CommandBarPage {
+            host: "terminal".into(),
+            url: "vmux://terminal/".into(),
+            title: "Terminal".into(),
+            keywords: vec!["shell".into()],
+            icon: vmux_core::PageIcon::None,
+            shortcut: String::new(),
+        });
+        let results = start_page_results(&pages, &[], &[], &[], "terminal");
+        assert_eq!(
+            results,
+            vec![CommandBarResultItem::Terminal {
+                path: String::new()
+            }]
+        );
     }
 
     #[test]
@@ -846,12 +914,14 @@ mod tests {
             url: "file:///work/vmux/README.md".into(),
             title: "README.md".into(),
         }];
-        let dir_results = start_page_results(&sample_pages(), &work_dirs, &recent_files, "vmux");
+        let dir_results =
+            start_page_results(&sample_pages(), &work_dirs, &recent_files, &[], "vmux");
         assert!(dir_results.iter().any(|result| matches!(
             result,
             CommandBarResultItem::WorkDir { path, .. } if path == "/work/vmux"
         )));
-        let file_results = start_page_results(&sample_pages(), &work_dirs, &recent_files, "readme");
+        let file_results =
+            start_page_results(&sample_pages(), &work_dirs, &recent_files, &[], "readme");
         assert!(file_results.iter().any(|result| matches!(
             result,
             CommandBarResultItem::RecentFile { url, .. }

--- a/crates/vmux_layout/src/command_bar/results.rs
+++ b/crates/vmux_layout/src/command_bar/results.rs
@@ -169,9 +169,19 @@ pub(crate) fn agent_page_matches_query(item: &CommandBarResultItem, query: &str)
             || url.to_lowercase().contains(&search_lower))
 }
 
-pub fn start_page_results(pages: &[CommandBarPage], query: &str) -> Vec<CommandBarResultItem> {
+pub fn start_page_results(
+    pages: &[CommandBarPage],
+    work_dirs: &[CommandBarWorkDir],
+    recent_files: &[CommandBarRecentFile],
+    query: &str,
+) -> Vec<CommandBarResultItem> {
     let search_lower = query.trim().to_lowercase();
     let mut results = agent_page_results(pages, query);
+    if !search_lower.is_empty() && "terminal".contains(&search_lower) {
+        results.push(CommandBarResultItem::Terminal {
+            path: String::new(),
+        });
+    }
     let mut app_pages: Vec<_> = pages
         .iter()
         .filter(|page| page.host != "agent" && page.host != "start")
@@ -188,6 +198,8 @@ pub fn start_page_results(pages: &[CommandBarPage], query: &str) -> Vec<CommandB
                 shortcut: page.shortcut.clone(),
             }),
     );
+    results.extend(work_dir_results(work_dirs, &search_lower));
+    results.extend(recent_file_results(recent_files, &search_lower));
     let trimmed = query.trim();
     if !trimmed.is_empty() {
         results.push(CommandBarResultItem::Navigate {
@@ -771,7 +783,7 @@ mod tests {
 
     #[test]
     fn start_page_lists_agents_before_other_vmux_pages() {
-        let results = start_page_results(&sample_pages(), "");
+        let results = start_page_results(&sample_pages(), &[], &[], "");
         let urls: Vec<_> = results
             .iter()
             .filter_map(|result| match result {
@@ -793,7 +805,7 @@ mod tests {
 
     #[test]
     fn start_page_filters_vmux_pages_but_keeps_prompt_agents() {
-        let results = start_page_results(&sample_pages(), "settings");
+        let results = start_page_results(&sample_pages(), &[], &[], "settings");
         let urls: Vec<_> = results
             .iter()
             .filter_map(|result| match result {
@@ -807,12 +819,44 @@ mod tests {
 
     #[test]
     fn start_page_offers_web_search_for_prompt_text() {
-        let results = start_page_results(&sample_pages(), "fix the failing test");
+        let results = start_page_results(&sample_pages(), &[], &[], "fix the failing test");
 
         assert!(matches!(
             results.last(),
             Some(CommandBarResultItem::Navigate { url }) if url == "fix the failing test"
         ));
+    }
+
+    #[test]
+    fn start_page_suggests_terminal_by_name() {
+        let results = start_page_results(&sample_pages(), &[], &[], "terminal");
+        assert!(matches!(
+            results.iter().find(|result| matches!(result, CommandBarResultItem::Terminal { .. })),
+            Some(CommandBarResultItem::Terminal { path }) if path.is_empty()
+        ));
+    }
+
+    #[test]
+    fn start_page_searches_work_dirs_and_recent_files() {
+        let work_dirs = vec![CommandBarWorkDir {
+            path: "/work/vmux".into(),
+            is_dir: true,
+        }];
+        let recent_files = vec![CommandBarRecentFile {
+            url: "file:///work/vmux/README.md".into(),
+            title: "README.md".into(),
+        }];
+        let dir_results = start_page_results(&sample_pages(), &work_dirs, &recent_files, "vmux");
+        assert!(dir_results.iter().any(|result| matches!(
+            result,
+            CommandBarResultItem::WorkDir { path, .. } if path == "/work/vmux"
+        )));
+        let file_results = start_page_results(&sample_pages(), &work_dirs, &recent_files, "readme");
+        assert!(file_results.iter().any(|result| matches!(
+            result,
+            CommandBarResultItem::RecentFile { url, .. }
+                if url == "file:///work/vmux/README.md"
+        )));
     }
 
     #[test]

--- a/crates/vmux_layout/src/command_bar/style.rs
+++ b/crates/vmux_layout/src/command_bar/style.rs
@@ -299,7 +299,7 @@ mod tests {
     fn start_shows_agents_as_result_rows() {
         let source = include_str!("palette.rs");
 
-        assert!(source.contains("start_page_results(&pages, &q)"));
+        assert!(source.contains("start_page_results(&pages, &work_dirs, &recent_files, &q)"));
         assert!(source.contains("agent_page_url(item)"));
         assert!(!source.contains("start-agent-select"));
     }

--- a/crates/vmux_layout/src/command_bar/style.rs
+++ b/crates/vmux_layout/src/command_bar/style.rs
@@ -296,15 +296,6 @@ mod tests {
     }
 
     #[test]
-    fn start_shows_agents_as_result_rows() {
-        let source = include_str!("palette.rs");
-
-        assert!(source.contains("start_page_results(&pages, &work_dirs, &recent_files, &q)"));
-        assert!(source.contains("agent_page_url(item)"));
-        assert!(!source.contains("start-agent-select"));
-    }
-
-    #[test]
     fn results_list_disables_horizontal_scroll() {
         let class = result_list_class();
 

--- a/crates/vmux_layout/src/command_bar/work_snapshot.rs
+++ b/crates/vmux_layout/src/command_bar/work_snapshot.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use vmux_command::event::{CommandBarRecentFile, CommandBarWorkDir};
+use vmux_command::event::{CommandBarRecentFile, CommandBarWorkDir, SearchEngine};
 use vmux_command::snapshot::CommandBarWorkSnapshot;
 use vmux_core::terminal::{Terminal, TerminalLaunch};
 use vmux_core::{LastVisitedAt, PageMetadata, Url, VisitCount};
@@ -140,8 +140,29 @@ pub fn update_recent_files_snapshot(
         .take(RECENT_FILES_CAP)
         .map(|(_, f)| f)
         .collect();
+    let mut engine_recency = SearchEngine::ALL
+        .into_iter()
+        .map(|engine| {
+            let latest = urls
+                .iter()
+                .filter_map(|(meta, _, visited)| {
+                    (SearchEngine::from_url(&meta.url) == Some(engine)).then_some(visited.0)
+                })
+                .max()
+                .unwrap_or(i64::MIN);
+            (engine, latest)
+        })
+        .collect::<Vec<_>>();
+    engine_recency.sort_by_key(|(_, visited)| std::cmp::Reverse(*visited));
+    let search_engines = engine_recency
+        .into_iter()
+        .map(|(engine, _)| engine)
+        .collect::<Vec<_>>();
     if recent_files != snapshot.recent_files {
         snapshot.recent_files = recent_files;
+    }
+    if search_engines != snapshot.search_engines {
+        snapshot.search_engines = search_engines;
     }
 }
 
@@ -274,5 +295,44 @@ mod tests {
         let snap = app.world().resource::<CommandBarWorkSnapshot>();
         assert_eq!(snap.recent_files.len(), 1);
         assert_eq!(snap.recent_files[0].title, "main.rs");
+    }
+
+    #[test]
+    fn search_engines_are_ordered_by_most_recent_visit() {
+        use vmux_core::CreatedAt;
+        let mut app = App::new();
+        app.init_resource::<CommandBarWorkSnapshot>()
+            .add_systems(Update, update_recent_files_snapshot);
+        for (url, visited) in [
+            ("https://www.google.com/search?q=old", 1000),
+            ("https://kagi.com/search?q=new", 3000),
+            ("https://search.brave.com/search?q=middle", 2000),
+        ] {
+            app.world_mut().spawn((
+                Url,
+                PageMetadata {
+                    url: url.into(),
+                    ..default()
+                },
+                VisitCount(1),
+                LastVisitedAt(visited),
+                CreatedAt(0),
+            ));
+        }
+        app.update();
+
+        let engines = &app
+            .world()
+            .resource::<CommandBarWorkSnapshot>()
+            .search_engines;
+        assert_eq!(engines.len(), SearchEngine::ALL.len());
+        assert_eq!(
+            &engines[..3],
+            &[
+                SearchEngine::Kagi,
+                SearchEngine::Brave,
+                SearchEngine::Google
+            ]
+        );
     }
 }

--- a/crates/vmux_layout/src/lib.rs
+++ b/crates/vmux_layout/src/lib.rs
@@ -218,6 +218,8 @@ pub struct BrowserNavigateRequest {
     pub url: String,
     pub pane: Option<String>,
     pub request_id: Option<[u8; 16]>,
+    pub new_stack: bool,
+    pub profile: Option<String>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/vmux_layout/src/page.rs
+++ b/crates/vmux_layout/src/page.rs
@@ -163,6 +163,9 @@ pub fn Page() -> Element {
         }
     });
     use_effect(move || {
+        if !layout_state().side_sheet_open {
+            return;
+        }
         let PaneTreeEvent { panes } = pane_tree_state();
         let active_pane = panes.iter().find(|p| p.is_active);
         let target = active_pane
@@ -186,7 +189,6 @@ pub fn Page() -> Element {
         if last_scrolled_stack() == Some((pane_id, stack_index)) {
             return;
         }
-        last_scrolled_stack.set(Some((pane_id, stack_index)));
         if let Some(el) = web_sys::window()
             .and_then(|w| w.document())
             .and_then(|d| d.get_element_by_id(&format!("sidesheet-stack-{pane_id}-{stack_index}")))
@@ -194,6 +196,7 @@ pub fn Page() -> Element {
             let opts = web_sys::ScrollIntoViewOptions::new();
             opts.set_block(web_sys::ScrollLogicalPosition::Nearest);
             el.scroll_into_view_with_scroll_into_view_options(&opts);
+            last_scrolled_stack.set(Some((pane_id, stack_index)));
         }
     });
     let side_sheet_vars = format!(
@@ -1042,8 +1045,8 @@ fn KnowledgeCard(pane_id: u64, knowledge: KnowledgeTreeEvent, loaded: bool) -> E
                 }
                 button {
                     r#type: "button",
-                    aria_label: if folded() { "Unfold knowledge" } else { "Fold knowledge" },
-                    title: if folded() { "Unfold knowledge" } else { "Fold knowledge" },
+                    aria_label: if folded() { "Expand knowledge" } else { "Collapse knowledge" },
+                    title: if folded() { "Expand knowledge" } else { "Collapse knowledge" },
                     class: if folded() {
                         "mr-2 flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-sm bg-foreground/10 text-foreground"
                     } else {
@@ -1650,6 +1653,7 @@ fn commit_folder_rename(uuid: String, name: String) {
 fn BookmarksSection(bookmarks: BookmarksHostEvent, active_page: Option<StackNode>) -> Element {
     let BookmarksHostEvent { pins, roots } = bookmarks;
     let drag_state: Signal<Option<BookmarkDragState>> = use_context();
+    let mut folded = use_signal(|| false);
     let mut creating_folder = use_signal(|| false);
     let new_folder_draft = use_signal(|| "New Folder".to_string());
     let folders = bookmark_folder_choices(&roots);
@@ -1667,7 +1671,7 @@ fn BookmarksSection(bookmarks: BookmarksHostEvent, active_page: Option<StackNode
     rsx! {
         div {
             "data-bookmark-drop": "root",
-            class: "glass relative z-30 mb-2 flex flex-col rounded-lg p-1.5",
+            class: "glass group relative z-30 mb-2 flex shrink-0 flex-col overflow-hidden rounded-lg",
             oncontextmenu: move |e: Event<MouseData>| {
                 let data = e.data();
                 let on_card = data
@@ -1682,87 +1686,114 @@ fn BookmarksSection(bookmarks: BookmarksHostEvent, active_page: Option<StackNode
             div {
                 "data-bookmark-drop": "root",
                 class: if root_targeted {
-                    "mb-0.5 flex h-8 items-center gap-1 rounded-md bg-foreground/10 px-2 ring-1 ring-ring"
+                    "flex items-center bg-foreground/10 ring-1 ring-inset ring-ring"
                 } else {
-                    "mb-0.5 flex h-8 items-center gap-1 rounded-md px-2"
+                    "flex items-center transition-colors hover:bg-glass-hover"
                 },
-                if let Some(label) = root_drop_label {
-                    Icon { class: "h-3.5 w-3.5 shrink-0",
-                        path { d: "m9 14-4-4 4-4" }
-                        path { d: "M5 10h11a4 4 0 0 1 4 4v4" }
+                div { class: "flex min-w-0 flex-1 items-center gap-2 px-2.5 py-2",
+                    div { class: "grid h-7 w-7 shrink-0 place-items-center rounded-lg bg-foreground/[0.07] text-foreground ring-1 ring-inset ring-foreground/10",
+                        Icon { class: "h-3.5 w-3.5",
+                            path { d: "M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" }
+                        }
                     }
-                    span { class: "min-w-0 flex-1 text-ui font-semibold text-foreground", "{label}" }
-                } else {
-                    span { class: "min-w-0 flex-1 text-ui font-semibold text-foreground", "Bookmarks" }
-                    button {
-                        r#type: "button",
-                        aria_label: "New bookmark folder",
-                        title: "New Folder",
-                        class: "flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-sm text-muted-foreground hover:bg-foreground/10 hover:text-foreground",
-                        onclick: move |event| {
-                            event.prevent_default();
-                            event.stop_propagation();
-                            begin_new_folder(creating_folder, new_folder_draft);
-                        },
-                        Icon { class: "h-3.5 w-3.5 pointer-events-none",
-                            path { d: "M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z" }
-                            path { d: "M12 10v6" }
-                            path { d: "M9 13h6" }
+                    if let Some(label) = root_drop_label {
+                        span { class: "min-w-0 flex-1 text-ui font-semibold text-foreground", "{label}" }
+                    } else {
+                        span { class: "min-w-0 flex-1 text-ui font-semibold text-foreground", "Bookmarks" }
+                        button {
+                            r#type: "button",
+                            aria_label: "New bookmark folder",
+                            title: "New Folder",
+                            class: "flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-sm text-muted-foreground hover:bg-foreground/10 hover:text-foreground",
+                            onclick: move |event| {
+                                event.prevent_default();
+                                event.stop_propagation();
+                                begin_new_folder(creating_folder, new_folder_draft);
+                            },
+                            Icon { class: "h-3.5 w-3.5 pointer-events-none",
+                                path { d: "M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z" }
+                                path { d: "M12 10v6" }
+                                path { d: "M9 13h6" }
+                            }
                         }
                     }
                 }
-            }
-            if !pins.is_empty() {
-                div {
-                    "data-bookmark-drop": "",
-                    class: "mb-1 grid grid-cols-4 gap-1.5 p-1",
-                    for p in pins.iter() {
-                        PinTile { key: "{p.uuid}", row: p.clone() }
+                button {
+                    r#type: "button",
+                    aria_label: if folded() { "Expand bookmarks" } else { "Collapse bookmarks" },
+                    title: if folded() { "Expand bookmarks" } else { "Collapse bookmarks" },
+                    class: if folded() {
+                        "mr-2 flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-sm bg-foreground/10 text-foreground"
+                    } else {
+                        "mr-2 flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-sm text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 hover:bg-foreground/10 hover:text-foreground"
+                    },
+                    onclick: move |_| folded.set(!folded()),
+                    Icon { class: "h-3.5 w-3.5 pointer-events-none",
+                        path { d: if folded() { "m9 18 6-6-6-6" } else { "m6 9 6 6 6-6" } }
                     }
                 }
             }
-            if creating_folder() {
-                div { class: "flex h-9 items-center gap-2 rounded-md border border-transparent px-2",
-                    Icon { class: "h-4 w-4 shrink-0 text-muted-foreground",
-                        path { d: "M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z" }
-                    }
-                    BookmarkNameInput {
-                        draft: new_folder_draft,
-                        class: "min-w-0 flex-1 bg-transparent text-ui font-medium text-foreground outline-none".to_string(),
-                        placeholder: "Folder name".to_string(),
-                        on_commit: move |name| {
-                            creating_folder.set(false);
-                            create_bookmark_folder(name, None);
-                        },
-                        on_cancel: move |_| creating_folder.set(false),
-                    }
-                }
-            }
-            if pins.is_empty() && roots.is_empty() && !creating_folder() {
-                div { class: "px-2 py-2 text-ui-xs text-muted-foreground", "No pins or bookmarks" }
-            } else {
-                div { class: "flex flex-col gap-1",
-                    for node in roots.iter() {
-                        match node {
-                            BookmarkNode::Folder(f) if f.parent.is_none() => rsx! {
-                                BookmarkFolder {
-                                    key: "{f.uuid}",
-                                    folder: f.clone(),
-                                    parent_uuid: None,
-                                    folders: folders.clone(),
-                                    folder_rows: folder_rows.clone(),
-                                    active_page: active_page.clone(),
+            div { class: if folded() {
+                    "grid grid-rows-[0fr] opacity-0 transition-[grid-template-rows,opacity] duration-200 ease-out"
+                } else {
+                    "grid grid-rows-[1fr] opacity-100 transition-[grid-template-rows,opacity] duration-200 ease-out"
+                },
+                div { class: "overflow-hidden",
+                    div { class: "border-t border-foreground/10 p-1.5",
+                        if !pins.is_empty() {
+                            div {
+                                "data-bookmark-drop": "",
+                                class: "mb-1 grid grid-cols-4 gap-1.5 p-1",
+                                for p in pins.iter() {
+                                    PinTile { key: "{p.uuid}", row: p.clone() }
                                 }
-                            },
-                            BookmarkNode::Folder(_) => rsx! {},
-                            BookmarkNode::Entry(b) => rsx! {
-                                BookmarkEntry {
-                                    key: "{b.uuid}",
-                                    row: b.clone(),
-                                    folder_uuid: None,
-                                    folders: folders.clone(),
+                            }
+                        }
+                        if creating_folder() {
+                            div { class: "flex h-9 items-center gap-2 rounded-md border border-transparent px-2",
+                                Icon { class: "h-4 w-4 shrink-0 text-muted-foreground",
+                                    path { d: "M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z" }
                                 }
-                            },
+                                BookmarkNameInput {
+                                    draft: new_folder_draft,
+                                    class: "min-w-0 flex-1 bg-transparent text-ui font-medium text-foreground outline-none".to_string(),
+                                    placeholder: "Folder name".to_string(),
+                                    on_commit: move |name| {
+                                        creating_folder.set(false);
+                                        create_bookmark_folder(name, None);
+                                    },
+                                    on_cancel: move |_| creating_folder.set(false),
+                                }
+                            }
+                        }
+                        if pins.is_empty() && roots.is_empty() && !creating_folder() {
+                            div { class: "px-2 py-2 text-ui-xs text-muted-foreground", "No pins or bookmarks" }
+                        } else {
+                            div { class: "flex flex-col gap-1",
+                                for node in roots.iter() {
+                                    match node {
+                                        BookmarkNode::Folder(f) if f.parent.is_none() => rsx! {
+                                            BookmarkFolder {
+                                                key: "{f.uuid}",
+                                                folder: f.clone(),
+                                                parent_uuid: None,
+                                                folders: folders.clone(),
+                                                folder_rows: folder_rows.clone(),
+                                                active_page: active_page.clone(),
+                                            }
+                                        },
+                                        BookmarkNode::Folder(_) => rsx! {},
+                                        BookmarkNode::Entry(b) => rsx! {
+                                            BookmarkEntry {
+                                                key: "{b.uuid}",
+                                                row: b.clone(),
+                                                folder_uuid: None,
+                                                folders: folders.clone(),
+                                            }
+                                        },
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -2276,35 +2307,41 @@ fn PaneSection(pane: PaneNode, index: usize) -> Element {
     let label = format!("Stack {}", index + 1);
     let pane_id = pane.id;
     let any_loading = pane.stacks.iter().any(|s| s.is_loading);
-    let folded_stack = pane.stacks.iter().find(|stack| stack.is_active).cloned();
     let mut folded = use_signal(|| false);
 
     rsx! {
         div { class: if pane.is_active && any_loading {
-                "glass group mb-2 flex shrink-0 flex-col rounded-lg p-1.5 pane-loading-ring"
+                "glass group mb-2 flex shrink-0 flex-col overflow-hidden rounded-lg pane-loading-ring"
             } else if pane.is_active {
-                "glass group mb-2 flex shrink-0 flex-col rounded-lg p-1.5 ring-2 ring-ring"
+                "glass group mb-2 flex shrink-0 flex-col overflow-hidden rounded-lg ring-2 ring-ring"
             } else {
-                "glass group mb-2 flex shrink-0 flex-col rounded-lg p-1.5"
+                "glass group mb-2 flex shrink-0 flex-col overflow-hidden rounded-lg"
             },
             div {
-                class: "mb-0.5 flex items-center gap-1 rounded-md px-2 py-1",
-                span {
-                    class: if pane.is_active {
-                        "min-w-0 flex-1 text-ui font-semibold text-foreground"
-                    } else {
-                        "min-w-0 flex-1 text-ui font-medium text-muted-foreground"
-                    },
-                    "{label}"
+                class: "flex items-center transition-colors hover:bg-glass-hover",
+                div { class: "flex min-w-0 flex-1 items-center gap-2 px-2.5 py-2",
+                    div { class: "grid h-7 w-7 shrink-0 place-items-center rounded-lg bg-foreground/[0.07] text-foreground ring-1 ring-inset ring-foreground/10",
+                        Icon { class: "h-3.5 w-3.5",
+                            path { d: "M4 6h16M4 12h16M4 18h16" }
+                        }
+                    }
+                    span {
+                        class: if pane.is_active {
+                            "min-w-0 flex-1 text-ui font-semibold text-foreground"
+                        } else {
+                            "min-w-0 flex-1 text-ui font-medium text-muted-foreground"
+                        },
+                        "{label}"
+                    }
                 }
                 button {
                     r#type: "button",
-                    aria_label: if folded() { "Unfold stack" } else { "Fold stack" },
-                    title: if folded() { "Unfold stack" } else { "Fold stack" },
+                    aria_label: if folded() { "Expand stack" } else { "Collapse stack" },
+                    title: if folded() { "Expand stack" } else { "Collapse stack" },
                     class: if folded() {
-                        "flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-sm bg-foreground/10 text-foreground"
+                        "mr-2 flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-sm bg-foreground/10 text-foreground"
                     } else {
-                        "flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-sm text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 hover:bg-foreground/10 hover:text-foreground"
+                        "mr-2 flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-sm text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 hover:bg-foreground/10 hover:text-foreground"
                     },
                     onclick: move |_| {
                         let next = !folded();
@@ -2315,20 +2352,22 @@ fn PaneSection(pane: PaneNode, index: usize) -> Element {
                     }
                 }
             }
-            if folded() {
-                if let Some(stack) = folded_stack {
-                    SideSheetStackRow { stack, pane_id }
-                }
-            } else {
-                div { class: "flex flex-col gap-1",
-                    for stack in pane
-                        .stacks
-                        .iter()
-                        .filter(|s| !(s.url.is_empty() && s.title == "New Stack"))
-                    {
-                        SideSheetStackRow { stack: stack.clone(), pane_id }
+            div { class: if folded() {
+                    "grid grid-rows-[0fr] opacity-0 transition-[grid-template-rows,opacity] duration-200 ease-out"
+                } else {
+                    "grid grid-rows-[1fr] opacity-100 transition-[grid-template-rows,opacity] duration-200 ease-out"
+                },
+                div { class: "overflow-hidden",
+                    div { class: "flex flex-col gap-1 border-t border-foreground/10 p-1.5",
+                        for stack in pane
+                            .stacks
+                            .iter()
+                            .filter(|s| !(s.url.is_empty() && s.title == "New Stack"))
+                        {
+                            SideSheetStackRow { stack: stack.clone(), pane_id }
+                        }
+                        NewStackRow { pane_id }
                     }
-                    NewStackRow { pane_id }
                 }
             }
         }

--- a/crates/vmux_layout/src/page.rs
+++ b/crates/vmux_layout/src/page.rs
@@ -151,6 +151,7 @@ pub fn Page() -> Element {
         listener_ready(spaces_state_received(), &spaces_error),
     );
     let radius_px = state.radius;
+    let mut last_scrolled_stack = use_signal(|| None::<(u64, u32)>);
     use_effect(move || {
         if let Some(doc) = web_sys::window().and_then(|w| w.document())
             && let Some(root) = doc.document_element()
@@ -182,6 +183,10 @@ pub fn Page() -> Element {
         let Some((pane_id, stack_index)) = target else {
             return;
         };
+        if last_scrolled_stack() == Some((pane_id, stack_index)) {
+            return;
+        }
+        last_scrolled_stack.set(Some((pane_id, stack_index)));
         if let Some(el) = web_sys::window()
             .and_then(|w| w.document())
             .and_then(|d| d.get_element_by_id(&format!("sidesheet-stack-{pane_id}-{stack_index}")))

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -4536,7 +4536,11 @@ mod tests {
             .world()
             .get::<PaneSplit>(browser)
             .expect("newest non-agent (browser) leaf must split for the new terminal type");
-        assert_eq!(split.direction, PaneSplitDirection::Row, "wide => Row");
+        assert_eq!(
+            split.direction,
+            PaneSplitDirection::Column,
+            "first terminal stacks below the browser"
+        );
         assert!(
             app.world().get::<PaneSplit>(agent).is_none(),
             "agent pane untouched"

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -1436,6 +1436,8 @@ fn spawn_beside_stack(
     open_or_prompt_stack(
         new_stack,
         Some(req.url.clone()),
+        (!req.url.starts_with("file:") && !req.url.starts_with("vmux://"))
+            .then_some(req.request_id),
         new_stack_ctx,
         page_open_requests,
     );
@@ -1882,6 +1884,7 @@ fn handle_open_in_pane(
             open_or_prompt_stack(
                 new_stack,
                 resolved,
+                None,
                 &mut new_stack_ctx,
                 &mut page_open_requests,
             );
@@ -1894,6 +1897,7 @@ fn handle_open_in_pane(
                         open_or_prompt_stack(
                             stack,
                             resolved,
+                            None,
                             &mut new_stack_ctx,
                             &mut page_open_requests,
                         );
@@ -1906,6 +1910,7 @@ fn handle_open_in_pane(
                     open_or_prompt_stack(
                         new_stack,
                         resolved,
+                        None,
                         &mut new_stack_ctx,
                         &mut page_open_requests,
                     );
@@ -1919,6 +1924,7 @@ fn handle_open_in_pane(
 fn open_or_prompt_stack(
     stack: Entity,
     url: Option<String>,
+    request_id: Option<[u8; 16]>,
     new_stack_ctx: &mut NewStackContext,
     page_open_requests: &mut MessageWriter<PageOpenRequest>,
 ) {
@@ -1929,7 +1935,7 @@ fn open_or_prompt_stack(
         page_open_requests.write(PageOpenRequest {
             target: PageOpenTarget::Stack(stack),
             url,
-            request_id: None,
+            request_id,
         });
     } else {
         new_stack_ctx.stack = Some(stack);

--- a/crates/vmux_layout/src/placement.rs
+++ b/crates/vmux_layout/src/placement.rs
@@ -124,6 +124,19 @@ pub fn resolve_placement(
         return Placement::AddTab { pane: same.pane };
     }
 
+    if kind == PageKind::Terminal
+        && leaves.iter().all(|leaf| {
+            leaf.kinds.contains(&PageKind::Agent)
+                || (leaf.kinds.len() == 1 && leaf.kinds.contains(&PageKind::Browser))
+        })
+        && let Some(browser) = newest_leaf_with_kind(leaves, PageKind::Browser)
+    {
+        return Placement::Spiral {
+            anchor: browser.pane,
+            axis: PaneSplitDirection::Column,
+        };
+    }
+
     if let Some(anchor) = newest_nonagent_leaf(leaves) {
         return Placement::Spiral {
             anchor: anchor.pane,
@@ -312,6 +325,22 @@ mod tests {
             Placement::Spiral {
                 anchor: e(3),
                 axis: PaneSplitDirection::Row
+            }
+        );
+    }
+
+    #[test]
+    fn first_terminal_splits_browser_into_top_and_bottom() {
+        let leaves = [
+            leaf(1, &[PageKind::Agent], 1, (800.0, 900.0)),
+            leaf(2, &[PageKind::Browser], 10, (900.0, 400.0)),
+        ];
+        let got = resolve_placement("vmux://terminal/", None, &leaves, e(1));
+        assert_eq!(
+            got,
+            Placement::Spiral {
+                anchor: e(2),
+                axis: PaneSplitDirection::Column
             }
         );
     }

--- a/crates/vmux_layout/src/stack.rs
+++ b/crates/vmux_layout/src/stack.rs
@@ -193,6 +193,17 @@ impl ActiveTabParam<'_, '_> {
         // empty and respawn startup content every frame.
         active_among(self.tabs.iter())
     }
+
+    fn has_sibling(&self, tab: Entity, all_children: &Query<&Children>) -> bool {
+        let Ok(parent) = self.child_of.get(tab).map(Relationship::get) else {
+            return false;
+        };
+        all_children.get(parent).is_ok_and(|children| {
+            children
+                .iter()
+                .any(|entity| entity != tab && self.tabs.contains(entity))
+        })
+    }
 }
 
 pub fn focused_stack(
@@ -358,6 +369,7 @@ fn handle_stack_commands(
                     children.iter().filter(|&e| stack_q.contains(e)).collect();
                 if stacks_in_pane.len() <= 1 {
                     if let Some(tab) = active_tab
+                        && active_tab_param.has_sibling(tab, &all_children)
                         && close_tab_if_only_closing_stack(
                             tab,
                             active,
@@ -838,7 +850,7 @@ mod tests {
     }
 
     #[test]
-    fn closing_last_stack_replaces_only_tab_with_fresh_tab() {
+    fn closing_last_stack_reuses_only_tab_and_workspace() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, CommandPlugin))
             .add_message::<CloseTabRequest>()
@@ -911,31 +923,37 @@ mod tests {
 
         app.update();
 
-        assert!(app.world().get_entity(tab_e).is_err());
+        assert!(app.world().get_entity(tab_e).is_ok());
         assert!(app.world().get_entity(original_stack).is_err());
-        let fresh_tab = app
+        let remaining_tab = app
             .world_mut()
             .query_filtered::<Entity, With<Tab>>()
             .single(app.world())
             .unwrap();
-        assert_ne!(fresh_tab, tab_e);
+        assert_eq!(remaining_tab, tab_e);
         assert!(
             app.world()
-                .get::<crate::tab::TabWorktree>(fresh_tab)
-                .is_none()
+                .get::<crate::tab::TabWorktree>(remaining_tab)
+                .is_some()
         );
         assert_eq!(
             app.world()
-                .get::<Tab>(fresh_tab)
+                .get::<Tab>(remaining_tab)
                 .unwrap()
                 .startup_dir
                 .as_deref(),
-            startup.path().canonicalize().unwrap().to_str()
+            worktree.path().to_str()
         );
         let ctx = app.world().resource::<NewStackContext>();
         assert!(ctx.needs_open);
         assert!(ctx.stack.is_some());
         assert_eq!(ctx.previous_stack, None);
+        assert_eq!(
+            app.world()
+                .get::<ChildOf>(ctx.stack.unwrap())
+                .map(Relationship::get),
+            Some(pane)
+        );
     }
 
     #[test]
@@ -1376,12 +1394,12 @@ mod tests {
     }
 
     #[test]
-    fn closing_last_stack_requests_tab_close_instead_of_reusing_pane() {
+    fn closing_last_stack_reuses_only_tab_and_opens_startup_page() {
         let mut app = build_app_with_collector();
         app.insert_resource(crate::settings::EffectiveStartupUrl(
             "https://startup.test".into(),
         ));
-        let (tab, _pane, original_stack) = build_hierarchy(&mut app);
+        let (tab, pane, original_stack) = build_hierarchy(&mut app);
 
         app.world_mut()
             .resource_mut::<Messages<AppCommand>>()
@@ -1391,20 +1409,30 @@ mod tests {
 
         app.update();
 
-        assert!(app.world().get_entity(original_stack).is_ok());
+        assert!(app.world().get_entity(original_stack).is_err());
+        assert!(app.world().get_entity(tab).is_ok());
         let ctx = app.world().resource::<NewStackContext>();
         assert_eq!(ctx.stack, None);
         assert!(!ctx.needs_open);
 
         let collected = app.world().resource::<CollectedSpawns>();
-        assert!(collected.0.is_empty());
+        assert_eq!(collected.0.len(), 1);
+        assert_eq!(collected.0[0].url, "https://startup.test");
+        let PageOpenTarget::Stack(replacement) = collected.0[0].target else {
+            panic!("startup page must target the replacement stack");
+        };
+        assert_eq!(
+            app.world()
+                .get::<ChildOf>(replacement)
+                .map(Relationship::get),
+            Some(pane)
+        );
         let close_requests: Vec<_> = app
             .world_mut()
             .resource_mut::<Messages<CloseTabRequest>>()
             .drain()
             .collect();
-        assert_eq!(close_requests.len(), 1);
-        assert_eq!(close_requests[0].tab, tab);
+        assert!(close_requests.is_empty());
     }
 
     #[test]

--- a/crates/vmux_layout/src/start/event.rs
+++ b/crates/vmux_layout/src/start/event.rs
@@ -15,6 +15,22 @@
 )]
 pub struct StartDataRequest;
 
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct StartSelectWorkspace {
+    pub current_dir: String,
+}
+
 /// Host→page signal: focus the start launcher's input. Sent when a command-bar
 /// shortcut fires while the start page is active (instead of opening the modal).
 pub const START_FOCUS_INPUT_EVENT: &str = "start-focus-input";

--- a/crates/vmux_layout/src/start/plugin.rs
+++ b/crates/vmux_layout/src/start/plugin.rs
@@ -1,9 +1,11 @@
+use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
+use bevy::tasks::{IoTaskPool, Task, futures_lite::future};
 use bevy_cef::prelude::{
     BinEventEmitterPlugin, BinHostEmitEvent, BinReceive, Browsers, CefKeyboardTarget,
     WebviewExtendStandardMaterial, WebviewSource,
 };
-use vmux_command::event::{COMMAND_BAR_OPEN_EVENT, CommandBarOpenEvent};
+use vmux_command::event::{COMMAND_BAR_OPEN_EVENT, CommandBarOpenEvent, CommandBarPromptContext};
 use vmux_command::open_target::OpenTarget;
 use vmux_command::snapshot::{
     CommandBarAgentsSnapshot, CommandBarPagesSnapshot, CommandBarSpacesSnapshot,
@@ -18,7 +20,10 @@ use crate::command_bar::handler::{
     TabGatherParams, build_command_bar_open_payload, gather_command_bar_tabs,
 };
 use crate::start::START_PAGE_URL;
-use crate::start::event::{START_FOCUS_INPUT_EVENT, StartDataRequest, StartFocusInput};
+use crate::start::event::{
+    START_FOCUS_INPUT_EVENT, StartDataRequest, StartFocusInput, StartSelectWorkspace,
+};
+use crate::tab::{Tab, TabWorkspace, TabWorktree};
 use crate::window::VmuxWindow;
 
 type PendingPageOpen = (Without<PageOpenHandled>, Without<PageOpenError>);
@@ -58,6 +63,81 @@ struct StartSpareRevealed {
     webview: Entity,
 }
 
+#[derive(Component)]
+struct PendingStartWorkspacePicker {
+    tab: Entity,
+    task: Task<Option<(std::path::PathBuf, bool)>>,
+}
+
+#[derive(SystemParam)]
+struct StartPromptContextParams<'w, 's> {
+    tabs: Query<
+        'w,
+        's,
+        (
+            Ref<'static, Tab>,
+            Option<Ref<'static, TabWorkspace>>,
+            Option<Ref<'static, TabWorktree>>,
+        ),
+    >,
+}
+
+impl StartPromptContextParams<'_, '_> {
+    fn changed(&self, tab: Option<Entity>) -> bool {
+        let Some(tab) = tab else {
+            return false;
+        };
+        self.tabs.get(tab).is_ok_and(|(tab, workspace, worktree)| {
+            tab.is_changed()
+                || workspace.as_ref().is_some_and(Ref::is_changed)
+                || worktree.as_ref().is_some_and(Ref::is_changed)
+        })
+    }
+
+    fn context(&self, tab: Option<Entity>) -> CommandBarPromptContext {
+        let Some(tab) = tab else {
+            return default();
+        };
+        let Ok((tab, workspace, worktree)) = self.tabs.get(tab) else {
+            return default();
+        };
+        let cwd = tab
+            .startup_dir
+            .clone()
+            .or_else(|| {
+                workspace
+                    .as_ref()
+                    .map(|workspace| workspace.project_dir.clone())
+            })
+            .unwrap_or_default();
+        if cwd.is_empty() {
+            return default();
+        }
+        let path = std::path::Path::new(&cwd);
+        let info = vmux_git::worktree::repo_info(path);
+        CommandBarPromptContext {
+            workspace_name: path
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .filter(|name| !name.is_empty())
+                .unwrap_or_else(|| cwd.clone()),
+            cwd,
+            is_git_repo: info.is_some(),
+            is_worktree: info.as_ref().is_some_and(|info| info.is_worktree),
+            branch: info
+                .as_ref()
+                .map(|info| info.branch.clone())
+                .unwrap_or_default(),
+            base_ref: worktree
+                .as_ref()
+                .map(|worktree| worktree.base_ref.clone())
+                .unwrap_or_default(),
+            uncommitted: info.as_ref().map(|info| info.uncommitted).unwrap_or(0),
+            ahead: info.as_ref().map(|info| info.ahead).unwrap_or(0),
+        }
+    }
+}
+
 /// Bevy plugin for `vmux://start/`: spawns the page manifest, keeps a warm pool of
 /// prewarmed launcher webviews, claims start page-open tasks (reusing a warm spare when
 /// available), and answers [`StartDataRequest`] with the shared command-bar payload.
@@ -66,20 +146,134 @@ pub struct StartPlugin;
 impl Plugin for StartPlugin {
     fn build(&self, app: &mut App) {
         app.world_mut().spawn(crate::start::PAGE_MANIFEST);
-        app.add_plugins(BinEventEmitterPlugin::<(StartDataRequest,)>::for_hosts(&[
-            "start",
-        ]))
-        .add_message::<StartSpareRevealed>()
-        .add_observer(on_start_data_request)
-        .add_systems(
-            Update,
-            (
-                handle_start_page_open.in_set(PageOpenSet::HandleKnownPages),
-                maintain_warm_start_pool,
-                on_start_spare_revealed.after(PageOpenSet::HandleKnownPages),
-                sync_live_start_pages,
-            ),
-        );
+        app.add_plugins(BinEventEmitterPlugin::<(
+            StartDataRequest,
+            StartSelectWorkspace,
+        )>::for_hosts(&["start"]))
+            .add_message::<StartSpareRevealed>()
+            .add_observer(on_start_data_request)
+            .add_observer(on_start_select_workspace)
+            .add_systems(
+                Update,
+                (
+                    handle_start_page_open.in_set(PageOpenSet::HandleKnownPages),
+                    maintain_warm_start_pool,
+                    on_start_spare_revealed.after(PageOpenSet::HandleKnownPages),
+                    sync_live_start_pages,
+                    drain_start_workspace_pickers,
+                ),
+            );
+    }
+}
+
+fn on_start_select_workspace(
+    trigger: On<BinReceive<StartSelectWorkspace>>,
+    child_of: Query<&ChildOf>,
+    tabs: Query<(), With<Tab>>,
+    pending: Query<&PendingStartWorkspacePicker>,
+    proxy: Option<Res<bevy::winit::EventLoopProxyWrapper>>,
+    mut commands: Commands,
+) {
+    let mut current = trigger.event().webview;
+    let tab = loop {
+        if tabs.contains(current) {
+            break Some(current);
+        }
+        let Ok(parent) = child_of.get(current) else {
+            break None;
+        };
+        current = parent.parent();
+    };
+    let Some(tab) = tab else {
+        return;
+    };
+    if pending.iter().any(|picker| picker.tab == tab) {
+        return;
+    }
+    let wake = proxy.as_deref().map(|proxy| (**proxy).clone());
+    let initial_dir = std::path::PathBuf::from(&trigger.event().payload.current_dir)
+        .canonicalize()
+        .ok()
+        .filter(|path| path.is_dir())
+        .or_else(|| std::env::current_dir().ok().filter(|path| path.is_dir()))
+        .or_else(|| std::env::var_os("HOME").map(std::path::PathBuf::from))
+        .filter(|path| path.is_dir())
+        .unwrap_or_else(|| std::path::PathBuf::from("/"));
+    let task = IoTaskPool::get().spawn(async move {
+        let selected = rfd::AsyncFileDialog::new()
+            .set_title("Create or select workspace")
+            .set_directory(initial_dir)
+            .pick_folder()
+            .await
+            .map(|handle| handle.path().to_path_buf());
+        let result = if let Some(path) = selected {
+            let initialize_git = if path.join(".git").exists() {
+                false
+            } else {
+                matches!(
+                    rfd::AsyncMessageDialog::new()
+                        .set_title("Initialize Git repository?")
+                        .set_description(
+                            "This workspace is not a Git repository. Initialize Git now?",
+                        )
+                        .set_buttons(rfd::MessageButtons::YesNo)
+                        .show()
+                        .await,
+                    rfd::MessageDialogResult::Yes
+                )
+            };
+            Some((path, initialize_git))
+        } else {
+            None
+        };
+        if let Some(wake) = wake {
+            let _ = wake.send_event(bevy::winit::WinitUserEvent::WakeUp);
+        }
+        result
+    });
+    commands.spawn(PendingStartWorkspacePicker { tab, task });
+}
+
+fn drain_start_workspace_pickers(
+    mut pending: Query<(Entity, &mut PendingStartWorkspacePicker)>,
+    mut tabs: Query<&mut Tab>,
+    mut commands: Commands,
+) {
+    for (entity, mut picker) in &mut pending {
+        let Some(selected) = future::block_on(future::poll_once(&mut picker.task)) else {
+            continue;
+        };
+        if let Some((path, initialize_git)) = selected
+            && let Ok(path) = path.canonicalize()
+            && path.is_dir()
+        {
+            if initialize_git {
+                let _ = vmux_git::worktree::repository_init(&path);
+            }
+            if let Ok(mut tab) = tabs.get_mut(picker.tab) {
+                tab.startup_dir = Some(path.to_string_lossy().into_owned());
+                if crate::worktree::is_generated_tab_name(&tab.name)
+                    && let Some(name) = path.file_name().and_then(|name| name.to_str())
+                    && !name.is_empty()
+                {
+                    tab.name = name.to_string();
+                }
+                commands
+                    .entity(picker.tab)
+                    .insert((
+                        TabWorkspace {
+                            project_dir: path.to_string_lossy().into_owned(),
+                        },
+                        crate::tab::TabDirDecided,
+                    ))
+                    .remove::<(
+                        TabWorktree,
+                        crate::worktree::TabWorktreeReady,
+                        crate::tab::TabWorktreeUnavailable,
+                    )>();
+            }
+        }
+        commands.entity(entity).despawn();
     }
 }
 
@@ -90,6 +284,7 @@ impl Plugin for StartPlugin {
 /// which does not reset the palette's input/selection.
 fn sync_live_start_pages(
     tab_gather: TabGatherParams,
+    prompt_context: StartPromptContextParams,
     spaces_snapshot: Res<CommandBarSpacesSnapshot>,
     agents_snapshot: Res<CommandBarAgentsSnapshot>,
     pages_snapshot: Res<CommandBarPagesSnapshot>,
@@ -115,7 +310,7 @@ fn sync_live_start_pages(
         pages_snapshot.is_changed(),
         work_snapshot.is_changed(),
         focus_changed,
-    );
+    ) || prompt_context.changed(tab_gather.active_tab.get());
     let targets: Vec<(Entity, bool)> = starts
         .iter()
         .filter_map(|(e, src, synced, keyboard_target)| {
@@ -146,6 +341,7 @@ fn sync_live_start_pages(
         &agents_snapshot,
         &pages_snapshot,
         &work_snapshot,
+        &prompt_context,
     );
     for (e, focus_requested) in targets {
         commands.trigger(BinHostEmitEvent::from_rkyv(
@@ -269,6 +465,7 @@ fn maintain_warm_start_pool(
 fn on_start_spare_revealed(
     mut revealed: MessageReader<StartSpareRevealed>,
     tab_gather: TabGatherParams,
+    prompt_context: StartPromptContextParams,
     spaces_snapshot: Res<CommandBarSpacesSnapshot>,
     agents_snapshot: Res<CommandBarAgentsSnapshot>,
     pages_snapshot: Res<CommandBarPagesSnapshot>,
@@ -282,6 +479,7 @@ fn on_start_spare_revealed(
             &agents_snapshot,
             &pages_snapshot,
             &work_snapshot,
+            &prompt_context,
         );
         commands.trigger(BinHostEmitEvent::from_rkyv(
             ev.webview,
@@ -303,6 +501,7 @@ fn on_start_data_request(
     spares: Query<(), With<WarmStartSpare>>,
     keyboard_targets: Query<(), With<CefKeyboardTarget>>,
     tab_gather: TabGatherParams,
+    prompt_context: StartPromptContextParams,
     spaces_snapshot: Res<CommandBarSpacesSnapshot>,
     agents_snapshot: Res<CommandBarAgentsSnapshot>,
     pages_snapshot: Res<CommandBarPagesSnapshot>,
@@ -320,6 +519,7 @@ fn on_start_data_request(
         &agents_snapshot,
         &pages_snapshot,
         &work_snapshot,
+        &prompt_context,
     );
     commands.trigger(BinHostEmitEvent::from_rkyv(
         webview,
@@ -342,6 +542,7 @@ fn build_start_payload(
     agents_snapshot: &CommandBarAgentsSnapshot,
     pages_snapshot: &CommandBarPagesSnapshot,
     work_snapshot: &CommandBarWorkSnapshot,
+    prompt_context: &StartPromptContextParams,
 ) -> CommandBarOpenEvent {
     let active_stack_count = tab_gather.stack_q.iter().count();
     let space_name = spaces_snapshot.active_space_name.clone();
@@ -357,7 +558,7 @@ fn build_start_payload(
         &tab_gather.child_of_q,
         &space_name,
     );
-    build_command_bar_open_payload(
+    let mut payload = build_command_bar_open_payload(
         0,
         false,
         space_name,
@@ -369,7 +570,9 @@ fn build_start_payload(
         active_stack_count,
         tabs,
         Some(OpenTarget::InPlace),
-    )
+    );
+    payload.prompt_context = prompt_context.context(tab_gather.active_tab.get());
+    payload
 }
 
 /// Despawn a stack's existing webview children before attaching new content.

--- a/crates/vmux_layout/src/target.rs
+++ b/crates/vmux_layout/src/target.rs
@@ -3,15 +3,62 @@ use bevy::prelude::*;
 use vmux_core::terminal::{ProcessExited, Terminal};
 
 use crate::pane::{Pane, PaneSplit};
+use crate::stack::Stack;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BrowserTarget {
+    Pane(Entity),
+    Stack(Entity),
+}
 
 #[allow(clippy::type_complexity)]
 pub fn parse_pane_target(
     s: &str,
     panes: &Query<Entity, (With<Pane>, Without<PaneSplit>)>,
 ) -> Option<Entity> {
-    let bits = s.parse::<u64>().ok()?;
+    let bits = match vmux_wire::protocol::parse_id(s) {
+        Ok((vmux_wire::protocol::NodeKind::Pane, bits)) => bits,
+        Ok(_) => return None,
+        Err(_) => s.parse::<u64>().ok()?,
+    };
     let entity = Entity::try_from_bits(bits)?;
     panes.contains(entity).then_some(entity)
+}
+
+pub fn parse_browser_target(
+    value: &str,
+    panes: &Query<Entity, (With<Pane>, Without<PaneSplit>)>,
+    stacks: &Query<Entity, With<Stack>>,
+) -> Option<BrowserTarget> {
+    if let Ok((kind, bits)) = vmux_wire::protocol::parse_id(value) {
+        let entity = Entity::try_from_bits(bits)?;
+        return match kind {
+            vmux_wire::protocol::NodeKind::Pane if panes.contains(entity) => {
+                Some(BrowserTarget::Pane(entity))
+            }
+            vmux_wire::protocol::NodeKind::Stack if stacks.contains(entity) => {
+                Some(BrowserTarget::Stack(entity))
+            }
+            _ => None,
+        };
+    }
+    parse_pane_target(value, panes).map(BrowserTarget::Pane)
+}
+
+pub fn webview_for_target<B: Component>(
+    target: BrowserTarget,
+    pane_children: &Query<&Children, With<Pane>>,
+    stack_ts: &Query<(Entity, &vmux_core::LastActivatedAt), With<Stack>>,
+    browsers: &Query<(Entity, &ChildOf), With<B>>,
+    terminals: &Query<(Entity, &ChildOf), (With<Terminal>, Without<ProcessExited>)>,
+) -> Option<Entity> {
+    let stack = match target {
+        BrowserTarget::Pane(pane) => {
+            crate::stack::active_stack_in_pane(pane, pane_children, stack_ts)
+        }
+        BrowserTarget::Stack(stack) => Some(stack),
+    };
+    active_webview_for_tab(stack, browsers, terminals)
 }
 
 #[allow(clippy::type_complexity)]

--- a/crates/vmux_layout/tests/page_source.rs
+++ b/crates/vmux_layout/tests/page_source.rs
@@ -108,8 +108,6 @@ fn knowledge_side_sheet_opens_markdown_tree_through_file_pages() {
     assert!(source.contains("if expanded() {"));
     assert!(!source.contains("if expanded() && has_children"));
     assert!(knowledge_card.contains("let mut folded = use_signal(|| false)"));
-    assert!(knowledge_card.contains("\"Unfold knowledge\""));
-    assert!(knowledge_card.contains("\"Fold knowledge\""));
     assert!(knowledge_card.contains("grid-rows-[0fr]"));
     assert!(knowledge_card.contains("grid-rows-[1fr]"));
     assert!(source.contains("overflow-x-hidden overflow-y-auto"));
@@ -119,17 +117,6 @@ fn knowledge_side_sheet_opens_markdown_tree_through_file_pages() {
     assert!(!source.contains("KnowledgeUse"));
     assert!(!source.contains("Build with"));
     assert!(!source.contains("vmux://notes"));
-}
-
-#[test]
-fn folded_pane_shows_its_active_stack() {
-    let pane = pane_section_component_source();
-
-    assert!(pane.contains(".find(|stack| stack.is_active"));
-    assert!(pane.contains("if folded()"));
-    assert!(pane.contains("if let Some(stack) = folded_stack"));
-    assert!(pane.contains("SideSheetStackRow { stack, pane_id }"));
-    assert!(pane.contains("flex shrink-0 flex-col"));
 }
 
 #[test]
@@ -281,12 +268,4 @@ fn side_sheet_stack_row_component_source() -> &'static str {
         .nth(1)
         .and_then(|rest| rest.split("fn download_pct").next())
         .expect("side sheet stack row component")
-}
-
-fn pane_section_component_source() -> &'static str {
-    include_str!("../src/page.rs")
-        .split("fn PaneSection(pane: PaneNode, index: usize)")
-        .nth(1)
-        .and_then(|rest| rest.split("fn NewStackRow").next())
-        .expect("pane section component")
 }

--- a/crates/vmux_mcp/src/protocol.rs
+++ b/crates/vmux_mcp/src/protocol.rs
@@ -329,12 +329,16 @@ async fn grep_result(
             )
             .await;
         }
+        let mut canonical_paths = std::collections::HashMap::new();
         let matches = search_matches
             .into_iter()
             .filter_map(|(path, line, col, end_col, preview)| {
-                let path = std::fs::canonicalize(path).ok()?;
+                let canonical = canonical_paths
+                    .entry(path.clone())
+                    .or_insert_with(|| std::fs::canonicalize(&path).ok())
+                    .clone()?;
                 Some(vmux_service::protocol::FileSearchMatch {
-                    path: path.to_string_lossy().into_owned(),
+                    path: canonical.to_string_lossy().into_owned(),
                     line,
                     col,
                     end_col,

--- a/crates/vmux_mcp/src/protocol.rs
+++ b/crates/vmux_mcp/src/protocol.rs
@@ -235,6 +235,7 @@ async fn grep_result(
     let mut first_cols: std::collections::HashMap<String, (u32, u32)> =
         std::collections::HashMap::new();
     let mut lines_out: Vec<String> = Vec::new();
+    let mut search_matches = Vec::new();
     let mut capped = false;
     for line in std::io::BufReader::new(stdout).lines() {
         let Ok(line) = line else { break };
@@ -259,24 +260,32 @@ async fn grep_result(
             .and_then(|l| l.get("text"))
             .and_then(Value::as_str)
             .unwrap_or("");
+        let first_match = data
+            .get("submatches")
+            .and_then(|s| s.as_array())
+            .and_then(|a| a.first());
+        let cols = first_match.map(|sm| {
+            let start = sm.get("start").and_then(Value::as_u64).unwrap_or(0) as usize;
+            let end = sm.get("end").and_then(Value::as_u64).unwrap_or(0) as usize;
+            (byte_to_utf16(raw, start), byte_to_utf16(raw, end))
+        });
         if !first_line.contains_key(path) {
             first_line.insert(path.to_string(), lineno);
-            if let Some(sm) = data
-                .get("submatches")
-                .and_then(|s| s.as_array())
-                .and_then(|a| a.first())
-            {
-                let s = sm.get("start").and_then(Value::as_u64).unwrap_or(0) as usize;
-                let e = sm.get("end").and_then(Value::as_u64).unwrap_or(0) as usize;
-                first_cols.insert(
-                    path.to_string(),
-                    (byte_to_utf16(raw, s), byte_to_utf16(raw, e)),
-                );
+            if let Some(cols) = cols {
+                first_cols.insert(path.to_string(), cols);
             }
             order.push(path.to_string());
         }
         if lines_out.len() < GREP_MAX_LINES {
             lines_out.push(format!("{path}:{lineno}: {}", raw.trim_end()));
+            let (col, end_col) = cols.unwrap_or((0, 0));
+            search_matches.push((
+                path.to_string(),
+                lineno,
+                col,
+                end_col,
+                raw.trim_end().to_string(),
+            ));
         }
         if lines_out.len() >= GREP_MAX_LINES || order.len() >= GREP_MAX_FILES {
             capped = true;
@@ -304,10 +313,9 @@ async fn grep_result(
     }
 
     if let Some(anchor) = anchor {
-        for file in order.iter().take(GREP_MAX_FILES) {
-            let Ok(abs) = std::fs::canonicalize(file) else {
-                continue;
-            };
+        if let Some(file) = order.first()
+            && let Ok(abs) = std::fs::canonicalize(file)
+        {
             let _ = run_agent_command(
                 AgentCommand::FileTouched {
                     anchor,
@@ -316,6 +324,33 @@ async fn grep_result(
                     col: first_cols.get(file).map(|c| c.0),
                     end_col: first_cols.get(file).map(|c| c.1),
                     kind: FileTouchKind::Read,
+                },
+                Some(anchor),
+            )
+            .await;
+        }
+        let matches = search_matches
+            .into_iter()
+            .filter_map(|(path, line, col, end_col, preview)| {
+                let path = std::fs::canonicalize(path).ok()?;
+                Some(vmux_service::protocol::FileSearchMatch {
+                    path: path.to_string_lossy().into_owned(),
+                    line,
+                    col,
+                    end_col,
+                    preview,
+                })
+            })
+            .collect::<Vec<_>>();
+        if !matches.is_empty() {
+            let root = std::fs::canonicalize(search_path)
+                .unwrap_or_else(|_| std::path::PathBuf::from(search_path));
+            let _ = run_agent_command(
+                AgentCommand::FileSearch {
+                    anchor,
+                    root: root.to_string_lossy().into_owned(),
+                    query: query.to_string(),
+                    matches,
                 },
                 Some(anchor),
             )

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -496,6 +496,26 @@ fn request_user_choice_definition() -> ToolDefinition {
     }
 }
 
+fn set_conversation_title_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "set_conversation_title".into(),
+        description: "Set the agent conversation header to a concise model-written summary. Call as the first tool after every user message, before skills or other tools. Summarize the whole conversation in 3 to 7 words, correct spelling and grammar, and never copy the user's prompt verbatim."
+            .into(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "required": ["title"],
+            "additionalProperties": false,
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 120
+                }
+            }
+        }),
+    }
+}
+
 fn resume_in_acp_definition() -> ToolDefinition {
     ToolDefinition {
         name: "resume_in_acp".into(),
@@ -757,6 +777,7 @@ pub fn tool_definitions_filtered(acp_session: bool, acp_terminals: bool) -> Vec<
         defs.push(run_definition());
     }
     defs.push(request_user_choice_definition());
+    defs.push(set_conversation_title_definition());
     defs.push(select_workspace_definition());
     defs.push(create_worktree_definition());
     if !acp_terminals {
@@ -990,6 +1011,26 @@ pub fn dispatch_with_anchor(
             question: question.to_string(),
             options,
         }));
+    }
+    if name == "set_conversation_title" {
+        let anchor = anchor.ok_or(
+            "set_conversation_title requires an agent anchor (not available to this client)",
+        )?;
+        let title = arguments
+            .get("title")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|title| !title.is_empty())
+            .ok_or("set_conversation_title.title is empty")?;
+        if title.chars().count() > 120 {
+            return Err("set_conversation_title.title exceeds 120 characters".to_string());
+        }
+        return Ok(DispatchTarget::Command(
+            AgentCommand::SetConversationTitle {
+                anchor,
+                title: title.to_string(),
+            },
+        ));
     }
     if name == "select_workspace" || name == "choose_workspace" {
         let anchor = anchor
@@ -1453,6 +1494,7 @@ mod tests {
             "run",
             "read_terminal",
             "request_user_choice",
+            "set_conversation_title",
             "select_workspace",
             "create_worktree",
         ] {
@@ -1624,6 +1666,30 @@ mod tests {
             DispatchTarget::Command(AgentCommand::ResumeInAcp { anchor: got }) if got == anchor
         ));
         assert!(dispatch_from_tool_call("resume_in_acp", serde_json::json!({})).is_err());
+    }
+
+    #[test]
+    fn conversation_title_dispatches_model_summary_to_agent_session() {
+        let anchor = vmux_service::protocol::ProcessId::new();
+        let target = dispatch_with_anchor(
+            "set_conversation_title",
+            serde_json::json!({"title": "  Refine model-generated summaries  "}),
+            Some(anchor),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            target,
+            DispatchTarget::Command(AgentCommand::SetConversationTitle { anchor: got, title })
+                if got == anchor && title == "Refine model-generated summaries"
+        ));
+        assert!(
+            dispatch_from_tool_call(
+                "set_conversation_title",
+                serde_json::json!({"title": "summary"})
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -444,7 +444,7 @@ is typed into an interactive shell, so the terminal stays usable afterwards."
 fn create_worktree_definition() -> ToolDefinition {
     ToolDefinition {
         name: "create_worktree".into(),
-        description: "Call immediately before the first edit, write, test, build, or other project mutation, after repository selection is complete. vmux reuses the current linked worktree, accepts a known existing worktree path, automatically uses a single unambiguous existing worktree, or creates a managed worktree when none exists. If multiple existing worktrees are returned as ambiguous, ask the user with request_user_choice to choose an existing path or Create new worktree; call again with path or create=true. Never run git worktree add manually. Returns the absolute worktree path."
+        description: "Call immediately before the first edit, write, test, build, or other project mutation, after a Git workspace is selected. vmux reuses the current linked worktree, accepts a known existing worktree path, automatically uses a single unambiguous existing worktree, or creates a managed worktree when none exists. If multiple existing worktrees are returned as ambiguous, ask the user with request_user_choice to choose an existing path or Create new worktree; call again with path or create=true. Never run git worktree add manually. Returns the absolute worktree path."
             .into(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -459,10 +459,10 @@ fn create_worktree_definition() -> ToolDefinition {
     }
 }
 
-fn choose_workspace_definition() -> ToolDefinition {
+fn select_workspace_definition() -> ToolDefinition {
     ToolDefinition {
-        name: "choose_workspace".into(),
-        description: "Bind the repository selected by the user after request_user_choice has asked, in order: Local repository, Remote repository, or Create repository. Pass path when the conversation already identifies a valid local checkout; vmux tries it first and opens the native folder picker only when the path is absent or invalid. Remote repositories must be cloned and new repositories initialized before calling this tool. This binds the repository only; call create_worktree later, immediately before the first mutation. The request returns immediately when user selection is needed: stop the current turn and do not call again while pending. Do not search the user's home directory for repositories. Do not call for general questions or self-contained terminal demonstrations."
+        name: "select_workspace".into(),
+        description: "Start the Create or select workspace flow. Pass path when the conversation already identifies a valid local directory; otherwise vmux opens the native folder picker immediately after approval. Any directory can be a workspace. vmux treats it as Git only when the selected directory contains .git; otherwise vmux asks whether to initialize a Git repository. A non-Git workspace remains usable when the user declines. For a Git workspace, call create_worktree immediately before the first mutation. The request returns immediately when user selection is needed: stop the current turn and do not call again while pending. Do not search the user's home directory for workspaces. Do not call for general questions or self-contained terminal demonstrations."
             .into(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -477,7 +477,7 @@ fn choose_workspace_definition() -> ToolDefinition {
 fn request_user_choice_definition() -> ToolDefinition {
     ToolDefinition {
         name: "request_user_choice".into(),
-        description: "Show a native multiple-choice question in the agent conversation. Use this for the required repository-source question before choose_workspace and for ambiguous worktree selection. The user can choose with arrow keys, Ctrl+N/Ctrl+P, number keys, mouse, or Enter. The request returns immediately: stop the current turn; vmux resumes the same conversation with the selected option."
+        description: "Show a native multiple-choice question in the agent conversation. Use this for ambiguous worktree selection or other short user decisions. The user can choose with arrow keys, Ctrl+N/Ctrl+P, number keys, mouse, or Enter. The request returns immediately: stop the current turn; vmux resumes the same conversation with the selected option."
             .into(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -757,7 +757,7 @@ pub fn tool_definitions_filtered(acp_session: bool, acp_terminals: bool) -> Vec<
         defs.push(run_definition());
     }
     defs.push(request_user_choice_definition());
-    defs.push(choose_workspace_definition());
+    defs.push(select_workspace_definition());
     defs.push(create_worktree_definition());
     if !acp_terminals {
         defs.push(read_terminal_definition());
@@ -991,9 +991,9 @@ pub fn dispatch_with_anchor(
             options,
         }));
     }
-    if name == "choose_workspace" {
+    if name == "select_workspace" || name == "choose_workspace" {
         let anchor = anchor
-            .ok_or("choose_workspace requires an agent anchor (not available to this client)")?;
+            .ok_or("select_workspace requires an agent anchor (not available to this client)")?;
         if let Some(path) = arguments
             .get("path")
             .and_then(Value::as_str)
@@ -1453,7 +1453,7 @@ mod tests {
             "run",
             "read_terminal",
             "request_user_choice",
-            "choose_workspace",
+            "select_workspace",
             "create_worktree",
         ] {
             assert!(
@@ -1629,35 +1629,31 @@ mod tests {
     #[test]
     fn workspace_tools_dispatch_with_anchor_and_branch() {
         let anchor = vmux_service::protocol::ProcessId::new();
-        let choose_definition = choose_workspace_definition();
+        let select_definition = select_workspace_definition();
         let choice_definition = request_user_choice_definition();
         assert!(
-            choose_definition
+            select_definition
                 .description
                 .contains("Do not call for general questions")
         );
         assert!(
-            choose_definition
+            select_definition
                 .description
                 .contains("Do not search the user's home directory")
         );
-        assert!(choose_definition.description.contains("Local repository"));
-        assert!(choose_definition.description.contains("folder picker"));
+        assert!(select_definition.description.contains("Any directory"));
+        assert!(select_definition.description.contains("folder picker"));
+        assert!(select_definition.description.contains("contains .git"));
         assert!(
-            choose_definition
-                .description
-                .contains("binds the repository only")
-        );
-        assert!(
-            choose_definition
+            select_definition
                 .description
                 .contains("returns immediately")
         );
         assert!(choice_definition.description.contains("Ctrl+N/Ctrl+P"));
         let choose =
-            dispatch_with_anchor("choose_workspace", serde_json::json!({}), Some(anchor)).unwrap();
+            dispatch_with_anchor("select_workspace", serde_json::json!({}), Some(anchor)).unwrap();
         let choose_path = dispatch_with_anchor(
-            "choose_workspace",
+            "select_workspace",
             serde_json::json!({"path": "/repo"}),
             Some(anchor),
         )
@@ -1677,8 +1673,8 @@ mod tests {
         let choice = dispatch_with_anchor(
             "request_user_choice",
             serde_json::json!({
-                "question": "Repository?",
-                "options": ["Local repository", "Remote repository", "Create repository"]
+                "question": "Worktree?",
+                "options": ["Create new worktree", "/repo/.worktrees/feature"]
             }),
             Some(anchor),
         )
@@ -1709,7 +1705,7 @@ mod tests {
         assert!(matches!(
             choice,
             DispatchTarget::Command(AgentCommand::RequestUserChoice { anchor: got, question, options })
-                if got == anchor && question == "Repository?" && options.len() == 3
+                if got == anchor && question == "Worktree?" && options.len() == 2
         ));
     }
 

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -477,7 +477,7 @@ fn select_workspace_definition() -> ToolDefinition {
 fn request_user_choice_definition() -> ToolDefinition {
     ToolDefinition {
         name: "request_user_choice".into(),
-        description: "Show a native multiple-choice question in the agent conversation. Use this for ambiguous worktree selection or other short user decisions. The user can choose with arrow keys, Ctrl+N/Ctrl+P, number keys, mouse, or Enter. The request returns immediately: stop the current turn; vmux resumes the same conversation with the selected option."
+        description: "Show a native multiple-choice question in the agent conversation. When the user asks for options, alternatives, or things to choose or play with, use this instead of returning a plain Markdown list. Also use it for ambiguous worktree selection and other short user decisions. Keep options concise and actionable. The user can choose with arrow keys, Ctrl+N/Ctrl+P, number keys, mouse, or Enter. The request returns immediately: stop the current turn; vmux resumes the same conversation with the selected option."
             .into(),
         input_schema: serde_json::json!({
             "type": "object",

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -30,7 +30,7 @@ use tokio::sync::{broadcast, mpsc, oneshot, watch};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use vmux_core::ProcessId;
 
-use super::projector::{AcpProjector, Intent};
+use super::projector::{AcpProjector, Intent, is_conversation_title_tool};
 use crate::process::{ProcessManager, PtyInputWriter};
 use crate::protocol::{
     AgentAttachment, AgentCommand, AgentRequestId, AgentRunStatus, ApprovalDecision,
@@ -624,6 +624,16 @@ pub async fn run(
                     let projector = perm_shared.projector.lock().unwrap();
                     approval_details(&req, &projector)
                 };
+                if is_conversation_title_tool(&name) {
+                    let outcome =
+                        match pick_permission_option(&req.options, ApprovalDecision::Allow) {
+                            Some(id) => RequestPermissionOutcome::Selected(
+                                SelectedPermissionOutcome::new(id),
+                            ),
+                            None => RequestPermissionOutcome::Cancelled,
+                        };
+                    return responder.respond(RequestPermissionResponse::new(outcome));
+                }
                 perm_shared.emit(ServiceMessage::AgentAwaitingApproval {
                     sid: perm_shared.sid.clone(),
                     call_id: call_id.clone(),
@@ -1096,6 +1106,7 @@ watch and take over. Use mcp__vmux__read_terminal to inspect continued output. O
 argument because it targets your own terminal pane. Do ALL web access via the vmux browser tools. \
 If you invoke a required Skill tool, continue the original user request in the same turn after \
 the skill loads. Never end the turn after skill activation or answer only Ready.";
+const CONVERSATION_TITLE_STEER_PROMPT: &str = "Immediately after every user message, call mcp__vmux__set_conversation_title as the first tool of the turn, before reading skills, calling any other tool, or answering. Write a concise 3 to 7 word model-generated summary of the whole conversation. Correct spelling and grammar. Never copy the user's prompt verbatim. Update the title even when the user sends a short follow-up.";
 
 fn session_meta_for_agent(agent_id: &str) -> Option<serde_json::Map<String, serde_json::Value>> {
     if let Err(error) = vmux_core::knowledge::sync_external_agent_configs() {
@@ -1117,9 +1128,11 @@ fn session_meta_for_agent_with_knowledge(
     } else {
         knowledge.to_string()
     };
-    if prompt.is_empty() {
-        return None;
-    }
+    let prompt = if prompt.is_empty() {
+        CONVERSATION_TITLE_STEER_PROMPT.to_string()
+    } else {
+        format!("{prompt}\n\n{CONVERSATION_TITLE_STEER_PROMPT}")
+    };
     if agent_id != "claude" {
         let serde_json::Value::Object(meta) = serde_json::json!({
             "systemPrompt": {
@@ -1138,6 +1151,7 @@ fn session_meta_for_agent_with_knowledge(
             "options": {
                 "disallowedTools": ["Bash", "Monitor", "WebSearch", "WebFetch"],
                 "allowedTools": [
+                    "mcp__vmux__set_conversation_title",
                     "mcp__vmux__run",
                     "mcp__vmux__read_terminal",
                     "mcp__vmux__browser_navigate",
@@ -2146,16 +2160,28 @@ mod tests {
                 .iter()
                 .any(|tool| tool == "mcp__vmux__run")
         );
+        assert!(
+            options["allowedTools"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|tool| tool == "mcp__vmux__set_conversation_title")
+        );
         let prompt = meta["systemPrompt"]["append"].as_str().unwrap();
         assert!(prompt.contains("mcp__vmux__run"));
         assert!(prompt.contains("continue the original user request"));
         assert!(prompt.contains("memory context"));
-        assert!(session_meta_for_agent_with_knowledge("vibe-acp", "").is_none());
-        assert_eq!(
-            session_meta_for_agent_with_knowledge("vibe-acp", "skill context").unwrap()["systemPrompt"]
-                ["append"],
-            "skill context"
-        );
+        assert!(prompt.contains("mcp__vmux__set_conversation_title"));
+        let generic = session_meta_for_agent_with_knowledge("vibe-acp", "skill context").unwrap()
+            ["systemPrompt"]["append"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert!(generic.starts_with("skill context\n\n"));
+        assert!(generic.contains("mcp__vmux__set_conversation_title"));
+        assert!(generic.contains("first tool of the turn"));
+        assert!(generic.contains("Correct spelling and grammar"));
+        assert!(generic.contains("Never copy the user's prompt verbatim"));
     }
 
     #[test]

--- a/crates/vmux_service/src/acp/projector.rs
+++ b/crates/vmux_service/src/acp/projector.rs
@@ -178,6 +178,7 @@ fn project_file_touches(
 #[derive(Default)]
 pub struct AcpProjector {
     messages: Vec<Message>,
+    hidden_tool_calls: HashSet<String>,
     file_touches: HashMap<String, FileTouchState>,
     file_touch_order: VecDeque<String>,
     finalized_file_touches: HashSet<String>,
@@ -399,6 +400,15 @@ impl AcpProjector {
 
     fn apply_tool_call(&mut self, tc: ToolCall) -> Vec<Intent> {
         let call_id = tc.tool_call_id.to_string();
+        if is_conversation_title_tool(&tc.title) {
+            if !matches!(
+                tc.status,
+                ToolCallStatus::Completed | ToolCallStatus::Failed
+            ) {
+                self.hidden_tool_calls.insert(call_id);
+            }
+            return Vec::new();
+        }
         let subagent = subagent_block(
             &call_id,
             &tc.title,
@@ -455,6 +465,17 @@ impl AcpProjector {
     fn apply_tool_call_update(&mut self, update: ToolCallUpdate) -> Vec<Intent> {
         let call_id = update.tool_call_id.to_string();
         let title = update.fields.title.clone().unwrap_or_default();
+        if self.hidden_tool_calls.contains(&call_id) || is_conversation_title_tool(&title) {
+            if matches!(
+                update.fields.status,
+                Some(ToolCallStatus::Completed | ToolCallStatus::Failed)
+            ) {
+                self.hidden_tool_calls.remove(&call_id);
+            } else {
+                self.hidden_tool_calls.insert(call_id);
+            }
+            return Vec::new();
+        }
         let subagent = subagent_block(
             &call_id,
             &title,
@@ -752,6 +773,14 @@ impl AcpProjector {
     }
 }
 
+pub(crate) fn is_conversation_title_tool(title: &str) -> bool {
+    title
+        .trim()
+        .to_ascii_lowercase()
+        .replace([' ', '-', '.', ':'], "_")
+        == "mcp__vmux__set_conversation_title"
+}
+
 fn subagent_block(
     call_id: &str,
     title: &str,
@@ -983,7 +1012,7 @@ mod tests {
     use super::*;
     use agent_client_protocol::schema::v1::{
         ContentChunk, Diff, SessionInfoUpdate, SessionUpdate, Terminal, TextContent, ToolCall,
-        ToolCallContent,
+        ToolCallContent, ToolCallUpdateFields,
     };
 
     fn chunk(text: &str) -> SessionUpdate {
@@ -1325,6 +1354,35 @@ mod tests {
                 r#"{"command":"echo hi","focus":true}"#.to_string(),
             ))
         );
+    }
+
+    #[test]
+    fn conversation_title_tool_stays_out_of_transcript() {
+        let mut p = AcpProjector::new();
+        let started = p.apply(SessionUpdate::ToolCall(ToolCall::new(
+            "title-1",
+            "mcp__vmux__set_conversation_title",
+        )));
+        let completed = p.apply(SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+            "title-1",
+            ToolCallUpdateFields::new().status(ToolCallStatus::Completed),
+        )));
+
+        assert!(started.is_empty());
+        assert!(completed.is_empty());
+        assert!(p.messages().is_empty());
+        assert!(p.tool_call_details("title-1").is_none());
+    }
+
+    #[test]
+    fn conversation_title_tool_requires_exact_vmux_identifier() {
+        assert!(is_conversation_title_tool(
+            "mcp__vmux__set_conversation_title"
+        ));
+        assert!(!is_conversation_title_tool(
+            "mcp__other__set_conversation_title"
+        ));
+        assert!(!is_conversation_title_tool("set_conversation_title"));
     }
 
     #[test]

--- a/crates/vmux_service/src/agent_broker.rs
+++ b/crates/vmux_service/src/agent_broker.rs
@@ -5,7 +5,8 @@ use tokio::sync::{Mutex, broadcast, oneshot};
 
 use crate::protocol::{
     AGENT_COMMAND_TIMEOUT, AGENT_QUERY_TIMEOUT, AGENT_TOOL_TIMEOUT, AgentCommand,
-    AgentCommandResult, AgentQuery, AgentQueryResult, AgentRequestId, ProcessId, ServiceMessage,
+    AgentCommandResult, AgentQuery, AgentQueryResult, AgentRequestId, BROWSER_NAVIGATE_TIMEOUT,
+    ProcessId, ServiceMessage,
 };
 
 pub type PendingCommands = Arc<Mutex<HashMap<AgentRequestId, oneshot::Sender<AgentCommandResult>>>>;
@@ -18,6 +19,13 @@ fn query_timeout(query: &AgentQuery) -> std::time::Duration {
     match query {
         AgentQuery::RecordStop { .. } => crate::protocol::RECORD_STOP_TIMEOUT,
         _ => AGENT_QUERY_TIMEOUT,
+    }
+}
+
+fn command_timeout(command: &AgentCommand) -> std::time::Duration {
+    match command {
+        AgentCommand::BrowserNavigate { .. } => BROWSER_NAVIGATE_TIMEOUT,
+        _ => AGENT_COMMAND_TIMEOUT,
     }
 }
 
@@ -55,6 +63,7 @@ impl AgentBroker {
         }
         let (tx, rx) = oneshot::channel::<AgentCommandResult>();
         self.pending_commands.lock().await.insert(request_id, tx);
+        let timeout = command_timeout(&command);
 
         if self
             .agent_tx
@@ -69,7 +78,7 @@ impl AgentBroker {
             return Err(NO_SUBSCRIBER.to_string());
         }
 
-        match tokio::time::timeout(AGENT_COMMAND_TIMEOUT, rx).await {
+        match tokio::time::timeout(timeout, rx).await {
             Ok(Ok(result)) => Ok(result),
             _ => {
                 self.pending_commands.lock().await.remove(&request_id);
@@ -177,6 +186,21 @@ mod tests {
         };
         assert_eq!(query_timeout(&stop), crate::protocol::RECORD_STOP_TIMEOUT);
         assert_eq!(query_timeout(&AgentQuery::GetSettings), AGENT_QUERY_TIMEOUT);
+    }
+
+    #[test]
+    fn browser_navigate_gets_longer_timeout() {
+        let navigate = AgentCommand::BrowserNavigate {
+            url: "https://example.com".into(),
+            pane: None,
+        };
+        assert_eq!(command_timeout(&navigate), BROWSER_NAVIGATE_TIMEOUT);
+        assert_eq!(
+            command_timeout(&AgentCommand::OpenInNewStack {
+                url: "https://example.com".into(),
+            }),
+            AGENT_COMMAND_TIMEOUT
+        );
     }
 
     #[tokio::test]

--- a/crates/vmux_ui/src/components/prompt_box.rs
+++ b/crates/vmux_ui/src/components/prompt_box.rs
@@ -2,7 +2,7 @@ use dioxus::prelude::*;
 use dioxus_primitives::dioxus_attributes::attributes;
 use dioxus_primitives::merge_attributes;
 
-const PROMPT_BOX_ROOT: &str = "vmux-prompt-box relative overflow-hidden rounded-2xl bg-white/45 p-1 shadow-[0_18px_55px_-24px_rgba(0,0,0,0.65),inset_0_1px_0_rgba(255,255,255,0.18),inset_0_-1px_0_rgba(255,255,255,0.04)] ring-1 ring-inset ring-black/10 backdrop-blur-3xl backdrop-saturate-150 transition-all duration-200 focus-within:bg-white/55 focus-within:ring-black/20 focus-within:shadow-[0_22px_65px_-24px_rgba(0,0,0,0.72),inset_0_1px_0_rgba(255,255,255,0.22)] dark:bg-white/[0.045] dark:ring-white/[0.16] dark:focus-within:bg-white/[0.065] dark:focus-within:ring-white/25";
+const PROMPT_BOX_ROOT: &str = "vmux-prompt-box relative overflow-hidden rounded-[1.25rem] bg-background/90 p-2 shadow-[0_20px_60px_-28px_rgba(0,0,0,0.58),0_6px_20px_-12px_rgba(0,0,0,0.22),inset_0_1px_0_rgba(255,255,255,0.4)] ring-1 ring-inset ring-foreground/[0.12] backdrop-blur-2xl backdrop-saturate-150 transition-[background-color,box-shadow,filter] duration-200 focus-within:bg-background/95 focus-within:shadow-[0_28px_80px_-32px_rgba(0,0,0,0.68),0_8px_24px_-14px_rgba(0,0,0,0.28),inset_0_1px_0_rgba(255,255,255,0.5)] dark:bg-[#171717]/90 dark:ring-white/[0.13] dark:focus-within:bg-[#171717]/95";
 
 const PROMPT_POPUP_ROOT: &str = "vmux-prompt-popup absolute left-0 z-20 max-h-80 w-full overflow-x-hidden overflow-y-auto rounded-2xl border border-foreground/10 bg-background/95 shadow-xl backdrop-blur-xl";
 
@@ -40,8 +40,8 @@ pub fn PromptBox(
     rsx! {
         div { ..merged,
             if glass {
-                div { class: "pointer-events-none absolute inset-px rounded-[0.9rem] bg-gradient-to-b from-white/[0.12] via-white/[0.025] to-transparent dark:from-white/[0.10]" }
-                div { class: "pointer-events-none absolute -left-12 -top-12 h-24 w-72 rotate-[-5deg] rounded-full bg-white/[0.09] blur-2xl" }
+                div { class: "pointer-events-none absolute inset-px rounded-[1.2rem] bg-gradient-to-b from-white/[0.18] via-white/[0.025] to-transparent dark:from-white/[0.075]" }
+                div { class: "pointer-events-none absolute -left-10 -top-16 h-28 w-80 rotate-[-5deg] rounded-full bg-white/[0.08] blur-3xl" }
             }
             {children}
         }

--- a/crates/vmux_ui/src/components/prompt_box.rs
+++ b/crates/vmux_ui/src/components/prompt_box.rs
@@ -2,7 +2,7 @@ use dioxus::prelude::*;
 use dioxus_primitives::dioxus_attributes::attributes;
 use dioxus_primitives::merge_attributes;
 
-const PROMPT_BOX_ROOT: &str = "vmux-prompt-box relative flex items-center overflow-hidden rounded-2xl bg-white/45 p-1 shadow-[0_18px_55px_-24px_rgba(0,0,0,0.65),inset_0_1px_0_rgba(255,255,255,0.18),inset_0_-1px_0_rgba(255,255,255,0.04)] ring-1 ring-inset ring-black/10 backdrop-blur-3xl backdrop-saturate-150 transition-all duration-200 focus-within:bg-white/55 focus-within:ring-black/20 focus-within:shadow-[0_22px_65px_-24px_rgba(0,0,0,0.72),inset_0_1px_0_rgba(255,255,255,0.22)] dark:bg-white/[0.045] dark:ring-white/[0.16] dark:focus-within:bg-white/[0.065] dark:focus-within:ring-white/25";
+const PROMPT_BOX_ROOT: &str = "vmux-prompt-box relative overflow-hidden rounded-2xl bg-white/45 p-1 shadow-[0_18px_55px_-24px_rgba(0,0,0,0.65),inset_0_1px_0_rgba(255,255,255,0.18),inset_0_-1px_0_rgba(255,255,255,0.04)] ring-1 ring-inset ring-black/10 backdrop-blur-3xl backdrop-saturate-150 transition-all duration-200 focus-within:bg-white/55 focus-within:ring-black/20 focus-within:shadow-[0_22px_65px_-24px_rgba(0,0,0,0.72),inset_0_1px_0_rgba(255,255,255,0.22)] dark:bg-white/[0.045] dark:ring-white/[0.16] dark:focus-within:bg-white/[0.065] dark:focus-within:ring-white/25";
 
 const PROMPT_POPUP_ROOT: &str = "vmux-prompt-popup absolute left-0 z-20 max-h-80 w-full overflow-x-hidden overflow-y-auto rounded-2xl border border-foreground/10 bg-background/95 shadow-xl backdrop-blur-xl";
 
@@ -18,10 +18,20 @@ pub enum PromptPopupPlacement {
 #[component]
 pub fn PromptBox(
     #[props(default = true)] glass: bool,
+    #[props(default)] vertical: bool,
     #[props(extends = GlobalAttributes)] attributes: Vec<Attribute>,
     children: Element,
 ) -> Element {
-    let class = if glass { PROMPT_BOX_ROOT } else { "" };
+    let layout = if vertical {
+        "flex flex-col items-stretch"
+    } else {
+        "flex items-center"
+    };
+    let class = if glass {
+        format!("{PROMPT_BOX_ROOT} {layout}")
+    } else {
+        layout.to_string()
+    };
     let base = attributes!(div {
         class,
         "data-slot": "prompt-box",

--- a/crates/vmux_ui/src/components/prompt_composer.rs
+++ b/crates/vmux_ui/src/components/prompt_composer.rs
@@ -63,6 +63,7 @@ pub fn PromptComposer(
     accent_bg: String,
     accent_color: String,
     accent_gradient: String,
+    #[props(default)] footer: Option<Element>,
     #[props(default)] action: PromptComposerAction,
     action_title: String,
     action_enabled: bool,
@@ -127,9 +128,11 @@ pub fn PromptComposer(
     rsx! {
         style { dangerous_inner_html: PROMPT_COMPOSER_CSS }
         PromptBox {
+            vertical: true,
             class: "vmux-prompt-composer",
             style: "--vmux-prompt-accent:{accent_color};",
-            button {
+            div { class: "relative z-10 flex w-full items-center",
+                button {
                 class: "relative z-10 ml-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg text-foreground/45 transition hover:bg-foreground/10 hover:text-foreground",
                 title: "Attach files (/upload)",
                 onmousedown: move |event| event.prevent_default(),
@@ -145,7 +148,7 @@ pub fn PromptComposer(
                     path { d: "M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48" }
                 }
             }
-            div { class: "relative z-10 flex min-w-0 flex-1 flex-wrap items-center gap-1 px-2",
+                div { class: "relative z-10 flex min-w-0 flex-1 flex-wrap items-center gap-1 px-2",
                 for attachment in attachments.iter().cloned() {
                     div {
                         key: "{attachment.key}",
@@ -243,7 +246,7 @@ pub fn PromptComposer(
                     }
                 }
             }
-            button {
+                button {
                 class: "{action_class}",
                 disabled: !action_enabled,
                 title: "{action_title}",
@@ -273,6 +276,10 @@ pub fn PromptComposer(
                         path { d: "M5 12l7-7 7 7" }
                     }
                 }
+                }
+            }
+            if let Some(footer) = footer {
+                div { class: "relative z-10 w-full", {footer} }
             }
         }
     }

--- a/crates/vmux_ui/src/components/prompt_composer.rs
+++ b/crates/vmux_ui/src/components/prompt_composer.rs
@@ -15,8 +15,8 @@ const PROMPT_COMPOSER_CSS: &str = r#"
 .vmux-prompt-input{caret-color:transparent}
 .vmux-prompt-caret{animation:vmux-prompt-caret-blink 1s step-end infinite;background:var(--vmux-prompt-accent)}
 @keyframes vmux-prompt-caret-blink{0%,49%{opacity:1}50%,100%{opacity:0}}
-.vmux-prompt-composer{border-color:rgba(255,255,255,0.18);box-shadow:0 22px 70px -28px rgba(255,255,255,0.2),inset 0 1px 0 rgba(255,255,255,0.16),inset 0 -1px 0 rgba(255,255,255,0.04)}
-.vmux-prompt-composer:focus-within{border-color:rgba(255,255,255,0.28);box-shadow:0 26px 78px -26px rgba(255,255,255,0.28),inset 0 1px 0 rgba(255,255,255,0.2)}
+.vmux-prompt-composer{box-shadow:0 22px 70px -30px rgba(0,0,0,.58),0 8px 24px -16px rgba(0,0,0,.3),inset 0 1px 0 rgba(255,255,255,.16)}
+.vmux-prompt-composer:focus-within{box-shadow:0 28px 84px -34px rgba(0,0,0,.7),0 10px 28px -18px color-mix(in srgb,var(--vmux-prompt-accent) 32%,transparent),inset 0 0 0 1px color-mix(in srgb,var(--vmux-prompt-accent) 28%,transparent),inset 0 1px 0 rgba(255,255,255,.2)}
 "#;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -117,169 +117,176 @@ pub fn PromptComposer(
     let action_class = if action_enabled {
         match action {
             PromptComposerAction::Send => format!(
-                "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg bg-gradient-to-br text-white shadow-lg transition hover:brightness-110 active:scale-95 {accent_gradient}"
+                "relative z-10 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gradient-to-br text-white shadow-[0_5px_14px_-5px_rgba(0,0,0,0.55)] transition hover:scale-[1.04] hover:brightness-110 active:scale-95 {accent_gradient}"
             ),
-            PromptComposerAction::Stop => "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg bg-white/40 text-foreground/70 shadow-sm ring-1 ring-inset ring-black/10 transition hover:bg-white/60 hover:text-foreground active:scale-95 dark:bg-white/[0.08] dark:ring-white/10 dark:hover:bg-white/[0.14]".to_string(),
+            PromptComposerAction::Stop => "relative z-10 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-foreground/[0.09] text-foreground/70 shadow-sm ring-1 ring-inset ring-foreground/10 transition hover:bg-foreground/[0.14] hover:text-foreground active:scale-95".to_string(),
         }
     } else {
-        "relative z-10 mr-0.5 flex h-8 w-8 shrink-0 cursor-default self-center items-center justify-center rounded-lg bg-white/25 text-muted-foreground/35 shadow-sm ring-1 ring-inset ring-black/[0.06] dark:bg-white/[0.055] dark:ring-white/[0.08]".to_string()
+        "relative z-10 flex h-8 w-8 shrink-0 cursor-default items-center justify-center rounded-full bg-foreground/[0.055] text-muted-foreground/35 ring-1 ring-inset ring-foreground/[0.07]".to_string()
     };
 
     rsx! {
-        style { dangerous_inner_html: PROMPT_COMPOSER_CSS }
-        PromptBox {
-            vertical: true,
-            class: "vmux-prompt-composer",
-            style: "--vmux-prompt-accent:{accent_color};",
-            div { class: "relative z-10 flex w-full items-center",
-                button {
-                class: "relative z-10 ml-0.5 flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-lg text-foreground/45 transition hover:bg-foreground/10 hover:text-foreground",
-                title: "Attach files (/upload)",
-                onmousedown: move |event| event.prevent_default(),
-                onclick: move |_| on_attach.call(()),
-                svg {
-                    class: "h-4 w-4",
-                    view_box: "0 0 24 24",
-                    fill: "none",
-                    stroke: "currentColor",
-                    stroke_width: "2",
-                    stroke_linecap: "round",
-                    stroke_linejoin: "round",
-                    path { d: "M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48" }
-                }
-            }
-                div { class: "relative z-10 flex min-w-0 flex-1 flex-wrap items-center gap-1 px-2",
-                for attachment in attachments.iter().cloned() {
-                    div {
-                        key: "{attachment.key}",
-                        class: if attachment.remove_index.is_some() { "group flex h-7 max-w-56 shrink-0 items-center gap-1.5 rounded-full bg-foreground/[0.08] pl-1 pr-1.5 text-xs text-foreground/80 ring-1 ring-inset ring-foreground/10" } else { "flex h-7 max-w-56 shrink-0 items-center gap-1.5 rounded-full bg-foreground/[0.08] pl-1 pr-2 text-xs text-foreground/80 ring-1 ring-inset ring-foreground/10" },
-                        if attachment.preview_data_url.is_empty() {
-                            span { class: "flex h-5 min-w-5 items-center justify-center rounded-full bg-foreground/[0.08] px-1 font-mono text-[8px] font-semibold text-muted-foreground",
-                                "{attachment.label}"
-                            }
-                        } else {
-                            img {
-                                src: "{attachment.preview_data_url}",
-                                alt: "{attachment.name}",
-                                class: "h-5 w-5 rounded-full object-cover",
-                            }
-                        }
-                        span { class: "min-w-0 max-w-40 truncate", "{attachment.name}" }
-                        if let Some(remove_index) = attachment.remove_index {
-                            button {
-                                class: "flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-foreground/45 transition hover:bg-foreground/10 hover:text-foreground",
-                                title: "Remove attachment",
-                                onmousedown: move |event| event.prevent_default(),
-                                onclick: move |_| {
-                                    on_remove_attachment.call(remove_index);
-                                    focus_prompt_end(PROMPT_INPUT_ID);
-                                },
-                                svg {
-                                    class: "h-3 w-3",
-                                    view_box: "0 0 24 24",
-                                    fill: "none",
-                                    stroke: "currentColor",
-                                    stroke_width: "2.5",
-                                    stroke_linecap: "round",
-                                    path { d: "M6 6l12 12M18 6L6 18" }
-                                }
-                            }
-                        }
-                    }
-                }
-                div { class: "relative min-w-32 flex-1 overflow-hidden",
-                    if value.is_empty() {
-                        div { class: "pointer-events-none absolute inset-0 flex -translate-y-px items-center overflow-hidden px-1.5",
-                            if !preview.is_empty() {
-                                div { class: "max-w-full truncate whitespace-nowrap text-[15px] leading-6 text-foreground", "{preview}" }
-                            } else if show_examples {
-                                PromptGhost {
-                                    accent_bg,
-                                    terminal: false,
+            style { dangerous_inner_html: PROMPT_COMPOSER_CSS }
+            PromptBox {
+                vertical: true,
+                class: "vmux-prompt-composer",
+                style: "--vmux-prompt-accent:{accent_color};",
+                div { class: "relative z-10 px-2 pt-1",
+                    if !attachments.is_empty() {
+                        div { class: "mb-1.5 flex flex-wrap items-center gap-1.5",
+                    for attachment in attachments.iter().cloned() {
+                        div {
+                            key: "{attachment.key}",
+                            class: if attachment.remove_index.is_some() { "group flex h-7 max-w-56 shrink-0 items-center gap-1.5 rounded-lg bg-foreground/[0.065] pl-1 pr-1 text-xs text-foreground/80 ring-1 ring-inset ring-foreground/[0.08]" } else { "flex h-7 max-w-56 shrink-0 items-center gap-1.5 rounded-lg bg-foreground/[0.065] pl-1 pr-2 text-xs text-foreground/80 ring-1 ring-inset ring-foreground/[0.08]" },
+                            if attachment.preview_data_url.is_empty() {
+                                span { class: "flex h-5 min-w-5 items-center justify-center rounded-full bg-foreground/[0.08] px-1 font-mono text-[8px] font-semibold text-muted-foreground",
+                                    "{attachment.label}"
                                 }
                             } else {
-                                div { class: "flex max-w-full items-center whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50",
-                                    if caret().is_some() {
-                                        span { class: "vmux-prompt-caret relative top-px mr-px h-4 w-1.5 shrink-0" }
+                                img {
+                                    src: "{attachment.preview_data_url}",
+                                    alt: "{attachment.name}",
+                                    class: "h-5 w-5 rounded-full object-cover",
+                                }
+                            }
+                            span { class: "min-w-0 max-w-40 truncate", "{attachment.name}" }
+                            if let Some(remove_index) = attachment.remove_index {
+                                button {
+                                    class: "flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-foreground/45 transition hover:bg-foreground/10 hover:text-foreground",
+                                    title: "Remove attachment",
+                                    onmousedown: move |event| event.prevent_default(),
+                                    onclick: move |_| {
+                                        on_remove_attachment.call(remove_index);
+                                        focus_prompt_end(PROMPT_INPUT_ID);
+                                    },
+                                    svg {
+                                        class: "h-3 w-3",
+                                        view_box: "0 0 24 24",
+                                        fill: "none",
+                                        stroke: "currentColor",
+                                        stroke_width: "2.5",
+                                        stroke_linecap: "round",
+                                        path { d: "M6 6l12 12M18 6L6 18" }
                                     }
-                                    span { class: "min-w-0 truncate", "{placeholder}" }
                                 }
                             }
                         }
                     }
-                    if !completion.is_empty() {
-                        div {
-                            class: "pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words px-1.5 py-2 text-[15px] leading-6",
-                            span { class: "text-transparent", "{value}" }
-                            span { class: "text-muted-foreground/40", "{completion}" }
                         }
                     }
-                    if let Some(prefix) = caret_prefix.as_ref() {
-                        div { class: "pointer-events-none absolute inset-0 z-20 overflow-hidden",
-                            div {
-                                class: "min-h-10 w-full whitespace-pre-wrap break-words px-1.5 py-2 text-[15px] leading-6 text-transparent",
-                                style: "transform:translateY(-{prompt_scroll_offset}px);",
-                                span { "{prefix}" }
-                                span { class: "vmux-prompt-caret relative top-px ml-px inline-block h-4 w-1.5 align-middle" }
+                    div { class: "relative min-w-32 overflow-hidden",
+                        if value.is_empty() {
+                            div { class: "pointer-events-none absolute inset-0 flex -translate-y-px items-center overflow-hidden px-1 py-1",
+                                if !preview.is_empty() {
+                                    div { class: "max-w-full truncate whitespace-nowrap text-[15px] leading-6 text-foreground", "{preview}" }
+                                } else if show_examples {
+                                    PromptGhost {
+                                        accent_bg,
+                                        terminal: false,
+                                    }
+                                } else {
+                                    div { class: "flex max-w-full items-center whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50",
+                                        if caret().is_some() {
+                                            span { class: "vmux-prompt-caret relative top-px mr-px h-4 w-1.5 shrink-0" }
+                                        }
+                                        span { class: "min-w-0 truncate", "{placeholder}" }
+                                    }
+                                }
                             }
                         }
-                    }
-                    textarea {
-                        id: PROMPT_INPUT_ID,
-                        class: "vmux-prompt-input relative z-10 max-h-40 min-h-10 w-full resize-none bg-transparent px-1.5 py-2 text-[15px] leading-6 placeholder:text-transparent focus:outline-none",
-                        autofocus: true,
-                        rows: "1",
-                        placeholder: "{placeholder}",
-                        value: "{value}",
-                        oninput: move |event| {
-                            on_input.call(event.value());
-                            resize_prompt_textarea(PROMPT_INPUT_ID);
-                            sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top);
-                        },
-                        onpaste: move |_| on_paste.call(()),
-                        onfocus: move |_| sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top),
-                        onblur: move |_| sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top),
-                        onkeyup: move |_| sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top),
-                        onmouseup: move |_| sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top),
-                        onscroll: move |_| sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top),
-                        onkeydown: move |event| on_keydown.call(event),
-                    }
-                }
-            }
-                button {
-                class: "{action_class}",
-                disabled: !action_enabled,
-                title: "{action_title}",
-                onmousedown: move |event| event.prevent_default(),
-                onclick: move |_| {
-                    if action_enabled {
-                        on_action.call(());
-                    }
-                },
-                if action == PromptComposerAction::Stop {
-                    svg {
-                        class: "h-4 w-4",
-                        view_box: "0 0 24 24",
-                        fill: "currentColor",
-                        rect { x: "6", y: "6", width: "12", height: "12", rx: "2.5" }
-                    }
-                } else {
-                    svg {
-                        class: "h-4 w-4",
-                        view_box: "0 0 24 24",
-                        fill: "none",
-                        stroke: "currentColor",
-                        stroke_width: "2",
-                        stroke_linecap: "round",
-                        stroke_linejoin: "round",
-                        path { d: "M12 19V5" }
-                        path { d: "M5 12l7-7 7 7" }
+                        if !completion.is_empty() {
+                            div {
+                                class: "pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words px-1 py-2 text-[15px] leading-6",
+                                span { class: "text-transparent", "{value}" }
+                                span { class: "text-muted-foreground/40", "{completion}" }
+                            }
+                        }
+                        if let Some(prefix) = caret_prefix.as_ref() {
+                            div { class: "pointer-events-none absolute inset-0 z-20 overflow-hidden",
+                                div {
+                                    class: "min-h-12 w-full whitespace-pre-wrap break-words px-1 py-2 text-[15px] leading-6 text-transparent",
+                                    style: "transform:translateY(-{prompt_scroll_offset}px);",
+                                    span { "{prefix}" }
+                                    span { class: "vmux-prompt-caret relative top-px ml-px inline-block h-4 w-1.5 align-middle" }
+                                }
+                            }
+                        }
+                        textarea {
+                            id: PROMPT_INPUT_ID,
+                            class: "vmux-prompt-input relative z-10 max-h-48 min-h-12 w-full resize-none bg-transparent px-1 py-2 text-[15px] leading-6 placeholder:text-transparent focus:outline-none",
+                            autofocus: true,
+                            rows: "1",
+                            placeholder: "{placeholder}",
+                            value: "{value}",
+                            oninput: move |event| {
+                                on_input.call(event.value());
+                                resize_prompt_textarea(PROMPT_INPUT_ID);
+                                sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top);
+                            },
+                            onpaste: move |_| on_paste.call(()),
+                            onfocus: move |_| sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top),
+                            onblur: move |_| sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top),
+                            onkeyup: move |_| sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top),
+                            onmouseup: move |_| sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top),
+                            onscroll: move |_| sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top),
+                            onkeydown: move |event| on_keydown.call(event),
+                        }
                     }
                 }
+                div { class: "relative z-10 mt-0.5 flex min-w-0 items-center gap-1 px-1",
+                    button {
+                        class: "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-foreground/50 transition hover:bg-foreground/[0.08] hover:text-foreground active:scale-95",
+                        title: "Attach files (/upload)",
+                        onmousedown: move |event| event.prevent_default(),
+                        onclick: move |_| on_attach.call(()),
+                        svg {
+                            class: "h-4 w-4",
+                            view_box: "0 0 24 24",
+                            fill: "none",
+                            stroke: "currentColor",
+                            stroke_width: "2",
+                            stroke_linecap: "round",
+                            path { d: "M12 5v14M5 12h14" }
+                        }
+                    }
+                    if let Some(footer) = footer {
+                        div { class: "min-w-0 flex-1 overflow-hidden", {footer} }
+                    } else {
+                        div { class: "min-w-0 flex-1 truncate px-1 text-[10px] text-muted-foreground/55",
+                            "Enter to send · Shift+Enter for new line"
+                        }
+                    }
+                    button {
+                    class: "{action_class}",
+                    disabled: !action_enabled,
+                    title: "{action_title}",
+                    onmousedown: move |event| event.prevent_default(),
+                    onclick: move |_| {
+                        if action_enabled {
+                            on_action.call(());
+                        }
+                    },
+                    if action == PromptComposerAction::Stop {
+                        svg {
+                            class: "h-4 w-4",
+                            view_box: "0 0 24 24",
+                            fill: "currentColor",
+                            rect { x: "6", y: "6", width: "12", height: "12", rx: "2.5" }
+                        }
+                    } else {
+                        svg {
+                            class: "h-4 w-4",
+                            view_box: "0 0 24 24",
+                            fill: "none",
+                            stroke: "currentColor",
+                            stroke_width: "2",
+                            stroke_linecap: "round",
+                            stroke_linejoin: "round",
+                            path { d: "M12 19V5" }
+                            path { d: "M5 12l7-7 7 7" }
+                        }
+                    }
                 }
-            }
-            if let Some(footer) = footer {
-                div { class: "relative z-10 w-full", {footer} }
             }
         }
     }
@@ -317,8 +324,8 @@ fn resize_prompt_textarea(input_id: &str) {
         return;
     };
     let _ = textarea.set_attribute("style", "height:auto;overflow-y:hidden");
-    let height = textarea.scroll_height().clamp(40, 160);
-    let overflow = if height == 160 { "auto" } else { "hidden" };
+    let height = textarea.scroll_height().clamp(48, 192);
+    let overflow = if height == 192 { "auto" } else { "hidden" };
     let _ = textarea.set_attribute("style", &format!("height:{height}px;overflow-y:{overflow}"));
 }
 

--- a/crates/vmux_wire/src/protocol.rs
+++ b/crates/vmux_wire/src/protocol.rs
@@ -238,11 +238,19 @@ pub enum AgentCommand {
         task: Option<String>,
         create: bool,
     },
+    /// Forward global-search matches to the editor. Appended to preserve existing positional enum
+    /// discriminants.
     FileSearch {
         anchor: ProcessId,
         root: String,
         query: String,
         matches: Vec<FileSearchMatch>,
+    },
+    /// Replace the generated conversation title. Appended to preserve existing positional enum
+    /// discriminants.
+    SetConversationTitle {
+        anchor: ProcessId,
+        title: String,
     },
 }
 

--- a/crates/vmux_wire/src/protocol.rs
+++ b/crates/vmux_wire/src/protocol.rs
@@ -425,7 +425,7 @@ pub fn validate_agent_command(command: &AgentCommand) -> Result<(), &'static str
             Err("request_user_choice requires a question and 2 to 9 non-empty options")
         }
         AgentCommand::ChooseWorkspaceAtPath { path, .. } if path.trim().is_empty() => {
-            Err("choose_workspace.path is empty")
+            Err("select_workspace.path is empty")
         }
         _ => Ok(()),
     }

--- a/crates/vmux_wire/src/protocol.rs
+++ b/crates/vmux_wire/src/protocol.rs
@@ -57,6 +57,15 @@ pub enum FileTouchKind {
     Edit,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub struct FileSearchMatch {
+    pub path: String,
+    pub line: u32,
+    pub col: u32,
+    pub end_col: u32,
+    pub preview: String,
+}
+
 #[derive(Debug, Clone, PartialEq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum AgentCommand {
     AppCommand {
@@ -229,6 +238,12 @@ pub enum AgentCommand {
         task: Option<String>,
         create: bool,
     },
+    FileSearch {
+        anchor: ProcessId,
+        root: String,
+        query: String,
+        matches: Vec<FileSearchMatch>,
+    },
 }
 
 pub const AGENT_QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
@@ -239,6 +254,8 @@ pub const AGENT_QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_s
 pub const RECORD_STOP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 pub const AGENT_COMMAND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+pub const BROWSER_NAVIGATE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
 pub const AGENT_TOOL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 


### PR DESCRIPTION
## Context

Agent tool activity exposed raw JSON, generic icons, and extra follow-up calls. Search and file-follow behavior also lost context after layout changes, while browser navigation could hide new work or require a separate snapshot call.

## Implementation

Render tool arguments as structured cards with file-aware icons and dedicated layout/worktree visuals. Forward grep matches into the editor Explorer, preserve nested file follow panes, and make browser navigation return the loaded page snapshot while stacking agent-opened pages without interrupting active user interaction.

## Checks / QA

- Run a global grep and confirm Explorer opens, lists matches, and highlights the clicked result.
- Trigger read, write, layout, and worktree tools and inspect their icons and structured argument cards.
- Navigate to multiple browser pages and confirm new pages surface on top with snapshot output; interact with the current page and confirm agent navigation does not steal the visible stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace selection/worktree creation from agent chat, plus Git initialization guidance.
  * Chat UI now shows conversation titles and a richer composer footer; composer context updates dynamically.
  * Added global file search with a Search panel and click-to-open match navigation.
  * Enhanced command palette/start results with prioritized search engines and “Search with …” actions.
  * Improved tool visualization (more activity types, richer icons, and structured tool arguments) and redesigned approvals (Allow / Allow always / Deny).
* **Bug Fixes**
  * Improved browser navigation targeting and snapshot reliability (including request-id “await snapshot” flow).
  * Reduced redundant scrolling and adjusted terminal split behavior when starting from terminal scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->