### PR TITLE
fix(ui): improve prompt performance and page lifecycle

### DIFF
--- a/crates/vmux_agent/Cargo.toml
+++ b/crates/vmux_agent/Cargo.toml
@@ -30,7 +30,7 @@ rfd = { workspace = true }
 crossbeam-channel = "0.5"
 futures-lite = "2"
 futures-util = "0.3"
-image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp", "tiff"] }
 tokio = { workspace = true, features = ["rt"] }
 toml = { workspace = true }
 uuid = { workspace = true }

--- a/crates/vmux_agent/src/agents_page.rs
+++ b/crates/vmux_agent/src/agents_page.rs
@@ -92,7 +92,7 @@ impl Plugin for AgentsManagerPlugin {
                 host: "agents",
                 url: "vmux://agents/",
                 title: "Agents",
-                pool_size: 1,
+                pool_size: 0,
             },
         ));
         vmux_core::register_host_spawn(app, "agents");

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -228,6 +228,7 @@ impl Plugin for AgentChatPagePlugin {
                     send_acp_model_requests,
                     drain_chat_attachment_tasks,
                     drain_chat_media_list_tasks,
+                    drain_chat_media_preview_tasks,
                     drain_resume_list_tasks,
                     drain_resume_handoff_tasks,
                 ),
