### PR TITLE
fix(agent): persist scoped approvals and avoid redundant titles

### DIFF
--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -1191,7 +1191,7 @@ pub fn Page(
                 }
                 span {
                     class: "flex h-7 shrink-0 items-center gap-1.5 rounded-lg px-2 text-[11px] text-muted-foreground",
-                    title: "Tools ask before protected actions; Allow always is remembered per tool",
+                    title: "Tools ask before protected actions; Allow always is remembered per agent, repository, and tool",
                     svg {
                         class: "h-3.5 w-3.5",
                         view_box: "0 0 24 24",

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -1191,7 +1191,7 @@ pub fn Page(
                 }
                 span {
                     class: "flex h-7 shrink-0 items-center gap-1.5 rounded-lg px-2 text-[11px] text-muted-foreground",
-                    title: "Tools ask before protected actions; Allow always is remembered per agent, repository, and tool",
+                    title: "Tools ask before protected actions; Allow always is remembered per agent, repository or working directory, and tool",
                     svg {
                         class: "h-3.5 w-3.5",
                         view_box: "0 0 24 24",

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -437,7 +437,7 @@ fn acp_auto_approval_message(
         .then(|| ClientMessage::AgentApprove {
             sid: session.sid.clone(),
             call_id: request.call_id.clone(),
-            decision: vmux_service::protocol::ApprovalDecision::Allow,
+            decision: vmux_service::protocol::ApprovalDecision::AllowAlways,
         })
 }
 
@@ -1096,7 +1096,7 @@ mod tests {
             Some(ClientMessage::AgentApprove { sid, call_id, decision })
                 if sid == "s1"
                     && call_id == "call-1"
-                    && decision == vmux_service::protocol::ApprovalDecision::Allow
+                    && decision == vmux_service::protocol::ApprovalDecision::AllowAlways
         ));
     }
 

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -20,7 +20,7 @@ use crate::events::AgentApprovalRequest;
 use crate::handoff::{ImportedConversation, PendingHandoff};
 use crate::run_state::AgentRunState;
 
-const CONVERSATION_TITLE_STEER_PROMPT: &str = "Immediately after every user message, call mcp__vmux__set_conversation_title as the first tool of the turn, before reading skills, calling any other tool, or answering. Write a concise 3 to 7 word model-generated summary of the whole conversation. Correct spelling and grammar. Never copy the user's prompt verbatim. Update the title even when the user sends a short follow-up.";
+const CONVERSATION_TITLE_STEER_PROMPT: &str = "Call mcp__vmux__set_conversation_title as the first tool of the turn only when the conversation has no title yet or the latest user message materially changes the conversation's topic. If the current title still accurately summarizes the conversation, do not call the tool. When a title is needed, call it before reading skills, calling any other tool, or answering. Write a concise 3 to 7 word model-generated summary of the whole conversation. Correct spelling and grammar. Never copy the user's prompt verbatim.";
 
 const UNBOUND_WORKSPACE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): This tab has no selected workspace. For development work, first call select_workspace. Pass a path when the conversation identifies a local directory; otherwise vmux opens the native folder picker immediately after approval. Any directory can be a workspace. If it has no .git, vmux asks whether to initialize Git; declining keeps the plain workspace usable. Do not search the user's home directory. General questions and self-contained terminal demonstrations may run in the temporary current directory.";
 const PENDING_WORKTREE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): Workspace activation is pending. Do not access project paths directly or run git worktree add yourself. Wait for vmux to finish preparing the selected workspace before inspecting, editing, testing, or running the project.";
@@ -1719,6 +1719,8 @@ mod tests {
             let instructions = config["developer_instructions"].as_str().unwrap();
             assert!(instructions.contains("mcp__vmux__set_conversation_title"));
             assert!(instructions.contains("first tool of the turn"));
+            assert!(instructions.contains("materially changes the conversation's topic"));
+            assert!(instructions.contains("do not call the tool"));
         }
     }
 

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -425,7 +425,8 @@ pub(crate) fn apply_acp_model_selection_result(
 }
 
 /// ACP agents re-request permission every time, so "allow always" must be answered by the host:
