### PR TITLE
chore(release): v0.0.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9558,7 +9558,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "base64 0.22.1",
  "bevy",
@@ -9607,7 +9607,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_browser"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -9644,7 +9644,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -9657,7 +9657,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9673,7 +9673,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command_mcp"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "serde_json",
  "vmux_command",
@@ -9682,7 +9682,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9705,7 +9705,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9769,7 +9769,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_editor"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "arboard",
  "bevy",
@@ -9813,7 +9813,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_git"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9833,7 +9833,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9854,7 +9854,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_knowledge"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9869,7 +9869,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -9905,7 +9905,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "muda",
  "proc-macro2",
@@ -9915,7 +9915,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -9928,14 +9928,14 @@ dependencies = [
 
 [[package]]
 name = "vmux_profile"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "vmux_server"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "dioxus",
  "regex",
@@ -9956,7 +9956,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "agent-client-protocol",
  "alacritty_terminal",
@@ -9996,7 +9996,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service_client"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "chrono",
  "libc",
@@ -10009,7 +10009,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10032,7 +10032,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10057,7 +10057,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_team"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10078,7 +10078,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10111,7 +10111,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "dioxus",
  "dioxus-primitives",
@@ -10133,7 +10133,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_wire"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "bevy_ecs",
  "bevy_reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.28"
+version = "0.0.29"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "GPL-3.0-or-later"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.28"
-  sha256 "69ba2264a570434042c71d8381bd07455661ed47ae9f5c208133b255c34cbb91"
+  version "0.0.29"
+  sha256 "94815b7b36e78cffafb857f47f0b66d9142701c59a045a73c5800599c3601a6c"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.28/Vmux_0.0.28_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.29/Vmux_0.0.29_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai/"

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.28",
-  "pub_date": "2026-07-22T08:44:54Z",
+  "version": "v0.0.29",
+  "pub_date": "2026-07-24T03:48:48Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.28/Vmux-v0.0.28-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzdRaDBndVJLRGIxY1owT09VZC9BMnk1bGoweGp2TlVzenB2b0xXNCtZdzhPL1lSdmVXUzI0b3RON3pEWGgvSkpyWDJOdW83RjkybHFJcE9rejBGMlEwPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg0NzA5ODkxCWZpbGU6Vm11eC12MC4wLjI4LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKS3RWM2E3Nk9tY0IrQndGTU1zVFNTc2VuZzY1dmR0TDRPL1gzWkplekVlMmNYdHpxdVU2RmVxOFc5MGczTm8zVXJhRVcvMlVLVlREdCtKeGpnYU1QQnc9PQo=",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.29/Vmux-v0.0.29-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzQ5dmhkNGVIWXhZdmFGUXpETnd5cmV3L1ViWjN3dFErNUszaTVXbXhOemVCUnRSM3lhc0xiVnFuakMwM0FLOVJIRnROQjhSSTFheFVsV1YybDZKeHcwPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg0ODY0OTI2CWZpbGU6Vm11eC12MC4wLjI5LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKN0RRY1FlVG5oU1RtVVlCQWhRc2x2L1NtSG41WktwaEhwMTQ2dS9nOUovREJocWxtVHoxL21rcDRFa0NURU1Wckl6bE9GNmloWW1zdDdnZ3V0a3VHQ2c9PQo=",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.28/Vmux_0.0.28_aarch64.dmg",
-      "filename": "Vmux_0.0.28_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.29/Vmux_0.0.29_aarch64.dmg",
+      "filename": "Vmux_0.0.29_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
## Context

Patch release after the scoped approval persistence fix.

## Implementation

Bumps the workspace version from `0.0.28` to `0.0.29`. Release artifacts are built and published after merge.

## Checks / QA

Pre-push fmt, clippy, and workspace tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Incremented the application version from 0.0.28 to 0.0.29.
  * Updated macOS installer metadata (including checksums and download links) to point to the v0.0.29 release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->