@@ -304,7 +305,12 @@ struct ChatMediaListTask {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-const ATTACHMENT_PREVIEW_LIMIT: u64 = 8 * 1024 * 1024;
+#[derive(Component)]
+struct ChatMediaPreviewTask {
+    webview: Entity,
+    task: Task<ChatMediaEntries>,
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 const MEDIA_THUMBNAIL_SOURCE_LIMIT: u64 = 25 * 1024 * 1024;
 #[cfg(not(target_arch = "wasm32"))]
@@ -349,26 +355,12 @@ fn chat_attachment(path: std::path::PathBuf) -> Option<ChatAttachment> {
     }
     let name = path.file_name()?.to_string_lossy().into_owned();
     let mime_type = attachment_mime(&path);
-    let preview_data_url =
-        if mime_type.starts_with("image/") && metadata.len() <= ATTACHMENT_PREVIEW_LIMIT {
-            std::fs::read(&path)
-                .ok()
-                .map(|bytes| {
-                    format!(
-                        "data:{mime_type};base64,{}",
-                        base64::engine::general_purpose::STANDARD.encode(bytes)
-                    )
-                })
-                .unwrap_or_default()
-        } else {
-            String::new()
-        };
     Some(ChatAttachment {
         path: path.to_string_lossy().into_owned(),
         name,
         mime_type,
         size: metadata.len(),
-        preview_data_url,
+        preview_data_url: String::new(),
     })
 }
 
@@ -404,10 +396,22 @@ fn media_thumbnail_data_url(path: &std::path::Path, source_size: u64) -> String 
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+fn chat_attachment_preview(path: std::path::PathBuf) -> Option<ChatAttachment> {
+    let mut attachment = chat_attachment(path)?;
+    if !attachment.mime_type.starts_with("image/") {
+        return None;
+    }
+    attachment.preview_data_url =
+        media_thumbnail_data_url(std::path::Path::new(&attachment.path), attachment.size);
+    (!attachment.preview_data_url.is_empty()).then_some(attachment)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 fn spawn_chat_attachment_task(
     webview: Entity,
     event: &'static str,
     paths: Vec<std::path::PathBuf>,
+    previews: bool,
     commands: &mut Commands,
 ) {
     if paths.is_empty() {
@@ -415,7 +419,14 @@ fn spawn_chat_attachment_task(
     }
     let task = IoTaskPool::get().spawn(async move {
         ChatAttachments {
-            attachments: paths.into_iter().filter_map(chat_attachment).collect(),
+            attachments: paths
+                .into_iter()
+                .filter_map(if previews {
+                    chat_attachment_preview
+                } else {
+                    chat_attachment
+                })
+                .collect(),
         }
     });
     commands.spawn(ChatAttachmentTask {
@@ -423,6 +434,21 @@ fn spawn_chat_attachment_task(
         event,
         task,
     });
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn spawn_selected_attachment_tasks(
+    webview: Entity,
+    paths: Vec<std::path::PathBuf>,
+    commands: &mut Commands,
+) {
+    spawn_chat_attachment_task(
+        webview,
+        CHAT_ATTACHMENTS_EVENT,
+        paths.clone(),
+        false,
+        commands,
+    );
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -564,8 +590,17 @@ fn chat_media_entries(request_id: u64, query: String) -> ChatMediaEntries {
         })
     });
     entries.truncate(100);
+    ChatMediaEntries {
+        request_id,
+        query,
+        entries,
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn chat_media_previews(mut response: ChatMediaEntries) -> ChatMediaEntries {
     let mut remaining_thumbnail_bytes = MEDIA_THUMBNAIL_TOTAL_LIMIT;
-    for entry in &mut entries {
+    for entry in &mut response.entries {
         if entry.is_dir || !entry.mime_type.starts_with("image/") {
             continue;
         }
@@ -581,11 +616,7 @@ fn chat_media_entries(request_id: u64, query: String) -> ChatMediaEntries {
             remaining_thumbnail_bytes = remaining_thumbnail_bytes.saturating_sub(source_size);
         }
     }
-    ChatMediaEntries {
-        request_id,
-        query,
-        entries,
-    }
+    response
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -612,12 +643,7 @@ fn on_chat_attach_paths(trigger: On<BinReceive<ChatAttachPaths>>, mut commands: 
         .filter(|path| !path.is_empty())
         .map(std::path::PathBuf::from)
         .collect();
-    spawn_chat_attachment_task(
-        trigger.event().webview,
-        CHAT_ATTACHMENTS_EVENT,
-        paths,
-        &mut commands,
-    );
+    spawn_selected_attachment_tasks(trigger.event().webview, paths, &mut commands);
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -637,6 +663,7 @@ fn on_chat_attachment_preview_request(
         trigger.event().webview,
         CHAT_ATTACHMENT_PREVIEWS_EVENT,
         paths,
+        true,
         &mut commands,
     );
 }
@@ -658,12 +685,15 @@ fn on_chat_pick_files(trigger: On<BinReceive<ChatPickFiles>>, mut commands: Comm
     let Some(paths) = dialog.pick_files() else {
         return;
     };
-    spawn_chat_attachment_task(
-        trigger.event().webview,
-        CHAT_ATTACHMENTS_EVENT,
-        paths,
-        &mut commands,
-    );
+    spawn_selected_attachment_tasks(trigger.event().webview, paths, &mut commands);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn tiff_to_png(bytes: &[u8]) -> Option<Vec<u8>> {
+    let image = image::load_from_memory_with_format(bytes, image::ImageFormat::Tiff).ok()?;
+    let mut output = std::io::Cursor::new(Vec::new());
+    image.write_to(&mut output, image::ImageFormat::Png).ok()?;
+    Some(output.into_inner())
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -671,7 +701,9 @@ fn clipboard_image_path() -> Option<std::path::PathBuf> {
     if let Some(path) = vmux_terminal::clipboard::image_file_path() {
         return Some(std::path::PathBuf::from(path));
     }
-    let png = vmux_terminal::clipboard::read_image_png()?;
+    let png = vmux_terminal::clipboard::read_image_png().or_else(|| {
+        vmux_terminal::clipboard::read_image_tiff().and_then(|bytes| tiff_to_png(&bytes))
+    })?;
     let directory = std::env::temp_dir().join("vmux-prompt-attachments");
     std::fs::create_dir_all(&directory).ok()?;
     let path = directory.join(format!("clipboard-{}.png", uuid::Uuid::new_v4()));
@@ -684,12 +716,7 @@ fn on_chat_paste_media(trigger: On<BinReceive<ChatPasteMedia>>, mut commands: Co
     let Some(path) = clipboard_image_path() else {
         return;
     };
-    spawn_chat_attachment_task(
-        trigger.event().webview,
-        CHAT_ATTACHMENTS_EVENT,
-        vec![path],
-        &mut commands,
-    );
+    spawn_selected_attachment_tasks(trigger.event().webview, vec![path], &mut commands);
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -701,11 +728,27 @@ fn drain_chat_attachment_tasks(
         let Some(attachments) = future::block_on(future::poll_once(&mut pending.task)) else {
             continue;
         };
+        let preview_paths = (pending.event == CHAT_ATTACHMENTS_EVENT).then(|| {
+            attachments
+                .attachments
+                .iter()
+                .map(|attachment| std::path::PathBuf::from(&attachment.path))
+                .collect::<Vec<_>>()
+        });
         commands.trigger(BinHostEmitEvent::from_rkyv(
             pending.webview,
             pending.event,
             &attachments,
         ));
+        if let Some(paths) = preview_paths {
+            spawn_chat_attachment_task(
+                pending.webview,
+                CHAT_ATTACHMENT_PREVIEWS_EVENT,
+                paths,
+                true,
+                &mut commands,
+            );
+        }
         commands.entity(entity).despawn();
     }
 }
@@ -713,6 +756,35 @@ fn drain_chat_attachment_tasks(
 #[cfg(not(target_arch = "wasm32"))]
 fn drain_chat_media_list_tasks(
     mut tasks: Query<(Entity, &mut ChatMediaListTask)>,
+    mut commands: Commands,
+) {
+    for (entity, mut pending) in &mut tasks {
+        let Some(entries) = future::block_on(future::poll_once(&mut pending.task)) else {
+            continue;
+        };
+        commands.trigger(BinHostEmitEvent::from_rkyv(
+            pending.webview,
+            CHAT_MEDIA_ENTRIES_EVENT,
+            &entries,
+        ));
+        if entries
+            .entries
+            .iter()
+            .any(|entry| !entry.is_dir && entry.mime_type.starts_with("image/"))
+        {
+            let task = IoTaskPool::get().spawn(async move { chat_media_previews(entries) });
+            commands.spawn(ChatMediaPreviewTask {
+                webview: pending.webview,
+                task,
+            });
+        }
+        commands.entity(entity).despawn();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn drain_chat_media_preview_tasks(
+    mut tasks: Query<(Entity, &mut ChatMediaPreviewTask)>,
     mut commands: Commands,
 ) {
     for (entity, mut pending) in &mut tasks {
@@ -1923,6 +1995,22 @@ mod native_tests {
             .unwrap();
         let thumbnail = image::load_from_memory(&bytes).unwrap();
         assert_eq!(thumbnail.width().max(thumbnail.height()), 96);
+    }
+
+    #[test]
+    fn clipboard_tiff_is_converted_to_png() {
+        let image = image::DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
+            4,
+            3,
+            image::Rgba([20, 40, 60, 255]),
+        ));
+        let mut tiff = std::io::Cursor::new(Vec::new());
+        image.write_to(&mut tiff, image::ImageFormat::Tiff).unwrap();
+
+        let png = tiff_to_png(&tiff.into_inner()).unwrap();
+        let decoded = image::load_from_memory_with_format(&png, image::ImageFormat::Png).unwrap();
+
+        assert_eq!((decoded.width(), decoded.height()), (4, 3));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -156,6 +156,68 @@ struct AcpSetModelRequest {
 
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Resource, Default)]
+struct LastUsedAcpModels {
+    by_agent: std::collections::BTreeMap<String, String>,
+    dirty: bool,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl LastUsedAcpModels {
+    fn remember(&mut self, agent_id: &str, model_id: &str) {
+        if self
+            .by_agent
+            .get(agent_id)
+            .is_some_and(|saved| saved == model_id)
+        {
+            return;
+        }
+        self.by_agent
+            .insert(agent_id.to_string(), model_id.to_string());
+        self.dirty = true;
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn last_used_acp_models_path() -> std::path::PathBuf {
+    vmux_core::profile::profile_dir().join("agent-models.json")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn load_last_used_acp_models(mut models: ResMut<LastUsedAcpModels>) {
+    let Ok(bytes) = std::fs::read(last_used_acp_models_path()) else {
+        return;
+    };
+    let Ok(saved) = serde_json::from_slice::<std::collections::BTreeMap<String, String>>(&bytes)
+    else {
+        return;
+    };
+    models.by_agent = saved;
+    models.dirty = false;
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn save_last_used_acp_models(mut models: ResMut<LastUsedAcpModels>) {
+    if !models.dirty {
+        return;
+    }
+    let path = last_used_acp_models_path();
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    let Ok(bytes) = serde_json::to_vec_pretty(&models.by_agent) else {
+        return;
+    };
+    let temp = path.with_extension("json.tmp");
+    if std::fs::create_dir_all(parent).is_ok()
+        && std::fs::write(&temp, bytes).is_ok()
+        && std::fs::rename(&temp, &path).is_ok()
+    {
+        models.dirty = false;
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Resource, Default)]
 struct AcpModelRequestCounter(u64);
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -171,7 +233,9 @@ impl Plugin for AgentChatPagePlugin {
     fn build(&self, app: &mut App) {
         app.world_mut().spawn(PAGE_MANIFEST);
         app.init_resource::<AcpModelRequestCounter>()
+            .init_resource::<LastUsedAcpModels>()
             .add_message::<AcpSetModelRequest>()
+            .add_systems(Startup, load_last_used_acp_models)
             .add_plugins(BinEventEmitterPlugin::<(
                 ChatSubmit,
                 ChatApproval,
@@ -225,7 +289,9 @@ impl Plugin for AgentChatPagePlugin {
                     push_acp_model_state_to_page,
                     push_removed_acp_model_state_to_page,
                     push_composer_context_to_page,
+                    apply_last_used_acp_model.after(crate::client::acp::apply_acp_model_info),
                     send_acp_model_requests,
+                    save_last_used_acp_models.after(apply_last_used_acp_model),
                     drain_chat_attachment_tasks,
                     drain_chat_media_list_tasks,
                     drain_chat_media_preview_tasks,
@@ -937,7 +1003,6 @@ struct ComposerContextCache {
 struct ComposerContextCacheEntry {
     input: ComposerContextInput,
     context: ComposerContext,
-    refreshed_at: f32,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -982,13 +1047,12 @@ fn composer_context_input(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn composer_context_from_input(input: &ComposerContextInput) -> ComposerContext {
-    let info = (!input.cwd.as_os_str().is_empty())
-        .then(|| vmux_git::worktree::repo_info(&input.cwd))
-        .flatten();
-    let is_git_repo = info.is_some() || input.cwd.join(".git").exists();
+fn composer_context_from_input(
+    input: &ComposerContextInput,
+    info: Option<&vmux_git::worktree::RepoInfo>,
+) -> ComposerContext {
+    let is_git_repo = info.is_some() || input.worktree.is_some() || input.cwd.join(".git").exists();
     let branch = info
-        .as_ref()
         .map(|info| info.branch.clone())
         .filter(|branch| !branch.is_empty())
         .or_else(|| {
@@ -996,11 +1060,6 @@ fn composer_context_from_input(input: &ComposerContextInput) -> ComposerContext 
                 .worktree
                 .as_ref()
                 .map(|worktree| worktree.branch.clone())
-        })
-        .or_else(|| {
-            is_git_repo
-                .then(|| vmux_git::worktree::head_ref(&input.cwd).ok())
-                .flatten()
         })
         .unwrap_or_default();
     let workspace_name = input
@@ -1014,18 +1073,15 @@ fn composer_context_from_input(input: &ComposerContextInput) -> ComposerContext 
         workspace_name,
         workspace_selected: input.workspace_selected,
         is_git_repo,
-        is_worktree: info.as_ref().is_some_and(|info| info.is_worktree) || input.worktree.is_some(),
+        is_worktree: info.is_some_and(|info| info.is_worktree) || input.worktree.is_some(),
         branch,
         base_ref: input
             .worktree
             .as_ref()
             .map(|worktree| worktree.base_ref.clone())
             .unwrap_or_default(),
-        uncommitted: info
-            .as_ref()
-            .map(|info| info.uncommitted)
-            .unwrap_or_default(),
-        ahead: info.as_ref().map(|info| info.ahead).unwrap_or_default(),
+        uncommitted: info.map(|info| info.uncommitted).unwrap_or_default(),
+        ahead: info.map(|info| info.ahead).unwrap_or_default(),
         can_manage_workspace: input.can_manage_workspace,
         auto_allow_count: input.auto_allow_count,
     }
@@ -1043,11 +1099,10 @@ fn push_composer_context_to_page(
         Option<&vmux_layout::tab::TabWorktree>,
     )>,
     browsers: NonSend<Browsers>,
-    time: Res<Time>,
+    mut repo_info: Option<ResMut<vmux_git::RepoInfoCache>>,
     mut cache: Local<ComposerContextCache>,
     mut commands: Commands,
 ) {
-    let now = time.elapsed_secs();
     let live_views = views
         .iter()
         .map(|(webview, _, _)| webview)
@@ -1064,22 +1119,18 @@ fn push_composer_context_to_page(
             continue;
         };
         let input = composer_context_input(stack, acp, policy, &child_of, &tabs);
-        let refresh = cache
-            .entries
-            .get(&webview)
-            .is_none_or(|entry| entry.input != input || now - entry.refreshed_at >= 3.0);
-        if !refresh && !ready.is_changed() {
-            continue;
-        }
-        let context = if refresh {
-            composer_context_from_input(&input)
-        } else {
-            cache.entries.get(&webview).unwrap().context.clone()
-        };
+        let info = (!input.cwd.as_os_str().is_empty())
+            .then(|| {
+                repo_info
+                    .as_mut()
+                    .and_then(|cache| cache.bypass_change_detection().get(&input.cwd))
+            })
+            .flatten();
+        let context = composer_context_from_input(&input, info.as_ref());
         let changed = cache
             .entries
             .get(&webview)
-            .is_none_or(|entry| entry.context != context);
+            .is_none_or(|entry| entry.input != input || entry.context != context);
         if changed || ready.is_changed() {
             commands.trigger(BinHostEmitEvent::from_rkyv(
                 webview,
@@ -1087,14 +1138,9 @@ fn push_composer_context_to_page(
                 &context,
             ));
         }
-        cache.entries.insert(
-            webview,
-            ComposerContextCacheEntry {
-                input,
-                context,
-                refreshed_at: now,
-            },
-        );
+        cache
+            .entries
+            .insert(webview, ComposerContextCacheEntry { input, context });
     }
 }
 
@@ -1605,6 +1651,7 @@ fn on_select_model(
     child_of: Query<&ChildOf>,
     mut sessions: Query<(&AcpSession, &mut AcpModelState)>,
     mut counter: ResMut<AcpModelRequestCounter>,
+    mut last_used: ResMut<LastUsedAcpModels>,
     mut requests: MessageWriter<AcpSetModelRequest>,
 ) {
     let Ok(parent) = child_of.get(trigger.event().webview) else {
@@ -1620,6 +1667,7 @@ fn on_select_model(
         return;
     }
     let request_id = counter.next();
+    last_used.remember(&session.agent_id, &model_id);
     requests.write(AcpSetModelRequest {
         sid: session.sid.clone(),
         request_id,
@@ -1630,6 +1678,36 @@ fn on_select_model(
         request_id,
         model_id,
     });
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn apply_last_used_acp_model(
+    mut sessions: Query<(&AcpSession, &mut AcpModelState), Added<AcpModelState>>,
+    last_used: Res<LastUsedAcpModels>,
+    mut counter: ResMut<AcpModelRequestCounter>,
+    mut requests: MessageWriter<AcpSetModelRequest>,
+) {
+    for (session, mut state) in &mut sessions {
+        let Some(model_id) = last_used.by_agent.get(&session.agent_id) else {
+            continue;
+        };
+        if state.display_model_id() == model_id
+            || !state.models.iter().any(|model| &model.id == model_id)
+        {
+            continue;
+        }
+        let request_id = counter.next();
+        requests.write(AcpSetModelRequest {
+            sid: session.sid.clone(),
+            request_id,
+            config_id: state.config_id.clone(),
+            model_id: model_id.clone(),
+        });
+        state.pending = Some(crate::client::acp::PendingAcpModelSelection {
+            request_id,
+            model_id: model_id.clone(),
+        });
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -2074,6 +2152,7 @@ mod native_tests {
     fn model_selection_updates_cached_state_before_response() {
         let mut app = App::new();
         app.init_resource::<AcpModelRequestCounter>()
+            .init_resource::<LastUsedAcpModels>()
             .add_message::<AcpSetModelRequest>()
             .add_observer(on_select_model);
         let stack = app
@@ -2138,6 +2217,14 @@ mod native_tests {
         assert_eq!(requests[0].request_id, 1);
         assert_eq!(requests[0].config_id, "model");
         assert_eq!(requests[0].model_id, "fable");
+        assert_eq!(
+            app.world()
+                .resource::<LastUsedAcpModels>()
+                .by_agent
+                .get("claude")
+                .map(String::as_str),
+            Some("fable")
+        );
 
         app.world_mut().trigger(BinReceive {
             webview,
@@ -2158,6 +2245,61 @@ mod native_tests {
                 .count(),
             0
         );
+    }
+
+    #[test]
+    fn fresh_agent_session_applies_last_used_model() {
+        let mut app = App::new();
+        app.init_resource::<AcpModelRequestCounter>()
+            .init_resource::<LastUsedAcpModels>()
+            .add_message::<AcpSetModelRequest>()
+            .add_systems(Update, apply_last_used_acp_model);
+        app.world_mut()
+            .resource_mut::<LastUsedAcpModels>()
+            .by_agent
+            .insert("claude".into(), "fable".into());
+        let stack = app
+            .world_mut()
+            .spawn((
+                AcpSession {
+                    agent_id: "claude".into(),
+                    sid: "s2".into(),
+                    cwd: "/tmp".into(),
+                    anchor: vmux_core::ProcessId::new(),
+                    resume: None,
+                },
+                AcpModelState {
+                    config_id: "model".into(),
+                    current_model_id: "default".into(),
+                    pending: None,
+                    models: vec![
+                        vmux_service::protocol::AcpModelOption {
+                            id: "default".into(),
+                            name: "Default".into(),
+                            description: None,
+                        },
+                        vmux_service::protocol::AcpModelOption {
+                            id: "fable".into(),
+                            name: "Fable".into(),
+                            description: None,
+                        },
+                    ],
+                },
+            ))
+            .id();
+
+        app.update();
+
+        let state = app.world().get::<AcpModelState>(stack).unwrap();
+        assert_eq!(state.display_model_id(), "fable");
+        let requests: Vec<_> = app
+            .world_mut()
+            .resource_mut::<Messages<AcpSetModelRequest>>()
+            .drain()
+            .collect();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].sid, "s2");
+        assert_eq!(requests[0].model_id, "fable");
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -801,7 +801,9 @@ pub fn Page(
             label: attachment_label(attachment),
             preview_data_url: prompt_attachment_previews
                 .get(&attachment.path)
-                .map(|preview| preview.preview_data_url.clone())
+                .and_then(|preview| {
+                    (!preview.preview_data_url.is_empty()).then(|| preview.preview_data_url.clone())
+                })
                 .unwrap_or_else(|| attachment.preview_data_url.clone()),
             remove_index: None,
         })
@@ -816,7 +818,10 @@ pub fn Page(
                     label: attachment_label(attachment),
                     preview_data_url: prompt_attachment_previews
                         .get(&attachment.path)
-                        .map(|preview| preview.preview_data_url.clone())
+                        .and_then(|preview| {
+                            (!preview.preview_data_url.is_empty())
+                                .then(|| preview.preview_data_url.clone())
+                        })
                         .unwrap_or_else(|| attachment.preview_data_url.clone()),
                     remove_index: Some(index),
                 }),

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -24,7 +24,8 @@ use dioxus::prelude::*;
 use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 use vmux_command::prompt_media::{
-    inline_media_query, media_display_path, media_reference, replace_inline_media_query,
+    inline_media_query, media_display_path, media_reference, merge_chat_attachments,
+    replace_inline_media_query,
 };
 use vmux_terminal::matrix_rain::MatrixRain;
 use vmux_ui::agent_accent::agent_accent;
@@ -601,16 +602,8 @@ pub fn Page(
         });
     let _attachments =
         use_bin_event_listener::<ChatAttachments, _>(CHAT_ATTACHMENTS_EVENT, move |selected| {
-            let mut next = attachments.peek().clone();
-            let mut previews = attachment_previews.peek().clone();
-            for attachment in &selected.attachments {
-                previews.insert(attachment.path.clone(), attachment.clone());
-                if !next.iter().any(|existing| existing.path == attachment.path) {
-                    next.push(attachment.clone());
-                }
-            }
-            attachment_previews.set(previews);
-            attachments.set(next);
+            let current = attachments.peek().clone();
+            attachments.set(merge_chat_attachments(&current, &selected.attachments));
             focus_prompt_end(PROMPT_INPUT_ID);
         });
     let _attachment_previews = use_bin_event_listener::<ChatAttachments, _>(
@@ -799,6 +792,7 @@ pub fn Page(
             is_dir: entry.is_dir,
         })
         .collect::<Vec<_>>();
+    let prompt_attachment_previews = attachment_previews.read();
     let prompt_attachments = transition_attachments
         .read()
         .iter()
@@ -806,7 +800,10 @@ pub fn Page(
             key: format!("transition-attachment-{}", attachment.path),
             name: attachment.name.clone(),
             label: attachment_label(attachment),
-            preview_data_url: attachment.preview_data_url.clone(),
+            preview_data_url: prompt_attachment_previews
+                .get(&attachment.path)
+                .map(|preview| preview.preview_data_url.clone())
+                .unwrap_or_else(|| attachment.preview_data_url.clone()),
             remove_index: None,
         })
         .chain(
@@ -818,7 +815,10 @@ pub fn Page(
                     key: format!("attachment-pill-{}", attachment.path),
                     name: attachment.name.clone(),
                     label: attachment_label(attachment),
-                    preview_data_url: attachment.preview_data_url.clone(),
+                    preview_data_url: prompt_attachment_previews
+                        .get(&attachment.path)
+                        .map(|preview| preview.preview_data_url.clone())
+                        .unwrap_or_else(|| attachment.preview_data_url.clone()),
                     remove_index: Some(index),
                 }),
         )

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -507,6 +507,8 @@ pub fn Page(
     let mut menu_sel = use_signal(|| 0usize);
     let mut resume_requested = use_signal(|| false);
     let mut resume_loading = use_signal(|| false);
+    let activity_counts = use_memo(move || composer_activity_counts(&items.read()));
+    let latest_tool = use_memo(move || latest_tool_location(&items.read()));
 
     use_effect(move || {
         install_global_prompt_input(draft, slash_cmds, choice_options, approval, approval_sel)
@@ -768,10 +770,7 @@ pub fn Page(
     let session_menu_open = resume_query.is_some();
     let model_menu_open = model_query.is_some();
     let media_menu_open = media_query.is_some();
-    let latest_tool = {
-        let items = items.read();
-        latest_tool_location(&items)
-    };
+    let latest_tool = latest_tool();
     let resume_state = resume_query.map(|_| {
         resume_menu_state(
             resume_requested(),
@@ -1114,7 +1113,7 @@ pub fn Page(
 
     let context = composer_context();
     let model_name = current_model();
-    let (active_subagents, active_tasks) = composer_activity_counts(&items.read());
+    let (active_subagents, active_tasks) = activity_counts();
     let queued_count = queued.read().len();
     let workspace_label = if context.workspace_selected && !context.workspace_name.is_empty() {
         context.workspace_name.clone()
@@ -1391,15 +1390,17 @@ pub fn Page(
                             p { class: "text-sm text-muted-foreground", {translate("agent-ready")} }
                         }
                     }
-                    for (i , item) in items.read().iter().enumerate() {
-                        {render_item(
-                            loaded_start() as usize + i,
-                            item,
+                    for i in 0..items.read().len() {
+                        ChatItemRow {
+                            key: "{loaded_start() as usize + i}",
+                            index: i,
+                            absolute_index: loaded_start() as usize + i,
+                            items,
                             attachment_previews,
-                            latest_tool
+                            latest_tool_block: latest_tool
                                 .filter(|(item_index, _)| *item_index == i)
                                 .map(|(_, block_index)| block_index),
-                        )}
+                        }
                         if !handoff_source().is_empty()
                             && is_handoff_boundary(
                                 loaded_start() as usize + i,
@@ -1842,6 +1843,21 @@ fn send_approval(call_id: String, decision: u8) -> bool {
     try_cef_bin_emit_rkyv(&ChatApproval { call_id, decision }).is_ok()
 }
 
+#[component]
+fn ChatItemRow(
+    index: usize,
+    absolute_index: usize,
+    items: Signal<Vec<ChatItem>>,
+    attachment_previews: Signal<HashMap<String, ChatAttachment>>,
+    latest_tool_block: Option<usize>,
+) -> Element {
+    let items = items.read();
+    let Some(item) = items.get(index) else {
+        return rsx! {};
+    };
+    render_item(absolute_index, item, attachment_previews, latest_tool_block)
+}
+
 fn render_item(
     key: usize,
     item: &ChatItem,
@@ -1857,6 +1873,7 @@ fn render_item(
             div {
                 key: "{key}",
                 class: "chat-user-bubble flex max-w-[80%] self-end flex-col gap-2 rounded-[1.35rem] rounded-tr-md border p-2.5 text-sm",
+                style: "content-visibility:auto;contain-intrinsic-size:auto 96px;",
                 if let Some(context) = context {
                     details { class: "disclosure user-context-panel rounded-xl border",
                         summary { class: "flex cursor-pointer select-none items-center gap-2 px-2.5 py-2 text-xs list-none [&::-webkit-details-marker]:hidden",
@@ -1984,7 +2001,10 @@ fn render_turn(key: usize, turn: &ChatTurn, latest_tool_index: Option<usize>) ->
         }
     });
     rsx! {
-        div { key: "{key}", class: "flex max-w-[92%] flex-col gap-2 self-start",
+        div {
+            key: "{key}",
+            class: "flex max-w-[92%] flex-col gap-2 self-start",
+            style: "content-visibility:auto;contain-intrinsic-size:auto 180px;",
             if !blocks.is_empty() {
                 div { class: "chat-assistant-turn relative flex flex-col gap-2.5 overflow-hidden rounded-2xl border px-3.5 py-3",
                     for (j , block , children) in blocks {

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -426,25 +426,38 @@ pub(crate) fn apply_acp_model_selection_result(
 
 /// ACP agents re-request permission every time, so "allow always" must be answered by the host:
 /// if the tool name is already in this session's auto-policy, reply `Allow` without prompting.
+fn acp_auto_approval_message(
+    session: &AcpSession,
+    policy: &AgentApprovalPolicy,
+    request: &AgentApprovalRequest,
+) -> Option<ClientMessage> {
+    policy
+        .auto
+        .contains(&request.name)
+        .then(|| ClientMessage::AgentApprove {
+            sid: session.sid.clone(),
+            call_id: request.call_id.clone(),
+            decision: vmux_service::protocol::ApprovalDecision::Allow,
+        })
+}
+
 fn auto_allow_acp_approval(
     trigger: On<AgentApprovalRequest>,
     sessions: Query<(&AcpSession, &AgentApprovalPolicy)>,
     service: Option<Res<ServiceClient>>,
 ) {
-    let Some(service) = service else {
-        return;
-    };
     let request = trigger.event();
     let Ok((session, policy)) = sessions.get(request.session) else {
         return;
     };
-    if policy.auto.contains(&request.name) {
-        service.0.send(ClientMessage::AgentApprove {
-            sid: session.sid.clone(),
-            call_id: request.call_id.clone(),
-            decision: vmux_service::protocol::ApprovalDecision::Allow,
-        });
-    }
+    let Some(message) = acp_auto_approval_message(session, policy, request) else {
+        return;
+    };
+    let Some(service) = service else {
+        warn!(sid = %session.sid, call_id = %request.call_id, "auto-approval waiting for service connection");
+        return;
+    };
+    service.0.send(message);
 }
 
 /// Marks an `AcpSession` whose install has already been kicked off, so
@@ -1058,6 +1071,33 @@ mod tests {
 
     fn s(k: &str, v: &str) -> (String, String) {
         (k.to_string(), v.to_string())
+    }
+
+    #[test]
+    fn auto_approval_message_targets_requested_session_and_call() {
+        let session = AcpSession {
+            agent_id: "claude".into(),
+            sid: "s1".into(),
+            cwd: "/tmp".into(),
+            anchor: vmux_core::ProcessId::new(),
+            resume: None,
+        };
+        let mut policy = AgentApprovalPolicy::default();
+        policy.auto.insert("run".into());
+        let request = AgentApprovalRequest {
+            session: Entity::PLACEHOLDER,
+            call_id: "call-1".into(),
+            name: "run".into(),
+            args: serde_json::json!({}),
+        };
+
+        assert!(matches!(
+            acp_auto_approval_message(&session, &policy, &request),
+            Some(ClientMessage::AgentApprove { sid, call_id, decision })
+                if sid == "s1"
+                    && call_id == "call-1"
+                    && decision == vmux_service::protocol::ApprovalDecision::Allow
+        ));
     }
 
     #[test]

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -368,7 +368,7 @@ fn apply_acp_workspace_changed(
     }
 }
 
-fn apply_acp_model_info(
+pub(crate) fn apply_acp_model_info(
     mut reader: MessageReader<vmux_service::agent_events::PageAgentModelInfo>,
     mut sessions: Query<(Entity, &AcpSession, Option<&mut AcpModelState>)>,
     mut commands: Commands,
@@ -404,7 +404,7 @@ fn apply_acp_model_info(
     }
 }
 
-fn apply_acp_model_selection_result(
+pub(crate) fn apply_acp_model_selection_result(
     mut reader: MessageReader<vmux_service::agent_events::PageAgentModelSelectionResult>,
     mut sessions: Query<(&AcpSession, &mut AcpModelState)>,
 ) {

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -16,7 +16,7 @@ use vmux_setting::AppSettings;
 use vmux_terminal::reattach_terminal_bundle;
 
 use crate::components::{AgentApprovalPolicy, PromptQueue};
-use crate::events::{AgentApprovalReply, AgentApprovalRequest, ApprovalDecision};
+use crate::events::AgentApprovalRequest;
 use crate::handoff::{ImportedConversation, PendingHandoff};
 use crate::run_state::AgentRunState;
 
@@ -428,18 +428,21 @@ fn apply_acp_model_selection_result(
 /// if the tool name is already in this session's auto-policy, reply `Allow` without prompting.
 fn auto_allow_acp_approval(
     trigger: On<AgentApprovalRequest>,
-    policies: Query<&AgentApprovalPolicy, With<AcpSession>>,
-    mut commands: Commands,
+    sessions: Query<(&AcpSession, &AgentApprovalPolicy)>,
+    service: Option<Res<ServiceClient>>,
 ) {
+    let Some(service) = service else {
+        return;
+    };
     let request = trigger.event();
-    let Ok(policy) = policies.get(request.session) else {
+    let Ok((session, policy)) = sessions.get(request.session) else {
         return;
     };
     if policy.auto.contains(&request.name) {
-        commands.trigger(AgentApprovalReply {
-            session: request.session,
+        service.0.send(ClientMessage::AgentApprove {
+            sid: session.sid.clone(),
             call_id: request.call_id.clone(),
-            decision: ApprovalDecision::Allow,
+            decision: vmux_service::protocol::ApprovalDecision::Allow,
         });
     }
 }

--- a/crates/vmux_agent/src/client/page/plugin.rs
+++ b/crates/vmux_agent/src/client/page/plugin.rs
@@ -194,6 +194,7 @@ fn consume_page_agent_stream(
         Option<&ImportedConversation>,
     )>,
     mut attention: MessageWriter<vmux_core::notify::AgentAttention>,
+    service: Option<Res<ServiceClient>>,
     mut commands: Commands,
 ) {
     let by_sid: std::collections::HashMap<String, Entity> = q
@@ -276,8 +277,9 @@ fn consume_page_agent_stream(
         let args: serde_json::Value =
             serde_json::from_str(&approval.args_json).unwrap_or_else(|_| serde_json::json!({}));
         if let Ok((_, _, mut state, _, _, acp, policy, _, _)) = q.get_mut(entity) {
-            let auto_allowed =
-                acp.is_some() && policy.is_some_and(|policy| policy.auto.contains(&approval.name));
+            let auto_allowed = service.is_some()
+                && acp.is_some()
+                && policy.is_some_and(|policy| policy.auto.contains(&approval.name));
             if !auto_allowed {
                 *state = AgentRunState::AwaitingApproval {
                     call_id: approval.call_id.clone(),
@@ -310,7 +312,7 @@ mod tests {
     }
 
     #[test]
-    fn auto_approved_acp_request_never_enters_awaiting_state() {
+    fn auto_approved_acp_request_without_service_falls_back_to_awaiting_state() {
         let mut app = App::new();
         app.add_message::<PageAgentDelta>()
             .add_message::<PageAgentRunStatus>()
@@ -347,7 +349,8 @@ mod tests {
 
         assert!(matches!(
             app.world().get::<AgentRunState>(entity),
-            Some(AgentRunState::Streaming)
+            Some(AgentRunState::AwaitingApproval { call_id, name, args })
+                if call_id == "call-1" && name == "run" && args == &serde_json::json!({})
         ));
     }
 

--- a/crates/vmux_agent/src/client/page/plugin.rs
+++ b/crates/vmux_agent/src/client/page/plugin.rs
@@ -189,6 +189,7 @@ fn consume_page_agent_stream(
         &mut PromptQueue,
         Option<&AgentSession>,
         Option<&AcpSession>,
+        Option<&AgentApprovalPolicy>,
         Option<&mut PendingHandoff>,
         Option<&ImportedConversation>,
     )>,
@@ -197,7 +198,7 @@ fn consume_page_agent_stream(
 ) {
     let by_sid: std::collections::HashMap<String, Entity> = q
         .iter()
-        .filter_map(|(e, _, _, _, page, acp, _, _)| {
+        .filter_map(|(e, _, _, _, page, acp, _, _, _)| {
             let sid = page
                 .map(|s| s.sid.clone())
                 .or_else(|| acp.map(|s| s.sid.clone()))?;
@@ -215,7 +216,7 @@ fn consume_page_agent_stream(
     }
     for snapshot in snapshots.read() {
         if let Some(&entity) = by_sid.get(&snapshot.sid)
-            && let Ok((_, mut messages, _, _, _, _, _, imported)) = q.get_mut(entity)
+            && let Ok((_, mut messages, _, _, _, _, _, _, imported)) = q.get_mut(entity)
             && let Ok(mut parsed) = serde_json::from_str::<Vec<Message>>(&snapshot.messages_json)
         {
             sanitize_replayed_messages(
@@ -227,7 +228,7 @@ fn consume_page_agent_stream(
     }
     for status in statuses.read() {
         if let Some(&entity) = by_sid.get(&status.sid)
-            && let Ok((_, _, mut state, mut queue, _, _, mut pending, _)) = q.get_mut(entity)
+            && let Ok((_, _, mut state, mut queue, _, _, _, mut pending, _)) = q.get_mut(entity)
         {
             let was_streaming = matches!(*state, AgentRunState::Streaming);
             match &status.status {
@@ -274,12 +275,16 @@ fn consume_page_agent_stream(
         };
         let args: serde_json::Value =
             serde_json::from_str(&approval.args_json).unwrap_or_else(|_| serde_json::json!({}));
-        if let Ok((_, _, mut state, _, _, _, _, _)) = q.get_mut(entity) {
-            *state = AgentRunState::AwaitingApproval {
-                call_id: approval.call_id.clone(),
-                name: approval.name.clone(),
-                args: args.clone(),
-            };
+        if let Ok((_, _, mut state, _, _, acp, policy, _, _)) = q.get_mut(entity) {
+            let auto_allowed =
+                acp.is_some() && policy.is_some_and(|policy| policy.auto.contains(&approval.name));
+            if !auto_allowed {
+                *state = AgentRunState::AwaitingApproval {
+                    call_id: approval.call_id.clone(),
+                    name: approval.name.clone(),
+                    args: args.clone(),
+                };
+            }
         }
         commands.trigger(AgentApprovalRequest {
             session: entity,
@@ -302,6 +307,48 @@ mod tests {
             .init_resource::<BinIpcEventRawBuffer>()
             .add_plugins(PageAgentPlugin);
         app.update();
+    }
+
+    #[test]
+    fn auto_approved_acp_request_never_enters_awaiting_state() {
+        let mut app = App::new();
+        app.add_message::<PageAgentDelta>()
+            .add_message::<PageAgentRunStatus>()
+            .add_message::<PageAgentAwaitingApproval>()
+            .add_message::<PageAgentSnapshot>()
+            .add_message::<vmux_core::notify::AgentAttention>()
+            .add_systems(Update, consume_page_agent_stream);
+        let mut policy = AgentApprovalPolicy::default();
+        policy.auto.insert("run".into());
+        let entity = app
+            .world_mut()
+            .spawn((
+                AcpSession {
+                    agent_id: "a".into(),
+                    sid: "s1".into(),
+                    cwd: std::path::PathBuf::from("/tmp"),
+                    anchor: vmux_core::ProcessId::new(),
+                    resume: None,
+                },
+                AgentMessages::default(),
+                AgentRunState::Streaming,
+                PromptQueue::default(),
+                policy,
+            ))
+            .id();
+        app.world_mut().write_message(PageAgentAwaitingApproval {
+            sid: "s1".into(),
+            call_id: "call-1".into(),
+            name: "run".into(),
+            args_json: "{}".into(),
+        });
+
+        app.update();
+
+        assert!(matches!(
+            app.world().get::<AgentRunState>(entity),
+            Some(AgentRunState::Streaming)
+        ));
     }
 
     #[test]

--- a/crates/vmux_browser/src/extensions/manager_page.rs
+++ b/crates/vmux_browser/src/extensions/manager_page.rs
@@ -55,7 +55,7 @@ impl Plugin for ExtensionsPlugin {
                 host: "extensions",
                 url: EXTENSIONS_PAGE_URL,
                 title: "Extensions",
-                pool_size: 1,
+                pool_size: 0,
             },
         ));
         vmux_core::register_host_spawn(app, "extensions");

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -56,7 +56,7 @@ use vmux_layout::{
         TabsHostEvent, UPDATE_CLEARED_EVENT, UPDATE_PROGRESS_EVENT, UPDATE_READY_EVENT,
         UpdateClearedEvent, UpdateProgressEvent, UpdateReadyEvent,
     },
-    pane::{Pane, PaneHoverIntent, PaneSplit, first_stack_in_pane},
+    pane::{Pane, PaneHoverIntent, PaneSplit, SideSheetCardCollapsed, first_stack_in_pane},
     side_sheet::{SideSheet, SideSheetPosition, SideSheetWidth},
     stack::{
         ActiveTabParam, Stack, active_stack_in_pane, collect_leaf_panes, focused_stack,
@@ -3447,6 +3447,7 @@ fn push_pane_tree_emit(
     tab_q: Query<(), With<Tab>>,
     all_children: Query<&Children>,
     leaf_pane_q: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
+    collapsed_panes: Query<(), With<SideSheetCardCollapsed>>,
     pane_children: Query<&Children, With<Pane>>,
     stack_ts: Query<(Entity, &LastActivatedAt), With<Stack>>,
     stack_q: Query<Entity, With<Stack>>,
@@ -3532,6 +3533,7 @@ fn push_pane_tree_emit(
         panes.push(PaneNode {
             id: pane_entity.to_bits(),
             is_active,
+            collapsed: collapsed_panes.contains(pane_entity),
             stacks,
         });
     }
@@ -3583,8 +3585,7 @@ fn abbreviate_home(path: &std::path::Path) -> String {
     s.into_owned()
 }
 
-/// Emit the active tab's working-directory boundary (dir + provenance + worktree/branch) to the
-/// layout side sheet.
+/// Emit the active tab's working-directory boundary from the shared event-driven Git cache.
 #[allow(clippy::too_many_arguments)]
 fn push_tab_boundary_emit(
     mut commands: Commands,
@@ -3598,8 +3599,7 @@ fn push_tab_boundary_emit(
     all_children: Query<&Children>,
     leaf_pane_q: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
     mut last: Local<String>,
-    mut git_cache: Local<(String, f32, Option<vmux_git::worktree::RepoInfo>)>,
-    time: Res<Time>,
+    mut repo_info: Option<ResMut<vmux_git::RepoInfoCache>>,
 ) {
     let Ok((cef_e, page_ready)) = cef_q.single() else {
         return;
@@ -3610,14 +3610,9 @@ fn push_tab_boundary_emit(
     let boundary = focus.tab.and_then(|tab_e| {
         let tab = tabs.get(tab_e).ok()?;
         let (path, source) = tab_boundary_dir(tab, &settings, active_space.as_deref())?;
-        // Auto-detect git status for the tab dir, cached by dir + refreshed every ~3s. This only
-        // runs when the loop wakes (Reactive mode), so it never polls git while idle.
-        let dir_key = path.to_string_lossy().to_string();
-        let now = time.elapsed_secs();
-        if git_cache.0 != dir_key || now - git_cache.1 > 3.0 {
-            *git_cache = (dir_key, now, vmux_git::worktree::repo_info(&path));
-        }
-        let info = git_cache.2.clone();
+        let info = repo_info
+            .as_mut()
+            .and_then(|cache| cache.bypass_change_detection().get(&path));
         let wt = worktrees.get(tab_e).ok();
         let branch = info.as_ref().map(|i| i.branch.clone()).unwrap_or_default();
         let base_ref = wt.map(|w| w.base_ref.clone()).unwrap_or_default();
@@ -4257,6 +4252,14 @@ fn on_side_sheet_command_emit(
                 command: cmd.clone(),
             });
             messages.write(cmd);
+        }
+        "collapse_card" => {
+            commands.entity(target_pane).insert(SideSheetCardCollapsed);
+        }
+        "expand_card" => {
+            commands
+                .entity(target_pane)
+                .remove::<SideSheetCardCollapsed>();
         }
         "open_knowledge_path" => {
             let Some(url) =

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -1635,7 +1635,6 @@ fn sync_windowed_frames(
     mut last_raised_frame: Local<std::collections::HashMap<Entity, (i32, i32, i32, i32)>>,
     mut last_visible_pages: Local<Vec<Entity>>,
     mut last_windowed_pages: Local<Vec<Entity>>,
-    mut visible_frames: Local<Vec<WindowedFrameRect>>,
 ) {
     let visible_pane_count =
         visible_pane_count_for_windowed_sync(focus.tab, &all_children, &leaf_panes);
@@ -1645,7 +1644,6 @@ fn sync_windowed_frames(
     let force_raise = layout_hidden.is_changed();
     let mut hidden = Vec::new();
     let mut visible = Vec::new();
-    visible_frames.clear();
     for (entity, tf, self_computed, self_ui_gt, child_of) in &browser_q {
         if tf.scale.x <= 1.0e-3 {
             hidden.push(entity);
@@ -1717,7 +1715,6 @@ fn sync_windowed_frames(
             [cover_rgb.red, cover_rgb.green, cover_rgb.blue],
         );
         if browsers.has_browser(entity) {
-            visible_frames.push(frame);
             let key = (
                 frame.left.round() as i32,
                 frame.top.round() as i32,
@@ -1743,7 +1740,6 @@ fn sync_windowed_frames(
     }
     *last_visible_pages = visible;
     *last_windowed_pages = current_windowed;
-    *visible_frames = set_native_windowed_page_frames(std::mem::take(&mut *visible_frames));
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1762,52 +1758,6 @@ impl WindowedFrameRect {
     fn bottom(self) -> f32 {
         self.top + self.height
     }
-}
-
-#[cfg(target_os = "macos")]
-static NATIVE_WINDOWED_PAGE_FRAMES: LazyLock<Mutex<Vec<WindowedFrameRect>>> =
-    LazyLock::new(|| Mutex::new(Vec::new()));
-
-#[cfg(any(target_os = "macos", test))]
-fn windowed_frame_contains(frame: WindowedFrameRect, point: Vec2) -> bool {
-    point.x >= frame.left
-        && point.x <= frame.right()
-        && point.y >= frame.top
-        && point.y <= frame.bottom()
-}
-
-#[cfg(target_os = "macos")]
-fn set_native_windowed_page_frames(mut frames: Vec<WindowedFrameRect>) -> Vec<WindowedFrameRect> {
-    let mut published = NATIVE_WINDOWED_PAGE_FRAMES
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    std::mem::swap(&mut *published, &mut frames);
-    frames.clear();
-    frames
-}
-
-#[cfg(not(target_os = "macos"))]
-fn set_native_windowed_page_frames(mut frames: Vec<WindowedFrameRect>) -> Vec<WindowedFrameRect> {
-    frames.clear();
-    frames
-}
-
-/// Returns whether a physical window coordinate is inside a visible native page.
-#[cfg(target_os = "macos")]
-pub fn native_windowed_page_contains_point(x_px: f32, y_px: f32) -> bool {
-    let point = Vec2::new(x_px, y_px);
-    NATIVE_WINDOWED_PAGE_FRAMES
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .iter()
-        .copied()
-        .any(|frame| windowed_frame_contains(frame, point))
-}
-
-/// Returns whether a physical window coordinate is inside a visible native page.
-#[cfg(not(target_os = "macos"))]
-pub fn native_windowed_page_contains_point(_: f32, _: f32) -> bool {
-    false
 }
 
 fn windowed_frame_rect_from_computed(
@@ -5922,21 +5872,6 @@ mod tests {
                 height: 299.0,
             }
         );
-    }
-
-    #[test]
-    fn windowed_frame_hit_test_uses_physical_page_bounds() {
-        let frame = WindowedFrameRect {
-            left: 100.0,
-            top: 50.0,
-            width: 400.0,
-            height: 300.0,
-        };
-
-        assert!(windowed_frame_contains(frame, Vec2::new(100.0, 50.0)));
-        assert!(windowed_frame_contains(frame, Vec2::new(500.0, 350.0)));
-        assert!(!windowed_frame_contains(frame, Vec2::new(99.0, 200.0)));
-        assert!(!windowed_frame_contains(frame, Vec2::new(300.0, 351.0)));
     }
 
     #[test]

--- a/crates/vmux_command/src/prompt_media.rs
+++ b/crates/vmux_command/src/prompt_media.rs
@@ -210,6 +210,28 @@ pub fn media_display_path(entry: &ChatMediaEntry) -> String {
     }
 }
 
+pub fn merge_chat_attachments(
+    current: &[ChatAttachment],
+    incoming: &[ChatAttachment],
+) -> Vec<ChatAttachment> {
+    let mut merged = current.to_vec();
+    for attachment in incoming {
+        if let Some(existing) = merged
+            .iter_mut()
+            .find(|existing| existing.path == attachment.path)
+        {
+            let mut replacement = attachment.clone();
+            if replacement.preview_data_url.is_empty() {
+                replacement.preview_data_url = existing.preview_data_url.clone();
+            }
+            *existing = replacement;
+        } else {
+            merged.push(attachment.clone());
+        }
+    }
+    merged
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -260,5 +282,35 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(media_display_path(&root_entry), "~/Pictures");
+    }
+
+    #[test]
+    fn attachment_batches_append_new_files_and_refresh_existing_metadata() {
+        let first = ChatAttachment {
+            path: "/tmp/one.png".into(),
+            name: "one.png".into(),
+            mime_type: "image/png".into(),
+            size: 1,
+            preview_data_url: "data:image/png;base64,preview".into(),
+        };
+        let second = ChatAttachment {
+            path: "/tmp/two.png".into(),
+            name: "two.png".into(),
+            mime_type: "image/png".into(),
+            size: 2,
+            preview_data_url: String::new(),
+        };
+        let refreshed = ChatAttachment {
+            size: 3,
+            ..first.clone()
+        };
+
+        let merged =
+            merge_chat_attachments(std::slice::from_ref(&first), &[second.clone(), refreshed]);
+
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].size, 3);
+        assert_eq!(merged[0].preview_data_url, first.preview_data_url);
+        assert_eq!(merged[1], second);
     }
 }

--- a/crates/vmux_command/src/prompt_media.rs
+++ b/crates/vmux_command/src/prompt_media.rs
@@ -302,6 +302,7 @@ mod tests {
         };
         let refreshed = ChatAttachment {
             size: 3,
+            preview_data_url: String::new(),
             ..first.clone()
         };
 

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -73,8 +73,6 @@ static IN_LIVE_RESIZE: AtomicBool = AtomicBool::new(false);
 static LIVE_RESIZE_MONITOR_INSTALLED: AtomicBool = AtomicBool::new(false);
 #[cfg(target_os = "macos")]
 static HOVER_OVER_PANE: AtomicBool = AtomicBool::new(false);
-#[cfg(target_os = "macos")]
-static NATIVE_WINDOWED_POINTER_INSIDE: AtomicBool = AtomicBool::new(false);
 
 #[cfg(target_os = "macos")]
 fn activate_primary_window_on_startup(
@@ -346,17 +344,12 @@ fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) 
                 | NSEventType::OtherMouseDown
                 | NSEventType::OtherMouseUp
         );
-        let scroll = event_type == NSEventType::ScrollWheel;
         let location = event_location_in_window_physical_px(ev);
-        let over_windowed_page =
-            location.is_some_and(|(x, y)| vmux_browser::native_windowed_page_contains_point(x, y));
-        let was_over_windowed_page =
-            NATIVE_WINDOWED_POINTER_INSIDE.swap(over_windowed_page, Ordering::Relaxed);
         let buttons = native_mouse_buttons();
         if let Some((x, y)) = location {
             vmux_layout::native_pointer::publish(Vec2::new(x, y), buttons, motion);
         }
-        let layout_pointer = (motion || button_event || scroll)
+        let layout_pointer = (motion || button_event)
             .then(|| {
                 location.map(|(x, y)| vmux_browser::queue_native_layout_pointer_move(x, y, buttons))
             })
@@ -382,12 +375,10 @@ fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) 
                 } else if result.pending {
                     flush_layout(interval);
                 }
-            } else if !over_windowed_page || !was_over_windowed_page || !event_window_is_key(ev) {
+            } else {
                 HOVER_OVER_PANE.store(true, Ordering::Relaxed);
                 local_wake(interval);
             }
-        } else if scroll {
-            local_wake(NATIVE_MOUSE_DRAG_WAKE_INTERVAL);
         } else {
             if layout_pointer.is_some_and(|result| {
                 result.owns_pointer && result.presenter_active && result.pending
@@ -513,14 +504,6 @@ fn event_location_in_window_physical_px(event: &objc2_app_kit::NSEvent) -> Optio
 }
 
 #[cfg(target_os = "macos")]
-fn event_window_is_key(event: &objc2_app_kit::NSEvent) -> bool {
-    let Some(mtm) = objc2::MainThreadMarker::new() else {
-        return false;
-    };
-    event.window(mtm).is_some_and(|window| window.isKeyWindow())
-}
-
-#[cfg(target_os = "macos")]
 fn native_mouse_buttons() -> bevy_cef_core::prelude::NativeMouseButtons {
     let pressed = objc2_app_kit::NSEvent::pressedMouseButtons();
     bevy_cef_core::prelude::NativeMouseButtons {
@@ -533,13 +516,13 @@ fn native_mouse_buttons() -> bevy_cef_core::prelude::NativeMouseButtons {
 /// `react_to_device_events` is off in browse (User) mode: native CEF views own scroll/input, so only
 /// Player mode's free camera consumes `AccumulatedMouseMotion`.
 ///
-/// At rest window events wake rendering except while native CEF content owns the pointer. Native
-/// hover and scroll then use explicit monitor wakes instead of rendering once per raw macOS pointer
-/// event. During live resize the 16ms timer caps rendering near 60Hz.
+/// At rest window events wake rendering except while native layout chrome owns the pointer. Layout
+/// hover and scroll then use the explicit 30Hz native monitor wake instead of rendering once per
+/// raw macOS pointer event. During live resize the 16ms timer caps rendering near 60Hz.
 pub(crate) fn foreground_winit_settings(
     player: bool,
     live_resize: bool,
-    native_pointer_inside: bool,
+    layout_pointer_inside: bool,
 ) -> WinitSettings {
     let focused_mode = if live_resize {
         UpdateMode::Reactive {
@@ -553,7 +536,7 @@ pub(crate) fn foreground_winit_settings(
             wait: FOCUSED_FRAME_INTERVAL,
             react_to_device_events: player,
             react_to_user_events: true,
-            react_to_window_events: player || !native_pointer_inside,
+            react_to_window_events: player || !layout_pointer_inside,
         }
     };
     WinitSettings {
@@ -584,17 +567,16 @@ fn sync_winit_power_mode(
     #[cfg(not(target_os = "macos"))]
     let live_resize = false;
     #[cfg(target_os = "macos")]
-    let native_pointer_inside = vmux_browser::native_layout_pointer_is_inside()
-        || NATIVE_WINDOWED_POINTER_INSIDE.load(Ordering::Relaxed);
+    let layout_pointer_inside = vmux_browser::native_layout_pointer_is_inside();
     #[cfg(not(target_os = "macos"))]
-    let native_pointer_inside = false;
+    let layout_pointer_inside = false;
     let next = if all_hidden {
         hidden_winit_settings()
     } else {
         foreground_winit_settings(
             *mode == InteractionMode::Player,
             live_resize,
-            native_pointer_inside,
+            layout_pointer_inside,
         )
     };
     if settings.focused_mode != next.focused_mode || settings.unfocused_mode != next.unfocused_mode
@@ -992,20 +974,6 @@ mod tests {
             "if result.region_changed {\n                    vmux_browser::flush_native_layout_pointer_move();\n                    local_wake(interval);\n                } else if result.pending {\n                    flush_layout(interval);\n                }"
         ));
         assert!(monitor.contains("layout_pointer.is_some_and"));
-    }
-
-    #[test]
-    fn native_mouse_motion_wakes_before_window_is_key() {
-        let source = include_str!("background_lifecycle.rs");
-        let monitor = source
-            .split("fn install_native_mouse_wake_monitor")
-            .nth(1)
-            .and_then(|tail| tail.split("fn foreground_winit_settings").next())
-            .unwrap_or_default();
-
-        assert!(monitor.contains("addLocalMonitorForEventsMatchingMask_handler"));
-        assert!(monitor.contains("addGlobalMonitorForEventsMatchingMask_handler"));
-        assert!(monitor.contains("!event_window_is_key(ev)"));
     }
 
     #[test]

--- a/crates/vmux_desktop/src/background_lifecycle.rs
+++ b/crates/vmux_desktop/src/background_lifecycle.rs
@@ -387,9 +387,7 @@ fn install_native_mouse_wake_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) 
                 local_wake(interval);
             }
         } else if scroll {
-            if layout_pointer.is_some_and(|result| result.owns_pointer) || !over_windowed_page {
-                local_wake(NATIVE_MOUSE_DRAG_WAKE_INTERVAL);
-            }
+            local_wake(NATIVE_MOUSE_DRAG_WAKE_INTERVAL);
         } else {
             if layout_pointer.is_some_and(|result| {
                 result.owns_pointer && result.presenter_active && result.pending
@@ -1021,21 +1019,6 @@ mod tests {
 
         assert!(monitor.contains("vmux_browser::set_native_left_mouse_down(true)"));
         assert!(monitor.contains("vmux_browser::set_native_left_mouse_down(false)"));
-    }
-
-    #[test]
-    fn native_layout_scroll_only_wakes_for_layout_regions() {
-        let source = include_str!("background_lifecycle.rs");
-        let monitor = source
-            .split("fn install_native_mouse_wake_monitor")
-            .nth(1)
-            .and_then(|tail| tail.split("fn foreground_winit_settings").next())
-            .unwrap_or_default();
-
-        assert!(monitor.contains("NSEventMask::ScrollWheel"));
-        assert!(monitor.contains("else if scroll"));
-        assert!(monitor.contains("layout_pointer.is_some_and(|result| result.owns_pointer)"));
-        assert!(monitor.contains("|| !over_windowed_page"));
     }
 
     #[test]

--- a/crates/vmux_desktop/src/event_tap.rs
+++ b/crates/vmux_desktop/src/event_tap.rs
@@ -73,6 +73,12 @@ unsafe extern "C-unwind" fn tap_callback(
     event: NonNull<CGEvent>,
     _user_info: *mut c_void,
 ) -> *mut CGEvent {
+    TAP_STATE.with(|s| {
+        if let Some(state) = s.borrow().as_ref() {
+            (state.wake)();
+        }
+    });
+
     if event_type == CGEventType::TapDisabledByTimeout
         || event_type == CGEventType::TapDisabledByUserInput
     {
@@ -83,12 +89,6 @@ unsafe extern "C-unwind" fn tap_callback(
         });
         return event.as_ptr();
     }
-
-    TAP_STATE.with(|s| {
-        if let Some(state) = s.borrow().as_ref() {
-            (state.wake)();
-        }
-    });
 
     if event_type != CGEventType::KeyDown {
         return event.as_ptr();

--- a/crates/vmux_desktop/src/event_tap.rs
+++ b/crates/vmux_desktop/src/event_tap.rs
@@ -84,6 +84,12 @@ unsafe extern "C-unwind" fn tap_callback(
         return event.as_ptr();
     }
 
+    TAP_STATE.with(|s| {
+        if let Some(state) = s.borrow().as_ref() {
+            (state.wake)();
+        }
+    });
+
     if event_type != CGEventType::KeyDown {
         return event.as_ptr();
     }
@@ -97,11 +103,6 @@ unsafe extern "C-unwind" fn tap_callback(
 
     match gate(app_is_frontmost(), || classify(combo)) {
         TapOutcome::Consume(cmd) => {
-            TAP_STATE.with(|s| {
-                if let Some(state) = s.borrow().as_ref() {
-                    (state.wake)();
-                }
-            });
             if let Some(cmd) = cmd {
                 push_command(cmd);
             }

--- a/crates/vmux_desktop/src/native_keyboard.rs
+++ b/crates/vmux_desktop/src/native_keyboard.rs
@@ -49,12 +49,6 @@ pub(crate) enum KeyAction {
     PassThrough,
 }
 
-impl KeyAction {
-    fn is_consumed(&self) -> bool {
-        matches!(self, Self::Consume(_))
-    }
-}
-
 pub(crate) fn decide(
     map: &ShortcutMap,
     pending: &mut Option<(KeyCombo, Instant)>,
@@ -201,6 +195,7 @@ pub(crate) fn key_code_from_vk(vk: u16) -> Option<KeyCode> {
 fn install(wake: impl Fn() + Send + Sync + 'static) {
     let block = block2::RcBlock::new(move |event: NonNull<NSEvent>| -> *mut NSEvent {
         let ev = unsafe { event.as_ref() };
+        wake();
         if ev.r#type() != NSEventType::KeyDown {
             return event.as_ptr();
         }
@@ -209,11 +204,7 @@ fn install(wake: impl Fn() + Send + Sync + 'static) {
         let Some(combo) = translate(key_code, flags) else {
             return event.as_ptr();
         };
-        let action = classify(combo);
-        if action.is_consumed() {
-            wake();
-        }
-        match action {
+        match classify(combo) {
             KeyAction::Consume(cmd) => {
                 if let Some(cmd) = cmd {
                     PENDING_COMMANDS.lock().push(cmd);
@@ -328,18 +319,6 @@ mod tests {
             Instant::now(),
         );
         assert!(matches!(action, KeyAction::PassThrough));
-        assert!(!action.is_consumed());
-    }
-
-    #[test]
-    fn consumed_shortcut_requires_host_wake() {
-        assert!(KeyAction::Consume(None).is_consumed());
-        assert!(
-            KeyAction::Consume(Some(AppCommand::Layout(LayoutCommand::Pane(
-                PaneCommand::SelectLeft
-            ),)))
-            .is_consumed()
-        );
     }
 
     #[test]

--- a/crates/vmux_desktop/src/native_keyboard.rs
+++ b/crates/vmux_desktop/src/native_keyboard.rs
@@ -101,6 +101,23 @@ pub(crate) fn push_command(cmd: AppCommand) {
     PENDING_COMMANDS.lock().push(cmd);
 }
 
+fn handle_key_action(
+    action: KeyAction,
+    wake: impl FnOnce(),
+    mut queue: impl FnMut(AppCommand),
+) -> bool {
+    match action {
+        KeyAction::Consume(cmd) => {
+            wake();
+            if let Some(cmd) = cmd {
+                queue(cmd);
+            }
+            true
+        }
+        KeyAction::PassThrough => false,
+    }
+}
+
 fn translate(key_code: u16, flags: NSEventModifierFlags) -> Option<KeyCombo> {
     let key = key_code_from_vk(key_code)?;
     let modifiers = Modifiers {
@@ -203,15 +220,12 @@ fn install(wake: impl Fn() + Send + Sync + 'static) {
         let Some(combo) = translate(key_code, flags) else {
             return event.as_ptr();
         };
-        match classify(combo) {
-            KeyAction::Consume(cmd) => {
-                wake();
-                if let Some(cmd) = cmd {
-                    PENDING_COMMANDS.lock().push(cmd);
-                }
-                std::ptr::null_mut()
-            }
-            KeyAction::PassThrough => event.as_ptr(),
+        if handle_key_action(classify(combo), &wake, |cmd| {
+            PENDING_COMMANDS.lock().push(cmd);
+        }) {
+            std::ptr::null_mut()
+        } else {
+            event.as_ptr()
         }
     });
     let mask = NSEventMask::KeyDown | NSEventMask::KeyUp | NSEventMask::FlagsChanged;
@@ -319,6 +333,29 @@ mod tests {
             Instant::now(),
         );
         assert!(matches!(action, KeyAction::PassThrough));
+    }
+
+    #[test]
+    fn consumed_shortcut_wakes_and_queues_command() {
+        let mut woke = false;
+        let mut queued = Vec::new();
+
+        let consumed = handle_key_action(
+            KeyAction::Consume(Some(AppCommand::Layout(LayoutCommand::Pane(
+                PaneCommand::SelectLeft,
+            )))),
+            || woke = true,
+            |command| queued.push(command),
+        );
+
+        assert!(consumed);
+        assert!(woke);
+        assert!(matches!(
+            queued.as_slice(),
+            [AppCommand::Layout(LayoutCommand::Pane(
+                PaneCommand::SelectLeft
+            ))]
+        ));
     }
 
     #[test]

--- a/crates/vmux_desktop/src/native_keyboard.rs
+++ b/crates/vmux_desktop/src/native_keyboard.rs
@@ -195,7 +195,6 @@ pub(crate) fn key_code_from_vk(vk: u16) -> Option<KeyCode> {
 fn install(wake: impl Fn() + Send + Sync + 'static) {
     let block = block2::RcBlock::new(move |event: NonNull<NSEvent>| -> *mut NSEvent {
         let ev = unsafe { event.as_ref() };
-        wake();
         if ev.r#type() != NSEventType::KeyDown {
             return event.as_ptr();
         }
@@ -206,6 +205,7 @@ fn install(wake: impl Fn() + Send + Sync + 'static) {
         };
         match classify(combo) {
             KeyAction::Consume(cmd) => {
+                wake();
                 if let Some(cmd) = cmd {
                     PENDING_COMMANDS.lock().push(cmd);
                 }

--- a/crates/vmux_editor/src/lsp/manager_page.rs
+++ b/crates/vmux_editor/src/lsp/manager_page.rs
@@ -40,7 +40,7 @@ impl Plugin for ManagerPlugin {
                 host: "lsp",
                 url: "vmux://lsp/",
                 title: "Language Servers",
-                pool_size: 1,
+                pool_size: 0,
             },
         ));
         vmux_core::register_host_spawn(app, "lsp");

--- a/crates/vmux_git/src/plugin.rs
+++ b/crates/vmux_git/src/plugin.rs
@@ -1,7 +1,10 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, mpsc};
+use std::time::{Duration, Instant};
 
+use bevy::tasks::{IoTaskPool, Task, futures_lite::future};
+use bevy::winit::{EventLoopProxyWrapper, WinitUserEvent};
 use bevy_cef::prelude::{BinEventEmitterPlugin, BinHostEmitEvent, BinReceive};
 use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 
@@ -74,6 +77,13 @@ impl GitStatusJobs {
 struct GitWatchTarget {
     path: PathBuf,
     recursive: bool,
+    kind: GitWatchKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum GitWatchKind {
+    Worktree,
+    Metadata,
 }
 
 struct GitSubscription {
@@ -88,6 +98,89 @@ struct GitWatch {
     rx: mpsc::Receiver<notify::Result<notify::Event>>,
     watched: HashSet<GitWatchTarget>,
     subscriptions: HashMap<Entity, GitSubscription>,
+    repo_info_subscriptions: HashMap<PathBuf, Vec<GitWatchTarget>>,
+}
+
+struct RepoInfoCacheEntry {
+    info: Option<crate::worktree::RepoInfo>,
+    loaded: bool,
+    dirty: bool,
+    watched: bool,
+    pending: Option<Task<Option<crate::worktree::RepoInfo>>>,
+    ignore_events_until: Option<Instant>,
+}
+
+#[derive(Resource)]
+pub struct RepoInfoCache {
+    entries: HashMap<PathBuf, RepoInfoCacheEntry>,
+    wake: Option<bevy::winit::EventLoopProxy<WinitUserEvent>>,
+}
+
+impl RepoInfoCache {
+    pub fn get(&mut self, path: &Path) -> Option<crate::worktree::RepoInfo> {
+        let path = canon(path);
+        let wake = self.wake.clone();
+        let entry = self
+            .entries
+            .entry(path.clone())
+            .or_insert_with(|| RepoInfoCacheEntry {
+                info: None,
+                loaded: false,
+                dirty: true,
+                watched: false,
+                pending: None,
+                ignore_events_until: None,
+            });
+        Self::poll_and_refresh(&path, entry, wake);
+        entry.info.clone()
+    }
+
+    fn poll_and_refresh(
+        path: &Path,
+        entry: &mut RepoInfoCacheEntry,
+        wake: Option<bevy::winit::EventLoopProxy<WinitUserEvent>>,
+    ) {
+        if let Some(task) = entry.pending.as_mut()
+            && let Some(info) = future::block_on(future::poll_once(task))
+        {
+            entry.info = info;
+            entry.loaded = true;
+            entry.watched = false;
+            entry.pending = None;
+            entry.ignore_events_until = Some(Instant::now() + Duration::from_millis(500));
+        }
+        if entry.pending.is_none() && (entry.dirty || !entry.loaded) {
+            entry.dirty = false;
+            let path = path.to_path_buf();
+            let delay = entry
+                .ignore_events_until
+                .and_then(|deadline| deadline.checked_duration_since(Instant::now()))
+                .unwrap_or_default();
+            entry.pending = Some(IoTaskPool::get().spawn(async move {
+                if !delay.is_zero() {
+                    std::thread::sleep(delay);
+                }
+                let info = crate::worktree::repo_info(&path);
+                if let Some(wake) = wake {
+                    let _ = wake.send_event(WinitUserEvent::WakeUp);
+                }
+                info
+            }));
+        }
+    }
+
+    fn poll(&mut self) {
+        let wake = self.wake.clone();
+        for (path, entry) in &mut self.entries {
+            Self::poll_and_refresh(path, entry, wake.clone());
+        }
+    }
+
+    fn invalidate(&mut self, path: &Path) {
+        if let Some(entry) = self.entries.get_mut(path) {
+            entry.dirty = true;
+        }
+    }
 }
 
 fn canon(path: &Path) -> PathBuf {
@@ -134,16 +227,19 @@ fn git_watch_targets(
     let mut targets = vec![GitWatchTarget {
         path: git_dir.clone(),
         recursive: false,
+        kind: GitWatchKind::Metadata,
     }];
     if common_dir != git_dir {
         targets.push(GitWatchTarget {
             path: common_dir.clone(),
             recursive: false,
+            kind: GitWatchKind::Metadata,
         });
     }
     targets.push(GitWatchTarget {
         path: common_dir.join("refs"),
         recursive: true,
+        kind: GitWatchKind::Metadata,
     });
     Ok((root, targets))
 }
@@ -154,16 +250,78 @@ fn is_git_lock_path(path: &Path) -> bool {
 }
 
 fn target_matches(target: &GitWatchTarget, changed: &Path) -> bool {
-    if is_git_lock_path(changed) {
-        return false;
-    }
     let changed = canon(changed);
-    changed == target.path
+    let matches = changed == target.path
         || if target.recursive {
             changed.starts_with(&target.path)
         } else {
             changed.parent() == Some(target.path.as_path())
+        };
+    if !matches {
+        return false;
+    }
+    match target.kind {
+        GitWatchKind::Metadata => !is_git_lock_path(&changed),
+        GitWatchKind::Worktree => changed
+            .strip_prefix(&target.path)
+            .ok()
+            .is_none_or(|relative| {
+                !relative
+                    .components()
+                    .any(|component| component.as_os_str() == ".git")
+            }),
+    }
+}
+
+fn repo_info_watch_targets(
+    path: &Path,
+    info: Option<&crate::worktree::RepoInfo>,
+) -> Vec<GitWatchTarget> {
+    let Some(info) = info else {
+        return vec![GitWatchTarget {
+            path: canon(path),
+            recursive: true,
+            kind: GitWatchKind::Worktree,
+        }];
+    };
+    let repo_root = canon(&info.repo_root);
+    let git_dir = canon(&info.git_dir);
+    let common_dir = canon(&info.common_dir);
+    let mut targets = vec![
+        GitWatchTarget {
+            path: repo_root,
+            recursive: true,
+            kind: GitWatchKind::Worktree,
+        },
+        GitWatchTarget {
+            path: git_dir.clone(),
+            recursive: false,
+            kind: GitWatchKind::Metadata,
+        },
+    ];
+    if common_dir != git_dir {
+        targets.push(GitWatchTarget {
+            path: common_dir.clone(),
+            recursive: false,
+            kind: GitWatchKind::Metadata,
+        });
+    }
+    targets.push(GitWatchTarget {
+        path: common_dir.join("refs"),
+        recursive: true,
+        kind: GitWatchKind::Metadata,
+    });
+    targets
+}
+
+fn should_forward_git_watch_result(result: &notify::Result<notify::Event>) -> bool {
+    match result {
+        Ok(event) => {
+            !matches!(event.kind, EventKind::Access(_))
+                && event.paths.iter().any(|path| !is_git_lock_path(path))
         }
+        Err(_) => true,
+    }
 }
 
 impl GitWatch {
@@ -210,6 +368,38 @@ impl GitWatch {
         );
         Ok(repo_root)
     }
+
+    fn subscribe_repo_info(
+        &mut self,
+        path: &Path,
+        info: Option<&crate::worktree::RepoInfo>,
+    ) -> bool {
+        let path = canon(path);
+        let targets = repo_info_watch_targets(&path, info);
+        if self.repo_info_subscriptions.get(&path) == Some(&targets) {
+            return true;
+        }
+        let mut complete = true;
+        for target in &targets {
+            if self.watched.contains(target) {
+                continue;
+            }
+            let mode = if target.recursive {
+                RecursiveMode::Recursive
+            } else {
+                RecursiveMode::NonRecursive
+            };
+            if self.watcher.watch(&target.path, mode).is_ok() {
+                self.watched.insert(target.clone());
+            } else {
+                complete = false;
+            }
+        }
+        if complete {
+            self.repo_info_subscriptions.insert(path, targets);
+        }
+        complete
+    }
 }
 
 /// Wires the git bridge: runs each git request on a background thread and drains completed
@@ -224,12 +414,11 @@ impl Plugin for GitPlugin {
             .get_resource::<bevy::winit::EventLoopProxyWrapper>()
             .map(|wrapper| (**wrapper).clone());
         match notify::recommended_watcher(move |result: notify::Result<notify::Event>| {
-            let wake = result.as_ref().is_ok_and(|event| {
-                !matches!(event.kind, EventKind::Access(_))
-                    && event.paths.iter().any(|path| !is_git_lock_path(path))
-            });
+            if !should_forward_git_watch_result(&result) {
+                return;
+            }
             let _ = tx.send(result);
-            if wake && let Some(proxy) = proxy.as_ref() {
+            if let Some(proxy) = proxy.as_ref() {
                 let _ = proxy.send_event(bevy::winit::WinitUserEvent::WakeUp);
             }
         }) {
@@ -239,12 +428,21 @@ impl Plugin for GitPlugin {
                     rx,
                     watched: HashSet::new(),
                     subscriptions: HashMap::new(),
+                    repo_info_subscriptions: HashMap::new(),
                 });
             }
             Err(error) => bevy::log::warn!("git watcher init failed: {error}"),
         }
+        let repo_info_wake = app
+            .world()
+            .get_resource::<EventLoopProxyWrapper>()
+            .map(|wrapper| (**wrapper).clone());
         app.init_resource::<GitOutbox>()
             .init_resource::<GitStatusJobs>()
+            .insert_resource(RepoInfoCache {
+                entries: HashMap::new(),
+                wake: repo_info_wake,
+            })
             .add_plugins(BinEventEmitterPlugin::<(
                 GitStatusRequest,
                 GitDiffRequest,
@@ -265,7 +463,14 @@ impl Plugin for GitPlugin {
             .add_observer(on_hunk_request)
             .add_systems(
                 Update,
-                (drain_git_watch, drain_git_outbox, dispatch_status_jobs).chain(),
+                (
+                    drain_git_watch,
+                    poll_repo_info_cache,
+                    sync_repo_info_watches,
+                    drain_git_outbox,
+                    dispatch_status_jobs,
+                )
+                    .chain(),
             );
     }
 }
@@ -367,7 +572,11 @@ fn dispatch_status_jobs(mut jobs: ResMut<GitStatusJobs>, outbox: Res<GitOutbox>)
     }
 }
 
-fn drain_git_watch(watch: Option<NonSendMut<GitWatch>>, mut commands: Commands) {
+fn drain_git_watch(
+    watch: Option<NonSendMut<GitWatch>>,
+    mut repo_info: ResMut<RepoInfoCache>,
+    mut commands: Commands,
+) {
     let Some(watch) = watch else {
         return;
     };
@@ -401,6 +610,47 @@ fn drain_git_watch(watch: Option<NonSendMut<GitWatch>>, mut commands: Commands) 
             GIT_CHANGED_EVENT,
             &GitChangedEvent {},
         ));
+    }
+    let affected_repo_info: Vec<PathBuf> = watch
+        .repo_info_subscriptions
+        .iter()
+        .filter(|(_, targets)| {
+            targets
+                .iter()
+                .any(|target| changed.iter().any(|path| target_matches(target, path)))
+        })
+        .map(|(path, _)| path.clone())
+        .collect();
+    for path in affected_repo_info {
+        repo_info.invalidate(&path);
+    }
+}
+
+fn poll_repo_info_cache(mut repo_info: ResMut<RepoInfoCache>) {
+    repo_info.poll();
+}
+
+fn sync_repo_info_watches(
+    watch: Option<NonSendMut<GitWatch>>,
+    mut repo_info: ResMut<RepoInfoCache>,
+) {
+    let Some(mut watch) = watch else {
+        return;
+    };
+    let paths: Vec<PathBuf> = repo_info
+        .entries
+        .iter()
+        .filter_map(|(path, entry)| (entry.loaded && !entry.watched).then_some(path.clone()))
+        .collect();
+    for path in paths {
+        let info = repo_info
+            .entries
+            .get(&path)
+            .and_then(|entry| entry.info.clone());
+        let watched = watch.subscribe_repo_info(&path, info.as_ref());
+        if let Some(entry) = repo_info.entries.get_mut(&path) {
+            entry.watched = watched;
+        }
     }
 }
 
@@ -544,10 +794,12 @@ mod tests {
         assert!(targets.contains(&GitWatchTarget {
             path: git_dir.clone(),
             recursive: false,
+            kind: GitWatchKind::Metadata,
         }));
         assert!(targets.contains(&GitWatchTarget {
             path: git_dir.join("refs"),
             recursive: true,
+            kind: GitWatchKind::Metadata,
         }));
     }
 
@@ -582,10 +834,12 @@ mod tests {
         assert!(targets.contains(&GitWatchTarget {
             path: common.clone(),
             recursive: false,
+            kind: GitWatchKind::Metadata,
         }));
         assert!(targets.contains(&GitWatchTarget {
             path: common.join("refs"),
             recursive: true,
+            kind: GitWatchKind::Metadata,
         }));
     }
 
@@ -595,10 +849,12 @@ mod tests {
         let direct = GitWatchTarget {
             path: root.clone(),
             recursive: false,
+            kind: GitWatchKind::Metadata,
         };
         let recursive = GitWatchTarget {
             path: root.clone(),
             recursive: true,
+            kind: GitWatchKind::Metadata,
         };
 
         assert!(target_matches(&direct, &root.join("index")));
@@ -609,6 +865,106 @@ mod tests {
             &recursive,
             &root.join("refs/heads/main.lock")
         ));
+
+        let worktree = GitWatchTarget {
+            path: root.clone(),
+            recursive: true,
+            kind: GitWatchKind::Worktree,
+        };
+        assert!(target_matches(&worktree, &root.join("Cargo.lock")));
+        assert!(!target_matches(&worktree, &root.join(".git/index")));
+    }
+
+    #[test]
+    fn repo_info_targets_cover_the_checkout_and_git_metadata() {
+        let repo = test_repo::init();
+        let file = test_repo::write(repo.path(), "a.txt", "one\n");
+        test_repo::run(repo.path(), &["add", "a.txt"]);
+        test_repo::run(repo.path(), &["commit", "-qm", "init"]);
+        let info = crate::worktree::repo_info(repo.path()).unwrap();
+        let targets = repo_info_watch_targets(repo.path(), Some(&info));
+
+        assert!(
+            targets
+                .iter()
+                .any(|target| target_matches(target, &file))
+        );
+        assert!(
+            targets
+                .iter()
+                .any(|target| target_matches(target, &info.git_dir.join("HEAD")))
+        );
+        assert!(
+            targets
+                .iter()
+                .all(|target| !target_matches(target, &info.git_dir.join("index.lock")))
+        );
+    }
+
+    #[test]
+    fn repo_info_cache_refreshes_only_after_invalidation() {
+        IoTaskPool::get_or_init(bevy::tasks::TaskPool::new);
+        let repo = test_repo::init();
+        test_repo::write(repo.path(), "a.txt", "one\n");
+        test_repo::run(repo.path(), &["add", "a.txt"]);
+        test_repo::run(repo.path(), &["commit", "-qm", "init"]);
+        let path = canon(repo.path());
+        let mut cache = RepoInfoCache {
+            entries: HashMap::new(),
+            wake: None,
+        };
+        let wait_for = |cache: &mut RepoInfoCache, expected| {
+            for _ in 0..100 {
+                if let Some(info) = cache.get(&path)
+                    && info.uncommitted == expected
+                {
+                    return info;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            panic!("repo info did not reach uncommitted={expected}");
+        };
+
+        assert_eq!(wait_for(&mut cache, 0).uncommitted, 0);
+        test_repo::write(repo.path(), "a.txt", "two\n");
+        assert_eq!(cache.get(&path).unwrap().uncommitted, 0);
+        cache.invalidate(&path);
+        assert_eq!(wait_for(&mut cache, 1).uncommitted, 1);
+    }
+
+    #[test]
+    fn repo_info_cache_keeps_changes_that_arrive_during_refresh() {
+        IoTaskPool::get_or_init(bevy::tasks::TaskPool::new);
+        let repo = test_repo::init();
+        test_repo::write(repo.path(), "a.txt", "one\n");
+        test_repo::run(repo.path(), &["add", "a.txt"]);
+        test_repo::run(repo.path(), &["commit", "-qm", "init"]);
+        let path = canon(repo.path());
+        let stale = crate::worktree::repo_info(&path);
+        test_repo::write(repo.path(), "a.txt", "two\n");
+        let mut cache = RepoInfoCache {
+            entries: HashMap::from([(
+                path.clone(),
+                RepoInfoCacheEntry {
+                    info: None,
+                    loaded: false,
+                    dirty: false,
+                    watched: false,
+                    pending: Some(IoTaskPool::get().spawn(async move { stale })),
+                    ignore_events_until: None,
+                },
+            )]),
+            wake: None,
+        };
+
+        cache.invalidate(&path);
+        for _ in 0..100 {
+            if cache.get(&path).is_some_and(|info| info.uncommitted == 1) {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("repo info stayed stale after an in-flight invalidation");
     }
 
     #[test]

--- a/crates/vmux_git/src/runner.rs
+++ b/crates/vmux_git/src/runner.rs
@@ -93,7 +93,7 @@ pub(crate) fn git(root: &Path, args: &[&str]) -> Result<(String, String, bool), 
     ))
 }
 
-fn git_read(root: &Path, args: &[&str]) -> Result<(String, String, bool), GitError> {
+pub(crate) fn git_read(root: &Path, args: &[&str]) -> Result<(String, String, bool), GitError> {
     let out = git_command(root)
         .env("GIT_OPTIONAL_LOCKS", "0")
         .args(args)

--- a/crates/vmux_git/src/worktree.rs
+++ b/crates/vmux_git/src/worktree.rs
@@ -8,7 +8,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::runner::{GitError, git, git_err};
+use crate::runner::{GitError, git, git_err, git_read};
 
 /// A vmux-managed worktree: its checkout path, branch, base ref, and owning repo root.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -401,18 +401,60 @@ pub struct RepoInfo {
     pub is_worktree: bool,
     pub uncommitted: u32,
     pub ahead: u32,
+    pub(crate) repo_root: PathBuf,
+    pub(crate) git_dir: PathBuf,
+    pub(crate) common_dir: PathBuf,
 }
 
 /// Detect git info for `dir`: `None` if it isn't inside a git repo, else the current branch,
 /// whether it's a linked worktree, and uncommitted/ahead counts. Auto-detected from git alone.
 pub fn repo_info(dir: &Path) -> Option<RepoInfo> {
-    repo_root_of(dir).ok()?;
-    let status = worktree_status(dir).unwrap_or_default();
+    let (status, _, ok) = git_read(dir, &["status", "--porcelain=v2", "--branch"]).ok()?;
+    if !ok {
+        return None;
+    }
+    let branch = status
+        .lines()
+        .find_map(|line| line.strip_prefix("# branch.head "))
+        .filter(|branch| *branch != "(detached)")
+        .unwrap_or_default()
+        .to_string();
+    let ahead = status
+        .lines()
+        .find_map(|line| line.strip_prefix("# branch.ab +"))
+        .and_then(|value| value.split_once(' '))
+        .and_then(|(ahead, _)| ahead.parse::<u32>().ok())
+        .unwrap_or_default();
+    let uncommitted = status
+        .lines()
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .count() as u32;
+    let (dirs, _, ok) = git_read(
+        dir,
+        &[
+            "rev-parse",
+            "--path-format=absolute",
+            "--show-toplevel",
+            "--git-dir",
+            "--git-common-dir",
+        ],
+    )
+    .ok()?;
+    if !ok {
+        return None;
+    }
+    let mut dirs = dirs.lines().map(PathBuf::from);
+    let repo_root = dirs.next()?;
+    let git_dir = dirs.next()?;
+    let common_dir = dirs.next()?;
     Some(RepoInfo {
-        branch: head_ref(dir).unwrap_or_default(),
-        is_worktree: is_linked_worktree(dir),
-        uncommitted: status.uncommitted,
-        ahead: status.ahead,
+        branch,
+        is_worktree: git_dir != common_dir,
+        uncommitted,
+        ahead,
+        repo_root,
+        git_dir,
+        common_dir,
     })
 }
 

--- a/crates/vmux_history/src/plugin.rs
+++ b/crates/vmux_history/src/plugin.rs
@@ -28,7 +28,7 @@ impl Plugin for HistoryPlugin {
                 host: "history",
                 url: "vmux://history/",
                 title: "History",
-                pool_size: 1,
+                pool_size: 0,
             },
         ));
         vmux_core::register_host_spawn(app, "history");

--- a/crates/vmux_layout/src/archive.rs
+++ b/crates/vmux_layout/src/archive.rs
@@ -23,7 +23,8 @@ use crate::settings::LayoutSettings;
 use crate::space::{ActiveSpaceEntity, Space, SpaceId, space_of};
 use crate::stack::{ActiveTabParam, FocusedStack, Stack, StackCommandSet, stack_bundle};
 use crate::tab::{
-    CloseTabRequest, LastTabCloseAt, Tab, active_tab_siblings, pick_after_close, tab_bundle,
+    CloseTabRequest, LastTabCloseAt, Tab, TabReplacementSource, active_tab_siblings,
+    pick_after_close, tab_bundle,
 };
 use crate::window::spawn_tab_scaffold_in_space;
 use crate::{TabLayoutSpawnContent, TabLayoutSpawnRequest};
@@ -304,9 +305,9 @@ pub(crate) fn handle_close_tab_requests(
     active_tab_param: ActiveTabParam,
     tab_data: Query<&Tab>,
     tab_q: Query<Entity, With<Tab>>,
+    replacement_sources: Query<(), With<TabReplacementSource>>,
     layout: TabArchiveLayout,
     primary_window: Single<Entity, With<PrimaryWindow>>,
-    effective_startup_dir: Option<Res<crate::settings::EffectiveStartupDir>>,
     mut layout_requests: MessageWriter<TabLayoutSpawnRequest>,
     mut last_tab_close: ResMut<LastTabCloseAt>,
     mut commands: Commands,
@@ -316,6 +317,7 @@ pub(crate) fn handle_close_tab_requests(
         .read()
         .filter_map(|request| seen.insert(request.tab).then_some(request.tab))
         .filter(|tab| tab_data.contains(*tab))
+        .filter(|tab| !replacement_sources.contains(*tab))
         .collect();
     let closing: HashSet<Entity> = requests.iter().copied().collect();
     let mut replacement_spaces = HashSet::new();
@@ -331,6 +333,7 @@ pub(crate) fn handle_close_tab_requests(
             .copied()
             .filter(|sibling| !closing.contains(sibling))
             .collect();
+        let mut defer_despawn = false;
         if surviving_siblings.is_empty() {
             let Ok(tab_space) = layout
                 .child_of
@@ -339,26 +342,24 @@ pub(crate) fn handle_close_tab_requests(
             else {
                 continue;
             };
-            if !replacement_spaces.contains(&tab_space) {
-                let Some((space, startup_dir)) = effective_startup_dir
-                    .as_deref()
-                    .and_then(|effective| effective.0.clone())
-                else {
-                    continue;
-                };
-                if space != tab_space {
-                    continue;
-                }
+            let preferred_source = active_tab_param
+                .get()
+                .filter(|active| siblings.contains(active) && closing.contains(active))
+                .unwrap_or(request.tab);
+            if request.tab == preferred_source && !replacement_spaces.contains(&tab_space) {
                 layout_requests.write(TabLayoutSpawnRequest {
-                    space,
+                    space: tab_space,
                     primary_window: *primary_window,
-                    name: Some(format!("Tab {}", tab_q.iter().count() + 1)),
-                    startup_dir: startup_dir.clone(),
+                    name: Some("Tab 1".to_string()),
+                    startup_dir: None,
                     content: TabLayoutSpawnContent::StartupUrlOrPrompt,
                     clear_pending_stack: true,
-                    focus: true,
+                    focus: false,
+                    replaces: Some(request.tab),
                 });
-                replacement_spaces.insert(space);
+                replacement_spaces.insert(tab_space);
+                commands.entity(request.tab).insert(TabReplacementSource);
+                defer_despawn = true;
             }
         } else if active_tab_param.get() == Some(request.tab)
             && let Some(next) = pick_after_close(
@@ -377,7 +378,9 @@ pub(crate) fn handle_close_tab_requests(
 
         archive_tab(request.tab, tab, &layout, &mut commands);
         last_tab_close.0 = Some(std::time::Instant::now());
-        commands.entity(request.tab).despawn();
+        if !defer_despawn {
+            commands.entity(request.tab).despawn();
+        }
     }
 }
 
@@ -1642,8 +1645,13 @@ mod tests {
 
         app.update();
 
-        assert!(app.world().get_entity(first).is_err());
+        assert!(app.world().get_entity(first).is_ok());
         assert!(app.world().get_entity(second).is_err());
+        assert!(
+            app.world()
+                .get::<crate::tab::TabReplacementSource>(first)
+                .is_some()
+        );
         let requests: Vec<TabLayoutSpawnRequest> = app
             .world_mut()
             .resource_mut::<Messages<TabLayoutSpawnRequest>>()
@@ -1651,6 +1659,9 @@ mod tests {
             .collect();
         assert_eq!(requests.len(), 1);
         assert_eq!(requests[0].space, space);
+        assert_eq!(requests[0].startup_dir, None);
+        assert!(!requests[0].focus);
+        assert_eq!(requests[0].replaces, Some(first));
     }
 
     fn reopen_app() -> App {

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -50,7 +50,6 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 
 const HOST_SEARCH_DEBOUNCE_MS: i32 = 300;
-const START_QUERY_COMMIT_DEBOUNCE_MS: i32 = 80;
 
 type HostSearchTimer = Rc<RefCell<Option<(i32, js_sys::Function, Rc<Cell<bool>>)>>>;
 
@@ -65,7 +64,7 @@ fn cancel_host_search(timer: &HostSearchTimer) {
     let _ = callback.call0(&JsValue::NULL);
 }
 
-fn schedule_deferred(timer: HostSearchTimer, delay_ms: i32, callback: impl FnOnce() + 'static) {
+fn schedule_host_search(timer: HostSearchTimer, callback: impl FnOnce() + 'static) {
     cancel_host_search(&timer);
     let Some(window) = web_sys::window() else {
         return;
@@ -80,30 +79,14 @@ fn schedule_deferred(timer: HostSearchTimer, delay_ms: i32, callback: impl FnOnc
         }
     })
     .unchecked_into::<js_sys::Function>();
-    match window.set_timeout_with_callback_and_timeout_and_arguments_0(&callback, delay_ms) {
+    match window
+        .set_timeout_with_callback_and_timeout_and_arguments_0(&callback, HOST_SEARCH_DEBOUNCE_MS)
+    {
         Ok(id) => *timer.borrow_mut() = Some((id, callback, cancelled)),
         Err(_) => {
             let _ = callback.call0(&JsValue::NULL);
         }
     }
-}
-
-fn schedule_host_search(timer: HostSearchTimer, callback: impl FnOnce() + 'static) {
-    schedule_deferred(timer, HOST_SEARCH_DEBOUNCE_MS, callback);
-}
-
-fn set_query_immediately(
-    mut query: Signal<String>,
-    mut live_query: Signal<String>,
-    mut query_revision: Signal<u64>,
-    timer: &HostSearchTimer,
-    value: String,
-) {
-    cancel_host_search(timer);
-    live_query.set(value.clone());
-    query.set(value);
-    let revision = (*query_revision.peek()).wrapping_add(1);
-    query_revision.set(revision);
 }
 
 /// Where a [`CommandPalette`] is rendered: the Cmd+K modal or the `vmux://start/` page.
@@ -153,9 +136,6 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let on_start_agent_transition = props.on_start_agent_transition;
 
     let mut query = use_signal(String::new);
-    let mut live_query = use_signal(String::new);
-    let query_revision = use_signal(|| 0u64);
-    let start_query_timer: HostSearchTimer = use_hook(|| Rc::new(RefCell::new(None)));
     let mut selected = use_signal(|| 0usize);
     let mut nav_mode = use_signal(|| false);
     let mut path_completions = use_signal(Vec::<PathEntry>::new);
@@ -178,18 +158,11 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let mut start_agent_menu_open = use_signal(|| false);
 
     let path_search_effect_timer = path_search_timer.clone();
-    let state_query_timer = start_query_timer.clone();
     use_effect(move || {
         let s = state();
         if last_open_id() != s.open_id {
             last_open_id.set(s.open_id);
-            set_query_immediately(
-                query,
-                live_query,
-                query_revision,
-                &state_query_timer,
-                s.url.clone(),
-            );
+            query.set(s.url.clone());
             selected.set(if s.space_switch {
                 active_space_index(&s.spaces)
             } else {
@@ -362,9 +335,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
         });
     });
 
-    let drop_start_query_timer = start_query_timer.clone();
     use_drop(move || {
-        cancel_host_search(&drop_start_query_timer);
         cancel_host_search(&path_search_timer);
         cancel_host_search(&suggestions_search_timer);
         cancel_host_search(&media_search_timer);
@@ -589,11 +560,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     });
 
     let execute = move |item: &ResultItem| {
-        let prompt = if is_start {
-            live_query.peek().clone()
-        } else {
-            query()
-        };
+        let prompt = query();
         let transition = if is_start
             && let Some(agent_url) = agent_page_url(item)
             && crate::start::supports_inline_agent_transition(agent_url)
@@ -845,24 +812,16 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
             }
         }
     };
+    let start_keydown_q = q.clone();
     let start_keydown_results = results.clone();
     let start_keydown_default_agent = default_agent_item.clone();
     let start_keydown_nav = nav;
     let start_keydown_ghost = ghost_text.clone();
-    let start_keydown_query_timer = start_query_timer.clone();
     let start_keydown = move |e: KeyboardEvent| {
-        let start_keydown_q = live_query.peek().clone();
-        let start_keydown_prompt_mode = is_start_prompt_query(&start_keydown_q);
         if e.key() == Key::Tab {
             e.prevent_default();
             if !start_keydown_ghost.is_empty() {
-                set_query_immediately(
-                    query,
-                    live_query,
-                    query_revision,
-                    &start_keydown_query_timer,
-                    format!("{}{}", start_keydown_q, start_keydown_ghost),
-                );
+                query.set(format!("{}{}", start_keydown_q, start_keydown_ghost));
                 selected.set(0);
                 focus_prompt_end(PROMPT_INPUT_ID);
             }
@@ -911,27 +870,18 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
             if e.key() == Key::Enter && !e.modifiers().shift() {
                 e.prevent_default();
                 if let Some(entry) = media_entries.read().get(media_sel).cloned() {
-                    select_start_media_entry(
-                        &entry,
-                        query,
-                        live_query,
-                        query_revision,
-                        start_keydown_query_timer.clone(),
-                        media_selected,
-                    );
+                    select_start_media_entry(&entry, query, media_selected);
                 }
                 return;
             }
             if e.key() == Key::Escape {
                 e.prevent_default();
                 if let Some(media_query) = inline_media_query(&start_keydown_q) {
-                    set_query_immediately(
-                        query,
-                        live_query,
-                        query_revision,
-                        &start_keydown_query_timer,
-                        replace_inline_media_query(&start_keydown_q, media_query, ""),
-                    );
+                    query.set(replace_inline_media_query(
+                        &start_keydown_q,
+                        media_query,
+                        "",
+                    ));
                 }
                 media_selected.set(0);
                 return;
@@ -964,7 +914,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                 if let Some(item) = start_keydown_results.get(sel) {
                     execute(item);
                 }
-            } else if start_keydown_prompt_mode {
+            } else if start_prompt_mode {
                 if let Some(item) = start_keydown_results.get(sel).filter(|item| {
                     start_keydown_nav
                         || agent_page_matches_query(item, &start_keydown_q)
@@ -1095,8 +1045,6 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
             }
         }
     };
-    let start_input_query_timer = start_query_timer.clone();
-    let media_select_query_timer = start_query_timer.clone();
 
     rsx! {
         div { class: "relative",
@@ -1154,7 +1102,6 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                 }
                 PromptComposer {
                     value: display_text.clone(),
-                    value_revision: query_revision(),
                     completion: ghost_text.clone(),
                     attachments: start_prompt_attachments,
                     show_examples: q.is_empty() && ghost_text.is_empty(),
@@ -1165,27 +1112,11 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                     footer: Some(start_composer_footer),
                     action_title: translate("command-send"),
                     action_enabled: start_action_enabled,
-                    on_input: move |value: String| {
-                        if *start_agent_menu_open.peek() {
-                            start_agent_menu_open.set(false);
-                        }
-                        live_query.set(value.clone());
-                        schedule_deferred(
-                            start_input_query_timer.clone(),
-                            START_QUERY_COMMIT_DEBOUNCE_MS,
-                            move || {
-                                if live_query.peek().as_str() != value {
-                                    return;
-                                }
-                                query.set(value);
-                                if *selected.peek() != 0 {
-                                    selected.set(0);
-                                }
-                                if *nav_mode.peek() {
-                                    nav_mode.set(false);
-                                }
-                            },
-                        );
+                    on_input: move |value| {
+                        start_agent_menu_open.set(false);
+                        query.set(value);
+                        selected.set(0);
+                        nav_mode.set(false);
                     },
                     on_keydown: start_keydown,
                     on_paste: move |_| {
@@ -1203,13 +1134,12 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                     },
                     on_action: {
                         let action_results = results.clone();
+                        let action_query = q.clone();
                         let action_default_agent = default_agent_item.clone();
                         let action_nav = nav;
                         move |_| {
-                            let action_query = live_query.peek().clone();
-                            let action_prompt_mode = is_start_prompt_query(&action_query);
                             if let Some(item) = action_results.get(sel).filter(|item| {
-                                !action_prompt_mode
+                                !start_prompt_mode
                                     || action_nav
                                     || agent_page_matches_query(item, &action_query)
                                     || (matches!(item, ResultItem::Terminal { .. })
@@ -1365,14 +1295,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                         on_hover: move |index| media_selected.set(index),
                         on_select: move |index| {
                             if let Some(entry) = media_entries.peek().get(index).cloned() {
-                                select_start_media_entry(
-                                    &entry,
-                                    query,
-                                    live_query,
-                                    query_revision,
-                                    media_select_query_timer.clone(),
-                                    media_selected,
-                                );
+                                select_start_media_entry(&entry, query, media_selected);
                             }
                         },
                     }
@@ -1669,13 +1592,10 @@ fn file_extension_label(name: &str) -> String {
 
 fn select_start_media_entry(
     entry: &ChatMediaEntry,
-    query: Signal<String>,
-    live_query: Signal<String>,
-    query_revision: Signal<u64>,
-    query_timer: HostSearchTimer,
+    mut query: Signal<String>,
     mut selected: Signal<usize>,
 ) {
-    let value = live_query.peek().clone();
+    let value = query.peek().clone();
     let Some(media_query) = inline_media_query(&value) else {
         return;
     };
@@ -1692,13 +1612,11 @@ fn select_start_media_entry(
         }
         String::new()
     };
-    set_query_immediately(
-        query,
-        live_query,
-        query_revision,
-        &query_timer,
-        replace_inline_media_query(&value, media_query, &replacement),
-    );
+    query.set(replace_inline_media_query(
+        &value,
+        media_query,
+        &replacement,
+    ));
     selected.set(0);
     focus_prompt_end(PROMPT_INPUT_ID);
 }

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -50,6 +50,7 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 
 const HOST_SEARCH_DEBOUNCE_MS: i32 = 300;
+const START_QUERY_COMMIT_DEBOUNCE_MS: i32 = 80;
 
 type HostSearchTimer = Rc<RefCell<Option<(i32, js_sys::Function, Rc<Cell<bool>>)>>>;
 
@@ -64,7 +65,7 @@ fn cancel_host_search(timer: &HostSearchTimer) {
     let _ = callback.call0(&JsValue::NULL);
 }
 
-fn schedule_host_search(timer: HostSearchTimer, callback: impl FnOnce() + 'static) {
+fn schedule_deferred(timer: HostSearchTimer, delay_ms: i32, callback: impl FnOnce() + 'static) {
     cancel_host_search(&timer);
     let Some(window) = web_sys::window() else {
         return;
@@ -79,14 +80,30 @@ fn schedule_host_search(timer: HostSearchTimer, callback: impl FnOnce() + 'stati
         }
     })
     .unchecked_into::<js_sys::Function>();
-    match window
-        .set_timeout_with_callback_and_timeout_and_arguments_0(&callback, HOST_SEARCH_DEBOUNCE_MS)
-    {
+    match window.set_timeout_with_callback_and_timeout_and_arguments_0(&callback, delay_ms) {
         Ok(id) => *timer.borrow_mut() = Some((id, callback, cancelled)),
         Err(_) => {
             let _ = callback.call0(&JsValue::NULL);
         }
     }
+}
+
+fn schedule_host_search(timer: HostSearchTimer, callback: impl FnOnce() + 'static) {
+    schedule_deferred(timer, HOST_SEARCH_DEBOUNCE_MS, callback);
+}
+
+fn set_query_immediately(
+    mut query: Signal<String>,
+    mut live_query: Signal<String>,
+    mut query_revision: Signal<u64>,
+    timer: &HostSearchTimer,
+    value: String,
+) {
+    cancel_host_search(timer);
+    live_query.set(value.clone());
+    query.set(value);
+    let revision = (*query_revision.peek()).wrapping_add(1);
+    query_revision.set(revision);
 }
 
 /// Where a [`CommandPalette`] is rendered: the Cmd+K modal or the `vmux://start/` page.
@@ -136,6 +153,9 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let on_start_agent_transition = props.on_start_agent_transition;
 
     let mut query = use_signal(String::new);
+    let mut live_query = use_signal(String::new);
+    let query_revision = use_signal(|| 0u64);
+    let start_query_timer: HostSearchTimer = use_hook(|| Rc::new(RefCell::new(None)));
     let mut selected = use_signal(|| 0usize);
     let mut nav_mode = use_signal(|| false);
     let mut path_completions = use_signal(Vec::<PathEntry>::new);
@@ -158,11 +178,18 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let mut start_agent_menu_open = use_signal(|| false);
 
     let path_search_effect_timer = path_search_timer.clone();
+    let state_query_timer = start_query_timer.clone();
     use_effect(move || {
         let s = state();
         if last_open_id() != s.open_id {
             last_open_id.set(s.open_id);
-            query.set(s.url.clone());
+            set_query_immediately(
+                query,
+                live_query,
+                query_revision,
+                &state_query_timer,
+                s.url.clone(),
+            );
             selected.set(if s.space_switch {
                 active_space_index(&s.spaces)
             } else {
@@ -335,7 +362,9 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
         });
     });
 
+    let drop_start_query_timer = start_query_timer.clone();
     use_drop(move || {
+        cancel_host_search(&drop_start_query_timer);
         cancel_host_search(&path_search_timer);
         cancel_host_search(&suggestions_search_timer);
         cancel_host_search(&media_search_timer);
@@ -560,7 +589,11 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     });
 
     let execute = move |item: &ResultItem| {
-        let prompt = query();
+        let prompt = if is_start {
+            live_query.peek().clone()
+        } else {
+            query()
+        };
         let transition = if is_start
             && let Some(agent_url) = agent_page_url(item)
             && crate::start::supports_inline_agent_transition(agent_url)
@@ -812,16 +845,24 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
             }
         }
     };
-    let start_keydown_q = q.clone();
     let start_keydown_results = results.clone();
     let start_keydown_default_agent = default_agent_item.clone();
     let start_keydown_nav = nav;
     let start_keydown_ghost = ghost_text.clone();
+    let start_keydown_query_timer = start_query_timer.clone();
     let start_keydown = move |e: KeyboardEvent| {
+        let start_keydown_q = live_query.peek().clone();
+        let start_keydown_prompt_mode = is_start_prompt_query(&start_keydown_q);
         if e.key() == Key::Tab {
             e.prevent_default();
             if !start_keydown_ghost.is_empty() {
-                query.set(format!("{}{}", start_keydown_q, start_keydown_ghost));
+                set_query_immediately(
+                    query,
+                    live_query,
+                    query_revision,
+                    &start_keydown_query_timer,
+                    format!("{}{}", start_keydown_q, start_keydown_ghost),
+                );
                 selected.set(0);
                 focus_prompt_end(PROMPT_INPUT_ID);
             }
@@ -870,18 +911,27 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
             if e.key() == Key::Enter && !e.modifiers().shift() {
                 e.prevent_default();
                 if let Some(entry) = media_entries.read().get(media_sel).cloned() {
-                    select_start_media_entry(&entry, query, media_selected);
+                    select_start_media_entry(
+                        &entry,
+                        query,
+                        live_query,
+                        query_revision,
+                        start_keydown_query_timer.clone(),
+                        media_selected,
+                    );
                 }
                 return;
             }
             if e.key() == Key::Escape {
                 e.prevent_default();
                 if let Some(media_query) = inline_media_query(&start_keydown_q) {
-                    query.set(replace_inline_media_query(
-                        &start_keydown_q,
-                        media_query,
-                        "",
-                    ));
+                    set_query_immediately(
+                        query,
+                        live_query,
+                        query_revision,
+                        &start_keydown_query_timer,
+                        replace_inline_media_query(&start_keydown_q, media_query, ""),
+                    );
                 }
                 media_selected.set(0);
                 return;
@@ -914,7 +964,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                 if let Some(item) = start_keydown_results.get(sel) {
                     execute(item);
                 }
-            } else if start_prompt_mode {
+            } else if start_keydown_prompt_mode {
                 if let Some(item) = start_keydown_results.get(sel).filter(|item| {
                     start_keydown_nav
                         || agent_page_matches_query(item, &start_keydown_q)
@@ -1045,6 +1095,8 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
             }
         }
     };
+    let start_input_query_timer = start_query_timer.clone();
+    let media_select_query_timer = start_query_timer.clone();
 
     rsx! {
         div { class: "relative",
@@ -1102,6 +1154,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                 }
                 PromptComposer {
                     value: display_text.clone(),
+                    value_revision: query_revision(),
                     completion: ghost_text.clone(),
                     attachments: start_prompt_attachments,
                     show_examples: q.is_empty() && ghost_text.is_empty(),
@@ -1112,11 +1165,27 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                     footer: Some(start_composer_footer),
                     action_title: translate("command-send"),
                     action_enabled: start_action_enabled,
-                    on_input: move |value| {
-                        start_agent_menu_open.set(false);
-                        query.set(value);
-                        selected.set(0);
-                        nav_mode.set(false);
+                    on_input: move |value: String| {
+                        if *start_agent_menu_open.peek() {
+                            start_agent_menu_open.set(false);
+                        }
+                        live_query.set(value.clone());
+                        schedule_deferred(
+                            start_input_query_timer.clone(),
+                            START_QUERY_COMMIT_DEBOUNCE_MS,
+                            move || {
+                                if live_query.peek().as_str() != value {
+                                    return;
+                                }
+                                query.set(value);
+                                if *selected.peek() != 0 {
+                                    selected.set(0);
+                                }
+                                if *nav_mode.peek() {
+                                    nav_mode.set(false);
+                                }
+                            },
+                        );
                     },
                     on_keydown: start_keydown,
                     on_paste: move |_| {
@@ -1134,12 +1203,13 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                     },
                     on_action: {
                         let action_results = results.clone();
-                        let action_query = q.clone();
                         let action_default_agent = default_agent_item.clone();
                         let action_nav = nav;
                         move |_| {
+                            let action_query = live_query.peek().clone();
+                            let action_prompt_mode = is_start_prompt_query(&action_query);
                             if let Some(item) = action_results.get(sel).filter(|item| {
-                                !start_prompt_mode
+                                !action_prompt_mode
                                     || action_nav
                                     || agent_page_matches_query(item, &action_query)
                                     || (matches!(item, ResultItem::Terminal { .. })
@@ -1295,7 +1365,14 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                         on_hover: move |index| media_selected.set(index),
                         on_select: move |index| {
                             if let Some(entry) = media_entries.peek().get(index).cloned() {
-                                select_start_media_entry(&entry, query, media_selected);
+                                select_start_media_entry(
+                                    &entry,
+                                    query,
+                                    live_query,
+                                    query_revision,
+                                    media_select_query_timer.clone(),
+                                    media_selected,
+                                );
                             }
                         },
                     }
@@ -1592,10 +1669,13 @@ fn file_extension_label(name: &str) -> String {
 
 fn select_start_media_entry(
     entry: &ChatMediaEntry,
-    mut query: Signal<String>,
+    query: Signal<String>,
+    live_query: Signal<String>,
+    query_revision: Signal<u64>,
+    query_timer: HostSearchTimer,
     mut selected: Signal<usize>,
 ) {
-    let value = query.peek().clone();
+    let value = live_query.peek().clone();
     let Some(media_query) = inline_media_query(&value) else {
         return;
     };
@@ -1612,11 +1692,13 @@ fn select_start_media_entry(
         }
         String::new()
     };
-    query.set(replace_inline_media_query(
-        &value,
-        media_query,
-        &replacement,
-    ));
+    set_query_immediately(
+        query,
+        live_query,
+        query_revision,
+        &query_timer,
+        replace_inline_media_query(&value, media_query, &replacement),
+    );
     selected.set(0);
     focus_prompt_end(PROMPT_INPUT_ID);
 }

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -10,8 +10,8 @@ use crate::command_bar::keyboard::{
 };
 use crate::command_bar::results::{
     CommandBarResultItem as ResultItem, active_space_index, agent_page_matches_query,
-    agent_page_results, agent_page_url, filter_results, prepend_prompt_agent, space_switch_results,
-    start_page_results,
+    agent_page_results, agent_page_url, filter_results, prepend_prompt_agents,
+    space_switch_results, start_page_results,
 };
 use crate::command_bar::style::{
     command_bar_input_class, command_bar_input_row_class, command_bar_input_wrap_class,
@@ -456,7 +456,12 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
         }
     };
     if start_prompt_mode {
-        prepend_prompt_agent(&mut results, default_agent_item.as_ref(), &q);
+        prepend_prompt_agents(
+            &mut results,
+            default_agent_item.as_ref(),
+            &start_agent_items,
+            &q,
+        );
     }
     let sel = selected().min(results.len().saturating_sub(1));
     let active_item = results.get(sel).cloned();
@@ -1452,10 +1457,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                                         class: result_favicon_class().to_string(),
                                         globe_class: result_leading_icon_class().to_string(),
                                     }
-                                    div { class: "flex min-w-0 flex-1 flex-col overflow-hidden",
-                                        span { class: result_primary_text_class(), "Search with {engine.name()}" }
-                                        span { class: result_secondary_text_class(), "{query}" }
-                                    }
+                                    span { class: result_primary_text_class(), "Search with {engine.name()}" }
                                 }
                                 span { class: result_trailing_slot_class(), "\u{21b5}" }
                             },

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 
 use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::command_bar::keyboard::{
@@ -29,10 +30,10 @@ use vmux_command::event::{
 };
 use vmux_command::open_target::OpenTarget;
 use vmux_command::prompt_media::{
-    CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT, ChatAttachPaths, ChatAttachment,
-    ChatAttachments, ChatMediaEntries, ChatMediaEntry, ChatMediaListRequest, ChatPasteMedia,
-    ChatPickFiles, inline_media_query, media_display_path, media_reference,
-    replace_inline_media_query,
+    CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_MEDIA_ENTRIES_EVENT,
+    ChatAttachPaths, ChatAttachment, ChatAttachments, ChatMediaEntries, ChatMediaEntry,
+    ChatMediaListRequest, ChatPasteMedia, ChatPickFiles, inline_media_query, media_display_path,
+    media_reference, merge_chat_attachments, replace_inline_media_query,
 };
 use vmux_ui::agent_accent::agent_accent;
 use vmux_ui::components::icon::Icon;
@@ -146,6 +147,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
     let mut last_open_id = use_signal(|| u64::MAX);
     let mut last_focus_open_id = use_signal(|| u64::MAX);
     let mut attachments = use_signal(Vec::<ChatAttachment>::new);
+    let mut attachment_previews = use_signal(HashMap::<String, ChatAttachment>::new);
     let mut media_entries = use_signal(Vec::<ChatMediaEntry>::new);
     let mut media_request_id = use_signal(|| 0u64);
     let mut media_requested_query = use_signal(|| None::<String>);
@@ -216,15 +218,34 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
             if !is_start {
                 return;
             }
-            let mut next = attachments.peek().clone();
-            for attachment in &selected.attachments {
-                if !next.iter().any(|existing| existing.path == attachment.path) {
-                    next.push(attachment.clone());
-                }
-            }
-            attachments.set(next);
+            let current = attachments.peek().clone();
+            attachments.set(merge_chat_attachments(&current, &selected.attachments));
             focus_prompt_end(PROMPT_INPUT_ID);
         });
+
+    let _attachment_previews_listener = use_bin_event_listener::<ChatAttachments, _>(
+        CHAT_ATTACHMENT_PREVIEWS_EVENT,
+        move |loaded| {
+            if !is_start {
+                return;
+            }
+            let mut previews = attachment_previews.peek().clone();
+            for attachment in &loaded.attachments {
+                previews.insert(attachment.path.clone(), attachment.clone());
+            }
+            attachment_previews.set(previews);
+            let mut current = attachments.peek().clone();
+            for preview in &loaded.attachments {
+                if let Some(attachment) = current
+                    .iter_mut()
+                    .find(|attachment| attachment.path == preview.path)
+                {
+                    attachment.preview_data_url = preview.preview_data_url.clone();
+                }
+            }
+            attachments.set(current);
+        },
+    );
 
     let _media_entries_listener =
         use_bin_event_listener::<ChatMediaEntries, _>(CHAT_MEDIA_ENTRIES_EVENT, move |response| {
@@ -636,6 +657,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
         }
     };
     let start_accent = active_agent_accent.unwrap_or_else(|| agent_accent("vibe"));
+    let start_attachment_previews = attachment_previews.read();
     let start_prompt_attachments = attachments
         .read()
         .iter()
@@ -644,7 +666,10 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
             key: format!("start-attachment-{}", attachment.path),
             name: attachment.name.clone(),
             label: file_extension_label(&attachment.name),
-            preview_data_url: attachment.preview_data_url.clone(),
+            preview_data_url: start_attachment_previews
+                .get(&attachment.path)
+                .map(|preview| preview.preview_data_url.clone())
+                .unwrap_or_else(|| attachment.preview_data_url.clone()),
             remove_index: Some(index),
         })
         .collect::<Vec<_>>();

--- a/crates/vmux_layout/src/command_bar/results.rs
+++ b/crates/vmux_layout/src/command_bar/results.rs
@@ -174,9 +174,10 @@ pub(crate) fn agent_page_matches_query(item: &CommandBarResultItem, query: &str)
 }
 
 #[cfg(any(target_arch = "wasm32", test))]
-pub(crate) fn prepend_prompt_agent(
+pub(crate) fn prepend_prompt_agents(
     results: &mut Vec<CommandBarResultItem>,
-    agent: Option<&CommandBarResultItem>,
+    selected_agent: Option<&CommandBarResultItem>,
+    recent_agents: &[CommandBarResultItem],
     query: &str,
 ) {
     if !vmux_command::event::is_start_prompt_query(query)
@@ -187,9 +188,23 @@ pub(crate) fn prepend_prompt_agent(
     {
         return;
     }
-    if let Some(agent) = agent {
-        results.insert(0, agent.clone());
+    let mut suggestions = Vec::new();
+    for agent in selected_agent.into_iter().chain(recent_agents) {
+        let Some(url) = agent_page_url(agent) else {
+            continue;
+        };
+        if suggestions
+            .iter()
+            .any(|existing| agent_page_url(existing) == Some(url))
+        {
+            continue;
+        }
+        suggestions.push(agent.clone());
+        if suggestions.len() == 3 {
+            break;
+        }
     }
+    results.splice(0..0, suggestions);
 }
 
 pub fn start_page_results(
@@ -234,15 +249,12 @@ pub fn start_page_results(
         } else {
             search_engines
         };
-        results.extend(
-            engines
-                .iter()
-                .copied()
-                .map(|engine| CommandBarResultItem::Search {
-                    engine,
-                    query: trimmed.to_string(),
-                }),
-        );
+        results.extend(engines.iter().take(3).copied().map(|engine| {
+            CommandBarResultItem::Search {
+                engine,
+                query: trimmed.to_string(),
+            }
+        }));
     } else if !trimmed.is_empty() {
         results.push(CommandBarResultItem::Navigate {
             url: trimmed.to_string(),
@@ -843,8 +855,13 @@ mod tests {
     }
 
     #[test]
-    fn start_page_offers_each_search_engine_in_supplied_order() {
-        let engines = [SearchEngine::Kagi, SearchEngine::Google, SearchEngine::Bing];
+    fn start_page_offers_three_recent_search_engines_in_supplied_order() {
+        let engines = [
+            SearchEngine::Kagi,
+            SearchEngine::Google,
+            SearchEngine::Bing,
+            SearchEngine::DuckDuckGo,
+        ];
         let results =
             start_page_results(&sample_pages(), &[], &[], &engines, "fix the failing test");
         let actual = results
@@ -855,24 +872,51 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        assert_eq!(actual, engines);
+        assert_eq!(actual, engines[..3]);
     }
 
     #[test]
-    fn selected_agent_precedes_web_search_for_prompt_text() {
-        let agent = agent_page_results(&sample_pages(), "").remove(0);
+    fn selected_agent_and_two_recent_agents_precede_web_search() {
+        let mut pages = sample_pages();
+        pages.extend([
+            CommandBarPage {
+                host: "agent".into(),
+                url: "vmux://agent/codex/cli".into(),
+                title: "Codex".into(),
+                keywords: vec!["codex".into(), "agent".into()],
+                icon: vmux_core::PageIcon::None,
+                shortcut: String::new(),
+            },
+            CommandBarPage {
+                host: "agent".into(),
+                url: "vmux://agent/claude".into(),
+                title: "Claude".into(),
+                keywords: vec!["claude".into(), "agent".into()],
+                icon: vmux_core::PageIcon::None,
+                shortcut: String::new(),
+            },
+        ]);
+        let agents = agent_page_results(&pages, "");
+        let selected = agents[1].clone();
         let mut results = start_page_results(
-            &sample_pages(),
+            &pages,
             &[],
             &[],
             &[SearchEngine::Google, SearchEngine::Bing],
             "show me something fun",
         );
 
-        prepend_prompt_agent(&mut results, Some(&agent), "show me something fun");
+        prepend_prompt_agents(
+            &mut results,
+            Some(&selected),
+            &agents,
+            "show me something fun",
+        );
 
-        assert_eq!(agent_page_url(&results[0]), Some("vmux://agent/vibe/"));
-        assert!(matches!(results[1], CommandBarResultItem::Search { .. }));
+        assert_eq!(agent_page_url(&results[0]), Some("vmux://agent/codex/cli"));
+        assert_eq!(agent_page_url(&results[1]), Some("vmux://agent/vibe/"));
+        assert_eq!(agent_page_url(&results[2]), Some("vmux://agent/claude"));
+        assert!(matches!(results[3], CommandBarResultItem::Search { .. }));
     }
 
     #[test]
@@ -880,7 +924,7 @@ mod tests {
         let agent = agent_page_results(&sample_pages(), "").remove(0);
         let mut results = start_page_results(&sample_pages(), &[], &[], &[], "terminal");
 
-        prepend_prompt_agent(&mut results, Some(&agent), "terminal");
+        prepend_prompt_agents(&mut results, Some(&agent), &[], "terminal");
 
         assert_eq!(
             results,

--- a/crates/vmux_layout/src/event.rs
+++ b/crates/vmux_layout/src/event.rs
@@ -413,6 +413,8 @@ pub struct PaneTreeEvent {
 pub struct PaneNode {
     pub id: u64,
     pub is_active: bool,
+    #[serde(default)]
+    pub collapsed: bool,
     pub stacks: Vec<StackNode>,
 }
 

--- a/crates/vmux_layout/src/lib.rs
+++ b/crates/vmux_layout/src/lib.rs
@@ -210,6 +210,7 @@ pub struct TabLayoutSpawnRequest {
     pub content: TabLayoutSpawnContent,
     pub clear_pending_stack: bool,
     pub focus: bool,
+    pub replaces: Option<Entity>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/vmux_layout/src/page.rs
+++ b/crates/vmux_layout/src/page.rs
@@ -2332,12 +2332,23 @@ fn PaneSection(pane: PaneNode, index: usize) -> Element {
     );
     let pane_id = pane.id;
     let any_loading = pane.stacks.iter().any(|s| s.is_loading);
-    let mut folded = use_signal(|| false);
+    let mut folded = use_signal(|| pane.collapsed);
     let fold_title = if folded() {
         translate("layout-unfold-stack")
     } else {
         translate("layout-fold-stack")
     };
+    let visible_stacks = pane
+        .stacks
+        .iter()
+        .filter(|stack| !(stack.url.is_empty() && stack.title == "New Stack"))
+        .cloned()
+        .collect::<Vec<_>>();
+    let collapsed_stack = visible_stacks
+        .iter()
+        .find(|stack| stack.is_active)
+        .or_else(|| visible_stacks.first())
+        .cloned();
 
     rsx! {
         div { class: if pane.is_active && any_loading {
@@ -2376,24 +2387,32 @@ fn PaneSection(pane: PaneNode, index: usize) -> Element {
                     onclick: move |_| {
                         let next = !folded();
                         folded.set(next);
+                        let _ = try_cef_bin_emit_rkyv(&crate::event::SideSheetCommandEvent {
+                            command: if next {
+                                "collapse_card".to_string()
+                            } else {
+                                "expand_card".to_string()
+                            },
+                            pane_id: pane_id.to_string(),
+                            stack_index: 0,
+                            path: String::new(),
+                        });
                     },
                     Icon { class: "h-3.5 w-3.5 pointer-events-none",
                         path { d: if folded() { "m9 18 6-6-6-6" } else { "m6 9 6 6 6-6" } }
                     }
                 }
             }
-            div { class: if folded() {
-                    "grid grid-rows-[0fr] opacity-0 transition-[grid-template-rows,opacity] duration-200 ease-out"
-                } else {
-                    "grid grid-rows-[1fr] opacity-100 transition-[grid-template-rows,opacity] duration-200 ease-out"
-                },
-                div { class: "overflow-hidden",
-                    div { class: "flex flex-col gap-1 border-t border-foreground/10 p-1.5",
-                        for stack in pane
-                            .stacks
-                            .iter()
-                            .filter(|s| !(s.url.is_empty() && s.title == "New Stack"))
-                        {
+            div { class: "border-t border-foreground/10 p-1.5",
+                div { class: "flex flex-col gap-1",
+                    if folded() {
+                        if let Some(stack) = collapsed_stack {
+                            SideSheetStackRow { stack, pane_id }
+                        } else {
+                            NewStackRow { pane_id }
+                        }
+                    } else {
+                        for stack in visible_stacks.iter() {
                             SideSheetStackRow { stack: stack.clone(), pane_id }
                         }
                         NewStackRow { pane_id }

--- a/crates/vmux_layout/src/pane.rs
+++ b/crates/vmux_layout/src/pane.rs
@@ -54,6 +54,7 @@ impl Plugin for PanePlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Pane>()
             .register_type::<PaneId>()
+            .register_type::<SideSheetCardCollapsed>()
             .register_type::<PaneSplit>()
             .register_type::<PaneSplitDirection>()
             .register_type::<PaneSize>()
@@ -162,6 +163,12 @@ pub struct Pane;
 #[type_path = "vmux_desktop::layout::pane"]
 #[require(Save)]
 pub struct PaneId(pub String);
+
+#[derive(Component, Reflect, Default, Clone, Copy, Debug, PartialEq, Eq)]
+#[reflect(Component)]
+#[type_path = "vmux_desktop::layout::pane"]
+#[require(Save)]
+pub struct SideSheetCardCollapsed;
 
 pub fn assign_pane_ids(
     panes: Query<Entity, (With<Pane>, Without<PaneId>)>,

--- a/crates/vmux_layout/src/stack.rs
+++ b/crates/vmux_layout/src/stack.rs
@@ -193,17 +193,6 @@ impl ActiveTabParam<'_, '_> {
         // empty and respawn startup content every frame.
         active_among(self.tabs.iter())
     }
-
-    fn has_sibling(&self, tab: Entity, all_children: &Query<&Children>) -> bool {
-        let Ok(parent) = self.child_of.get(tab).map(Relationship::get) else {
-            return false;
-        };
-        all_children.get(parent).is_ok_and(|children| {
-            children
-                .iter()
-                .any(|entity| entity != tab && self.tabs.contains(entity))
-        })
-    }
 }
 
 pub fn focused_stack(
@@ -369,7 +358,6 @@ fn handle_stack_commands(
                     children.iter().filter(|&e| stack_q.contains(e)).collect();
                 if stacks_in_pane.len() <= 1 {
                     if let Some(tab) = active_tab
-                        && active_tab_param.has_sibling(tab, &all_children)
                         && close_tab_if_only_closing_stack(
                             tab,
                             active,
@@ -850,7 +838,7 @@ mod tests {
     }
 
     #[test]
-    fn closing_last_stack_reuses_only_tab_and_workspace() {
+    fn closing_last_stack_preloads_fresh_tab_without_workspace_state() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, CommandPlugin))
             .add_message::<CloseTabRequest>()
@@ -883,11 +871,10 @@ mod tests {
                 vmux_core::Active,
             ))
             .id();
-        let startup = tempfile::tempdir().unwrap();
         let worktree = tempfile::tempdir().unwrap();
         app.insert_resource(crate::settings::EffectiveStartupDir(Some((
             space,
-            Some(startup.path().to_path_buf()),
+            Some(worktree.path().to_path_buf()),
         ))));
         let tab_e = app
             .world_mut()
@@ -901,6 +888,13 @@ mod tests {
                     checkout_dir: worktree.path().to_string_lossy().into_owned(),
                     branch: "test".to_string(),
                     base_ref: "main".to_string(),
+                },
+                crate::tab::TabWorkspace {
+                    project_dir: worktree.path().to_string_lossy().into_owned(),
+                },
+                crate::tab::TabDirDecided,
+                crate::tab::TabWorktreeUnavailable {
+                    message: "stale".to_string(),
                 },
                 vmux_core::Active,
                 LastActivatedAt::now(),
@@ -924,35 +918,68 @@ mod tests {
         app.update();
 
         assert!(app.world().get_entity(tab_e).is_ok());
-        assert!(app.world().get_entity(original_stack).is_err());
-        let remaining_tab = app
-            .world_mut()
-            .query_filtered::<Entity, With<Tab>>()
-            .single(app.world())
-            .unwrap();
-        assert_eq!(remaining_tab, tab_e);
+        assert!(app.world().get_entity(original_stack).is_ok());
         assert!(
             app.world()
-                .get::<crate::tab::TabWorktree>(remaining_tab)
+                .get::<crate::tab::TabReplacementSource>(tab_e)
                 .is_some()
         );
+        let replacement_tab = app
+            .world_mut()
+            .query_filtered::<Entity, With<crate::tab::PendingTabReplacement>>()
+            .single(app.world())
+            .unwrap();
+        assert_ne!(replacement_tab, tab_e);
         assert_eq!(
             app.world()
-                .get::<Tab>(remaining_tab)
+                .get::<crate::tab::PendingTabReplacement>(replacement_tab)
                 .unwrap()
-                .startup_dir
-                .as_deref(),
-            worktree.path().to_str()
+                .old_tab,
+            tab_e
+        );
+        assert!(
+            app.world()
+                .get::<crate::tab::TabWorkspace>(replacement_tab)
+                .is_none()
+        );
+        assert!(
+            app.world()
+                .get::<crate::tab::TabWorktree>(replacement_tab)
+                .is_none()
+        );
+        assert!(
+            app.world()
+                .get::<crate::tab::TabDirDecided>(replacement_tab)
+                .is_none()
+        );
+        assert!(
+            app.world()
+                .get::<crate::tab::TabWorktreeUnavailable>(replacement_tab)
+                .is_none()
+        );
+        assert_eq!(
+            app.world().get::<Tab>(replacement_tab).unwrap().startup_dir,
+            None
         );
         let ctx = app.world().resource::<NewStackContext>();
         assert!(ctx.needs_open);
         assert!(ctx.stack.is_some());
         assert_eq!(ctx.previous_stack, None);
+        let new_pane = app
+            .world()
+            .get::<ChildOf>(ctx.stack.unwrap())
+            .map(Relationship::get)
+            .unwrap();
+        let split_root = app
+            .world()
+            .get::<ChildOf>(new_pane)
+            .map(Relationship::get)
+            .unwrap();
         assert_eq!(
             app.world()
-                .get::<ChildOf>(ctx.stack.unwrap())
+                .get::<ChildOf>(split_root)
                 .map(Relationship::get),
-            Some(pane)
+            Some(replacement_tab)
         );
     }
 
@@ -1394,7 +1421,7 @@ mod tests {
     }
 
     #[test]
-    fn closing_last_stack_reuses_only_tab_and_opens_startup_page() {
+    fn closing_last_stack_requests_tab_replacement() {
         let mut app = build_app_with_collector();
         app.insert_resource(crate::settings::EffectiveStartupUrl(
             "https://startup.test".into(),
@@ -1409,30 +1436,27 @@ mod tests {
 
         app.update();
 
-        assert!(app.world().get_entity(original_stack).is_err());
+        assert!(app.world().get_entity(original_stack).is_ok());
         assert!(app.world().get_entity(tab).is_ok());
         let ctx = app.world().resource::<NewStackContext>();
         assert_eq!(ctx.stack, None);
         assert!(!ctx.needs_open);
 
         let collected = app.world().resource::<CollectedSpawns>();
-        assert_eq!(collected.0.len(), 1);
-        assert_eq!(collected.0[0].url, "https://startup.test");
-        let PageOpenTarget::Stack(replacement) = collected.0[0].target else {
-            panic!("startup page must target the replacement stack");
-        };
-        assert_eq!(
-            app.world()
-                .get::<ChildOf>(replacement)
-                .map(Relationship::get),
-            Some(pane)
-        );
+        assert!(collected.0.is_empty());
         let close_requests: Vec<_> = app
             .world_mut()
             .resource_mut::<Messages<CloseTabRequest>>()
             .drain()
             .collect();
-        assert!(close_requests.is_empty());
+        assert_eq!(close_requests.len(), 1);
+        assert_eq!(close_requests[0].tab, tab);
+        assert_eq!(
+            app.world()
+                .get::<ChildOf>(original_stack)
+                .map(Relationship::get),
+            Some(pane)
+        );
     }
 
     #[test]

--- a/crates/vmux_layout/src/start/plugin.rs
+++ b/crates/vmux_layout/src/start/plugin.rs
@@ -12,8 +12,10 @@ use vmux_command::snapshot::{
     CommandBarWorkSnapshot,
 };
 use vmux_core::{
-    CefPageAttachRequest, PageMetadata, PageOpenError, PageOpenHandled, PageOpenSet, PageOpenTask,
+    Active, CefPageAttachRequest, PageMetadata, PageOpenError, PageOpenHandled, PageOpenSet,
+    PageOpenTask,
 };
+use vmux_history::LastActivatedAt;
 
 use crate::cef::Browser;
 use crate::command_bar::handler::{
@@ -24,14 +26,14 @@ use crate::start::START_PAGE_URL;
 use crate::start::event::{
     START_FOCUS_INPUT_EVENT, StartDataRequest, StartFocusInput, StartSelectWorkspace,
 };
-use crate::tab::{Tab, TabWorkspace, TabWorktree};
+use crate::tab::{PendingTabReplacement, Tab, TabWorkspace, TabWorktree};
+use crate::webview_reveal::PendingWebviewReveal;
 use crate::window::VmuxWindow;
 
 type PendingPageOpen = (Without<PageOpenHandled>, Without<PageOpenError>);
 
-/// How many prewarmed `vmux://start/` webviews to keep ready. Zero keeps hidden start
-/// pages from consuming rendering resources; pages still spawn on demand.
-const WARM_START_POOL_SIZE: usize = 0;
+/// How many prewarmed `vmux://start/` webviews to keep ready.
+const WARM_START_POOL_SIZE: usize = 1;
 
 /// Marks a prewarmed, parked `vmux://start/` webview waiting to be claimed by the next
 /// start open. Removed when the spare is reparented into a real stack.
@@ -55,6 +57,9 @@ struct WarmStartPoolNode;
 /// becomes ready after snapshots were populated still gets the data.
 #[derive(Component)]
 struct StartWorkSynced;
+
+#[derive(Component)]
+struct StartMountReady;
 
 /// Host-internal signal that a warm spare was just revealed into a stack, so its launcher
 /// data must be refreshed (it captured boot-time tabs/spaces) and its input refocused.
@@ -94,27 +99,39 @@ impl StartPromptContextParams<'_, '_> {
         })
     }
 
-    fn context(&self, tab: Option<Entity>) -> CommandBarPromptContext {
+    fn cwd(&self, tab: Option<Entity>) -> String {
         let Some(tab) = tab else {
-            return default();
+            return String::new();
         };
-        let Ok((tab, workspace, worktree)) = self.tabs.get(tab) else {
-            return default();
+        let Ok((tab, workspace, _)) = self.tabs.get(tab) else {
+            return String::new();
         };
-        let cwd = tab
-            .startup_dir
+        tab.startup_dir
             .clone()
             .or_else(|| {
                 workspace
                     .as_ref()
                     .map(|workspace| workspace.project_dir.clone())
             })
-            .unwrap_or_default();
+            .unwrap_or_default()
+    }
+
+    fn context(
+        &self,
+        tab: Option<Entity>,
+        info: Option<&vmux_git::worktree::RepoInfo>,
+    ) -> CommandBarPromptContext {
+        let Some(tab) = tab else {
+            return default();
+        };
+        let Ok((_, _, worktree)) = self.tabs.get(tab) else {
+            return default();
+        };
+        let cwd = self.cwd(Some(tab));
         if cwd.is_empty() {
             return default();
         }
         let path = std::path::Path::new(&cwd);
-        let info = vmux_git::worktree::repo_info(path);
         CommandBarPromptContext {
             workspace_name: path
                 .file_name()
@@ -123,17 +140,14 @@ impl StartPromptContextParams<'_, '_> {
                 .unwrap_or_else(|| cwd.clone()),
             cwd,
             is_git_repo: info.is_some(),
-            is_worktree: info.as_ref().is_some_and(|info| info.is_worktree),
-            branch: info
-                .as_ref()
-                .map(|info| info.branch.clone())
-                .unwrap_or_default(),
+            is_worktree: info.is_some_and(|info| info.is_worktree),
+            branch: info.map(|info| info.branch.clone()).unwrap_or_default(),
             base_ref: worktree
                 .as_ref()
                 .map(|worktree| worktree.base_ref.clone())
                 .unwrap_or_default(),
-            uncommitted: info.as_ref().map(|info| info.uncommitted).unwrap_or(0),
-            ahead: info.as_ref().map(|info| info.ahead).unwrap_or(0),
+            uncommitted: info.map(|info| info.uncommitted).unwrap_or(0),
+            ahead: info.map(|info| info.ahead).unwrap_or(0),
         }
     }
 }
@@ -161,6 +175,10 @@ impl Plugin for StartPlugin {
                     sync_live_start_pages,
                     drain_start_workspace_pickers,
                 ),
+            )
+            .add_systems(
+                Update,
+                finish_ready_tab_replacements.after(sync_live_start_pages),
             );
     }
 }
@@ -300,9 +318,26 @@ fn sync_live_start_pages(
         Without<crate::start::StartAgentTransitionView>,
     >,
     added_keyboard_targets: Query<(), Added<CefKeyboardTarget>>,
+    replacements: Query<&PendingTabReplacement>,
     browsers: NonSend<Browsers>,
+    mut repo_info: Option<ResMut<vmux_git::RepoInfoCache>>,
+    mut last_git: Local<(String, Option<vmux_git::worktree::RepoInfo>)>,
     mut commands: Commands,
 ) {
+    let cwd = prompt_context.cwd(tab_gather.active_tab.get());
+    let git_info = (!cwd.is_empty())
+        .then(|| {
+            repo_info.as_mut().and_then(|cache| {
+                cache
+                    .bypass_change_detection()
+                    .get(std::path::Path::new(&cwd))
+            })
+        })
+        .flatten();
+    let git_changed = last_git.0 != cwd || last_git.1 != git_info;
+    if git_changed {
+        *last_git = (cwd, git_info.clone());
+    }
     let focus_changed = focused.is_changed();
     let changed = should_refresh_start_payload(
         spaces_snapshot.is_changed(),
@@ -311,6 +346,7 @@ fn sync_live_start_pages(
         work_snapshot.is_changed(),
         focus_changed,
     ) || prompt_context.changed(tab_gather.active_tab.get())
+        || git_changed
         || locale.as_ref().is_some_and(|locale| locale.is_changed());
     let locale = locale
         .as_deref()
@@ -319,6 +355,9 @@ fn sync_live_start_pages(
     let targets: Vec<(Entity, bool)> = starts
         .iter()
         .filter_map(|(e, src, synced, keyboard_target)| {
+            if ancestor_replacement_tab(e, &tab_gather.child_of_q, &replacements).is_some() {
+                return None;
+            }
             let WebviewSource::Url(url) = src else {
                 return None;
             };
@@ -347,6 +386,8 @@ fn sync_live_start_pages(
         &pages_snapshot,
         &work_snapshot,
         &prompt_context,
+        tab_gather.active_tab.get(),
+        git_info.as_ref(),
         &locale,
     );
     for (e, focus_requested) in targets {
@@ -491,6 +532,8 @@ fn on_start_spare_revealed(
             &pages_snapshot,
             &work_snapshot,
             &prompt_context,
+            tab_gather.active_tab.get(),
+            None,
             &locale,
         );
         commands.trigger(BinHostEmitEvent::from_rkyv(
@@ -512,6 +555,8 @@ fn on_start_data_request(
     trigger: On<BinReceive<StartDataRequest>>,
     spares: Query<(), With<WarmStartSpare>>,
     keyboard_targets: Query<(), With<CefKeyboardTarget>>,
+    child_of: Query<&ChildOf>,
+    replacements: Query<&PendingTabReplacement>,
     tab_gather: TabGatherParams,
     prompt_context: StartPromptContextParams,
     spaces_snapshot: Res<CommandBarSpacesSnapshot>,
@@ -526,6 +571,8 @@ fn on_start_data_request(
     if is_spare {
         commands.entity(webview).insert(WarmStartReady);
     }
+    commands.entity(webview).insert(StartMountReady);
+    let replacement_tab = ancestor_replacement_tab(webview, &child_of, &replacements);
     let payload = build_start_payload(
         &tab_gather,
         &spaces_snapshot,
@@ -533,6 +580,8 @@ fn on_start_data_request(
         &pages_snapshot,
         &work_snapshot,
         &prompt_context,
+        replacement_tab.or_else(|| tab_gather.active_tab.get()),
+        None,
         &locale
             .as_deref()
             .map(|locale| locale.0.clone())
@@ -543,7 +592,7 @@ fn on_start_data_request(
         COMMAND_BAR_OPEN_EVENT,
         &payload,
     ));
-    if keyboard_targets.contains(webview) {
+    if keyboard_targets.contains(webview) && replacement_tab.is_none() {
         commands.trigger(BinHostEmitEvent::from_rkyv(
             webview,
             START_FOCUS_INPUT_EVENT,
@@ -560,12 +609,14 @@ fn build_start_payload(
     pages_snapshot: &CommandBarPagesSnapshot,
     work_snapshot: &CommandBarWorkSnapshot,
     prompt_context: &StartPromptContextParams,
+    active_tab: Option<Entity>,
+    git_info: Option<&vmux_git::worktree::RepoInfo>,
     locale: &str,
 ) -> CommandBarOpenEvent {
     let active_stack_count = tab_gather.stack_q.iter().count();
     let space_name = spaces_snapshot.active_space_name.clone();
     let tabs = gather_command_bar_tabs(
-        tab_gather.active_tab.get(),
+        active_tab,
         &tab_gather.all_children,
         &tab_gather.leaf_panes,
         &tab_gather.pane_ts,
@@ -591,8 +642,64 @@ fn build_start_payload(
         tabs,
         Some(OpenTarget::InPlace),
     );
-    payload.prompt_context = prompt_context.context(tab_gather.active_tab.get());
+    payload.prompt_context = prompt_context.context(active_tab, git_info);
     payload
+}
+
+fn ancestor_replacement_tab(
+    entity: Entity,
+    child_of: &Query<&ChildOf>,
+    replacements: &Query<&PendingTabReplacement>,
+) -> Option<Entity> {
+    let mut current = entity;
+    loop {
+        if replacements.contains(current) {
+            return Some(current);
+        }
+        current = child_of.get(current).ok()?.parent();
+    }
+}
+
+fn finish_ready_tab_replacements(
+    ready: Query<Entity, (With<StartMountReady>, Without<PendingWebviewReveal>)>,
+    child_of: Query<&ChildOf>,
+    replacements: Query<&PendingTabReplacement>,
+    mut focused: ResMut<crate::stack::FocusedStack>,
+    mut commands: Commands,
+) {
+    for webview in &ready {
+        let Some(tab) = ancestor_replacement_tab(webview, &child_of, &replacements) else {
+            continue;
+        };
+        let Ok(replacement) = replacements.get(tab) else {
+            continue;
+        };
+        let Some(stack) = child_of.get(webview).ok().map(ChildOf::parent) else {
+            continue;
+        };
+        let Some(pane) = child_of.get(stack).ok().map(ChildOf::parent) else {
+            continue;
+        };
+        commands.entity(replacement.old_tab).try_despawn();
+        commands
+            .entity(tab)
+            .insert((Active, LastActivatedAt::now()))
+            .remove::<PendingTabReplacement>();
+        commands
+            .entity(pane)
+            .insert((Active, LastActivatedAt::now()));
+        commands
+            .entity(stack)
+            .insert((Active, LastActivatedAt::now()));
+        focused.tab = Some(tab);
+        focused.pane = Some(pane);
+        focused.stack = Some(stack);
+        commands.trigger(BinHostEmitEvent::from_rkyv(
+            webview,
+            START_FOCUS_INPUT_EVENT,
+            &StartFocusInput,
+        ));
+    }
 }
 
 /// Despawn a stack's existing webview children before attaching new content.
@@ -716,6 +823,56 @@ mod tests {
 
         let emitted = &app.world().resource::<EmittedIds>().0;
         assert_eq!(emitted, &[COMMAND_BAR_OPEN_EVENT]);
+    }
+
+    #[test]
+    fn replacement_keeps_old_tab_until_start_mounts_then_switches_atomically() {
+        let mut app = App::new();
+        app.init_resource::<crate::stack::FocusedStack>()
+            .init_resource::<EmittedIds>()
+            .add_observer(capture_emit)
+            .add_systems(Update, finish_ready_tab_replacements);
+        let old_tab = app
+            .world_mut()
+            .spawn((Tab::default(), Active, LastActivatedAt(10)))
+            .id();
+        let new_tab = app
+            .world_mut()
+            .spawn((
+                Tab::default(),
+                PendingTabReplacement { old_tab },
+                LastActivatedAt(0),
+            ))
+            .id();
+        let split = app.world_mut().spawn(ChildOf(new_tab)).id();
+        let pane = app
+            .world_mut()
+            .spawn((LastActivatedAt(0), ChildOf(split)))
+            .id();
+        let stack = app
+            .world_mut()
+            .spawn((LastActivatedAt(0), ChildOf(pane)))
+            .id();
+        let webview = app.world_mut().spawn(ChildOf(stack)).id();
+
+        app.update();
+        assert!(app.world().get_entity(old_tab).is_ok());
+        assert!(app.world().get::<Active>(new_tab).is_none());
+
+        app.world_mut().entity_mut(webview).insert(StartMountReady);
+        app.update();
+
+        assert!(app.world().get_entity(old_tab).is_err());
+        assert!(app.world().get::<Active>(new_tab).is_some());
+        assert!(app.world().get::<PendingTabReplacement>(new_tab).is_none());
+        let focused = app.world().resource::<crate::stack::FocusedStack>();
+        assert_eq!(focused.tab, Some(new_tab));
+        assert_eq!(focused.pane, Some(pane));
+        assert_eq!(focused.stack, Some(stack));
+        assert_eq!(
+            app.world().resource::<EmittedIds>().0,
+            [START_FOCUS_INPUT_EVENT]
+        );
     }
 
     #[test]
@@ -846,7 +1003,7 @@ mod tests {
     }
 
     #[test]
-    fn start_pool_stays_empty_when_disabled() {
+    fn start_pool_fills_one_ready_slot() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .init_resource::<Assets<Mesh>>()
@@ -861,6 +1018,6 @@ mod tests {
             .query_filtered::<(), With<WarmStartSpare>>()
             .iter(app.world())
             .count();
-        assert_eq!(count, 0);
+        assert_eq!(count, WARM_START_POOL_SIZE);
     }
 }

--- a/crates/vmux_layout/src/start/plugin.rs
+++ b/crates/vmux_layout/src/start/plugin.rs
@@ -29,10 +29,9 @@ use crate::window::VmuxWindow;
 
 type PendingPageOpen = (Without<PageOpenHandled>, Without<PageOpenError>);
 
-/// How many prewarmed `vmux://start/` webviews to keep ready. Each new tab / stack /
-/// pane / space is an independent persistent start page, so a singleton (like the
-/// command-bar modal) cannot serve them — a small pool is refilled after each claim.
-const WARM_START_POOL_SIZE: usize = 1;
+/// How many prewarmed `vmux://start/` webviews to keep ready. Zero keeps hidden start
+/// pages from consuming rendering resources; pages still spawn on demand.
+const WARM_START_POOL_SIZE: usize = 0;
 
 /// Marks a prewarmed, parked `vmux://start/` webview waiting to be claimed by the next
 /// start open. Removed when the spare is reparented into a real stack.
@@ -139,9 +138,8 @@ impl StartPromptContextParams<'_, '_> {
     }
 }
 
-/// Bevy plugin for `vmux://start/`: spawns the page manifest, keeps a warm pool of
-/// prewarmed launcher webviews, claims start page-open tasks (reusing a warm spare when
-/// available), and answers [`StartDataRequest`] with the shared command-bar payload.
+/// Bevy plugin for `vmux://start/`: spawns the page manifest, claims start page-open tasks,
+/// and answers [`StartDataRequest`] with the shared command-bar payload.
 pub struct StartPlugin;
 
 impl Plugin for StartPlugin {
@@ -848,7 +846,7 @@ mod tests {
     }
 
     #[test]
-    fn pool_fills_to_target() {
+    fn start_pool_stays_empty_when_disabled() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .init_resource::<Assets<Mesh>>()
@@ -863,6 +861,6 @@ mod tests {
             .query_filtered::<(), With<WarmStartSpare>>()
             .iter(app.world())
             .count();
-        assert_eq!(count, WARM_START_POOL_SIZE);
+        assert_eq!(count, 0);
     }
 }

--- a/crates/vmux_layout/src/tab.rs
+++ b/crates/vmux_layout/src/tab.rs
@@ -27,6 +27,14 @@ pub struct CloseTabRequest {
     pub tab: Entity,
 }
 
+#[derive(Component)]
+pub(crate) struct TabReplacementSource;
+
+#[derive(Component)]
+pub(crate) struct PendingTabReplacement {
+    pub old_tab: Entity,
+}
+
 impl Plugin for TabPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Tab>()
@@ -193,6 +201,7 @@ fn handle_tab_commands(
                     content,
                     clear_pending_stack: true,
                     focus: true,
+                    replaces: None,
                 });
             }
             AppCommand::Layout(LayoutCommand::Tab(tab_cmd)) => match tab_cmd {
@@ -216,6 +225,7 @@ fn handle_tab_commands(
                         content: TabLayoutSpawnContent::StartupUrlOrPrompt,
                         clear_pending_stack: true,
                         focus: true,
+                        replaces: None,
                     });
                 }
                 TabCommand::Next | TabCommand::Previous => {
@@ -928,6 +938,7 @@ mod tests {
                 content: crate::TabLayoutSpawnContent::StartupUrlOrPrompt,
                 clear_pending_stack: false,
                 focus: true,
+                replaces: None,
             });
 
         app.update();

--- a/crates/vmux_layout/src/warm_page.rs
+++ b/crates/vmux_layout/src/warm_page.rs
@@ -14,7 +14,7 @@ pub trait WarmPage: Component {
     const HOST: &'static str;
     const URL: &'static str;
     const TITLE: &'static str;
-    const POOL_SIZE: usize = 1;
+    const POOL_SIZE: usize = 0;
 
     fn spawn(
         commands: &mut Commands,
@@ -125,11 +125,7 @@ fn handle_registered_page_open(
     mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
-    let pages: HashMap<&str, &PrewarmPage> = pages
-        .iter()
-        .filter(|page| page.pool_size > 0)
-        .map(|page| (page.url, page))
-        .collect();
+    let pages: HashMap<&str, &PrewarmPage> = pages.iter().map(|page| (page.url, page)).collect();
     let mut available: HashMap<&str, Vec<Entity>> = HashMap::new();
     for (entity, spare) in &spares {
         available.entry(spare.url).or_default().push(entity);
@@ -330,6 +326,7 @@ mod tests {
         const HOST: &'static str = "test";
         const URL: &'static str = "vmux://test/";
         const TITLE: &'static str = "Test";
+        const POOL_SIZE: usize = 1;
 
         fn spawn(
             commands: &mut Commands,
@@ -480,6 +477,42 @@ mod tests {
         );
         assert!(app.world().get::<WarmPageSpare>(spare).is_none());
         assert!(app.world().get::<PageOpenHandled>(task).is_some());
+    }
+
+    #[test]
+    fn registered_page_without_pool_opens_cold() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<Assets<Mesh>>()
+            .init_resource::<Assets<WebviewExtendStandardMaterial>>()
+            .add_systems(Update, handle_registered_page_open);
+        app.world_mut().spawn(PrewarmPage {
+            host: "history",
+            url: "vmux://history/",
+            title: "History",
+            pool_size: 0,
+        });
+        let stack = app.world_mut().spawn_empty().id();
+        let task = app
+            .world_mut()
+            .spawn(PageOpenTask {
+                id: PageOpenId::new(),
+                stack,
+                url: "vmux://history/".to_string(),
+                request_id: None,
+            })
+            .id();
+
+        app.update();
+
+        assert!(app.world().get::<PageOpenHandled>(task).is_some());
+        let pages = app
+            .world_mut()
+            .query_filtered::<&ChildOf, With<Browser>>()
+            .iter(app.world())
+            .filter(|child| child.parent() == stack)
+            .count();
+        assert_eq!(pages, 1);
     }
 
     #[test]

--- a/crates/vmux_layout/src/window.rs
+++ b/crates/vmux_layout/src/window.rs
@@ -9,7 +9,7 @@ use crate::{
     settings::LayoutSettings,
     side_sheet::{SideSheet, SideSheetPosition, SideSheetWidth},
     stack::stack_bundle,
-    tab::{Tab, tab_bundle},
+    tab::{PendingTabReplacement, Tab, tab_bundle},
     unit::WindowExt,
 };
 use bevy::{
@@ -481,6 +481,7 @@ fn request_default_layout(
         content: TabLayoutSpawnContent::StartupUrlOrPrompt,
         clear_pending_stack: false,
         focus: true,
+        replaces: None,
     });
 }
 
@@ -585,6 +586,16 @@ pub fn spawn_requested_tab_layouts(
             name: request.name.clone().unwrap_or_default(),
             startup_dir,
         });
+        if !request.focus {
+            commands.entity(tab_e).insert(LastActivatedAt(0));
+            commands.entity(leaf).insert(LastActivatedAt(0));
+            commands.entity(stack).insert(LastActivatedAt(0));
+        }
+        if let Some(old_tab) = request.replaces {
+            commands
+                .entity(tab_e)
+                .insert(PendingTabReplacement { old_tab });
+        }
 
         if request.clear_pending_stack
             && let Some(old_stack) = new_stack_ctx.stack.take()
@@ -1397,6 +1408,7 @@ mod tests {
                 content: crate::TabLayoutSpawnContent::StartupUrlOrPrompt,
                 clear_pending_stack: false,
                 focus: true,
+                replaces: None,
             });
 
         app.update();
@@ -1436,6 +1448,7 @@ mod tests {
                 content: crate::TabLayoutSpawnContent::StartupUrlOrPrompt,
                 clear_pending_stack: false,
                 focus: true,
+                replaces: None,
             });
         app.world_mut()
             .entity_mut(requested_space)

--- a/crates/vmux_service/src/registry.rs
+++ b/crates/vmux_service/src/registry.rs
@@ -35,6 +35,9 @@ pub fn start_mode_for_profile(profile: &str, exe: &Path) -> StartMode {
 }
 
 pub fn prepare_spawn_detached(exe: &Path) {
+    #[cfg(not(target_os = "macos"))]
+    let _ = exe;
+
     #[cfg(target_os = "macos")]
     if bundle::bundle_root_for(exe).is_some()
         && let Err(error) = crate::sm_app_service::unregister_agent(bundle::EMBEDDED_AGENT_PLIST)

--- a/crates/vmux_service/src/registry.rs
+++ b/crates/vmux_service/src/registry.rs
@@ -23,10 +23,23 @@ pub enum StartMode {
 }
 
 pub fn start_mode_for(exe: &Path) -> StartMode {
-    if bundle::bundle_root_for(exe).is_some() {
+    start_mode_for_profile(crate::current_profile(), exe)
+}
+
+pub fn start_mode_for_profile(profile: &str, exe: &Path) -> StartMode {
+    if profile == "release" && bundle::bundle_root_for(exe).is_some() {
         StartMode::Register
     } else {
         StartMode::SpawnDetached
+    }
+}
+
+pub fn prepare_spawn_detached(exe: &Path) {
+    #[cfg(target_os = "macos")]
+    if bundle::bundle_root_for(exe).is_some()
+        && let Err(error) = crate::sm_app_service::unregister_agent(bundle::EMBEDDED_AGENT_PLIST)
+    {
+        tracing::debug!(%error, "unregister embedded agent before detached spawn");
     }
 }
 

--- a/crates/vmux_service/tests/start_mode.rs
+++ b/crates/vmux_service/tests/start_mode.rs
@@ -1,28 +1,23 @@
 use std::path::PathBuf;
-use vmux_service::registry::{StartMode, start_mode_for};
+use vmux_service::registry::{StartMode, start_mode_for_profile};
 
 #[test]
-fn bundled_service_app_registers() {
-    let exe = PathBuf::from(
+fn start_mode_depends_on_profile_and_bundle_location() {
+    let service_app = PathBuf::from(
         "/Applications/Vmux.app/Contents/Library/LoginItems/Vmux Service.app/Contents/MacOS/Vmux Service",
     );
-    assert_eq!(start_mode_for(&exe), StartMode::Register);
-}
+    let main_app = PathBuf::from("/Applications/Vmux.app/Contents/MacOS/Vmux");
+    let dev_binary = PathBuf::from("/Users/x/repo/target/debug/vmux_service");
+    let plain_binary = PathBuf::from("/usr/local/bin/vmux_service");
 
-#[test]
-fn bundled_main_app_registers() {
-    let exe = PathBuf::from("/Applications/Vmux.app/Contents/MacOS/Vmux");
-    assert_eq!(start_mode_for(&exe), StartMode::Register);
-}
-
-#[test]
-fn dev_target_debug_spawns_detached() {
-    let exe = PathBuf::from("/Users/x/repo/target/debug/vmux_service");
-    assert_eq!(start_mode_for(&exe), StartMode::SpawnDetached);
-}
-
-#[test]
-fn plain_bin_spawns_detached() {
-    let exe = PathBuf::from("/usr/local/bin/vmux_service");
-    assert_eq!(start_mode_for(&exe), StartMode::SpawnDetached);
+    for (profile, exe, expected) in [
+        ("release", &service_app, StartMode::Register),
+        ("release", &main_app, StartMode::Register),
+        ("local", &service_app, StartMode::SpawnDetached),
+        ("dev", &main_app, StartMode::SpawnDetached),
+        ("release", &dev_binary, StartMode::SpawnDetached),
+        ("release", &plain_binary, StartMode::SpawnDetached),
+    ] {
+        assert_eq!(start_mode_for_profile(profile, exe), expected);
+    }
 }

--- a/crates/vmux_space/src/plugin.rs
+++ b/crates/vmux_space/src/plugin.rs
@@ -548,6 +548,7 @@ fn on_space_command(
                 content: TabLayoutSpawnContent::Url(SPACES_PAGE_URL.to_string()),
                 clear_pending_stack: true,
                 focus: true,
+                replaces: None,
             });
         }
         _ => {}
@@ -623,6 +624,7 @@ fn handle_open_in_new_space(
             content,
             clear_pending_stack: true,
             focus: true,
+            replaces: None,
         });
     }
 }

--- a/crates/vmux_terminal/src/clipboard.rs
+++ b/crates/vmux_terminal/src/clipboard.rs
@@ -66,6 +66,24 @@ fn read_image_png_inner() -> Option<Vec<u8>> {
     None
 }
 
+/// Read TIFF image bytes from the system clipboard, if present.
+pub fn read_image_tiff() -> Option<Vec<u8>> {
+    read_image_tiff_inner()
+}
+
+#[cfg(target_os = "macos")]
+fn read_image_tiff_inner() -> Option<Vec<u8>> {
+    use objc2_app_kit::{NSPasteboard, NSPasteboardTypeTIFF};
+    let tiff_type = unsafe { NSPasteboardTypeTIFF };
+    let data = NSPasteboard::generalPasteboard().dataForType(tiff_type)?;
+    Some(data.to_vec())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn read_image_tiff_inner() -> Option<Vec<u8>> {
+    None
+}
+
 /// Absolute path of an image *file* on the clipboard (a copied file, e.g. a
 /// saved screenshot), if any.
 ///

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -1032,7 +1032,10 @@ fn ensure_service_started() {
                 tracing::error!(error = ?e, "service registration failed");
             }
         }
-        vmux_service::registry::StartMode::SpawnDetached => spawn_detached_service(&binary),
+        vmux_service::registry::StartMode::SpawnDetached => {
+            vmux_service::registry::prepare_spawn_detached(&binary);
+            spawn_detached_service(&binary);
+        }
     }
 }
 

--- a/crates/vmux_ui/src/components/prompt_composer.rs
+++ b/crates/vmux_ui/src/components/prompt_composer.rs
@@ -1,6 +1,3 @@
-use std::cell::RefCell;
-use std::rc::Rc;
-
 use crate::i18n::translate;
 use dioxus::prelude::*;
 use wasm_bindgen::{JsCast, closure::Closure};
@@ -13,6 +10,7 @@ pub const PROMPT_INPUT_ID: &str = "vmux-prompt-input";
 
 const PROMPT_COMPOSER_CSS: &str = r#"
 .vmux-prompt-input{caret-color:var(--vmux-prompt-accent)}
+.vmux-prompt-input.vmux-prompt-input-empty{caret-color:transparent}
 .vmux-prompt-composer{box-shadow:0 22px 70px -30px rgba(0,0,0,.58),0 8px 24px -16px rgba(0,0,0,.3),inset 0 1px 0 rgba(255,255,255,.16)}
 .vmux-prompt-composer:focus-within{box-shadow:0 28px 84px -34px rgba(0,0,0,.7),0 10px 28px -18px color-mix(in srgb,var(--vmux-prompt-accent) 32%,transparent),inset 0 0 0 1px color-mix(in srgb,var(--vmux-prompt-accent) 28%,transparent),inset 0 1px 0 rgba(255,255,255,.2)}
 "#;
@@ -69,6 +67,11 @@ pub fn PromptComposer(
     } else {
         "relative z-10 flex h-8 w-8 shrink-0 cursor-default items-center justify-center rounded-full bg-foreground/[0.055] text-muted-foreground/35 ring-1 ring-inset ring-foreground/[0.07]".to_string()
     };
+    let input_class = if value.is_empty() && preview.is_empty() && show_examples {
+        "vmux-prompt-input vmux-prompt-input-empty relative z-10 max-h-48 min-h-12 w-full resize-none bg-transparent px-1 py-2 text-[15px] leading-6 placeholder:text-transparent focus:outline-none"
+    } else {
+        "vmux-prompt-input relative z-10 max-h-48 min-h-12 w-full resize-none bg-transparent px-1 py-2 text-[15px] leading-6 placeholder:text-transparent focus:outline-none"
+    };
 
     rsx! {
             style { dangerous_inner_html: PROMPT_COMPOSER_CSS }
@@ -121,16 +124,16 @@ pub fn PromptComposer(
                     }
                     div { class: "relative min-w-32 overflow-hidden",
                         if value.is_empty() {
-                            div { class: "pointer-events-none absolute inset-0 flex -translate-y-px items-center overflow-hidden px-1 py-1",
+                            div { class: "pointer-events-none absolute inset-0 overflow-hidden px-1 py-2 text-[15px] leading-6",
                                 if !preview.is_empty() {
-                                    div { class: "max-w-full truncate whitespace-nowrap text-[15px] leading-6 text-foreground", "{preview}" }
+                                    div { class: "max-w-full truncate whitespace-nowrap text-foreground", "{preview}" }
                                 } else if show_examples {
                                     PromptGhost {
                                         accent_bg,
                                         terminal: false,
                                     }
                                 } else {
-                                    div { class: "flex max-w-full items-center whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50",
+                                    div { class: "max-w-full truncate whitespace-nowrap text-muted-foreground/50",
                                         span { class: "min-w-0 truncate", "{placeholder}" }
                                     }
                                 }
@@ -145,7 +148,7 @@ pub fn PromptComposer(
                         }
                         textarea {
                             id: PROMPT_INPUT_ID,
-                            class: "vmux-prompt-input relative z-10 max-h-48 min-h-12 w-full resize-none bg-transparent px-1 py-2 text-[15px] leading-6 placeholder:text-transparent focus:outline-none",
+                            class: "{input_class}",
                             autofocus: true,
                             rows: "1",
                             placeholder: "{placeholder}",

--- a/crates/vmux_ui/src/components/prompt_composer.rs
+++ b/crates/vmux_ui/src/components/prompt_composer.rs
@@ -5,7 +5,6 @@ use crate::i18n::translate;
 use dioxus::prelude::*;
 use wasm_bindgen::{JsCast, closure::Closure};
 
-use crate::listener_guard::GuardedListener;
 use crate::prompt_ghost::PromptGhost;
 
 use super::prompt_box::PromptBox;
@@ -13,9 +12,7 @@ use super::prompt_box::PromptBox;
 pub const PROMPT_INPUT_ID: &str = "vmux-prompt-input";
 
 const PROMPT_COMPOSER_CSS: &str = r#"
-.vmux-prompt-input{caret-color:transparent}
-.vmux-prompt-caret{animation:vmux-prompt-caret-blink 1s step-end infinite;background:var(--vmux-prompt-accent)}
-@keyframes vmux-prompt-caret-blink{0%,49%{opacity:1}50%,100%{opacity:0}}
+.vmux-prompt-input{caret-color:var(--vmux-prompt-accent)}
 .vmux-prompt-composer{box-shadow:0 22px 70px -30px rgba(0,0,0,.58),0 8px 24px -16px rgba(0,0,0,.3),inset 0 1px 0 rgba(255,255,255,.16)}
 .vmux-prompt-composer:focus-within{box-shadow:0 28px 84px -34px rgba(0,0,0,.7),0 10px 28px -18px color-mix(in srgb,var(--vmux-prompt-accent) 32%,transparent),inset 0 0 0 1px color-mix(in srgb,var(--vmux-prompt-accent) 28%,transparent),inset 0 1px 0 rgba(255,255,255,.2)}
 "#;
@@ -34,23 +31,6 @@ pub enum PromptComposerAction {
     #[default]
     Send,
     Stop,
-}
-
-struct PromptFocusTracking {
-    window: web_sys::Window,
-    focus: Closure<dyn FnMut()>,
-    blur: Closure<dyn FnMut()>,
-}
-
-impl Drop for PromptFocusTracking {
-    fn drop(&mut self) {
-        let _ = self
-            .window
-            .remove_event_listener_with_callback("focus", self.focus.as_ref().unchecked_ref());
-        let _ = self
-            .window
-            .remove_event_listener_with_callback("blur", self.blur.as_ref().unchecked_ref());
-    }
 }
 
 #[component]
@@ -75,46 +55,10 @@ pub fn PromptComposer(
     on_remove_attachment: EventHandler<usize>,
     on_action: EventHandler<()>,
 ) -> Element {
-    let mut caret = use_signal(|| None::<u32>);
-    let scroll_top = use_signal(|| 0i32);
-
-    let focus_listener = use_hook(|| {
-        GuardedListener::new(Box::new(move |_: ()| {
-            sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top);
-        }) as Box<dyn FnMut(())>)
-    });
-    let blur_listener = use_hook(|| {
-        GuardedListener::new(Box::new(move |_: ()| {
-            caret.set(None);
-        }) as Box<dyn FnMut(())>)
-    });
-    let focus_tracking = use_hook(|| Rc::new(RefCell::new(None::<PromptFocusTracking>)));
-    use_effect({
-        let focus_listener = focus_listener.clone();
-        let blur_listener = blur_listener.clone();
-        let focus_tracking = focus_tracking.clone();
-        move || {
-            *focus_tracking.borrow_mut() =
-                install_prompt_focus_tracking(focus_listener.clone(), blur_listener.clone());
-        }
-    });
-    let focus_guard = focus_listener.guard();
-    let blur_guard = blur_listener.guard();
-    use_drop(move || {
-        focus_guard.deactivate();
-        blur_guard.deactivate();
-        focus_tracking.borrow_mut().take();
-    });
-
     use_effect(use_reactive((&value,), move |_| {
         resize_prompt_textarea(PROMPT_INPUT_ID);
-        sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top);
     }));
 
-    let caret_prefix = caret()
-        .filter(|_| !value.is_empty())
-        .map(|offset| prompt_prefix_at_utf16(&value, offset).to_string());
-    let prompt_scroll_offset = scroll_top();
     let action_class = if action_enabled {
         match action {
             PromptComposerAction::Send => format!(
@@ -187,9 +131,6 @@ pub fn PromptComposer(
                                     }
                                 } else {
                                     div { class: "flex max-w-full items-center whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50",
-                                        if caret().is_some() {
-                                            span { class: "vmux-prompt-caret relative top-px mr-px h-4 w-1.5 shrink-0" }
-                                        }
                                         span { class: "min-w-0 truncate", "{placeholder}" }
                                     }
                                 }
@@ -202,16 +143,6 @@ pub fn PromptComposer(
                                 span { class: "text-muted-foreground/40", "{completion}" }
                             }
                         }
-                        if let Some(prefix) = caret_prefix.as_ref() {
-                            div { class: "pointer-events-none absolute inset-0 z-20 overflow-hidden",
-                                div {
-                                    class: "min-h-12 w-full whitespace-pre-wrap break-words px-1 py-2 text-[15px] leading-6 text-transparent",
-                                    style: "transform:translateY(-{prompt_scroll_offset}px);",
-                                    span { "{prefix}" }
-                                    span { class: "vmux-prompt-caret relative top-px ml-px inline-block h-4 w-1.5 align-middle" }
-                                }
-                            }
-                        }
                         textarea {
                             id: PROMPT_INPUT_ID,
                             class: "vmux-prompt-input relative z-10 max-h-48 min-h-12 w-full resize-none bg-transparent px-1 py-2 text-[15px] leading-6 placeholder:text-transparent focus:outline-none",
@@ -219,17 +150,8 @@ pub fn PromptComposer(
                             rows: "1",
                             placeholder: "{placeholder}",
                             value: "{value}",
-                            oninput: move |event| {
-                                on_input.call(event.value());
-                                resize_prompt_textarea(PROMPT_INPUT_ID);
-                                sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top);
-                            },
+                            oninput: move |event| on_input.call(event.value()),
                             onpaste: move |_| on_paste.call(()),
-                            onfocus: move |_| sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top),
-                            onblur: move |_| sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top),
-                            onkeyup: move |_| sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top),
-                            onmouseup: move |_| sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top),
-                            onscroll: move |_| sync_prompt_caret(PROMPT_INPUT_ID, caret, scroll_top),
                             onkeydown: move |event| on_keydown.call(event),
                         }
                     }
@@ -328,54 +250,4 @@ fn resize_prompt_textarea(input_id: &str) {
     let height = textarea.scroll_height().clamp(48, 192);
     let overflow = if height == 192 { "auto" } else { "hidden" };
     let _ = textarea.set_attribute("style", &format!("height:{height}px;overflow-y:{overflow}"));
-}
-
-fn sync_prompt_caret(input_id: &str, mut caret: Signal<Option<u32>>, mut scroll_top: Signal<i32>) {
-    let page_active = web_sys::window()
-        .and_then(|window| window.document())
-        .is_some_and(|document| document.has_focus().unwrap_or(false));
-    if !page_active {
-        caret.set(None);
-        return;
-    }
-    let Some(textarea) = prompt_textarea(input_id) else {
-        return;
-    };
-    let start = textarea.selection_start().ok().flatten().unwrap_or(0);
-    let end = textarea.selection_end().ok().flatten().unwrap_or(start);
-    caret.set((start == end).then_some(start));
-    scroll_top.set(textarea.scroll_top());
-}
-
-fn install_prompt_focus_tracking(
-    focus_listener: GuardedListener<Box<dyn FnMut(())>>,
-    blur_listener: GuardedListener<Box<dyn FnMut(())>>,
-) -> Option<PromptFocusTracking> {
-    let window = web_sys::window()?;
-    let focus = Closure::wrap(Box::new(move || {
-        focus_listener.call(());
-    }) as Box<dyn FnMut()>);
-    let _ = window.add_event_listener_with_callback("focus", focus.as_ref().unchecked_ref());
-
-    let blur = Closure::wrap(Box::new(move || {
-        blur_listener.call(());
-    }) as Box<dyn FnMut()>);
-    let _ = window.add_event_listener_with_callback("blur", blur.as_ref().unchecked_ref());
-
-    Some(PromptFocusTracking {
-        window,
-        focus,
-        blur,
-    })
-}
-
-fn prompt_prefix_at_utf16(value: &str, offset: u32) -> &str {
-    let mut units = 0u32;
-    for (byte, character) in value.char_indices() {
-        if units >= offset {
-            return &value[..byte];
-        }
-        units += character.len_utf16() as u32;
-    }
-    value
 }

--- a/crates/vmux_ui/src/components/prompt_composer.rs
+++ b/crates/vmux_ui/src/components/prompt_composer.rs
@@ -34,81 +34,8 @@ pub enum PromptComposerAction {
 }
 
 #[component]
-fn PromptComposerInput(
-    value: String,
-    value_revision: u64,
-    preview: String,
-    completion: String,
-    show_examples: bool,
-    placeholder: String,
-    accent_bg: String,
-    on_input: EventHandler<String>,
-    on_keydown: EventHandler<KeyboardEvent>,
-    on_paste: EventHandler<()>,
-) -> Element {
-    let initial_value = value.clone();
-    let mut input_value = use_signal(move || initial_value);
-
-    use_effect(use_reactive(
-        (&value, &value_revision),
-        move |(value, _)| {
-            if input_value.peek().as_str() != value {
-                input_value.set(value);
-            }
-        },
-    ));
-
-    let rendered_value = input_value();
-
-    rsx! {
-        div { class: "relative min-w-32 overflow-hidden",
-            if rendered_value.is_empty() {
-                div { class: "pointer-events-none absolute inset-0 flex -translate-y-px items-center overflow-hidden px-1 py-1",
-                    if !preview.is_empty() {
-                        div { class: "max-w-full truncate whitespace-nowrap text-[15px] leading-6 text-foreground", "{preview}" }
-                    } else if show_examples {
-                        PromptGhost {
-                            accent_bg,
-                            terminal: false,
-                        }
-                    } else {
-                        div { class: "flex max-w-full items-center whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50",
-                            span { class: "min-w-0 truncate", "{placeholder}" }
-                        }
-                    }
-                }
-            }
-            if !completion.is_empty() {
-                div {
-                    class: "pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words px-1 py-2 text-[15px] leading-6",
-                    span { class: "text-transparent", "{rendered_value}" }
-                    span { class: "text-muted-foreground/40", "{completion}" }
-                }
-            }
-            textarea {
-                id: PROMPT_INPUT_ID,
-                class: "vmux-prompt-input relative z-10 max-h-48 min-h-12 w-full resize-none bg-transparent px-1 py-2 text-[15px] leading-6 placeholder:text-transparent focus:outline-none",
-                style: "field-sizing:content;",
-                autofocus: true,
-                rows: "1",
-                placeholder: "{placeholder}",
-                value: "{rendered_value}",
-                oninput: move |event| {
-                    let value = event.value();
-                    input_value.set(value.clone());
-                    on_input.call(value);
-                },
-                onpaste: move |_| on_paste.call(()),
-                onkeydown: move |event| on_keydown.call(event),
-            }
-        }
-    }
-}
-
-#[component]
 pub fn PromptComposer(
     value: String,
-    #[props(default)] value_revision: u64,
     #[props(default)] preview: String,
     #[props(default)] completion: String,
     #[props(default)] attachments: Vec<PromptComposerAttachment>,
@@ -128,6 +55,10 @@ pub fn PromptComposer(
     on_remove_attachment: EventHandler<usize>,
     on_action: EventHandler<()>,
 ) -> Element {
+    use_effect(use_reactive((&value,), move |_| {
+        resize_prompt_textarea(PROMPT_INPUT_ID);
+    }));
+
     let action_class = if action_enabled {
         match action {
             PromptComposerAction::Send => format!(
@@ -188,17 +119,41 @@ pub fn PromptComposer(
                     }
                         }
                     }
-                    PromptComposerInput {
-                        value,
-                        value_revision,
-                        preview,
-                        completion,
-                        show_examples,
-                        placeholder: placeholder.clone(),
-                        accent_bg,
-                        on_input,
-                        on_keydown,
-                        on_paste,
+                    div { class: "relative min-w-32 overflow-hidden",
+                        if value.is_empty() {
+                            div { class: "pointer-events-none absolute inset-0 flex -translate-y-px items-center overflow-hidden px-1 py-1",
+                                if !preview.is_empty() {
+                                    div { class: "max-w-full truncate whitespace-nowrap text-[15px] leading-6 text-foreground", "{preview}" }
+                                } else if show_examples {
+                                    PromptGhost {
+                                        accent_bg,
+                                        terminal: false,
+                                    }
+                                } else {
+                                    div { class: "flex max-w-full items-center whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50",
+                                        span { class: "min-w-0 truncate", "{placeholder}" }
+                                    }
+                                }
+                            }
+                        }
+                        if !completion.is_empty() {
+                            div {
+                                class: "pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words px-1 py-2 text-[15px] leading-6",
+                                span { class: "text-transparent", "{value}" }
+                                span { class: "text-muted-foreground/40", "{completion}" }
+                            }
+                        }
+                        textarea {
+                            id: PROMPT_INPUT_ID,
+                            class: "vmux-prompt-input relative z-10 max-h-48 min-h-12 w-full resize-none bg-transparent px-1 py-2 text-[15px] leading-6 placeholder:text-transparent focus:outline-none",
+                            autofocus: true,
+                            rows: "1",
+                            placeholder: "{placeholder}",
+                            value: "{value}",
+                            oninput: move |event| on_input.call(event.value()),
+                            onpaste: move |_| on_paste.call(()),
+                            onkeydown: move |event| on_keydown.call(event),
+                        }
                     }
                 }
                 div { class: "relative z-10 mt-0.5 flex min-w-0 items-center gap-1 px-1",
@@ -285,4 +240,14 @@ pub fn focus_prompt_end(input_id: &str) {
         );
     }
     closure.forget();
+}
+
+fn resize_prompt_textarea(input_id: &str) {
+    let Some(textarea) = prompt_textarea(input_id) else {
+        return;
+    };
+    let _ = textarea.set_attribute("style", "height:auto;overflow-y:hidden");
+    let height = textarea.scroll_height().clamp(48, 192);
+    let overflow = if height == 192 { "auto" } else { "hidden" };
+    let _ = textarea.set_attribute("style", &format!("height:{height}px;overflow-y:{overflow}"));
 }

--- a/crates/vmux_ui/src/components/prompt_composer.rs
+++ b/crates/vmux_ui/src/components/prompt_composer.rs
@@ -34,8 +34,81 @@ pub enum PromptComposerAction {
 }
 
 #[component]
+fn PromptComposerInput(
+    value: String,
+    value_revision: u64,
+    preview: String,
+    completion: String,
+    show_examples: bool,
+    placeholder: String,
+    accent_bg: String,
+    on_input: EventHandler<String>,
+    on_keydown: EventHandler<KeyboardEvent>,
+    on_paste: EventHandler<()>,
+) -> Element {
+    let initial_value = value.clone();
+    let mut input_value = use_signal(move || initial_value);
+
+    use_effect(use_reactive(
+        (&value, &value_revision),
+        move |(value, _)| {
+            if input_value.peek().as_str() != value {
+                input_value.set(value);
+            }
+        },
+    ));
+
+    let rendered_value = input_value();
+
+    rsx! {
+        div { class: "relative min-w-32 overflow-hidden",
+            if rendered_value.is_empty() {
+                div { class: "pointer-events-none absolute inset-0 flex -translate-y-px items-center overflow-hidden px-1 py-1",
+                    if !preview.is_empty() {
+                        div { class: "max-w-full truncate whitespace-nowrap text-[15px] leading-6 text-foreground", "{preview}" }
+                    } else if show_examples {
+                        PromptGhost {
+                            accent_bg,
+                            terminal: false,
+                        }
+                    } else {
+                        div { class: "flex max-w-full items-center whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50",
+                            span { class: "min-w-0 truncate", "{placeholder}" }
+                        }
+                    }
+                }
+            }
+            if !completion.is_empty() {
+                div {
+                    class: "pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words px-1 py-2 text-[15px] leading-6",
+                    span { class: "text-transparent", "{rendered_value}" }
+                    span { class: "text-muted-foreground/40", "{completion}" }
+                }
+            }
+            textarea {
+                id: PROMPT_INPUT_ID,
+                class: "vmux-prompt-input relative z-10 max-h-48 min-h-12 w-full resize-none bg-transparent px-1 py-2 text-[15px] leading-6 placeholder:text-transparent focus:outline-none",
+                style: "field-sizing:content;",
+                autofocus: true,
+                rows: "1",
+                placeholder: "{placeholder}",
+                value: "{rendered_value}",
+                oninput: move |event| {
+                    let value = event.value();
+                    input_value.set(value.clone());
+                    on_input.call(value);
+                },
+                onpaste: move |_| on_paste.call(()),
+                onkeydown: move |event| on_keydown.call(event),
+            }
+        }
+    }
+}
+
+#[component]
 pub fn PromptComposer(
     value: String,
+    #[props(default)] value_revision: u64,
     #[props(default)] preview: String,
     #[props(default)] completion: String,
     #[props(default)] attachments: Vec<PromptComposerAttachment>,
@@ -55,10 +128,6 @@ pub fn PromptComposer(
     on_remove_attachment: EventHandler<usize>,
     on_action: EventHandler<()>,
 ) -> Element {
-    use_effect(use_reactive((&value,), move |_| {
-        resize_prompt_textarea(PROMPT_INPUT_ID);
-    }));
-
     let action_class = if action_enabled {
         match action {
             PromptComposerAction::Send => format!(
@@ -119,41 +188,17 @@ pub fn PromptComposer(
                     }
                         }
                     }
-                    div { class: "relative min-w-32 overflow-hidden",
-                        if value.is_empty() {
-                            div { class: "pointer-events-none absolute inset-0 flex -translate-y-px items-center overflow-hidden px-1 py-1",
-                                if !preview.is_empty() {
-                                    div { class: "max-w-full truncate whitespace-nowrap text-[15px] leading-6 text-foreground", "{preview}" }
-                                } else if show_examples {
-                                    PromptGhost {
-                                        accent_bg,
-                                        terminal: false,
-                                    }
-                                } else {
-                                    div { class: "flex max-w-full items-center whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50",
-                                        span { class: "min-w-0 truncate", "{placeholder}" }
-                                    }
-                                }
-                            }
-                        }
-                        if !completion.is_empty() {
-                            div {
-                                class: "pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words px-1 py-2 text-[15px] leading-6",
-                                span { class: "text-transparent", "{value}" }
-                                span { class: "text-muted-foreground/40", "{completion}" }
-                            }
-                        }
-                        textarea {
-                            id: PROMPT_INPUT_ID,
-                            class: "vmux-prompt-input relative z-10 max-h-48 min-h-12 w-full resize-none bg-transparent px-1 py-2 text-[15px] leading-6 placeholder:text-transparent focus:outline-none",
-                            autofocus: true,
-                            rows: "1",
-                            placeholder: "{placeholder}",
-                            value: "{value}",
-                            oninput: move |event| on_input.call(event.value()),
-                            onpaste: move |_| on_paste.call(()),
-                            onkeydown: move |event| on_keydown.call(event),
-                        }
+                    PromptComposerInput {
+                        value,
+                        value_revision,
+                        preview,
+                        completion,
+                        show_examples,
+                        placeholder: placeholder.clone(),
+                        accent_bg,
+                        on_input,
+                        on_keydown,
+                        on_paste,
                     }
                 }
                 div { class: "relative z-10 mt-0.5 flex min-w-0 items-center gap-1 px-1",
@@ -240,14 +285,4 @@ pub fn focus_prompt_end(input_id: &str) {
         );
     }
     closure.forget();
-}
-
-fn resize_prompt_textarea(input_id: &str) {
-    let Some(textarea) = prompt_textarea(input_id) else {
-        return;
-    };
-    let _ = textarea.set_attribute("style", "height:auto;overflow-y:hidden");
-    let height = textarea.scroll_height().clamp(48, 192);
-    let overflow = if height == 192 { "auto" } else { "hidden" };
-    let _ = textarea.set_attribute("style", &format!("height:{height}px;overflow-y:{overflow}"));
 }

--- a/crates/vmux_ui/src/prompt_ghost.rs
+++ b/crates/vmux_ui/src/prompt_ghost.rs
@@ -90,8 +90,9 @@ mod component {
         next_prompt_typed_count,
     };
 
-    const PROMPT_CARET_CSS: &str = ".vmux-prompt-caret{animation:vmux-prompt-caret-blink 1s step-end infinite}@keyframes vmux-prompt-caret-blink{0%,49%{opacity:1}50%,100%{opacity:0}}";
+    const PROMPT_CARET_CSS: &str = ".vmux-prompt-caret{animation:vmux-prompt-caret-blink 1s step-end infinite}.vmux-prompt-caret-paused{animation-play-state:paused}@keyframes vmux-prompt-caret-blink{0%,49%{opacity:1}50%,100%{opacity:0}}";
     type PromptTimerCallback = Rc<RefCell<Option<Closure<dyn FnMut()>>>>;
+    type ActivityCallback = Rc<RefCell<Option<Closure<dyn FnMut()>>>>;
 
     #[component]
     pub fn PromptGhost(accent_bg: String, terminal: bool) -> Element {
@@ -104,21 +105,89 @@ mod component {
         let typed = use_signal(|| 0usize);
         let cb: PromptTimerCallback = use_hook(|| Rc::new(RefCell::new(None)));
         let timer: Rc<RefCell<Option<i32>>> = use_hook(|| Rc::new(RefCell::new(None)));
+        let mut active = use_signal(document_active);
+        let activity_cb: ActivityCallback = use_hook(|| Rc::new(RefCell::new(None)));
+        use_effect({
+            let activity_cb = activity_cb.clone();
+            move || {
+                let callback = Closure::wrap(
+                    Box::new(move || active.set(document_active())) as Box<dyn FnMut()>
+                );
+                if let Some(window) = web_sys::window() {
+                    let window_target: &web_sys::EventTarget = window.as_ref();
+                    let _ = window_target.add_event_listener_with_callback(
+                        "focus",
+                        callback.as_ref().unchecked_ref(),
+                    );
+                    let _ = window_target.add_event_listener_with_callback(
+                        "blur",
+                        callback.as_ref().unchecked_ref(),
+                    );
+                    if let Some(document) = window.document() {
+                        let document_target: &web_sys::EventTarget = document.as_ref();
+                        let _ = document_target.add_event_listener_with_callback(
+                            "focusin",
+                            callback.as_ref().unchecked_ref(),
+                        );
+                        let _ = document_target.add_event_listener_with_callback(
+                            "focusout",
+                            callback.as_ref().unchecked_ref(),
+                        );
+                    }
+                }
+                if let Some(document) = web_sys::window().and_then(|window| window.document()) {
+                    let _ = document.add_event_listener_with_callback(
+                        "visibilitychange",
+                        callback.as_ref().unchecked_ref(),
+                    );
+                }
+                *activity_cb.borrow_mut() = Some(callback);
+            }
+        });
         use_effect({
             let cb = cb.clone();
             let timer = timer.clone();
-            move || start_prompt_typewriter(examples, ex_idx, typed, cb.clone(), timer.clone())
+            move || {
+                stop_prompt_typewriter(cb.clone(), timer.clone());
+                if active() {
+                    start_prompt_typewriter(examples, ex_idx, typed, cb.clone(), timer.clone());
+                }
+            }
         });
         use_drop({
             let cb = cb.clone();
             let timer = timer.clone();
+            let activity_cb = activity_cb.clone();
             move || {
-                if let Some(id) = timer.borrow_mut().take()
-                    && let Some(win) = web_sys::window()
+                stop_prompt_typewriter(cb.clone(), timer.clone());
+                if let Some(callback) = activity_cb.borrow_mut().take()
+                    && let Some(window) = web_sys::window()
                 {
-                    win.clear_interval_with_handle(id);
+                    let window_target: &web_sys::EventTarget = window.as_ref();
+                    let _ = window_target.remove_event_listener_with_callback(
+                        "focus",
+                        callback.as_ref().unchecked_ref(),
+                    );
+                    let _ = window_target.remove_event_listener_with_callback(
+                        "blur",
+                        callback.as_ref().unchecked_ref(),
+                    );
+                    if let Some(document) = window.document() {
+                        let document_target: &web_sys::EventTarget = document.as_ref();
+                        let _ = document_target.remove_event_listener_with_callback(
+                            "focusin",
+                            callback.as_ref().unchecked_ref(),
+                        );
+                        let _ = document_target.remove_event_listener_with_callback(
+                            "focusout",
+                            callback.as_ref().unchecked_ref(),
+                        );
+                        let _ = document_target.remove_event_listener_with_callback(
+                            "visibilitychange",
+                            callback.as_ref().unchecked_ref(),
+                        );
+                    }
                 }
-                *cb.borrow_mut() = None;
             }
         });
         let example = examples[ex_idx() % examples.len()];
@@ -129,10 +198,17 @@ mod component {
         } else {
             "flex max-w-full items-center whitespace-nowrap text-[15px] leading-6 text-muted-foreground/50"
         };
-        let caret_class = if terminal {
-            format!("vmux-prompt-caret ml-px inline-block h-3.5 w-1.5 align-middle {accent_bg}")
+        let caret_state = if active() {
+            ""
         } else {
-            format!("vmux-prompt-caret relative top-px ml-px h-4 w-1.5 shrink-0 {accent_bg}")
+            " vmux-prompt-caret-paused"
+        };
+        let caret_class = if terminal {
+            format!(
+                "vmux-prompt-caret{caret_state} ml-px inline-block h-3.5 w-1.5 align-middle {accent_bg}"
+            )
+        } else {
+            format!("vmux-prompt-caret{caret_state} ml-px h-5 w-px shrink-0 {accent_bg}")
         };
         rsx! {
             style { dangerous_inner_html: PROMPT_CARET_CSS }
@@ -147,6 +223,37 @@ mod component {
     fn random_prompt_example_index(len: usize, current: Option<usize>) -> usize {
         let candidate = (js_sys::Math::random() * len as f64) as usize;
         distinct_prompt_example_index(len, current, candidate)
+    }
+
+    fn document_visible() -> bool {
+        web_sys::window()
+            .and_then(|window| window.document())
+            .and_then(|document| {
+                js_sys::Reflect::get(
+                    document.as_ref(),
+                    &wasm_bindgen::JsValue::from_str("hidden"),
+                )
+                .ok()
+                .and_then(|hidden| hidden.as_bool())
+            })
+            .is_none_or(|hidden| !hidden)
+    }
+
+    fn document_active() -> bool {
+        document_visible()
+            && web_sys::window()
+                .and_then(|window| window.document())
+                .and_then(|document| document.has_focus().ok())
+                .unwrap_or(false)
+    }
+
+    fn stop_prompt_typewriter(cb_cell: PromptTimerCallback, timer_cell: Rc<RefCell<Option<i32>>>) {
+        if let Some(id) = timer_cell.borrow_mut().take()
+            && let Some(window) = web_sys::window()
+        {
+            window.clear_interval_with_handle(id);
+        }
+        *cb_cell.borrow_mut() = None;
     }
 
     fn start_prompt_typewriter(


### PR DESCRIPTION
## Context

Prompt typing and page scrolling had become CPU-heavy, while media attachment, tab reset, and Start-page warmup behavior regressed. Git status polling also kept doing unnecessary work.

## Implementation

- Keep prompt input updates local, stop hidden placeholder animation, and bound chat rendering work.
- Make screenshot selection and clipboard paste immediate, preserve multiple attachments, and convert macOS TIFF clipboard images to PNG.
- Replace Git polling with watched repository metadata and coalesced invalidation.
- Respawn a fresh tab after closing the last page and clear stale worktree/working-directory state.
- Persist side-sheet card state and each agent's last-used model.
- Keep Start warmup inert, suppress already-approved permission flashes, and harden native input wake paths.
- Isolate local packaged builds from the registered release service.

## Checks / QA

- User-verified responsive typing on Start and chat pages with reduced CPU usage.
- User-verified Start warmup and agent-page behavior.
- WASM checks and native desktop check passed.
- Full pre-push fmt, clippy, workspace tests, and doctests passed.
- Review fixes cover empty media previews, approval delivery fallback, and native keyboard/event-tap wake behavior.
