### PR TITLE
fix(agent): refine agent and knowledge workflows

### DIFF
--- a/crates/vmux_agent/Cargo.toml
+++ b/crates/vmux_agent/Cargo.toml
@@ -54,6 +54,7 @@ vmux_ui = { path = "../vmux_ui", default-features = false }
 vmux_core = { path = "../vmux_core" }
 wasm-bindgen = { workspace = true }
 web-sys = { version = "0.3", features = [
+    "Clipboard",
     "Window",
     "Document",
     "Element",
@@ -63,6 +64,7 @@ web-sys = { version = "0.3", features = [
     "HtmlTextAreaElement",
     "KeyboardEvent",
     "KeyboardEventInit",
+    "Navigator",
     "ScrollIntoViewOptions",
     "ScrollLogicalPosition",
     "Selection",

--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -42,6 +42,7 @@ use crate::client::acp::{AcpModelState, AcpSession};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::components::{
     AgentApprovalPolicy, AgentConversationTitle, AgentMessages, AgentSession, PromptQueue,
+    provisional_conversation_title,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use crate::events::{
@@ -1457,7 +1458,12 @@ fn on_chat_history_request(
 fn on_chat_submit(
     trigger: On<BinReceive<ChatSubmit>>,
     child_of: Query<&ChildOf>,
-    mut sessions: Query<(&mut PromptQueue, &mut AgentRunState)>,
+    mut sessions: Query<(
+        &mut PromptQueue,
+        &mut AgentRunState,
+        Option<&AgentConversationTitle>,
+    )>,
+    mut commands: Commands,
 ) {
     let webview = trigger.event().webview;
     let payload = &trigger.event().payload;
@@ -1479,7 +1485,15 @@ fn on_chat_submit(
     let Ok(parent) = child_of.get(webview) else {
         return;
     };
-    if let Ok((mut queue, mut state)) = sessions.get_mut(parent.parent()) {
+    let session = parent.parent();
+    if let Ok((mut queue, mut state, title)) = sessions.get_mut(session) {
+        if title.is_none()
+            && let Some(title) = provisional_conversation_title(&text)
+        {
+            commands
+                .entity(session)
+                .insert(AgentConversationTitle(title));
+        }
         enqueue_prompt(&mut queue, &mut state, text, attachments);
     }
 }
@@ -2588,6 +2602,58 @@ mod native_tests {
         assert!(page.contains("current_activity_icon(&items, &status)"));
         assert!(page.contains("ActivityIcon::Python"));
         assert!(page.contains("language_activity_icon(path)"));
+    }
+
+    #[test]
+    fn first_prompt_updates_conversation_title_immediately() {
+        use bevy_cef::prelude::BinReceive;
+
+        let mut app = App::new();
+        app.add_observer(on_chat_submit);
+        let session = app
+            .world_mut()
+            .spawn((PromptQueue::default(), AgentRunState::Idle))
+            .id();
+        let webview = app.world_mut().spawn(ChildOf(session)).id();
+
+        app.world_mut().trigger(BinReceive {
+            webview,
+            payload: ChatSubmit {
+                text: "  make me a new\nJapanese restaurant website  ".into(),
+                attachments: Vec::new(),
+            },
+        });
+        app.world_mut().flush();
+
+        assert_eq!(
+            app.world().get::<AgentConversationTitle>(session),
+            Some(&AgentConversationTitle(
+                "make me a new Japanese restaurant website".into()
+            ))
+        );
+        assert_eq!(
+            app.world()
+                .get::<PromptQueue>(session)
+                .and_then(|queue| queue.items.front())
+                .map(|prompt| prompt.text.as_str()),
+            Some("  make me a new\nJapanese restaurant website  ")
+        );
+
+        app.world_mut().trigger(BinReceive {
+            webview,
+            payload: ChatSubmit {
+                text: "make it darker".into(),
+                attachments: Vec::new(),
+            },
+        });
+        app.world_mut().flush();
+
+        assert_eq!(
+            app.world().get::<AgentConversationTitle>(session),
+            Some(&AgentConversationTitle(
+                "make me a new Japanese restaurant website".into()
+            ))
+        );
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/composer.rs
+++ b/crates/vmux_agent/src/chat_page/composer.rs
@@ -283,6 +283,7 @@ pub(crate) fn tool_activity(name: &str) -> ToolActivity {
         ToolActivity::WriteFile
     } else if lower.contains("worktree")
         || lower.contains("workspace")
+        || lower == "select_project"
         || lower.contains("repository")
     {
         ToolActivity::Worktree
@@ -313,6 +314,40 @@ pub(crate) fn tool_activity(name: &str) -> ToolActivity {
     } else {
         ToolActivity::Other
     }
+}
+
+pub(crate) fn tool_args_read_skill(args: &str) -> bool {
+    fn skill_path(value: &serde_json::Value) -> bool {
+        match value {
+            serde_json::Value::Object(map) => map.iter().any(|(key, value)| {
+                matches!(key.as_str(), "path" | "file" | "file_path" | "filename")
+                    && value.as_str().is_some_and(|path| {
+                        std::path::Path::new(path)
+                            .file_name()
+                            .and_then(|name| name.to_str())
+                            .is_some_and(|name| name.eq_ignore_ascii_case("SKILL.md"))
+                    })
+                    || skill_path(value)
+            }),
+            serde_json::Value::Array(values) => values.iter().any(skill_path),
+            _ => false,
+        }
+    }
+
+    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(args) else {
+        return false;
+    };
+    while let serde_json::Value::Object(map) = &value {
+        let Some(arguments) = map.get("arguments") else {
+            break;
+        };
+        if map.contains_key("server") || map.contains_key("tool") || map.contains_key("name") {
+            value = arguments.clone();
+        } else {
+            break;
+        }
+    }
+    skill_path(&value)
 }
 
 fn normalize_chat_page_title(value: &str) -> String {
@@ -671,6 +706,7 @@ mod tests {
         assert_eq!(tool_activity("apply_patch"), ToolActivity::WriteFile);
         assert_eq!(tool_activity("read_layout"), ToolActivity::Layout);
         assert_eq!(tool_activity("create_worktree"), ToolActivity::Worktree);
+        assert_eq!(tool_activity("select_project"), ToolActivity::Worktree);
         assert_eq!(tool_activity("view_image"), ToolActivity::Image);
         assert_eq!(tool_activity("vmux_screenshot"), ToolActivity::Screenshot);
         assert_eq!(tool_activity("vmux_open_page"), ToolActivity::OpenPage);
@@ -679,6 +715,16 @@ mod tests {
         assert_eq!(tool_activity("search_files"), ToolActivity::Search);
         assert_eq!(tool_activity("exec_command"), ToolActivity::Command);
         assert_eq!(tool_activity("custom_tool"), ToolActivity::Other);
+    }
+
+    #[test]
+    fn skill_reads_are_identified_from_nested_tool_arguments() {
+        assert!(tool_args_read_skill(
+            r#"{"arguments":{"path":"/tmp/skills/caveman/SKILL.md"},"server":"vmux","tool":"read_file"}"#
+        ));
+        assert!(!tool_args_read_skill(
+            r#"{"arguments":{"path":"/tmp/src/lib.rs"},"server":"vmux","tool":"read_file"}"#
+        ));
     }
 
     #[test]

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -766,7 +766,7 @@ mod tests {
         let items = vec![
             ChatItem::User {
                 text: "hi".into(),
-                context: Some("workspace policy".into()),
+                context: Some("project policy".into()),
                 attachments: vec![ChatSubmitAttachment {
                     path: "/tmp/image.png".into(),
                     name: "image.png".into(),
@@ -795,7 +795,7 @@ mod tests {
         assert!(matches!(
             &back[0],
             ChatItem::User { context, attachments, .. }
-                if context.as_deref() == Some("workspace policy")
+                if context.as_deref() == Some("project policy")
                     && attachments.first().is_some_and(|attachment| attachment.name == "image.png")
         ));
         let ChatItem::Turn(turn) = &back[1] else {

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -5,7 +5,7 @@ use crate::chat_page::composer::{
     approval_decision_for_index, chat_page_title, choice_number_index, edit_prompt, filter_models,
     filter_sessions, is_handoff_boundary, menu_direction, move_prompt_history, move_selection,
     prompt_history_direction, resume_menu_state, selector_mode, should_clear_draft_on_escape,
-    should_expand_thinking, should_fetch_resume, tool_activity,
+    should_expand_thinking, should_fetch_resume, tool_activity, tool_args_read_skill,
 };
 use crate::chat_page::event::{
     CHAT_ATTACHMENT_PREVIEWS_EVENT, CHAT_ATTACHMENTS_EVENT, CHAT_HISTORY_PAGE_EVENT,
@@ -94,6 +94,12 @@ fn has_text_selection() -> bool {
         .and_then(|w| w.get_selection().ok().flatten())
         .map(|s| !s.is_collapsed())
         .unwrap_or(false)
+}
+
+fn copy_to_clipboard(text: &str) {
+    if let Some(window) = web_sys::window() {
+        let _ = window.navigator().clipboard().write_text(text);
+    }
 }
 
 /// The agent id from the page URL (`vmux://agent/<id>` → `<id>`); the chat UI is shared
@@ -1125,7 +1131,7 @@ pub fn Page(
     let workspace_label = if context.workspace_selected && !context.workspace_name.is_empty() {
         context.workspace_name.clone()
     } else {
-        "Select workspace".to_string()
+        "Select project".to_string()
     };
     let access_label = if context.auto_allow_count == 0 {
         "Ask".to_string()
@@ -1133,9 +1139,9 @@ pub fn Page(
         format!("Ask · {} allowed", context.auto_allow_count)
     };
     let workspace_title = if context.cwd.is_empty() {
-        "Create or select workspace".to_string()
+        "Choose project".to_string()
     } else {
-        format!("Create or select workspace · {}", context.cwd)
+        format!("Choose project · {}", context.cwd)
     };
     let branch_title = if context.branch.is_empty() {
         "Git repository".to_string()
@@ -1270,7 +1276,7 @@ pub fn Page(
                     } else if context.can_manage_workspace {
                         button {
                             class: "flex h-7 shrink-0 items-center gap-1 rounded-lg px-2 text-[10px] font-medium text-muted-foreground transition hover:bg-violet-500/[0.08] hover:text-violet-600 dark:hover:text-violet-300",
-                            title: "Create or select a worktree for this workspace",
+                            title: "Create or select a worktree for this project",
                             onmousedown: move |event| event.prevent_default(),
                             onclick: move |_| {
                                 let _ = try_cef_bin_emit_rkyv(&ChatCreateWorktree);
@@ -1850,6 +1856,33 @@ fn send_approval(call_id: String, decision: u8) -> bool {
 }
 
 #[component]
+fn MessageCopyButton(text: String) -> Element {
+    let label = translate("agent-copy");
+    rsx! {
+        button {
+            class: "absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground/60 transition hover:bg-foreground/[0.08] hover:text-foreground",
+            title: "{label}",
+            aria_label: "{label}",
+            onclick: move |event| {
+                event.stop_propagation();
+                copy_to_clipboard(&text);
+            },
+            svg {
+                class: "h-3.5 w-3.5",
+                view_box: "0 0 24 24",
+                fill: "none",
+                stroke: "currentColor",
+                stroke_width: "1.8",
+                stroke_linecap: "round",
+                stroke_linejoin: "round",
+                rect { x: "9", y: "9", width: "13", height: "13", rx: "2" }
+                path { d: "M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" }
+            }
+        }
+    }
+}
+
+#[component]
 fn ChatItemRow(
     absolute_index: usize,
     item: ChatItem,
@@ -1878,8 +1911,11 @@ fn render_item(
         } => rsx! {
             div {
                 key: "{key}",
-                class: "chat-user-bubble flex max-w-[80%] self-end flex-col gap-2 rounded-[1.35rem] rounded-tr-md border p-2.5 text-sm",
+                class: "chat-user-bubble relative flex max-w-[80%] self-end flex-col gap-2 rounded-[1.35rem] rounded-tr-md border py-2.5 pl-2.5 pr-10 text-sm",
                 style: "content-visibility:auto;contain-intrinsic-size:auto 96px;",
+                if !text.is_empty() {
+                    MessageCopyButton { text: text.clone() }
+                }
                 if let Some(context) = context {
                     details { class: "disclosure user-context-panel rounded-xl border",
                         summary { class: "flex cursor-pointer select-none items-center gap-2 px-2.5 py-2 text-xs list-none [&::-webkit-details-marker]:hidden",
@@ -2006,13 +2042,25 @@ fn render_turn(key: usize, turn: &ChatTurn, latest_tool_index: Option<usize>) ->
             )
         }
     });
+    let copy_text = turn
+        .blocks
+        .iter()
+        .filter_map(|block| match block {
+            ChatBlock::Text(text) if !text.is_empty() => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
     rsx! {
         div {
             key: "{key}",
             class: "flex max-w-[92%] flex-col gap-2 self-start",
             style: "content-visibility:auto;contain-intrinsic-size:auto 180px;",
             if !blocks.is_empty() {
-                div { class: "chat-assistant-turn relative flex flex-col gap-2.5 overflow-hidden rounded-2xl border px-3.5 py-3",
+                div { class: "chat-assistant-turn relative flex flex-col gap-2.5 overflow-hidden rounded-2xl border py-3 pl-3.5 pr-10",
+                    if !copy_text.is_empty() {
+                        MessageCopyButton { text: copy_text.clone() }
+                    }
                     for (j , block , children) in blocks {
                         {render_block(
                             j,
@@ -2484,9 +2532,13 @@ fn tool_presentation(name: &str, args: &str) -> (ActivityIcon, String) {
     let icon = tool_activity_icon_for(name, args);
     match activity {
         ToolActivity::Guardian => (icon, translate("agent-tool-guardian-review")),
+        ToolActivity::ReadFile if tool_args_read_skill(args) => (icon, "Read skill".into()),
         ToolActivity::ReadFile => (icon, translate("agent-tool-read-files")),
         ToolActivity::WriteFile => (icon, translate("agent-edited")),
         ToolActivity::Layout => (icon, translate("schema-layout")),
+        ToolActivity::Worktree if name.ends_with("select_project") => {
+            (icon, "Select project".into())
+        }
         ToolActivity::Worktree => (icon, translate("layout-worktree")),
         ToolActivity::Image => (icon, translate("agent-tool-viewed-image")),
         ToolActivity::Screenshot => (icon, translate("agent-tool-viewed-image")),

--- a/crates/vmux_agent/src/chat_page/turns.rs
+++ b/crates/vmux_agent/src/chat_page/turns.rs
@@ -493,11 +493,11 @@ mod tests {
     fn private_continuation_starts_hidden_turn() {
         let private = vmux_service::protocol::compose_agent_prompt(
             "",
-            Some("Workspace selected. Continue the original request."),
+            Some("Project selected. Continue the original request."),
         );
         let messages = vec![
             Message::user("fix it"),
-            assistant(vec![AssistantBlock::Text("Choose a workspace.".into())]),
+            assistant(vec![AssistantBlock::Text("Choose a project.".into())]),
             Message::user(private),
             assistant(vec![AssistantBlock::Text("Which branch?".into())]),
         ];
@@ -509,7 +509,7 @@ mod tests {
         assert!(matches!(
             &items[1],
             ChatItem::Turn(turn)
-                if matches!(&turn.blocks[0], ChatBlock::Text(text) if text == "Choose a workspace.")
+                if matches!(&turn.blocks[0], ChatBlock::Text(text) if text == "Choose a project.")
         ));
         assert!(matches!(
             &items[2],
@@ -522,7 +522,7 @@ mod tests {
     fn private_context_is_collapsed_separately_from_display_prompt() {
         let private = vmux_service::protocol::compose_agent_prompt(
             "show me something fun",
-            Some("workspace policy"),
+            Some("project policy"),
         );
         let messages = vec![Message::user(format!("show me something fun{private}"))];
 
@@ -532,7 +532,7 @@ mod tests {
             &items[0],
             ChatItem::User { text, context, .. }
                 if text == "show me something fun"
-                    && context.as_deref() == Some("workspace policy")
+                    && context.as_deref() == Some("project policy")
         ));
     }
 

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -20,11 +20,11 @@ use crate::events::AgentApprovalRequest;
 use crate::handoff::{ImportedConversation, PendingHandoff};
 use crate::run_state::AgentRunState;
 
-const CONVERSATION_TITLE_STEER_PROMPT: &str = "Call mcp__vmux__set_conversation_title as the first tool of the turn only when the conversation has no title yet or the latest user message materially changes the conversation's topic. If the current title still accurately summarizes the conversation, do not call the tool. When a title is needed, call it before reading skills, calling any other tool, or answering. Write a concise 3 to 7 word model-generated summary of the whole conversation. Correct spelling and grammar. Never copy the user's prompt verbatim.";
+const CONVERSATION_TITLE_STEER_PROMPT: &str = "On the first user message, always call mcp__vmux__set_conversation_title as the first tool of the turn. The host immediately shows the raw first prompt as a provisional title; replace it with a concise 3 to 7 word summary with corrected spelling and grammar. On later user messages, call the tool only when the conversation topic materially changes; keep the current title for same-topic follow-ups. When needed, call it before reading skills, calling any other tool, or answering. Never copy the user's prompt verbatim. This tool never needs user permission.";
 
-const UNBOUND_WORKSPACE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): This tab has no selected workspace. For development work, first call select_workspace. Pass a path when the conversation identifies a local directory; otherwise vmux opens the native folder picker immediately after approval. Any directory can be a workspace. If it has no .git, vmux asks whether to initialize Git; declining keeps the plain workspace usable. Do not search the user's home directory. General questions and self-contained terminal demonstrations may run in the temporary current directory.";
-const PENDING_WORKTREE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): Workspace activation is pending. Do not access project paths directly or run git worktree add yourself. Wait for vmux to finish preparing the selected workspace before inspecting, editing, testing, or running the project.";
-const REPOSITORY_WORKTREE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): The selected workspace is a Git repository, but this tab is not isolated. Reading and inspection are allowed. Immediately before the first edit, write, test, build, or other mutation, call create_worktree. It reuses a known linked worktree, automatically uses one unambiguous existing worktree, or creates one when none exists. If it reports multiple candidates, ask the user with request_user_choice to choose an existing path or Create new worktree, then call create_worktree again with path or create=true. Never run git worktree add yourself.";
+const UNBOUND_WORKSPACE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): This tab has no selected project. Read-only inspection may use the current directory or a known path immediately. Never call select_project or create_worktree for requests that only read, show, search, or explain existing files. Before the first edit, write, test, build, or other mutation in an existing project, call select_project with its known path or without a path to open the project picker rooted at ~/.vmux/workspace. For a new project, do not ask the user to invent a folder location. First call request_user_choice with two concrete options: create the project at a suggested path under ~/.vmux/workspace, or choose an existing project. Use ~/.vmux/workspace/<remote-host>/<organization>/<repository> when a remote is known and ~/.vmux/workspace/local/<project> otherwise. If the user chooses creation, use run only to create the empty directory, then call select_project with that path. vmux will offer Git initialization and use the new project root directly; never call create_worktree for that new project. Do not search the user's home directory. General questions and self-contained terminal demonstrations may run in the temporary current directory.";
+const PENDING_WORKTREE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): Project activation is pending. Do not access project paths directly or run git worktree add yourself. Wait for vmux to finish preparing the selected project before inspecting, editing, testing, or running it.";
+const REPOSITORY_WORKTREE_CONTEXT: &str = "VMUX HOST POLICY (mandatory): The selected project is a Git repository, but this tab is not isolated. Reading and inspection are allowed without a worktree. Never call create_worktree for requests that only read, show, search, or explain existing files. Immediately before the first edit, write, test, build, or other mutation, call create_worktree. It reuses a known linked worktree, automatically uses one unambiguous existing worktree, or creates one when none exists. If it reports multiple candidates, ask the user with request_user_choice to choose an existing path or Create new worktree, then call create_worktree again with path or create=true. Never run git worktree add yourself.";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum AcpWorkspaceState {
@@ -733,6 +733,11 @@ fn apply_codex_compatibility_env(mut env: Vec<(String, String)>) -> Vec<(String,
         .unwrap()
         .insert("web_search".to_string(), serde_json::Value::Bool(false));
 
+    disable_codex_skills(
+        &mut config,
+        &crate::client::cli::codex::codex_disabled_skill_files(),
+    );
+
     let mcp_servers = config
         .entry("mcp_servers")
         .or_insert_with(|| serde_json::json!({}));
@@ -783,6 +788,49 @@ fn apply_codex_compatibility_env(mut env: Vec<(String, String)>) -> Vec<(String,
         serde_json::Value::Object(config).to_string(),
     ));
     env
+}
+
+fn disable_codex_skills(
+    config: &mut serde_json::Map<String, serde_json::Value>,
+    skill_files: &[std::path::PathBuf],
+) {
+    if skill_files.is_empty() {
+        return;
+    }
+    let skills = config
+        .entry("skills")
+        .or_insert_with(|| serde_json::json!({}));
+    if !skills.is_object() {
+        *skills = serde_json::json!({});
+    }
+    let configured = skills
+        .as_object_mut()
+        .unwrap()
+        .entry("config")
+        .or_insert_with(|| serde_json::json!([]));
+    if !configured.is_array() {
+        *configured = serde_json::json!([]);
+    }
+    let configured = configured.as_array_mut().unwrap();
+    for skill_file in skill_files {
+        let path = skill_file.to_string_lossy();
+        if let Some(existing) = configured.iter_mut().find(|entry| {
+            entry
+                .get("path")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|candidate| candidate == path)
+        }) {
+            existing
+                .as_object_mut()
+                .unwrap()
+                .insert("enabled".to_string(), serde_json::Value::Bool(false));
+        } else {
+            configured.push(serde_json::json!({
+                "path": path,
+                "enabled": false,
+            }));
+        }
+    }
 }
 
 fn parse_codex_config(
@@ -1126,14 +1174,19 @@ mod tests {
     }
 
     #[test]
-    fn unbound_workspace_context_requires_picker_before_project_work() {
+    fn unbound_workspace_context_allows_reading_before_project_setup() {
         let context = acp_prompt_context(None, Some(AcpWorkspaceState::Unbound)).unwrap();
 
-        assert!(context.contains("select_workspace"));
-        assert!(context.contains("Any directory can be a workspace"));
-        assert!(context.contains("initialize Git"));
+        assert!(context.contains("Read-only inspection"));
+        assert!(context.contains("Never call select_project or create_worktree"));
+        assert!(context.contains("select_project"));
+        assert!(context.contains("request_user_choice"));
+        assert!(context.contains("~/.vmux/workspace/<remote-host>"));
+        assert!(context.contains("~/.vmux/workspace/local/<project>"));
+        assert!(context.contains("create the empty directory"));
+        assert!(context.contains("use the new project root directly"));
         assert!(context.contains("Do not search the user's home directory"));
-        assert!(context.contains("folder picker"));
+        assert!(context.contains("project picker"));
     }
 
     #[test]
@@ -1142,6 +1195,7 @@ mod tests {
             acp_prompt_context(None, Some(AcpWorkspaceState::RepositoryNeedsWorktree)).unwrap();
 
         assert!(context.contains("Reading and inspection are allowed"));
+        assert!(context.contains("Never call create_worktree"));
         assert!(context.contains("Immediately before the first edit"));
         assert!(context.contains("create_worktree"));
         assert!(context.contains("request_user_choice"));
@@ -1719,9 +1773,42 @@ mod tests {
             let instructions = config["developer_instructions"].as_str().unwrap();
             assert!(instructions.contains("mcp__vmux__set_conversation_title"));
             assert!(instructions.contains("first tool of the turn"));
-            assert!(instructions.contains("materially changes the conversation's topic"));
-            assert!(instructions.contains("do not call the tool"));
+            assert!(instructions.contains("raw first prompt as a provisional title"));
+            assert!(instructions.contains("topic materially changes"));
+            assert!(instructions.contains("same-topic follow-ups"));
+            assert!(instructions.contains("never needs user permission"));
+            assert!(instructions.contains("mcp__vmux__browser_snapshot"));
+            assert!(instructions.contains("page already visible beside you"));
         }
+    }
+
+    #[test]
+    fn codex_acp_disables_session_skill_files() {
+        let mut config = serde_json::json!({
+            "skills": {
+                "config": [
+                    {"path": "/tmp/knowledge/alpha/SKILL.md", "enabled": true},
+                    {"path": "/tmp/other", "enabled": true}
+                ]
+            }
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        disable_codex_skills(
+            &mut config,
+            &[
+                std::path::PathBuf::from("/tmp/knowledge/alpha/SKILL.md"),
+                std::path::PathBuf::from("/tmp/knowledge/beta/SKILL.md"),
+            ],
+        );
+
+        assert_eq!(config["skills"]["config"][0]["enabled"], false);
+        assert_eq!(config["skills"]["config"][1]["enabled"], true);
+        assert_eq!(
+            config["skills"]["config"][2],
+            serde_json::json!({"path": "/tmp/knowledge/beta/SKILL.md", "enabled": false})
+        );
     }
 
     #[test]

--- a/crates/vmux_agent/src/client/cli/claude.rs
+++ b/crates/vmux_agent/src/client/cli/claude.rs
@@ -13,21 +13,30 @@ use crate::{AgentKind, AgentVariant, AssistantBlock, McpServerConfig, Message};
 const DISALLOWED_TOOLS: &str = "Bash,Monitor,WebSearch,WebFetch";
 const ALLOWED_TOOLS: &str = "mcp__vmux__run,mcp__vmux__read_terminal,\
 mcp__vmux__browser_navigate,mcp__vmux__browser_snapshot,mcp__vmux__browser_scroll,\
-mcp__vmux__request_user_choice,mcp__vmux__select_workspace,mcp__vmux__create_worktree";
+mcp__vmux__request_user_choice,mcp__vmux__set_conversation_title,\
+mcp__vmux__select_project,mcp__vmux__create_worktree";
 const RUN_STEER_PROMPT: &str = "The native Bash, WebSearch, and WebFetch tools are disabled. Run \
 ALL shell commands via the mcp__vmux__run tool (a visible terminal the user can watch and take \
 over). Use the output returned by run directly; call read_terminal only when run says the command \
 is still running. Do ALL web access via the vmux browser tools in the user's visible browser: \
 mcp__vmux__browser_navigate (it returns the page snapshot on load), then mcp__vmux__browser_scroll \
 to read more. Omit the pane argument - it targets your own browser pane. Do not look for a \
-built-in web search. For development work without a selected workspace, first call \
-mcp__vmux__select_workspace. Pass a known local directory or omit it so vmux opens the native folder \
-picker immediately after approval. Any directory can be a workspace; vmux asks whether to initialize \
-Git when .git is absent. Immediately before the first edit, write, \
-test, build, or mutation, call mcp__vmux__create_worktree. If it reports ambiguous existing \
+built-in web search. Read-only inspection may use the current directory or a known path directly; \
+never call mcp__vmux__select_project or mcp__vmux__create_worktree for requests that only read, \
+show, search, or explain existing files. Before the first mutation in an existing project without a selected project, call \
+mcp__vmux__select_project with its known path or omit it to choose under ~/.vmux/workspace. For a \
+new project, first use mcp__vmux__request_user_choice to offer a concrete suggested path and \
+Choose existing project. Use ~/.vmux/workspace/<remote-host>/<organization>/<repository> when a \
+remote is known and ~/.vmux/workspace/local/<project> otherwise. If creation is selected, use run \
+only to create the empty directory, then select that path. vmux will offer Git initialization and \
+use the new project root directly; never call create_worktree for that new project. Do not ask the \
+user to invent a folder location. In a previously existing Git project, immediately before any \
+edit, write, test, build, or other mutation, call mcp__vmux__create_worktree. If it reports ambiguous existing \
 worktrees, ask whether to create or choose an existing path, then call create_worktree with \
 create=true or the selected path. Never \
-run git worktree add yourself.";
+run git worktree add yourself. After project or worktree setup succeeds, continue the original \
+request immediately. Never enumerate tool registries or wait for optional tools. If a skill requires \
+an unavailable tool, continue with the available tools.";
 const FILE_TOUCH_MATCHER: &str = "Read|Edit|Write|MultiEdit";
 
 pub struct ClaudeStrategy;
@@ -448,7 +457,7 @@ mod tests {
         assert!(args[allowed + 1].contains("mcp__vmux__run"));
         assert!(args[allowed + 1].contains("mcp__vmux__read_terminal"));
         assert!(args[allowed + 1].contains("mcp__vmux__request_user_choice"));
-        assert!(args[allowed + 1].contains("mcp__vmux__select_workspace"));
+        assert!(args[allowed + 1].contains("mcp__vmux__select_project"));
         assert!(args[allowed + 1].contains("mcp__vmux__create_worktree"));
 
         let steer = args
@@ -457,7 +466,7 @@ mod tests {
             .unwrap();
         assert!(args[steer + 1].contains("mcp__vmux__run"));
         assert!(args[steer + 1].contains("browser_navigate"));
-        let workspace = args[steer + 1].find("mcp__vmux__select_workspace").unwrap();
+        let workspace = args[steer + 1].find("mcp__vmux__select_project").unwrap();
         let worktree = args[steer + 1].find("mcp__vmux__create_worktree").unwrap();
         assert!(workspace < worktree);
     }

--- a/crates/vmux_agent/src/client/cli/codex.rs
+++ b/crates/vmux_agent/src/client/cli/codex.rs
@@ -15,17 +15,28 @@ commands via the mcp__vmux__run tool (a visible terminal the user can watch and 
 output returned by run directly; call read_terminal only when run says the command is still running. To READ \
 a file, use the mcp__vmux__read_file tool (it shows the file in a pane beside you and returns its \
 text) - do NOT cat/sed/head/tail a file via run. To SEARCH code, use the mcp__vmux__grep tool (it \
-opens each matching file in a pane and returns the matches) - do NOT run rg/grep/ag via run. Do ALL web access via the vmux browser tools in the \
-user's visible browser: mcp__vmux__browser_navigate (it returns the page snapshot on load), then \
-mcp__vmux__browser_scroll to read more. Omit the pane argument - it targets your own browser pane. \
-Do not look for a built-in web search. For development work without a selected workspace, first \
-call mcp__vmux__select_workspace. Pass a known local directory or omit it so vmux opens the native \
-folder picker immediately after approval. Any directory can be a workspace; vmux asks whether to \
-initialize Git when .git is absent. Immediately before the first edit, \
-write, test, build, or mutation, call mcp__vmux__create_worktree. If it reports ambiguous existing \
+opens each matching file in a pane and returns the matches) - do NOT run rg/grep/ag via run. OpenAI's bundled browser skill is disabled inside vmux. \
+Never use browser:control-in-app-browser, a Node REPL, agent.browsers, or connector discovery. Do ALL web access via the vmux browser tools in the \
+user's visible browser. If the user refers to a page already visible beside you, first call mcp__vmux__browser_snapshot without a pane argument. \
+For a new URL, call mcp__vmux__browser_navigate, then mcp__vmux__browser_scroll to read more. Omitting the pane targets the visible browser pane associated with you. \
+Do not look for a built-in web search. Read-only inspection may use the current directory or a known \
+path directly; never call mcp__vmux__select_project or mcp__vmux__create_worktree for requests \
+that only read, show, search, or explain existing files. Before the first mutation in an existing \
+project without a selected project, call mcp__vmux__select_project, passing its known path or omitting it to \
+choose under ~/.vmux/workspace. For a new project, first use mcp__vmux__request_user_choice to offer \
+a concrete suggested path and Choose existing project. Use \
+~/.vmux/workspace/<remote-host>/<organization>/<repository> when a remote is known and \
+~/.vmux/workspace/local/<project> otherwise. If creation is selected, use run to create the \
+empty directory, then select that path. vmux will offer Git initialization and use the new project \
+root directly; never call create_worktree for that new project. Do not ask the user to invent a \
+folder location. In a previously existing Git project, immediately before any edit, write, test, \
+build, or other mutation, call mcp__vmux__create_worktree. If it reports ambiguous existing \
 worktrees, ask whether to create or choose an existing path, then call mcp__vmux__create_worktree with \
 create=true or the selected path. Never \
-run git worktree add yourself.";
+run git worktree add yourself. After project or worktree setup succeeds, continue the original \
+request immediately. Never enumerate tool registries or wait for optional tools. If a skill requires \
+an unavailable tool, continue with the available tools; for website visuals, use code-native design \
+or available project assets.";
 const FILE_TOUCH_MATCHER: &str = "apply_patch|Edit|Write";
 
 pub struct CodexStrategy;
@@ -72,6 +83,10 @@ impl CliAgentStrategy for CodexStrategy {
         ));
         args.push("-c".into());
         args.push("tools.web_search=false".to_string());
+        if let Some(skills) = build_skills_config_override(&codex_disabled_skill_files()) {
+            args.push("-c".into());
+            args.push(skills);
+        }
         args.push("-c".into());
         args.push(format!(
             "developer_instructions={}",
@@ -137,6 +152,63 @@ pub(crate) fn quote_toml(s: &str) -> String {
 pub(crate) fn toml_array(items: &[String]) -> String {
     let inner: Vec<String> = items.iter().map(|s| quote_toml(s)).collect();
     format!("[{}]", inner.join(","))
+}
+
+fn build_skills_config_override(skill_files: &[PathBuf]) -> Option<String> {
+    if skill_files.is_empty() {
+        return None;
+    }
+    let entries = skill_files
+        .iter()
+        .map(|path| {
+            format!(
+                "{{path={},enabled=false}}",
+                quote_toml(&path.to_string_lossy())
+            )
+        })
+        .collect::<Vec<_>>();
+    Some(format!("skills.config=[{}]", entries.join(",")))
+}
+
+pub(crate) fn codex_disabled_skill_files() -> Vec<PathBuf> {
+    let mut files = vmux_core::knowledge::configured_skill_files();
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/"));
+    let codex_home = std::env::var_os("CODEX_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.join(".codex"));
+    collect_skill_files(
+        &codex_home.join("plugins/cache/openai-bundled/browser"),
+        &mut files,
+    );
+    files.sort();
+    files.dedup();
+    files
+}
+
+fn collect_skill_files(root: &Path, files: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            collect_skill_files(&path, files);
+        } else if file_type.is_file()
+            && path
+                .file_name()
+                .is_some_and(|name| name.eq_ignore_ascii_case("SKILL.md"))
+        {
+            files.push(path);
+        }
+    }
 }
 
 /// `-c` override registering a PostToolUse hook that pings vmux on file edits.
@@ -529,6 +601,34 @@ mod tests {
     }
 
     #[test]
+    fn skill_config_override_disables_embedded_vmux_skills() {
+        let override_value = build_skills_config_override(&[
+            PathBuf::from("/tmp/knowledge/alpha/SKILL.md"),
+            PathBuf::from("/tmp/knowledge/beta/SKILL.md"),
+        ])
+        .unwrap();
+        assert_eq!(
+            override_value,
+            "skills.config=[{path=\"/tmp/knowledge/alpha/SKILL.md\",enabled=false},{path=\"/tmp/knowledge/beta/SKILL.md\",enabled=false}]"
+        );
+    }
+
+    #[test]
+    fn bundled_browser_skill_discovery_finds_versioned_skill_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let skill = temp
+            .path()
+            .join("26.1/skills/control-in-app-browser/SKILL.md");
+        std::fs::create_dir_all(skill.parent().unwrap()).unwrap();
+        std::fs::write(&skill, "browser").unwrap();
+        std::fs::write(temp.path().join("ignored.md"), "ignored").unwrap();
+
+        let mut files = Vec::new();
+        collect_skill_files(temp.path(), &mut files);
+        assert_eq!(files, vec![skill]);
+    }
+
+    #[test]
     fn build_args_steers_web_access_to_vmux_browser() {
         let mcp = McpServerConfig {
             command: "/bin/vmux".into(),
@@ -542,6 +642,9 @@ mod tests {
             .expect("developer_instructions override present");
         assert!(steer.contains("mcp__vmux__run"));
         assert!(steer.contains("browser_navigate"));
+        assert!(steer.contains("browser_snapshot"));
+        assert!(steer.contains("page already visible beside you"));
+        assert!(steer.contains("Never use browser:control-in-app-browser"));
     }
 
     #[test]

--- a/crates/vmux_agent/src/components.rs
+++ b/crates/vmux_agent/src/components.rs
@@ -23,6 +23,21 @@ pub struct AgentMessages(pub Vec<Message>);
 #[derive(Component, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AgentConversationTitle(pub String);
 
+pub(crate) fn provisional_conversation_title(text: &str) -> Option<String> {
+    let normalized = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalized.is_empty() {
+        return None;
+    }
+    if normalized.chars().count() <= 120 {
+        return Some(normalized);
+    }
+    let mut title = normalized.chars().take(119).collect::<String>();
+    let trimmed_len = title.trim_end().len();
+    title.truncate(trimmed_len);
+    title.push('…');
+    Some(title)
+}
+
 #[derive(Component, Clone, Debug, Default, Serialize, Deserialize, Reflect)]
 #[reflect(Component)]
 pub struct AgentApprovalPolicy {

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -53,9 +53,9 @@ pub use vmux_space::cwd::valid_cwd;
 
 const BUILTIN_AGENT_PROVIDERS: &[AgentKind] =
     &[AgentKind::Vibe, AgentKind::Claude, AgentKind::Codex];
-const WORKSPACE_SELECTION_REQUESTED: &str = "Workspace selection requested. Stop this turn and wait. vmux will resume this same conversation after the user chooses or cancels.";
+const WORKSPACE_SELECTION_REQUESTED: &str = "Project selection requested. Stop this turn and wait. vmux will resume this same conversation after the user chooses or cancels.";
 const USER_CHOICE_REQUESTED: &str = "User choice requested. Stop this turn and wait. vmux will resume this same conversation with the selected option.";
-const WORKSPACE_SELECTION_PENDING: &str = "Workspace selection is already pending. Stop this turn and wait. vmux will resume this same conversation after the user chooses or cancels.";
+const WORKSPACE_SELECTION_PENDING: &str = "Project selection is already pending. Stop this turn and wait. vmux will resume this same conversation after the user chooses or cancels.";
 const INITIALIZE_GIT_QUESTION: &str = "Initialize Git repository?";
 const INITIALIZE_GIT_OPTIONS: [&str; 2] = ["Initialize Git", "Not now"];
 
@@ -1892,7 +1892,7 @@ fn handle_agent_commands(
                             AgentCommandResult::Ok
                         } else {
                             AgentCommandResult::Error(
-                                "workspace directory is required to run a command".to_string(),
+                                "project directory is required to run a command".to_string(),
                             )
                         }
                     }
@@ -2119,6 +2119,7 @@ fn handle_agent_commands(
             | ServiceAgentCommand::PrepareWorktree { .. }
             | ServiceAgentCommand::RequestUserChoice { .. }
             | ServiceAgentCommand::SetConversationTitle { .. }
+            | ServiceAgentCommand::WriteKnowledge { .. }
             | ServiceAgentCommand::CreateWorktreeOnBranch { .. }
             | ServiceAgentCommand::ResumeInAcp { .. } => {
                 continue;
@@ -2223,6 +2224,7 @@ fn self_command_anchor(command: &ServiceAgentCommand) -> Option<ProcessId> {
         | ServiceAgentCommand::PrepareWorktree { anchor, .. }
         | ServiceAgentCommand::RequestUserChoice { anchor, .. }
         | ServiceAgentCommand::SetConversationTitle { anchor, .. }
+        | ServiceAgentCommand::WriteKnowledge { anchor, .. }
         | ServiceAgentCommand::CreateWorktreeOnBranch { anchor, .. } => Some(*anchor),
         _ => None,
     }
@@ -2237,6 +2239,7 @@ fn self_command_priority(command: &ServiceAgentCommand) -> u8 {
             | ServiceAgentCommand::PrepareWorktree { .. }
             | ServiceAgentCommand::RequestUserChoice { .. }
             | ServiceAgentCommand::SetConversationTitle { .. }
+            | ServiceAgentCommand::WriteKnowledge { .. }
             | ServiceAgentCommand::CreateWorktreeOnBranch { .. }
     ) {
         0
@@ -2257,6 +2260,7 @@ fn self_command_blocked_by_worktree_failure(
             | ServiceAgentCommand::PrepareWorktree { .. }
             | ServiceAgentCommand::RequestUserChoice { .. }
             | ServiceAgentCommand::SetConversationTitle { .. }
+            | ServiceAgentCommand::WriteKnowledge { .. }
             | ServiceAgentCommand::CreateWorktreeOnBranch { .. }
     ) && self_command_anchor(command).is_some_and(|anchor| failed.contains(&anchor))
 }
@@ -2671,7 +2675,7 @@ fn run_terminal_cwd(
     if let Some(Ok(Some(path))) = agent_launch_cwd.map(valid_cwd) {
         return Ok(path);
     }
-    Err("tab and agent workspace directories are missing".to_string())
+    Err("tab and agent project directories are missing".to_string())
 }
 
 #[cfg(test)]
@@ -2765,13 +2769,10 @@ fn handle_agent_choice_selected(
             workspace,
         } => {
             if !tabs.contains(*tab_entity) {
-                failed_workspace_continuation("The workspace tab no longer exists")
+                failed_workspace_continuation("The project tab no longer exists")
             } else if event.index == 0 {
                 match vmux_git::worktree::repository_init(workspace) {
-                    Ok(root) => {
-                        commands.entity(*tab_entity).insert(RepositoryNeedsWorktree);
-                        git_workspace_ready_continuation(&root)
-                    }
+                    Ok(root) => new_git_workspace_ready_continuation(&root),
                     Err(error) => git_initialization_failed_continuation(workspace, &error.0),
                 }
             } else {
@@ -2792,15 +2793,18 @@ fn workspace_picker_task(
     proxy: Option<&bevy::winit::EventLoopProxyWrapper>,
 ) -> Task<Option<PathBuf>> {
     let wake = proxy.map(|proxy| (**proxy).clone());
-    let initial_dir = std::env::current_dir()
+    let workspace_dir = vmux_core::profile::workspace_dir();
+    let initial_dir = std::fs::create_dir_all(&workspace_dir)
         .ok()
+        .map(|_| workspace_dir)
         .filter(|path| path.is_dir())
+        .or_else(|| std::env::current_dir().ok().filter(|path| path.is_dir()))
         .or_else(|| std::env::var_os("HOME").map(PathBuf::from))
         .filter(|path| path.is_dir())
         .unwrap_or_else(|| PathBuf::from("/"));
     IoTaskPool::get().spawn(async move {
         let selected = rfd::AsyncFileDialog::new()
-            .set_title("Create or select workspace")
+            .set_title("Choose existing project")
             .set_directory(initial_dir)
             .pick_folder()
             .await
@@ -2837,28 +2841,35 @@ fn bind_tab_workspace(tab: &mut vmux_layout::tab::Tab, project_dir: &Path, execu
 
 fn git_workspace_ready_continuation(path: &Path) -> String {
     format!(
-        "VMUX WORKSPACE SELECTION COMPLETED: Git workspace {} is ready for reading and inspection. Continue the original user request in this same conversation. Immediately before the first edit, write, test, build, or other mutation, call create_worktree; if it reports multiple candidates, ask the user whether to create or choose an existing worktree.",
+        "VMUX PROJECT SELECTION COMPLETED: Git project {} is ready for reading and inspection. Continue the original user request in this same conversation. Immediately before the first edit, write, test, build, or other mutation, call create_worktree; if it reports multiple candidates, ask the user whether to create or choose an existing worktree.",
+        path.display()
+    )
+}
+
+fn new_git_workspace_ready_continuation(path: &Path) -> String {
+    format!(
+        "VMUX NEW PROJECT READY: Git project {} is the dedicated project root. Continue the original user request immediately in this directory. Do not call create_worktree for this project.",
         path.display()
     )
 }
 
 fn plain_workspace_ready_continuation(path: &Path) -> String {
     format!(
-        "VMUX WORKSPACE SELECTION COMPLETED: Workspace {} is ready without Git. Continue the original user request in this same conversation. Do not call create_worktree unless Git is initialized later.",
+        "VMUX PROJECT SELECTION COMPLETED: Project {} is ready without Git. Continue the original user request in this same conversation. Do not call create_worktree unless Git is initialized later.",
         path.display()
     )
 }
 
 fn git_initialization_failed_continuation(path: &Path, error: &str) -> String {
     format!(
-        "VMUX GIT INITIALIZATION FAILED: {error}. Workspace {} remains selected and usable without Git. Continue the original user request in this same conversation. Do not call create_worktree.",
+        "VMUX GIT INITIALIZATION FAILED: {error}. Project {} remains selected and usable without Git. Continue the original user request in this same conversation. Do not call create_worktree.",
         path.display()
     )
 }
 
 fn failed_workspace_continuation(message: &str) -> String {
     format!(
-        "VMUX WORKSPACE SELECTION DID NOT COMPLETE: {message}. Do not retry automatically. Wait for the user to request workspace selection again."
+        "VMUX PROJECT SELECTION DID NOT COMPLETE: {message}. Do not retry automatically. Wait for the user to request project selection again."
     )
 }
 
@@ -2961,7 +2972,7 @@ fn activate_selected_workspace(
 ) -> Result<(PathBuf, Option<ClientMessage>, SelectedWorkspaceKind), String> {
     let kind = if selected.join(".git").exists() {
         vmux_git::worktree::checkout_info(selected)
-            .map_err(|error| format!("selected workspace has invalid Git metadata: {}", error.0))?;
+            .map_err(|error| format!("selected project has invalid Git metadata: {}", error.0))?;
         SelectedWorkspaceKind::Git {
             needs_worktree: !vmux_git::worktree::is_linked_worktree(selected),
         }
@@ -3499,6 +3510,29 @@ fn handle_agent_self_commands(
                     }
                 }
             }
+            ServiceAgentCommand::WriteKnowledge {
+                anchor,
+                path,
+                title,
+                content,
+            } => match resolve_self_pane(*anchor, &agent_terms, &ctx.child_of_q) {
+                None => AgentCommandResult::Error("agent pane not found".to_string()),
+                Some((_, pane)) => {
+                    match vmux_core::knowledge::write_note(path.as_deref(), title, content) {
+                        Ok(path) => {
+                            writers.open_beside.write(vmux_layout::OpenBesideRequest {
+                                pane,
+                                direction: None,
+                                url: file_touch_url(&path.to_string_lossy(), None, None, None),
+                                request_id: request.request_id.0,
+                                focus: false,
+                            });
+                            AgentCommandResult::Text(format!("Knowledge saved: {}", path.display()))
+                        }
+                        Err(error) => AgentCommandResult::Error(error),
+                    }
+                }
+            },
             ServiceAgentCommand::ChooseWorkspace { anchor }
             | ServiceAgentCommand::ChooseWorkspaceAtPath { anchor, .. } => {
                 match resolve_self_pane(*anchor, &agent_terms, &ctx.child_of_q) {
@@ -3604,7 +3638,7 @@ fn handle_agent_self_commands(
                             service.0.send(ClientMessage::AgentCommandResponse {
                                 request_id: request.request_id,
                                 result: AgentCommandResult::Error(
-                                    "No Git workspace selected. Complete select_workspace and initialize Git first."
+                                    "No Git project selected. Complete select_project and initialize Git first."
                                         .to_string(),
                                 ),
                             });
@@ -3650,7 +3684,7 @@ fn handle_agent_self_commands(
                                             service.0.send(message);
                                         }
                                         AgentCommandResult::Text(format!(
-                                            "Worktree ready: {}\nContinue the user's request in this directory.",
+                                            "Worktree ready: {}\nContinue the original request immediately in this directory. Do not stop after setup or search for optional tools.",
                                             candidate.execution_dir.display()
                                         ))
                                     }
@@ -3698,7 +3732,7 @@ fn handle_agent_self_commands(
                                                         .unwrap_or_default(),
                                                 );
                                                 AgentCommandResult::Text(format!(
-                                                    "Worktree ready: {}\nContinue the user's request in this directory.",
+                                                    "Worktree ready: {}\nContinue the original request immediately in this directory. Do not stop after setup or search for optional tools.",
                                                     execution_dir.display()
                                                 ))
                                             }
@@ -3742,7 +3776,7 @@ fn handle_agent_self_commands(
                                         path.to_string_lossy().into_owned(),
                                     ),
                                     Ok(None) => AgentCommandResult::Error(
-                                        "tab workspace directory is missing".to_string(),
+                                        "tab project directory is missing".to_string(),
                                     ),
                                     Err(message) => AgentCommandResult::Error(message),
                                 }
@@ -3781,7 +3815,7 @@ fn handle_agent_self_commands(
                                             .or_else(|| workspace_dir.clone())
                                         else {
                                             break 'create_worktree AgentCommandResult::Error(
-                                                "tab workspace directory is missing".to_string(),
+                                                "tab project directory is missing".to_string(),
                                             );
                                         };
                                         if vmux_git::worktree::is_linked_worktree(&current_dir) {
@@ -3901,7 +3935,7 @@ fn handle_agent_self_commands(
                                 service.0.send(ClientMessage::AgentCommandResponse {
                                     request_id: request.request_id,
                                     result: AgentCommandResult::Error(
-                                        "No workspace selected. Call select_workspace first."
+                                        "No project selected. Call select_project first."
                                             .to_string(),
                                     ),
                                 });
@@ -3930,7 +3964,7 @@ fn handle_agent_self_commands(
                                             .insert(tab_entity, branch.clone());
                                         let path = execution_dir.to_string_lossy().into_owned();
                                         AgentCommandResult::Text(format!(
-                                            "Worktree ready: {path}\nContinue the user's request in this directory."
+                                            "Worktree ready: {path}\nContinue the original request immediately in this directory. Do not stop after setup or search for optional tools."
                                         ))
                                     }
                                     Err(error) => AgentCommandResult::Error(error),
@@ -3983,13 +4017,13 @@ fn drain_workspace_picker_tasks(
         };
         let continuation = match selected {
             None => Some(failed_workspace_continuation(
-                "The user cancelled workspace selection",
+                "The user cancelled project selection",
             )),
             Some(selected) => match selected.canonicalize() {
                 Ok(selected) if selected.is_dir() => {
                     if tabs.get(picker.tab_entity).is_err() {
                         Some(failed_workspace_continuation(
-                            "The workspace tab no longer exists",
+                            "The project tab no longer exists",
                         ))
                     } else {
                         match activate_selected_workspace(
@@ -4030,22 +4064,22 @@ fn drain_workspace_picker_tasks(
                                         None
                                     }
                                     SelectedWorkspaceKind::Plain => Some(format!(
-                                        "VMUX WORKSPACE SELECTION COMPLETED: Workspace {} is ready without Git. Ask the user: \"Initialize Git repository?\" If yes, initialize Git in this exact workspace, then call create_worktree before mutation. If no, continue the original request without a worktree.",
+                                        "VMUX PROJECT SELECTION COMPLETED: Project {} is ready without Git. Ask the user: \"Initialize Git repository?\" If yes, initialize Git in this exact project and continue directly in the project root without calling create_worktree. If no, continue the original request without a worktree.",
                                         execution_dir.display()
                                     )),
                                 }
                             }
                             Err(error) => Some(failed_workspace_continuation(&format!(
-                                "The selected workspace could not be prepared: {error}"
+                                "The selected project could not be prepared: {error}"
                             ))),
                         }
                     }
                 }
                 Ok(_) => Some(failed_workspace_continuation(
-                    "The selected workspace is not a directory",
+                    "The selected project is not a directory",
                 )),
                 Err(error) => Some(failed_workspace_continuation(&format!(
-                    "The selected workspace directory is invalid: {error}"
+                    "The selected project directory is invalid: {error}"
                 ))),
             },
         };
@@ -5210,6 +5244,11 @@ fn insert_initial_prompt_queue(
     if prompt.trim().is_empty() && initial_attachments.is_empty() {
         return;
     }
+    if let Some(title) = crate::components::provisional_conversation_title(&prompt) {
+        commands
+            .entity(stack)
+            .insert(crate::components::AgentConversationTitle(title));
+    }
     let mut queue = crate::components::PromptQueue::default();
     queue.enqueue_with_attachments(prompt, initial_attachments);
     commands
@@ -5756,13 +5795,13 @@ mod tests {
     fn workspace_selection_continuations_resume_original_request() {
         let ready = git_workspace_ready_continuation(Path::new("/repo/dashboard"));
         let plain = plain_workspace_ready_continuation(Path::new("/tmp/demo"));
-        let cancelled = failed_workspace_continuation("The user cancelled workspace selection");
+        let cancelled = failed_workspace_continuation("The user cancelled project selection");
 
         assert!(ready.contains("same conversation"));
-        assert!(ready.contains("Git workspace /repo/dashboard is ready"));
+        assert!(ready.contains("Git project /repo/dashboard is ready"));
         assert!(ready.contains("Immediately before the first edit"));
         assert!(ready.contains("create_worktree"));
-        assert!(plain.contains("Workspace /tmp/demo is ready without Git"));
+        assert!(plain.contains("Project /tmp/demo is ready without Git"));
         assert!(plain.contains("Do not call create_worktree"));
         assert!(cancelled.contains("Do not retry automatically"));
     }
@@ -5795,7 +5834,7 @@ mod tests {
     }
 
     #[test]
-    fn initialize_git_choice_marks_workspace_for_worktree_creation() {
+    fn initialize_git_choice_uses_new_project_root_directly() {
         let workspace = tempfile::tempdir().unwrap();
         let workspace_path = workspace.path().canonicalize().unwrap();
         let mut app = App::new();
@@ -5804,7 +5843,7 @@ mod tests {
         let tab = app
             .world_mut()
             .spawn(vmux_layout::tab::Tab {
-                name: "Workspace".into(),
+                name: "Project".into(),
                 startup_dir: Some(workspace_path.to_string_lossy().into_owned()),
             })
             .id();
@@ -5829,13 +5868,13 @@ mod tests {
         app.update();
 
         assert!(workspace_path.join(".git").is_dir());
-        assert!(app.world().get::<RepositoryNeedsWorktree>(tab).is_some());
+        assert!(app.world().get::<RepositoryNeedsWorktree>(tab).is_none());
         assert!(
             app.world()
                 .get::<PendingAgentContinuation>(session)
                 .unwrap()
                 .0
-                .contains("call create_worktree")
+                .contains("Do not call create_worktree")
         );
     }
 
@@ -8700,6 +8739,11 @@ mod tests {
         assert_eq!(
             queue.items.front().map(|item| item.text.as_str()),
             Some("ship it")
+        );
+        assert_eq!(
+            app.world()
+                .get::<crate::components::AgentConversationTitle>(stack),
+            Some(&crate::components::AgentConversationTitle("ship it".into()))
         );
         assert!(app.world().get::<PendingAgentPrompt>(stack).is_none());
     }

--- a/crates/vmux_browser/src/extensions/shim.js
+++ b/crates/vmux_browser/src/extensions/shim.js
@@ -357,8 +357,51 @@
     patchWindowEvent("onBoundsChanged");
   }
 
+  function defaultPopupPath() {
+    if (!c.runtime || typeof c.runtime.getManifest !== "function") return "";
+    var manifest = c.runtime.getManifest() || {};
+    var action = manifest.action || manifest.browser_action || {};
+    return typeof action.default_popup === "string" ? action.default_popup : "";
+  }
+  function replaceActionMethod(action, name, method) {
+    try {
+      Object.defineProperty(action, name, {
+        value: method,
+        configurable: true,
+      });
+      return;
+    } catch (_error) {}
+    try { action[name] = method; } catch (_ignored) {}
+  }
+  var patchedActions = [];
+  function patchActionPopup(action) {
+    if (!action || patchedActions.indexOf(action) >= 0) return;
+    patchedActions.push(action);
+    var popup = defaultPopupPath();
+    var nativeSetPopup = typeof action.setPopup === "function" ? action.setPopup.bind(action) : null;
+    if (nativeSetPopup) {
+      replaceActionMethod(action, "setPopup", function (details, cb) {
+        if (details && typeof details.popup === "string") popup = details.popup;
+        return nativeSetPopup(details || {}, cb);
+      });
+    }
+    var openPopup = function (options, cb) {
+      if (typeof options === "function") { cb = options; options = undefined; }
+      if (!popup) return callbackResult(Promise.resolve(undefined), cb, false);
+      var url = c.runtime.getURL(popup);
+      var promise = windowRequest("create", [{ url: url, type: "popup", focused: true }], function () {
+        return fallbackCreate({ url: url });
+      });
+      return callbackResult(promise, cb, false);
+    };
+    replaceActionMethod(action, "openPopup", openPopup);
+  }
+  patchActionPopup(c.action);
+  patchActionPopup(c.browserAction);
+
   if (globalThis.window === globalThis && typeof globalThis.close === "function") {
     var nativeWindowClose = globalThis.close.bind(globalThis);
+    var firstExtensionWindowId = 1000000000;
     globalThis.close = function () {
       if (!bridgeRuntime || typeof bridgeRuntime.request !== "function") {
         nativeWindowClose();
@@ -370,6 +413,7 @@
             nativeWindowClose();
             return;
           }
+          if (win.id < firstExtensionWindowId) return;
           bridgeRuntime.request("windows", "remove", [win.id]).catch(nativeWindowClose);
         },
         nativeWindowClose,

--- a/crates/vmux_browser/src/extensions/windows.rs
+++ b/crates/vmux_browser/src/extensions/windows.rs
@@ -14,6 +14,7 @@ use super::model::{ChromeModel, ChromeModelEvent, ChromeStableIds, ChromeTab, Ch
 pub const WINDOW_ID_NONE: i32 = -1;
 pub const WINDOW_ID_CURRENT: i32 = -2;
 const FIRST_EXTENSION_WINDOW_ID: i32 = 1_000_000_000;
+const FALLBACK_HOST_WINDOW_ID: i32 = 1;
 
 #[derive(Clone, Debug)]
 struct ExtensionWindow {
@@ -250,7 +251,7 @@ fn get_last_focused(
         .filter(|id| window_exists(*id, model, windows))
         .or_else(|| focused_host_window(model))
         .or_else(|| model.windows.first().map(|window| window.id))
-        .ok_or_else(|| ChromeError::new("window_not_found", "focused window is unavailable"))?;
+        .unwrap_or(FALLBACK_HOST_WINDOW_ID);
     let result = window_by_id(
         id,
         argument(request, 0),
@@ -582,6 +583,7 @@ fn current_window_id(
         .map(|window| window.window.id)
         .or_else(|| focused_host_window(model))
         .or_else(|| model.windows.first().map(|window| window.id))
+        .or(Some(FALLBACK_HOST_WINDOW_ID))
 }
 
 fn focused_host_window(model: &ChromeModel) -> Option<i32> {
@@ -610,9 +612,9 @@ fn resolve_native_window_alias(
             "extension window is unavailable",
         ));
     }
-    focused_host_window(model)
+    Ok(focused_host_window(model)
         .or_else(|| model.windows.first().map(|window| window.id))
-        .ok_or_else(|| ChromeError::new("window_not_found", "window is unavailable"))
+        .unwrap_or(id))
 }
 
 fn window_by_id(
@@ -639,11 +641,13 @@ fn window_by_id(
             authorization,
         ));
     }
-    let window = model
-        .windows
-        .iter()
-        .find(|window| window.id == id)
-        .ok_or_else(|| ChromeError::new("window_not_found", "window is unavailable"))?;
+    let fallback;
+    let window = if let Some(window) = model.windows.iter().find(|window| window.id == id) {
+        window
+    } else {
+        fallback = fallback_host_window(id);
+        &fallback
+    };
     if !type_matches(window, options) {
         return Err(ChromeError::new(
             "window_not_found",
@@ -662,6 +666,21 @@ fn window_by_id(
         request,
         authorization,
     ))
+}
+
+fn fallback_host_window(id: i32) -> ChromeWindow {
+    ChromeWindow {
+        id,
+        focused: true,
+        left: 0,
+        top: 0,
+        width: 1920,
+        height: 1080,
+        incognito: false,
+        window_type: "normal".into(),
+        state: "normal".into(),
+        always_on_top: false,
+    }
 }
 
 fn window_value(
@@ -1152,6 +1171,39 @@ mod tests {
         assert_eq!(result.result["id"], 1);
         assert_eq!(result.result["left"], 10);
         assert_eq!(result.result["tabs"][0]["id"], 7);
+    }
+
+    #[test]
+    fn window_queries_return_fallback_geometry_before_host_projection() {
+        let model = ChromeModel {
+            windows: Vec::new(),
+            tabs: Vec::new(),
+        };
+        let mut windows = ExtensionWindows::default();
+
+        let by_id = dispatch(
+            &request("get", json!([1_798_152_106, { "populate": true }])),
+            &model,
+            &mut windows,
+            &BridgeAuthorization::default(),
+        )
+        .unwrap();
+        let current = dispatch(
+            &request("getCurrent", json!([{ "populate": true }])),
+            &model,
+            &mut windows,
+            &BridgeAuthorization::default(),
+        )
+        .unwrap();
+
+        assert_eq!(by_id.result["id"], 1_798_152_106);
+        assert_eq!(by_id.result["left"], 0);
+        assert_eq!(by_id.result["top"], 0);
+        assert_eq!(by_id.result["width"], 1920);
+        assert_eq!(by_id.result["height"], 1080);
+        assert_eq!(by_id.result["tabs"], json!([]));
+        assert_eq!(current.result["id"], FALLBACK_HOST_WINDOW_ID);
+        assert_eq!(current.result["width"], 1920);
     }
 
     #[test]

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -143,10 +143,7 @@ impl Plugin for BrowserPlugin {
                 .collect(),
         );
         webview_debug_log(format!("BrowserPlugin embedded_hosts={embedded_hosts:?}"));
-        let cef_command_line = CommandLineConfig {
-            switches: vmux_core::profile::cef_keychain_switches().to_vec(),
-            switch_values: Vec::new(),
-        };
+        let cef_command_line = cef_command_line_config();
         configure_cef_backend_sync(app)
             .insert_resource(crate::extensions::load::PreparedExtensions(
                 prepared_extensions,
@@ -357,6 +354,13 @@ impl Plugin for BrowserPlugin {
                     .after(sync_windowed_frames)
                     .after(sync_windowed_command_bar),
             );
+    }
+}
+
+fn cef_command_line_config() -> CommandLineConfig {
+    CommandLineConfig {
+        switches: vmux_core::profile::cef_keychain_switches().to_vec(),
+        switch_values: vec![("disable-features", "BackForwardCache")],
     }
 }
 
@@ -5058,6 +5062,15 @@ fn cef_root_cache_path() -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cef_disables_bfcache_for_extension_ports() {
+        assert!(
+            cef_command_line_config()
+                .switch_values
+                .contains(&("disable-features", "BackForwardCache"))
+        );
+    }
 
     #[test]
     fn knowledge_paths_only_open_vault_markdown_and_directories() {

--- a/crates/vmux_core/src/event.rs
+++ b/crates/vmux_core/src/event.rs
@@ -666,6 +666,7 @@ pub enum LspServerState {
 pub struct FileLspStatusEvent {
     pub path: String,
     pub server: String,
+    pub package: Option<String>,
     pub state: LspServerState,
 }
 
@@ -1412,12 +1413,14 @@ mod file_event_tests {
         let ev = FileLspStatusEvent {
             path: "/x.rs".into(),
             server: "rust-analyzer".into(),
+            package: Some("rust-analyzer".into()),
             state: LspServerState::Ready,
         };
         let b = rkyv::to_bytes::<rkyv::rancor::Error>(&ev).unwrap();
         let d = rkyv::from_bytes::<FileLspStatusEvent, rkyv::rancor::Error>(&b).unwrap();
         assert_eq!(d.path, "/x.rs");
         assert_eq!(d.server, "rust-analyzer");
+        assert_eq!(d.package.as_deref(), Some("rust-analyzer"));
         assert_eq!(d.state, LspServerState::Ready);
     }
 

--- a/crates/vmux_core/src/knowledge.rs
+++ b/crates/vmux_core/src/knowledge.rs
@@ -93,7 +93,7 @@ pub fn markdown_metadata(text: &str) -> MarkdownMetadata {
 #[cfg(not(target_arch = "wasm32"))]
 use std::io::{self, Write};
 #[cfg(not(target_arch = "wasm32"))]
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 #[cfg(not(target_arch = "wasm32"))]
 mod agent_config;
@@ -105,9 +105,13 @@ const MAX_SKILLS: usize = 64;
 #[cfg(not(target_arch = "wasm32"))]
 const MAX_EMBEDDED_BYTES: usize = 24 * 1024;
 #[cfg(not(target_arch = "wasm32"))]
-const SKILLS_PROMPT_MARKER: &str = "vmux Knowledge skills are user-owned instructions";
+const SKILLS_PROMPT_MARKER: &str = "vmux Knowledge skill instructions are already loaded";
 #[cfg(not(target_arch = "wasm32"))]
 const MEMORIES_PROMPT_MARKER: &str = "vmux Knowledge memories are user-owned context";
+#[cfg(not(target_arch = "wasm32"))]
+const KNOWLEDGE_SECTIONS: [&str; 5] = ["skills", "memories", "projects", "meetings", "handbook"];
+#[cfg(not(target_arch = "wasm32"))]
+const MAX_NOTE_BYTES: usize = 2 * 1024 * 1024;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub fn knowledge_dir() -> PathBuf {
@@ -115,8 +119,202 @@ pub fn knowledge_dir() -> PathBuf {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+pub fn write_note(path: Option<&str>, title: &str, content: &str) -> Result<PathBuf, String> {
+    write_note_in(&knowledge_dir(), path, title, content)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn write_note_in(
+    root: &Path,
+    path: Option<&str>,
+    title: &str,
+    content: &str,
+) -> Result<PathBuf, String> {
+    let title = title.trim();
+    if title.is_empty() || title.chars().count() > 200 {
+        return Err("knowledge title must be 1 to 200 characters".to_string());
+    }
+    let content = content.trim();
+    if content.is_empty() {
+        return Err("knowledge content is empty".to_string());
+    }
+    if content.len() > MAX_NOTE_BYTES {
+        return Err("knowledge content exceeds 2 MiB".to_string());
+    }
+    let relative = match path.map(str::trim).filter(|path| !path.is_empty()) {
+        Some(path) => PathBuf::from(path),
+        None => PathBuf::from("projects").join(format!("{}.md", knowledge_slug(title))),
+    };
+    if relative.is_absolute() {
+        return Err("knowledge path must be relative".to_string());
+    }
+    let components = relative
+        .components()
+        .map(|component| match component {
+            Component::Normal(value) => Ok(value.to_os_string()),
+            _ => Err("knowledge path contains an invalid component".to_string()),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if components.len() < 2 {
+        return Err("knowledge path must include a section and file name".to_string());
+    }
+    let section = components[0].to_string_lossy();
+    if !KNOWLEDGE_SECTIONS.contains(&section.as_ref()) {
+        return Err(
+            "knowledge path must start with skills, memories, projects, meetings, or handbook"
+                .to_string(),
+        );
+    }
+    let extension = relative.extension().and_then(|value| value.to_str());
+    if !extension.is_some_and(|extension| {
+        extension.eq_ignore_ascii_case("md")
+            || extension.eq_ignore_ascii_case("markdown")
+            || extension.eq_ignore_ascii_case("mdx")
+    }) {
+        return Err("knowledge file must use .md, .markdown, or .mdx".to_string());
+    }
+
+    if std::fs::symlink_metadata(root).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+        return Err("knowledge root cannot be a symlink".to_string());
+    }
+    std::fs::create_dir_all(root).map_err(|error| error.to_string())?;
+    set_private_directory(root)?;
+    let canonical_root = root.canonicalize().map_err(|error| error.to_string())?;
+    let mut parent = canonical_root.clone();
+    for component in &components[..components.len() - 1] {
+        parent.push(component);
+        match std::fs::symlink_metadata(&parent) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err("knowledge path cannot traverse a symlink".to_string());
+            }
+            Ok(metadata) if !metadata.is_dir() => {
+                return Err("knowledge parent path is not a directory".to_string());
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                std::fs::create_dir(&parent).map_err(|error| error.to_string())?;
+                set_private_directory(&parent)?;
+            }
+            Err(error) => return Err(error.to_string()),
+        }
+        let canonical = parent.canonicalize().map_err(|error| error.to_string())?;
+        if !canonical.starts_with(&canonical_root) {
+            return Err("knowledge path escapes the knowledge root".to_string());
+        }
+    }
+    let destination = parent.join(&components[components.len() - 1]);
+    match std::fs::symlink_metadata(&destination) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err("knowledge file cannot be a symlink".to_string());
+        }
+        Ok(metadata) if !metadata.is_file() => {
+            return Err("knowledge destination is not a file".to_string());
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.to_string()),
+    }
+    let source = format!(
+        "---\ntitle: {}\n---\n\n{}\n",
+        serde_json::to_string(title).map_err(|error| error.to_string())?,
+        content
+    );
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&destination)
+        .map_err(|error| error.to_string())?;
+    file.write_all(source.as_bytes())
+        .map_err(|error| error.to_string())?;
+    set_private_file(&destination)?;
+    Ok(destination)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn knowledge_slug(title: &str) -> String {
+    let mut slug = String::new();
+    let mut separator = false;
+    for character in title.chars().flat_map(char::to_lowercase) {
+        if character.is_alphanumeric() {
+            if separator && !slug.is_empty() {
+                slug.push('-');
+            }
+            slug.push(character);
+            separator = false;
+        } else {
+            separator = true;
+        }
+        if slug.chars().count() >= 80 {
+            break;
+        }
+    }
+    let slug = slug.trim_matches('-');
+    if slug.is_empty() {
+        "note".to_string()
+    } else {
+        slug.to_string()
+    }
+}
+
+#[cfg(all(not(target_arch = "wasm32"), unix))]
+fn set_private_directory(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(all(not(target_arch = "wasm32"), not(unix)))]
+fn set_private_directory(_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(all(not(target_arch = "wasm32"), unix))]
+fn set_private_file(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(all(not(target_arch = "wasm32"), not(unix)))]
+fn set_private_file(_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 pub fn skills_dir() -> PathBuf {
     knowledge_dir().join("skills")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn configured_skill_dirs() -> Vec<PathBuf> {
+    configured_skill_dirs_from(&skills_dir())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn configured_skill_files() -> Vec<PathBuf> {
+    configured_skill_dirs()
+        .into_iter()
+        .map(|path| path.join("SKILL.md"))
+        .collect()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(super) fn configured_skill_dirs_from(root: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return Vec::new();
+    };
+    let mut skills = entries
+        .flatten()
+        .filter_map(|entry| {
+            let file_type = entry.file_type().ok()?;
+            let path = entry.path();
+            (!file_type.is_symlink() && file_type.is_dir() && path.join("SKILL.md").is_file())
+                .then_some(path)
+        })
+        .collect::<Vec<_>>();
+    skills.sort();
+    skills
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -311,20 +509,8 @@ fn agent_skills_prompt_from(root: &Path) -> String {
     }
 
     let mut prompt = String::from(
-        "vmux Knowledge skills are user-owned instructions stored under ~/.vmux/knowledge/skills. Apply relevant skills automatically. Skill catalog:\n",
+        "vmux Knowledge skill instructions are already loaded below for this conversation. Apply them directly. Do not read their SKILL.md files again unless explicitly asked to refresh.\n",
     );
-    for path in &files {
-        let label = path
-            .parent()
-            .and_then(Path::file_name)
-            .map(|name| name.to_string_lossy())
-            .unwrap_or_default();
-        prompt.push_str("- ");
-        prompt.push_str(&label);
-        prompt.push_str(": ");
-        prompt.push_str(&path.to_string_lossy());
-        prompt.push('\n');
-    }
 
     let mut embedded = 0usize;
     for path in files {
@@ -335,14 +521,19 @@ fn agent_skills_prompt_from(root: &Path) -> String {
             continue;
         }
         embedded += body.len();
-        prompt.push_str("\n<vmux-knowledge-skill path=\"");
-        prompt.push_str(&path.to_string_lossy());
+        let label = path
+            .parent()
+            .and_then(Path::file_name)
+            .map(|name| name.to_string_lossy())
+            .unwrap_or_default();
+        prompt.push_str("\n<vmux-knowledge-instructions name=\"");
+        prompt.push_str(&label);
         prompt.push_str("\">\n");
         prompt.push_str(&body);
         if !body.ends_with('\n') {
             prompt.push('\n');
         }
-        prompt.push_str("</vmux-knowledge-skill>\n");
+        prompt.push_str("</vmux-knowledge-instructions>\n");
     }
     prompt
 }
@@ -448,7 +639,51 @@ mod tests {
     }
 
     #[test]
-    fn loads_sorted_skill_catalog_and_bodies() {
+    fn writes_private_markdown_note_under_projects_by_default() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = write_note_in(temp.path(), None, "YC Startup School", "Useful content").unwrap();
+        let source = std::fs::read_to_string(&path).unwrap();
+
+        assert_eq!(
+            path,
+            temp.path()
+                .canonicalize()
+                .unwrap()
+                .join("projects/yc-startup-school.md")
+        );
+        assert_eq!(markdown_metadata(&source).title, "YC Startup School");
+        assert!(source.ends_with("Useful content\n"));
+    }
+
+    #[test]
+    fn rejects_knowledge_path_escape_and_non_markdown_files() {
+        let temp = tempfile::tempdir().unwrap();
+
+        assert!(write_note_in(temp.path(), Some("../outside.md"), "Title", "Body").is_err());
+        assert!(write_note_in(temp.path(), Some("projects/note.txt"), "Title", "Body").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlinks_inside_knowledge_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("projects")).unwrap();
+        std::os::unix::fs::symlink(outside.path(), temp.path().join("projects/linked")).unwrap();
+
+        assert!(
+            write_note_in(
+                temp.path(),
+                Some("projects/linked/note.md"),
+                "Title",
+                "Body"
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn loads_sorted_skill_bodies_without_file_catalog() {
         let temp = tempfile::tempdir().unwrap();
         let beta = temp.path().join("beta");
         let alpha = temp.path().join("alpha");
@@ -460,6 +695,10 @@ mod tests {
         assert!(prompt.find("alpha").unwrap() < prompt.find("beta").unwrap());
         assert!(prompt.contains("# Alpha"));
         assert!(prompt.contains("# Beta"));
+        assert!(prompt.contains("already loaded below for this conversation"));
+        assert!(prompt.contains("Do not read their SKILL.md files again"));
+        assert!(!prompt.contains(&temp.path().to_string_lossy().to_string()));
+        assert!(!prompt.contains("Skill catalog"));
     }
 
     #[test]

--- a/crates/vmux_core/src/knowledge/agent_config.rs
+++ b/crates/vmux_core/src/knowledge/agent_config.rs
@@ -5,7 +5,10 @@ use std::path::{Path, PathBuf};
 #[cfg(unix)]
 use std::collections::HashSet;
 
-use super::{agent_memories_prompt, memories_dir, migrate_external_memories, skills_dir};
+use super::{
+    agent_memories_prompt, configured_skill_dirs_from, memories_dir, migrate_external_memories,
+    skills_dir,
+};
 
 const KNOWLEDGE_START: &str = "<!-- vmux-knowledge:start -->";
 const KNOWLEDGE_END: &str = "<!-- vmux-knowledge:end -->";
@@ -74,7 +77,7 @@ fn sync_external_agent_configs_from(
     memories_root: &Path,
     memories: &str,
 ) -> io::Result<()> {
-    let skills = skill_dirs(skills_root);
+    let skills = configured_skill_dirs_from(skills_root);
     let mut error = None;
     keep_first_error(
         &mut error,
@@ -183,23 +186,6 @@ fn merge_managed_section(
         "{without_managed}{separator}{start_marker}\n{}\n{end_marker}\n",
         body.trim_end()
     ))
-}
-
-fn skill_dirs(root: &Path) -> Vec<PathBuf> {
-    let Ok(entries) = std::fs::read_dir(root) else {
-        return Vec::new();
-    };
-    let mut skills = entries
-        .flatten()
-        .filter_map(|entry| {
-            let file_type = entry.file_type().ok()?;
-            let path = entry.path();
-            (!file_type.is_symlink() && file_type.is_dir() && path.join("SKILL.md").is_file())
-                .then_some(path)
-        })
-        .collect::<Vec<_>>();
-    skills.sort();
-    skills
 }
 
 fn sync_claude_settings(path: &Path, memories: &Path) -> io::Result<()> {

--- a/crates/vmux_editor/Cargo.toml
+++ b/crates/vmux_editor/Cargo.toml
@@ -59,8 +59,8 @@ unicode-width = "0.2"
 vmux_ui = { path = "../vmux_ui", default-features = false }
 wasm-bindgen = { workspace = true }
 web-sys = { version = "0.3", features = [
-    "Window", "Document", "Element", "HtmlElement", "Node",
-    "DomRect", "CssStyleDeclaration",
+    "Window", "Document", "DocumentFragment", "Element", "FocusOptions", "HtmlElement", "Node",
+    "CaretPosition", "DomRect", "Range", "CssStyleDeclaration",
     "ResizeObserver", "ResizeObserverEntry",
     "WheelEvent", "KeyboardEvent", "Location",
     "Blob", "Url",

--- a/crates/vmux_editor/src/lsp/manager.rs
+++ b/crates/vmux_editor/src/lsp/manager.rs
@@ -881,6 +881,10 @@ fn lsp_status_system(
             &FileLspStatusEvent {
                 path: fv.path.to_string_lossy().into_owned(),
                 server: spec.command.clone(),
+                package: (!overrides.contains_key(ext))
+                    .then(|| crate::lsp::registry::preferred_package(ext))
+                    .flatten()
+                    .map(str::to_string),
                 state: desired,
             },
         ));

--- a/crates/vmux_editor/src/lsp/manager_page.rs
+++ b/crates/vmux_editor/src/lsp/manager_page.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
@@ -30,6 +31,9 @@ pub enum ManagerMsg {
 #[derive(Resource, Clone, Default)]
 pub struct ManagerOutbox(pub Arc<Mutex<Vec<(Entity, ManagerMsg)>>>);
 
+#[derive(Resource, Clone, Default)]
+struct ActiveInstalls(Arc<Mutex<HashSet<String>>>);
+
 pub struct ManagerPlugin;
 
 impl Plugin for ManagerPlugin {
@@ -45,6 +49,7 @@ impl Plugin for ManagerPlugin {
         ));
         vmux_core::register_host_spawn(app, "lsp");
         app.init_resource::<ManagerOutbox>()
+            .init_resource::<ActiveInstalls>()
             .add_plugins(BinEventEmitterPlugin::<(
                 LspCatalogRequest,
                 LspInstallRequest,
@@ -141,12 +146,24 @@ fn on_catalog_request(trigger: On<BinReceive<LspCatalogRequest>>, outbox: Res<Ma
     });
 }
 
-fn install_named(outbox: &ManagerOutbox, entity: Entity, name: String) {
+fn install_named(outbox: &ManagerOutbox, active: &ActiveInstalls, entity: Entity, name: String) {
+    {
+        let mut installs = active.0.lock().unwrap_or_else(|error| error.into_inner());
+        if !installs.insert(name.clone()) {
+            return;
+        }
+    }
     let sink = outbox.clone();
+    let active = active.clone();
     std::thread::spawn(move || {
         let root = store::default_root();
         let pkgs = catalog::ensure_catalog(&root, false).unwrap_or_default();
         let Some(pkg) = pkgs.iter().find(|p| p.name == name).cloned() else {
+            active
+                .0
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .remove(&name);
             push(
                 &sink,
                 entity,
@@ -174,6 +191,11 @@ fn install_named(outbox: &ManagerOutbox, entity: Entity, name: String) {
                 }),
             );
         });
+        active
+            .0
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .remove(&name);
         match result {
             Ok(receipt) => push(
                 &sink,
@@ -198,17 +220,27 @@ fn install_named(outbox: &ManagerOutbox, entity: Entity, name: String) {
     });
 }
 
-fn on_install_request(trigger: On<BinReceive<LspInstallRequest>>, outbox: Res<ManagerOutbox>) {
+fn on_install_request(
+    trigger: On<BinReceive<LspInstallRequest>>,
+    outbox: Res<ManagerOutbox>,
+    active: Res<ActiveInstalls>,
+) {
     install_named(
         &outbox,
+        &active,
         trigger.event().webview,
         trigger.event().payload.name.clone(),
     );
 }
 
-fn on_update_request(trigger: On<BinReceive<LspUpdateRequest>>, outbox: Res<ManagerOutbox>) {
+fn on_update_request(
+    trigger: On<BinReceive<LspUpdateRequest>>,
+    outbox: Res<ManagerOutbox>,
+    active: Res<ActiveInstalls>,
+) {
     install_named(
         &outbox,
+        &active,
         trigger.event().webview,
         trigger.event().payload.name.clone(),
     );
@@ -254,9 +286,32 @@ fn on_uninstall_request(trigger: On<BinReceive<LspUninstallRequest>>, outbox: Re
     });
 }
 
+fn file_uses_package(view: &crate::plugin::FileView, package: &str) -> bool {
+    view.path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .and_then(crate::lsp::registry::preferred_package)
+        == Some(package)
+}
+
+fn install_targets(
+    source: Entity,
+    package: &str,
+    views: &Query<(Entity, &crate::plugin::FileView)>,
+) -> Vec<Entity> {
+    let mut targets = vec![source];
+    for (entity, view) in views {
+        if file_uses_package(view, package) && !targets.contains(&entity) {
+            targets.push(entity);
+        }
+    }
+    targets
+}
+
 fn drain_manager_outbox(
     outbox: Res<ManagerOutbox>,
     browsers: NonSend<Browsers>,
+    views: Query<(Entity, &crate::plugin::FileView)>,
     mut commands: Commands,
 ) {
     let drained: Vec<(Entity, ManagerMsg)> = {
@@ -264,23 +319,48 @@ fn drain_manager_outbox(
         q.drain(..).collect()
     };
     for (entity, msg) in drained {
-        if !browsers.has_browser(entity) || !browsers.host_emit_ready(&entity) {
-            continue;
-        }
         match msg {
             ManagerMsg::Catalog(ev) => {
-                commands.trigger(BinHostEmitEvent::from_rkyv(entity, LSP_CATALOG_EVENT, &ev))
+                if browsers.has_browser(entity) && browsers.host_emit_ready(&entity) {
+                    commands.trigger(BinHostEmitEvent::from_rkyv(entity, LSP_CATALOG_EVENT, &ev));
+                }
             }
-            ManagerMsg::Progress(ev) => commands.trigger(BinHostEmitEvent::from_rkyv(
-                entity,
-                LSP_INSTALL_PROGRESS_EVENT,
-                &ev,
-            )),
-            ManagerMsg::Status(ev) => commands.trigger(BinHostEmitEvent::from_rkyv(
-                entity,
-                LSP_PKG_STATUS_EVENT,
-                &ev,
-            )),
+            ManagerMsg::Progress(ev) => {
+                for target in install_targets(entity, &ev.name, &views) {
+                    if browsers.has_browser(target) && browsers.host_emit_ready(&target) {
+                        commands.trigger(BinHostEmitEvent::from_rkyv(
+                            target,
+                            LSP_INSTALL_PROGRESS_EVENT,
+                            &ev,
+                        ));
+                    }
+                }
+            }
+            ManagerMsg::Status(ev) => {
+                let targets = install_targets(entity, &ev.name, &views);
+                if ev.status == LspPkgStatus::Installed {
+                    for target in targets.iter().copied() {
+                        if views
+                            .get(target)
+                            .is_ok_and(|(_, view)| file_uses_package(view, &ev.name))
+                        {
+                            commands
+                                .entity(target)
+                                .remove::<crate::lsp::manager::LspOpened>()
+                                .remove::<crate::lsp::manager::LspStatusSent>();
+                        }
+                    }
+                }
+                for target in targets {
+                    if browsers.has_browser(target) && browsers.host_emit_ready(&target) {
+                        commands.trigger(BinHostEmitEvent::from_rkyv(
+                            target,
+                            LSP_PKG_STATUS_EVENT,
+                            &ev,
+                        ));
+                    }
+                }
+            }
         }
     }
 }

--- a/crates/vmux_editor/src/lsp/registry.rs
+++ b/crates/vmux_editor/src/lsp/registry.rs
@@ -73,6 +73,26 @@ pub fn builtin_spec(ext: &str) -> Option<ServerSpec> {
     })
 }
 
+pub fn preferred_package(ext: &str) -> Option<&'static str> {
+    Some(match ext {
+        "rs" => "rust-analyzer",
+        "py" | "pyi" => "pyright",
+        "ts" | "tsx" | "js" | "jsx" => "typescript-language-server",
+        "go" => "gopls",
+        "c" | "h" | "cpp" | "cc" | "cxx" | "hpp" | "hh" => "clangd",
+        "lua" => "lua-language-server",
+        "rb" => "solargraph",
+        "zig" => "zls",
+        "sh" | "bash" => "bash-language-server",
+        "json" => "json-lsp",
+        "yaml" | "yml" => "yaml-language-server",
+        "toml" => "taplo",
+        "md" | "markdown" => "marksman",
+        "java" => "jdtls",
+        _ => return None,
+    })
+}
+
 pub fn resolve_spec(
     ext: &str,
     overrides: &std::collections::BTreeMap<String, ServerSpec>,
@@ -150,6 +170,29 @@ mod tests {
         assert_eq!(builtin_spec("tsx").unwrap().language_id, "typescriptreact");
         assert_eq!(builtin_spec("cpp").unwrap().language_id, "cpp");
         assert!(builtin_spec("xyzzy").is_none());
+    }
+
+    #[test]
+    fn known_extensions_map_to_preferred_packages() {
+        for (extension, package) in [
+            ("rs", "rust-analyzer"),
+            ("py", "pyright"),
+            ("tsx", "typescript-language-server"),
+            ("go", "gopls"),
+            ("cpp", "clangd"),
+            ("lua", "lua-language-server"),
+            ("rb", "solargraph"),
+            ("zig", "zls"),
+            ("sh", "bash-language-server"),
+            ("json", "json-lsp"),
+            ("yaml", "yaml-language-server"),
+            ("toml", "taplo"),
+            ("md", "marksman"),
+            ("java", "jdtls"),
+        ] {
+            assert_eq!(preferred_package(extension), Some(package));
+        }
+        assert_eq!(preferred_package("xyzzy"), None);
     }
 
     #[test]

--- a/crates/vmux_editor/src/markdown.rs
+++ b/crates/vmux_editor/src/markdown.rs
@@ -108,6 +108,31 @@ fn line_start_offsets(text: &str) -> Vec<usize> {
     offsets
 }
 
+fn inline_text(inlines: &[MdInline], output: &mut String) {
+    for inline in inlines {
+        match inline {
+            MdInline::Text(text) | MdInline::Code(text) => output.push_str(text),
+            MdInline::Strong(children)
+            | MdInline::Emph(children)
+            | MdInline::Strike(children)
+            | MdInline::Link {
+                inlines: children, ..
+            } => inline_text(children, output),
+            MdInline::Image { alt, .. } => output.push_str(alt),
+            MdInline::SoftBreak | MdInline::HardBreak => output.push(' '),
+        }
+    }
+}
+
+fn heading_matches_title(block: &MdBlock, title: &str) -> bool {
+    let MdBlock::Heading { level: 1, inlines } = block else {
+        return false;
+    };
+    let mut text = String::new();
+    inline_text(inlines, &mut text);
+    text.trim() == title.trim()
+}
+
 fn offset_to_line(line_starts: &[usize], byte: usize) -> u32 {
     match line_starts.binary_search(&byte) {
         Ok(index) => index as u32,
@@ -347,6 +372,9 @@ pub fn parse_note_document(text: &str) -> ParsedNote {
         })
         .collect::<Vec<_>>();
     if !metadata.title.is_empty()
+        && !parsed
+            .first()
+            .is_some_and(|block| heading_matches_title(&block.block, &metadata.title))
         && let Some(title_line) = metadata.title_line
     {
         let source = text
@@ -417,5 +445,18 @@ mod tests {
             MdBlock::Heading { level: 1, .. }
         ));
         assert_eq!(note.blocks[1].start_line, 4);
+    }
+
+    #[test]
+    fn frontmatter_title_does_not_duplicate_matching_heading() {
+        let note = parse_note_document("---\ntitle: Welcome Home\n---\n\n# Welcome Home\n\nBody\n");
+
+        assert_eq!(note.title, "Welcome Home");
+        assert_eq!(note.blocks.len(), 2);
+        assert_eq!(note.blocks[0].start_line, 4);
+        assert!(matches!(
+            &note.blocks[0].block,
+            MdBlock::Heading { level: 1, .. }
+        ));
     }
 }

--- a/crates/vmux_editor/src/page.rs
+++ b/crates/vmux_editor/src/page.rs
@@ -26,6 +26,9 @@ const VIDEO_HOST_ID: &str = "vmux-video-host";
 const INPUT_ID: &str = "file-input";
 const SCROLL_ID: &str = "file-scroll";
 const GIT_REFRESH_DEBOUNCE_MS: i32 = 120;
+const NOTE_MAX_CONTENT_WIDTH_PX: u32 = 768;
+const LSP_NOTICE_DONE_MS: i32 = 2_500;
+const LSP_NOTICE_FAILED_MS: i32 = 6_000;
 
 fn is_markdown_file(path: &str) -> bool {
     path.rsplit_once('.')
@@ -65,6 +68,46 @@ fn note_pointer_line(event: &Event<MouseData>, start: u32, end: u32) -> u32 {
     start + ((ratio * count as f64).floor() as u32).min(count - 1)
 }
 
+fn note_pointer_anchor_top(event: &Event<MouseData>) -> Option<f64> {
+    let data = event.data();
+    let raw = data.downcast::<web_sys::MouseEvent>()?;
+    if let Some(document) = web_sys::window().and_then(|window| window.document())
+        && let Some(caret) =
+            document.caret_position_from_point(raw.client_x() as f32, raw.client_y() as f32)
+        && let Some(rect) = caret.get_client_rect()
+    {
+        return Some(rect.top());
+    }
+    raw.target()
+        .and_then(|target| target.dyn_into::<web_sys::Element>().ok())
+        .map(|element| element.get_bounding_client_rect().top())
+}
+
+fn restore_note_line_position(line: u32, top: f64) {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let callback = Closure::once_into_js(move || {
+        let Some(element) = web_sys::window()
+            .and_then(|window| window.document())
+            .and_then(|document| document.get_element_by_id(&format!("note-line-{line}")))
+        else {
+            return;
+        };
+        let Some(scroll) = scroll_el() else {
+            return;
+        };
+        let delta = element.get_bounding_client_rect().top() - top;
+        if delta.abs() >= 0.5 {
+            scroll.set_scroll_top(scroll.scroll_top().saturating_add(delta.round() as i32));
+        }
+    })
+    .unchecked_into::<js_sys::Function>();
+    if window.request_animation_frame(&callback).is_err() {
+        let _ = callback.call0(&JsValue::NULL);
+    }
+}
+
 fn note_pointer_col(event: &Event<MouseData>, text: &str) -> u32 {
     let data = event.data();
     let Some(raw) = data.downcast::<web_sys::MouseEvent>() else {
@@ -81,6 +124,27 @@ fn note_pointer_col(event: &Event<MouseData>, text: &str) -> u32 {
         .ok()
         .flatten()
         .unwrap_or(target);
+    let char_count = text.chars().count() as u32;
+    if let Some(document) = web_sys::window().and_then(|window| window.document())
+        && let Some(caret) =
+            document.caret_position_from_point(raw.client_x() as f32, raw.client_y() as f32)
+        && let Some(offset_node) = caret.offset_node()
+    {
+        let text_node: &web_sys::Node = text_target.as_ref();
+        if text_node.contains(Some(&offset_node))
+            && let Ok(range) = document.create_range()
+            && range.select_node_contents(text_node).is_ok()
+            && range.set_end(&offset_node, caret.offset()).is_ok()
+            && let Ok(fragment) = range.clone_contents()
+        {
+            return fragment
+                .text_content()
+                .unwrap_or_default()
+                .chars()
+                .count()
+                .min(char_count as usize) as u32;
+        }
+    }
     let rect = text_target.get_bounding_client_rect();
     if rect.width() <= 0.0 {
         return 0;
@@ -90,10 +154,68 @@ fn note_pointer_col(event: &Event<MouseData>, text: &str) -> u32 {
         return 0;
     }
     if x >= rect.width() {
-        return text.chars().count() as u32;
+        return char_count;
     }
     let ratio = x / rect.width();
-    (ratio * text.chars().count() as f64).round() as u32
+    (ratio * char_count as f64).round() as u32
+}
+
+#[derive(Clone, PartialEq)]
+struct NoteLineChunk {
+    text: String,
+    selected: bool,
+    caret_before: bool,
+}
+
+fn note_line_chunks(
+    text: &str,
+    caret: Option<u32>,
+    selection: Option<vmux_core::editor::SelSpan>,
+) -> Vec<NoteLineChunk> {
+    let chars = text.chars().collect::<Vec<_>>();
+    let len = chars.len() as u32;
+    let caret = caret.map(|column| column.min(len));
+    let selection = selection.map(|span| {
+        let start = span.start.min(len);
+        let end = if span.end == u32::MAX {
+            len
+        } else {
+            span.end.min(len)
+        };
+        (start.min(end), start.max(end))
+    });
+    let mut boundaries = vec![0, len];
+    if let Some(caret) = caret {
+        boundaries.push(caret);
+    }
+    if let Some((start, end)) = selection {
+        boundaries.push(start);
+        boundaries.push(end);
+    }
+    boundaries.sort_unstable();
+    boundaries.dedup();
+    let mut chunks = boundaries
+        .windows(2)
+        .map(|range| {
+            let start = range[0];
+            let end = range[1];
+            NoteLineChunk {
+                text: chars[start as usize..end as usize].iter().collect(),
+                selected: selection.is_some_and(|(selection_start, selection_end)| {
+                    start < selection_end && end > selection_start
+                }),
+                caret_before: caret == Some(start),
+            }
+        })
+        .collect::<Vec<_>>();
+    if chunks.is_empty() || caret == Some(len) {
+        chunks.push(NoteLineChunk {
+            text: String::new(),
+            selected: false,
+            caret_before: caret == Some(len),
+        });
+    }
+    chunks
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -425,6 +547,61 @@ fn set_explorer_visible(
     }
 }
 
+fn show_explorer_if_room(
+    visible: Signal<bool>,
+    width: Signal<u32>,
+    client_id: Signal<u64>,
+    request_id: Signal<u64>,
+    mode: Signal<Mode>,
+) {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let callback = Closure::once_into_js(move || {
+        if visible() {
+            return;
+        }
+        let Some(page_width) = web_sys::window()
+            .and_then(|window| window.document())
+            .and_then(|document| document.get_element_by_id(CONTAINER_ID))
+            .map(|element| element.client_width().max(0) as u32)
+        else {
+            return;
+        };
+        if NOTE_MAX_CONTENT_WIDTH_PX.saturating_add(width()) <= page_width {
+            set_explorer_visible(true, visible, client_id, request_id, mode);
+        }
+    })
+    .unchecked_into::<js_sys::Function>();
+    if window.request_animation_frame(&callback).is_err() {
+        let _ = callback.call0(&JsValue::NULL);
+    }
+}
+
+fn schedule_lsp_notice_clear(
+    mut notice: Signal<Option<LspInstallProgress>>,
+    mut request: Signal<Option<(String, String)>>,
+    mut generation: Signal<u32>,
+    delay: i32,
+) {
+    let id = generation().wrapping_add(1);
+    generation.set(id);
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let clear = Closure::once(move || {
+        if generation() == id {
+            notice.set(None);
+            request.set(None);
+        }
+    });
+    let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(
+        clear.as_ref().unchecked_ref(),
+        delay,
+    );
+    clear.forget();
+}
+
 fn toggle_explorer(
     visible: Signal<bool>,
     client_id: Signal<u64>,
@@ -556,6 +733,9 @@ pub fn Page() -> Element {
     let mut diagnostics = use_signal(Vec::<FileDiagnostic>::new);
     let mut hover_diag = use_signal(|| Option::<FileDiagnostic>::None);
     let mut lsp_status = use_signal(|| Option::<FileLspStatusEvent>::None);
+    let mut lsp_install_notice = use_signal(|| Option::<LspInstallProgress>::None);
+    let mut lsp_install_request = use_signal(|| Option::<(String, String)>::None);
+    let mut lsp_notice_generation = use_signal(|| 0u32);
     let mut error = use_signal(String::new);
     let dir_entries = use_signal(Vec::<FileDirEntry>::new);
     let parent_entries = use_signal(Vec::<FileDirEntry>::new);
@@ -577,6 +757,7 @@ pub fn Page() -> Element {
     let mut note_blocks = use_signal(Vec::<NoteBlock>::new);
     let mut note_active = use_signal(|| Option::<u32>::None);
     let mut note_editing = use_signal(|| false);
+    let mut note_dragging = use_signal(|| false);
     let mut git_nonce = use_signal(|| 0u32);
     let git_refresh_generation = use_signal(|| 0u32);
     let git_display = use_signal(String::new);
@@ -651,6 +832,16 @@ pub fn Page() -> Element {
         git_path.set(m.abs_path);
         total_lines.set(m.total_lines);
         mode.set(Mode::Text);
+        lsp_install_notice.set(None);
+        lsp_install_request.set(None);
+        lsp_notice_generation.set(lsp_notice_generation().wrapping_add(1));
+        show_explorer_if_room(
+            explorer_visible,
+            explorer_width,
+            explorer_client_id,
+            explorer_request_id,
+            mode,
+        );
         note_blocks.set(Vec::new());
         note_active.set(None);
         note_editing.set(false);
@@ -671,7 +862,7 @@ pub fn Page() -> Element {
         ed_label.set(c.mode_label);
         cursor.set(c.primary);
         sel.set(c.selections);
-        if moved {
+        if moved && (file_view_mode() != FileViewMode::Note || !is_markdown_file(&git_path())) {
             ensure_line_visible(c.primary.row, cell_dims().1);
         }
     });
@@ -742,7 +933,68 @@ pub fn Page() -> Element {
             if s.path != git_path() {
                 return;
             }
+            if s.state == LspServerState::Missing
+                && let Some(package) = s.package.clone()
+            {
+                let request = (s.path.clone(), package.clone());
+                if lsp_install_request() != Some(request.clone()) {
+                    lsp_notice_generation.set(lsp_notice_generation().wrapping_add(1));
+                    lsp_install_request.set(Some(request));
+                    lsp_install_notice.set(Some(LspInstallProgress {
+                        name: package.clone(),
+                        phase: InstallPhase::Resolving,
+                        pct: None,
+                        message: translate("lsp-status-installing"),
+                    }));
+                    let _ = try_cef_bin_emit_rkyv(&LspInstallRequest { name: package });
+                }
+            }
             lsp_status.set(Some(s));
+        });
+
+    let _lsp_install_progress = use_bin_event_listener::<LspInstallProgress, _>(
+        LSP_INSTALL_PROGRESS_EVENT,
+        move |progress| {
+            let active = lsp_install_request().is_some_and(|(_, package)| package == progress.name);
+            if !active {
+                return;
+            }
+            let delay = match progress.phase {
+                InstallPhase::Done => Some(LSP_NOTICE_DONE_MS),
+                InstallPhase::Failed => Some(LSP_NOTICE_FAILED_MS),
+                _ => None,
+            };
+            lsp_install_notice.set(Some(progress));
+            if let Some(delay) = delay {
+                schedule_lsp_notice_clear(
+                    lsp_install_notice,
+                    lsp_install_request,
+                    lsp_notice_generation,
+                    delay,
+                );
+            }
+        },
+    );
+
+    let _lsp_package_status =
+        use_bin_event_listener::<LspPkgStatusEvent, _>(LSP_PKG_STATUS_EVENT, move |status| {
+            if status.status != LspPkgStatus::Installed
+                || lsp_install_request().is_none_or(|(_, package)| package != status.name)
+            {
+                return;
+            }
+            lsp_install_notice.set(Some(LspInstallProgress {
+                name: status.name,
+                phase: InstallPhase::Done,
+                pct: Some(100),
+                message: translate("lsp-status-installed"),
+            }));
+            schedule_lsp_notice_clear(
+                lsp_install_notice,
+                lsp_install_request,
+                lsp_notice_generation,
+                LSP_NOTICE_DONE_MS,
+            );
         });
 
     let _err = use_bin_event_listener::<FileErrorEvent, _>(FILE_ERROR_EVENT, move |e| {
@@ -922,6 +1174,7 @@ pub fn Page() -> Element {
                 }
             },
             onmouseup: move |_| {
+                note_dragging.set(false);
                 if explorer_resizing() {
                     explorer_resizing.set(false);
                     let _ = try_cef_bin_emit_rkyv(&ExplorerPanelWidth { px: explorer_width() });
@@ -1339,6 +1592,7 @@ pub fn Page() -> Element {
                         {
                             let active = note_active();
                             let current = cursor();
+                            let selections = sel();
                             rsx! {
                                 div {
                                     id: "file-scroll",
@@ -1361,47 +1615,72 @@ pub fn Page() -> Element {
                                                             for (line_offset, raw) in source_lines.iter().enumerate() {
                                                                 {
                                                                     let line = start + line_offset as u32;
-                                                                    let pointer_raw = raw.clone();
-                                                                    if line == current.line {
-                                                                        let column = current.col as usize;
-                                                                        let byte = raw
-                                                                            .char_indices()
-                                                                            .nth(column)
-                                                                            .map(|(byte, _)| byte)
-                                                                            .unwrap_or(raw.len());
-                                                                        let before = raw[..byte].to_string();
-                                                                        let after = raw[byte..].to_string();
-                                                                        rsx! {
-                                                                            div {
-                                                                                key: "{line}",
-                                                                                class: "min-h-7 w-full whitespace-pre-wrap break-words font-sans text-[15px] leading-7",
-                                                                                onmousedown: move |event| {
-                                                                                    event.stop_propagation();
-                                                                                    event.prevent_default();
-                                                                                    let col = note_pointer_col(&event, &pointer_raw);
-                                                                                    let _ = try_cef_bin_emit_rkyv(&FilePointerEvent { line, col, extend: false });
-                                                                                    focus_file_input();
-                                                                                },
-                                                                                span { "data-note-line-text": "true", class: "inline-block min-w-[1ch]",
-                                                                                    span { "{before}" }
-                                                                                    span { class: "inline-block w-px animate-pulse bg-primary align-text-bottom", style: "height:1.15em;" }
-                                                                                    span { "{after}" }
+                                                                    let pointer_raw_down = raw.clone();
+                                                                    let pointer_raw_drag = raw.clone();
+                                                                    let line_selection = selections
+                                                                        .iter()
+                                                                        .find(|selection| selection.line == line)
+                                                                        .copied();
+                                                                    let chunks = note_line_chunks(
+                                                                        raw,
+                                                                        (line == current.line).then_some(current.col),
+                                                                        line_selection,
+                                                                    );
+                                                                    rsx! {
+                                                                        div {
+                                                                            key: "{line}",
+                                                                            id: "note-line-{line}",
+                                                                            class: "min-h-7 w-full whitespace-pre-wrap break-words font-sans text-[15px] leading-7",
+                                                                            onmousedown: move |event| {
+                                                                                event.stop_propagation();
+                                                                                event.prevent_default();
+                                                                                let extend = event
+                                                                                    .data()
+                                                                                    .downcast::<web_sys::MouseEvent>()
+                                                                                    .is_some_and(|raw| raw.shift_key());
+                                                                                let col = note_pointer_col(&event, &pointer_raw_down);
+                                                                                note_dragging.set(true);
+                                                                                let _ = try_cef_bin_emit_rkyv(&FilePointerEvent { line, col, extend });
+                                                                                focus_file_input();
+                                                                            },
+                                                                            onmousemove: move |event| {
+                                                                                if !note_dragging() {
+                                                                                    return;
                                                                                 }
-                                                                            }
-                                                                        }
-                                                                    } else {
-                                                                        rsx! {
-                                                                            div {
-                                                                                key: "{line}",
-                                                                                class: "min-h-7 w-full whitespace-pre-wrap break-words font-sans text-[15px] leading-7",
-                                                                                onmousedown: move |event| {
-                                                                                    event.stop_propagation();
-                                                                                    event.prevent_default();
-                                                                                    let col = note_pointer_col(&event, &pointer_raw);
-                                                                                    let _ = try_cef_bin_emit_rkyv(&FilePointerEvent { line, col, extend: false });
-                                                                                    focus_file_input();
-                                                                                },
-                                                                                span { "data-note-line-text": "true", class: "inline-block min-w-[1ch]", "{raw}" }
+                                                                                let pressed = event
+                                                                                    .data()
+                                                                                    .downcast::<web_sys::MouseEvent>()
+                                                                                    .is_some_and(|raw| raw.buttons() & 1 == 1);
+                                                                                if !pressed {
+                                                                                    note_dragging.set(false);
+                                                                                    return;
+                                                                                }
+                                                                                event.stop_propagation();
+                                                                                event.prevent_default();
+                                                                                let col = note_pointer_col(&event, &pointer_raw_drag);
+                                                                                let _ = try_cef_bin_emit_rkyv(&FilePointerEvent {
+                                                                                    line,
+                                                                                    col,
+                                                                                    extend: true,
+                                                                                });
+                                                                            },
+                                                                            span { "data-note-line-text": "true", class: "inline-block min-w-[1ch]",
+                                                                                for (chunk_index, chunk) in chunks.iter().enumerate() {
+                                                                                    if chunk.caret_before {
+                                                                                        span {
+                                                                                            key: "caret-{chunk_index}",
+                                                                                            class: "relative inline-block h-[1.15em] w-0 align-text-bottom",
+                                                                                            span { class: "pointer-events-none absolute inset-y-0 left-0 w-px animate-pulse bg-primary" }
+                                                                                        }
+                                                                                    }
+                                                                                    if !chunk.text.is_empty() {
+                                                                                        span {
+                                                                                            key: "text-{chunk_index}",
+                                                                                            class: if chunk.selected { "bg-cyan-400/20" } else { "" },
+                                                                                            "{chunk.text}"
+                                                                                        }
+                                                                                    }
+                                                                                }
                                                                             }
                                                                         }
                                                                     }
@@ -1473,8 +1752,12 @@ pub fn Page() -> Element {
                                                                 event.stop_propagation();
                                                                 event.prevent_default();
                                                                 let line = note_pointer_line(&event, start, end);
+                                                                let anchor_top = note_pointer_anchor_top(&event);
                                                                 note_active.set(Some(index as u32));
                                                                 note_editing.set(true);
+                                                                if let Some(top) = anchor_top {
+                                                                    restore_note_line_position(line, top);
+                                                                }
                                                                 let _ = try_cef_bin_emit_rkyv(&FilePointerEvent {
                                                                     line,
                                                                     col: 0,
@@ -1893,6 +2176,34 @@ pub fn Page() -> Element {
             }
 
             {
+                lsp_install_notice().map(|progress| {
+                    let (icon_class, icon, spinning) = match progress.phase {
+                        InstallPhase::Done => ("text-ansi-2", "✓", false),
+                        InstallPhase::Failed => ("text-ansi-1", "×", false),
+                        _ => ("text-cyan-400", "", true),
+                    };
+                    let detail = progress.pct.map_or_else(
+                        || progress.message.clone(),
+                        |percent| format!("{} {percent}%", progress.message),
+                    );
+                    rsx! {
+                        div {
+                            class: "pointer-events-none fixed right-4 bottom-14 z-[60] flex min-w-64 max-w-sm items-center gap-3 rounded-xl bg-background/95 px-3 py-2.5 text-xs text-foreground shadow-[0_12px_40px_rgba(0,0,0,0.28)] ring-1 ring-inset ring-foreground/10 backdrop-blur-xl",
+                            if spinning {
+                                span { class: "h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-cyan-400/25 border-t-cyan-400" }
+                            } else {
+                                span { class: "grid h-4 w-4 shrink-0 place-items-center text-base font-semibold {icon_class}", "{icon}" }
+                            }
+                            div { class: "min-w-0",
+                                div { class: "truncate font-medium", "{progress.name}" }
+                                div { class: "truncate text-[10px] text-muted-foreground", "{detail}" }
+                            }
+                        }
+                    }
+                })
+            }
+
+            {
                 hover_diag().map(|d| rsx! {
                     div {
                         class: "pointer-events-none absolute right-4 bottom-12 z-50 max-w-md rounded-xl bg-foreground/[0.04] px-3 py-2 text-xs text-foreground/90 ring-1 ring-inset ring-foreground/10 backdrop-blur-2xl shadow-lg dark:shadow-[0_8px_40px_-12px_rgba(0,0,0,0.7)]",
@@ -2120,7 +2431,9 @@ fn focus_by_id(id: &str) {
         .and_then(|d| d.get_element_by_id(id))
         && let Ok(html) = el.dyn_into::<web_sys::HtmlElement>()
     {
-        let _ = html.focus();
+        let options = web_sys::FocusOptions::new();
+        options.set_prevent_scroll(true);
+        let _ = html.focus_with_options(&options);
     }
 }
 

--- a/crates/vmux_editor/tests/page_source.rs
+++ b/crates/vmux_editor/tests/page_source.rs
@@ -90,7 +90,6 @@ fn page_wires_shared_note_editor_diff_toggle() {
     assert!(s.contains("let mut note_editing = use_signal(|| false)"));
     assert!(s.contains("if note_editing() && Some(index as u32) == active"));
     assert!(s.contains("note_pointer_line(&event, start, end)"));
-    assert!(s.contains("note_pointer_col(&event, &pointer_raw)"));
     assert!(s.contains("query_selector(\"[data-note-line-text]\")"));
     assert!(s.contains("class: \"flow-root w-full cursor-text\""));
     assert!(

--- a/crates/vmux_git/src/worktree.rs
+++ b/crates/vmux_git/src/worktree.rs
@@ -162,6 +162,28 @@ pub fn repository_init(dir: &Path) -> Result<PathBuf, GitError> {
     checkout_info(&dir).map(|info| info.root)
 }
 
+/// Create the empty root commit required before Git can add a linked worktree.
+pub fn ensure_initial_commit(root: &Path) -> Result<(), GitError> {
+    let (_, _, has_head) = git(root, &["rev-parse", "--verify", "HEAD"])?;
+    if has_head {
+        return Ok(());
+    }
+    let (stdout, stderr, ok) = git(
+        root,
+        &[
+            "commit",
+            "--allow-empty",
+            "--no-gpg-sign",
+            "--message",
+            "Initial commit",
+        ],
+    )?;
+    if !ok {
+        return Err(git_err(&stdout, &stderr));
+    }
+    Ok(())
+}
+
 /// The absolute common Git directory shared by a repository's main and linked worktrees.
 pub fn common_dir_of(dir: &Path) -> Result<PathBuf, GitError> {
     checkout_info(dir).map(|info| info.common_dir)

--- a/crates/vmux_layout/src/archive.rs
+++ b/crates/vmux_layout/src/archive.rs
@@ -23,8 +23,7 @@ use crate::settings::LayoutSettings;
 use crate::space::{ActiveSpaceEntity, Space, SpaceId, space_of};
 use crate::stack::{ActiveTabParam, FocusedStack, Stack, StackCommandSet, stack_bundle};
 use crate::tab::{
-    CloseTabRequest, LastTabCloseAt, Tab, TabReplacementSource, active_tab_siblings,
-    pick_after_close, tab_bundle,
+    CloseTabRequest, LastTabCloseAt, Tab, active_tab_siblings, pick_after_close, tab_bundle,
 };
 use crate::window::spawn_tab_scaffold_in_space;
 use crate::{TabLayoutSpawnContent, TabLayoutSpawnRequest};
@@ -305,7 +304,6 @@ pub(crate) fn handle_close_tab_requests(
     active_tab_param: ActiveTabParam,
     tab_data: Query<&Tab>,
     tab_q: Query<Entity, With<Tab>>,
-    replacement_sources: Query<(), With<TabReplacementSource>>,
     layout: TabArchiveLayout,
     primary_window: Single<Entity, With<PrimaryWindow>>,
     mut layout_requests: MessageWriter<TabLayoutSpawnRequest>,
@@ -317,7 +315,6 @@ pub(crate) fn handle_close_tab_requests(
         .read()
         .filter_map(|request| seen.insert(request.tab).then_some(request.tab))
         .filter(|tab| tab_data.contains(*tab))
-        .filter(|tab| !replacement_sources.contains(*tab))
         .collect();
     let closing: HashSet<Entity> = requests.iter().copied().collect();
     let mut replacement_spaces = HashSet::new();
@@ -333,7 +330,6 @@ pub(crate) fn handle_close_tab_requests(
             .copied()
             .filter(|sibling| !closing.contains(sibling))
             .collect();
-        let mut defer_despawn = false;
         if surviving_siblings.is_empty() {
             let Ok(tab_space) = layout
                 .child_of
@@ -354,12 +350,9 @@ pub(crate) fn handle_close_tab_requests(
                     startup_dir: None,
                     content: TabLayoutSpawnContent::StartupUrlOrPrompt,
                     clear_pending_stack: true,
-                    focus: false,
-                    replaces: Some(request.tab),
+                    focus: true,
                 });
                 replacement_spaces.insert(tab_space);
-                commands.entity(request.tab).insert(TabReplacementSource);
-                defer_despawn = true;
             }
         } else if active_tab_param.get() == Some(request.tab)
             && let Some(next) = pick_after_close(
@@ -378,9 +371,7 @@ pub(crate) fn handle_close_tab_requests(
 
         archive_tab(request.tab, tab, &layout, &mut commands);
         last_tab_close.0 = Some(std::time::Instant::now());
-        if !defer_despawn {
-            commands.entity(request.tab).despawn();
-        }
+        commands.entity(request.tab).despawn();
     }
 }
 
@@ -1645,13 +1636,8 @@ mod tests {
 
         app.update();
 
-        assert!(app.world().get_entity(first).is_ok());
+        assert!(app.world().get_entity(first).is_err());
         assert!(app.world().get_entity(second).is_err());
-        assert!(
-            app.world()
-                .get::<crate::tab::TabReplacementSource>(first)
-                .is_some()
-        );
         let requests: Vec<TabLayoutSpawnRequest> = app
             .world_mut()
             .resource_mut::<Messages<TabLayoutSpawnRequest>>()
@@ -1660,8 +1646,7 @@ mod tests {
         assert_eq!(requests.len(), 1);
         assert_eq!(requests[0].space, space);
         assert_eq!(requests[0].startup_dir, None);
-        assert!(!requests[0].focus);
-        assert_eq!(requests[0].replaces, Some(first));
+        assert!(requests[0].focus);
     }
 
     fn reopen_app() -> App {

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -692,7 +692,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
         .unwrap_or_default()
         .to_string();
     let workspace_label = if prompt_context.workspace_name.is_empty() {
-        "Select workspace".to_string()
+        "Select project".to_string()
     } else {
         prompt_context.workspace_name.clone()
     };
@@ -756,7 +756,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                 }
                 button {
                         class: "flex h-7 max-w-44 shrink-0 items-center gap-1.5 rounded-lg px-2 text-[11px] text-muted-foreground transition hover:bg-foreground/[0.08] hover:text-foreground",
-                        title: if prompt_context.cwd.is_empty() { "Create or select workspace" } else { "{prompt_context.cwd}" },
+                        title: if prompt_context.cwd.is_empty() { "Choose project" } else { "{prompt_context.cwd}" },
                         onmousedown: move |event| event.prevent_default(),
                         onclick: move |_| {
                             let _ = try_cef_bin_emit_rkyv(&StartSelectWorkspace {

--- a/crates/vmux_layout/src/lib.rs
+++ b/crates/vmux_layout/src/lib.rs
@@ -210,7 +210,6 @@ pub struct TabLayoutSpawnRequest {
     pub content: TabLayoutSpawnContent,
     pub clear_pending_stack: bool,
     pub focus: bool,
-    pub replaces: Option<Entity>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/vmux_layout/src/page.rs
+++ b/crates/vmux_layout/src/page.rs
@@ -21,6 +21,7 @@ use vmux_ui::components::context_menu::{
 };
 use vmux_ui::components::icon::Icon;
 use vmux_ui::favicon::{favicon_src_for_url, host_for_favicon_fallback};
+use vmux_ui::file_icon::type_icon;
 use vmux_ui::hooks::{try_cef_bin_emit_rkyv, use_bin_event_listener, use_event, use_theme};
 use vmux_ui::i18n::{TranslationValue, translate, translate_with};
 use vmux_ui::icon::PageIconView;
@@ -840,6 +841,14 @@ fn SideSheetView(
         .find(|pane| pane.is_active)
         .or_else(|| panes.first())
         .map(|pane| pane.id);
+    let project_boundary = tab_boundary.clone().or_else(|| {
+        active_space.as_ref().and_then(|space| {
+            (!space.startup_dir.is_empty()).then(|| crate::event::TabBoundary {
+                effective_dir: space.startup_dir.clone(),
+                ..Default::default()
+            })
+        })
+    });
     rsx! {
         div {
             class: "flex min-h-0 flex-1 flex-col overflow-x-hidden overflow-y-auto px-2 pb-3 pt-2 text-foreground",
@@ -850,23 +859,9 @@ fn SideSheetView(
             if let Some(space) = active_space {
                 div { class: "glass mb-2 flex shrink-0 flex-col overflow-hidden rounded-lg",
                     SideSheetSpaceRow { key: "{space.id}", space: space.clone() }
-                    if let Some(b) = tab_boundary {
-                        TabBoundaryPanel { boundary: b }
-                    } else if !space.startup_dir.is_empty() {
-                        div { class: "flex items-center gap-1.5 border-t border-foreground/10 px-2.5 py-2 text-muted-foreground",
-                            Icon { class: "h-3.5 w-3.5 shrink-0",
-                                path { d: "M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z" }
-                            }
-                            span {
-                                class: "min-w-0 flex-1 truncate text-xs",
-                                style: "direction:rtl;",
-                                title: "{space.startup_dir}",
-                                bdi { style: "unicode-bidi:isolate;direction:ltr;", "{space.startup_dir}" }
-                            }
-                        }
-                    }
                 }
             }
+            ProjectsCard { boundary: project_boundary }
             BookmarksSection { bookmarks: bookmarks.clone(), active_page }
             if let Some(pane_id) = active_pane_id {
                 KnowledgeCard { pane_id, knowledge, loaded: knowledge_loaded }
@@ -883,6 +878,44 @@ fn SideSheetView(
                 for (i, pane) in panes.iter().enumerate() {
                     PaneSection { key: "{pane.id}", pane: pane.clone(), index: i }
                 }
+            }
+        }
+    }
+}
+
+#[component]
+fn ProjectsCard(boundary: Option<crate::event::TabBoundary>) -> Element {
+    let title = translate("layout-projects");
+    let empty = translate("layout-no-project-selected");
+    let project_name = boundary
+        .as_ref()
+        .and_then(|boundary| {
+            boundary
+                .effective_dir
+                .trim_end_matches('/')
+                .rsplit('/')
+                .next()
+                .filter(|name| !name.is_empty())
+        })
+        .map(str::to_string)
+        .unwrap_or_else(|| empty.clone());
+    rsx! {
+        div { class: "glass mb-2 flex shrink-0 flex-col overflow-hidden rounded-lg",
+            div { class: "flex min-w-0 items-center gap-2 px-2.5 py-2",
+                div { class: "grid h-7 w-7 shrink-0 place-items-center rounded-lg bg-foreground/[0.07] text-foreground ring-1 ring-inset ring-foreground/10",
+                    Icon { class: "h-3.5 w-3.5",
+                        path { d: "M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z" }
+                    }
+                }
+                div { class: "min-w-0 flex-1",
+                    div { class: "text-ui font-semibold text-foreground", "{title}" }
+                    div { class: "truncate text-[10px] text-muted-foreground", "{project_name}" }
+                }
+            }
+            if let Some(boundary) = boundary {
+                TabBoundaryPanel { boundary }
+            } else {
+                div { class: "border-t border-foreground/10 px-2.5 py-2 text-ui-xs text-muted-foreground", "{empty}" }
             }
         }
     }
@@ -1155,19 +1188,13 @@ fn KnowledgeEntryRow(entry: KnowledgeEntry, entries: Vec<KnowledgeEntry>, pane_i
                 title: "{entry.path}",
                 class: "flex h-8 cursor-pointer items-center gap-1.5 rounded-md px-1.5 pl-6 text-left text-muted-foreground hover:bg-glass-hover hover:text-foreground",
                 onclick: move |_| open_knowledge_path(pane_id, path.clone()),
-                Icon { class: "h-3.5 w-3.5 shrink-0",
-                    path { d: "M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z" }
-                    path { d: "M14 2v6h6" }
-                }
+                {type_icon(&entry.path, false, "h-3.5 w-3.5 shrink-0")}
                 span { class: "min-w-0 flex-1 truncate text-ui", "{title}" }
             }
         }
     }
 }
 
-/// The active tab's working directory + live git status, rendered inside the space card. Shows the
-/// dir always; when it's a git repo, adds an auto-detected git row (branch, worktree, dirty/ahead).
-/// Read-only — worktree lifecycle is agent-driven (no UI actions).
 #[component]
 fn TabBoundaryPanel(boundary: crate::event::TabBoundary) -> Element {
     let b = boundary;

--- a/crates/vmux_layout/src/stack.rs
+++ b/crates/vmux_layout/src/stack.rs
@@ -917,25 +917,17 @@ mod tests {
 
         app.update();
 
-        assert!(app.world().get_entity(tab_e).is_ok());
-        assert!(app.world().get_entity(original_stack).is_ok());
-        assert!(
-            app.world()
-                .get::<crate::tab::TabReplacementSource>(tab_e)
-                .is_some()
-        );
+        assert!(app.world().get_entity(tab_e).is_err());
+        assert!(app.world().get_entity(original_stack).is_err());
         let replacement_tab = app
             .world_mut()
-            .query_filtered::<Entity, With<crate::tab::PendingTabReplacement>>()
+            .query_filtered::<Entity, With<Tab>>()
             .single(app.world())
             .unwrap();
         assert_ne!(replacement_tab, tab_e);
         assert_eq!(
-            app.world()
-                .get::<crate::tab::PendingTabReplacement>(replacement_tab)
-                .unwrap()
-                .old_tab,
-            tab_e
+            app.world().resource::<FocusedStack>().tab,
+            Some(replacement_tab)
         );
         assert!(
             app.world()

--- a/crates/vmux_layout/src/start/plugin.rs
+++ b/crates/vmux_layout/src/start/plugin.rs
@@ -12,10 +12,8 @@ use vmux_command::snapshot::{
     CommandBarWorkSnapshot,
 };
 use vmux_core::{
-    Active, CefPageAttachRequest, PageMetadata, PageOpenError, PageOpenHandled, PageOpenSet,
-    PageOpenTask,
+    CefPageAttachRequest, PageMetadata, PageOpenError, PageOpenHandled, PageOpenSet, PageOpenTask,
 };
-use vmux_history::LastActivatedAt;
 
 use crate::cef::Browser;
 use crate::command_bar::handler::{
@@ -26,8 +24,7 @@ use crate::start::START_PAGE_URL;
 use crate::start::event::{
     START_FOCUS_INPUT_EVENT, StartDataRequest, StartFocusInput, StartSelectWorkspace,
 };
-use crate::tab::{PendingTabReplacement, Tab, TabWorkspace, TabWorktree};
-use crate::webview_reveal::PendingWebviewReveal;
+use crate::tab::{Tab, TabWorkspace, TabWorktree};
 use crate::window::VmuxWindow;
 
 type PendingPageOpen = (Without<PageOpenHandled>, Without<PageOpenError>);
@@ -57,9 +54,6 @@ struct WarmStartPoolNode;
 /// becomes ready after snapshots were populated still gets the data.
 #[derive(Component)]
 struct StartWorkSynced;
-
-#[derive(Component)]
-struct StartMountReady;
 
 /// Host-internal signal that a warm spare was just revealed into a stack, so its launcher
 /// data must be refreshed (it captured boot-time tabs/spaces) and its input refocused.
@@ -175,10 +169,6 @@ impl Plugin for StartPlugin {
                     sync_live_start_pages,
                     drain_start_workspace_pickers,
                 ),
-            )
-            .add_systems(
-                Update,
-                finish_ready_tab_replacements.after(sync_live_start_pages),
             );
     }
 }
@@ -208,17 +198,24 @@ fn on_start_select_workspace(
         return;
     }
     let wake = proxy.as_deref().map(|proxy| (**proxy).clone());
-    let initial_dir = std::path::PathBuf::from(&trigger.event().payload.current_dir)
-        .canonicalize()
+    let workspace_dir = vmux_core::profile::workspace_dir();
+    let initial_dir = std::fs::create_dir_all(&workspace_dir)
         .ok()
+        .map(|_| workspace_dir)
         .filter(|path| path.is_dir())
+        .or_else(|| {
+            std::path::PathBuf::from(&trigger.event().payload.current_dir)
+                .canonicalize()
+                .ok()
+                .filter(|path| path.is_dir())
+        })
         .or_else(|| std::env::current_dir().ok().filter(|path| path.is_dir()))
         .or_else(|| std::env::var_os("HOME").map(std::path::PathBuf::from))
         .filter(|path| path.is_dir())
         .unwrap_or_else(|| std::path::PathBuf::from("/"));
     let task = IoTaskPool::get().spawn(async move {
         let selected = rfd::AsyncFileDialog::new()
-            .set_title("Create or select workspace")
+            .set_title("Choose existing project")
             .set_directory(initial_dir)
             .pick_folder()
             .await
@@ -231,7 +228,7 @@ fn on_start_select_workspace(
                     rfd::AsyncMessageDialog::new()
                         .set_title("Initialize Git repository?")
                         .set_description(
-                            "This workspace is not a Git repository. Initialize Git now?",
+                            "This project is not a Git repository. Initialize Git now?",
                         )
                         .set_buttons(rfd::MessageButtons::YesNo)
                         .show()
@@ -318,7 +315,6 @@ fn sync_live_start_pages(
         Without<crate::start::StartAgentTransitionView>,
     >,
     added_keyboard_targets: Query<(), Added<CefKeyboardTarget>>,
-    replacements: Query<&PendingTabReplacement>,
     browsers: NonSend<Browsers>,
     mut repo_info: Option<ResMut<vmux_git::RepoInfoCache>>,
     mut last_git: Local<(String, Option<vmux_git::worktree::RepoInfo>)>,
@@ -355,9 +351,6 @@ fn sync_live_start_pages(
     let targets: Vec<(Entity, bool)> = starts
         .iter()
         .filter_map(|(e, src, synced, keyboard_target)| {
-            if ancestor_replacement_tab(e, &tab_gather.child_of_q, &replacements).is_some() {
-                return None;
-            }
             let WebviewSource::Url(url) = src else {
                 return None;
             };
@@ -555,8 +548,6 @@ fn on_start_data_request(
     trigger: On<BinReceive<StartDataRequest>>,
     spares: Query<(), With<WarmStartSpare>>,
     keyboard_targets: Query<(), With<CefKeyboardTarget>>,
-    child_of: Query<&ChildOf>,
-    replacements: Query<&PendingTabReplacement>,
     tab_gather: TabGatherParams,
     prompt_context: StartPromptContextParams,
     spaces_snapshot: Res<CommandBarSpacesSnapshot>,
@@ -571,8 +562,6 @@ fn on_start_data_request(
     if is_spare {
         commands.entity(webview).insert(WarmStartReady);
     }
-    commands.entity(webview).insert(StartMountReady);
-    let replacement_tab = ancestor_replacement_tab(webview, &child_of, &replacements);
     let payload = build_start_payload(
         &tab_gather,
         &spaces_snapshot,
@@ -580,7 +569,7 @@ fn on_start_data_request(
         &pages_snapshot,
         &work_snapshot,
         &prompt_context,
-        replacement_tab.or_else(|| tab_gather.active_tab.get()),
+        tab_gather.active_tab.get(),
         None,
         &locale
             .as_deref()
@@ -592,7 +581,7 @@ fn on_start_data_request(
         COMMAND_BAR_OPEN_EVENT,
         &payload,
     ));
-    if keyboard_targets.contains(webview) && replacement_tab.is_none() {
+    if keyboard_targets.contains(webview) {
         commands.trigger(BinHostEmitEvent::from_rkyv(
             webview,
             START_FOCUS_INPUT_EVENT,
@@ -644,62 +633,6 @@ fn build_start_payload(
     );
     payload.prompt_context = prompt_context.context(active_tab, git_info);
     payload
-}
-
-fn ancestor_replacement_tab(
-    entity: Entity,
-    child_of: &Query<&ChildOf>,
-    replacements: &Query<&PendingTabReplacement>,
-) -> Option<Entity> {
-    let mut current = entity;
-    loop {
-        if replacements.contains(current) {
-            return Some(current);
-        }
-        current = child_of.get(current).ok()?.parent();
-    }
-}
-
-fn finish_ready_tab_replacements(
-    ready: Query<Entity, (With<StartMountReady>, Without<PendingWebviewReveal>)>,
-    child_of: Query<&ChildOf>,
-    replacements: Query<&PendingTabReplacement>,
-    mut focused: ResMut<crate::stack::FocusedStack>,
-    mut commands: Commands,
-) {
-    for webview in &ready {
-        let Some(tab) = ancestor_replacement_tab(webview, &child_of, &replacements) else {
-            continue;
-        };
-        let Ok(replacement) = replacements.get(tab) else {
-            continue;
-        };
-        let Some(stack) = child_of.get(webview).ok().map(ChildOf::parent) else {
-            continue;
-        };
-        let Some(pane) = child_of.get(stack).ok().map(ChildOf::parent) else {
-            continue;
-        };
-        commands.entity(replacement.old_tab).try_despawn();
-        commands
-            .entity(tab)
-            .insert((Active, LastActivatedAt::now()))
-            .remove::<PendingTabReplacement>();
-        commands
-            .entity(pane)
-            .insert((Active, LastActivatedAt::now()));
-        commands
-            .entity(stack)
-            .insert((Active, LastActivatedAt::now()));
-        focused.tab = Some(tab);
-        focused.pane = Some(pane);
-        focused.stack = Some(stack);
-        commands.trigger(BinHostEmitEvent::from_rkyv(
-            webview,
-            START_FOCUS_INPUT_EVENT,
-            &StartFocusInput,
-        ));
-    }
 }
 
 /// Despawn a stack's existing webview children before attaching new content.
@@ -823,56 +756,6 @@ mod tests {
 
         let emitted = &app.world().resource::<EmittedIds>().0;
         assert_eq!(emitted, &[COMMAND_BAR_OPEN_EVENT]);
-    }
-
-    #[test]
-    fn replacement_keeps_old_tab_until_start_mounts_then_switches_atomically() {
-        let mut app = App::new();
-        app.init_resource::<crate::stack::FocusedStack>()
-            .init_resource::<EmittedIds>()
-            .add_observer(capture_emit)
-            .add_systems(Update, finish_ready_tab_replacements);
-        let old_tab = app
-            .world_mut()
-            .spawn((Tab::default(), Active, LastActivatedAt(10)))
-            .id();
-        let new_tab = app
-            .world_mut()
-            .spawn((
-                Tab::default(),
-                PendingTabReplacement { old_tab },
-                LastActivatedAt(0),
-            ))
-            .id();
-        let split = app.world_mut().spawn(ChildOf(new_tab)).id();
-        let pane = app
-            .world_mut()
-            .spawn((LastActivatedAt(0), ChildOf(split)))
-            .id();
-        let stack = app
-            .world_mut()
-            .spawn((LastActivatedAt(0), ChildOf(pane)))
-            .id();
-        let webview = app.world_mut().spawn(ChildOf(stack)).id();
-
-        app.update();
-        assert!(app.world().get_entity(old_tab).is_ok());
-        assert!(app.world().get::<Active>(new_tab).is_none());
-
-        app.world_mut().entity_mut(webview).insert(StartMountReady);
-        app.update();
-
-        assert!(app.world().get_entity(old_tab).is_err());
-        assert!(app.world().get::<Active>(new_tab).is_some());
-        assert!(app.world().get::<PendingTabReplacement>(new_tab).is_none());
-        let focused = app.world().resource::<crate::stack::FocusedStack>();
-        assert_eq!(focused.tab, Some(new_tab));
-        assert_eq!(focused.pane, Some(pane));
-        assert_eq!(focused.stack, Some(stack));
-        assert_eq!(
-            app.world().resource::<EmittedIds>().0,
-            [START_FOCUS_INPUT_EVENT]
-        );
     }
 
     #[test]

--- a/crates/vmux_layout/src/tab.rs
+++ b/crates/vmux_layout/src/tab.rs
@@ -27,14 +27,6 @@ pub struct CloseTabRequest {
     pub tab: Entity,
 }
 
-#[derive(Component)]
-pub(crate) struct TabReplacementSource;
-
-#[derive(Component)]
-pub(crate) struct PendingTabReplacement {
-    pub old_tab: Entity,
-}
-
 impl Plugin for TabPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Tab>()
@@ -201,7 +193,6 @@ fn handle_tab_commands(
                     content,
                     clear_pending_stack: true,
                     focus: true,
-                    replaces: None,
                 });
             }
             AppCommand::Layout(LayoutCommand::Tab(tab_cmd)) => match tab_cmd {
@@ -225,7 +216,6 @@ fn handle_tab_commands(
                         content: TabLayoutSpawnContent::StartupUrlOrPrompt,
                         clear_pending_stack: true,
                         focus: true,
-                        replaces: None,
                     });
                 }
                 TabCommand::Next | TabCommand::Previous => {
@@ -938,7 +928,6 @@ mod tests {
                 content: crate::TabLayoutSpawnContent::StartupUrlOrPrompt,
                 clear_pending_stack: false,
                 focus: true,
-                replaces: None,
             });
 
         app.update();

--- a/crates/vmux_layout/src/window.rs
+++ b/crates/vmux_layout/src/window.rs
@@ -9,7 +9,7 @@ use crate::{
     settings::LayoutSettings,
     side_sheet::{SideSheet, SideSheetPosition, SideSheetWidth},
     stack::stack_bundle,
-    tab::{PendingTabReplacement, Tab, tab_bundle},
+    tab::{Tab, tab_bundle},
     unit::WindowExt,
 };
 use bevy::{
@@ -481,7 +481,6 @@ fn request_default_layout(
         content: TabLayoutSpawnContent::StartupUrlOrPrompt,
         clear_pending_stack: false,
         focus: true,
-        replaces: None,
     });
 }
 
@@ -591,12 +590,6 @@ pub fn spawn_requested_tab_layouts(
             commands.entity(leaf).insert(LastActivatedAt(0));
             commands.entity(stack).insert(LastActivatedAt(0));
         }
-        if let Some(old_tab) = request.replaces {
-            commands
-                .entity(tab_e)
-                .insert(PendingTabReplacement { old_tab });
-        }
-
         if request.clear_pending_stack
             && let Some(old_stack) = new_stack_ctx.stack.take()
         {
@@ -1408,7 +1401,6 @@ mod tests {
                 content: crate::TabLayoutSpawnContent::StartupUrlOrPrompt,
                 clear_pending_stack: false,
                 focus: true,
-                replaces: None,
             });
 
         app.update();
@@ -1448,7 +1440,6 @@ mod tests {
                 content: crate::TabLayoutSpawnContent::StartupUrlOrPrompt,
                 clear_pending_stack: false,
                 focus: true,
-                replaces: None,
             });
         app.world_mut()
             .entity_mut(requested_space)

--- a/crates/vmux_layout/src/worktree.rs
+++ b/crates/vmux_layout/src/worktree.rs
@@ -230,7 +230,7 @@ pub fn validate_linked_workspace(
         .map_err(|error| format!("invalid worktree directory: {error}"))?;
     let workspace_cwd = workspace_cwd
         .canonicalize()
-        .map_err(|error| format!("invalid workspace directory: {error}"))?;
+        .map_err(|error| format!("invalid project directory: {error}"))?;
     let checkout = worktree::checkout_info(&cwd).map_err(|error| error.0)?;
     let workspace = worktree::checkout_info(&workspace_cwd).map_err(|error| error.0)?;
     if checkout.common_dir != workspace.common_dir {
@@ -337,6 +337,7 @@ pub fn create_worktree_blocking(
         .canonicalize()
         .map_err(|error| format!("invalid project directory: {error}"))?;
     let checkout = worktree::checkout_info(&base_dir).map_err(|error| error.0)?;
+    worktree::ensure_initial_commit(&checkout.root).map_err(|error| error.0)?;
     let relative_dir = base_dir
         .strip_prefix(&checkout.root)
         .map_err(|_| "project directory is outside its checkout".to_string())?;
@@ -364,6 +365,7 @@ pub fn create_worktree_for_branch_blocking(
         .map_err(|error| format!("invalid project directory: {error}"))?;
     let checkout = worktree::checkout_info(&base_dir).map_err(|error| error.0)?;
     worktree::validate_branch_name(&checkout.root, branch).map_err(|error| error.0)?;
+    worktree::ensure_initial_commit(&checkout.root).map_err(|error| error.0)?;
     if let Some(registration) = worktree::worktree_registrations(&checkout.root)
         .map_err(|error| error.0)?
         .into_iter()
@@ -932,6 +934,30 @@ mod tests {
             worktree::head_ref(&activation.execution_dir).unwrap(),
             "vmux/fix-dashboard-tests"
         );
+    }
+
+    #[test]
+    fn create_worktree_for_branch_initializes_unborn_repository() {
+        let repo = tempfile::tempdir().unwrap();
+        git(repo.path(), &["init", "-q", "-b", "main"]);
+        git(repo.path(), &["config", "user.email", "t@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test"]);
+        git(repo.path(), &["config", "commit.gpgsign", "false"]);
+        let managed_root = tempfile::tempdir().unwrap();
+
+        let activation = create_worktree_for_branch_blocking(
+            repo.path(),
+            "feat/izakaya-website",
+            managed_root.path(),
+        )
+        .unwrap();
+
+        assert_eq!(activation.metadata.base_ref, "main");
+        assert_eq!(
+            worktree::head_ref(&activation.execution_dir).unwrap(),
+            "feat/izakaya-website"
+        );
+        assert_eq!(worktree::head_ref(repo.path()).unwrap(), "main");
     }
 
     #[test]

--- a/crates/vmux_mcp/Cargo.toml
+++ b/crates/vmux_mcp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vmux_mcp"
 version.workspace = true
 edition.workspace = true
-description = "MCP stdio server for Vmux workspace controls"
+description = "MCP stdio server for Vmux project controls"
 publish = false
 
 [lib]

--- a/crates/vmux_mcp/src/tools.rs
+++ b/crates/vmux_mcp/src/tools.rs
@@ -444,7 +444,7 @@ is typed into an interactive shell, so the terminal stays usable afterwards."
 fn create_worktree_definition() -> ToolDefinition {
     ToolDefinition {
         name: "create_worktree".into(),
-        description: "Call immediately before the first edit, write, test, build, or other project mutation, after a Git workspace is selected. vmux reuses the current linked worktree, accepts a known existing worktree path, automatically uses a single unambiguous existing worktree, or creates a managed worktree when none exists. If multiple existing worktrees are returned as ambiguous, ask the user with request_user_choice to choose an existing path or Create new worktree; call again with path or create=true. Never run git worktree add manually. Returns the absolute worktree path."
+        description: "Call immediately before the first edit, write, test, build, or other project mutation, after a Git project is selected. Never call for requests that only read, show, search, or explain existing files. vmux reuses the current linked worktree, accepts a known existing worktree path, automatically uses a single unambiguous existing worktree, or creates a managed worktree when none exists. If multiple existing worktrees are returned as ambiguous, ask the user with request_user_choice to choose an existing path or Create new worktree; call again with path or create=true. Never run git worktree add manually. Returns the absolute worktree path."
             .into(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -459,10 +459,10 @@ fn create_worktree_definition() -> ToolDefinition {
     }
 }
 
-fn select_workspace_definition() -> ToolDefinition {
+fn select_project_definition() -> ToolDefinition {
     ToolDefinition {
-        name: "select_workspace".into(),
-        description: "Start the Create or select workspace flow. Pass path when the conversation already identifies a valid local directory; otherwise vmux opens the native folder picker immediately after approval. Any directory can be a workspace. vmux treats it as Git only when the selected directory contains .git; otherwise vmux asks whether to initialize a Git repository. A non-Git workspace remains usable when the user declines. For a Git workspace, call create_worktree immediately before the first mutation. The request returns immediately when user selection is needed: stop the current turn and do not call again while pending. Do not search the user's home directory for workspaces. Do not call for general questions or self-contained terminal demonstrations."
+        name: "select_project".into(),
+        description: "Select an existing project before the first edit, write, test, build, or other project mutation. Never call for requests that only read, show, search, or explain existing files. Pass a known path or omit it to open the native project picker rooted at ~/.vmux/workspace. For a new project, first use request_user_choice to offer a concrete suggested location and Choose existing project; do not ask the user to invent a folder. Use ~/.vmux/workspace/<remote-host>/<organization>/<repository> when a remote is known and ~/.vmux/workspace/local/<project> otherwise. When creation is selected, use run only to create the empty directory, then call this tool with that path. vmux offers Git initialization and uses that new project root directly without a linked worktree. For a previously existing Git project, call create_worktree immediately before the first mutation. The request returns immediately when user selection is needed: stop the current turn and do not call again while pending. Do not search the user's home directory. Do not call for general questions or self-contained terminal demonstrations."
             .into(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -477,7 +477,7 @@ fn select_workspace_definition() -> ToolDefinition {
 fn request_user_choice_definition() -> ToolDefinition {
     ToolDefinition {
         name: "request_user_choice".into(),
-        description: "Show a native multiple-choice question in the agent conversation. When the user asks for options, alternatives, or things to choose or play with, use this instead of returning a plain Markdown list. Also use it for ambiguous worktree selection and other short user decisions. Keep options concise and actionable. The user can choose with arrow keys, Ctrl+N/Ctrl+P, number keys, mouse, or Enter. The request returns immediately: stop the current turn; vmux resumes the same conversation with the selected option."
+        description: "Show a native multiple-choice question in the agent conversation. For a new project without a selected project, use it to offer the concrete suggested ~/.vmux/workspace path or Choose existing project. Also use it for other user-requested options and ambiguous worktree selection. Keep options concise and actionable. The user can choose with arrow keys, Ctrl+N/Ctrl+P, number keys, mouse, or Enter. The request returns immediately: stop the current turn; vmux resumes the same conversation with the selected option."
             .into(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -499,7 +499,7 @@ fn request_user_choice_definition() -> ToolDefinition {
 fn set_conversation_title_definition() -> ToolDefinition {
     ToolDefinition {
         name: "set_conversation_title".into(),
-        description: "Set the agent conversation header to a concise model-written summary. Call as the first tool after every user message, before skills or other tools. Summarize the whole conversation in 3 to 7 words, correct spelling and grammar, and never copy the user's prompt verbatim."
+        description: "Set the agent conversation header to a concise model-written summary without asking permission. Always call first after the first user message to replace the provisional raw-prompt title. On later messages, call first only when the topic materially changes. Use 3 to 7 words, correct spelling and grammar, and never copy the user's prompt verbatim."
             .into(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -511,6 +511,24 @@ fn set_conversation_title_definition() -> ToolDefinition {
                     "minLength": 1,
                     "maxLength": 120
                 }
+            }
+        }),
+    }
+}
+
+fn write_knowledge_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "write_knowledge".into(),
+        description: "Create or replace a Markdown note in the user's vmux Knowledge base, then open it beside the conversation. Use this when the user asks to save, copy, or organize information in Knowledge. Provide a relative path under skills/, memories/, projects/, meetings/, or handbook/; omit path to create projects/<title-slug>.md. Never write directly to ~/.vmux/knowledge with shell commands."
+            .into(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "required": ["title", "content"],
+            "additionalProperties": false,
+            "properties": {
+                "path": {"type": "string"},
+                "title": {"type": "string"},
+                "content": {"type": "string"}
             }
         }),
     }
@@ -778,7 +796,8 @@ pub fn tool_definitions_filtered(acp_session: bool, acp_terminals: bool) -> Vec<
     }
     defs.push(request_user_choice_definition());
     defs.push(set_conversation_title_definition());
-    defs.push(select_workspace_definition());
+    defs.push(write_knowledge_definition());
+    defs.push(select_project_definition());
     defs.push(create_worktree_definition());
     if !acp_terminals {
         defs.push(read_terminal_definition());
@@ -1032,9 +1051,40 @@ pub fn dispatch_with_anchor(
             },
         ));
     }
-    if name == "select_workspace" || name == "choose_workspace" {
+    if name == "write_knowledge" {
         let anchor = anchor
-            .ok_or("select_workspace requires an agent anchor (not available to this client)")?;
+            .ok_or("write_knowledge requires an agent anchor (not available to this client)")?;
+        let path = arguments
+            .get("path")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+            .map(str::to_string);
+        let title = arguments
+            .get("title")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|title| !title.is_empty())
+            .ok_or("write_knowledge.title is empty")?;
+        let content = arguments
+            .get("content")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|content| !content.is_empty())
+            .ok_or("write_knowledge.content is empty")?;
+        return Ok(DispatchTarget::Command(AgentCommand::WriteKnowledge {
+            anchor,
+            path,
+            title: title.to_string(),
+            content: content.to_string(),
+        }));
+    }
+    if matches!(
+        name,
+        "select_project" | "select_workspace" | "choose_workspace"
+    ) {
+        let anchor = anchor
+            .ok_or("select_project requires an agent anchor (not available to this client)")?;
         if let Some(path) = arguments
             .get("path")
             .and_then(Value::as_str)
@@ -1495,7 +1545,8 @@ mod tests {
             "read_terminal",
             "request_user_choice",
             "set_conversation_title",
-            "select_workspace",
+            "write_knowledge",
+            "select_project",
             "create_worktree",
         ] {
             assert!(
@@ -1503,7 +1554,12 @@ mod tests {
                 "missing hand-written {hand}"
             );
         }
-        for removed_tool in ["new_terminal_tab", "run_shell", "in_pane"] {
+        for removed_tool in [
+            "new_terminal_tab",
+            "run_shell",
+            "in_pane",
+            "select_workspace",
+        ] {
             assert!(
                 !names.contains(&removed_tool.to_string()),
                 "superseded tool {removed_tool} should no longer appear in MCP tools"
@@ -1693,10 +1749,49 @@ mod tests {
     }
 
     #[test]
-    fn workspace_tools_dispatch_with_anchor_and_branch() {
+    fn knowledge_write_dispatches_validated_note_to_host() {
         let anchor = vmux_service::protocol::ProcessId::new();
-        let select_definition = select_workspace_definition();
+        let target = dispatch_with_anchor(
+            "write_knowledge",
+            serde_json::json!({
+                "path": "projects/yc.md",
+                "title": "YC Startup School",
+                "content": "Notes"
+            }),
+            Some(anchor),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            target,
+            DispatchTarget::Command(AgentCommand::WriteKnowledge {
+                anchor: got,
+                path: Some(path),
+                title,
+                content,
+            }) if got == anchor
+                && path == "projects/yc.md"
+                && title == "YC Startup School"
+                && content == "Notes"
+        ));
+    }
+
+    #[test]
+    fn project_tools_dispatch_with_anchor_and_branch() {
+        let anchor = vmux_service::protocol::ProcessId::new();
+        let worktree_definition = create_worktree_definition();
+        let select_definition = select_project_definition();
         let choice_definition = request_user_choice_definition();
+        assert!(
+            worktree_definition
+                .description
+                .contains("Never call for requests that only read")
+        );
+        assert!(
+            select_definition
+                .description
+                .contains("Never call for requests that only read")
+        );
         assert!(
             select_definition
                 .description
@@ -1707,19 +1802,38 @@ mod tests {
                 .description
                 .contains("Do not search the user's home directory")
         );
-        assert!(select_definition.description.contains("Any directory"));
-        assert!(select_definition.description.contains("folder picker"));
-        assert!(select_definition.description.contains("contains .git"));
+        assert!(
+            select_definition
+                .description
+                .contains("native project picker")
+        );
+        assert!(
+            select_definition
+                .description
+                .contains("~/.vmux/workspace/<remote-host>")
+        );
+        assert!(
+            select_definition
+                .description
+                .contains("~/.vmux/workspace/local/<project>")
+        );
+        assert!(select_definition.description.contains("empty directory"));
+        assert!(
+            select_definition
+                .description
+                .contains("without a linked worktree")
+        );
         assert!(
             select_definition
                 .description
                 .contains("returns immediately")
         );
+        assert!(choice_definition.description.contains("~/.vmux/workspace"));
         assert!(choice_definition.description.contains("Ctrl+N/Ctrl+P"));
         let choose =
-            dispatch_with_anchor("select_workspace", serde_json::json!({}), Some(anchor)).unwrap();
+            dispatch_with_anchor("select_project", serde_json::json!({}), Some(anchor)).unwrap();
         let choose_path = dispatch_with_anchor(
-            "select_workspace",
+            "select_project",
             serde_json::json!({"path": "/repo"}),
             Some(anchor),
         )

--- a/crates/vmux_profile/src/lib.rs
+++ b/crates/vmux_profile/src/lib.rs
@@ -116,6 +116,11 @@ pub fn config_dir() -> PathBuf {
     home.join(".vmux")
 }
 
+/// Default root for repositories and local projects managed through vmux.
+pub fn workspace_dir() -> PathBuf {
+    config_dir().join("workspace")
+}
+
 /// Default output directory for screenshots and screen recordings:
 /// `~/.vmux/profiles/<profile>/recording`. Overridable via the
 /// `recording.output_dir` setting.

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -686,7 +686,7 @@ pub async fn run(
                         RequestPermissionOutcome::Cancelled,
                     ));
                 };
-                if is_conversation_title_tool(&name) {
+                if is_permissionless_host_tool(&name) {
                     let outcome =
                         match pick_permission_option(&req.options, ApprovalDecision::Allow) {
                             Some(id) => RequestPermissionOutcome::Selected(
@@ -1168,7 +1168,7 @@ watch and take over. Use mcp__vmux__read_terminal to inspect continued output. O
 argument because it targets your own terminal pane. Do ALL web access via the vmux browser tools. \
 If you invoke a required Skill tool, continue the original user request in the same turn after \
 the skill loads. Never end the turn after skill activation or answer only Ready.";
-const CONVERSATION_TITLE_STEER_PROMPT: &str = "Call mcp__vmux__set_conversation_title as the first tool of the turn only when the conversation has no title yet or the latest user message materially changes the conversation's topic. If the current title still accurately summarizes the conversation, do not call the tool. When a title is needed, call it before reading skills, calling any other tool, or answering. Write a concise 3 to 7 word model-generated summary of the whole conversation. Correct spelling and grammar. Never copy the user's prompt verbatim.";
+const CONVERSATION_TITLE_STEER_PROMPT: &str = "On the first user message, always call mcp__vmux__set_conversation_title as the first tool of the turn. The host immediately shows the raw first prompt as a provisional title; replace it with a concise 3 to 7 word summary with corrected spelling and grammar. On later user messages, call the tool only when the conversation topic materially changes; keep the current title for same-topic follow-ups. When needed, call it before reading skills, calling any other tool, or answering. Never copy the user's prompt verbatim. This tool never needs user permission.";
 
 fn session_meta_for_agent(agent_id: &str) -> Option<serde_json::Map<String, serde_json::Value>> {
     if let Err(error) = vmux_core::knowledge::sync_external_agent_configs() {
@@ -1214,6 +1214,9 @@ fn session_meta_for_agent_with_knowledge(
                 "disallowedTools": ["Bash", "Monitor", "WebSearch", "WebFetch"],
                 "allowedTools": [
                     "mcp__vmux__set_conversation_title",
+                    "mcp__vmux__request_user_choice",
+                    "mcp__vmux__select_workspace",
+                    "mcp__vmux__create_worktree",
                     "mcp__vmux__run",
                     "mcp__vmux__read_terminal",
                     "mcp__vmux__browser_navigate",
@@ -1475,6 +1478,41 @@ fn pick_permission_option(
         .iter()
         .find_map(|kind| options.iter().find(|option| &option.kind == kind))
         .map(|option| option.option_id.clone())
+}
+
+fn is_permissionless_host_tool(name: &str) -> bool {
+    if is_conversation_title_tool(name) {
+        return true;
+    }
+    let parts = name
+        .trim()
+        .to_ascii_lowercase()
+        .split(|character: char| {
+            character.is_ascii_whitespace() || matches!(character, '-' | '.' | ':' | '_')
+        })
+        .filter(|part| !part.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    matches!(
+        parts.as_slice(),
+        [mcp, vmux, request, user, choice]
+            if mcp == "mcp"
+                && vmux == "vmux"
+                && request == "request"
+                && user == "user"
+                && choice == "choice"
+    ) || matches!(
+        parts.as_slice(),
+        [vmux, request, user, choice]
+            if vmux == "vmux"
+                && request == "request"
+                && user == "user"
+                && choice == "choice"
+    ) || matches!(
+        parts.as_slice(),
+        [request, user, choice]
+            if request == "request" && user == "user" && choice == "choice"
+    )
 }
 
 /// Resolve an ACP fs path against the session cwd, rejecting traversal and anything outside
@@ -2195,6 +2233,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn conversation_title_permission_resolves_as_host_owned_tool() {
+        let (stream_tx, _) = broadcast::channel(2);
+        let shared = AcpShared::new(
+            "s1".into(),
+            PathBuf::from("/tmp"),
+            ProcessId::new(),
+            stream_tx,
+            Arc::new(tokio::sync::Mutex::new(ProcessManager::default())),
+            Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        );
+        project_session_update(
+            &shared,
+            SessionUpdate::ToolCall(
+                ToolCall::new("title-1", "mcp__vmux__set_conversation_title")
+                    .raw_input(serde_json::json!({"title": "Paris Izakaya Website"})),
+            ),
+        );
+        let request = RequestPermissionRequest::new(
+            "session-1",
+            agent_client_protocol::schema::v1::ToolCallUpdate::new(
+                "title-1",
+                ToolCallUpdateFields::new()
+                    .kind(ToolKind::Execute)
+                    .raw_input(serde_json::json!({"title": "Paris Izakaya Website"})),
+            ),
+            Vec::new(),
+        );
+
+        let (name, _) = resolve_approval_details(&request, &shared).await.unwrap();
+        assert!(is_conversation_title_tool(&name));
+    }
+
+    #[test]
+    fn native_choice_tool_is_always_permissionless() {
+        for name in [
+            "mcp__vmux__request_user_choice",
+            "mcp.vmux.request_user_choice",
+            "vmux:request-user-choice",
+            "request_user_choice",
+        ] {
+            assert!(is_permissionless_host_tool(name), "{name}");
+        }
+        assert!(!is_permissionless_host_tool("other_request_user_choice"));
+    }
+
+    #[tokio::test]
     async fn requested_resume_loads_only_when_supported() {
         let calls = std::sync::atomic::AtomicUsize::new(0);
         let loaded = load_requested_session(Some("resume-1".into()), true, |sid| {
@@ -2322,10 +2406,12 @@ mod tests {
         assert!(generic.starts_with("skill context\n\n"));
         assert!(generic.contains("mcp__vmux__set_conversation_title"));
         assert!(generic.contains("first tool of the turn"));
-        assert!(generic.contains("materially changes the conversation's topic"));
-        assert!(generic.contains("do not call the tool"));
-        assert!(generic.contains("Correct spelling and grammar"));
+        assert!(generic.contains("raw first prompt as a provisional title"));
+        assert!(generic.contains("topic materially changes"));
+        assert!(generic.contains("same-topic follow-ups"));
+        assert!(generic.contains("corrected spelling and grammar"));
         assert!(generic.contains("Never copy the user's prompt verbatim"));
+        assert!(generic.contains("never needs user permission"));
     }
 
     #[test]

--- a/crates/vmux_service/src/acp/projector.rs
+++ b/crates/vmux_service/src/acp/projector.rs
@@ -179,6 +179,7 @@ fn project_file_touches(
 pub struct AcpProjector {
     messages: Vec<Message>,
     hidden_tool_calls: HashSet<String>,
+    hidden_tool_details: HashMap<String, (String, String)>,
     file_touches: HashMap<String, FileTouchState>,
     file_touch_order: VecDeque<String>,
     finalized_file_touches: HashSet<String>,
@@ -197,6 +198,9 @@ impl AcpProjector {
 
     /// Returns the projected title and raw input for a tool call.
     pub fn tool_call_details(&self, call_id: &str) -> Option<(String, String)> {
+        if let Some(details) = self.hidden_tool_details.get(call_id) {
+            return Some(details.clone());
+        }
         self.messages.iter().find_map(|message| {
             let Message::Assistant { blocks } = message else {
                 return None;
@@ -405,7 +409,9 @@ impl AcpProjector {
                 tc.status,
                 ToolCallStatus::Completed | ToolCallStatus::Failed
             ) {
-                self.hidden_tool_calls.insert(call_id);
+                self.hidden_tool_calls.insert(call_id.clone());
+                self.hidden_tool_details
+                    .insert(call_id, (tc.title, raw_input_json(tc.raw_input.as_ref())));
             }
             return Vec::new();
         }
@@ -471,8 +477,19 @@ impl AcpProjector {
                 Some(ToolCallStatus::Completed | ToolCallStatus::Failed)
             ) {
                 self.hidden_tool_calls.remove(&call_id);
+                self.hidden_tool_details.remove(&call_id);
             } else {
-                self.hidden_tool_calls.insert(call_id);
+                self.hidden_tool_calls.insert(call_id.clone());
+                let details = self
+                    .hidden_tool_details
+                    .entry(call_id)
+                    .or_insert_with(|| (String::new(), "{}".to_string()));
+                if !title.is_empty() {
+                    details.0 = title;
+                }
+                if let Some(raw_input) = update.fields.raw_input.as_ref() {
+                    details.1 = raw_input.to_string();
+                }
             }
             return Vec::new();
         }
@@ -1362,10 +1379,17 @@ mod tests {
     #[test]
     fn conversation_title_tool_stays_out_of_transcript() {
         let mut p = AcpProjector::new();
-        let started = p.apply(SessionUpdate::ToolCall(ToolCall::new(
-            "title-1",
-            "mcp__vmux__set_conversation_title",
-        )));
+        let started = p.apply(SessionUpdate::ToolCall(
+            ToolCall::new("title-1", "mcp__vmux__set_conversation_title")
+                .raw_input(serde_json::json!({"title": "Paris Izakaya Website"})),
+        ));
+        assert_eq!(
+            p.tool_call_details("title-1"),
+            Some((
+                "mcp__vmux__set_conversation_title".to_string(),
+                r#"{"title":"Paris Izakaya Website"}"#.to_string(),
+            ))
+        );
         let completed = p.apply(SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
             "title-1",
             ToolCallUpdateFields::new().status(ToolCallStatus::Completed),

--- a/crates/vmux_space/src/plugin.rs
+++ b/crates/vmux_space/src/plugin.rs
@@ -548,7 +548,6 @@ fn on_space_command(
                 content: TabLayoutSpawnContent::Url(SPACES_PAGE_URL.to_string()),
                 clear_pending_stack: true,
                 focus: true,
-                replaces: None,
             });
         }
         _ => {}
@@ -624,7 +623,6 @@ fn handle_open_in_new_space(
             content,
             clear_pending_stack: true,
             focus: true,
-            replaces: None,
         });
     }
 }

--- a/crates/vmux_ui/locales/af.ftl
+++ b/crates/vmux_ui/locales/af.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Boekmerk
 menu-edit = Wysig
 
 layout-knowledge = Kennis
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Maak Kennis oop
 layout-open-welcome-knowledge = Maak Welkom by Kennis oop
 layout-open-path = Maak { $path } oop
@@ -435,6 +437,7 @@ agent-loading-media = Laai media…
 agent-no-matching-media = Geen ooreenstemmende media nie
 agent-prompt-context = Opdragkonteks
 agent-details = Besonderhede
+agent-copy = Copy
 agent-path = Pad
 agent-tool = Nutsding
 agent-server = Bediener

--- a/crates/vmux_ui/locales/am.ftl
+++ b/crates/vmux_ui/locales/am.ftl
@@ -279,6 +279,8 @@ menu-bookmark = ዕልባት
 menu-edit = አርትዕ
 
 layout-knowledge = ዕውቀት
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = ዕውቀትን ክፈት
 layout-open-welcome-knowledge = የዕውቀት እንኳን ደህና መጡን ክፈት
 layout-open-path = { $path } ክፈት
@@ -435,6 +437,7 @@ agent-loading-media = ሚዲያ በመጫን ላይ…
 agent-no-matching-media = የሚዛመድ ሚዲያ የለም
 agent-prompt-context = የፕሮምፕት አውድ
 agent-details = ዝርዝሮች
+agent-copy = Copy
 agent-path = ዱካ
 agent-tool = መሳሪያ
 agent-server = አገልጋይ

--- a/crates/vmux_ui/locales/ar.ftl
+++ b/crates/vmux_ui/locales/ar.ftl
@@ -279,6 +279,8 @@ menu-bookmark = الإشارة المرجعية
 menu-edit = تحرير
 
 layout-knowledge = المعرفة
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = فتح المعرفة
 layout-open-welcome-knowledge = فتح مرحبًا بك في المعرفة
 layout-open-path = فتح { $path }
@@ -435,6 +437,7 @@ agent-loading-media = جارٍ تحميل الوسائط…
 agent-no-matching-media = لا توجد وسائط مطابقة
 agent-prompt-context = سياق المطالبة
 agent-details = التفاصيل
+agent-copy = Copy
 agent-path = المسار
 agent-tool = الأداة
 agent-server = الخادم

--- a/crates/vmux_ui/locales/az.ftl
+++ b/crates/vmux_ui/locales/az.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Əlfəcin
 menu-edit = Redaktə
 
 layout-knowledge = Bilik
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Biliyi aç
 layout-open-welcome-knowledge = Biliyə xoş gəlmisiniz səhifəsini aç
 layout-open-path = { $path } aç
@@ -435,6 +437,7 @@ agent-loading-media = Media yüklənir…
 agent-no-matching-media = Uyğun media yoxdur
 agent-prompt-context = Prompt konteksti
 agent-details = Təfərrüatlar
+agent-copy = Copy
 agent-path = Yol
 agent-tool = Alət
 agent-server = Server

--- a/crates/vmux_ui/locales/be.ftl
+++ b/crates/vmux_ui/locales/be.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Закладка
 menu-edit = Рэдагаванне
 
 layout-knowledge = Веды
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Адкрыць Веды
 layout-open-welcome-knowledge = Адкрыць «Вітаем у Ведах»
 layout-open-path = Адкрыць { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Загрузка медыя…
 agent-no-matching-media = Няма адпаведных медыя
 agent-prompt-context = Кантэкст запыту
 agent-details = Падрабязнасці
+agent-copy = Copy
 agent-path = Шлях
 agent-tool = Інструмент
 agent-server = Сервер

--- a/crates/vmux_ui/locales/bg.ftl
+++ b/crates/vmux_ui/locales/bg.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Отметка
 menu-edit = Редактиране
 
 layout-knowledge = Знания
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Отвори Знания
 layout-open-welcome-knowledge = Отвори „Добре дошли в Знания“
 layout-open-path = Отвори { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Зареждане на мултимедия…
 agent-no-matching-media = Няма съвпадаща мултимедия
 agent-prompt-context = Контекст на подканата
 agent-details = Подробности
+agent-copy = Copy
 agent-path = Път
 agent-tool = Инструмент
 agent-server = Сървър

--- a/crates/vmux_ui/locales/bn.ftl
+++ b/crates/vmux_ui/locales/bn.ftl
@@ -279,6 +279,8 @@ menu-bookmark = বুকমার্ক
 menu-edit = সম্পাদনা
 
 layout-knowledge = জ্ঞান
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = জ্ঞান খুলুন
 layout-open-welcome-knowledge = জ্ঞানে স্বাগতম খুলুন
 layout-open-path = { $path } খুলুন
@@ -435,6 +437,7 @@ agent-loading-media = মিডিয়া লোড হচ্ছে…
 agent-no-matching-media = মিল থাকা কোনো মিডিয়া নেই
 agent-prompt-context = প্রম্পট কনটেক্সট
 agent-details = বিবরণ
+agent-copy = Copy
 agent-path = পাথ
 agent-tool = টুল
 agent-server = সার্ভার

--- a/crates/vmux_ui/locales/bs.ftl
+++ b/crates/vmux_ui/locales/bs.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Oznaka
 menu-edit = Uredi
 
 layout-knowledge = Znanje
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Otvori Znanje
 layout-open-welcome-knowledge = Otvori Dobrodošlicu u Znanje
 layout-open-path = Otvori { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Učitavanje medija…
 agent-no-matching-media = Nema odgovarajućih medija
 agent-prompt-context = Kontekst upita
 agent-details = Detalji
+agent-copy = Copy
 agent-path = Putanja
 agent-tool = Alat
 agent-server = Server

--- a/crates/vmux_ui/locales/ca.ftl
+++ b/crates/vmux_ui/locales/ca.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Marcador
 menu-edit = Edició
 
 layout-knowledge = Coneixement
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Obre Coneixement
 layout-open-welcome-knowledge = Obre Benvinguda al coneixement
 layout-open-path = Obre { $path }
@@ -435,6 +437,7 @@ agent-loading-media = S’estan carregant els mitjans…
 agent-no-matching-media = No hi ha cap mitjà coincident
 agent-prompt-context = Context del prompt
 agent-details = Detalls
+agent-copy = Copy
 agent-path = Camí
 agent-tool = Eina
 agent-server = Servidor

--- a/crates/vmux_ui/locales/ceb.ftl
+++ b/crates/vmux_ui/locales/ceb.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Bookmark
 menu-edit = Edit
 
 layout-knowledge = Kahibalo
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Ablihi ang Kahibalo
 layout-open-welcome-knowledge = Ablihi ang Welcome to Knowledge
 layout-open-path = Ablihi ang { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Nag-load sa media…
 agent-no-matching-media = Walay parehas nga media
 agent-prompt-context = Context sa prompt
 agent-details = Mga detalye
+agent-copy = Copy
 agent-path = Path
 agent-tool = Tool
 agent-server = Server

--- a/crates/vmux_ui/locales/co.ftl
+++ b/crates/vmux_ui/locales/co.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Segnalibru
 menu-edit = Mudificà
 
 layout-knowledge = Cunniscenza
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Apre Cunniscenza
 layout-open-welcome-knowledge = Apre Benvenutu in Cunniscenza
 layout-open-path = Apre { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Caricamentu di i media…
 agent-no-matching-media = Nisun media currispundente
 agent-prompt-context = Cuntestu di a richiesta
 agent-details = Detagli
+agent-copy = Copy
 agent-path = Percorsu
 agent-tool = Strumentu
 agent-server = Servitore

--- a/crates/vmux_ui/locales/cs.ftl
+++ b/crates/vmux_ui/locales/cs.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Záložka
 menu-edit = Úpravy
 
 layout-knowledge = Znalosti
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Otevřít znalosti
 layout-open-welcome-knowledge = Otevřít Vítejte ve znalostech
 layout-open-path = Otevřít { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Načítání médií…
 agent-no-matching-media = Žádná odpovídající média
 agent-prompt-context = Kontext výzvy
 agent-details = Podrobnosti
+agent-copy = Copy
 agent-path = Cesta
 agent-tool = Nástroj
 agent-server = Server

--- a/crates/vmux_ui/locales/cy.ftl
+++ b/crates/vmux_ui/locales/cy.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Nod Tudalen
 menu-edit = Golygu
 
 layout-knowledge = Gwybodaeth
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Agor Gwybodaeth
 layout-open-welcome-knowledge = Agor Croeso i Wybodaeth
 layout-open-path = Agor { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Yn llwytho cyfryngau…
 agent-no-matching-media = Dim cyfryngau sy’n cyfateb
 agent-prompt-context = Cyd-destun anogiad
 agent-details = Manylion
+agent-copy = Copy
 agent-path = Llwybr
 agent-tool = Offeryn
 agent-server = Gweinydd

--- a/crates/vmux_ui/locales/da.ftl
+++ b/crates/vmux_ui/locales/da.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Bogmærke
 menu-edit = Rediger
 
 layout-knowledge = Viden
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Åbn Viden
 layout-open-welcome-knowledge = Åbn Velkommen til Viden
 layout-open-path = Åbn { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Indlæser medier…
 agent-no-matching-media = Ingen matchende medier
 agent-prompt-context = Promptkontekst
 agent-details = Detaljer
+agent-copy = Copy
 agent-path = Sti
 agent-tool = Værktøj
 agent-server = Server

--- a/crates/vmux_ui/locales/de.ftl
+++ b/crates/vmux_ui/locales/de.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Lesezeichen
 menu-edit = Bearbeiten
 
 layout-knowledge = Wissen
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Wissen öffnen
 layout-open-welcome-knowledge = Willkommen im Wissen öffnen
 layout-open-path = { $path } öffnen
@@ -435,6 +437,7 @@ agent-loading-media = Medien werden geladen…
 agent-no-matching-media = Keine passenden Medien
 agent-prompt-context = Prompt-Kontext
 agent-details = Details
+agent-copy = Copy
 agent-path = Pfad
 agent-tool = Tool
 agent-server = Server

--- a/crates/vmux_ui/locales/el.ftl
+++ b/crates/vmux_ui/locales/el.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Σελιδοδείκτης
 menu-edit = Επεξεργασία
 
 layout-knowledge = Γνώση
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Άνοιγμα Γνώσης
 layout-open-welcome-knowledge = Άνοιγμα Καλωσορίσματος στη Γνώση
 layout-open-path = Άνοιγμα { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Φόρτωση πολυμέσων…
 agent-no-matching-media = Δεν υπάρχουν αντίστοιχα πολυμέσα
 agent-prompt-context = Περιεχόμενο προτροπής
 agent-details = Λεπτομέρειες
+agent-copy = Copy
 agent-path = Διαδρομή
 agent-tool = Εργαλείο
 agent-server = Διακομιστής

--- a/crates/vmux_ui/locales/en-US.ftl
+++ b/crates/vmux_ui/locales/en-US.ftl
@@ -380,6 +380,8 @@ menu-edit = Edit
 menu-close-vmux = Close Vmux
 
 layout-knowledge = Knowledge
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Open Knowledge
 layout-open-welcome-knowledge = Open Welcome to Knowledge
 layout-open-path = Open { $path }
@@ -444,6 +446,7 @@ agent-loading-media = Loading media…
 agent-no-matching-media = No matching media
 agent-prompt-context = Prompt context
 agent-details = Details
+agent-copy = Copy
 agent-path = Path
 agent-tool = Tool
 agent-server = Server

--- a/crates/vmux_ui/locales/eo.ftl
+++ b/crates/vmux_ui/locales/eo.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Legosigno
 menu-edit = Redakto
 
 layout-knowledge = Scioj
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Malfermi Sciojn
 layout-open-welcome-knowledge = Malfermi Bonvenon al Scioj
 layout-open-path = Malfermi { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Ŝargante aŭdvidaĵojn…
 agent-no-matching-media = Neniuj kongruaj aŭdvidaĵoj
 agent-prompt-context = Invita kunteksto
 agent-details = Detaloj
+agent-copy = Copy
 agent-path = Vojo
 agent-tool = Ilo
 agent-server = Servilo

--- a/crates/vmux_ui/locales/es.ftl
+++ b/crates/vmux_ui/locales/es.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Marcador
 menu-edit = Edición
 
 layout-knowledge = Conocimiento
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Abrir Conocimiento
 layout-open-welcome-knowledge = Abrir Bienvenida a Conocimiento
 layout-open-path = Abrir { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Cargando contenido multimedia…
 agent-no-matching-media = No hay contenido multimedia coincidente
 agent-prompt-context = Contexto de la instrucción
 agent-details = Detalles
+agent-copy = Copy
 agent-path = Ruta
 agent-tool = Herramienta
 agent-server = Servidor

--- a/crates/vmux_ui/locales/et.ftl
+++ b/crates/vmux_ui/locales/et.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Järjehoidja
 menu-edit = Redigeerimine
 
 layout-knowledge = Teadmised
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Ava teadmised
 layout-open-welcome-knowledge = Ava „Tere tulemast teadmistesse“
 layout-open-path = Ava { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Meedia laadimine…
 agent-no-matching-media = Sobivat meediat pole
 agent-prompt-context = Viiba kontekst
 agent-details = Üksikasjad
+agent-copy = Copy
 agent-path = Tee
 agent-tool = Tööriist
 agent-server = Server

--- a/crates/vmux_ui/locales/eu.ftl
+++ b/crates/vmux_ui/locales/eu.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Laster-marka
 menu-edit = Editatu
 
 layout-knowledge = Ezagutza
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Ireki Ezagutza
 layout-open-welcome-knowledge = Ireki Ongi etorri Ezagutzara
 layout-open-path = Ireki { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Media kargatzen…
 agent-no-matching-media = Ez dago bat datorren mediarik
 agent-prompt-context = Promptaren testuingurua
 agent-details = Xehetasunak
+agent-copy = Copy
 agent-path = Bidea
 agent-tool = Tresna
 agent-server = Zerbitzaria

--- a/crates/vmux_ui/locales/fa.ftl
+++ b/crates/vmux_ui/locales/fa.ftl
@@ -279,6 +279,8 @@ menu-bookmark = نشانک
 menu-edit = ویرایش
 
 layout-knowledge = دانش
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = بازکردن دانش
 layout-open-welcome-knowledge = بازکردن خوشامدگویی دانش
 layout-open-path = بازکردن { $path }
@@ -435,6 +437,7 @@ agent-loading-media = در حال بارگذاری رسانه…
 agent-no-matching-media = رسانهٔ منطبقی وجود ندارد
 agent-prompt-context = زمینهٔ درخواست
 agent-details = جزئیات
+agent-copy = Copy
 agent-path = مسیر
 agent-tool = ابزار
 agent-server = سرور

--- a/crates/vmux_ui/locales/fi.ftl
+++ b/crates/vmux_ui/locales/fi.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Kirjanmerkki
 menu-edit = Muokkaa
 
 layout-knowledge = Tietämys
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Avaa tietämys
 layout-open-welcome-knowledge = Avaa Tervetuloa tietämykseen
 layout-open-path = Avaa { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Ladataan mediaa…
 agent-no-matching-media = Ei vastaavaa mediaa
 agent-prompt-context = Kehotteen konteksti
 agent-details = Tiedot
+agent-copy = Copy
 agent-path = Polku
 agent-tool = Työkalu
 agent-server = Palvelin

--- a/crates/vmux_ui/locales/fil.ftl
+++ b/crates/vmux_ui/locales/fil.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Pananda
 menu-edit = Pag-edit
 
 layout-knowledge = Kaalaman
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Buksan ang Kaalaman
 layout-open-welcome-knowledge = Buksan ang Welcome to Knowledge
 layout-open-path = Buksan ang { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Nilo-load ang media…
 agent-no-matching-media = Walang tugmang media
 agent-prompt-context = Konteksto ng prompt
 agent-details = Mga detalye
+agent-copy = Copy
 agent-path = Path
 agent-tool = Tool
 agent-server = Server

--- a/crates/vmux_ui/locales/fr.ftl
+++ b/crates/vmux_ui/locales/fr.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Signet
 menu-edit = Édition
 
 layout-knowledge = Connaissances
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Ouvrir les connaissances
 layout-open-welcome-knowledge = Ouvrir Bienvenue dans les connaissances
 layout-open-path = Ouvrir { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Chargement des médias…
 agent-no-matching-media = Aucun média correspondant
 agent-prompt-context = Contexte de l’invite
 agent-details = Détails
+agent-copy = Copy
 agent-path = Chemin
 agent-tool = Outil
 agent-server = Serveur

--- a/crates/vmux_ui/locales/fy.ftl
+++ b/crates/vmux_ui/locales/fy.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Blêdwizer
 menu-edit = Bewurkje
 
 layout-knowledge = Kennis
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Kennis iepenje
 layout-open-welcome-knowledge = Wolkom by Kennis iepenje
 layout-open-path = { $path } iepenje
@@ -435,6 +437,7 @@ agent-loading-media = Media lade…
 agent-no-matching-media = Gjin oerienkommende media
 agent-prompt-context = Promptkontekst
 agent-details = Details
+agent-copy = Copy
 agent-path = Paad
 agent-tool = Ark
 agent-server = Server

--- a/crates/vmux_ui/locales/ga.ftl
+++ b/crates/vmux_ui/locales/ga.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Leabharmharc
 menu-edit = Eagar
 
 layout-knowledge = Eolas
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Oscail Eolas
 layout-open-welcome-knowledge = Oscail Fáilte chuig Eolas
 layout-open-path = Oscail { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Meáin á lódáil…
 agent-no-matching-media = Níl aon mheáin mheaitseála ann
 agent-prompt-context = Comhthéacs leide
 agent-details = Sonraí
+agent-copy = Copy
 agent-path = Conair
 agent-tool = Uirlis
 agent-server = Freastalaí

--- a/crates/vmux_ui/locales/gd.ftl
+++ b/crates/vmux_ui/locales/gd.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Comharra-lìn
 menu-edit = Deasaich
 
 layout-knowledge = Eòlas
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Fosgail Eòlas
 layout-open-welcome-knowledge = Fosgail Fàilte gu Eòlas
 layout-open-path = Fosgail { $path }
@@ -435,6 +437,7 @@ agent-loading-media = A’ luchdadh mheadhanan…
 agent-no-matching-media = Chan eil meadhanan a’ freagairt ann
 agent-prompt-context = Co-theacsa a’ phroimt
 agent-details = Mion-fhiosrachadh
+agent-copy = Copy
 agent-path = Slighe
 agent-tool = Inneal
 agent-server = Frithealaiche

--- a/crates/vmux_ui/locales/gl.ftl
+++ b/crates/vmux_ui/locales/gl.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Marcador
 menu-edit = Editar
 
 layout-knowledge = Coñecemento
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Abrir Coñecemento
 layout-open-welcome-knowledge = Abrir Benvida ao Coñecemento
 layout-open-path = Abrir { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Cargando contido multimedia…
 agent-no-matching-media = Non hai contido multimedia coincidente
 agent-prompt-context = Contexto da indicación
 agent-details = Detalles
+agent-copy = Copy
 agent-path = Ruta
 agent-tool = Ferramenta
 agent-server = Servidor

--- a/crates/vmux_ui/locales/gu.ftl
+++ b/crates/vmux_ui/locales/gu.ftl
@@ -279,6 +279,8 @@ menu-bookmark = બુકમાર્ક
 menu-edit = સંપાદન
 
 layout-knowledge = જ્ઞાન
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = જ્ઞાન ખોલો
 layout-open-welcome-knowledge = જ્ઞાનમાં સ્વાગત ખોલો
 layout-open-path = { $path } ખોલો
@@ -435,6 +437,7 @@ agent-loading-media = મીડિયા લોડ થઈ રહ્યું છ
 agent-no-matching-media = મેળ ખાતું મીડિયા નથી
 agent-prompt-context = પ્રોમ્પ્ટ સંદર્ભ
 agent-details = વિગતો
+agent-copy = Copy
 agent-path = પાથ
 agent-tool = ટૂલ
 agent-server = સર્વર

--- a/crates/vmux_ui/locales/ha.ftl
+++ b/crates/vmux_ui/locales/ha.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Alamar shafi
 menu-edit = Gyara
 
 layout-knowledge = Ilimi
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Buɗe Ilimi
 layout-open-welcome-knowledge = Buɗe Maraba zuwa Ilimi
 layout-open-path = Buɗe { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Ana loda midiya…
 agent-no-matching-media = Babu midiya da ta dace
 agent-prompt-context = Mahallin prompt
 agent-details = Cikakkun bayanai
+agent-copy = Copy
 agent-path = Hanya
 agent-tool = Kayan aiki
 agent-server = Sabar

--- a/crates/vmux_ui/locales/haw.ftl
+++ b/crates/vmux_ui/locales/haw.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Lepe puke
 menu-edit = Hoʻoponopono
 
 layout-knowledge = ʻIke
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Wehe i ka ʻIke
 layout-open-welcome-knowledge = Wehe i ka Welina i ka ʻIke
 layout-open-path = Wehe iā { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Ke hoʻouka nei i ka pāpaho…
 agent-no-matching-media = ʻAʻohe pāpaho kūlike
 agent-prompt-context = Pōʻaiapili paipai
 agent-details = ʻIke kikoʻī
+agent-copy = Copy
 agent-path = Ala
 agent-tool = Mea hana
 agent-server = Kikowaena

--- a/crates/vmux_ui/locales/he.ftl
+++ b/crates/vmux_ui/locales/he.ftl
@@ -279,6 +279,8 @@ menu-bookmark = סימנייה
 menu-edit = עריכה
 
 layout-knowledge = ידע
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = פתיחת ידע
 layout-open-welcome-knowledge = פתיחת ״ברוכים הבאים לידע״
 layout-open-path = פתיחת { $path }
@@ -435,6 +437,7 @@ agent-loading-media = מדיה נטענת…
 agent-no-matching-media = אין מדיה תואמת
 agent-prompt-context = הקשר ההנחיה
 agent-details = פרטים
+agent-copy = Copy
 agent-path = נתיב
 agent-tool = כלי
 agent-server = שרת

--- a/crates/vmux_ui/locales/hi.ftl
+++ b/crates/vmux_ui/locales/hi.ftl
@@ -279,6 +279,8 @@ menu-bookmark = बुकमार्क
 menu-edit = संपादन
 
 layout-knowledge = ज्ञान
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = ज्ञान खोलें
 layout-open-welcome-knowledge = ज्ञान में स्वागत खोलें
 layout-open-path = { $path } खोलें
@@ -435,6 +437,7 @@ agent-loading-media = मीडिया लोड हो रहा है…
 agent-no-matching-media = कोई मेल खाता मीडिया नहीं
 agent-prompt-context = प्रॉम्प्ट संदर्भ
 agent-details = विवरण
+agent-copy = Copy
 agent-path = पाथ
 agent-tool = टूल
 agent-server = सर्वर

--- a/crates/vmux_ui/locales/hmn.ftl
+++ b/crates/vmux_ui/locales/hmn.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Cim tseg
 menu-edit = Kho
 
 layout-knowledge = Kev paub
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Qhib Kev paub
 layout-open-welcome-knowledge = Qhib Zoo siab txais tos rau Kev paub
 layout-open-path = Qhib { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Tab tom thauj media…
 agent-no-matching-media = Tsis muaj media phim
 agent-prompt-context = Prompt context
 agent-details = Lus qhia ntxiv
+agent-copy = Copy
 agent-path = Path
 agent-tool = Cuab yeej
 agent-server = Server

--- a/crates/vmux_ui/locales/hr.ftl
+++ b/crates/vmux_ui/locales/hr.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Oznaka
 menu-edit = Uredi
 
 layout-knowledge = Znanje
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Otvori Znanje
 layout-open-welcome-knowledge = Otvori Dobro došli u Znanje
 layout-open-path = Otvori { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Učitavanje medija…
 agent-no-matching-media = Nema podudarnih medija
 agent-prompt-context = Kontekst upita
 agent-details = Pojedinosti
+agent-copy = Copy
 agent-path = Putanja
 agent-tool = Alat
 agent-server = Poslužitelj

--- a/crates/vmux_ui/locales/ht.ftl
+++ b/crates/vmux_ui/locales/ht.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Makè
 menu-edit = Edite
 
 layout-knowledge = Konesans
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Louvri Konesans
 layout-open-welcome-knowledge = Louvri Byenveni nan Konesans
 layout-open-path = Louvri { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Ap chaje medya…
 agent-no-matching-media = Pa gen medya ki koresponn
 agent-prompt-context = Kontèks envit
 agent-details = Detay
+agent-copy = Copy
 agent-path = Chemen
 agent-tool = Zouti
 agent-server = Sèvè

--- a/crates/vmux_ui/locales/hu.ftl
+++ b/crates/vmux_ui/locales/hu.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Könyvjelző
 menu-edit = Szerkesztés
 
 layout-knowledge = Tudástár
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Tudástár megnyitása
 layout-open-welcome-knowledge = Tudástár üdvözlőlapjának megnyitása
 layout-open-path = { $path } megnyitása
@@ -435,6 +437,7 @@ agent-loading-media = Média betöltése…
 agent-no-matching-media = Nincs egyező média
 agent-prompt-context = Promptkörnyezet
 agent-details = Részletek
+agent-copy = Copy
 agent-path = Útvonal
 agent-tool = Eszköz
 agent-server = Kiszolgáló

--- a/crates/vmux_ui/locales/hy.ftl
+++ b/crates/vmux_ui/locales/hy.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Էջանիշ
 menu-edit = Խմբագրել
 
 layout-knowledge = Գիտելիք
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Բացել գիտելիքը
 layout-open-welcome-knowledge = Բացել «Բարի գալուստ Գիտելիք»
 layout-open-path = Բացել { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Մեդիան բեռնվում է…
 agent-no-matching-media = Համապատասխան մեդիա չկա
 agent-prompt-context = Հուշման համատեքստ
 agent-details = Մանրամասներ
+agent-copy = Copy
 agent-path = Ուղի
 agent-tool = Գործիք
 agent-server = Սերվեր

--- a/crates/vmux_ui/locales/id.ftl
+++ b/crates/vmux_ui/locales/id.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Markah
 menu-edit = Sunting
 
 layout-knowledge = Pengetahuan
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Buka Pengetahuan
 layout-open-welcome-knowledge = Buka Selamat Datang di Pengetahuan
 layout-open-path = Buka { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Memuat media…
 agent-no-matching-media = Tidak ada media yang cocok
 agent-prompt-context = Konteks prompt
 agent-details = Detail
+agent-copy = Copy
 agent-path = Path
 agent-tool = Alat
 agent-server = Server

--- a/crates/vmux_ui/locales/ig.ftl
+++ b/crates/vmux_ui/locales/ig.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Edokọbara
 menu-edit = Dezie
 
 layout-knowledge = Ọmụma
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Mepee Ọmụma
 layout-open-welcome-knowledge = Mepee Nnọọ na Ọmụma
 layout-open-path = Mepee { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Na-ebubata media…
 agent-no-matching-media = Enweghị media dabara
 agent-prompt-context = Ọnọdụ prompt
 agent-details = Nkọwa
+agent-copy = Copy
 agent-path = Ụzọ
 agent-tool = Ngwaọrụ
 agent-server = Sava

--- a/crates/vmux_ui/locales/is.ftl
+++ b/crates/vmux_ui/locales/is.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Bókamerki
 menu-edit = Breyta
 
 layout-knowledge = Þekking
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Opna þekkingu
 layout-open-welcome-knowledge = Opna Velkomin í þekkingu
 layout-open-path = Opna { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Hleð miðli…
 agent-no-matching-media = Enginn samsvarandi miðill
 agent-prompt-context = Samhengi kvaðningar
 agent-details = Upplýsingar
+agent-copy = Copy
 agent-path = Slóð
 agent-tool = Verkfæri
 agent-server = Þjónn

--- a/crates/vmux_ui/locales/it.ftl
+++ b/crates/vmux_ui/locales/it.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Segnalibro
 menu-edit = Modifica
 
 layout-knowledge = Conoscenza
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Apri Conoscenza
 layout-open-welcome-knowledge = Apri Benvenuto in Conoscenza
 layout-open-path = Apri { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Caricamento media…
 agent-no-matching-media = Nessun media corrispondente
 agent-prompt-context = Contesto del prompt
 agent-details = Dettagli
+agent-copy = Copy
 agent-path = Percorso
 agent-tool = Strumento
 agent-server = Server

--- a/crates/vmux_ui/locales/ja.ftl
+++ b/crates/vmux_ui/locales/ja.ftl
@@ -265,6 +265,8 @@ menu-bookmark = ブックマーク
 menu-edit = 編集
 
 layout-knowledge = ナレッジ
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = ナレッジを開く
 layout-open-welcome-knowledge = 「ナレッジへようこそ」を開く
 layout-open-path = { $path } を開く
@@ -421,6 +423,7 @@ agent-loading-media = メディアを読み込み中…
 agent-no-matching-media = 一致するメディアがありません
 agent-prompt-context = プロンプトのコンテキスト
 agent-details = 詳細
+agent-copy = Copy
 agent-path = パス
 agent-tool = ツール
 agent-server = サーバー

--- a/crates/vmux_ui/locales/jv.ftl
+++ b/crates/vmux_ui/locales/jv.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Tetenger
 menu-edit = Sunting
 
 layout-knowledge = Kawruh
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Bukak Kawruh
 layout-open-welcome-knowledge = Bukak Sugeng rawuh ing Kawruh
 layout-open-path = Bukak { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Ngemot media…
 agent-no-matching-media = Ora ana media sing cocog
 agent-prompt-context = Konteks prompt
 agent-details = Rincian
+agent-copy = Copy
 agent-path = Path
 agent-tool = Piranti
 agent-server = Server

--- a/crates/vmux_ui/locales/ka.ftl
+++ b/crates/vmux_ui/locales/ka.ftl
@@ -279,6 +279,8 @@ menu-bookmark = სანიშნე
 menu-edit = რედაქტირება
 
 layout-knowledge = ცოდნა
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = ცოდნის გახსნა
 layout-open-welcome-knowledge = „კეთილი იყოს თქვენი მობრძანება ცოდნაში“-ს გახსნა
 layout-open-path = გახსნა: { $path }
@@ -435,6 +437,7 @@ agent-loading-media = მედია იტვირთება…
 agent-no-matching-media = შესაბამისი მედია არ არის
 agent-prompt-context = მოთხოვნის კონტექსტი
 agent-details = დეტალები
+agent-copy = Copy
 agent-path = ბილიკი
 agent-tool = ხელსაწყო
 agent-server = სერვერი

--- a/crates/vmux_ui/locales/kk.ftl
+++ b/crates/vmux_ui/locales/kk.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Бетбелгі
 menu-edit = Өңдеу
 
 layout-knowledge = Білім
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Білімді ашу
 layout-open-welcome-knowledge = «Білімге қош келдіңіз» бетін ашу
 layout-open-path = { $path } ашу
@@ -435,6 +437,7 @@ agent-loading-media = Медиа жүктелуде…
 agent-no-matching-media = Сәйкес медиа жоқ
 agent-prompt-context = Промпт контексті
 agent-details = Мәліметтер
+agent-copy = Copy
 agent-path = Жол
 agent-tool = Құрал
 agent-server = Сервер

--- a/crates/vmux_ui/locales/km.ftl
+++ b/crates/vmux_ui/locales/km.ftl
@@ -279,6 +279,8 @@ menu-bookmark = ចំណាំ
 menu-edit = កែសម្រួល
 
 layout-knowledge = ចំណេះដឹង
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = បើកចំណេះដឹង
 layout-open-welcome-knowledge = បើក «សូមស្វាគមន៍មកកាន់ចំណេះដឹង»
 layout-open-path = បើក { $path }
@@ -435,6 +437,7 @@ agent-loading-media = កំពុងផ្ទុកមេឌៀ…
 agent-no-matching-media = គ្មានមេឌៀដែលត្រូវគ្នា
 agent-prompt-context = បរិបទ prompt
 agent-details = ព័ត៌មានលម្អិត
+agent-copy = Copy
 agent-path = ផ្លូវ
 agent-tool = ឧបករណ៍
 agent-server = ម៉ាស៊ីនបម្រើ

--- a/crates/vmux_ui/locales/kn.ftl
+++ b/crates/vmux_ui/locales/kn.ftl
@@ -279,6 +279,8 @@ menu-bookmark = ಬುಕ್‌ಮಾರ್ಕ್
 menu-edit = ಸಂಪಾದನೆ
 
 layout-knowledge = ಜ್ಞಾನ
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = ಜ್ಞಾನ ತೆರೆಯಿರಿ
 layout-open-welcome-knowledge = ಜ್ಞಾನಕ್ಕೆ ಸ್ವಾಗತ ತೆರೆಯಿರಿ
 layout-open-path = { $path } ತೆರೆಯಿರಿ
@@ -435,6 +437,7 @@ agent-loading-media = ಮೀಡಿಯಾ ಲೋಡ್ ಆಗುತ್ತಿದ�
 agent-no-matching-media = ಹೊಂದುವ ಮೀಡಿಯಾ ಇಲ್ಲ
 agent-prompt-context = ಪ್ರಾಂಪ್ಟ್ ಸಂದರ್ಭ
 agent-details = ವಿವರಗಳು
+agent-copy = Copy
 agent-path = ಪಾಥ್
 agent-tool = ಟೂಲ್
 agent-server = ಸರ್ವರ್

--- a/crates/vmux_ui/locales/ko.ftl
+++ b/crates/vmux_ui/locales/ko.ftl
@@ -279,6 +279,8 @@ menu-bookmark = 북마크
 menu-edit = 편집
 
 layout-knowledge = 지식
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = 지식 열기
 layout-open-welcome-knowledge = 지식 시작하기 열기
 layout-open-path = { $path } 열기
@@ -435,6 +437,7 @@ agent-loading-media = 미디어 로드 중…
 agent-no-matching-media = 일치하는 미디어 없음
 agent-prompt-context = 프롬프트 컨텍스트
 agent-details = 세부 정보
+agent-copy = Copy
 agent-path = 경로
 agent-tool = 도구
 agent-server = 서버

--- a/crates/vmux_ui/locales/ku.ftl
+++ b/crates/vmux_ui/locales/ku.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Nîşank
 menu-edit = Sererastkirin
 
 layout-knowledge = Zanîn
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Zanînê veke
 layout-open-welcome-knowledge = Bi xêr hatî Zanînê veke
 layout-open-path = { $path } veke
@@ -435,6 +437,7 @@ agent-loading-media = بارکردنی میدیا…
 agent-no-matching-media = هیچ میدیایەکی هاوتا نییە
 agent-prompt-context = کۆنتێکستی داواکاری
 agent-details = وردەکاری
+agent-copy = Copy
 agent-path = ڕێڕەو
 agent-tool = ئامراز
 agent-server = سێرڤەر

--- a/crates/vmux_ui/locales/ky.ftl
+++ b/crates/vmux_ui/locales/ky.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Кыстарма
 menu-edit = Түзөтүү
 
 layout-knowledge = Билим
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Билимди ачуу
 layout-open-welcome-knowledge = «Билимге кош келиңиз» барагын ачуу
 layout-open-path = { $path } ачуу
@@ -435,6 +437,7 @@ agent-loading-media = Медиа жүктөлүүдө…
 agent-no-matching-media = Дал келген медиа жок
 agent-prompt-context = Сурам контексти
 agent-details = Чоо-жайы
+agent-copy = Copy
 agent-path = Жол
 agent-tool = Курал
 agent-server = Сервер

--- a/crates/vmux_ui/locales/la.ftl
+++ b/crates/vmux_ui/locales/la.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Signum
 menu-edit = Editio
 
 layout-knowledge = Scientia
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Aperire Scientiam
 layout-open-welcome-knowledge = Aperire “Salve in Scientia”
 layout-open-path = Aperire { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Media onerantur…
 agent-no-matching-media = Nulla media congruentia
 agent-prompt-context = Contextus prompti
 agent-details = Singula
+agent-copy = Copy
 agent-path = Semita
 agent-tool = Instrumentum
 agent-server = Servitor

--- a/crates/vmux_ui/locales/lb.ftl
+++ b/crates/vmux_ui/locales/lb.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Lieszeechen
 menu-edit = Änneren
 
 layout-knowledge = Wëssen
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Wëssen opmaachen
 layout-open-welcome-knowledge = Wëllkomm am Wëssen opmaachen
 layout-open-path = { $path } opmaachen
@@ -435,6 +437,7 @@ agent-loading-media = Medien gi gelueden…
 agent-no-matching-media = Keng passend Medien
 agent-prompt-context = Prompt-Kontext
 agent-details = Detailer
+agent-copy = Copy
 agent-path = Pad
 agent-tool = Tool
 agent-server = Server

--- a/crates/vmux_ui/locales/lo.ftl
+++ b/crates/vmux_ui/locales/lo.ftl
@@ -279,6 +279,8 @@ menu-bookmark = ບຸກມາກ
 menu-edit = ແກ້ໄຂ
 
 layout-knowledge = ຄວາມຮູ້
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = ເປີດຄວາມຮູ້
 layout-open-welcome-knowledge = ເປີດຍິນດີຕ້ອນຮັບສູ່ຄວາມຮູ້
 layout-open-path = ເປີດ { $path }
@@ -435,6 +437,7 @@ agent-loading-media = ກຳລັງໂຫຼດມີເດຍ…
 agent-no-matching-media = ບໍ່ມີມີເດຍທີ່ກົງກັນ
 agent-prompt-context = ບໍລິບົດພຣອມ
 agent-details = ລາຍລະອຽດ
+agent-copy = Copy
 agent-path = ພາທ
 agent-tool = ເຄື່ອງມື
 agent-server = ເຊີບເວີ

--- a/crates/vmux_ui/locales/lt.ftl
+++ b/crates/vmux_ui/locales/lt.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Žymelė
 menu-edit = Redagavimas
 
 layout-knowledge = Žinios
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Atidaryti žinias
 layout-open-welcome-knowledge = Atidaryti „Sveiki atvykę į žinias“
 layout-open-path = Atidaryti { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Įkeliama medija…
 agent-no-matching-media = Atitinkančios medijos nėra
 agent-prompt-context = Užklausos kontekstas
 agent-details = Išsamiau
+agent-copy = Copy
 agent-path = Kelias
 agent-tool = Įrankis
 agent-server = Serveris

--- a/crates/vmux_ui/locales/lv.ftl
+++ b/crates/vmux_ui/locales/lv.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Grāmatzīme
 menu-edit = Rediģēt
 
 layout-knowledge = Zināšanas
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Atvērt Zināšanas
 layout-open-welcome-knowledge = Atvērt “Laipni lūdzam Zināšanās”
 layout-open-path = Atvērt { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Ielādē multividi…
 agent-no-matching-media = Nav atbilstošas multivides
 agent-prompt-context = Uzvednes konteksts
 agent-details = Detalizēti
+agent-copy = Copy
 agent-path = Ceļš
 agent-tool = Rīks
 agent-server = Serveris

--- a/crates/vmux_ui/locales/mg.ftl
+++ b/crates/vmux_ui/locales/mg.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Tsoratadidy
 menu-edit = Fanitsiana
 
 layout-knowledge = Fahalalana
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Sokafy ny Fahalalana
 layout-open-welcome-knowledge = Sokafy ny Tongasoa eto amin'ny Fahalalana
 layout-open-path = Sokafy { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Mampiditra media…
 agent-no-matching-media = Tsy misy media mifanaraka
 agent-prompt-context = Contexte prompt
 agent-details = Antsipiriany
+agent-copy = Copy
 agent-path = Lalana
 agent-tool = Fitaovana
 agent-server = Server

--- a/crates/vmux_ui/locales/mi.ftl
+++ b/crates/vmux_ui/locales/mi.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Tohuwāhi
 menu-edit = Whakatika
 
 layout-knowledge = Mātauranga
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Whakatuwhera Mātauranga
 layout-open-welcome-knowledge = Whakatuwhera Nau mai ki te Mātauranga
 layout-open-path = Whakatuwhera { $path }
@@ -435,6 +437,7 @@ agent-loading-media = E uta ana i te pāpāho…
 agent-no-matching-media = Kāore he pāpāho ōrite
 agent-prompt-context = Horopaki akiaki
 agent-details = Taipitopito
+agent-copy = Copy
 agent-path = Ara
 agent-tool = Utauta
 agent-server = Tūmau

--- a/crates/vmux_ui/locales/mk.ftl
+++ b/crates/vmux_ui/locales/mk.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Обележувач
 menu-edit = Уредување
 
 layout-knowledge = Знаење
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Отвори Знаење
 layout-open-welcome-knowledge = Отвори Добре дојдовте во Знаење
 layout-open-path = Отвори { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Се вчитуваат медиуми…
 agent-no-matching-media = Нема соодветни медиуми
 agent-prompt-context = Контекст на порака
 agent-details = Детали
+agent-copy = Copy
 agent-path = Патека
 agent-tool = Алатка
 agent-server = Сервер

--- a/crates/vmux_ui/locales/ml.ftl
+++ b/crates/vmux_ui/locales/ml.ftl
@@ -279,6 +279,8 @@ menu-bookmark = ബുക്ക്‌മാർക്ക്
 menu-edit = തിരുത്തുക
 
 layout-knowledge = അറിവ്
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = അറിവ് തുറക്കുക
 layout-open-welcome-knowledge = അറിവിലേക്ക് സ്വാഗതം തുറക്കുക
 layout-open-path = { $path } തുറക്കുക
@@ -435,6 +437,7 @@ agent-loading-media = മീഡിയ ലോഡ് ചെയ്യുന്ന�
 agent-no-matching-media = പൊരുത്തപ്പെടുന്ന മീഡിയ ഇല്ല
 agent-prompt-context = പ്രോംപ്റ്റ് സന്ദർഭം
 agent-details = വിശദാംശങ്ങൾ
+agent-copy = Copy
 agent-path = പാത്ത്
 agent-tool = ടൂൾ
 agent-server = സർവർ

--- a/crates/vmux_ui/locales/mn.ftl
+++ b/crates/vmux_ui/locales/mn.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Хавчуурга
 menu-edit = Засах
 
 layout-knowledge = Мэдлэг
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Мэдлэгийг нээх
 layout-open-welcome-knowledge = Мэдлэгт тавтай морилыг нээх
 layout-open-path = { $path } нээх
@@ -435,6 +437,7 @@ agent-loading-media = Медиа ачаалж байна…
 agent-no-matching-media = Тохирох медиа алга
 agent-prompt-context = Хүсэлтийн контекст
 agent-details = Дэлгэрэнгүй
+agent-copy = Copy
 agent-path = Зам
 agent-tool = Хэрэгсэл
 agent-server = Сервер

--- a/crates/vmux_ui/locales/mr.ftl
+++ b/crates/vmux_ui/locales/mr.ftl
@@ -279,6 +279,8 @@ menu-bookmark = बुकमार्क
 menu-edit = संपादन
 
 layout-knowledge = ज्ञान
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = ज्ञान उघडा
 layout-open-welcome-knowledge = ज्ञानामध्ये स्वागत उघडा
 layout-open-path = { $path } उघडा
@@ -435,6 +437,7 @@ agent-loading-media = मीडिया लोड होत आहे…
 agent-no-matching-media = जुळणारा मीडिया नाही
 agent-prompt-context = प्रॉम्प्ट संदर्भ
 agent-details = तपशील
+agent-copy = Copy
 agent-path = पाथ
 agent-tool = साधन
 agent-server = सर्व्हर

--- a/crates/vmux_ui/locales/ms.ftl
+++ b/crates/vmux_ui/locales/ms.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Penanda Buku
 menu-edit = Sunting
 
 layout-knowledge = Pengetahuan
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Buka Pengetahuan
 layout-open-welcome-knowledge = Buka Selamat Datang ke Pengetahuan
 layout-open-path = Buka { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Memuatkan media…
 agent-no-matching-media = Tiada media sepadan
 agent-prompt-context = Konteks prompt
 agent-details = Butiran
+agent-copy = Copy
 agent-path = Laluan
 agent-tool = Alat
 agent-server = Pelayan

--- a/crates/vmux_ui/locales/mt.ftl
+++ b/crates/vmux_ui/locales/mt.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Bookmark
 menu-edit = Editja
 
 layout-knowledge = Għarfien
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Iftaħ l-Għarfien
 layout-open-welcome-knowledge = Iftaħ Merħba fl-Għarfien
 layout-open-path = Iftaħ { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Qed titgħabba l-media…
 agent-no-matching-media = L-ebda media taqbel
 agent-prompt-context = Kuntest tal-prompt
 agent-details = Dettalji
+agent-copy = Copy
 agent-path = Mogħdija
 agent-tool = Għodda
 agent-server = Server

--- a/crates/vmux_ui/locales/my.ftl
+++ b/crates/vmux_ui/locales/my.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Bookmark
 menu-edit = တည်းဖြတ်
 
 layout-knowledge = Knowledge
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Knowledge ကို ဖွင့်ရန်
 layout-open-welcome-knowledge = Knowledge ကြိုဆိုရေးကို ဖွင့်ရန်
 layout-open-path = { $path } ကို ဖွင့်ရန်
@@ -435,6 +437,7 @@ agent-loading-media = မီဒီယာ ဖွင့်နေသည်…
 agent-no-matching-media = ကိုက်ညီသော မီဒီယာ မရှိပါ
 agent-prompt-context = Prompt context
 agent-details = အသေးစိတ်
+agent-copy = Copy
 agent-path = Path
 agent-tool = Tool
 agent-server = Server

--- a/crates/vmux_ui/locales/nb.ftl
+++ b/crates/vmux_ui/locales/nb.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Bokmerke
 menu-edit = Rediger
 
 layout-knowledge = Kunnskap
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Åpne Kunnskap
 layout-open-welcome-knowledge = Åpne Velkommen til Kunnskap
 layout-open-path = Åpne { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Laster inn medier …
 agent-no-matching-media = Ingen samsvarende medier
 agent-prompt-context = Forespørselskontekst
 agent-details = Detaljer
+agent-copy = Copy
 agent-path = Sti
 agent-tool = Verktøy
 agent-server = Tjener

--- a/crates/vmux_ui/locales/ne.ftl
+++ b/crates/vmux_ui/locales/ne.ftl
@@ -279,6 +279,8 @@ menu-bookmark = बुकमार्क
 menu-edit = सम्पादन
 
 layout-knowledge = ज्ञान
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = ज्ञान खोल्नुहोस्
 layout-open-welcome-knowledge = ज्ञानमा स्वागत खोल्नुहोस्
 layout-open-path = { $path } खोल्नुहोस्
@@ -435,6 +437,7 @@ agent-loading-media = मिडिया लोड हुँदै…
 agent-no-matching-media = मिल्ने मिडिया छैन
 agent-prompt-context = प्रम्प्ट सन्दर्भ
 agent-details = विवरण
+agent-copy = Copy
 agent-path = पाथ
 agent-tool = टुल
 agent-server = सर्भर

--- a/crates/vmux_ui/locales/nl.ftl
+++ b/crates/vmux_ui/locales/nl.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Bladwijzer
 menu-edit = Bewerk
 
 layout-knowledge = Kennis
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Kennis openen
 layout-open-welcome-knowledge = Welkom bij Kennis openen
 layout-open-path = { $path } openen
@@ -435,6 +437,7 @@ agent-loading-media = Media laden…
 agent-no-matching-media = Geen overeenkomende media
 agent-prompt-context = Promptcontext
 agent-details = Details
+agent-copy = Copy
 agent-path = Pad
 agent-tool = Tool
 agent-server = Server

--- a/crates/vmux_ui/locales/no.ftl
+++ b/crates/vmux_ui/locales/no.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Bokmerke
 menu-edit = Rediger
 
 layout-knowledge = Kunnskap
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Åpne Kunnskap
 layout-open-welcome-knowledge = Åpne Velkommen til Kunnskap
 layout-open-path = Åpne { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Laster medier…
 agent-no-matching-media = Ingen samsvarende medier
 agent-prompt-context = Ledetekstkontekst
 agent-details = Detaljer
+agent-copy = Copy
 agent-path = Sti
 agent-tool = Verktøy
 agent-server = Server

--- a/crates/vmux_ui/locales/ny.ftl
+++ b/crates/vmux_ui/locales/ny.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Chosungira tsamba
 menu-edit = Sinthani
 
 layout-knowledge = Chidziwitso
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Tsegulani Chidziwitso
 layout-open-welcome-knowledge = Tsegulani Takulandirani ku Chidziwitso
 layout-open-path = Tsegulani { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Kutsegula media…
 agent-no-matching-media = Palibe media yofanana
 agent-prompt-context = Nkhani ya mawu
 agent-details = Tsatanetsatane
+agent-copy = Copy
 agent-path = Njira
 agent-tool = Chida
 agent-server = Seva

--- a/crates/vmux_ui/locales/or.ftl
+++ b/crates/vmux_ui/locales/or.ftl
@@ -279,6 +279,8 @@ menu-bookmark = ବୁକ୍‌ମାର୍କ
 menu-edit = ସମ୍ପାଦନ
 
 layout-knowledge = ଜ୍ଞାନ
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = ଜ୍ଞାନ ଖୋଲନ୍ତୁ
 layout-open-welcome-knowledge = ଜ୍ଞାନକୁ ସ୍ୱାଗତ ଖୋଲନ୍ତୁ
 layout-open-path = { $path } ଖୋଲନ୍ତୁ
@@ -435,6 +437,7 @@ agent-loading-media = ମିଡିଆ ଲୋଡ୍ ହେଉଛି…
 agent-no-matching-media = ମିଳୁଥିବା ମିଡିଆ ନାହିଁ
 agent-prompt-context = ପ୍ରମ୍ପ୍ଟ କଣ୍ଟେକ୍ସ୍ଟ
 agent-details = ବିବରଣୀ
+agent-copy = Copy
 agent-path = ପଥ
 agent-tool = ଟୁଲ୍
 agent-server = ସର୍ଭର୍

--- a/crates/vmux_ui/locales/pa.ftl
+++ b/crates/vmux_ui/locales/pa.ftl
@@ -279,6 +279,8 @@ menu-bookmark = ਬੁੱਕਮਾਰਕ
 menu-edit = ਸੰਪਾਦਨ
 
 layout-knowledge = ਗਿਆਨ
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = ਗਿਆਨ ਖੋਲ੍ਹੋ
 layout-open-welcome-knowledge = ਗਿਆਨ ਵਿੱਚ ਸਵਾਗਤ ਖੋਲ੍ਹੋ
 layout-open-path = { $path } ਖੋਲ੍ਹੋ
@@ -435,6 +437,7 @@ agent-loading-media = ਮੀਡੀਆ ਲੋਡ ਹੋ ਰਿਹਾ ਹੈ…
 agent-no-matching-media = ਕੋਈ ਮਿਲਦਾ ਮੀਡੀਆ ਨਹੀਂ
 agent-prompt-context = ਪ੍ਰੌਂਪਟ ਸੰਦਰਭ
 agent-details = ਵੇਰਵੇ
+agent-copy = Copy
 agent-path = ਪਾਥ
 agent-tool = ਟੂਲ
 agent-server = ਸਰਵਰ

--- a/crates/vmux_ui/locales/pl.ftl
+++ b/crates/vmux_ui/locales/pl.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Zakładka
 menu-edit = Edycja
 
 layout-knowledge = Wiedza
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Otwórz Wiedzę
 layout-open-welcome-knowledge = Otwórz „Witamy w Wiedzy”
 layout-open-path = Otwórz { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Wczytywanie multimediów…
 agent-no-matching-media = Brak pasujących multimediów
 agent-prompt-context = Kontekst promptu
 agent-details = Szczegóły
+agent-copy = Copy
 agent-path = Ścieżka
 agent-tool = Narzędzie
 agent-server = Serwer

--- a/crates/vmux_ui/locales/ps.ftl
+++ b/crates/vmux_ui/locales/ps.ftl
@@ -279,6 +279,8 @@ menu-bookmark = نښه
 menu-edit = سمون
 
 layout-knowledge = پوهه
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = پوهه پرانیزه
 layout-open-welcome-knowledge = د پوهې ښه راغلاست پرانیزه
 layout-open-path = { $path } پرانیزه
@@ -435,6 +437,7 @@ agent-loading-media = رسنۍ پورته کېږي…
 agent-no-matching-media = برابره رسنۍ نشته
 agent-prompt-context = د پرامپټ متن
 agent-details = جزئیات
+agent-copy = Copy
 agent-path = مسیر
 agent-tool = وسیله
 agent-server = سرور

--- a/crates/vmux_ui/locales/pt-BR.ftl
+++ b/crates/vmux_ui/locales/pt-BR.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Favorito
 menu-edit = Editar
 
 layout-knowledge = Conhecimento
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Abrir Conhecimento
 layout-open-welcome-knowledge = Abrir Boas-vindas ao Conhecimento
 layout-open-path = Abrir { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Carregando mídia…
 agent-no-matching-media = Nenhuma mídia correspondente
 agent-prompt-context = Contexto do prompt
 agent-details = Detalhes
+agent-copy = Copy
 agent-path = Caminho
 agent-tool = Ferramenta
 agent-server = Servidor

--- a/crates/vmux_ui/locales/pt-PT.ftl
+++ b/crates/vmux_ui/locales/pt-PT.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Marcador
 menu-edit = Edição
 
 layout-knowledge = Conhecimento
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Abrir Conhecimento
 layout-open-welcome-knowledge = Abrir Boas-vindas ao Conhecimento
 layout-open-path = Abrir { $path }
@@ -435,6 +437,7 @@ agent-loading-media = A carregar multimédia…
 agent-no-matching-media = Sem multimédia correspondente
 agent-prompt-context = Contexto do pedido
 agent-details = Detalhes
+agent-copy = Copy
 agent-path = Caminho
 agent-tool = Ferramenta
 agent-server = Servidor

--- a/crates/vmux_ui/locales/pt.ftl
+++ b/crates/vmux_ui/locales/pt.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Marcador
 menu-edit = Editar
 
 layout-knowledge = Conhecimento
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Abrir Conhecimento
 layout-open-welcome-knowledge = Abrir Boas-vindas ao Conhecimento
 layout-open-path = Abrir { $path }
@@ -435,6 +437,7 @@ agent-loading-media = A carregar multimédia…
 agent-no-matching-media = Nenhuma multimédia correspondente
 agent-prompt-context = Contexto do pedido
 agent-details = Detalhes
+agent-copy = Copy
 agent-path = Caminho
 agent-tool = Ferramenta
 agent-server = Servidor

--- a/crates/vmux_ui/locales/ro.ftl
+++ b/crates/vmux_ui/locales/ro.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Semn de carte
 menu-edit = Editare
 
 layout-knowledge = Cunoștințe
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Deschide Cunoștințe
 layout-open-welcome-knowledge = Deschide Bun venit în Cunoștințe
 layout-open-path = Deschide { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Se încarcă media…
 agent-no-matching-media = Niciun media potrivit
 agent-prompt-context = Contextul promptului
 agent-details = Detalii
+agent-copy = Copy
 agent-path = Cale
 agent-tool = Instrument
 agent-server = Server

--- a/crates/vmux_ui/locales/ru.ftl
+++ b/crates/vmux_ui/locales/ru.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Закладка
 menu-edit = Правка
 
 layout-knowledge = Знания
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Открыть Знания
 layout-open-welcome-knowledge = Открыть «Добро пожаловать» в Знаниях
 layout-open-path = Открыть { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Загрузка медиа…
 agent-no-matching-media = Подходящих медиа нет
 agent-prompt-context = Контекст запроса
 agent-details = Подробности
+agent-copy = Copy
 agent-path = Путь
 agent-tool = Инструмент
 agent-server = Сервер

--- a/crates/vmux_ui/locales/rw.ftl
+++ b/crates/vmux_ui/locales/rw.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Akamenyetso
 menu-edit = Guhindura
 
 layout-knowledge = Ubumenyi
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Fungura Ubumenyi
 layout-open-welcome-knowledge = Fungura Ikaze mu Bumenyi
 layout-open-path = Fungura { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Kuzana media…
 agent-no-matching-media = Nta media ihuye
 agent-prompt-context = Context ya prompt
 agent-details = Ibisobanuro
+agent-copy = Copy
 agent-path = Inzira
 agent-tool = Igikoresho
 agent-server = Serveri

--- a/crates/vmux_ui/locales/sd.ftl
+++ b/crates/vmux_ui/locales/sd.ftl
@@ -279,6 +279,8 @@ menu-bookmark = نشان
 menu-edit = سنوار
 
 layout-knowledge = ڄاڻ
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = ڄاڻ کوليو
 layout-open-welcome-knowledge = ڄاڻ ۾ ڀليڪار کوليو
 layout-open-path = { $path } کوليو
@@ -435,6 +437,7 @@ agent-loading-media = ميڊيا لوڊ ٿي رهي آهي…
 agent-no-matching-media = ملندڙ ميڊيا ناهي
 agent-prompt-context = پرامپٽ جو حوالو
 agent-details = تفصيل
+agent-copy = Copy
 agent-path = پاٿ
 agent-tool = ٽول
 agent-server = سرور

--- a/crates/vmux_ui/locales/si.ftl
+++ b/crates/vmux_ui/locales/si.ftl
@@ -279,6 +279,8 @@ menu-bookmark = පොත්සලකුණ
 menu-edit = සංස්කරණය
 
 layout-knowledge = දැනුම
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = දැනුම විවෘත කරන්න
 layout-open-welcome-knowledge = දැනුම වෙත පිළිගැනීම විවෘත කරන්න
 layout-open-path = { $path } විවෘත කරන්න
@@ -435,6 +437,7 @@ agent-loading-media = මාධ්‍ය පූරණය වෙමින්…
 agent-no-matching-media = ගැළපෙන මාධ්‍ය නැත
 agent-prompt-context = ප්‍රොම්ප්ට් සන්දර්භය
 agent-details = විස්තර
+agent-copy = Copy
 agent-path = මාර්ගය
 agent-tool = මෙවලම
 agent-server = සේවාදායකය

--- a/crates/vmux_ui/locales/sk.ftl
+++ b/crates/vmux_ui/locales/sk.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Záložka
 menu-edit = Upraviť
 
 layout-knowledge = Znalosti
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Otvoriť Znalosti
 layout-open-welcome-knowledge = Otvoriť uvítanie v Znalostiach
 layout-open-path = Otvoriť { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Načítavajú sa médiá…
 agent-no-matching-media = Žiadne zodpovedajúce médiá
 agent-prompt-context = Kontext promptu
 agent-details = Podrobnosti
+agent-copy = Copy
 agent-path = Cesta
 agent-tool = Nástroj
 agent-server = Server

--- a/crates/vmux_ui/locales/sl.ftl
+++ b/crates/vmux_ui/locales/sl.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Zaznamek
 menu-edit = Uredi
 
 layout-knowledge = Znanje
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Odpri znanje
 layout-open-welcome-knowledge = Odpri Dobrodošli v znanju
 layout-open-path = Odpri { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Nalaganje predstavnosti …
 agent-no-matching-media = Ni ujemajoče se predstavnosti
 agent-prompt-context = Kontekst poziva
 agent-details = Podrobnosti
+agent-copy = Copy
 agent-path = Pot
 agent-tool = Orodje
 agent-server = Strežnik

--- a/crates/vmux_ui/locales/sm.ftl
+++ b/crates/vmux_ui/locales/sm.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Fa'ailoga tusi
 menu-edit = Teuteu
 
 layout-knowledge = Malamalama
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Tatala Malamalama
 layout-open-welcome-knowledge = Tatala Afio mai i le Malamalama
 layout-open-path = Tatala { $path }
@@ -435,6 +437,7 @@ agent-loading-media = O lo‘o utaina media…
 agent-no-matching-media = E leai ni media e fetaui
 agent-prompt-context = Context o le prompt
 agent-details = Fa‘amatalaga
+agent-copy = Copy
 agent-path = Ala
 agent-tool = Meafaigaluega
 agent-server = Server

--- a/crates/vmux_ui/locales/sn.ftl
+++ b/crates/vmux_ui/locales/sn.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Bhukumaki
 menu-edit = Gadzirisa
 
 layout-knowledge = Ruzivo
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Vhura Ruzivo
 layout-open-welcome-knowledge = Vhura Kugamuchirwa kuRuzivo
 layout-open-path = Vhura { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Kurodha midhiya…
 agent-no-matching-media = Hapana midhiya inoenderana
 agent-prompt-context = Mamiriro eprompt
 agent-details = Ruzivo
+agent-copy = Copy
 agent-path = Nzira
 agent-tool = Chishandiso
 agent-server = Sevha

--- a/crates/vmux_ui/locales/so.ftl
+++ b/crates/vmux_ui/locales/so.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Calaamad
 menu-edit = Tafatir
 
 layout-knowledge = Aqoon
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Fur Aqoon
 layout-open-welcome-knowledge = Fur Ku soo dhawoow Aqoon
 layout-open-path = Fur { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Warbaahin ayaa la raranayaa…
 agent-no-matching-media = Warbaahin ku habboon ma jirto
 agent-prompt-context = Macnaha codsiga
 agent-details = Faahfaahin
+agent-copy = Copy
 agent-path = Waddo
 agent-tool = Qalab
 agent-server = Seerfar

--- a/crates/vmux_ui/locales/sq.ftl
+++ b/crates/vmux_ui/locales/sq.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Faqeshënuesi
 menu-edit = Redaktimi
 
 layout-knowledge = Njohuri
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Hap Njohuritë
 layout-open-welcome-knowledge = Hap Mirë se vini te Njohuritë
 layout-open-path = Hap { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Po ngarkohet media…
 agent-no-matching-media = Nuk ka media që përputhet
 agent-prompt-context = Konteksti i kërkesës
 agent-details = Detaje
+agent-copy = Copy
 agent-path = Shtegu
 agent-tool = Vegla
 agent-server = Serveri

--- a/crates/vmux_ui/locales/sr.ftl
+++ b/crates/vmux_ui/locales/sr.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Obeleživač
 menu-edit = Uređivanje
 
 layout-knowledge = Znanje
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Otvori Znanje
 layout-open-welcome-knowledge = Otvori Dobro došli u Znanje
 layout-open-path = Otvori { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Učitavanje medija…
 agent-no-matching-media = Nema odgovarajućih medija
 agent-prompt-context = Kontekst prompta
 agent-details = Detalji
+agent-copy = Copy
 agent-path = Putanja
 agent-tool = Alatka
 agent-server = Server

--- a/crates/vmux_ui/locales/st.ftl
+++ b/crates/vmux_ui/locales/st.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Letshwao la leqephe
 menu-edit = Fetola
 
 layout-knowledge = Tsebo
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Bula Tsebo
 layout-open-welcome-knowledge = Bula Rea o amohela ho Tsebo
 layout-open-path = Bula { $path }
@@ -435,6 +437,7 @@ agent-loading-media = E kenya media…
 agent-no-matching-media = Ha ho media e tshwanang
 agent-prompt-context = Moelelo wa potso
 agent-details = Dintlha
+agent-copy = Copy
 agent-path = Tsela
 agent-tool = Sesebediswa
 agent-server = Seva

--- a/crates/vmux_ui/locales/su.ftl
+++ b/crates/vmux_ui/locales/su.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Tetengger
 menu-edit = Édit
 
 layout-knowledge = Pangaweruh
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Buka Pangaweruh
 layout-open-welcome-knowledge = Buka Wilujeng sumping ka Pangaweruh
 layout-open-path = Buka { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Ngamuat média…
 agent-no-matching-media = Euweuh média nu cocog
 agent-prompt-context = Kontéks prompt
 agent-details = Rincian
+agent-copy = Copy
 agent-path = Path
 agent-tool = Pakakas
 agent-server = Server

--- a/crates/vmux_ui/locales/sv.ftl
+++ b/crates/vmux_ui/locales/sv.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Bokmärke
 menu-edit = Redigera
 
 layout-knowledge = Kunskap
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Öppna Kunskap
 layout-open-welcome-knowledge = Öppna Välkommen till Kunskap
 layout-open-path = Öppna { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Läser in media…
 agent-no-matching-media = Inga matchande media
 agent-prompt-context = Promptkontext
 agent-details = Detaljer
+agent-copy = Copy
 agent-path = Sökväg
 agent-tool = Verktyg
 agent-server = Server

--- a/crates/vmux_ui/locales/sw.ftl
+++ b/crates/vmux_ui/locales/sw.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Alamisho
 menu-edit = Hariri
 
 layout-knowledge = Maarifa
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Fungua Maarifa
 layout-open-welcome-knowledge = Fungua Karibu kwenye Maarifa
 layout-open-path = Fungua { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Inapakia midia…
 agent-no-matching-media = Hakuna midia inayolingana
 agent-prompt-context = Muktadha wa kidokezo
 agent-details = Maelezo
+agent-copy = Copy
 agent-path = Njia
 agent-tool = Zana
 agent-server = Seva

--- a/crates/vmux_ui/locales/ta.ftl
+++ b/crates/vmux_ui/locales/ta.ftl
@@ -279,6 +279,8 @@ menu-bookmark = புத்தகக்குறி
 menu-edit = திருத்து
 
 layout-knowledge = அறிவு
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = அறிவைத் திற
 layout-open-welcome-knowledge = அறிவுக்கு வரவேற்பைத் திற
 layout-open-path = { $path } திற
@@ -435,6 +437,7 @@ agent-loading-media = மீடியா ஏற்றப்படுகிறத
 agent-no-matching-media = பொருந்தும் மீடியா இல்லை
 agent-prompt-context = Prompt சூழல்
 agent-details = விவரங்கள்
+agent-copy = Copy
 agent-path = பாதை
 agent-tool = கருவி
 agent-server = சேவையகம்

--- a/crates/vmux_ui/locales/te.ftl
+++ b/crates/vmux_ui/locales/te.ftl
@@ -279,6 +279,8 @@ menu-bookmark = బుక్‌మార్క్
 menu-edit = సవరించు
 
 layout-knowledge = జ్ఞానం
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = జ్ఞానం తెరువు
 layout-open-welcome-knowledge = జ్ఞానానికి స్వాగతం తెరువు
 layout-open-path = { $path } తెరువు
@@ -435,6 +437,7 @@ agent-loading-media = మీడియా లోడ్ అవుతోంది�
 agent-no-matching-media = సరిపోలే మీడియా లేదు
 agent-prompt-context = ప్రాంప్ట్ సందర్భం
 agent-details = వివరాలు
+agent-copy = Copy
 agent-path = పాత్
 agent-tool = టూల్
 agent-server = సర్వర్

--- a/crates/vmux_ui/locales/tg.ftl
+++ b/crates/vmux_ui/locales/tg.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Хатчӯб
 menu-edit = Таҳрир
 
 layout-knowledge = Дониш
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Кушодани Дониш
 layout-open-welcome-knowledge = Кушодани «Хуш омадед ба Дониш»
 layout-open-path = Кушодани { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Медиа бор мешавад…
 agent-no-matching-media = Медияи мувофиқ нест
 agent-prompt-context = Контексти дархост
 agent-details = Тафсилот
+agent-copy = Copy
 agent-path = Масир
 agent-tool = Абзор
 agent-server = Сервер

--- a/crates/vmux_ui/locales/th.ftl
+++ b/crates/vmux_ui/locales/th.ftl
@@ -279,6 +279,8 @@ menu-bookmark = ที่คั่นหน้า
 menu-edit = แก้ไข
 
 layout-knowledge = คลังความรู้
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = เปิดคลังความรู้
 layout-open-welcome-knowledge = เปิดยินดีต้อนรับสู่คลังความรู้
 layout-open-path = เปิด { $path }
@@ -435,6 +437,7 @@ agent-loading-media = กำลังโหลดสื่อ…
 agent-no-matching-media = ไม่มีสื่อที่ตรงกัน
 agent-prompt-context = บริบทพรอมป์
 agent-details = รายละเอียด
+agent-copy = Copy
 agent-path = พาธ
 agent-tool = เครื่องมือ
 agent-server = เซิร์ฟเวอร์

--- a/crates/vmux_ui/locales/tk.ftl
+++ b/crates/vmux_ui/locales/tk.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Bellik
 menu-edit = Düzet
 
 layout-knowledge = Bilim
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Bilimi aç
 layout-open-welcome-knowledge = Bilime hoş geldiňiz sahypasyny aç
 layout-open-path = { $path } aç
@@ -435,6 +437,7 @@ agent-loading-media = Media ýüklenýär…
 agent-no-matching-media = Gabat gelýän media ýok
 agent-prompt-context = Prompt konteksti
 agent-details = Jikme-jiklikler
+agent-copy = Copy
 agent-path = Ýol
 agent-tool = Gural
 agent-server = Serwer

--- a/crates/vmux_ui/locales/tl.ftl
+++ b/crates/vmux_ui/locales/tl.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Pananda
 menu-edit = I-edit
 
 layout-knowledge = Kaalaman
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Buksan ang Kaalaman
 layout-open-welcome-knowledge = Buksan ang Maligayang Pagdating sa Kaalaman
 layout-open-path = Buksan ang { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Nilo-load ang media…
 agent-no-matching-media = Walang tugmang media
 agent-prompt-context = Konteksto ng prompt
 agent-details = Mga detalye
+agent-copy = Copy
 agent-path = Path
 agent-tool = Tool
 agent-server = Server

--- a/crates/vmux_ui/locales/tr.ftl
+++ b/crates/vmux_ui/locales/tr.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Yer İmi
 menu-edit = Düzen
 
 layout-knowledge = Bilgi
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Bilgiyi Aç
 layout-open-welcome-knowledge = Bilgiye Hoş Geldiniz’i Aç
 layout-open-path = { $path } Yolunu Aç
@@ -435,6 +437,7 @@ agent-loading-media = Medya yükleniyor…
 agent-no-matching-media = Eşleşen medya yok
 agent-prompt-context = İstem bağlamı
 agent-details = Ayrıntılar
+agent-copy = Copy
 agent-path = Yol
 agent-tool = Araç
 agent-server = Sunucu

--- a/crates/vmux_ui/locales/tt.ftl
+++ b/crates/vmux_ui/locales/tt.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Кыстыргыч
 menu-edit = Үзгәртү
 
 layout-knowledge = Белем
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Белемне ачу
 layout-open-welcome-knowledge = «Белемгә рәхим итегез»не ачу
 layout-open-path = { $path } ачу
@@ -435,6 +437,7 @@ agent-loading-media = Медиа йөкләнә…
 agent-no-matching-media = Туры килгән медиа юк
 agent-prompt-context = Сорау контексты
 agent-details = Тулырак
+agent-copy = Copy
 agent-path = Юл
 agent-tool = Корал
 agent-server = Сервер

--- a/crates/vmux_ui/locales/ug.ftl
+++ b/crates/vmux_ui/locales/ug.ftl
@@ -279,6 +279,8 @@ menu-bookmark = خەتكۈچ
 menu-edit = تەھرىرلەش
 
 layout-knowledge = بىلىم
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = بىلىمنى ئېچىش
 layout-open-welcome-knowledge = بىلىمگە خۇش كەلدىڭىزنى ئېچىش
 layout-open-path = { $path } نى ئېچىش
@@ -435,6 +437,7 @@ agent-loading-media = مېدىيا يۈكلىنىۋاتىدۇ…
 agent-no-matching-media = ماس مېدىيا يوق
 agent-prompt-context = ئەسكەرتىش مەزمۇنى
 agent-details = تەپسىلاتلار
+agent-copy = Copy
 agent-path = يول
 agent-tool = قورال
 agent-server = مۇلازىمېتىر

--- a/crates/vmux_ui/locales/uk.ftl
+++ b/crates/vmux_ui/locales/uk.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Закладка
 menu-edit = Зміни
 
 layout-knowledge = Знання
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Відкрити Знання
 layout-open-welcome-knowledge = Відкрити привітання у Знаннях
 layout-open-path = Відкрити { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Завантаження медіа…
 agent-no-matching-media = Немає відповідних медіа
 agent-prompt-context = Контекст запиту
 agent-details = Докладно
+agent-copy = Copy
 agent-path = Шлях
 agent-tool = Інструмент
 agent-server = Сервер

--- a/crates/vmux_ui/locales/ur.ftl
+++ b/crates/vmux_ui/locales/ur.ftl
@@ -279,6 +279,8 @@ menu-bookmark = بک مارک
 menu-edit = تدوین
 
 layout-knowledge = علم
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = علم کھولیں
 layout-open-welcome-knowledge = علم میں خوش آمدید کھولیں
 layout-open-path = { $path } کھولیں
@@ -435,6 +437,7 @@ agent-loading-media = میڈیا لوڈ ہو رہا ہے…
 agent-no-matching-media = کوئی مماثل میڈیا نہیں
 agent-prompt-context = پرامپٹ سیاق
 agent-details = تفصیلات
+agent-copy = Copy
 agent-path = پاتھ
 agent-tool = ٹول
 agent-server = سرور

--- a/crates/vmux_ui/locales/uz.ftl
+++ b/crates/vmux_ui/locales/uz.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Xatcho‘p
 menu-edit = Tahrir
 
 layout-knowledge = Bilim
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Bilimni ochish
 layout-open-welcome-knowledge = Bilimga xush kelibsizni ochish
 layout-open-path = { $path } ni ochish
@@ -435,6 +437,7 @@ agent-loading-media = Media yuklanmoqda…
 agent-no-matching-media = Mos media yo‘q
 agent-prompt-context = Prompt konteksti
 agent-details = Tafsilotlar
+agent-copy = Copy
 agent-path = Yo‘l
 agent-tool = Vosita
 agent-server = Server

--- a/crates/vmux_ui/locales/vi.ftl
+++ b/crates/vmux_ui/locales/vi.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Dấu trang
 menu-edit = Sửa
 
 layout-knowledge = Tri thức
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Mở Tri thức
 layout-open-welcome-knowledge = Mở Chào mừng đến với Tri thức
 layout-open-path = Mở { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Đang tải phương tiện…
 agent-no-matching-media = Không có phương tiện phù hợp
 agent-prompt-context = Ngữ cảnh prompt
 agent-details = Chi tiết
+agent-copy = Copy
 agent-path = Đường dẫn
 agent-tool = Công cụ
 agent-server = Máy chủ

--- a/crates/vmux_ui/locales/xh.ftl
+++ b/crates/vmux_ui/locales/xh.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Isiphawuli
 menu-edit = Hlela
 
 layout-knowledge = Ulwazi
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Vula Ulwazi
 layout-open-welcome-knowledge = Vula Wamkelekile kuLwazi
 layout-open-path = Vula { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Kulayishwa imidiya…
 agent-no-matching-media = Akukho midiya ingqinelanayo
 agent-prompt-context = Umxholo wombuzo
 agent-details = Iinkcukacha
+agent-copy = Copy
 agent-path = Indlela
 agent-tool = Isixhobo
 agent-server = Iseva

--- a/crates/vmux_ui/locales/yi.ftl
+++ b/crates/vmux_ui/locales/yi.ftl
@@ -279,6 +279,8 @@ menu-bookmark = לייענצייכן
 menu-edit = רעדאַגירן
 
 layout-knowledge = וויסן
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = עפֿן וויסן
 layout-open-welcome-knowledge = עפֿן ברוכים הבאים צו וויסן
 layout-open-path = עפֿן { $path }
@@ -435,6 +437,7 @@ agent-loading-media = מעדיע לאָדט זיך…
 agent-no-matching-media = קיין פּאַסיקע מעדיע ניטאָ
 agent-prompt-context = פּראַמפּט־קאָנטעקסט
 agent-details = פּרטים
+agent-copy = Copy
 agent-path = וועג
 agent-tool = געצייג
 agent-server = סערווער

--- a/crates/vmux_ui/locales/yo.ftl
+++ b/crates/vmux_ui/locales/yo.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Àmì ìwé
 menu-edit = Ṣàtúnṣe
 
 layout-knowledge = Ìmọ̀
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Ṣí Ìmọ̀
 layout-open-welcome-knowledge = Ṣí Káàbọ̀ sí Ìmọ̀
 layout-open-path = Ṣí { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Ń ṣàkójọpọ̀ mídíà…
 agent-no-matching-media = Kò sí mídíà tó bá mu
 agent-prompt-context = Àyíká prompt
 agent-details = Àlàyé
+agent-copy = Copy
 agent-path = Ipa
 agent-tool = Irinṣẹ́
 agent-server = Sàbà

--- a/crates/vmux_ui/locales/zh-Hans.ftl
+++ b/crates/vmux_ui/locales/zh-Hans.ftl
@@ -279,6 +279,8 @@ menu-bookmark = 书签
 menu-edit = 编辑
 
 layout-knowledge = 知识
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = 打开知识
 layout-open-welcome-knowledge = 打开“欢迎使用知识”
 layout-open-path = 打开 { $path }
@@ -435,6 +437,7 @@ agent-loading-media = 正在加载媒体…
 agent-no-matching-media = 没有匹配的媒体
 agent-prompt-context = 提示上下文
 agent-details = 详情
+agent-copy = Copy
 agent-path = 路径
 agent-tool = 工具
 agent-server = 服务器

--- a/crates/vmux_ui/locales/zh-Hant.ftl
+++ b/crates/vmux_ui/locales/zh-Hant.ftl
@@ -279,6 +279,8 @@ menu-bookmark = 書籤
 menu-edit = 編輯
 
 layout-knowledge = 知識
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = 開啟知識
 layout-open-welcome-knowledge = 開啟「歡迎使用知識」
 layout-open-path = 開啟 { $path }
@@ -435,6 +437,7 @@ agent-loading-media = 正在載入媒體…
 agent-no-matching-media = 沒有相符的媒體
 agent-prompt-context = 提示脈絡
 agent-details = 詳細資訊
+agent-copy = Copy
 agent-path = 路徑
 agent-tool = 工具
 agent-server = 伺服器

--- a/crates/vmux_ui/locales/zh-TW.ftl
+++ b/crates/vmux_ui/locales/zh-TW.ftl
@@ -279,6 +279,8 @@ menu-bookmark = 書籤
 menu-edit = 編輯
 
 layout-knowledge = 知識庫
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = 開啟知識庫
 layout-open-welcome-knowledge = 開啟歡迎使用知識庫
 layout-open-path = 開啟 { $path }
@@ -435,6 +437,7 @@ agent-loading-media = 正在載入媒體…
 agent-no-matching-media = 沒有相符媒體
 agent-prompt-context = 提示脈絡
 agent-details = 詳細資訊
+agent-copy = Copy
 agent-path = 路徑
 agent-tool = 工具
 agent-server = 伺服器

--- a/crates/vmux_ui/locales/zh.ftl
+++ b/crates/vmux_ui/locales/zh.ftl
@@ -279,6 +279,8 @@ menu-bookmark = 书签
 menu-edit = 编辑
 
 layout-knowledge = 知识
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = 打开知识
 layout-open-welcome-knowledge = 打开“欢迎使用知识”
 layout-open-path = 打开 { $path }
@@ -435,6 +437,7 @@ agent-loading-media = 正在加载媒体…
 agent-no-matching-media = 没有匹配的媒体
 agent-prompt-context = 提示上下文
 agent-details = 详细信息
+agent-copy = Copy
 agent-path = 路径
 agent-tool = 工具
 agent-server = 服务器

--- a/crates/vmux_ui/locales/zu.ftl
+++ b/crates/vmux_ui/locales/zu.ftl
@@ -279,6 +279,8 @@ menu-bookmark = Ibhukhimakhi
 menu-edit = Hlela
 
 layout-knowledge = Ulwazi
+layout-projects = Projects
+layout-no-project-selected = No project selected
 layout-open-knowledge = Vula Ulwazi
 layout-open-welcome-knowledge = Vula okuthi Siyakwamukela kuLwazi
 layout-open-path = Vula { $path }
@@ -435,6 +437,7 @@ agent-loading-media = Kulayishwa imidiya…
 agent-no-matching-media = Ayikho imidiya efanayo
 agent-prompt-context = Umongo womlayezo
 agent-details = Imininingwane
+agent-copy = Copy
 agent-path = Indlela
 agent-tool = Ithuluzi
 agent-server = Iseva

--- a/crates/vmux_wire/src/protocol.rs
+++ b/crates/vmux_wire/src/protocol.rs
@@ -252,6 +252,14 @@ pub enum AgentCommand {
         anchor: ProcessId,
         title: String,
     },
+    /// Write a user-approved Markdown note into the vmux Knowledge base.
+    /// Appended to preserve existing positional enum discriminants.
+    WriteKnowledge {
+        anchor: ProcessId,
+        path: Option<String>,
+        title: String,
+        content: String,
+    },
 }
 
 pub const AGENT_QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
@@ -434,7 +442,18 @@ pub fn validate_agent_command(command: &AgentCommand) -> Result<(), &'static str
             Err("request_user_choice requires a question and 2 to 9 non-empty options")
         }
         AgentCommand::ChooseWorkspaceAtPath { path, .. } if path.trim().is_empty() => {
-            Err("select_workspace.path is empty")
+            Err("select_project.path is empty")
+        }
+        AgentCommand::WriteKnowledge {
+            path,
+            title,
+            content,
+            ..
+        } if path.as_ref().is_some_and(|path| path.trim().is_empty())
+            || title.trim().is_empty()
+            || content.trim().is_empty() =>
+        {
+            Err("write_knowledge requires a non-empty title and content")
         }
         _ => Ok(()),
     }
@@ -1531,6 +1550,19 @@ mod tests {
             let decoded = rkyv::from_bytes::<AgentCommand, rkyv::rancor::Error>(&bytes).unwrap();
             assert_eq!(decoded, command);
         }
+    }
+
+    #[test]
+    fn write_knowledge_rkyv_roundtrip() {
+        let command = AgentCommand::WriteKnowledge {
+            anchor: ProcessId::new(),
+            path: Some("projects/yc.md".into()),
+            title: "YC".into(),
+            content: "Notes".into(),
+        };
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&command).unwrap();
+        let decoded = rkyv::from_bytes::<AgentCommand, rkyv::rancor::Error>(&bytes).unwrap();
+        assert_eq!(decoded, command);
     }
 
     #[test]


### PR DESCRIPTION
## Context
Agent conversations, project setup, extension unlock, and note editing had several broken or inconsistent flows. This consolidates the refinement pass before deeper knowledge-base work.

## Implementation
Updates conversation titles and copy actions, project selection and managed worktrees, host-owned permissionless choices, knowledge access, Bitwarden popup handling, note selection and scroll stability, explorer/file icons, and preferred LSP installation feedback. Project and copy labels are added to every bundled locale with English fallback text.

## Checks / QA
- Submit a first prompt, continue the topic, then change topics; verify title behavior and copy actions.
- Create or select a project and verify worktree setup completes without blocking reads.
- Unlock Bitwarden and verify the popup remains functional.
- Open a note and verify click, drag, keyboard selection, scrolling, explorer visibility, and file icons.
- Open a file without an installed LSP and verify installation progress appears.