### PR TITLE
chore(release): v0.0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9471,7 +9471,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "base64 0.22.1",
  "bevy",
@@ -9520,7 +9520,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_browser"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -9557,7 +9557,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -9570,7 +9570,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9586,7 +9586,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command_mcp"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "serde_json",
  "vmux_command",
@@ -9595,7 +9595,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9618,7 +9618,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9681,7 +9681,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_editor"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "arboard",
  "bevy",
@@ -9725,7 +9725,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_git"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9745,7 +9745,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9766,7 +9766,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_knowledge"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9781,7 +9781,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -9817,7 +9817,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "muda",
  "proc-macro2",
@@ -9827,7 +9827,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -9840,14 +9840,14 @@ dependencies = [
 
 [[package]]
 name = "vmux_profile"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "vmux_server"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "dioxus",
  "regex",
@@ -9867,7 +9867,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "agent-client-protocol",
  "alacritty_terminal",
@@ -9907,7 +9907,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service_client"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "chrono",
  "libc",
@@ -9920,7 +9920,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9943,7 +9943,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9968,7 +9968,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_team"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9989,7 +9989,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10022,7 +10022,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "dioxus",
  "dioxus-primitives",
@@ -10041,7 +10041,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_wire"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "bevy_ecs",
  "bevy_reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.27"
+version = "0.0.28"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "GPL-3.0-or-later"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.27"
-  sha256 "673d1aea2df23a45dc1d8bf807ad899b4925abad759a2433f226052a9fa3b28d"
+  version "0.0.28"
+  sha256 "69ba2264a570434042c71d8381bd07455661ed47ae9f5c208133b255c34cbb91"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.27/Vmux_0.0.27_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.28/Vmux_0.0.28_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai/"

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.27",
-  "pub_date": "2026-07-21T00:01:35Z",
+  "version": "v0.0.28",
+  "pub_date": "2026-07-22T08:44:54Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.27/Vmux-v0.0.27-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HT3lQS0thR1habWVjZE9sWEJ2VlY5YlJqSzU0dldxSUZVQjJNQVk5QXBwdzF4TW4yQ2h1Vnhra2RwMzQ2NFRvL1ZpbUh2UEhROE5OcDVpd0RmYWU5U0FjPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg0NTkyMDkzCWZpbGU6Vm11eC12MC4wLjI3LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKeXVrRnNHS3JuRW5OTEIwSXNaOFdFNndBRVhYQUowaTNHejlSSUNWeG5vdW1YN0w5ZlYzZWR4NEthSjdBQ1NGaHlNNUxxOXQzeHEzaU9WWGtxeXBnQnc9PQo=",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.28/Vmux-v0.0.28-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzdRaDBndVJLRGIxY1owT09VZC9BMnk1bGoweGp2TlVzenB2b0xXNCtZdzhPL1lSdmVXUzI0b3RON3pEWGgvSkpyWDJOdW83RjkybHFJcE9rejBGMlEwPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg0NzA5ODkxCWZpbGU6Vm11eC12MC4wLjI4LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKS3RWM2E3Nk9tY0IrQndGTU1zVFNTc2VuZzY1dmR0TDRPL1gzWkplekVlMmNYdHpxdVU2RmVxOFc5MGczTm8zVXJhRVcvMlVLVlREdCtKeGpnYU1QQnc9PQo=",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.27/Vmux_0.0.27_aarch64.dmg",
-      "filename": "Vmux_0.0.27_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.28/Vmux_0.0.28_aarch64.dmg",
+      "filename": "Vmux_0.0.28_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
## Context

Prepare the v0.0.28 patch release.

## Implementation

Bump the workspace and lockfile package versions from 0.0.27 to 0.0.28. Release metadata will be added after CI produces the signed draft assets.

## Checks / QA

- Confirm the release workflow creates the v0.0.28 draft assets.
- Confirm the final app reports version 0.0.28.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version from 0.0.27 to 0.0.28.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->