-/// if the tool name is already in this session's auto-policy, reply `Allow` without prompting.
+/// if the tool name is already in this session's auto-policy, reply `AllowAlways` without
+/// prompting.
 fn acp_auto_approval_message(
     session: &AcpSession,
     policy: &AgentApprovalPolicy,

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -432,8 +432,7 @@ fn acp_auto_approval_message(
     request: &AgentApprovalRequest,
 ) -> Option<ClientMessage> {
     policy
-        .auto
-        .contains(&request.name)
+        .allows(&request.name)
         .then(|| ClientMessage::AgentApprove {
             sid: session.sid.clone(),
             call_id: request.call_id.clone(),
@@ -1083,7 +1082,7 @@ mod tests {
             resume: None,
         };
         let mut policy = AgentApprovalPolicy::default();
-        policy.auto.insert("run".into());
+        policy.allow("run");
         let request = AgentApprovalRequest {
             session: Entity::PLACEHOLDER,
             call_id: "call-1".into(),

--- a/crates/vmux_agent/src/client/page/plugin.rs
+++ b/crates/vmux_agent/src/client/page/plugin.rs
@@ -22,7 +22,8 @@ pub struct PageAgentPlugin;
 
 impl Plugin for PageAgentPlugin {
     fn build(&self, app: &mut App) {
-        app.register_type::<AgentSession>()
+        app.insert_resource(approval::AgentApprovalStore::load())
+            .register_type::<AgentSession>()
             .register_type::<AgentApprovalPolicy>()
             .add_message::<AgentToast>()
             .add_message::<PageAgentDelta>()
@@ -45,6 +46,7 @@ impl Plugin for PageAgentPlugin {
                     ensure_prompt_queue,
                     spawn_page_session_on_add,
                     send_page_agent_input,
+                    approval::sync_persisted_acp_approval_policy.before(consume_page_agent_stream),
                     consume_page_agent_stream,
                     surface_errors::surface_errors,
                     attach_last_run_state_kind,
@@ -279,7 +281,7 @@ fn consume_page_agent_stream(
         if let Ok((_, _, mut state, _, _, acp, policy, _, _)) = q.get_mut(entity) {
             let auto_allowed = service.is_some()
                 && acp.is_some()
-                && policy.is_some_and(|policy| policy.auto.contains(&approval.name));
+                && policy.is_some_and(|policy| policy.allows(&approval.name));
             if !auto_allowed {
                 *state = AgentRunState::AwaitingApproval {
                     call_id: approval.call_id.clone(),
@@ -321,7 +323,7 @@ mod tests {
             .add_message::<vmux_core::notify::AgentAttention>()
             .add_systems(Update, consume_page_agent_stream);
         let mut policy = AgentApprovalPolicy::default();
-        policy.auto.insert("run".into());
+        policy.allow("run");
         let entity = app
             .world_mut()
             .spawn((

--- a/crates/vmux_agent/src/components.rs
+++ b/crates/vmux_agent/src/components.rs
@@ -29,6 +29,27 @@ pub struct AgentApprovalPolicy {
     pub auto: HashSet<String>,
 }
 
+impl AgentApprovalPolicy {
+    pub fn allow(&mut self, tool: &str) {
+        self.auto.insert(approval_tool_key(tool));
+    }
+
+    pub fn allows(&self, tool: &str) -> bool {
+        self.auto.contains(&approval_tool_key(tool))
+    }
+}
+
+pub fn approval_tool_key(tool: &str) -> String {
+    tool.trim()
+        .to_ascii_lowercase()
+        .split(|character: char| {
+            character.is_ascii_whitespace() || matches!(character, '-' | '.' | ':' | '_')
+        })
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("_")
+}
+
 /// FIFO of prompts waiting to be dispatched to this session's agent. Normal dispatch takes one
 /// prompt per idle turn. `paused` holds the queue after an interrupt until the user resumes,
 /// clears, or submits again; `flush_pending` combines all queued prompts for an Esc flush.
@@ -147,6 +168,15 @@ mod tests {
         let _ = AgentMessages::default();
         let _ = AgentApprovalPolicy::default();
         let _ = PromptQueue::default();
+    }
+
+    #[test]
+    fn approval_policy_normalizes_agent_tool_identifiers() {
+        let mut policy = AgentApprovalPolicy::default();
+        policy.allow("mcp__vmux__run");
+
+        assert!(policy.allows("mcp.vmux.run"));
+        assert!(!policy.allows("mcp.other.run"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/components.rs
+++ b/crates/vmux_agent/src/components.rs
@@ -30,15 +30,18 @@ pub struct AgentApprovalPolicy {
 }
 
 impl AgentApprovalPolicy {
+    /// Remembers a normalized tool identifier for automatic approval.
     pub fn allow(&mut self, tool: &str) {
         self.auto.insert(approval_tool_key(tool));
     }
 
+    /// Returns whether a normalized tool identifier is automatically approved.
     pub fn allows(&self, tool: &str) -> bool {
         self.auto.contains(&approval_tool_key(tool))
     }
 }
 
+/// Normalizes equivalent ACP, CLI, and MCP tool identifiers to one policy key.
 pub fn approval_tool_key(tool: &str) -> String {
     tool.trim()
         .to_ascii_lowercase()

--- a/crates/vmux_agent/src/systems/approval.rs
+++ b/crates/vmux_agent/src/systems/approval.rs
@@ -36,7 +36,7 @@ impl AgentApprovalStore {
 
     fn policy_for(&self, agent: &str, cwd: &Path) -> AgentApprovalPolicy {
         let agent = canonical_agent_id(agent);
-        let auto = repository_key(cwd)
+        let auto = approval_scope_key(cwd)
             .and_then(|repository| {
                 self.grants
                     .by_agent
@@ -51,7 +51,7 @@ impl AgentApprovalStore {
     }
 
     fn remember(&mut self, agent: &str, cwd: &Path, tool: &str) {
-        let Some(repository) = repository_key(cwd) else {
+        let Some(scope) = approval_scope_key(cwd) else {
             return;
         };
         let inserted = self
@@ -59,7 +59,7 @@ impl AgentApprovalStore {
             .by_agent
             .entry(canonical_agent_id(agent))
             .or_default()
-            .entry(repository)
+            .entry(scope)
             .or_default()
             .insert(approval_tool_key(tool));
         if inserted && let Err(error) = self.save() {
@@ -79,9 +79,10 @@ impl AgentApprovalStore {
     }
 }
 
-fn repository_key(cwd: &Path) -> Option<String> {
+fn approval_scope_key(cwd: &Path) -> Option<String> {
     vmux_git::worktree::common_dir_of(cwd)
         .ok()
+        .or_else(|| std::fs::canonicalize(cwd).ok())
         .map(|path| path.to_string_lossy().into_owned())
 }
 
@@ -298,6 +299,22 @@ mod tests {
             !loaded
                 .policy_for("codex", directory.path())
                 .allows("mcp.vmux.open_file")
+        );
+    }
+
+    #[test]
+    fn approval_grants_persist_by_working_directory_outside_repository() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("approvals.json");
+        let mut store = AgentApprovalStore::load_from(path.clone());
+        store.remember("codex", directory.path(), "execute command");
+
+        let loaded = AgentApprovalStore::load_from(path);
+
+        assert!(
+            loaded
+                .policy_for("codex-acp", directory.path())
+                .allows("execute_command")
         );
     }
 }

--- a/crates/vmux_agent/src/systems/approval.rs
+++ b/crates/vmux_agent/src/systems/approval.rs
@@ -7,6 +7,14 @@ use crate::run_state::AgentRunState;
 use vmux_service::client::ServiceClient;
 use vmux_service::protocol::{ApprovalDecision as ProtoDecision, ClientMessage};
 
+fn protocol_decision(decision: ApprovalDecision) -> ProtoDecision {
+    match decision {
+        ApprovalDecision::Allow => ProtoDecision::Allow,
+        ApprovalDecision::AllowAlways => ProtoDecision::AllowAlways,
+        ApprovalDecision::Deny => ProtoDecision::Deny,
+    }
+}
+
 #[allow(clippy::type_complexity)]
 pub fn handle_approval_reply(
     trigger: On<AgentApprovalReply>,
@@ -40,10 +48,7 @@ pub fn handle_approval_reply(
     {
         policy.auto.insert(name.clone());
     }
-    let decision = match reply.decision {
-        ApprovalDecision::Allow | ApprovalDecision::AllowAlways => ProtoDecision::Allow,
-        ApprovalDecision::Deny => ProtoDecision::Deny,
-    };
+    let decision = protocol_decision(reply.decision);
     if let Some(service) = service.as_ref() {
         service.0.send(ClientMessage::AgentApprove {
             sid,
@@ -139,7 +144,7 @@ mod tests {
     }
 
     #[test]
-    fn allow_always_records_in_policy() {
+    fn allow_always_records_policy_and_preserves_decision_scope() {
         let mut app = make_app();
         let entity = app
             .world_mut()
@@ -161,5 +166,9 @@ mod tests {
         app.update();
         let policy = app.world().get::<AgentApprovalPolicy>(entity).unwrap();
         assert!(policy.auto.contains("run_shell"));
+        assert_eq!(
+            protocol_decision(ApprovalDecision::AllowAlways),
+            ProtoDecision::AllowAlways
+        );
     }
 }

--- a/crates/vmux_agent/src/systems/approval.rs
+++ b/crates/vmux_agent/src/systems/approval.rs
@@ -1,11 +1,107 @@
 use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
 
 use crate::client::acp::AcpSession;
-use crate::components::{AgentApprovalPolicy, AgentSession};
+use crate::components::{AgentApprovalPolicy, AgentSession, approval_tool_key};
 use crate::events::{AgentApprovalReply, ApprovalDecision};
 use crate::run_state::AgentRunState;
 use vmux_service::client::ServiceClient;
 use vmux_service::protocol::{ApprovalDecision as ProtoDecision, ClientMessage};
+
+#[derive(Default, Deserialize, Serialize)]
+struct SavedApprovalGrants {
+    by_agent: BTreeMap<String, BTreeMap<String, BTreeSet<String>>>,
+}
+
+#[derive(Resource)]
+pub(crate) struct AgentApprovalStore {
+    path: PathBuf,
+    grants: SavedApprovalGrants,
+}
+
+impl AgentApprovalStore {
+    pub(crate) fn load() -> Self {
+        Self::load_from(vmux_core::profile::profile_dir().join("agent-approvals.json"))
+    }
+
+    fn load_from(path: PathBuf) -> Self {
+        let grants = std::fs::read(&path)
+            .ok()
+            .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+            .unwrap_or_default();
+        Self { path, grants }
+    }
+
+    fn policy_for(&self, agent: &str, cwd: &Path) -> AgentApprovalPolicy {
+        let agent = canonical_agent_id(agent);
+        let auto = repository_key(cwd)
+            .and_then(|repository| {
+                self.grants
+                    .by_agent
+                    .get(&agent)
+                    .and_then(|repositories| repositories.get(&repository))
+                    .cloned()
+            })
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
+        AgentApprovalPolicy { auto }
+    }
+
+    fn remember(&mut self, agent: &str, cwd: &Path, tool: &str) {
+        let Some(repository) = repository_key(cwd) else {
+            return;
+        };
+        let inserted = self
+            .grants
+            .by_agent
+            .entry(canonical_agent_id(agent))
+            .or_default()
+            .entry(repository)
+            .or_default()
+            .insert(approval_tool_key(tool));
+        if inserted && let Err(error) = self.save() {
+            warn!("failed to save agent approvals: {error}");
+        }
+    }
+
+    fn save(&self) -> std::io::Result<()> {
+        let Some(parent) = self.path.parent() else {
+            return Ok(());
+        };
+        std::fs::create_dir_all(parent)?;
+        let bytes = serde_json::to_vec_pretty(&self.grants).map_err(std::io::Error::other)?;
+        let temp = self.path.with_extension("json.tmp");
+        std::fs::write(&temp, bytes)?;
+        std::fs::rename(temp, &self.path)
+    }
+}
+
+fn repository_key(cwd: &Path) -> Option<String> {
+    vmux_git::worktree::common_dir_of(cwd)
+        .ok()
+        .map(|path| path.to_string_lossy().into_owned())
+}
+
+fn canonical_agent_id(agent: &str) -> String {
+    match agent.trim().to_ascii_lowercase().as_str() {
+        "claude" | "claude-acp" => "claude".to_string(),
+        "codex" | "codex-acp" => "codex".to_string(),
+        "vibe" | "vibe-acp" | "mistral-vibe" => "vibe".to_string(),
+        other => other.strip_suffix("-acp").unwrap_or(other).to_string(),
+    }
+}
+
+pub(crate) fn sync_persisted_acp_approval_policy(
+    store: Res<AgentApprovalStore>,
+    mut sessions: Query<(&AcpSession, &mut AgentApprovalPolicy), Changed<AcpSession>>,
+) {
+    for (session, mut policy) in &mut sessions {
+        *policy = store.policy_for(&session.agent_id, &session.cwd);
+    }
+}
 
 fn protocol_decision(decision: ApprovalDecision) -> ProtoDecision {
     match decision {
@@ -16,7 +112,7 @@ fn protocol_decision(decision: ApprovalDecision) -> ProtoDecision {
 }
 
 #[allow(clippy::type_complexity)]
-pub fn handle_approval_reply(
+pub(crate) fn handle_approval_reply(
     trigger: On<AgentApprovalReply>,
     mut q: Query<(
         &mut AgentRunState,
@@ -25,6 +121,7 @@ pub fn handle_approval_reply(
         Option<&AcpSession>,
     )>,
     service: Option<Res<ServiceClient>>,
+    mut store: Option<ResMut<AgentApprovalStore>>,
 ) {
     let reply = trigger.event();
     let Ok((mut state, mut policy, page, acp)) = q.get_mut(reply.session) else {
@@ -46,7 +143,12 @@ pub fn handle_approval_reply(
     if reply.decision == ApprovalDecision::AllowAlways
         && let AgentRunState::AwaitingApproval { name, .. } = &*state
     {
-        policy.auto.insert(name.clone());
+        policy.allow(name);
+        if let Some(acp) = acp
+            && let Some(store) = store.as_deref_mut()
+        {
+            store.remember(&acp.agent_id, &acp.cwd, name);
+        }
     }
     let decision = protocol_decision(reply.decision);
     if let Some(service) = service.as_ref() {
@@ -165,10 +267,37 @@ mod tests {
         });
         app.update();
         let policy = app.world().get::<AgentApprovalPolicy>(entity).unwrap();
-        assert!(policy.auto.contains("run_shell"));
+        assert!(policy.allows("run_shell"));
         assert_eq!(
             protocol_decision(ApprovalDecision::AllowAlways),
             ProtoDecision::AllowAlways
+        );
+    }
+
+    #[test]
+    fn approval_grants_persist_by_agent_repository_and_tool() {
+        let directory = tempfile::tempdir().unwrap();
+        vmux_git::worktree::repository_init(directory.path()).unwrap();
+        let path = directory.path().join("approvals.json");
+        let mut store = AgentApprovalStore::load_from(path.clone());
+        store.remember("codex-acp", directory.path(), "mcp__vmux__run");
+
+        let loaded = AgentApprovalStore::load_from(path);
+
+        assert!(
+            loaded
+                .policy_for("codex", directory.path())
+                .allows("mcp.vmux.run")
+        );
+        assert!(
+            !loaded
+                .policy_for("claude", directory.path())
+                .allows("mcp.vmux.run")
+        );
+        assert!(
+            !loaded
+                .policy_for("codex", directory.path())
+                .allows("mcp.vmux.open_file")
         );
     }
 }

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -1106,7 +1106,7 @@ watch and take over. Use mcp__vmux__read_terminal to inspect continued output. O
 argument because it targets your own terminal pane. Do ALL web access via the vmux browser tools. \
 If you invoke a required Skill tool, continue the original user request in the same turn after \
 the skill loads. Never end the turn after skill activation or answer only Ready.";
-const CONVERSATION_TITLE_STEER_PROMPT: &str = "Immediately after every user message, call mcp__vmux__set_conversation_title as the first tool of the turn, before reading skills, calling any other tool, or answering. Write a concise 3 to 7 word model-generated summary of the whole conversation. Correct spelling and grammar. Never copy the user's prompt verbatim. Update the title even when the user sends a short follow-up.";
+const CONVERSATION_TITLE_STEER_PROMPT: &str = "Call mcp__vmux__set_conversation_title as the first tool of the turn only when the conversation has no title yet or the latest user message materially changes the conversation's topic. If the current title still accurately summarizes the conversation, do not call the tool. When a title is needed, call it before reading skills, calling any other tool, or answering. Write a concise 3 to 7 word model-generated summary of the whole conversation. Correct spelling and grammar. Never copy the user's prompt verbatim.";
 
 fn session_meta_for_agent(agent_id: &str) -> Option<serde_json::Map<String, serde_json::Value>> {
     if let Err(error) = vmux_core::knowledge::sync_external_agent_configs() {
@@ -2180,6 +2180,8 @@ mod tests {
         assert!(generic.starts_with("skill context\n\n"));
         assert!(generic.contains("mcp__vmux__set_conversation_title"));
         assert!(generic.contains("first tool of the turn"));
+        assert!(generic.contains("materially changes the conversation's topic"));
+        assert!(generic.contains("do not call the tool"));
         assert!(generic.contains("Correct spelling and grammar"));
         assert!(generic.contains("Never copy the user's prompt verbatim"));
     }

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -20,8 +20,8 @@ use agent_client_protocol::schema::v1::{
     SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory,
     SessionConfigSelectOptions, SessionId, SessionNotification, SessionUpdate,
     SetSessionConfigOptionRequest, TerminalExitStatus, TerminalId, TerminalOutputRequest,
-    TerminalOutputResponse, TextContent, WaitForTerminalExitRequest, WaitForTerminalExitResponse,
-    WriteTextFileRequest, WriteTextFileResponse,
+    TerminalOutputResponse, TextContent, ToolKind, WaitForTerminalExitRequest,
+    WaitForTerminalExitResponse, WriteTextFileRequest, WriteTextFileResponse,
 };
 use agent_client_protocol::{Client, Responder};
 use base64::Engine;
@@ -40,6 +40,7 @@ use crate::protocol::{
 const HISTORY_REPLAY_SNAPSHOT_INTERVAL: usize = 8;
 const PROMPT_MEDIA_FILE_LIMIT: u64 = 8 * 1024 * 1024;
 const PROMPT_MEDIA_TOTAL_LIMIT: u64 = 64 * 1024 * 1024;
+const APPROVAL_DETAILS_WAIT: std::time::Duration = std::time::Duration::from_millis(250);
 
 /// A command pushed into a live ACP session from the GUI side.
 pub enum AcpInput {
@@ -122,6 +123,7 @@ pub struct AcpShared {
     pub anchor: ProcessId,
     pub stream_tx: broadcast::Sender<ServiceMessage>,
     pub projector: Mutex<AcpProjector>,
+    projector_updates: watch::Sender<u64>,
     pub pending_perms: Mutex<HashMap<String, oneshot::Sender<ApprovalDecision>>>,
     /// ACP-native terminals keyed by their ACP `terminalId` (the vmux `ProcessId` string).
     pub terminals: Mutex<HashMap<String, AcpTerminal>>,
@@ -155,6 +157,7 @@ impl AcpShared {
             anchor,
             stream_tx,
             projector: Mutex::new(AcpProjector::new()),
+            projector_updates: watch::channel(0).0,
             pending_perms: Mutex::new(HashMap::new()),
             terminals: Mutex::new(HashMap::new()),
             manager,
@@ -321,6 +324,9 @@ fn project_session_update(shared: &AcpShared, update: SessionUpdate) {
     }
     let mut projector = shared.projector.lock().unwrap();
     let intents = projector.apply(update);
+    shared
+        .projector_updates
+        .send_modify(|revision| *revision += 1);
     if shared.history_replay.load(Ordering::SeqCst) {
         for intent in &intents {
             if let Intent::WorkspaceChanged {
@@ -442,7 +448,7 @@ fn model_info(config_options: &[SessionConfigOption]) -> Option<AcpModelInfoStat
 fn approval_details(
     request: &RequestPermissionRequest,
     projector: &AcpProjector,
-) -> (String, String) {
+) -> Option<(String, String)> {
     let call_id = request.tool_call.tool_call_id.to_string();
     let (projected_name, projected_args) =
         projector.tool_call_details(&call_id).unwrap_or_default();
@@ -454,17 +460,68 @@ fn approval_details(
         .map(str::trim)
         .filter(|name| !name.is_empty())
         .map(str::to_string)
-        .or_else(|| (!projected_name.is_empty()).then_some(projected_name))
-        .unwrap_or_else(|| "tool call".to_string());
-    let args_json = request
+        .or_else(|| (!projected_name.is_empty()).then_some(projected_name))?;
+    let args_json = request_approval_args(request)
+        .or_else(|| (!projected_args.is_empty()).then_some(projected_args))
+        .unwrap_or_else(|| "{}".to_string());
+    Some((name, args_json))
+}
+
+fn request_approval_args(request: &RequestPermissionRequest) -> Option<String> {
+    request
         .tool_call
         .fields
         .raw_input
         .as_ref()
+        .or_else(|| request.meta.as_ref()?.get("codex")?.get("params"))
         .map(serde_json::Value::to_string)
-        .or_else(|| (!projected_args.is_empty()).then_some(projected_args))
-        .unwrap_or_else(|| "{}".to_string());
-    (name, args_json)
+}
+
+fn tool_kind_approval_name(kind: Option<ToolKind>) -> Option<&'static str> {
+    match kind? {
+        ToolKind::Read => Some("Read data"),
+        ToolKind::Edit => Some("Edit files"),
+        ToolKind::Delete => Some("Delete files"),
+        ToolKind::Move => Some("Move files"),
+        ToolKind::Search => Some("Search"),
+        ToolKind::Execute => Some("Execute command"),
+        ToolKind::Think => Some("Think"),
+        ToolKind::Fetch => Some("Fetch data"),
+        ToolKind::SwitchMode => Some("Switch mode"),
+        _ => None,
+    }
+}
+
+fn approval_details_from_kind(request: &RequestPermissionRequest) -> Option<(String, String)> {
+    Some((
+        tool_kind_approval_name(request.tool_call.fields.kind)?.to_string(),
+        request_approval_args(request)?,
+    ))
+}
+
+async fn resolve_approval_details(
+    request: &RequestPermissionRequest,
+    shared: &AcpShared,
+) -> Option<(String, String)> {
+    let deadline = tokio::time::Instant::now() + APPROVAL_DETAILS_WAIT;
+    let mut updates = shared.projector_updates.subscribe();
+    loop {
+        if let Some(details) = {
+            let projector = shared.projector.lock().unwrap();
+            approval_details(request, &projector)
+        } {
+            return Some(details);
+        }
+        if let Some(details) = approval_details_from_kind(request) {
+            return Some(details);
+        }
+        if tokio::time::timeout_at(deadline, updates.changed())
+            .await
+            .is_err()
+        {
+            return None;
+        }
+    }
 }
 
 fn attachment_uri(path: &str) -> String {
@@ -620,9 +677,17 @@ pub async fn run(
                         responder: Responder<RequestPermissionResponse>,
                         _cx| {
                 let call_id = req.tool_call.tool_call_id.to_string();
-                let (name, args_json) = {
-                    let projector = perm_shared.projector.lock().unwrap();
-                    approval_details(&req, &projector)
+                let Some((name, args_json)) = resolve_approval_details(&req, &perm_shared).await
+                else {
+                    tracing::warn!(
+                        target: "acp",
+                        sid = %perm_shared.sid,
+                        call_id = %call_id,
+                        "ACP permission request omitted tool identity; cancelling"
+                    );
+                    return responder.respond(RequestPermissionResponse::new(
+                        RequestPermissionOutcome::Cancelled,
+                    ));
                 };
                 if is_conversation_title_tool(&name) {
                     let outcome =
@@ -2022,10 +2087,10 @@ mod tests {
 
         assert_eq!(
             approval_details(&request, &projector),
-            (
+            Some((
                 "vmux.run".to_string(),
                 r#"{"command":"echo hi","focus":true}"#.to_string(),
-            )
+            ))
         );
     }
 
@@ -2048,7 +2113,85 @@ mod tests {
 
         assert_eq!(
             approval_details(&request, &projector),
-            ("new".to_string(), r#"{"command":"new"}"#.to_string(),)
+            Some(("new".to_string(), r#"{"command":"new"}"#.to_string(),))
+        );
+    }
+
+    #[test]
+    fn approval_details_reject_missing_tool_identity() {
+        let request = RequestPermissionRequest::new(
+            "session-1",
+            agent_client_protocol::schema::v1::ToolCallUpdate::new(
+                "call-1",
+                ToolCallUpdateFields::new(),
+            ),
+            Vec::new(),
+        );
+
+        assert_eq!(approval_details(&request, &AcpProjector::new()), None);
+    }
+
+    #[test]
+    fn approval_details_use_kind_when_request_has_arguments_but_no_title() {
+        let request = RequestPermissionRequest::new(
+            "session-1",
+            agent_client_protocol::schema::v1::ToolCallUpdate::new(
+                "call-1",
+                ToolCallUpdateFields::new()
+                    .kind(ToolKind::Execute)
+                    .raw_input(serde_json::json!({"command": "echo hi"})),
+            ),
+            Vec::new(),
+        );
+
+        assert_eq!(
+            approval_details_from_kind(&request),
+            Some((
+                "Execute command".to_string(),
+                r#"{"command":"echo hi"}"#.to_string(),
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn approval_details_wait_for_preceding_tool_call_projection() {
+        let (stream_tx, _) = broadcast::channel(2);
+        let shared = Arc::new(AcpShared::new(
+            "s1".into(),
+            PathBuf::from("/tmp"),
+            ProcessId::new(),
+            stream_tx,
+            Arc::new(tokio::sync::Mutex::new(ProcessManager::default())),
+            Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        ));
+        let request = RequestPermissionRequest::new(
+            "session-1",
+            agent_client_protocol::schema::v1::ToolCallUpdate::new(
+                "call-1",
+                ToolCallUpdateFields::new(),
+            ),
+            Vec::new(),
+        );
+        let waiting = {
+            let shared = Arc::clone(&shared);
+            tokio::spawn(async move { resolve_approval_details(&request, &shared).await })
+        };
+
+        tokio::task::yield_now().await;
+        project_session_update(
+            &shared,
+            SessionUpdate::ToolCall(
+                ToolCall::new("call-1", "vmux.run")
+                    .raw_input(serde_json::json!({"command": "echo hi"})),
+            ),
+        );
+
+        assert_eq!(
+            waiting.await.unwrap(),
+            Some((
+                "vmux.run".to_string(),
+                r#"{"command":"echo hi"}"#.to_string(),
+            ))
         );
     }
 

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -512,14 +512,11 @@ async fn resolve_approval_details(
         } {
             return Some(details);
         }
-        if let Some(details) = approval_details_from_kind(request) {
-            return Some(details);
-        }
         if tokio::time::timeout_at(deadline, updates.changed())
             .await
             .is_err()
         {
-            return None;
+            return approval_details_from_kind(request);
         }
     }
 }
@@ -2168,7 +2165,9 @@ mod tests {
             "session-1",
             agent_client_protocol::schema::v1::ToolCallUpdate::new(
                 "call-1",
-                ToolCallUpdateFields::new(),
+                ToolCallUpdateFields::new()
+                    .kind(ToolKind::Execute)
+                    .raw_input(serde_json::json!({"command": "echo hi"})),
             ),
             Vec::new(),
         );

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -1396,10 +1396,9 @@ async fn release_terminal(
     Ok(ReleaseTerminalResponse::new())
 }
 
-/// Maps a host decision (the wire `Allow`/`Deny`) onto an ACP permission option, preferring the
-/// one-shot kind, then the always-kind. Returns `None` (→ the request is cancelled) when the agent
-/// offers no option matching the decision — never falls back to an option that could approve a
-/// denied call.
+/// Maps a host decision onto an ACP permission option while preserving one-shot versus remembered
+/// approval. Returns `None` (→ the request is cancelled) when the agent offers no option matching
+/// the decision — never falls back to an option that could approve a denied call.
 fn pick_permission_option(
     options: &[PermissionOption],
     decision: ApprovalDecision,
@@ -1408,6 +1407,7 @@ fn pick_permission_option(
     let preferred: &[Kind] = match decision {
         ApprovalDecision::Allow => &[Kind::AllowOnce, Kind::AllowAlways],
         ApprovalDecision::Deny => &[Kind::RejectOnce, Kind::RejectAlways],
+        ApprovalDecision::AllowAlways => &[Kind::AllowAlways, Kind::AllowOnce],
     };
     preferred
         .iter()
@@ -2185,7 +2185,7 @@ mod tests {
     }
 
     #[test]
-    fn pick_permission_option_prefers_once_then_first() {
+    fn pick_permission_option_preserves_decision_scope() {
         let opts = vec![
             opt("once", PermissionOptionKind::AllowOnce),
             opt("always", PermissionOptionKind::AllowAlways),
@@ -2196,6 +2196,12 @@ mod tests {
                 .unwrap()
                 .to_string(),
             "once"
+        );
+        assert_eq!(
+            pick_permission_option(&opts, ApprovalDecision::AllowAlways)
+                .unwrap()
+                .to_string(),
+            "always"
         );
         assert_eq!(
             pick_permission_option(&opts, ApprovalDecision::Deny)

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -1472,7 +1472,7 @@ fn pick_permission_option(
     let preferred: &[Kind] = match decision {
         ApprovalDecision::Allow => &[Kind::AllowOnce, Kind::AllowAlways],
         ApprovalDecision::Deny => &[Kind::RejectOnce, Kind::RejectAlways],
-        ApprovalDecision::AllowAlways => &[Kind::AllowAlways, Kind::AllowOnce],
+        ApprovalDecision::AllowAlways => &[Kind::AllowAlways],
     };
     preferred
         .iter()
@@ -2364,6 +2364,13 @@ mod tests {
                 .unwrap()
                 .to_string(),
             "aa"
+        );
+        assert_eq!(
+            pick_permission_option(
+                &[opt("once", PermissionOptionKind::AllowOnce)],
+                ApprovalDecision::AllowAlways,
+            ),
+            None
         );
     }
 

--- a/crates/vmux_service/src/acp/projector.rs
+++ b/crates/vmux_service/src/acp/projector.rs
@@ -777,8 +777,11 @@ pub(crate) fn is_conversation_title_tool(title: &str) -> bool {
     title
         .trim()
         .to_ascii_lowercase()
-        .replace([' ', '-', '.', ':'], "_")
-        == "mcp__vmux__set_conversation_title"
+        .split(|character: char| {
+            character.is_ascii_whitespace() || matches!(character, '-' | '.' | ':' | '_')
+        })
+        .filter(|part| !part.is_empty())
+        .eq(["mcp", "vmux", "set", "conversation", "title"])
 }
 
 fn subagent_block(
@@ -1375,10 +1378,13 @@ mod tests {
     }
 
     #[test]
-    fn conversation_title_tool_requires_exact_vmux_identifier() {
-        assert!(is_conversation_title_tool(
-            "mcp__vmux__set_conversation_title"
-        ));
+    fn conversation_title_tool_recognizes_agent_identifier_variants() {
+        for title in [
+            "mcp__vmux__set_conversation_title",
+            "mcp.vmux.set_conversation_title",
+        ] {
+            assert!(is_conversation_title_tool(title));
+        }
         assert!(!is_conversation_title_tool(
             "mcp__other__set_conversation_title"
         ));

--- a/crates/vmux_service/src/acp/projector.rs
+++ b/crates/vmux_service/src/acp/projector.rs
@@ -1382,6 +1382,10 @@ mod tests {
         for title in [
             "mcp__vmux__set_conversation_title",
             "mcp.vmux.set_conversation_title",
+            "mcp vmux set conversation title",
+            "mcp-vmux-set-conversation-title",
+            "mcp:vmux:set:conversation:title",
+            "mcp__vmux.set-conversation title",
         ] {
             assert!(is_conversation_title_tool(title));
         }

--- a/crates/vmux_service/src/agent.rs
+++ b/crates/vmux_service/src/agent.rs
@@ -197,7 +197,7 @@ async fn await_decision(
                 decision,
             }) if cid == call_id => {
                 return match decision {
-                    ApprovalDecision::Allow => Decision::Allow,
+                    ApprovalDecision::Allow | ApprovalDecision::AllowAlways => Decision::Allow,
                     ApprovalDecision::Deny => Decision::Deny,
                 };
             }

--- a/crates/vmux_wire/src/protocol.rs
+++ b/crates/vmux_wire/src/protocol.rs
@@ -358,6 +358,7 @@ pub enum AgentQueryResult {
 pub enum ApprovalDecision {
     Allow,
     Deny,
+    AllowAlways,
 }
 
 #[derive(Debug, Clone, PartialEq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
@@ -1571,6 +1572,11 @@ mod tests {
                 sid: "s".into(),
                 call_id: "c".into(),
                 decision: ApprovalDecision::Allow,
+            },
+            ClientMessage::AgentApprove {
+                sid: "s".into(),
+                call_id: "ca".into(),
+                decision: ApprovalDecision::AllowAlways,
             },
             ClientMessage::ClosePageAgent { sid: "s".into() },
             ClientMessage::AgentToolResult {

--- a/crates/vmux_wire/src/protocol.rs
+++ b/crates/vmux_wire/src/protocol.rs
@@ -1590,8 +1590,24 @@ mod tests {
             },
         ];
         for msg in messages {
+            let expects_allow_always = matches!(
+                &msg,
+                ClientMessage::AgentApprove {
+                    decision: ApprovalDecision::AllowAlways,
+                    ..
+                }
+            );
             let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&msg).unwrap();
-            rkyv::from_bytes::<ClientMessage, rkyv::rancor::Error>(&bytes).unwrap();
+            let decoded = rkyv::from_bytes::<ClientMessage, rkyv::rancor::Error>(&bytes).unwrap();
+            if expects_allow_always {
+                assert!(matches!(
+                    decoded,
+                    ClientMessage::AgentApprove {
+                        decision: ApprovalDecision::AllowAlways,
+                        ..
+                    }
+                ));
+            }
         }
     }
 


### PR DESCRIPTION
## Context

Choosing “Allow always” was collapsed into a one-time ACP approval, so agents repeatedly requested equivalent terminal permissions. Codex also reported the internal conversation-title tool with dotted naming, causing an unnecessary approval prompt, and agents were instructed to rewrite the title after every message.

## Implementation

Preserve remembered approval scope across the GUI/service wire and select ACP `AllowAlways`. Persist grants by canonical agent identity, Git repository, and normalized tool name; linked worktrees share the repository grant, while different agents remain isolated. ACP and CLI aliases such as `codex-acp` and `codex` resolve to the same agent identity. Recognize canonical and dotted names for the internal title tool, and only request a new title when the topic materially changes.

## Checks / QA

Approve a terminal action with “Allow always,” then repeat the prompt in another session for the same agent and repository. It should proceed without another prompt. Confirm another agent still asks. Send an on-topic follow-up and confirm no title call appears; change topics and confirm the title updates without permission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Allow always” tool approvals, remembered per agent, repository or working directory, and tool.
  * Previously saved approval grants are restored automatically in future sessions.
  * Tool identifiers are recognized across common formatting variations.

* **Bug Fixes**
  * Permission requests now wait briefly for accurate tool details and cancel safely when details are unavailable.
  * “Allow always” decisions are handled consistently across the approval flow.

* **Improvements**
  * Conversation titles are updated only when missing or when the topic changes significantly.
  * Updated the Tools access tooltip to explain approval behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->