### PR TITLE
feat(knowledge): migrate agent memories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9608,6 +9608,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "toml",
  "url",
  "uuid",
  "vmux_profile",

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -748,7 +748,7 @@ fn apply_codex_compatibility_env(mut env: Vec<(String, String)>) -> Vec<(String,
             crate::client::cli::codex::RUN_STEER_PROMPT
         )
     };
-    let instructions = vmux_core::knowledge::append_agent_skills(&instructions);
+    let instructions = vmux_core::knowledge::append_agent_context(&instructions);
     config.insert(
         "developer_instructions".to_string(),
         serde_json::Value::String(instructions),

--- a/crates/vmux_agent/src/client/cli/claude.rs
+++ b/crates/vmux_agent/src/client/cli/claude.rs
@@ -59,7 +59,7 @@ impl CliAgentStrategy for ClaudeStrategy {
             "--allowedTools".to_string(),
             ALLOWED_TOOLS.to_string(),
             "--append-system-prompt".to_string(),
-            vmux_core::knowledge::append_agent_skills(RUN_STEER_PROMPT),
+            vmux_core::knowledge::append_agent_context(RUN_STEER_PROMPT),
         ];
         if let Some(sid) = session_id {
             args.push("--resume".to_string());

--- a/crates/vmux_agent/src/client/cli/codex.rs
+++ b/crates/vmux_agent/src/client/cli/codex.rs
@@ -75,7 +75,9 @@ impl CliAgentStrategy for CodexStrategy {
         args.push("-c".into());
         args.push(format!(
             "developer_instructions={}",
-            quote_toml(&vmux_core::knowledge::append_agent_skills(RUN_STEER_PROMPT))
+            quote_toml(&vmux_core::knowledge::append_agent_context(
+                RUN_STEER_PROMPT
+            ))
         ));
         args.push("-c".into());
         args.push("features.hooks=true".into());

--- a/crates/vmux_agent/src/client/cli/vibe.rs
+++ b/crates/vmux_agent/src/client/cli/vibe.rs
@@ -12,6 +12,15 @@ use crate::{AgentKind, AgentVariant, AssistantBlock, McpServerConfig, Message};
 
 pub struct VibeStrategy;
 
+fn vibe_home() -> PathBuf {
+    std::env::var("VIBE_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            let home = std::env::var("HOME").unwrap_or_default();
+            PathBuf::from(home).join(".vibe")
+        })
+}
+
 impl AgentStrategy for VibeStrategy {
     fn kind(&self) -> AgentKind {
         AgentKind::Vibe
@@ -24,14 +33,7 @@ impl AgentStrategy for VibeStrategy {
 
 impl CliAgentStrategy for VibeStrategy {
     fn sessions_root(&self) -> PathBuf {
-        std::env::var("VIBE_HOME")
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| {
-                let home = std::env::var("HOME").unwrap_or_default();
-                PathBuf::from(home).join(".vibe")
-            })
-            .join("logs")
-            .join("session")
+        vibe_home().join("logs").join("session")
     }
 
     fn build_args(&self, _mcp: &McpServerConfig, session_id: Option<&str>) -> Vec<String> {
@@ -74,6 +76,7 @@ impl CliAgentStrategy for VibeStrategy {
 
     fn prepare_launch(&self, mcp: &McpServerConfig) {
         ensure_vibe_hooks(&mcp.command);
+        ensure_vibe_knowledge_instructions();
     }
 
     fn discover_session(
@@ -157,13 +160,58 @@ const VMUX_HOOK_NAME: &str = "vmux-file-follow";
 const VMUX_TURN_END_HOOK_NAME: &str = "vmux-turn-end";
 
 fn vibe_hooks_path() -> PathBuf {
-    std::env::var("VIBE_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            let home = std::env::var("HOME").unwrap_or_default();
-            PathBuf::from(home).join(".vibe")
-        })
-        .join("hooks.toml")
+    vibe_home().join("hooks.toml")
+}
+
+const VMUX_KNOWLEDGE_START: &str = "<!-- vmux-knowledge:start -->";
+const VMUX_KNOWLEDGE_END: &str = "<!-- vmux-knowledge:end -->";
+
+fn ensure_vibe_knowledge_instructions() {
+    let path = vibe_home().join("AGENTS.md");
+    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+    let knowledge = vmux_core::knowledge::agent_memories_prompt();
+    let Some(updated) = merge_vibe_knowledge_instructions(&existing, &knowledge) else {
+        bevy::log::warn!("vibe AGENTS.md contains an incomplete vmux Knowledge block");
+        return;
+    };
+    if updated == existing {
+        return;
+    }
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Err(error) = std::fs::write(&path, updated) {
+        bevy::log::warn!("vibe Knowledge instructions write failed: {error}");
+    }
+}
+
+fn merge_vibe_knowledge_instructions(existing: &str, knowledge: &str) -> Option<String> {
+    let without_managed = match existing.find(VMUX_KNOWLEDGE_START) {
+        Some(start) => {
+            let end = existing[start..]
+                .find(VMUX_KNOWLEDGE_END)
+                .map(|offset| start + offset + VMUX_KNOWLEDGE_END.len())?;
+            let before = &existing[..start];
+            let after = existing[end..]
+                .strip_prefix('\n')
+                .unwrap_or(&existing[end..]);
+            format!("{before}{after}")
+        }
+        None => existing.to_string(),
+    };
+    if knowledge.is_empty() {
+        return Some(without_managed);
+    }
+    let separator = if without_managed.is_empty() || without_managed.ends_with("\n\n") {
+        ""
+    } else if without_managed.ends_with('\n') {
+        "\n"
+    } else {
+        "\n\n"
+    };
+    Some(format!(
+        "{without_managed}{separator}{VMUX_KNOWLEDGE_START}\n{knowledge}\n{VMUX_KNOWLEDGE_END}\n"
+    ))
 }
 
 /// Idempotently register vmux-managed hooks in `~/.vibe/hooks.toml`: an
@@ -518,6 +566,27 @@ mod tests {
         let merged = merged_skill_paths(Some("[\"/existing\"]"), Path::new("/knowledge"));
         let paths: Vec<String> = serde_json::from_str(&merged).unwrap();
         assert_eq!(paths, vec!["/existing", "/knowledge"]);
+    }
+
+    #[test]
+    fn vibe_knowledge_block_preserves_user_instructions_and_updates_in_place() {
+        let first = merge_vibe_knowledge_instructions("user rules\n", "memory one").unwrap();
+        assert!(first.starts_with("user rules\n\n"));
+        assert!(first.contains("memory one"));
+        let second = merge_vibe_knowledge_instructions(&first, "memory two").unwrap();
+        assert!(second.starts_with("user rules\n\n"));
+        assert!(!second.contains("memory one"));
+        assert!(second.contains("memory two"));
+        assert_eq!(second.matches(VMUX_KNOWLEDGE_START).count(), 1);
+        assert_eq!(
+            merge_vibe_knowledge_instructions(&second, "").unwrap(),
+            "user rules\n\n"
+        );
+    }
+
+    #[test]
+    fn vibe_knowledge_block_refuses_incomplete_managed_section() {
+        assert!(merge_vibe_knowledge_instructions(VMUX_KNOWLEDGE_START, "memory").is_none());
     }
 
     #[test]

--- a/crates/vmux_agent/src/client/cli/vibe.rs
+++ b/crates/vmux_agent/src/client/cli/vibe.rs
@@ -76,7 +76,6 @@ impl CliAgentStrategy for VibeStrategy {
 
     fn prepare_launch(&self, mcp: &McpServerConfig) {
         ensure_vibe_hooks(&mcp.command);
-        ensure_vibe_knowledge_instructions();
     }
 
     fn discover_session(
@@ -161,57 +160,6 @@ const VMUX_TURN_END_HOOK_NAME: &str = "vmux-turn-end";
 
 fn vibe_hooks_path() -> PathBuf {
     vibe_home().join("hooks.toml")
-}
-
-const VMUX_KNOWLEDGE_START: &str = "<!-- vmux-knowledge:start -->";
-const VMUX_KNOWLEDGE_END: &str = "<!-- vmux-knowledge:end -->";
-
-fn ensure_vibe_knowledge_instructions() {
-    let path = vibe_home().join("AGENTS.md");
-    let existing = std::fs::read_to_string(&path).unwrap_or_default();
-    let knowledge = vmux_core::knowledge::agent_memories_prompt();
-    let Some(updated) = merge_vibe_knowledge_instructions(&existing, &knowledge) else {
-        bevy::log::warn!("vibe AGENTS.md contains an incomplete vmux Knowledge block");
-        return;
-    };
-    if updated == existing {
-        return;
-    }
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    if let Err(error) = std::fs::write(&path, updated) {
-        bevy::log::warn!("vibe Knowledge instructions write failed: {error}");
-    }
-}
-
-fn merge_vibe_knowledge_instructions(existing: &str, knowledge: &str) -> Option<String> {
-    let without_managed = match existing.find(VMUX_KNOWLEDGE_START) {
-        Some(start) => {
-            let end = existing[start..]
-                .find(VMUX_KNOWLEDGE_END)
-                .map(|offset| start + offset + VMUX_KNOWLEDGE_END.len())?;
-            let before = &existing[..start];
-            let after = existing[end..]
-                .strip_prefix('\n')
-                .unwrap_or(&existing[end..]);
-            format!("{before}{after}")
-        }
-        None => existing.to_string(),
-    };
-    if knowledge.is_empty() {
-        return Some(without_managed);
-    }
-    let separator = if without_managed.is_empty() || without_managed.ends_with("\n\n") {
-        ""
-    } else if without_managed.ends_with('\n') {
-        "\n"
-    } else {
-        "\n\n"
-    };
-    Some(format!(
-        "{without_managed}{separator}{VMUX_KNOWLEDGE_START}\n{knowledge}\n{VMUX_KNOWLEDGE_END}\n"
-    ))
 }
 
 /// Idempotently register vmux-managed hooks in `~/.vibe/hooks.toml`: an
@@ -566,27 +514,6 @@ mod tests {
         let merged = merged_skill_paths(Some("[\"/existing\"]"), Path::new("/knowledge"));
         let paths: Vec<String> = serde_json::from_str(&merged).unwrap();
         assert_eq!(paths, vec!["/existing", "/knowledge"]);
-    }
-
-    #[test]
-    fn vibe_knowledge_block_preserves_user_instructions_and_updates_in_place() {
-        let first = merge_vibe_knowledge_instructions("user rules\n", "memory one").unwrap();
-        assert!(first.starts_with("user rules\n\n"));
-        assert!(first.contains("memory one"));
-        let second = merge_vibe_knowledge_instructions(&first, "memory two").unwrap();
-        assert!(second.starts_with("user rules\n\n"));
-        assert!(!second.contains("memory one"));
-        assert!(second.contains("memory two"));
-        assert_eq!(second.matches(VMUX_KNOWLEDGE_START).count(), 1);
-        assert_eq!(
-            merge_vibe_knowledge_instructions(&second, "").unwrap(),
-            "user rules\n\n"
-        );
-    }
-
-    #[test]
-    fn vibe_knowledge_block_refuses_incomplete_managed_section() {
-        assert!(merge_vibe_knowledge_instructions(VMUX_KNOWLEDGE_START, "memory").is_none());
     }
 
     #[test]

--- a/crates/vmux_agent/src/launch.rs
+++ b/crates/vmux_agent/src/launch.rs
@@ -15,6 +15,9 @@ pub fn build_agent_launch(
         .get_cli(kind)
         .ok_or_else(|| format!("CLI strategy not registered for {:?}", kind))?;
     let mcp_cfg = mcp::resolve(cwd, anchor, kind)?;
+    if let Err(error) = vmux_core::knowledge::sync_external_agent_configs() {
+        bevy::log::warn!("external agent Knowledge sync failed: {error}");
+    }
     strategy.prepare_launch(&mcp_cfg);
     let args = strategy.build_args(&mcp_cfg, session_id);
     let mut env: Vec<(String, String)> = std::env::vars().collect();

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -7222,7 +7222,12 @@ mod tests {
         let joined = args.join(" ");
         assert!(joined.contains("--anchor"), "args carry --anchor: {joined}");
         assert!(joined.contains(&new_id.to_string()), "anchor is the new id");
-        assert!(!joined.contains("OLD"), "old args replaced");
+        assert!(
+            !args
+                .windows(2)
+                .any(|pair| pair[0] == "--mcp-config" && pair[1] == "OLD"),
+            "old args replaced"
+        );
     }
 
     #[test]

--- a/crates/vmux_core/Cargo.toml
+++ b/crates/vmux_core/Cargo.toml
@@ -25,5 +25,6 @@ bevy_reflect = { workspace = true }
 moonshine-save = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10"
+toml = { workspace = true }
 url = { workspace = true }
 zip = { version = "2", default-features = false, features = ["deflate"] }

--- a/crates/vmux_core/src/knowledge.rs
+++ b/crates/vmux_core/src/knowledge.rs
@@ -96,6 +96,11 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 #[cfg(not(target_arch = "wasm32"))]
+mod agent_config;
+#[cfg(not(target_arch = "wasm32"))]
+pub use agent_config::sync_external_agent_configs;
+
+#[cfg(not(target_arch = "wasm32"))]
 const MAX_SKILLS: usize = 64;
 #[cfg(not(target_arch = "wasm32"))]
 const MAX_EMBEDDED_BYTES: usize = 24 * 1024;

--- a/crates/vmux_core/src/knowledge.rs
+++ b/crates/vmux_core/src/knowledge.rs
@@ -91,12 +91,18 @@ pub fn markdown_metadata(text: &str) -> MarkdownMetadata {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+use std::io::{self, Write};
+#[cfg(not(target_arch = "wasm32"))]
 use std::path::{Path, PathBuf};
 
 #[cfg(not(target_arch = "wasm32"))]
 const MAX_SKILLS: usize = 64;
 #[cfg(not(target_arch = "wasm32"))]
 const MAX_EMBEDDED_BYTES: usize = 24 * 1024;
+#[cfg(not(target_arch = "wasm32"))]
+const SKILLS_PROMPT_MARKER: &str = "vmux Knowledge skills are user-owned instructions";
+#[cfg(not(target_arch = "wasm32"))]
+const MEMORIES_PROMPT_MARKER: &str = "vmux Knowledge memories are user-owned context";
 
 #[cfg(not(target_arch = "wasm32"))]
 pub fn knowledge_dir() -> PathBuf {
@@ -106,6 +112,117 @@ pub fn knowledge_dir() -> PathBuf {
 #[cfg(not(target_arch = "wasm32"))]
 pub fn skills_dir() -> PathBuf {
     knowledge_dir().join("skills")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn memories_dir() -> PathBuf {
+    knowledge_dir().join("memories")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn migrate_external_memories() -> io::Result<usize> {
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/"));
+    let claude = std::env::var_os("CLAUDE_CONFIG_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.join(".claude"));
+    let codex = std::env::var_os("CODEX_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.join(".codex"));
+    migrate_external_memories_from(
+        &memories_dir(),
+        &claude.join("projects"),
+        &codex.join("memories"),
+        &codex.join("memories_extensions"),
+    )
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn migrate_external_memories_from(
+    destination: &Path,
+    claude_projects: &Path,
+    codex_memories: &Path,
+    codex_extensions: &Path,
+) -> io::Result<usize> {
+    std::fs::create_dir_all(destination)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(destination, std::fs::Permissions::from_mode(0o700))?;
+    }
+
+    let mut imported = migrate_claude_memories(
+        claude_projects,
+        &destination.join("claude").join("projects"),
+    )?;
+    imported += migrate_memory_tree(codex_memories, &destination.join("codex").join("local"))?;
+    imported += migrate_memory_tree(
+        codex_extensions,
+        &destination.join("codex").join("extensions"),
+    )?;
+    Ok(imported)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn migrate_claude_memories(projects: &Path, destination: &Path) -> io::Result<usize> {
+    let Ok(entries) = std::fs::read_dir(projects) else {
+        return Ok(0);
+    };
+    let mut imported = 0;
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_symlink() || !file_type.is_dir() {
+            continue;
+        }
+        imported += migrate_memory_tree(
+            &entry.path().join("memory"),
+            &destination.join(entry.file_name()),
+        )?;
+    }
+    Ok(imported)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn migrate_memory_tree(source: &Path, destination: &Path) -> io::Result<usize> {
+    let mut files = Vec::new();
+    collect_markdown_files(source, &mut files);
+    files.sort();
+    let mut imported = 0;
+    for source_file in files {
+        let Ok(relative) = source_file.strip_prefix(source) else {
+            continue;
+        };
+        imported += usize::from(copy_new_file(&source_file, &destination.join(relative))?);
+    }
+    Ok(imported)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn copy_new_file(source: &Path, destination: &Path) -> io::Result<bool> {
+    let Some(parent) = destination.parent() else {
+        return Ok(false);
+    };
+    std::fs::create_dir_all(parent)?;
+    let mut output = match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(destination)
+    {
+        Ok(output) => output,
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => return Ok(false),
+        Err(error) => return Err(error),
+    };
+    let result = std::fs::File::open(source)
+        .and_then(|mut input| io::copy(&mut input, &mut output))
+        .and_then(|_| output.flush());
+    if let Err(error) = result {
+        let _ = std::fs::remove_file(destination);
+        return Err(error);
+    }
+    Ok(true)
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -132,6 +249,46 @@ fn collect_skill_files(dir: &Path, files: &mut Vec<PathBuf>) {
             && path
                 .file_name()
                 .is_some_and(|name| name.eq_ignore_ascii_case("SKILL.md"))
+        {
+            files.push(path);
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn collect_markdown_files(dir: &Path, files: &mut Vec<PathBuf>) {
+    let Ok(metadata) = std::fs::symlink_metadata(dir) else {
+        return;
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        if name.to_string_lossy().starts_with('.') {
+            continue;
+        }
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            collect_markdown_files(&path, files);
+        } else if file_type.is_file()
+            && path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| {
+                    extension.eq_ignore_ascii_case("md")
+                        || extension.eq_ignore_ascii_case("markdown")
+                        || extension.eq_ignore_ascii_case("mdx")
+                })
         {
             files.push(path);
         }
@@ -186,8 +343,51 @@ fn agent_skills_prompt_from(root: &Path) -> String {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+pub fn agent_memories_prompt() -> String {
+    agent_memories_prompt_from(&memories_dir())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn agent_memories_prompt_from(root: &Path) -> String {
+    let mut files = Vec::new();
+    collect_markdown_files(root, &mut files);
+    files.sort();
+    if files.is_empty() {
+        return String::new();
+    }
+
+    let mut prompt = String::from(
+        "vmux Knowledge memories are user-owned context migrated from local agents. Use them as background context. Explicit current instructions and repository guidance win, and memories are not a source for current external facts.\n",
+    );
+    for path in files {
+        let Ok(body) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let label = path.strip_prefix(root).unwrap_or(&path).to_string_lossy();
+        prompt.push_str("\n<vmux-knowledge-memory path=\"");
+        prompt.push_str(&label);
+        prompt.push_str("\">\n");
+        prompt.push_str(&body);
+        if !body.ends_with('\n') {
+            prompt.push('\n');
+        }
+        prompt.push_str("</vmux-knowledge-memory>\n");
+    }
+    prompt
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn agent_context_prompt() -> String {
+    [agent_skills_prompt(), agent_memories_prompt()]
+        .into_iter()
+        .filter(|section| !section.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 pub fn append_agent_skills(base: &str) -> String {
-    if base.contains("vmux Knowledge skills are user-owned instructions") {
+    if base.contains(SKILLS_PROMPT_MARKER) {
         return base.to_string();
     }
     let knowledge = agent_skills_prompt();
@@ -198,6 +398,26 @@ pub fn append_agent_skills(base: &str) -> String {
     } else {
         format!("{base}\n\n{knowledge}")
     }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn append_agent_memories(base: &str) -> String {
+    if base.contains(MEMORIES_PROMPT_MARKER) {
+        return base.to_string();
+    }
+    let memories = agent_memories_prompt();
+    if memories.is_empty() {
+        base.to_string()
+    } else if base.is_empty() {
+        memories
+    } else {
+        format!("{base}\n\n{memories}")
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn append_agent_context(base: &str) -> String {
+    append_agent_memories(&append_agent_skills(base))
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
@@ -235,5 +455,60 @@ mod tests {
         assert!(prompt.find("alpha").unwrap() < prompt.find("beta").unwrap());
         assert!(prompt.contains("# Alpha"));
         assert!(prompt.contains("# Beta"));
+    }
+
+    #[test]
+    fn migrates_all_external_markdown_memories_without_overwriting_edits() {
+        let temp = tempfile::tempdir().unwrap();
+        let claude = temp.path().join("claude-projects");
+        let codex = temp.path().join("codex-memories");
+        let extensions = temp.path().join("codex-extensions");
+        let destination = temp.path().join("knowledge-memories");
+        std::fs::create_dir_all(claude.join("project-a/memory/nested")).unwrap();
+        std::fs::create_dir_all(&codex).unwrap();
+        std::fs::create_dir_all(extensions.join("chronicle")).unwrap();
+        std::fs::write(claude.join("project-a/memory/MEMORY.md"), "claude index").unwrap();
+        std::fs::write(
+            claude.join("project-a/memory/nested/topic.md"),
+            "claude topic",
+        )
+        .unwrap();
+        std::fs::write(claude.join("project-a/memory/ignored.json"), "ignored").unwrap();
+        std::fs::write(codex.join("durable.md"), "codex durable").unwrap();
+        std::fs::write(extensions.join("chronicle/recent.mdx"), "chronicle").unwrap();
+
+        assert_eq!(
+            migrate_external_memories_from(&destination, &claude, &codex, &extensions).unwrap(),
+            4
+        );
+        assert_eq!(
+            std::fs::read_to_string(destination.join("claude/projects/project-a/MEMORY.md"))
+                .unwrap(),
+            "claude index"
+        );
+        assert_eq!(
+            std::fs::read_to_string(destination.join("codex/local/durable.md")).unwrap(),
+            "codex durable"
+        );
+        let migrated = destination.join("claude/projects/project-a/MEMORY.md");
+        std::fs::write(&migrated, "vmux edit").unwrap();
+        std::fs::write(claude.join("project-a/memory/MEMORY.md"), "source edit").unwrap();
+        assert_eq!(
+            migrate_external_memories_from(&destination, &claude, &codex, &extensions).unwrap(),
+            0
+        );
+        assert_eq!(std::fs::read_to_string(migrated).unwrap(), "vmux edit");
+    }
+
+    #[test]
+    fn embeds_every_migrated_memory_in_sorted_order() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("nested")).unwrap();
+        std::fs::write(temp.path().join("z.md"), "Zulu").unwrap();
+        std::fs::write(temp.path().join("nested/a.markdown"), "Alpha").unwrap();
+        let prompt = agent_memories_prompt_from(temp.path());
+        assert!(prompt.find("nested/a.markdown").unwrap() < prompt.find("z.md").unwrap());
+        assert!(prompt.contains("Alpha"));
+        assert!(prompt.contains("Zulu"));
     }
 }

--- a/crates/vmux_core/src/knowledge/agent_config.rs
+++ b/crates/vmux_core/src/knowledge/agent_config.rs
@@ -1,0 +1,684 @@
+use std::io;
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::collections::HashSet;
+
+use super::{agent_memories_prompt, memories_dir, migrate_external_memories, skills_dir};
+
+const KNOWLEDGE_START: &str = "<!-- vmux-knowledge:start -->";
+const KNOWLEDGE_END: &str = "<!-- vmux-knowledge:end -->";
+const CODEX_SKILLS_START: &str = "# vmux-knowledge-skills:start";
+const CODEX_SKILLS_END: &str = "# vmux-knowledge-skills:end";
+const MIN_CODEX_PROJECT_DOC_BYTES: usize = 1024 * 1024;
+const CODEX_PROJECT_DOC_HEADROOM: usize = 256 * 1024;
+
+struct AgentConfigPaths {
+    claude_instructions: PathBuf,
+    claude_settings: PathBuf,
+    claude_skills: PathBuf,
+    codex_instructions: PathBuf,
+    codex_config: PathBuf,
+    codex_memories: PathBuf,
+    codex_extension_memories: PathBuf,
+    vibe_instructions: PathBuf,
+    vibe_config: PathBuf,
+}
+
+impl AgentConfigPaths {
+    fn from_env() -> Self {
+        let home = std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/"));
+        let claude = std::env::var_os("CLAUDE_CONFIG_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".claude"));
+        let codex = std::env::var_os("CODEX_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".codex"));
+        let vibe = std::env::var_os("VIBE_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".vibe"));
+        Self {
+            claude_instructions: claude.join("CLAUDE.md"),
+            claude_settings: claude.join("settings.json"),
+            claude_skills: claude.join("skills"),
+            codex_instructions: codex.join("AGENTS.md"),
+            codex_config: codex.join("config.toml"),
+            codex_memories: codex.join("memories"),
+            codex_extension_memories: codex.join("memories_extensions"),
+            vibe_instructions: vibe.join("AGENTS.md"),
+            vibe_config: vibe.join("config.toml"),
+        }
+    }
+}
+
+pub fn sync_external_agent_configs() -> io::Result<()> {
+    migrate_external_memories()?;
+    let skills = skills_dir();
+    let memories = memories_dir();
+    std::fs::create_dir_all(&skills)?;
+    std::fs::create_dir_all(&memories)?;
+    sync_external_agent_configs_from(
+        &AgentConfigPaths::from_env(),
+        &skills,
+        &memories,
+        &agent_memories_prompt(),
+    )
+}
+
+fn sync_external_agent_configs_from(
+    paths: &AgentConfigPaths,
+    skills_root: &Path,
+    memories_root: &Path,
+    memories: &str,
+) -> io::Result<()> {
+    let skills = skill_dirs(skills_root);
+    let mut error = None;
+    keep_first_error(
+        &mut error,
+        sync_markdown(&paths.claude_instructions, memories),
+    );
+    let claude_memories = memories_root.join("claude").join("auto");
+    keep_first_error(
+        &mut error,
+        std::fs::create_dir_all(&claude_memories)
+            .and_then(|_| sync_claude_settings(&paths.claude_settings, &claude_memories)),
+    );
+    keep_first_error(
+        &mut error,
+        sync_claude_skills(&paths.claude_skills, skills_root, &skills),
+    );
+    keep_first_error(
+        &mut error,
+        sync_markdown(&paths.codex_instructions, memories),
+    );
+    keep_first_error(
+        &mut error,
+        sync_codex_config(&paths.codex_config, &skills, memories.len()),
+    );
+    keep_first_error(
+        &mut error,
+        redirect_empty_directory(
+            &paths.codex_memories,
+            &memories_root.join("codex").join("local"),
+        ),
+    );
+    keep_first_error(
+        &mut error,
+        redirect_empty_directory(
+            &paths.codex_extension_memories,
+            &memories_root.join("codex").join("extensions"),
+        ),
+    );
+    keep_first_error(
+        &mut error,
+        sync_markdown(&paths.vibe_instructions, memories),
+    );
+    keep_first_error(
+        &mut error,
+        sync_vibe_config(&paths.vibe_config, skills_root),
+    );
+    error.map_or(Ok(()), Err)
+}
+
+fn keep_first_error(first: &mut Option<io::Error>, result: io::Result<()>) {
+    if first.is_none()
+        && let Err(error) = result
+    {
+        *first = Some(error);
+    }
+}
+
+fn sync_markdown(path: &Path, memories: &str) -> io::Result<()> {
+    let existing = read_optional(path)?;
+    let updated = merge_managed_section(&existing, memories, KNOWLEDGE_START, KNOWLEDGE_END)?;
+    write_changed(path, &existing, &updated)
+}
+
+fn merge_managed_section(
+    existing: &str,
+    body: &str,
+    start_marker: &str,
+    end_marker: &str,
+) -> io::Result<String> {
+    let start = existing.find(start_marker);
+    let end = existing.find(end_marker);
+    if start.is_some() != end.is_some() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("incomplete {start_marker} section"),
+        ));
+    }
+    let without_managed = match (start, end) {
+        (Some(start), Some(end)) if end >= start => {
+            let end = end + end_marker.len();
+            let before = &existing[..start];
+            let after = existing[end..]
+                .strip_prefix('\n')
+                .unwrap_or(&existing[end..]);
+            format!("{before}{after}")
+        }
+        (Some(_), Some(_)) => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("invalid {start_marker} section"),
+            ));
+        }
+        (None, None) => existing.to_string(),
+        _ => unreachable!(),
+    };
+    if body.is_empty() {
+        return Ok(without_managed);
+    }
+    let separator = if without_managed.is_empty() || without_managed.ends_with("\n\n") {
+        ""
+    } else if without_managed.ends_with('\n') {
+        "\n"
+    } else {
+        "\n\n"
+    };
+    Ok(format!(
+        "{without_managed}{separator}{start_marker}\n{}\n{end_marker}\n",
+        body.trim_end()
+    ))
+}
+
+fn skill_dirs(root: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return Vec::new();
+    };
+    let mut skills = entries
+        .flatten()
+        .filter_map(|entry| {
+            let file_type = entry.file_type().ok()?;
+            let path = entry.path();
+            (!file_type.is_symlink() && file_type.is_dir() && path.join("SKILL.md").is_file())
+                .then_some(path)
+        })
+        .collect::<Vec<_>>();
+    skills.sort();
+    skills
+}
+
+fn sync_claude_settings(path: &Path, memories: &Path) -> io::Result<()> {
+    let existing = read_optional(path)?;
+    let mut settings = if existing.is_empty() {
+        serde_json::json!({})
+    } else {
+        serde_json::from_str::<serde_json::Value>(&existing)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?
+    };
+    let object = settings.as_object_mut().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Claude settings root must be an object",
+        )
+    })?;
+    object.insert(
+        "autoMemoryDirectory".to_string(),
+        serde_json::Value::String(memories.to_string_lossy().into_owned()),
+    );
+    let mut updated = serde_json::to_string_pretty(&settings)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    updated.push('\n');
+    write_changed(path, &existing, &updated)
+}
+
+#[cfg(unix)]
+fn sync_claude_skills(
+    destination: &Path,
+    skills_root: &Path,
+    skills: &[PathBuf],
+) -> io::Result<()> {
+    use std::os::unix::fs::symlink;
+
+    std::fs::create_dir_all(destination)?;
+    let desired = skills.iter().cloned().collect::<HashSet<_>>();
+    for entry in std::fs::read_dir(destination)?.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_symlink() {
+            continue;
+        }
+        let Ok(target) = std::fs::read_link(entry.path()) else {
+            continue;
+        };
+        let target = if target.is_absolute() {
+            target
+        } else {
+            destination.join(target)
+        };
+        if target.starts_with(skills_root) && !desired.contains(&target) {
+            std::fs::remove_file(entry.path())?;
+        }
+    }
+    for skill in skills {
+        let Some(name) = skill.file_name() else {
+            continue;
+        };
+        let link = destination.join(name);
+        match std::fs::symlink_metadata(&link) {
+            Ok(_) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => symlink(skill, link)?,
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn redirect_empty_directory(path: &Path, target: &Path) -> io::Result<()> {
+    use std::os::unix::fs::symlink;
+
+    std::fs::create_dir_all(target)?;
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            let link = std::fs::read_link(path)?;
+            let link = if link.is_absolute() {
+                link
+            } else {
+                path.parent().unwrap_or_else(|| Path::new("/")).join(link)
+            };
+            if link == target {
+                return Ok(());
+            }
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!("{} points to {}", path.display(), link.display()),
+            ));
+        }
+        Ok(metadata) if metadata.is_dir() => {
+            if std::fs::read_dir(path)?.next().is_some() {
+                return Ok(());
+            }
+            std::fs::remove_dir(path)?;
+        }
+        Ok(_) => return Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    symlink(target, path)
+}
+
+#[cfg(not(unix))]
+fn redirect_empty_directory(_path: &Path, _target: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn sync_claude_skills(
+    _destination: &Path,
+    _skills_root: &Path,
+    _skills: &[PathBuf],
+) -> io::Result<()> {
+    Ok(())
+}
+
+fn sync_codex_config(path: &Path, skills: &[PathBuf], memories_bytes: usize) -> io::Result<()> {
+    let existing = read_optional(path)?;
+    let minimum =
+        MIN_CODEX_PROJECT_DOC_BYTES.max(memories_bytes.saturating_add(CODEX_PROJECT_DOC_HEADROOM));
+    let with_limit = ensure_root_integer(&existing, "project_doc_max_bytes", minimum);
+    let block = skills
+        .iter()
+        .map(|skill| {
+            format!(
+                "[[skills.config]]\npath = {}\nenabled = true",
+                toml_string(&skill.to_string_lossy())
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    let updated = merge_managed_section(&with_limit, &block, CODEX_SKILLS_START, CODEX_SKILLS_END)?;
+    write_changed(path, &existing, &updated)
+}
+
+fn ensure_root_integer(existing: &str, key: &str, minimum: usize) -> String {
+    if let Some(range) = root_assignment_line(existing, key) {
+        let line = &existing[range.clone()];
+        let value = line
+            .split_once('=')
+            .map(|(_, value)| value)
+            .unwrap_or_default()
+            .split('#')
+            .next()
+            .unwrap_or_default()
+            .trim()
+            .parse::<usize>()
+            .unwrap_or_default();
+        if value >= minimum {
+            return existing.to_string();
+        }
+        return format!(
+            "{}{} = {}{}",
+            &existing[..range.start],
+            key,
+            minimum,
+            &existing[range.end..]
+        );
+    }
+    if existing.is_empty() {
+        format!("{key} = {minimum}\n")
+    } else {
+        format!("{key} = {minimum}\n\n{existing}")
+    }
+}
+
+fn sync_vibe_config(path: &Path, skills_root: &Path) -> io::Result<()> {
+    let existing = read_optional(path)?;
+    let mut values = if existing.is_empty() {
+        Vec::new()
+    } else {
+        let parsed = existing
+            .parse::<toml::Value>()
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        match parsed.get("skill_paths") {
+            Some(value) => value
+                .as_array()
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "skill_paths must be an array")
+                })?
+                .iter()
+                .map(|value| {
+                    value.as_str().map(str::to_string).ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "skill_paths entries must be strings",
+                        )
+                    })
+                })
+                .collect::<io::Result<Vec<_>>>()?,
+            None => Vec::new(),
+        }
+    };
+    let knowledge = skills_root.to_string_lossy().into_owned();
+    if !values.contains(&knowledge) {
+        values.push(knowledge);
+    }
+    let rendered = format!(
+        "[{}]",
+        values
+            .iter()
+            .map(|value| toml_string(value))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    let updated = replace_root_array(&existing, "skill_paths", &rendered);
+    write_changed(path, &existing, &updated)
+}
+
+fn replace_root_array(existing: &str, key: &str, rendered: &str) -> String {
+    if let Some(range) = root_array_assignment(existing, key) {
+        return format!(
+            "{}{} = {}{}",
+            &existing[..range.start],
+            key,
+            rendered,
+            &existing[range.end..]
+        );
+    }
+    if existing.is_empty() {
+        format!("{key} = {rendered}\n")
+    } else {
+        format!("{key} = {rendered}\n\n{existing}")
+    }
+}
+
+fn root_assignment_line(text: &str, key: &str) -> Option<Range<usize>> {
+    let mut offset = 0;
+    for line in text.split_inclusive('\n') {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('[') {
+            return None;
+        }
+        if assignment_value_offset(trimmed, key).is_some() {
+            let indentation = line.len() - trimmed.len();
+            let end = offset + line.trim_end_matches('\n').len();
+            return Some(offset + indentation..end);
+        }
+        offset += line.len();
+    }
+    None
+}
+
+fn root_array_assignment(text: &str, key: &str) -> Option<Range<usize>> {
+    let mut offset = 0;
+    for line in text.split_inclusive('\n') {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('[') {
+            return None;
+        }
+        if let Some(value_offset) = assignment_value_offset(trimmed, key) {
+            let start = offset + line.len() - trimmed.len();
+            let value_start = start + value_offset;
+            let suffix = &text[value_start..];
+            let array_start = suffix.find('[')?;
+            let array_end = array_end(&suffix[array_start..])?;
+            return Some(start..value_start + array_start + array_end);
+        }
+        offset += line.len();
+    }
+    None
+}
+
+fn assignment_value_offset(line: &str, key: &str) -> Option<usize> {
+    let rest = line.strip_prefix(key)?;
+    if rest
+        .chars()
+        .next()
+        .is_some_and(|character| character.is_alphanumeric() || character == '_')
+    {
+        return None;
+    }
+    let equals = rest.find('=')?;
+    Some(key.len() + equals + 1)
+}
+
+fn array_end(text: &str) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut quoted = None;
+    let mut escaped = false;
+    for (index, character) in text.char_indices() {
+        if let Some(quote) = quoted {
+            if escaped {
+                escaped = false;
+            } else if quote == '"' && character == '\\' {
+                escaped = true;
+            } else if character == quote {
+                quoted = None;
+            }
+            continue;
+        }
+        match character {
+            '"' | '\'' => quoted = Some(character),
+            '[' => depth += 1,
+            ']' => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(index + character.len_utf8());
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn toml_string(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
+}
+
+fn read_optional(path: &Path) -> io::Result<String> {
+    match std::fs::read_to_string(path) {
+        Ok(text) => Ok(text),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(String::new()),
+        Err(error) => Err(error),
+    }
+}
+
+fn write_changed(path: &Path, existing: &str, updated: &str) -> io::Result<()> {
+    if existing == updated {
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, updated)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn paths(root: &Path) -> AgentConfigPaths {
+        AgentConfigPaths {
+            claude_instructions: root.join("claude/CLAUDE.md"),
+            claude_settings: root.join("claude/settings.json"),
+            claude_skills: root.join("claude/skills"),
+            codex_instructions: root.join("codex/AGENTS.md"),
+            codex_config: root.join("codex/config.toml"),
+            codex_memories: root.join("codex/memories"),
+            codex_extension_memories: root.join("codex/memories_extensions"),
+            vibe_instructions: root.join("vibe/AGENTS.md"),
+            vibe_config: root.join("vibe/config.toml"),
+        }
+    }
+
+    #[test]
+    fn syncs_native_agent_config_and_preserves_user_content() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = paths(temp.path());
+        let skills = temp.path().join("knowledge/skills");
+        let memories = temp.path().join("knowledge/memories");
+        std::fs::create_dir_all(skills.join("caveman")).unwrap();
+        std::fs::create_dir_all(&paths.codex_memories).unwrap();
+        std::fs::write(skills.join("caveman/SKILL.md"), "skill").unwrap();
+        std::fs::create_dir_all(paths.claude_instructions.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(paths.codex_config.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(paths.vibe_config.parent().unwrap()).unwrap();
+        std::fs::write(&paths.claude_instructions, "claude user\n").unwrap();
+        std::fs::write(&paths.claude_settings, "{\"userSetting\":true}\n").unwrap();
+        std::fs::write(&paths.codex_instructions, "codex user\n").unwrap();
+        std::fs::write(&paths.codex_config, "model = \"gpt\"\n").unwrap();
+        std::fs::write(
+            &paths.vibe_config,
+            "skill_paths = [\n  \"/existing\",\n]\nactive_model = \"model\"\n",
+        )
+        .unwrap();
+
+        sync_external_agent_configs_from(&paths, &skills, &memories, "memory one").unwrap();
+        sync_external_agent_configs_from(&paths, &skills, &memories, "memory two").unwrap();
+
+        for path in [
+            &paths.claude_instructions,
+            &paths.codex_instructions,
+            &paths.vibe_instructions,
+        ] {
+            let text = std::fs::read_to_string(path).unwrap();
+            assert!(text.contains("memory two"));
+            assert!(!text.contains("memory one"));
+            assert_eq!(text.matches(KNOWLEDGE_START).count(), 1);
+        }
+        assert!(
+            std::fs::read_to_string(&paths.claude_instructions)
+                .unwrap()
+                .starts_with("claude user\n")
+        );
+        assert!(
+            std::fs::read_to_string(&paths.codex_instructions)
+                .unwrap()
+                .starts_with("codex user\n")
+        );
+        let claude_settings = std::fs::read_to_string(&paths.claude_settings)
+            .unwrap()
+            .parse::<serde_json::Value>()
+            .unwrap();
+        assert_eq!(
+            claude_settings
+                .get("userSetting")
+                .and_then(|value| value.as_bool()),
+            Some(true)
+        );
+        assert_eq!(
+            claude_settings
+                .get("autoMemoryDirectory")
+                .and_then(|value| value.as_str()),
+            Some(memories.join("claude/auto").to_string_lossy().as_ref())
+        );
+        let codex = std::fs::read_to_string(&paths.codex_config).unwrap();
+        assert!(codex.contains("model = \"gpt\""));
+        assert!(codex.contains(&skills.join("caveman").to_string_lossy().to_string()));
+        assert_eq!(codex.matches(CODEX_SKILLS_START).count(), 1);
+        assert!(
+            codex
+                .parse::<toml::Value>()
+                .unwrap()
+                .get("project_doc_max_bytes")
+                .and_then(toml::Value::as_integer)
+                .is_some_and(|value| value >= MIN_CODEX_PROJECT_DOC_BYTES as i64)
+        );
+        let vibe = std::fs::read_to_string(&paths.vibe_config)
+            .unwrap()
+            .parse::<toml::Value>()
+            .unwrap();
+        assert_eq!(
+            vibe.get("skill_paths")
+                .and_then(toml::Value::as_array)
+                .unwrap()
+                .iter()
+                .filter_map(toml::Value::as_str)
+                .collect::<Vec<_>>(),
+            vec!["/existing", skills.to_string_lossy().as_ref()]
+        );
+        #[cfg(unix)]
+        {
+            assert_eq!(
+                std::fs::read_link(paths.claude_skills.join("caveman")).unwrap(),
+                skills.join("caveman")
+            );
+            assert_eq!(
+                std::fs::read_link(&paths.codex_memories).unwrap(),
+                memories.join("codex/local")
+            );
+            assert_eq!(
+                std::fs::read_link(&paths.codex_extension_memories).unwrap(),
+                memories.join("codex/extensions")
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_incomplete_managed_sections() {
+        assert!(
+            merge_managed_section(KNOWLEDGE_START, "memory", KNOWLEDGE_START, KNOWLEDGE_END)
+                .is_err()
+        );
+        assert!(
+            merge_managed_section(KNOWLEDGE_END, "memory", KNOWLEDGE_START, KNOWLEDGE_END).is_err()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preserves_nonempty_native_memory_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("codex/memories");
+        let target = temp.path().join("knowledge/codex/local");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::write(source.join("existing.md"), "memory").unwrap();
+
+        redirect_empty_directory(&source, &target).unwrap();
+
+        assert!(source.is_dir());
+        assert_eq!(
+            std::fs::read_to_string(source.join("existing.md")).unwrap(),
+            "memory"
+        );
+    }
+}

--- a/crates/vmux_knowledge/src/plugin.rs
+++ b/crates/vmux_knowledge/src/plugin.rs
@@ -48,6 +48,9 @@ impl Plugin for KnowledgePlugin {
     fn build(&self, app: &mut App) {
         let vault = vault_dir();
         if ensure_vault(&vault).is_ok() {
+            if let Err(error) = vmux_core::knowledge::migrate_external_memories() {
+                bevy::log::warn!("knowledge memory migration failed: {error}");
+            }
             let (tx, rx) = mpsc::channel();
             match notify::recommended_watcher(move |result| {
                 let _ = tx.send(result);

--- a/crates/vmux_knowledge/src/plugin.rs
+++ b/crates/vmux_knowledge/src/plugin.rs
@@ -48,8 +48,8 @@ impl Plugin for KnowledgePlugin {
     fn build(&self, app: &mut App) {
         let vault = vault_dir();
         if ensure_vault(&vault).is_ok() {
-            if let Err(error) = vmux_core::knowledge::migrate_external_memories() {
-                bevy::log::warn!("knowledge memory migration failed: {error}");
+            if let Err(error) = vmux_core::knowledge::sync_external_agent_configs() {
+                bevy::log::warn!("external agent Knowledge sync failed: {error}");
             }
             let (tx, rx) = mpsc::channel();
             match notify::recommended_watcher(move |result| {

--- a/crates/vmux_knowledge/src/store.rs
+++ b/crates/vmux_knowledge/src/store.rs
@@ -7,7 +7,7 @@ use std::os::unix::fs::MetadataExt;
 use std::os::unix::fs::PermissionsExt;
 use vmux_core::knowledge::{KnowledgeEntry, KnowledgeTreeEvent, markdown_metadata};
 
-const DIRECTORIES: [&str; 4] = ["skills", "projects", "meetings", "handbook"];
+const DIRECTORIES: [&str; 5] = ["skills", "memories", "projects", "meetings", "handbook"];
 const LEGACY_DIRECTORIES: [&str; 4] = ["decisions", "runbooks", "research", "templates"];
 const MAX_DEPTH: usize = 16;
 const MAX_ENTRIES: usize = 2_048;

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -1098,8 +1098,8 @@ If you invoke a required Skill tool, continue the original user request in the s
 the skill loads. Never end the turn after skill activation or answer only Ready.";
 
 fn session_meta_for_agent(agent_id: &str) -> Option<serde_json::Map<String, serde_json::Value>> {
-    if let Err(error) = vmux_core::knowledge::migrate_external_memories() {
-        bevy::log::warn!("knowledge memory migration failed: {error}");
+    if let Err(error) = vmux_core::knowledge::sync_external_agent_configs() {
+        bevy::log::warn!("external agent Knowledge sync failed: {error}");
     }
     session_meta_for_agent_with_knowledge(agent_id, &vmux_core::knowledge::agent_context_prompt())
 }

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -1098,7 +1098,10 @@ If you invoke a required Skill tool, continue the original user request in the s
 the skill loads. Never end the turn after skill activation or answer only Ready.";
 
 fn session_meta_for_agent(agent_id: &str) -> Option<serde_json::Map<String, serde_json::Value>> {
-    session_meta_for_agent_with_knowledge(agent_id, &vmux_core::knowledge::agent_skills_prompt())
+    if let Err(error) = vmux_core::knowledge::migrate_external_memories() {
+        bevy::log::warn!("knowledge memory migration failed: {error}");
+    }
+    session_meta_for_agent_with_knowledge(agent_id, &vmux_core::knowledge::agent_context_prompt())
 }
 
 fn session_meta_for_agent_with_knowledge(
@@ -2128,7 +2131,8 @@ mod tests {
 
     #[test]
     fn claude_acp_disables_native_shell_and_steers_skill_continuation() {
-        let meta = session_meta_for_agent("claude").expect("Claude ACP metadata");
+        let meta = session_meta_for_agent_with_knowledge("claude", "memory context")
+            .expect("Claude ACP metadata");
         let options = &meta["claudeCode"]["options"];
 
         assert_eq!(
@@ -2145,6 +2149,7 @@ mod tests {
         let prompt = meta["systemPrompt"]["append"].as_str().unwrap();
         assert!(prompt.contains("mcp__vmux__run"));
         assert!(prompt.contains("continue the original user request"));
+        assert!(prompt.contains("memory context"));
         assert!(session_meta_for_agent_with_knowledge("vibe-acp", "").is_none());
         assert_eq!(
             session_meta_for_agent_with_knowledge("vibe-acp", "skill context").unwrap()["systemPrompt"]

--- a/docs/specs/2026-07-18-knowledge-base-design.md
+++ b/docs/specs/2026-07-18-knowledge-base-design.md
@@ -52,6 +52,9 @@ entire rendered block activates editing, and clicks within the active block keep
 ```text
 ~/.vmux/knowledge/
   welcome.md
+  memories/claude/projects/<project>/
+  memories/codex/local/
+  memories/codex/extensions/
   projects/
   skills/<slug>/SKILL.md
   meetings/
@@ -77,6 +80,18 @@ follow-up.
 vmux injects a deterministic skill catalog and up to 24 KiB of skill bodies into supported CLI and
 ACP instruction surfaces. Additional skills remain discoverable by path. vmux never writes a
 managed `AGENTS.md` into user projects.
+
+## Agent Memories
+
+At startup and before building agent context, vmux copies previously unseen Markdown memories from
+Claude Code and Codex into `~/.vmux/knowledge/memories/`. Claude project memories preserve their
+encoded project directory. Codex local and extension memories remain separate. Existing Knowledge
+files are never overwritten, so the imported copy becomes user-owned after migration.
+
+Every ACP session receives the complete migrated memory set through its appended system prompt.
+Claude and Codex CLI sessions receive the same context through their native appended-instruction
+surfaces. Vibe CLI receives a vmux-managed block in the user-level `~/.vibe/AGENTS.md`; vmux never
+writes agent instruction files into project directories and preserves user-authored Vibe content.
 
 ## Safety
 

--- a/docs/specs/2026-07-18-knowledge-base-design.md
+++ b/docs/specs/2026-07-18-knowledge-base-design.md
@@ -92,6 +92,13 @@ Every ACP session receives the complete migrated memory set through its appended
 Claude and Codex CLI sessions receive the same context through their native appended-instruction
 surfaces. Vibe CLI receives a vmux-managed block in the user-level `~/.vibe/AGENTS.md`; vmux never
 writes agent instruction files into project directories and preserves user-authored Vibe content.
+Standalone Claude, Codex, and Vibe sessions receive the same memory context through managed blocks
+in their user-level instruction files. Knowledge skills are symlinked into Claude's personal skill
+directory, registered in Codex's user config, and added to Vibe's `skill_paths`. User content and
+non-vmux skill settings remain untouched.
+Claude's auto-memory output is redirected to `memories/claude/auto/`. Empty Codex native memory
+directories are replaced with symlinks to the corresponding Knowledge directories, so new native
+memories stay in the vault without deleting an existing non-empty directory.
 
 ## Safety
 


### PR DESCRIPTION
## Context

Claude Code and Codex keep reusable memories in separate local stores, so vmux agents do not share one durable context source. This centralizes imported memories in Knowledge and makes them available to every ACP, vmux CLI, and standalone CLI launch.

## Implementation

- Imports previously unseen Markdown memories from Claude project stores and Codex local/extension stores without overwriting Knowledge edits.
- Injects complete Knowledge memory context into ACP and vmux-launched Claude, Codex, and Vibe sessions.
- Maintains user-level instruction blocks for standalone Claude, Codex, and Vibe while preserving user-authored content.
- Redirects Claude auto memory and empty Codex native memory stores into `~/.vmux/knowledge/memories/`.
- Registers `~/.vmux/knowledge/skills` through Claude skill symlinks, Codex skill config, and Vibe `skill_paths`.

## Checks / QA

- Full pre-push fmt, clippy, workspace tests, and doctests pass.
- Native config merge tests cover idempotence, user-content preservation, malformed managed blocks, multiline Vibe paths, Claude settings, skill registration, and non-empty Codex memory preservation.
- Applied and verified the standalone Claude, Codex, and Vibe configuration locally.
