### PR TITLE
chore(release): v0.0.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9558,7 +9558,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "base64 0.22.1",
  "bevy",
@@ -9607,7 +9607,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_browser"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -9644,7 +9644,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -9659,7 +9659,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "bevy",
  "bevy_ecs",
@@ -9675,7 +9675,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command_mcp"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "serde_json",
  "vmux_command",
@@ -9684,7 +9684,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9707,7 +9707,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9773,7 +9773,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_editor"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "arboard",
  "bevy",
@@ -9817,7 +9817,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_git"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9837,7 +9837,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9858,7 +9858,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_knowledge"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -9874,7 +9874,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -9911,7 +9911,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "muda",
  "proc-macro2",
@@ -9921,7 +9921,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -9935,7 +9935,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_profile"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "chrono",
  "libc",
@@ -9952,7 +9952,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_server"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "dioxus",
  "regex",
@@ -9973,7 +9973,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "agent-client-protocol",
  "alacritty_terminal",
@@ -10013,7 +10013,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service_client"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "chrono",
  "libc",
@@ -10026,7 +10026,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10049,7 +10049,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10074,7 +10074,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_team"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10095,7 +10095,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10128,7 +10128,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "dioxus",
  "dioxus-primitives",
@@ -10150,7 +10150,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_wire"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "bevy_ecs",
  "bevy_reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.29"
+version = "0.0.30"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "GPL-3.0-or-later"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.29"
-  sha256 "94815b7b36e78cffafb857f47f0b66d9142701c59a045a73c5800599c3601a6c"
+  version "0.0.30"
+  sha256 "eca282cdc344b6349c7c8eb17949ab4734b7fc2dfdc491dcb3205605bcfc6626"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.29/Vmux_0.0.29_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.30/Vmux_0.0.30_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai/"

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.29",
-  "pub_date": "2026-07-24T03:48:48Z",
+  "version": "v0.0.30",
+  "pub_date": "2026-07-31T08:30:10Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.29/Vmux-v0.0.29-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzQ5dmhkNGVIWXhZdmFGUXpETnd5cmV3L1ViWjN3dFErNUszaTVXbXhOemVCUnRSM3lhc0xiVnFuakMwM0FLOVJIRnROQjhSSTFheFVsV1YybDZKeHcwPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg0ODY0OTI2CWZpbGU6Vm11eC12MC4wLjI5LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKN0RRY1FlVG5oU1RtVVlCQWhRc2x2L1NtSG41WktwaEhwMTQ2dS9nOUovREJocWxtVHoxL21rcDRFa0NURU1Wckl6bE9GNmloWW1zdDdnZ3V0a3VHQ2c9PQo=",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.30/Vmux-v0.0.30-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HT3h5eGx6bVBWeUs3b1JLSFE2Rk9OZFdhSmNoKzVYazZ5NmViNHZIMDhLWEJaZDV5ZnJyMFZmT0Z0bjhDNzZjbnZnUTFKMVUrS0d2MmcvajE3NlVkbVFBPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg1NDg2NjA3CWZpbGU6Vm11eC12MC4wLjMwLWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKRDcxMHkrc2kvMmhmQTE3aXJHWDhIbnFGOWlkaEdjdjZOMGwrRjlOVExraUYxcUlsR0g2N0dSSmMzUWVsZlVQazhFcWpYaUVRSXpsYUErMk9PaTFTQ3c9PQo=",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.29/Vmux_0.0.29_aarch64.dmg",
-      "filename": "Vmux_0.0.29_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.30/Vmux_0.0.30_aarch64.dmg",
+      "filename": "Vmux_0.0.30_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
Patch release. Bumps workspace version 0.0.29 -> 0.0.30. Releases on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workspace package version to 0.0.30.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->