### PR TITLE
perf(terminal): coalesce high-frequency rendering

### DIFF
--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -1311,6 +1311,14 @@ fn snapshot_of(
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+const CHAT_STREAM_PUSH_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
+
+#[cfg(not(target_arch = "wasm32"))]
+fn chat_snapshot_due(streaming: bool, urgent: bool, elapsed: Option<std::time::Duration>) -> bool {
+    urgent || !streaming || elapsed.is_none_or(|elapsed| elapsed >= CHAT_STREAM_PUSH_INTERVAL)
+}
+
 /// Push each changed session's conversation + run-state to its pane webview (the child
 /// `Browser` of the session entity).
 #[cfg(not(target_arch = "wasm32"))]
@@ -1318,14 +1326,14 @@ fn push_chat_to_page(
     sessions: Query<
         (
             Entity,
-            &AgentMessages,
-            &AgentRunState,
-            Option<&AgentTurnMeta>,
-            Option<&Profile>,
+            Ref<AgentMessages>,
+            Ref<AgentRunState>,
+            Option<Ref<AgentTurnMeta>>,
+            Option<Ref<Profile>>,
             Option<&PageMetadata>,
-            &PromptQueue,
-            Option<&ImportedConversation>,
-            Option<&AgentConversationTitle>,
+            Ref<PromptQueue>,
+            Option<Ref<ImportedConversation>>,
+            Option<Ref<AgentConversationTitle>>,
         ),
         Or<(
             Changed<AgentMessages>,
@@ -1341,8 +1349,13 @@ fn push_chat_to_page(
     is_browser: Query<(), With<vmux_layout::Browser>>,
     choices: Query<&crate::plugin::PendingAgentChoice>,
     browsers: NonSend<Browsers>,
+    mut last_push: Local<std::collections::HashMap<Entity, std::time::Instant>>,
+    mut removed_messages: RemovedComponents<AgentMessages>,
     mut commands: Commands,
 ) {
+    for stack in removed_messages.read() {
+        last_push.remove(&stack);
+    }
     for (stack, messages, state, turn_meta, profile, meta, queue, imported, title) in &sessions {
         let Ok(kids) = children.get(stack) else {
             continue;
@@ -1353,21 +1366,37 @@ fn push_chat_to_page(
         if !browsers.has_browser(webview) || !browsers.host_emit_ready(&webview) {
             continue;
         }
+        let urgent = state.is_changed()
+            || turn_meta.as_ref().is_some_and(|meta| meta.is_changed())
+            || profile.as_ref().is_some_and(|profile| profile.is_changed())
+            || queue.is_changed()
+            || imported
+                .as_ref()
+                .is_some_and(|imported| imported.is_changed())
+            || title.as_ref().is_some_and(|title| title.is_changed());
+        let now = std::time::Instant::now();
+        let elapsed = last_push
+            .get(&stack)
+            .map(|last| now.saturating_duration_since(*last));
+        if !chat_snapshot_due(matches!(*state, AgentRunState::Streaming), urgent, elapsed) {
+            continue;
+        }
         commands.trigger(BinHostEmitEvent::from_rkyv(
             webview,
             CHAT_SNAPSHOT_EVENT,
             &snapshot_of(
-                messages,
-                state,
-                turn_meta,
-                profile,
+                &messages,
+                &state,
+                turn_meta.as_deref(),
+                profile.as_deref(),
                 meta,
-                queue,
-                imported,
-                title,
+                &queue,
+                imported.as_deref(),
+                title.as_deref(),
                 choices.get(webview).ok(),
             ),
         ));
+        last_push.insert(stack, now);
     }
 }
 
@@ -2049,6 +2078,34 @@ mod native_tests {
     use std::path::Path;
 
     #[test]
+    fn streaming_snapshots_wait_for_frame_interval() {
+        assert!(!chat_snapshot_due(
+            true,
+            false,
+            Some(CHAT_STREAM_PUSH_INTERVAL - std::time::Duration::from_millis(1)),
+        ));
+        assert!(chat_snapshot_due(
+            true,
+            false,
+            Some(CHAT_STREAM_PUSH_INTERVAL),
+        ));
+    }
+
+    #[test]
+    fn state_changes_and_completed_turns_push_immediately() {
+        assert!(chat_snapshot_due(
+            true,
+            true,
+            Some(std::time::Duration::ZERO)
+        ));
+        assert!(chat_snapshot_due(
+            false,
+            false,
+            Some(std::time::Duration::ZERO),
+        ));
+    }
+
+    #[test]
     fn media_query_paths_decode_percent_escapes() {
         assert_eq!(
             decode_media_query_path("Pictures/My%20Image%25.png"),
@@ -2531,21 +2588,6 @@ mod native_tests {
         assert!(page.contains("current_activity_icon(&items, &status)"));
         assert!(page.contains("ActivityIcon::Python"));
         assert!(page.contains("language_activity_icon(path)"));
-    }
-
-    #[test]
-    fn chat_page_bounds_gpu_work_without_losing_motion() {
-        let page = include_str!("chat_page/page.rs");
-        assert!(!page.contains("agent-chat-glow"));
-        assert!(!page.contains("backdrop-blur"));
-        assert!(!page.contains("blur-["));
-        assert!(page.contains("content-visibility:auto"));
-        assert!(page.contains("PromptComposer {"));
-        assert!(page.contains("agent-working-hop"));
-        assert!(page.contains("prefers-reduced-motion:reduce"));
-        assert!(page.contains("CHAT_HISTORY_PAGE_EVENT"));
-        assert!(page.contains("request_chat_history"));
-        assert!(page.contains("WorkingIndicator {}"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -20,6 +20,8 @@ pub use vmux_command::prompt_media::{
     Clone,
     Debug,
     Default,
+    PartialEq,
+    Eq,
     serde::Serialize,
     serde::Deserialize,
     rkyv::Archive,
@@ -448,7 +450,7 @@ pub struct RuntimeSwitchRequest {
 
 /// The page's block type inside a [`ChatTurn`]. Mirrors `vmux_service::message::AssistantBlock`
 /// plus folded tool results and reconnect progress.
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum ChatBlock {
     Text(String),
     Thinking(String),
@@ -480,7 +482,7 @@ pub enum ChatBlock {
 }
 
 /// Page representation of `vmux_service::message::SubagentBlock`.
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ChatSubagent {
     pub call_id: String,
     pub provider: String,
@@ -499,7 +501,7 @@ pub struct ChatSubagent {
 }
 
 /// Mirror of `vmux_service::message::PlanStep`.
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ChatPlanStep {
     pub content: String,
     pub status: String,
@@ -507,7 +509,7 @@ pub struct ChatPlanStep {
 
 /// A rendered conversation entry: a user bubble or a grouped assistant turn. Built backend by
 /// `group_turns`, carried as JSON in [`ChatSnapshot::messages_json`].
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum ChatItem {
     User {
         text: String,
@@ -530,7 +532,7 @@ impl ChatItem {
 }
 
 /// One assistant turn: its ordered prose/activity timeline and run-state.
-#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ChatTurn {
     /// Prose, thinking, tools, reconnects, plans, and diffs in transcript order.
     pub blocks: Vec<ChatBlock>,

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -44,6 +44,12 @@ use wasm_bindgen::{JsCast, JsValue, closure::Closure};
 
 const APPROVAL_OPTION_COUNT: usize = 3;
 
+fn set_if_changed<T: PartialEq + 'static>(mut signal: Signal<T>, value: T) {
+    if signal.peek().ne(&value) {
+        signal.set(value);
+    }
+}
+
 fn slash_command_description(command: &SlashCommandEntry) -> String {
     match command.name.as_str() {
         "upload" => translate("agent-slash-attach-files"),
@@ -463,25 +469,25 @@ pub fn Page(
 ) -> Element {
     use_theme();
     let agent = agent_override.unwrap_or_else(current_agent);
-    let mut transition_preview = use_signal(|| transition_prompt.unwrap_or_default());
-    let mut transition_attachments = use_signal(|| transition_attachments.unwrap_or_default());
+    let transition_preview = use_signal(|| transition_prompt.unwrap_or_default());
+    let transition_attachments = use_signal(|| transition_attachments.unwrap_or_default());
     let mut items = use_signal(Vec::<ChatItem>::new);
     let mut loaded_start = use_signal(|| 0u32);
     let mut messages_total = use_signal(|| 0u32);
     let mut history_loading = use_signal(|| false);
     let mut recent_messages_json = use_signal(String::new);
     let mut recent_messages_start = use_signal(|| u32::MAX);
-    let mut status = use_signal(|| "installing".to_string());
-    let mut error = use_signal(String::new);
+    let status = use_signal(|| "installing".to_string());
+    let error = use_signal(String::new);
     let mut approval = use_signal(|| Option::<(String, String, String)>::None);
     let mut approval_sel = use_signal(|| 0usize);
-    let mut agent_name = use_signal(String::new);
-    let mut conversation_title = use_signal(String::new);
-    let mut agent_icon = use_signal(String::new);
-    let mut accent = use_signal(String::new);
-    let mut handoff_source = use_signal(String::new);
-    let mut handoff_truncated = use_signal(|| false);
-    let mut handoff_message_count = use_signal(|| 0u32);
+    let agent_name = use_signal(String::new);
+    let conversation_title = use_signal(String::new);
+    let agent_icon = use_signal(String::new);
+    let accent = use_signal(String::new);
+    let handoff_source = use_signal(String::new);
+    let handoff_truncated = use_signal(|| false);
+    let handoff_message_count = use_signal(|| 0u32);
     let mut choice_question = use_signal(String::new);
     let mut choice_options = use_signal(Vec::<String>::new);
     let mut draft = use_signal(String::new);
@@ -492,8 +498,8 @@ pub fn Page(
     let mut history_scratch = use_signal(String::new);
     let mut at_bottom = use_signal(|| true);
     let mut last_top = use_signal(|| 0i32);
-    let mut queued = use_signal(Vec::<QueuedPromptSnapshot>::new);
-    let mut paused = use_signal(|| false);
+    let queued = use_signal(Vec::<QueuedPromptSnapshot>::new);
+    let paused = use_signal(|| false);
     let mut slash_cmds = use_signal(Vec::<SlashCommandEntry>::new);
     let mut sessions = use_signal(Vec::<ResumableSessionEntry>::new);
     let mut models = use_signal(Vec::<ModelOptionEntry>::new);
@@ -539,48 +545,44 @@ pub fn Page(
                 parsed,
                 snap.messages_start,
             );
-            loaded_start.set(start);
+            set_if_changed(loaded_start, start);
             recent_messages_json.set(snap.messages_json.clone());
             recent_messages_start.set(snap.messages_start);
             if start == 0 {
-                history_loading.set(false);
+                set_if_changed(history_loading, false);
             }
         }
-        messages_total.set(snap.messages_total);
-        status.set(snap.status.clone());
-        error.set(snap.error.clone());
-        queued.set(snap.queued.clone());
-        transition_preview.set(String::new());
-        transition_attachments.set(Vec::new());
-        paused.set(snap.paused);
-        agent_name.set(snap.agent_name.clone());
-        conversation_title.set(snap.conversation_title.clone());
-        agent_icon.set(snap.agent_icon.clone());
-        accent.set(snap.accent_color.clone());
-        handoff_source.set(snap.handoff_source.clone());
-        handoff_truncated.set(snap.handoff_truncated);
-        handoff_message_count.set(snap.handoff_message_count);
+        set_if_changed(messages_total, snap.messages_total);
+        set_if_changed(status, snap.status.clone());
+        set_if_changed(error, snap.error.clone());
+        set_if_changed(queued, snap.queued.clone());
+        set_if_changed(transition_preview, String::new());
+        set_if_changed(transition_attachments, Vec::new());
+        set_if_changed(paused, snap.paused);
+        set_if_changed(agent_name, snap.agent_name.clone());
+        set_if_changed(conversation_title, snap.conversation_title.clone());
+        set_if_changed(agent_icon, snap.agent_icon.clone());
+        set_if_changed(accent, snap.accent_color.clone());
+        set_if_changed(handoff_source, snap.handoff_source.clone());
+        set_if_changed(handoff_truncated, snap.handoff_truncated);
+        set_if_changed(handoff_message_count, snap.handoff_message_count);
+        set_if_changed(choice_question, snap.choice_question.clone());
         if choice_options.peek().as_slice() != snap.choice_options.as_slice() {
-            menu_sel.set(0);
+            set_if_changed(menu_sel, 0);
+            choice_options.set(snap.choice_options.clone());
         }
-        choice_question.set(snap.choice_question.clone());
-        choice_options.set(snap.choice_options.clone());
-        if snap.status == "awaiting" {
-            let changed = approval
-                .peek()
-                .as_ref()
-                .is_none_or(|(call_id, _, _)| call_id != &snap.approval_call_id);
-            approval.set(Some((
+        let next_approval = if snap.status == "awaiting" {
+            Some((
                 snap.approval_call_id.clone(),
                 snap.approval_name.clone(),
                 snap.approval_args_json.clone(),
-            )));
-            if changed {
-                approval_sel.set(0);
-            }
+            ))
         } else {
-            approval.set(None);
-            approval_sel.set(0);
+            None
+        };
+        if approval.peek().ne(&next_approval) {
+            approval.set(next_approval);
+            set_if_changed(approval_sel, 0);
         }
     });
     let _history =
@@ -1395,12 +1397,11 @@ pub fn Page(
                             p { class: "text-sm text-muted-foreground", {translate("agent-ready")} }
                         }
                     }
-                    for i in 0..items.read().len() {
+                    for (i, item) in items.read().iter().cloned().enumerate() {
                         ChatItemRow {
                             key: "{loaded_start() as usize + i}",
-                            index: i,
                             absolute_index: loaded_start() as usize + i,
-                            items,
+                            item,
                             attachment_previews,
                             latest_tool_block: latest_tool
                                 .filter(|(item_index, _)| *item_index == i)
@@ -1850,17 +1851,17 @@ fn send_approval(call_id: String, decision: u8) -> bool {
 
 #[component]
 fn ChatItemRow(
-    index: usize,
     absolute_index: usize,
-    items: Signal<Vec<ChatItem>>,
+    item: ChatItem,
     attachment_previews: Signal<HashMap<String, ChatAttachment>>,
     latest_tool_block: Option<usize>,
 ) -> Element {
-    let items = items.read();
-    let Some(item) = items.get(index) else {
-        return rsx! {};
-    };
-    render_item(absolute_index, item, attachment_previews, latest_tool_block)
+    render_item(
+        absolute_index,
+        &item,
+        attachment_previews,
+        latest_tool_block,
+    )
 }
 
 fn render_item(
@@ -3007,9 +3008,9 @@ fn render_standalone_tool_result(key: usize, content: &str, is_error: bool) -> E
 
 fn status_dot_class(status: &str) -> &'static str {
     match status {
-        "streaming" => "agent-status-dot bg-amber-400 shadow-[0_0_8px_rgba(251,191,36,0.65)]",
-        "installing" => "agent-status-dot bg-sky-400 shadow-[0_0_8px_rgba(56,189,248,0.65)]",
-        "awaiting" => "agent-status-dot bg-violet-400 shadow-[0_0_8px_rgba(167,139,250,0.65)]",
+        "streaming" => "bg-amber-400 shadow-[0_0_8px_rgba(251,191,36,0.65)]",
+        "installing" => "bg-sky-400 shadow-[0_0_8px_rgba(56,189,248,0.65)]",
+        "awaiting" => "bg-violet-400 shadow-[0_0_8px_rgba(167,139,250,0.65)]",
         "errored" => "bg-red-500 shadow-[0_0_8px_rgba(239,68,68,0.65)]",
         _ => "bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.65)]",
     }
@@ -3093,10 +3094,6 @@ fn md_to_html(src: &str) -> String {
 /// HTML, and its preflight strips heading/list defaults). Theme-neutral rgba so it works in both
 /// light and dark.
 const MD_CSS: &str = r#"
-@keyframes agent-status-breathe{0%,100%{opacity:0.58;transform:scale(0.82)}50%{opacity:1;transform:scale(1)}}
-@keyframes agent-working-hop{0%,60%,100%{opacity:0.42;transform:translateY(0)}30%{opacity:1;transform:translateY(-3px)}}
-.agent-status-dot{animation:agent-status-breathe 1.8s ease-in-out infinite;will-change:opacity,transform}
-.agent-working-dot{animation:agent-working-hop 900ms ease-in-out infinite;will-change:opacity,transform}
 .agent-chat-prompt-shell::before{content:"";position:absolute;inset:-28px -42px;z-index:-1;border-radius:2.5rem;background:radial-gradient(60% 90% at 50% 75%,rgba(255,255,255,0.1),transparent 72%);pointer-events:none}
 .agent-chat-page{background-image:radial-gradient(80% 55% at 15% 0%,color-mix(in srgb,var(--agent-accent) 9%,transparent),transparent 65%),radial-gradient(75% 55% at 90% 10%,color-mix(in srgb,var(--agent-accent) 7%,transparent),transparent 62%),radial-gradient(65% 45% at 55% 100%,color-mix(in srgb,var(--agent-accent) 5%,transparent),transparent 70%)}
 .agent-chat-header{border-color:color-mix(in srgb,var(--agent-accent) 12%,transparent)}
@@ -3142,5 +3139,5 @@ const MD_CSS: &str = r#"
 .chat-md hr{border:0;border-top:1px solid rgba(127,127,127,0.25);margin:0.9em 0}
 .chat-md table{border-collapse:collapse;margin:0.5em 0;font-size:0.95em}
 .chat-md th,.chat-md td{border:1px solid rgba(127,127,127,0.3);padding:0.3em 0.6em;text-align:left}
-@media (prefers-reduced-motion:reduce){.agent-chat-caret,.agent-status-dot,.agent-working-dot{animation:none}.chat-user-bubble,.chat-assistant-turn{transition:none}.chat-user-bubble:hover{transform:none}}
+@media (prefers-reduced-motion:reduce){.agent-chat-caret{animation:none}.chat-user-bubble,.chat-assistant-turn{transition:none}.chat-user-bubble:hover{transform:none}}
 "#;

--- a/crates/vmux_git/src/plugin.rs
+++ b/crates/vmux_git/src/plugin.rs
@@ -914,7 +914,7 @@ mod tests {
             wake: None,
         };
         let wait_for = |cache: &mut RepoInfoCache, expected| {
-            for _ in 0..100 {
+            for _ in 0..500 {
                 if let Some(info) = cache.get(&path)
                     && info.uncommitted == expected
                 {

--- a/crates/vmux_git/src/plugin.rs
+++ b/crates/vmux_git/src/plugin.rs
@@ -958,7 +958,7 @@ mod tests {
         };
 
         cache.invalidate(&path);
-        for _ in 0..100 {
+        for _ in 0..500 {
             if cache.get(&path).is_some_and(|info| info.uncommitted == 1) {
                 return;
             }

--- a/crates/vmux_service/src/client.rs
+++ b/crates/vmux_service/src/client.rs
@@ -2,6 +2,7 @@ use crate::protocol::{ClientMessage, ServiceMessage};
 use crate::socket_path;
 use bevy::ecs::resource::Resource;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 pub use vmux_service_client::client::ServiceConnection;
 
@@ -15,6 +16,7 @@ const MAX_SERVICE_MESSAGES_PER_DRAIN: usize = 128;
 pub struct ServiceHandle {
     cmd_tx: std::sync::mpsc::Sender<ClientMessage>,
     msg_rx: std::sync::Mutex<std::sync::mpsc::Receiver<ServiceMessage>>,
+    wake_pending: Arc<AtomicBool>,
     _runtime: Arc<tokio::runtime::Runtime>,
 }
 
@@ -24,10 +26,13 @@ pub type ServiceWake = Arc<dyn Fn() + Send + Sync + 'static>;
 fn forward_service_message(
     msg_tx: &std::sync::mpsc::Sender<ServiceMessage>,
     wake: Option<&ServiceWake>,
+    wake_pending: &AtomicBool,
     msg: ServiceMessage,
 ) -> Result<(), std::sync::mpsc::SendError<ServiceMessage>> {
     msg_tx.send(msg)?;
-    if let Some(wake) = wake {
+    if let Some(wake) = wake
+        && !wake_pending.swap(true, Ordering::AcqRel)
+    {
         wake();
     }
     Ok(())
@@ -155,10 +160,12 @@ impl ServiceHandle {
 
         let (cmd_tx, cmd_rx) = std::sync::mpsc::channel::<ClientMessage>();
         let (msg_tx, msg_rx) = std::sync::mpsc::channel::<ServiceMessage>();
+        let wake_pending = Arc::new(AtomicBool::new(false));
 
         // Reader task: service -> msg_tx
         let conn_r = Arc::clone(&conn);
         let rt2 = Arc::clone(&rt);
+        let reader_wake_pending = Arc::clone(&wake_pending);
         std::thread::Builder::new()
             .name("service-reader".into())
             .spawn(move || {
@@ -166,7 +173,14 @@ impl ServiceHandle {
                     loop {
                         match conn_r.recv().await {
                             Ok(Some(msg)) => {
-                                if forward_service_message(&msg_tx, wake.as_ref(), msg).is_err() {
+                                if forward_service_message(
+                                    &msg_tx,
+                                    wake.as_ref(),
+                                    &reader_wake_pending,
+                                    msg,
+                                )
+                                .is_err()
+                                {
                                     break;
                                 }
                             }
@@ -196,6 +210,7 @@ impl ServiceHandle {
         Some(Self {
             cmd_tx,
             msg_rx: std::sync::Mutex::new(msg_rx),
+            wake_pending,
             _runtime: rt,
         })
     }
@@ -217,6 +232,7 @@ impl ServiceHandle {
     /// the tail is processed on the next frame instead of stalling until the
     /// reactive timeout.
     pub fn drain_with_status(&self) -> (Vec<ServiceMessage>, bool) {
+        self.wake_pending.store(false, Ordering::Release);
         let rx = self.msg_rx.lock().unwrap();
         drain_service_messages_bounded(&rx)
     }
@@ -241,17 +257,28 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
-    fn forwarding_service_message_wakes_consumer() {
+    fn forwarding_burst_wakes_consumer_once_until_drain() {
         let (tx, rx) = std::sync::mpsc::channel();
         let wakes = Arc::new(AtomicUsize::new(0));
         let wakes_for_callback = Arc::clone(&wakes);
         let wake: ServiceWake = Arc::new(move || {
             wakes_for_callback.fetch_add(1, Ordering::Relaxed);
         });
+        let wake_pending = AtomicBool::new(false);
 
         forward_service_message(
             &tx,
             Some(&wake),
+            &wake_pending,
+            ServiceMessage::ProcessList {
+                processes: Vec::new(),
+            },
+        )
+        .expect("message should forward");
+        forward_service_message(
+            &tx,
+            Some(&wake),
+            &wake_pending,
             ServiceMessage::ProcessList {
                 processes: Vec::new(),
             },
@@ -262,7 +289,24 @@ mod tests {
             rx.try_recv(),
             Ok(ServiceMessage::ProcessList { processes }) if processes.is_empty()
         ));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(ServiceMessage::ProcessList { processes }) if processes.is_empty()
+        ));
         assert_eq!(wakes.load(Ordering::Relaxed), 1);
+
+        wake_pending.store(false, Ordering::Release);
+        forward_service_message(
+            &tx,
+            Some(&wake),
+            &wake_pending,
+            ServiceMessage::ProcessList {
+                processes: Vec::new(),
+            },
+        )
+        .expect("message should forward");
+
+        assert_eq!(wakes.load(Ordering::Relaxed), 2);
     }
 
     #[test]

--- a/crates/vmux_service/src/process.rs
+++ b/crates/vmux_service/src/process.rs
@@ -7,12 +7,13 @@ use alacritty_terminal::{
     vte::ansi::{Color, NamedColor, Processor},
 };
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
-#[cfg(unix)]
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
     collections::HashMap,
     io::{Read, Write},
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{Duration, Instant},
 };
 #[cfg(unix)]
@@ -22,8 +23,22 @@ use vmux_core::event::*;
 
 const MAX_PTY_CHUNKS_PER_POLL: usize = 64;
 const _: () = assert!(MAX_PTY_CHUNKS_PER_POLL <= 256);
+const HEAVY_OUTPUT_FRAME_INTERVAL: Duration = Duration::from_millis(100);
 
-pub type PtyInputWriter = Arc<Mutex<Box<dyn Write + Send>>>;
+#[derive(Clone)]
+pub struct PtyInputWriter {
+    writer: Arc<Mutex<Box<dyn Write + Send>>>,
+    input_pending: Arc<AtomicBool>,
+}
+
+impl PtyInputWriter {
+    fn new(writer: Box<dyn Write + Send>) -> Self {
+        Self {
+            writer: Arc::new(Mutex::new(writer)),
+            input_pending: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
 
 #[cfg(unix)]
 fn is_executable(path: &std::path::Path) -> bool {
@@ -139,7 +154,7 @@ impl TermEventListener for ServiceEventProxy {
     fn send_event(&self, event: TermEvent) {
         match event {
             TermEvent::PtyWrite(text) => {
-                if let Ok(mut writer) = self.pty_writer.lock() {
+                if let Ok(mut writer) = self.pty_writer.writer.lock() {
                     let _ = writer.write_all(text.as_bytes());
                 }
             }
@@ -222,6 +237,9 @@ pub struct Process {
     last_selection: Option<TermSelectionRange>,
     /// Last copy-mode value emitted in a viewport patch.
     last_viewport_copy_mode: Option<bool>,
+    output_viewport_dirty: bool,
+    last_output_viewport_at: Option<Instant>,
+    last_output_viewport_heavy: bool,
     /// Last broadcast (mouse_capture, copy_mode, alt_screen) flags.
     last_terminal_mode: Option<(bool, bool, bool, bool)>,
     /// Active copy-mode state (cursor, anchor, visual state). None when not in copy mode.
@@ -483,7 +501,7 @@ impl Process {
             .master
             .as_raw_fd()
             .ok_or_else(|| "PTY master has no file descriptor".to_string())?;
-        let writer: PtyInputWriter = Arc::new(Mutex::new(
+        let writer = PtyInputWriter::new(Box::new(
             pair.master
                 .take_writer()
                 .map_err(|e| format!("failed to take PTY writer: {e}"))?,
@@ -538,7 +556,7 @@ impl Process {
         let (patch_tx, _) = broadcast::channel(256);
         let event_proxy = ServiceEventProxy {
             process_id: id,
-            pty_writer: Arc::clone(&writer),
+            pty_writer: writer.clone(),
             patch_tx: patch_tx.clone(),
         };
         let dims = PtyDimensions { cols, rows };
@@ -576,6 +594,9 @@ impl Process {
             selection: None,
             last_selection: None,
             last_viewport_copy_mode: None,
+            output_viewport_dirty: false,
+            last_output_viewport_at: None,
+            last_output_viewport_heavy: false,
             last_terminal_mode: None,
             copy_mode: None,
             keep_after_exit: false,
@@ -621,11 +642,12 @@ impl Process {
     }
 
     pub fn input_writer(&self) -> PtyInputWriter {
-        Arc::clone(&self.pty_writer)
+        self.pty_writer.clone()
     }
 
     pub fn write_input_to_writer(writer: &PtyInputWriter, data: &[u8]) {
-        if let Ok(mut w) = writer.lock() {
+        writer.input_pending.store(true, Ordering::Release);
+        if let Ok(mut w) = writer.writer.lock() {
             let _ = w.write_all(data);
         }
     }
@@ -1533,14 +1555,17 @@ impl Process {
             self.selection = None;
         }
         if got_data {
-            self.sync_viewport();
+            self.output_viewport_dirty = true;
         }
-        self.maybe_broadcast_mode();
         if self.exit_code.is_none()
             && let Ok(Some(status)) = self.child.try_wait()
         {
             self.exit_code = Some(status.exit_code() as i32);
         }
+        if self.output_viewport_dirty {
+            self.maybe_sync_output_viewport(pty_closed || self.exit_code.is_some(), got_data);
+        }
+        self.maybe_broadcast_mode();
         if !self.exit_reported
             && let Some(code) = self.exit_code
             && self.pty_reader_drained()
@@ -1559,7 +1584,26 @@ impl Process {
         false
     }
 
-    fn sync_viewport(&mut self) {
+    fn maybe_sync_output_viewport(&mut self, force: bool, got_data: bool) {
+        let now = Instant::now();
+        let elapsed = self
+            .last_output_viewport_at
+            .map(|last| now.saturating_duration_since(last));
+        let input_pending = take_input_priority(&self.pty_writer.input_pending, got_data);
+        if !output_viewport_due(
+            self.last_output_viewport_heavy,
+            force || input_pending,
+            elapsed,
+        ) {
+            return;
+        }
+        let changed_rows = self.sync_viewport();
+        self.output_viewport_dirty = false;
+        self.last_output_viewport_at = Some(now);
+        self.last_output_viewport_heavy = changed_rows.saturating_mul(2) >= self.rows as usize;
+    }
+
+    fn sync_viewport(&mut self) -> usize {
         let mode = self.term.mode();
         let passthrough = self.copy_mode.is_some()
             || mode.contains(alacritty_terminal::term::TermMode::ALT_SCREEN)
@@ -1571,16 +1615,16 @@ impl Process {
             self.last_passthrough = passthrough;
         }
         if passthrough {
-            self.sync_screen_relative();
+            self.sync_screen_relative()
         } else {
-            self.sync_document_window();
+            self.sync_document_window()
         }
     }
 
     /// Passthrough path (alt-screen / copy-mode): render the visible screen at
     /// document rows `0..screen_lines` with `first_row = 0` and no native scroll.
     /// Preserves the pre-native-scroll behavior for TUIs and copy-mode.
-    fn sync_screen_relative(&mut self) {
+    fn sync_screen_relative(&mut self) -> usize {
         let grid = self.term.grid();
         let num_lines = grid.screen_lines();
         let num_cols = grid.columns();
@@ -1635,8 +1679,9 @@ impl Process {
             && !selection_changed
             && !copy_mode_changed
         {
-            return;
+            return 0;
         }
+        let changed_rows = changed_lines.len();
         self.last_cursor = Some(cursor_pos);
         self.last_selection = self.selection;
         self.last_viewport_copy_mode = Some(copy_mode);
@@ -1677,12 +1722,13 @@ impl Process {
             evicted_total: 0,
         };
         let _ = self.patch_tx.send(patch);
+        changed_rows
     }
 
     /// Native-scroll path (primary screen, no copy-mode): serve a document-row
     /// window around `view_top` (or the bottom when `following`) by direct grid
     /// `Line` indexing. `display_offset` stays 0.
-    fn sync_document_window(&mut self) {
+    fn sync_document_window(&mut self) -> usize {
         let grid = self.term.grid();
         let screen = grid.screen_lines();
         let num_cols = grid.columns();
@@ -1690,12 +1736,16 @@ impl Process {
         let history = total_rows.saturating_sub(screen as u32);
         let visible = screen as u16;
 
-        let overscan = vmux_core::scroll::overscan_for(
-            visible,
-            vmux_core::scroll::TERMINAL_OVERSCAN_K,
-            vmux_core::scroll::OVERSCAN_FLOOR,
-            vmux_core::scroll::OVERSCAN_CAP,
-        );
+        let overscan = if self.following {
+            0
+        } else {
+            vmux_core::scroll::overscan_for(
+                visible,
+                vmux_core::scroll::TERMINAL_OVERSCAN_K,
+                vmux_core::scroll::OVERSCAN_FLOOR,
+                vmux_core::scroll::OVERSCAN_CAP,
+            )
+        };
         let view_top = if self.following {
             history
         } else {
@@ -1735,8 +1785,9 @@ impl Process {
 
         if changed_lines.is_empty() && !full && !cursor_moved && !selection_changed && !win_changed
         {
-            return;
+            return 0;
         }
+        let changed_rows = changed_lines.len();
         self.last_cursor = Some(cursor_key);
         self.last_selection = self.selection;
         self.last_win = Some(win);
@@ -1764,6 +1815,7 @@ impl Process {
             evicted_total: 0,
         };
         let _ = self.patch_tx.send(patch);
+        changed_rows
     }
 
     pub fn snapshot(&self) -> ServiceMessage {
@@ -1952,38 +2004,51 @@ impl ProcessManager {
 
 // --- Grid helpers ---
 
+fn output_viewport_due(heavy: bool, force: bool, elapsed: Option<Duration>) -> bool {
+    force || !heavy || elapsed.is_none_or(|elapsed| elapsed >= HEAVY_OUTPUT_FRAME_INTERVAL)
+}
+
+fn take_input_priority(input_pending: &AtomicBool, got_data: bool) -> bool {
+    got_data && input_pending.swap(false, Ordering::AcqRel)
+}
+
+fn mix_row_hash(hash: &mut u64, value: u64) {
+    *hash ^= value;
+    *hash = hash.wrapping_mul(0x100000001b3);
+}
+
+fn mix_color_hash(hash: &mut u64, color: &Color) {
+    match color {
+        Color::Named(color) => {
+            mix_row_hash(hash, 0);
+            mix_row_hash(hash, *color as u8 as u64);
+        }
+        Color::Spec(rgb) => {
+            mix_row_hash(hash, 1);
+            mix_row_hash(hash, rgb.r as u64);
+            mix_row_hash(hash, rgb.g as u64);
+            mix_row_hash(hash, rgb.b as u64);
+        }
+        Color::Indexed(index) => {
+            mix_row_hash(hash, 2);
+            mix_row_hash(hash, *index as u64);
+        }
+    }
+}
+
 fn hash_grid_row<T: TermEventListener>(term: &Term<T>, row_idx: usize, offset: i32) -> u64 {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    let mut hash = 0xcbf29ce484222325;
     let grid = term.grid();
     let num_cols = grid.columns();
     let row = &grid[Line(row_idx as i32 - offset)];
     for col_idx in 0..num_cols {
         let cell = &row[Column(col_idx)];
-        cell.c.hash(&mut hasher);
-        std::mem::discriminant(&cell.fg).hash(&mut hasher);
-        match &cell.fg {
-            Color::Named(c) => (*c as u8).hash(&mut hasher),
-            Color::Spec(rgb) => {
-                rgb.r.hash(&mut hasher);
-                rgb.g.hash(&mut hasher);
-                rgb.b.hash(&mut hasher);
-            }
-            Color::Indexed(i) => i.hash(&mut hasher),
-        }
-        std::mem::discriminant(&cell.bg).hash(&mut hasher);
-        match &cell.bg {
-            Color::Named(c) => (*c as u8).hash(&mut hasher),
-            Color::Spec(rgb) => {
-                rgb.r.hash(&mut hasher);
-                rgb.g.hash(&mut hasher);
-                rgb.b.hash(&mut hasher);
-            }
-            Color::Indexed(i) => i.hash(&mut hasher),
-        }
-        cell.flags.bits().hash(&mut hasher);
+        mix_row_hash(&mut hash, cell.c as u32 as u64);
+        mix_color_hash(&mut hash, &cell.fg);
+        mix_color_hash(&mut hash, &cell.bg);
+        mix_row_hash(&mut hash, cell.flags.bits() as u64);
     }
-    hasher.finish()
+    hash
 }
 
 fn build_line<T: TermEventListener>(term: &Term<T>, row_idx: usize, offset: i32) -> TermLine {
@@ -2126,6 +2191,32 @@ fn ansi_256_to_rgb(idx: u8) -> [u8; 3] {
 mod tests {
     use super::*;
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn heavy_output_waits_for_frame_interval_but_sparse_and_final_output_do_not() {
+        assert!(!output_viewport_due(
+            true,
+            false,
+            Some(HEAVY_OUTPUT_FRAME_INTERVAL - Duration::from_millis(1)),
+        ));
+        assert!(output_viewport_due(
+            true,
+            false,
+            Some(HEAVY_OUTPUT_FRAME_INTERVAL),
+        ));
+        assert!(output_viewport_due(true, true, Some(Duration::ZERO)));
+        assert!(output_viewport_due(false, false, Some(Duration::ZERO)));
+    }
+
+    #[test]
+    fn input_priority_waits_for_fresh_pty_output() {
+        let input_pending = AtomicBool::new(true);
+
+        assert!(!take_input_priority(&input_pending, false));
+        assert!(input_pending.load(Ordering::Acquire));
+        assert!(take_input_priority(&input_pending, true));
+        assert!(!input_pending.load(Ordering::Acquire));
+    }
 
     #[test]
     fn pty_reader_notifies_when_output_arrives() {
@@ -2405,12 +2496,12 @@ mod tests {
         }
 
         let captured = Arc::new(Mutex::new(Vec::new()));
-        let writer: PtyInputWriter =
-            Arc::new(Mutex::new(Box::new(CapturingWriter(captured.clone()))));
+        let writer = PtyInputWriter::new(Box::new(CapturingWriter(captured.clone())));
 
         Process::write_input_to_writer(&writer, b"abc");
 
         assert_eq!(*captured.lock().unwrap(), b"abc".to_vec());
+        assert!(writer.input_pending.load(Ordering::Acquire));
     }
 
     #[test]
@@ -2442,7 +2533,7 @@ mod tests {
         )
         .expect("process should spawn");
         let captured = Arc::new(Mutex::new(Vec::new()));
-        process.pty_writer = Arc::new(Mutex::new(Box::new(CapturingWriter(captured.clone()))));
+        process.pty_writer = PtyInputWriter::new(Box::new(CapturingWriter(captured.clone())));
 
         process.process_output_for_test(b"\x1b[?1049h\x1b[Hone\r\ntwo\r\nthree\x1b[H");
         process.enter_copy_mode();
@@ -2484,7 +2575,7 @@ mod tests {
         )
         .expect("process should spawn");
         let captured = Arc::new(Mutex::new(Vec::new()));
-        process.pty_writer = Arc::new(Mutex::new(Box::new(CapturingWriter(captured.clone()))));
+        process.pty_writer = PtyInputWriter::new(Box::new(CapturingWriter(captured.clone())));
         (process, captured)
     }
 
@@ -2580,6 +2671,27 @@ mod tests {
     }
 
     #[test]
+    fn following_patch_contains_only_visible_rows() {
+        let (mut process, _) = capturing_process(12, 4);
+        let mut patches = process.subscribe();
+        let mut feed = Vec::new();
+        for i in 0..40 {
+            feed.extend_from_slice(format!("line{i}\r\n").as_bytes());
+        }
+
+        process.process_output_for_test(&feed);
+
+        let changed_lines = std::iter::from_fn(|| patches.try_recv().ok())
+            .find_map(|message| match message {
+                ServiceMessage::ViewportPatch { changed_lines, .. } => Some(changed_lines),
+                _ => None,
+            })
+            .expect("output must broadcast a viewport patch");
+        assert!(changed_lines.len() <= process.rows as usize);
+        process.kill();
+    }
+
+    #[test]
     fn terminal_mode_broadcasts_alt_screen_toggle() {
         let (wake_tx, _) = mpsc::unbounded_channel();
         let mut process = Process::new_with_wake(
@@ -2654,7 +2766,7 @@ mod tests {
         use std::io;
 
         let (tx, mut rx) = broadcast::channel::<ServiceMessage>(8);
-        let writer: PtyInputWriter = Arc::new(Mutex::new(Box::new(io::sink())));
+        let writer = PtyInputWriter::new(Box::new(io::sink()));
         let process_id = ProcessId::new();
         let proxy = ServiceEventProxy {
             process_id,
@@ -2682,7 +2794,7 @@ mod tests {
         use std::io;
 
         let (tx, mut rx) = broadcast::channel::<ServiceMessage>(8);
-        let writer: PtyInputWriter = Arc::new(Mutex::new(Box::new(io::sink())));
+        let writer = PtyInputWriter::new(Box::new(io::sink()));
         let process_id = ProcessId::new();
         let proxy = ServiceEventProxy {
             process_id,

--- a/crates/vmux_service/src/server.rs
+++ b/crates/vmux_service/src/server.rs
@@ -7,7 +7,7 @@ use crate::{read_message, write_message};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::OnceLock;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio::io::BufReader;
 use tokio::net::UnixListener;
 use tokio::sync::{Mutex, broadcast, mpsc};
@@ -19,7 +19,7 @@ pub(crate) fn init_started_at() {
     SERVICE_STARTED.get_or_init(Instant::now);
 }
 
-const MAX_WAKE_EVENTS_PER_TICK: usize = 1024;
+const PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(16);
 type InputWriters = Arc<Mutex<HashMap<ProcessId, PtyInputWriter>>>;
 type PendingQueries = Arc<
     Mutex<
@@ -120,16 +120,12 @@ pub async fn run_server(listener: UnixListener) {
     let poll_mgr = Arc::clone(&manager);
     let poll_input_writers = Arc::clone(&input_writers);
     let poll_handle = tokio::spawn(async move {
-        let mut interval = tokio::time::interval(std::time::Duration::from_millis(16));
+        let mut interval = tokio::time::interval(PROCESS_POLL_INTERVAL);
         interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         loop {
-            tokio::select! {
-                _ = interval.tick() => {}
-                Some(_) = wake_rx.recv() => {
-                    drain_pending_wakes(&mut wake_rx);
-                }
-            }
+            interval.tick().await;
+            drain_pending_wakes(&mut wake_rx);
 
             let reaped = {
                 let mut mgr = poll_mgr.lock().await;
@@ -209,11 +205,7 @@ pub async fn run_server(listener: UnixListener) {
 }
 
 fn drain_pending_wakes(wake_rx: &mut mpsc::UnboundedReceiver<ProcessId>) {
-    for _ in 0..MAX_WAKE_EVENTS_PER_TICK {
-        if wake_rx.try_recv().is_err() {
-            break;
-        }
-    }
+    while wake_rx.try_recv().is_ok() {}
 }
 
 fn command_result_to_content(result: crate::protocol::AgentCommandResult) -> (String, bool) {
@@ -1069,9 +1061,9 @@ mod tests {
     }
 
     #[test]
-    fn wake_drain_leaves_excess_events_for_later_ticks() {
+    fn wake_drain_coalesces_all_pending_output() {
         let (wake_tx, mut wake_rx) = mpsc::unbounded_channel();
-        for _ in 0..=MAX_WAKE_EVENTS_PER_TICK {
+        for _ in 0..1024 {
             wake_tx
                 .send(ProcessId::new())
                 .expect("wake event should queue");
@@ -1079,7 +1071,7 @@ mod tests {
 
         drain_pending_wakes(&mut wake_rx);
 
-        assert!(wake_rx.try_recv().is_ok());
+        assert!(wake_rx.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/crates/vmux_terminal/src/link.rs
+++ b/crates/vmux_terminal/src/link.rs
@@ -14,6 +14,8 @@ const TRAILING_TRIM: &[char] = &['.', ',', ';', ':', '!', '?', ')', ']', '}', '"
 /// Punctuation trimmed from the start of a detected token.
 const LEADING_TRIM: &[char] = &['(', '[', '{', '<', '"', '\''];
 
+const MAX_LINKS_PER_LINE: usize = 16;
+
 /// Annotate `line` with the links found in its visible text.
 ///
 /// `cwd` is the terminal's working directory, used to resolve relative file
@@ -22,24 +24,30 @@ const LEADING_TRIM: &[char] = &['(', '[', '{', '<', '"', '\''];
 pub fn annotate_links(line: &mut TermLine, cwd: Option<&Path>) {
     line.links.clear();
 
-    // Reconstruct the row text and, per char, its starting column and width,
-    // honoring wide characters via each span's starting column.
-    let mut text = String::new();
-    let mut cols: Vec<(u16, u16)> = Vec::new();
+    let mut text = String::with_capacity(line.spans.iter().map(|span| span.text.len()).sum());
     for span in &line.spans {
-        let mut col = span.col;
-        for ch in span.text.chars() {
-            let w = UnicodeWidthChar::width(ch).unwrap_or(0).max(1) as u16;
-            text.push(ch);
-            cols.push((col, w));
-            col = col.saturating_add(w);
-        }
+        text.push_str(&span.text);
     }
     if text.is_empty() {
         return;
     }
 
-    for (char_start, char_end, url) in detect_links_in_text(&text, cwd) {
+    let detected = detect_links_in_text(&text, cwd);
+    if detected.is_empty() {
+        return;
+    }
+
+    let mut cols: Vec<(u16, u16)> = Vec::with_capacity(text.chars().count());
+    for span in &line.spans {
+        let mut col = span.col;
+        for ch in span.text.chars() {
+            let width = UnicodeWidthChar::width(ch).unwrap_or(0).max(1) as u16;
+            cols.push((col, width));
+            col = col.saturating_add(width);
+        }
+    }
+
+    for (char_start, char_end, url) in detected.into_iter().take(MAX_LINKS_PER_LINE) {
         let Some(&(start_col, _)) = cols.get(char_start) else {
             continue;
         };
@@ -96,10 +104,17 @@ fn resolve_target(token: &str, cwd: Option<&Path>) -> Option<String> {
     if is_data_uri(token) || token.contains("://") {
         return Some(token.to_string());
     }
-    if looks_like_path(token) {
+    if looks_like_path(token) && path_token_has_name(token) {
         return resolve_path(token, cwd);
     }
     None
+}
+
+fn path_token_has_name(token: &str) -> bool {
+    !token.contains('\\')
+        && token
+            .chars()
+            .any(|ch| ch.is_alphanumeric() || matches!(ch, '_' | '-'))
 }
 
 /// Resolve a file path token to a `file://` URL, expanding `~/` and resolving
@@ -168,6 +183,15 @@ mod tests {
         annotate_links(&mut l, None);
         assert_eq!(l.links.len(), 1);
         assert_eq!(l.links[0].url, "file:///Users/me/main.rs");
+    }
+
+    #[test]
+    fn ignores_ascii_art_path_punctuation() {
+        let mut line = line_of(r"/ \/ /\\ \\// |/\\| ////");
+
+        annotate_links(&mut line, None);
+
+        assert!(line.links.is_empty());
     }
 
     #[test]

--- a/crates/vmux_terminal/src/page.rs
+++ b/crates/vmux_terminal/src/page.rs
@@ -23,6 +23,12 @@ const CONTAINER_ID: &str = "term-container";
 /// ID for the hidden measurement span used to compute character dimensions.
 const MEASURE_ID: &str = "term-measure";
 
+#[derive(Clone, PartialEq)]
+struct TerminalRowState {
+    line: TermLine,
+    cursor: Option<TermCursor>,
+}
+
 fn localized_terminal_title(title: &str) -> String {
     if title == "Terminal" {
         translate("command-terminal")
@@ -42,7 +48,7 @@ fn localized_terminal_title(title: &str) -> String {
 #[component]
 pub fn Page() -> Element {
     let locale = use_theme();
-    let mut rows = use_signal(std::collections::BTreeMap::<u32, Signal<TermLine>>::new);
+    let mut rows = use_signal(std::collections::BTreeMap::<u32, Signal<TerminalRowState>>::new);
     let mut first_row = use_signal(|| 0u32);
     let mut raw_title = use_signal(String::new);
     let mut total_rows = use_signal(|| 0u32);
@@ -68,8 +74,12 @@ pub fn Page() -> Element {
     let _listener =
         use_bin_event_listener::<TermViewportPatch, _>(TERM_VIEWPORT_EVENT, move |patch| {
             let first = patch.first_row;
-            first_row.set(first);
-            total_rows.set(patch.total_rows);
+            if *first_row.peek() != first {
+                first_row.set(first);
+            }
+            if *total_rows.peek() != patch.total_rows {
+                total_rows.set(patch.total_rows);
+            }
             if *alt.peek() != patch.alt {
                 alt.set(patch.alt);
             }
@@ -87,21 +97,82 @@ pub fn Page() -> Element {
                 vmux_core::scroll::OVERSCAN_CAP,
             );
             let keep_hi = first + patch.rows as u32 + overscan * 2 + 2;
-            rows.with_mut(|map| {
-                if patch.full {
-                    map.clear();
-                }
+            let previous_cursor = cursor.peek().clone();
+            let next_cursor = patch.cursor.clone();
+            let cursor_for_row =
+                |doc_row| (next_cursor.row == doc_row).then_some(next_cursor.clone());
+            if patch.full {
+                let next = patch
+                    .changed_lines
+                    .iter()
+                    .filter(|(doc_row, _)| *doc_row >= first && *doc_row <= keep_hi)
+                    .map(|(doc_row, line)| {
+                        (
+                            *doc_row,
+                            Signal::new(TerminalRowState {
+                                line: line.clone(),
+                                cursor: cursor_for_row(*doc_row),
+                            }),
+                        )
+                    })
+                    .collect();
+                rows.set(next);
+            } else {
+                let mut missing = Vec::new();
                 for (doc_row, line) in &patch.changed_lines {
-                    if let Some(mut existing) = map.get(doc_row).copied() {
-                        if *existing.peek() != *line {
-                            existing.set(line.clone());
+                    let state = TerminalRowState {
+                        line: line.clone(),
+                        cursor: cursor_for_row(*doc_row),
+                    };
+                    if let Some(mut existing) = rows.peek().get(doc_row).copied() {
+                        if *existing.peek() != state {
+                            existing.set(state);
                         }
                     } else {
-                        map.insert(*doc_row, Signal::new(line.clone()));
+                        missing.push((*doc_row, state));
                     }
                 }
-                map.retain(|k, _| *k >= first && *k <= keep_hi);
-            });
+
+                let line_changed = |doc_row| {
+                    patch
+                        .changed_lines
+                        .iter()
+                        .any(|(changed_row, _)| *changed_row == doc_row)
+                };
+                if previous_cursor.as_ref().map(|cursor| cursor.row) != Some(next_cursor.row)
+                    && let Some(old_row) = previous_cursor.as_ref().map(|cursor| cursor.row)
+                    && !line_changed(old_row)
+                    && let Some(mut state) = rows.peek().get(&old_row).copied()
+                    && state.peek().cursor.is_some()
+                {
+                    let line = state.peek().line.clone();
+                    state.set(TerminalRowState { line, cursor: None });
+                }
+                if !line_changed(next_cursor.row)
+                    && let Some(mut state) = rows.peek().get(&next_cursor.row).copied()
+                {
+                    let current = state.peek().clone();
+                    if current.cursor.as_ref() != Some(&next_cursor) {
+                        state.set(TerminalRowState {
+                            line: current.line,
+                            cursor: Some(next_cursor.clone()),
+                        });
+                    }
+                }
+
+                let prune = rows
+                    .peek()
+                    .keys()
+                    .any(|doc_row| *doc_row < first || *doc_row > keep_hi);
+                if !missing.is_empty() || prune {
+                    rows.with_mut(|map| {
+                        for (doc_row, state) in missing {
+                            map.insert(doc_row, Signal::new(state));
+                        }
+                        map.retain(|doc_row, _| *doc_row >= first && *doc_row <= keep_hi);
+                    });
+                }
+            }
 
             if *selection.peek() != patch.selection {
                 selection.set(patch.selection);
@@ -465,23 +536,19 @@ pub fn Page() -> Element {
                     style: "height:{spacer_h}px;",
                     {
                         let base_rows = rows();
-                        let cur = cursor();
                         rsx! {
-                            for (doc_row, line) in base_rows.iter() {
+                            for (doc_row, row) in base_rows.iter() {
                                 {
                                     let top = *doc_row as f64 * ch;
-                                    let row_cursor =
-                                        cur.as_ref().filter(|c| c.row == *doc_row).cloned();
                                     rsx! {
                                         div {
                                             key: "{doc_row}",
                                             style: "position:absolute;left:0;right:0;top:{top}px;",
                                             TerminalRow {
                                                 row_idx: *doc_row as usize,
-                                                line: *line,
+                                                row: *row,
                                                 selection,
                                                 cols,
-                                                cursor: row_cursor,
                                             }
                                         }
                                     }
@@ -514,12 +581,12 @@ const _TW_SAFELIST: &[&str] = &[
 #[component]
 fn TerminalRow(
     row_idx: usize,
-    line: Signal<TermLine>,
+    row: Signal<TerminalRowState>,
     selection: Signal<Option<TermSelectionRange>>,
     cols: Signal<u16>,
-    cursor: Option<TermCursor>,
 ) -> Element {
-    let line = line();
+    let state = row();
+    let line = &state.line;
     let selected_cols = row_selection_cols(&selection(), row_idx, cols());
 
     rsx! {
@@ -536,7 +603,7 @@ fn TerminalRow(
                 }
             }
             for (span_idx, span) in line.spans.iter().enumerate() {
-                {render_span(span, span_idx, cursor.as_ref(), "block")}
+                {render_span(span, span_idx, state.cursor.as_ref(), "block")}
             }
             if let Some((sel_start, sel_end)) = selected_cols {
                 div {

--- a/patches/bevy_cef-0.5.2/src/common/message_loop.rs
+++ b/patches/bevy_cef-0.5.2/src/common/message_loop.rs
@@ -109,8 +109,7 @@ impl Plugin for MessageLoopPlugin {
 
         #[cfg(target_os = "macos")]
         {
-            drop(rx);
-            app.insert_non_send(cef_pump_timer::install(1.0 / 120.0));
+            app.insert_non_send(cef_pump_timer::install(rx, 1.0 / 60.0));
         }
     }
 }
@@ -383,6 +382,13 @@ mod tests {
 #[cfg(target_os = "macos")]
 mod cef_pump_timer {
     use std::os::raw::c_void;
+    use std::sync::mpsc::Receiver;
+    use std::sync::{Mutex, OnceLock};
+    use std::time::{Duration, Instant};
+
+    use bevy_cef_core::prelude::MessageLoopTimer;
+
+    const IDLE_PUMP_INTERVAL: Duration = Duration::from_secs(1);
 
     type CFRunLoopRef = *mut c_void;
     type CFRunLoopTimerRef = *mut c_void;
@@ -408,8 +414,45 @@ mod cef_pump_timer {
         fn CFRelease(cf: *const c_void);
     }
 
+    struct PumpState {
+        receiver: Receiver<MessageLoopTimer>,
+        next: Option<MessageLoopTimer>,
+        last_pump: Instant,
+    }
+
+    impl PumpState {
+        fn should_pump(&mut self, now: Instant) -> bool {
+            while let Ok(timer) = self.receiver.try_recv() {
+                self.next = Some(self.next.map_or(timer, |next| next.earliest(timer)));
+            }
+            let requested = self.next.is_some_and(|timer| timer.is_finished());
+            let fallback = now.duration_since(self.last_pump) >= IDLE_PUMP_INTERVAL;
+            if !requested && !fallback {
+                return false;
+            }
+            if requested {
+                self.next = None;
+            }
+            self.last_pump = now;
+            true
+        }
+    }
+
+    static PUMP_STATE: OnceLock<Mutex<Option<PumpState>>> = OnceLock::new();
+
+    fn pump_state() -> &'static Mutex<Option<PumpState>> {
+        PUMP_STATE.get_or_init(|| Mutex::new(None))
+    }
+
     extern "C" fn pump(_timer: CFRunLoopTimerRef, _info: *mut c_void) {
-        cef::do_message_loop_work();
+        let should_pump = pump_state()
+            .lock()
+            .unwrap()
+            .as_mut()
+            .is_some_and(|state| state.should_pump(Instant::now()));
+        if should_pump {
+            cef::do_message_loop_work();
+        }
     }
 
     pub struct Controller {
@@ -429,6 +472,7 @@ mod cef_pump_timer {
                 CFRunLoopTimerInvalidate(self.timer);
                 CFRelease(self.timer.cast_const());
             }
+            pump_state().lock().unwrap().take();
         }
     }
 
@@ -438,7 +482,15 @@ mod cef_pump_timer {
         }
     }
 
-    pub fn install(interval: f64) -> Controller {
+    pub fn install(receiver: Receiver<MessageLoopTimer>, interval: f64) -> Controller {
+        let mut state = pump_state().lock().unwrap();
+        assert!(state.is_none(), "CEF pump already installed");
+        *state = Some(PumpState {
+            receiver,
+            next: Some(MessageLoopTimer::new(0)),
+            last_pump: Instant::now(),
+        });
+        drop(state);
         unsafe {
             let timer = CFRunLoopTimerCreate(
                 std::ptr::null(),
@@ -457,6 +509,48 @@ mod cef_pump_timer {
                 timer,
                 stopped: false,
             }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn state(receiver: Receiver<MessageLoopTimer>) -> PumpState {
+            PumpState {
+                receiver,
+                next: None,
+                last_pump: Instant::now(),
+            }
+        }
+
+        #[test]
+        fn immediate_requests_coalesce_into_one_pump() {
+            let (tx, rx) = std::sync::mpsc::channel();
+            tx.send(MessageLoopTimer::new(0)).unwrap();
+            tx.send(MessageLoopTimer::new(0)).unwrap();
+            let mut state = state(rx);
+
+            assert!(state.should_pump(Instant::now()));
+            assert!(!state.should_pump(Instant::now()));
+        }
+
+        #[test]
+        fn future_request_waits_for_its_deadline() {
+            let (tx, rx) = std::sync::mpsc::channel();
+            tx.send(MessageLoopTimer::new(100)).unwrap();
+            let mut state = state(rx);
+
+            assert!(!state.should_pump(Instant::now()));
+        }
+
+        #[test]
+        fn idle_fallback_keeps_cef_alive() {
+            let (_tx, rx) = std::sync::mpsc::channel();
+            let mut state = state(rx);
+            state.last_pump = Instant::now() - IDLE_PUMP_INTERVAL;
+
+            assert!(state.should_pump(Instant::now()));
         }
     }
 }


### PR DESCRIPTION
## Context

High-frequency terminal and agent output caused excessive CPU use and delayed interactive input.

## Implementation

- coalesce CEF, service, PTY, terminal-row, and chat rendering updates
- cap heavy full-screen output while prioritizing fresh user input
- reduce terminal overscan, link detection, row hashing, and unchanged chat rerenders
- remove infinite agent status animations

## Checks / QA

- full pre-push fmt, clippy, workspace tests, and doctests
- patched `bevy_cef` pump tests
- native + WASM targeted checks
- manually verified `ascii.live/forrest` CPU and instant terminal typing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Chat updates now remain responsive during streaming while reducing unnecessary refreshes.
  - Terminal input and viewport updates feel more responsive, especially during active typing and scrolling.
  - Cursor movement and rendering are more reliable across terminal updates.
  - Service activity is handled more efficiently during bursts of events.
  - macOS embedded content rendering now uses more consistent background processing.

- **Bug Fixes**
  - Reduced false-positive links caused by ASCII-art punctuation.
  - Improved terminal viewport behavior when following live output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->