### PR TITLE
feat(agent): per-agent reasoning-effort selector

### DIFF
--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -32,8 +32,8 @@ use crate::chat_page::event::{
     ChatPickFiles, ChatResume, ChatSelectWorkspace, ChatSnapshot, ChatSubmit, ComposerContext,
     MODEL_STATE_EVENT, ModelOptionEntry, ModelState, QueuedPromptSnapshot,
     RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions, ResumeListRequest,
-    ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry,
-    SlashCommands,
+    ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel, SetAgentEffort,
+    SlashCommandEntry, SlashCommands,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use crate::chat_page::turns::{group_turns_before, group_turns_tail, grouped_item_count};
@@ -249,6 +249,7 @@ impl Plugin for AgentChatPagePlugin {
                 ResumeSession,
                 RuntimeSwitchRequest,
                 SelectModel,
+                SetAgentEffort,
             )>::for_hosts(&["agent", "start"]))
             .add_plugins(BinEventEmitterPlugin::<(
                 ChatPickFiles,
@@ -279,6 +280,7 @@ impl Plugin for AgentChatPagePlugin {
             .add_observer(on_resume_session)
             .add_observer(on_runtime_switch_request)
             .add_observer(on_select_model)
+            .add_observer(on_set_agent_effort)
             .add_observer(on_chat_select_workspace)
             .add_observer(on_chat_create_worktree)
             .add_observer(reset_chat_synced_on_page_ready)
@@ -895,6 +897,7 @@ fn sync_chat_to_ready_views(
     )>,
     acp_sessions: Query<(&AcpSession, Option<&AcpModelState>)>,
     choices: Query<&crate::plugin::PendingAgentChoice>,
+    settings: Option<Res<vmux_setting::AppSettings>>,
     browsers: NonSend<Browsers>,
     mut commands: Commands,
 ) {
@@ -926,7 +929,7 @@ fn sync_chat_to_ready_views(
                 choices.get(webview).ok(),
             ),
         ));
-        let (cross, model_state) = acp_sessions
+        let (cross, model_state, agent_key) = acp_sessions
             .get(stack)
             .ok()
             .map(|(acp, model)| {
@@ -935,10 +938,18 @@ fn sync_chat_to_ready_views(
                         .map(kind_supports_cross_runtime)
                         .unwrap_or(false),
                     model,
+                    acp.agent_id.clone(),
                 )
             })
-            .unwrap_or((false, None));
-        emit_model_state(webview, model_state, cross, &mut commands);
+            .unwrap_or((false, None, String::new()));
+        emit_model_state(
+            webview,
+            model_state,
+            cross,
+            &agent_key,
+            effort_current_for(settings.as_ref(), &agent_key),
+            &mut commands,
+        );
         commands.entity(webview).insert(ChatSynced);
     }
 }
@@ -960,6 +971,7 @@ fn model_state_of(state: Option<&AcpModelState>) -> ModelState {
                 description: model.description.clone().unwrap_or_default(),
             })
             .collect(),
+        ..Default::default()
     }
 }
 
@@ -968,12 +980,21 @@ fn emit_model_state(
     webview: Entity,
     model_state: Option<&AcpModelState>,
     cross_runtime: bool,
+    agent_key: &str,
+    effort_current: &str,
     commands: &mut Commands,
 ) {
+    let mut state = model_state_of(model_state);
+    state.agent_key = agent_key.to_string();
+    state.effort_current = effort_current.to_string();
+    state.effort_levels = vmux_core::agent::effort_levels(agent_key)
+        .iter()
+        .map(|level| level.to_string())
+        .collect();
     commands.trigger(BinHostEmitEvent::from_rkyv(
         webview,
         MODEL_STATE_EVENT,
-        &model_state_of(model_state),
+        &state,
     ));
     commands.trigger(BinHostEmitEvent::from_rkyv(
         webview,
@@ -982,6 +1003,17 @@ fn emit_model_state(
             commands: slash_commands_for(cross_runtime, model_state.is_some()),
         },
     ));
+}
+
+/// The persisted launch-time effort for `agent_key`, or `""` (agent default).
+#[cfg(not(target_arch = "wasm32"))]
+fn effort_current_for<'a>(
+    settings: Option<&'a Res<vmux_setting::AppSettings>>,
+    agent_key: &str,
+) -> &'a str {
+    settings
+        .and_then(|settings| settings.agent.effort_for(agent_key))
+        .unwrap_or("")
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -1150,6 +1182,7 @@ fn push_acp_model_state_to_page(
     sessions: Query<(Entity, &AcpSession, &AcpModelState), Changed<AcpModelState>>,
     children: Query<&Children>,
     is_browser: Query<(), With<vmux_layout::Browser>>,
+    settings: Option<Res<vmux_setting::AppSettings>>,
     browsers: NonSend<Browsers>,
     mut commands: Commands,
 ) {
@@ -1166,7 +1199,14 @@ fn push_acp_model_state_to_page(
         let cross = acp_agent_kind(&session.agent_id)
             .map(kind_supports_cross_runtime)
             .unwrap_or(false);
-        emit_model_state(webview, Some(model_state), cross, &mut commands);
+        emit_model_state(
+            webview,
+            Some(model_state),
+            cross,
+            &session.agent_id,
+            effort_current_for(settings.as_ref(), &session.agent_id),
+            &mut commands,
+        );
     }
 }
 
@@ -1176,6 +1216,7 @@ fn push_removed_acp_model_state_to_page(
     sessions: Query<&AcpSession>,
     children: Query<&Children>,
     is_browser: Query<(), With<vmux_layout::Browser>>,
+    settings: Option<Res<vmux_setting::AppSettings>>,
     browsers: NonSend<Browsers>,
     mut commands: Commands,
 ) {
@@ -1195,7 +1236,14 @@ fn push_removed_acp_model_state_to_page(
         let cross = acp_agent_kind(&session.agent_id)
             .map(kind_supports_cross_runtime)
             .unwrap_or(false);
-        emit_model_state(webview, None, cross, &mut commands);
+        emit_model_state(
+            webview,
+            None,
+            cross,
+            &session.agent_id,
+            effort_current_for(settings.as_ref(), &session.agent_id),
+            &mut commands,
+        );
     }
 }
 
@@ -1721,6 +1769,49 @@ fn on_select_model(
         request_id,
         model_id,
     });
+}
+
+/// Persist the launch-time effort level for an agent. Blank `level` clears the override; only
+/// levels valid for the agent (see [`vmux_core::agent::effort_levels`]) are stored. Takes effect
+/// when the agent next launches a session/process.
+#[cfg(not(target_arch = "wasm32"))]
+fn on_set_agent_effort(
+    trigger: On<BinReceive<SetAgentEffort>>,
+    mut settings: ResMut<vmux_setting::AppSettings>,
+    mut writes: MessageWriter<vmux_setting::SettingsWriteRequest>,
+) {
+    let payload = &trigger.event().payload;
+    let agent_key = payload.agent_key.trim();
+    let level = payload.level.trim();
+    if agent_key.is_empty() {
+        return;
+    }
+    if !level.is_empty() && !vmux_core::agent::effort_levels(agent_key).contains(&level) {
+        return;
+    }
+    let mut effort = settings.agent.effort.clone();
+    if level.is_empty() {
+        if effort.remove(agent_key).is_none() {
+            return;
+        }
+    } else if effort.get(agent_key).map(String::as_str) == Some(level) {
+        return;
+    } else {
+        effort.insert(agent_key.to_string(), level.to_string());
+    }
+    let value = match serde_json::to_value(&effort) {
+        Ok(value) => value,
+        Err(error) => {
+            bevy::log::warn!("effort: serialize failed: {error}");
+            return;
+        }
+    };
+    match vmux_setting::apply_settings_update(settings.as_mut(), "agent.effort", value) {
+        Ok(ron_bytes) => {
+            writes.write(vmux_setting::SettingsWriteRequest { ron_bytes });
+        }
+        Err(error) => bevy::log::warn!("effort: persist for {agent_key} failed: {error}"),
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/vmux_agent/src/chat_page/event.rs
+++ b/crates/vmux_agent/src/chat_page/event.rs
@@ -386,6 +386,12 @@ pub struct ModelState {
     pub current_model_id: String,
     pub current_model_name: String,
     pub models: Vec<ModelOptionEntry>,
+    /// Agent key for the effort selector (ACP agent id, e.g. `claude`). Empty when unknown.
+    pub agent_key: String,
+    /// Currently selected launch-time reasoning-effort level (`""` = agent default).
+    pub effort_current: String,
+    /// Effort levels this agent supports, low→high. Empty hides the effort selector.
+    pub effort_levels: Vec<String>,
 }
 
 /// Page → native selected ACP model.
@@ -401,6 +407,23 @@ pub struct ModelState {
 )]
 pub struct SelectModel {
     pub model_id: String,
+}
+
+/// Page → native: set the launch-time reasoning-effort level for an agent. `level` empty clears
+/// it back to the agent's default. Applied to the next session/process the agent launches.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct SetAgentEffort {
+    pub agent_key: String,
+    pub level: String,
 }
 
 /// Page → native: open the `/resume` picker (native replies with [`ResumableSessions`]).

--- a/crates/vmux_agent/src/chat_page/page.rs
+++ b/crates/vmux_agent/src/chat_page/page.rs
@@ -17,8 +17,8 @@ use crate::chat_page::event::{
     ChatResume, ChatSelectWorkspace, ChatSnapshot, ChatSubmit, ChatSubmitAttachment, ChatTurn,
     ComposerContext, MODEL_STATE_EVENT, ModelOptionEntry, ModelState, QueuedPromptSnapshot,
     RESUMABLE_SESSIONS_EVENT, ResumableSessionEntry, ResumableSessions, ResumeListRequest,
-    ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel, SlashCommandEntry,
-    SlashCommands, WORKING_VERB_IDS, latest_tool_location,
+    ResumeSession, RuntimeSwitchRequest, SLASH_COMMANDS_EVENT, SelectModel, SetAgentEffort,
+    SlashCommandEntry, SlashCommands, WORKING_VERB_IDS, latest_tool_location,
 };
 use dioxus::prelude::*;
 use std::cell::Cell;
@@ -515,6 +515,10 @@ pub fn Page(
     let mut media_loading = use_signal(|| false);
     let mut current_model_id = use_signal(String::new);
     let mut current_model = use_signal(String::new);
+    let mut effort_levels = use_signal(Vec::<String>::new);
+    let mut effort_current = use_signal(String::new);
+    let mut effort_agent_key = use_signal(String::new);
+    let mut effort_menu_open = use_signal(|| false);
     let mut composer_context = use_signal(ComposerContext::default);
     let mut menu_sel = use_signal(|| 0usize);
     let mut resume_requested = use_signal(|| false);
@@ -643,6 +647,9 @@ pub fn Page(
         models.set(state.models.clone());
         current_model_id.set(state.current_model_id.clone());
         current_model.set(state.current_model_name.clone());
+        effort_levels.set(state.effort_levels.clone());
+        effort_current.set(state.effort_current.clone());
+        effort_agent_key.set(state.agent_key.clone());
         menu_sel.set(0);
     });
     let _composer_context =
@@ -1192,6 +1199,92 @@ pub fn Page(
                             stroke: "currentColor",
                             stroke_width: "2",
                             path { d: "m8 10 4 4 4-4" }
+                        }
+                    }
+                }
+                if !effort_levels().is_empty() {
+                    div { class: "relative shrink-0",
+                        button {
+                            id: "chat-effort-trigger",
+                            class: "flex h-7 shrink-0 items-center gap-1.5 rounded-lg px-2 text-[11px] font-medium text-foreground/70 transition hover:bg-foreground/[0.08] hover:text-foreground",
+                            title: translate("agent-effort-tooltip"),
+                            onmousedown: move |event| event.prevent_default(),
+                            onclick: move |_| {
+                                let next = !effort_menu_open();
+                                effort_menu_open.set(next);
+                                focus_prompt_end(PROMPT_INPUT_ID);
+                            },
+                            svg {
+                                class: "h-3.5 w-3.5 shrink-0",
+                                view_box: "0 0 24 24",
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_width: "1.8",
+                                stroke_linecap: "round",
+                                stroke_linejoin: "round",
+                                path { d: "M12 20a8 8 0 1 1 8-8" }
+                                path { d: "M12 12l3.5-2" }
+                            }
+                            span { class: "truncate capitalize",
+                                {if effort_current().is_empty() { translate("agent-effort") } else { effort_current() }}
+                            }
+                            svg {
+                                class: "h-3 w-3 shrink-0 opacity-50",
+                                view_box: "0 0 24 24",
+                                fill: "none",
+                                stroke: "currentColor",
+                                stroke_width: "2",
+                                path { d: "m8 10 4 4 4-4" }
+                            }
+                        }
+                        if effort_menu_open() {
+                            div { class: "absolute bottom-full left-0 z-20 mb-2 min-w-[9rem] rounded-2xl border border-foreground/10 bg-background/95 p-1.5 shadow-xl backdrop-blur-xl",
+                                div { class: "px-2 pb-1 pt-0.5 text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground/60", {translate("agent-effort")} }
+                                {
+                                    let key = effort_agent_key();
+                                    let is_default = effort_current().is_empty();
+                                    rsx! {
+                                        button {
+                                            class: if is_default { "flex w-full items-center gap-2 rounded-xl bg-foreground/[0.08] px-2.5 py-1.5 text-left text-sm text-foreground" } else { "flex w-full items-center gap-2 rounded-xl px-2.5 py-1.5 text-left text-sm text-foreground/75 transition hover:bg-foreground/[0.06] hover:text-foreground" },
+                                            onmousedown: move |event| event.prevent_default(),
+                                            onclick: move |_| {
+                                                effort_current.set(String::new());
+                                                effort_menu_open.set(false);
+                                                let _ = try_cef_bin_emit_rkyv(&SetAgentEffort { agent_key: key.clone(), level: String::new() });
+                                                focus_prompt_end(PROMPT_INPUT_ID);
+                                            },
+                                            span { class: "min-w-0 flex-1 truncate", {translate("agent-effort-default")} }
+                                            if is_default {
+                                                svg { class: "h-3.5 w-3.5 shrink-0 text-emerald-500", view_box: "0 0 24 24", fill: "none", stroke: "currentColor", stroke_width: "2.2", stroke_linecap: "round", stroke_linejoin: "round", path { d: "m5 12 4 4L19 6" } }
+                                            }
+                                        }
+                                    }
+                                }
+                                for level in effort_levels() {
+                                    {
+                                        let level_value = level.clone();
+                                        let key = effort_agent_key();
+                                        let selected = level == effort_current();
+                                        rsx! {
+                                            button {
+                                                key: "effort-{level}",
+                                                class: if selected { "flex w-full items-center gap-2 rounded-xl bg-foreground/[0.08] px-2.5 py-1.5 text-left text-sm text-foreground" } else { "flex w-full items-center gap-2 rounded-xl px-2.5 py-1.5 text-left text-sm text-foreground/75 transition hover:bg-foreground/[0.06] hover:text-foreground" },
+                                                onmousedown: move |event| event.prevent_default(),
+                                                onclick: move |_| {
+                                                    effort_current.set(level_value.clone());
+                                                    effort_menu_open.set(false);
+                                                    let _ = try_cef_bin_emit_rkyv(&SetAgentEffort { agent_key: key.clone(), level: level_value.clone() });
+                                                    focus_prompt_end(PROMPT_INPUT_ID);
+                                                },
+                                                span { class: "min-w-0 flex-1 truncate capitalize", "{level}" }
+                                                if selected {
+                                                    svg { class: "h-3.5 w-3.5 shrink-0 text-emerald-500", view_box: "0 0 24 24", fill: "none", stroke: "currentColor", stroke_width: "2.2", stroke_linecap: "round", stroke_linejoin: "round", path { d: "m5 12 4 4L19 6" } }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -871,6 +871,7 @@ fn parse_codex_config(
 fn drain_acp_installs(
     installs: Res<AcpInstallChannel>,
     service: Option<Res<ServiceClient>>,
+    settings: Option<Res<AppSettings>>,
     mut install_generation: ResMut<AcpInstallGeneration>,
     mut q: Query<(&AcpSession, &mut AgentRunState)>,
 ) {
@@ -931,6 +932,10 @@ fn drain_acp_installs(
                         mcp_args: mcp.map(|m| m.args).unwrap_or_default(),
                         resume_acp_session_id: session.resume.clone(),
                         managed_mcp_servers: crate::managed_mcp::acp_servers(),
+                        effort: settings
+                            .as_ref()
+                            .and_then(|settings| settings.agent.effort_for(&session.agent_id))
+                            .map(str::to_string),
                     });
                 }
             }

--- a/crates/vmux_agent/src/client/cli/claude.rs
+++ b/crates/vmux_agent/src/client/cli/claude.rs
@@ -77,6 +77,10 @@ impl CliAgentStrategy for ClaudeStrategy {
         args
     }
 
+    fn effort_args(&self, level: &str) -> Vec<String> {
+        vec!["--effort".to_string(), level.to_string()]
+    }
+
     fn build_env(&self, _mcp: &McpServerConfig) -> Vec<(String, String)> {
         vec![(
             "MCP_TOOL_TIMEOUT".to_string(),
@@ -411,6 +415,11 @@ mod tests {
         let id = discover_claude_session_id(&dir, spawn, &claimed);
         assert_eq!(id.as_deref(), Some("session-b"));
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn effort_args_pass_claude_effort_flag() {
+        assert_eq!(ClaudeStrategy.effort_args("high"), ["--effort", "high"]);
     }
 
     #[test]

--- a/crates/vmux_agent/src/client/cli/codex.rs
+++ b/crates/vmux_agent/src/client/cli/codex.rs
@@ -112,6 +112,10 @@ impl CliAgentStrategy for CodexStrategy {
         args
     }
 
+    fn effort_args(&self, level: &str) -> Vec<String> {
+        vec!["-c".to_string(), format!("model_reasoning_effort={level}")]
+    }
+
     fn build_env(&self, _mcp: &McpServerConfig) -> Vec<(String, String)> {
         vec![]
     }
@@ -555,6 +559,14 @@ mod tests {
             r#"{{"timestamp":"2026-04-30T11:41:00.170Z","type":"session_meta","payload":{{"id":"{id}","timestamp":"2026-04-30T09:56:21.846Z","cwd":"{cwd}"}}}}"#
         );
         std::fs::write(dir.join(file), format!("{line}\n")).unwrap();
+    }
+
+    #[test]
+    fn effort_args_pass_codex_reasoning_override() {
+        assert_eq!(
+            CodexStrategy.effort_args("high"),
+            ["-c", "model_reasoning_effort=high"]
+        );
     }
 
     #[test]

--- a/crates/vmux_agent/src/client/cli/strategy.rs
+++ b/crates/vmux_agent/src/client/cli/strategy.rs
@@ -39,6 +39,12 @@ pub(crate) fn lines_skipping_invalid_utf8<R: std::io::BufRead>(
 pub trait CliAgentStrategy: AgentStrategy {
     fn sessions_root(&self) -> PathBuf;
     fn build_args(&self, mcp: &McpServerConfig, session_id: Option<&str>) -> Vec<String>;
+    /// Launch flags that pin the reasoning-effort `level` for this run, prepended ahead of
+    /// [`Self::build_args`] so any trailing `--resume`/`resume` stays last. `level` is already
+    /// validated against [`vmux_core::agent::effort_levels`]. Default: unsupported, no flags.
+    fn effort_args(&self, _level: &str) -> Vec<String> {
+        Vec::new()
+    }
     fn build_env(&self, mcp: &McpServerConfig) -> Vec<(String, String)>;
     /// Launch-time side effects (e.g. writing a managed hooks config file).
     /// Runs once per spawn, after the MCP config is resolved. Default: nothing.

--- a/crates/vmux_agent/src/launch.rs
+++ b/crates/vmux_agent/src/launch.rs
@@ -10,6 +10,7 @@ pub fn build_agent_launch(
     strategies: &AgentStrategies,
     exe_path: &Path,
     anchor: vmux_core::ProcessId,
+    effort: Option<&str>,
 ) -> Result<TerminalLaunch, String> {
     let strategy = strategies
         .get_cli(kind)
@@ -19,7 +20,13 @@ pub fn build_agent_launch(
         bevy::log::warn!("external agent Knowledge sync failed: {error}");
     }
     strategy.prepare_launch(&mcp_cfg);
-    let args = strategy.build_args(&mcp_cfg, session_id);
+    let effort_key = format!("cli:{}", kind.as_url_segment());
+    let mut args =
+        match effort.filter(|level| vmux_core::agent::effort_levels(&effort_key).contains(level)) {
+            Some(level) => strategy.effort_args(level),
+            None => Vec::new(),
+        };
+    args.extend(strategy.build_args(&mcp_cfg, session_id));
     let mut env: Vec<(String, String)> = std::env::vars().collect();
     env.extend(strategy.build_env(&mcp_cfg));
     env.push(("VMUX_ANCHOR".to_string(), anchor.to_string()));

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -5557,6 +5557,8 @@ fn handle_spawn_agent_requests(
             continue;
         };
         let process_id = ProcessId::new();
+        let effort_key = format!("cli:{}", req.kind.as_url_segment());
+        let effort = settings.agent.effort_for(&effort_key);
         match crate::build_agent_launch(
             req.kind,
             &req.cwd,
@@ -5564,6 +5566,7 @@ fn handle_spawn_agent_requests(
             strategies,
             &exe_path,
             process_id,
+            effort,
         ) {
             Ok(launch) => {
                 clear_stack_children(req.stack, &children_q, &mut commands);

--- a/crates/vmux_core/src/agent.rs
+++ b/crates/vmux_core/src/agent.rs
@@ -69,6 +69,21 @@ impl AgentKind {
     }
 }
 
+/// Reasoning-effort levels selectable for an agent, keyed by agent key — an ACP agent id
+/// (`"claude"`) or a CLI key (`"cli:claude"`, `"cli:codex"`). Ordered low→high for display.
+/// Empty means the agent exposes no effort knob vmux can drive, and the selector is hidden.
+///
+/// Only keys vmux actually wires are listed: ACP `claude` (forwarded through the adapter's
+/// `claudeCode.options` session meta) and the CLI `claude`/`codex` launch flags. ACP `codex`
+/// and `gemini` return empty until their runtimes expose an effort control.
+pub fn effort_levels(agent_key: &str) -> &'static [&'static str] {
+    match agent_key {
+        "claude" | "cli:claude" => &["low", "medium", "high", "max"],
+        "cli:codex" => &["minimal", "low", "medium", "high"],
+        _ => &[],
+    }
+}
+
 impl From<AgentKind> for TerminalKind {
     fn from(kind: AgentKind) -> Self {
         match kind {
@@ -277,5 +292,23 @@ mod tests {
     #[test]
     fn parse_page_agent_url_rejects_non_agent_host() {
         assert!(parse_page_agent_url("https://google.com").is_none());
+    }
+
+    #[test]
+    fn effort_levels_exposed_only_for_wired_agents() {
+        assert_eq!(effort_levels("claude"), ["low", "medium", "high", "max"]);
+        assert_eq!(
+            effort_levels("cli:claude"),
+            ["low", "medium", "high", "max"]
+        );
+        assert_eq!(
+            effort_levels("cli:codex"),
+            ["minimal", "low", "medium", "high"]
+        );
+        // ACP codex/gemini and unknown agents have no vmux-driven effort control yet.
+        assert!(effort_levels("codex").is_empty());
+        assert!(effort_levels("gemini").is_empty());
+        assert!(effort_levels("vibe").is_empty());
+        assert!(effort_levels("cli:vibe").is_empty());
     }
 }

--- a/crates/vmux_service/src/acp.rs
+++ b/crates/vmux_service/src/acp.rs
@@ -45,6 +45,7 @@ impl AcpSessionManager {
         input_writers: Arc<tokio::sync::Mutex<HashMap<ProcessId, PtyInputWriter>>>,
         mcp_servers: Vec<agent_client_protocol::schema::v1::McpServer>,
         resume: Option<String>,
+        effort: Option<String>,
     ) {
         if self.sessions.contains_key(&sid) {
             return;
@@ -66,6 +67,7 @@ impl AcpSessionManager {
             agent_id,
             mcp_servers,
             resume,
+            effort,
             shared.clone(),
             input_rx,
         ));

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -607,6 +607,7 @@ pub async fn run(
     agent_id: String,
     mcp_servers: Vec<McpServer>,
     resume: Option<String>,
+    effort: Option<String>,
     shared: Arc<AcpShared>,
     mut input_rx: mpsc::UnboundedReceiver<AcpInput>,
 ) {
@@ -630,7 +631,7 @@ pub async fn run(
         Some(root) => root.apply_env(env),
         None => env,
     };
-    let session_meta = session_meta_for_agent(&agent_id);
+    let session_meta = session_meta_for_agent(&agent_id, effort.as_deref());
     let agent_cwd = shared.cwd();
     let mut child = match Command::new(&command)
         .args(&args)
@@ -1170,16 +1171,24 @@ If you invoke a required Skill tool, continue the original user request in the s
 the skill loads. Never end the turn after skill activation or answer only Ready.";
 const CONVERSATION_TITLE_STEER_PROMPT: &str = "On the first user message, always call mcp__vmux__set_conversation_title as the first tool of the turn. The host immediately shows the raw first prompt as a provisional title; replace it with a concise 3 to 7 word summary with corrected spelling and grammar. On later user messages, call the tool only when the conversation topic materially changes; keep the current title for same-topic follow-ups. When needed, call it before reading skills, calling any other tool, or answering. Never copy the user's prompt verbatim. This tool never needs user permission.";
 
-fn session_meta_for_agent(agent_id: &str) -> Option<serde_json::Map<String, serde_json::Value>> {
+fn session_meta_for_agent(
+    agent_id: &str,
+    effort: Option<&str>,
+) -> Option<serde_json::Map<String, serde_json::Value>> {
     if let Err(error) = vmux_core::knowledge::sync_external_agent_configs() {
         bevy::log::warn!("external agent Knowledge sync failed: {error}");
     }
-    session_meta_for_agent_with_knowledge(agent_id, &vmux_core::knowledge::agent_context_prompt())
+    session_meta_for_agent_with_knowledge(
+        agent_id,
+        &vmux_core::knowledge::agent_context_prompt(),
+        effort,
+    )
 }
 
 fn session_meta_for_agent_with_knowledge(
     agent_id: &str,
     knowledge: &str,
+    effort: Option<&str>,
 ) -> Option<serde_json::Map<String, serde_json::Value>> {
     let prompt = if agent_id == "claude" {
         if knowledge.is_empty() {
@@ -1205,7 +1214,7 @@ fn session_meta_for_agent_with_knowledge(
         };
         return Some(meta);
     }
-    let serde_json::Value::Object(meta) = serde_json::json!({
+    let serde_json::Value::Object(mut meta) = serde_json::json!({
         "systemPrompt": {
             "append": prompt,
         },
@@ -1228,6 +1237,18 @@ fn session_meta_for_agent_with_knowledge(
     }) else {
         unreachable!()
     };
+    if let Some(level) =
+        effort.filter(|level| vmux_core::agent::effort_levels("claude").contains(level))
+        && let Some(options) = meta
+            .get_mut("claudeCode")
+            .and_then(|claude_code| claude_code.get_mut("options"))
+            .and_then(|options| options.as_object_mut())
+    {
+        options.insert(
+            "effort".to_string(),
+            serde_json::Value::String(level.to_string()),
+        );
+    }
     Some(meta)
 }
 
@@ -2402,10 +2423,11 @@ mod tests {
 
     #[test]
     fn claude_acp_disables_native_shell_and_steers_skill_continuation() {
-        let meta = session_meta_for_agent_with_knowledge("claude", "memory context")
+        let meta = session_meta_for_agent_with_knowledge("claude", "memory context", Some("high"))
             .expect("Claude ACP metadata");
         let options = &meta["claudeCode"]["options"];
 
+        assert_eq!(options["effort"], "high");
         assert_eq!(
             options["disallowedTools"],
             serde_json::json!(["Bash", "Monitor", "WebSearch", "WebFetch"])
@@ -2429,8 +2451,15 @@ mod tests {
         assert!(prompt.contains("continue the original user request"));
         assert!(prompt.contains("memory context"));
         assert!(prompt.contains("mcp__vmux__set_conversation_title"));
-        let generic = session_meta_for_agent_with_knowledge("vibe-acp", "skill context").unwrap()
-            ["systemPrompt"]["append"]
+        let unset = session_meta_for_agent_with_knowledge("claude", "memory context", None)
+            .expect("Claude ACP metadata");
+        assert!(unset["claudeCode"]["options"].get("effort").is_none());
+        let bogus =
+            session_meta_for_agent_with_knowledge("claude", "memory context", Some("turbo"))
+                .expect("Claude ACP metadata");
+        assert!(bogus["claudeCode"]["options"].get("effort").is_none());
+        let generic = session_meta_for_agent_with_knowledge("vibe-acp", "skill context", None)
+            .unwrap()["systemPrompt"]["append"]
             .as_str()
             .unwrap()
             .to_string();

--- a/crates/vmux_service/src/server.rs
+++ b/crates/vmux_service/src/server.rs
@@ -972,6 +972,7 @@ async fn handle_client(
                 mcp_args,
                 resume_acp_session_id,
                 managed_mcp_servers,
+                effort,
             } => {
                 let mut mcp_servers = mcp_command
                     .map(|cmd| {
@@ -1001,6 +1002,7 @@ async fn handle_client(
                     Arc::clone(&input_writers),
                     mcp_servers,
                     resume_acp_session_id,
+                    effort,
                 );
                 // ACP has no separate Attach message; forward this session's stream now.
                 let rx = acp_manager.lock().await.subscribe(&sid);

--- a/crates/vmux_setting/src/plugin/runtime.rs
+++ b/crates/vmux_setting/src/plugin/runtime.rs
@@ -184,6 +184,23 @@ pub struct AgentSettings {
     /// External ACP (Agent Client Protocol) agents available at `vmux://agent/<id>`.
     #[serde(default = "default_acp_agents")]
     pub acp: Vec<AcpAgentConfig>,
+    /// Default reasoning-effort level per agent, keyed by agent key (ACP agent id, or
+    /// `cli:<segment>` for a CLI agent). Applied when a session/process is launched — the
+    /// underlying agents fix effort at start, so this is a launch-time default, not a live
+    /// switch. Empty / missing = leave the agent's own default.
+    #[serde(default)]
+    pub effort: std::collections::BTreeMap<String, String>,
+}
+
+impl AgentSettings {
+    /// The launch-time reasoning-effort level for `key` (ACP agent id or `cli:<segment>`),
+    /// or `None` when unset or blank.
+    pub fn effort_for(&self, key: &str) -> Option<&str> {
+        self.effort
+            .get(key)
+            .map(|level| level.trim())
+            .filter(|level| !level.is_empty())
+    }
 }
 
 impl Default for AgentSettings {
@@ -205,6 +222,7 @@ fn default_agent_settings() -> AgentSettings {
         tidy_files_max: 5,
         tidy_files_auto: false,
         acp: default_acp_agents(),
+        effort: std::collections::BTreeMap::new(),
     }
 }
 

--- a/crates/vmux_ui/locales/af.ftl
+++ b/crates/vmux_ui/locales/af.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Datum
 editor-property-kind-list = Lys
 editor-property-kind-link = Skakel
 editor-property-kind-tags = Merkers
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/am.ftl
+++ b/crates/vmux_ui/locales/am.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = ቀን
 editor-property-kind-list = ዝርዝር
 editor-property-kind-link = አገናኝ
 editor-property-kind-tags = መለያዎች
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ar.ftl
+++ b/crates/vmux_ui/locales/ar.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = تاريخ
 editor-property-kind-list = قائمة
 editor-property-kind-link = وصلة
 editor-property-kind-tags = العلامات
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/az.ftl
+++ b/crates/vmux_ui/locales/az.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Tarix
 editor-property-kind-list = Siyahı
 editor-property-kind-link = Link
 editor-property-kind-tags = Teqlər
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/be.ftl
+++ b/crates/vmux_ui/locales/be.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Дата
 editor-property-kind-list = Спіс
 editor-property-kind-link = Спасылка
 editor-property-kind-tags = Тэгі
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/bg.ftl
+++ b/crates/vmux_ui/locales/bg.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Дата
 editor-property-kind-list = списък
 editor-property-kind-link = Връзка
 editor-property-kind-tags = Тагове
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/bn.ftl
+++ b/crates/vmux_ui/locales/bn.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = তারিখ
 editor-property-kind-list = তালিকা
 editor-property-kind-link = লিঙ্ক
 editor-property-kind-tags = ট্যাগ
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/bs.ftl
+++ b/crates/vmux_ui/locales/bs.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Datum
 editor-property-kind-list = Lista
 editor-property-kind-link = Link
 editor-property-kind-tags = Oznake
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ca.ftl
+++ b/crates/vmux_ui/locales/ca.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Data
 editor-property-kind-list = Llista
 editor-property-kind-link = Enllaç
 editor-property-kind-tags = Etiquetes
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ceb.ftl
+++ b/crates/vmux_ui/locales/ceb.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Petsa
 editor-property-kind-list = Listahan
 editor-property-kind-link = Link
 editor-property-kind-tags = Mga tag
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/co.ftl
+++ b/crates/vmux_ui/locales/co.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Data
 editor-property-kind-list = Lista
 editor-property-kind-link = Link
 editor-property-kind-tags = Tags
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/cs.ftl
+++ b/crates/vmux_ui/locales/cs.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Datum
 editor-property-kind-list = Seznam
 editor-property-kind-link = Odkaz
 editor-property-kind-tags = Tagy
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/cy.ftl
+++ b/crates/vmux_ui/locales/cy.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Dyddiad
 editor-property-kind-list = Rhestr
 editor-property-kind-link = Cyswllt
 editor-property-kind-tags = Tagiau
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/da.ftl
+++ b/crates/vmux_ui/locales/da.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Dato
 editor-property-kind-list = Liste
 editor-property-kind-link = Forbindelse
 editor-property-kind-tags = Tags
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/de.ftl
+++ b/crates/vmux_ui/locales/de.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Datum
 editor-property-kind-list = Liste
 editor-property-kind-link = Link
 editor-property-kind-tags = Schlagworte
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/el.ftl
+++ b/crates/vmux_ui/locales/el.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Ημερομηνία
 editor-property-kind-list = Λίστα
 editor-property-kind-link = Σύνδεσμος
 editor-property-kind-tags = Ετικέτες
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/en-US.ftl
+++ b/crates/vmux_ui/locales/en-US.ftl
@@ -718,3 +718,7 @@ debug-simulate-update = Simulate update available
 debug-simulate-download = Simulate download
 debug-clear-update = Clear update
 debug-trigger-restart = Trigger restart
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/eo.ftl
+++ b/crates/vmux_ui/locales/eo.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Dato
 editor-property-kind-list = Listo
 editor-property-kind-link = Ligo
 editor-property-kind-tags = Etikedoj
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/es.ftl
+++ b/crates/vmux_ui/locales/es.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Fecha
 editor-property-kind-list = Lista
 editor-property-kind-link = Enlace
 editor-property-kind-tags = Etiquetas
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/et.ftl
+++ b/crates/vmux_ui/locales/et.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Kuupäev
 editor-property-kind-list = Nimekiri
 editor-property-kind-link = Link
 editor-property-kind-tags = Sildid
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/eu.ftl
+++ b/crates/vmux_ui/locales/eu.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Data
 editor-property-kind-list = Zerrenda
 editor-property-kind-link = Esteka
 editor-property-kind-tags = Etiketak
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/fa.ftl
+++ b/crates/vmux_ui/locales/fa.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = تاریخ
 editor-property-kind-list = فهرست کنید
 editor-property-kind-link = پیوند
 editor-property-kind-tags = برچسب ها
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/fi.ftl
+++ b/crates/vmux_ui/locales/fi.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Päivämäärä
 editor-property-kind-list = Lista
 editor-property-kind-link = Linkki
 editor-property-kind-tags = Tunnisteet
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/fil.ftl
+++ b/crates/vmux_ui/locales/fil.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Petsa
 editor-property-kind-list = Listahan
 editor-property-kind-link = Link
 editor-property-kind-tags = Mga tag
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/fr.ftl
+++ b/crates/vmux_ui/locales/fr.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Date
 editor-property-kind-list = Liste
 editor-property-kind-link = Lien
 editor-property-kind-tags = Balises
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/fy.ftl
+++ b/crates/vmux_ui/locales/fy.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Datum
 editor-property-kind-list = List
 editor-property-kind-link = Link
 editor-property-kind-tags = Tags
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ga.ftl
+++ b/crates/vmux_ui/locales/ga.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Dáta
 editor-property-kind-list = Liosta
 editor-property-kind-link = Nasc
 editor-property-kind-tags = Clibeanna
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/gd.ftl
+++ b/crates/vmux_ui/locales/gd.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Ceann-latha
 editor-property-kind-list = Liosta
 editor-property-kind-link = Ceangal
 editor-property-kind-tags = Tagaichean
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/gl.ftl
+++ b/crates/vmux_ui/locales/gl.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Data
 editor-property-kind-list = Lista
 editor-property-kind-link = Ligazón
 editor-property-kind-tags = Etiquetas
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/gu.ftl
+++ b/crates/vmux_ui/locales/gu.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = તારીખ
 editor-property-kind-list = યાદી
 editor-property-kind-link = લિંક
 editor-property-kind-tags = ટૅગ્સ
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ha.ftl
+++ b/crates/vmux_ui/locales/ha.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Kwanan wata
 editor-property-kind-list = Jerin
 editor-property-kind-link = mahada
 editor-property-kind-tags = Tags
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/haw.ftl
+++ b/crates/vmux_ui/locales/haw.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Lā
 editor-property-kind-list = Papa inoa
 editor-property-kind-link = loulou
 editor-property-kind-tags = Nā huaʻōlelo
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/he.ftl
+++ b/crates/vmux_ui/locales/he.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = תַאֲרִיך
 editor-property-kind-list = רְשִׁימָה
 editor-property-kind-link = לְקַשֵׁר
 editor-property-kind-tags = תגים
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/hi.ftl
+++ b/crates/vmux_ui/locales/hi.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = तारीख
 editor-property-kind-list = सूची
 editor-property-kind-link = जोड़ना
 editor-property-kind-tags = टैग
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/hmn.ftl
+++ b/crates/vmux_ui/locales/hmn.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Hnub tim
 editor-property-kind-list = Sau npe
 editor-property-kind-link = Txuas
 editor-property-kind-tags = Cim npe
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/hr.ftl
+++ b/crates/vmux_ui/locales/hr.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Datum
 editor-property-kind-list = Popis
 editor-property-kind-link = Link
 editor-property-kind-tags = oznake
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ht.ftl
+++ b/crates/vmux_ui/locales/ht.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Dat
 editor-property-kind-list = Lis
 editor-property-kind-link = Link
 editor-property-kind-tags = Tags
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/hu.ftl
+++ b/crates/vmux_ui/locales/hu.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Dátum
 editor-property-kind-list = Lista
 editor-property-kind-link = Link
 editor-property-kind-tags = Címkék
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/hy.ftl
+++ b/crates/vmux_ui/locales/hy.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Ամսաթիվ
 editor-property-kind-list = Ցուցակ
 editor-property-kind-link = Հղում
 editor-property-kind-tags = Պիտակներ
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/id.ftl
+++ b/crates/vmux_ui/locales/id.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Tanggal
 editor-property-kind-list = Daftar
 editor-property-kind-link = Link
 editor-property-kind-tags = Tag
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ig.ftl
+++ b/crates/vmux_ui/locales/ig.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Ụbọchị
 editor-property-kind-list = Ndepụta
 editor-property-kind-link = Njikọ
 editor-property-kind-tags = Tags
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/is.ftl
+++ b/crates/vmux_ui/locales/is.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Dagsetning
 editor-property-kind-list = Listi
 editor-property-kind-link = Tengill
 editor-property-kind-tags = Merki
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/it.ftl
+++ b/crates/vmux_ui/locales/it.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Data
 editor-property-kind-list = Lista
 editor-property-kind-link = Collegamento
 editor-property-kind-tags = Tag
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ja.ftl
+++ b/crates/vmux_ui/locales/ja.ftl
@@ -712,3 +712,7 @@ editor-property-kind-date = 日付
 editor-property-kind-list = リスト
 editor-property-kind-link = リンク
 editor-property-kind-tags = タグ
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/jv.ftl
+++ b/crates/vmux_ui/locales/jv.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Tanggal
 editor-property-kind-list = Dhaptar
 editor-property-kind-link = Link
 editor-property-kind-tags = Tag
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ka.ftl
+++ b/crates/vmux_ui/locales/ka.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = თარიღი
 editor-property-kind-list = სია
 editor-property-kind-link = ბმული
 editor-property-kind-tags = ტეგები
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/kk.ftl
+++ b/crates/vmux_ui/locales/kk.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Күн
 editor-property-kind-list = Тізім
 editor-property-kind-link = Сілтеме
 editor-property-kind-tags = Тегтер
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/km.ftl
+++ b/crates/vmux_ui/locales/km.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = កាលបរិច្ឆេទ
 editor-property-kind-list = បញ្ជី
 editor-property-kind-link = តំណភ្ជាប់
 editor-property-kind-tags = ស្លាក
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/kn.ftl
+++ b/crates/vmux_ui/locales/kn.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = ದಿನಾಂಕ
 editor-property-kind-list = ಪಟ್ಟಿ
 editor-property-kind-link = ಲಿಂಕ್
 editor-property-kind-tags = ಟ್ಯಾಗ್‌ಗಳು
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ko.ftl
+++ b/crates/vmux_ui/locales/ko.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = 날짜
 editor-property-kind-list = 목록
 editor-property-kind-link = 링크
 editor-property-kind-tags = 태그
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ku.ftl
+++ b/crates/vmux_ui/locales/ku.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Rojek
 editor-property-kind-list = Rêzkirin
 editor-property-kind-link = Girêk
 editor-property-kind-tags = Tags
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ky.ftl
+++ b/crates/vmux_ui/locales/ky.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Дата
 editor-property-kind-list = Тизме
 editor-property-kind-link = Шилтеме
 editor-property-kind-tags = Тегдер
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/la.ftl
+++ b/crates/vmux_ui/locales/la.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Date
 editor-property-kind-list = List
 editor-property-kind-link = Link
 editor-property-kind-tags = Tags
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/lb.ftl
+++ b/crates/vmux_ui/locales/lb.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Datum
 editor-property-kind-list = Lëscht
 editor-property-kind-link = Link
 editor-property-kind-tags = Tags
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/lo.ftl
+++ b/crates/vmux_ui/locales/lo.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = ວັນທີ
 editor-property-kind-list = ລາຍການ
 editor-property-kind-link = ເຊື່ອມຕໍ່
 editor-property-kind-tags = ປ້າຍກຳກັບ
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/lt.ftl
+++ b/crates/vmux_ui/locales/lt.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Data
 editor-property-kind-list = Sąrašas
 editor-property-kind-link = Nuoroda
 editor-property-kind-tags = Žymos
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/lv.ftl
+++ b/crates/vmux_ui/locales/lv.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Datums
 editor-property-kind-list = Saraksts
 editor-property-kind-link = Saite
 editor-property-kind-tags = Tagi
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/mg.ftl
+++ b/crates/vmux_ui/locales/mg.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Daty
 editor-property-kind-list = Lisitra
 editor-property-kind-link = Rohy
 editor-property-kind-tags = Tags
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/mi.ftl
+++ b/crates/vmux_ui/locales/mi.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Rā
 editor-property-kind-list = Rarangi
 editor-property-kind-link = Hononga
 editor-property-kind-tags = Tohutohu
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/mk.ftl
+++ b/crates/vmux_ui/locales/mk.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Датум
 editor-property-kind-list = Список
 editor-property-kind-link = Врска
 editor-property-kind-tags = Тагови
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ml.ftl
+++ b/crates/vmux_ui/locales/ml.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = തീയതി
 editor-property-kind-list = ലിസ്റ്റ്
 editor-property-kind-link = ലിങ്ക്
 editor-property-kind-tags = ടാഗുകൾ
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/mn.ftl
+++ b/crates/vmux_ui/locales/mn.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Огноо
 editor-property-kind-list = Жагсаалт
 editor-property-kind-link = Холбоос
 editor-property-kind-tags = Шошго
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/mr.ftl
+++ b/crates/vmux_ui/locales/mr.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = तारीख
 editor-property-kind-list = यादी
 editor-property-kind-link = दुवा
 editor-property-kind-tags = टॅग्ज
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ms.ftl
+++ b/crates/vmux_ui/locales/ms.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = tarikh
 editor-property-kind-list = Senaraikan
 editor-property-kind-link = Pautan
 editor-property-kind-tags = Tag
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/mt.ftl
+++ b/crates/vmux_ui/locales/mt.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Data
 editor-property-kind-list = Lista
 editor-property-kind-link = Link
 editor-property-kind-tags = Tikketti
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/my.ftl
+++ b/crates/vmux_ui/locales/my.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = ရက်စွဲ
 editor-property-kind-list = စာရင်း
 editor-property-kind-link = လင့်
 editor-property-kind-tags = တဂ်
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/nb.ftl
+++ b/crates/vmux_ui/locales/nb.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Dato
 editor-property-kind-list = Liste
 editor-property-kind-link = Link
 editor-property-kind-tags = Tagger
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ne.ftl
+++ b/crates/vmux_ui/locales/ne.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = मिति
 editor-property-kind-list = सूची
 editor-property-kind-link = लिङ्क
 editor-property-kind-tags = ट्यागहरू
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/nl.ftl
+++ b/crates/vmux_ui/locales/nl.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Datum
 editor-property-kind-list = Lijst
 editor-property-kind-link = Link
 editor-property-kind-tags = Labels
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/no.ftl
+++ b/crates/vmux_ui/locales/no.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Dato
 editor-property-kind-list = Liste
 editor-property-kind-link = Link
 editor-property-kind-tags = Tagger
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ny.ftl
+++ b/crates/vmux_ui/locales/ny.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Tsiku
 editor-property-kind-list = Mndandanda
 editor-property-kind-link = Lumikizani
 editor-property-kind-tags = Tags
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/or.ftl
+++ b/crates/vmux_ui/locales/or.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = ତାରିଖ
 editor-property-kind-list = ତାଲିକା |
 editor-property-kind-link = ଲିଙ୍କ୍ |
 editor-property-kind-tags = ଟ୍ୟାଗ୍ସ
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/pa.ftl
+++ b/crates/vmux_ui/locales/pa.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = ਮਿਤੀ
 editor-property-kind-list = ਸੂਚੀ
 editor-property-kind-link = ਲਿੰਕ
 editor-property-kind-tags = ਟੈਗਸ
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/pl.ftl
+++ b/crates/vmux_ui/locales/pl.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Data
 editor-property-kind-list = Lista
 editor-property-kind-link = Połączyć
 editor-property-kind-tags = Tagi
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ps.ftl
+++ b/crates/vmux_ui/locales/ps.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = نیټه
 editor-property-kind-list = لیست
 editor-property-kind-link = لینک
 editor-property-kind-tags = ټګونه
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/pt-BR.ftl
+++ b/crates/vmux_ui/locales/pt-BR.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Data
 editor-property-kind-list = Lista
 editor-property-kind-link = Link
 editor-property-kind-tags = Etiquetas
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/pt-PT.ftl
+++ b/crates/vmux_ui/locales/pt-PT.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Data
 editor-property-kind-list = Lista
 editor-property-kind-link = Ligação
 editor-property-kind-tags = Etiquetas
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/pt.ftl
+++ b/crates/vmux_ui/locales/pt.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Data
 editor-property-kind-list = Lista
 editor-property-kind-link = Link
 editor-property-kind-tags = Etiquetas
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ro.ftl
+++ b/crates/vmux_ui/locales/ro.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Data
 editor-property-kind-list = Listă
 editor-property-kind-link = Legătură
 editor-property-kind-tags = Etichete
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ru.ftl
+++ b/crates/vmux_ui/locales/ru.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Дата
 editor-property-kind-list = Список
 editor-property-kind-link = Связь
 editor-property-kind-tags = Теги
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/rw.ftl
+++ b/crates/vmux_ui/locales/rw.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Itariki
 editor-property-kind-list = Urutonde
 editor-property-kind-link = Ihuza
 editor-property-kind-tags = Etiquetas
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/sd.ftl
+++ b/crates/vmux_ui/locales/sd.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = تاريخ
 editor-property-kind-list = فهرست
 editor-property-kind-link = ڳنڍ
 editor-property-kind-tags = ٽيگ
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/si.ftl
+++ b/crates/vmux_ui/locales/si.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = දිනය
 editor-property-kind-list = ලැයිස්තුව
 editor-property-kind-link = සබැඳිය
 editor-property-kind-tags = ටැග්
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/sk.ftl
+++ b/crates/vmux_ui/locales/sk.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Dátum
 editor-property-kind-list = Zoznam
 editor-property-kind-link = Odkaz
 editor-property-kind-tags = Tagy
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/sl.ftl
+++ b/crates/vmux_ui/locales/sl.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Datum
 editor-property-kind-list = Seznam
 editor-property-kind-link = Povezava
 editor-property-kind-tags = Oznake
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/sm.ftl
+++ b/crates/vmux_ui/locales/sm.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Aso
 editor-property-kind-list = Lisi
 editor-property-kind-link = So'oga
 editor-property-kind-tags = Fa'ailoga
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/sn.ftl
+++ b/crates/vmux_ui/locales/sn.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Date
 editor-property-kind-list = List
 editor-property-kind-link = Link
 editor-property-kind-tags = Tags
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/so.ftl
+++ b/crates/vmux_ui/locales/so.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Taariikhda
 editor-property-kind-list = Liiska
 editor-property-kind-link = Xiriirinta
 editor-property-kind-tags = Tags
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/sq.ftl
+++ b/crates/vmux_ui/locales/sq.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Data
 editor-property-kind-list = Lista
 editor-property-kind-link = Lidhje
 editor-property-kind-tags = Etiketat
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/sr.ftl
+++ b/crates/vmux_ui/locales/sr.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Датум
 editor-property-kind-list = Лист
 editor-property-kind-link = Линк
 editor-property-kind-tags = Ознаке
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/st.ftl
+++ b/crates/vmux_ui/locales/st.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Letsatsi
 editor-property-kind-list = Lenane
 editor-property-kind-link = Sehokelo
 editor-property-kind-tags = Li-tag
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/su.ftl
+++ b/crates/vmux_ui/locales/su.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = titimangsa
 editor-property-kind-list = Daptar
 editor-property-kind-link = Tumbu
 editor-property-kind-tags = Tag
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/sv.ftl
+++ b/crates/vmux_ui/locales/sv.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Datum
 editor-property-kind-list = Lista
 editor-property-kind-link = Länk
 editor-property-kind-tags = Taggar
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/sw.ftl
+++ b/crates/vmux_ui/locales/sw.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Tarehe
 editor-property-kind-list = Orodha
 editor-property-kind-link = Kiungo
 editor-property-kind-tags = Lebo
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ta.ftl
+++ b/crates/vmux_ui/locales/ta.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = தேதி
 editor-property-kind-list = பட்டியல்
 editor-property-kind-link = இணைப்பு
 editor-property-kind-tags = குறிச்சொற்கள்
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/te.ftl
+++ b/crates/vmux_ui/locales/te.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = తేదీ
 editor-property-kind-list = జాబితా
 editor-property-kind-link = లింక్
 editor-property-kind-tags = ట్యాగ్‌లు
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/tg.ftl
+++ b/crates/vmux_ui/locales/tg.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Сана
 editor-property-kind-list = Рӯйхат
 editor-property-kind-link = Пайванд
 editor-property-kind-tags = Тегҳо
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/th.ftl
+++ b/crates/vmux_ui/locales/th.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = วันที่
 editor-property-kind-list = รายการ
 editor-property-kind-link = ลิงค์
 editor-property-kind-tags = แท็ก
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/tk.ftl
+++ b/crates/vmux_ui/locales/tk.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Sene
 editor-property-kind-list = Sanaw
 editor-property-kind-link = Baglanyşyk
 editor-property-kind-tags = Bellikler
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/tl.ftl
+++ b/crates/vmux_ui/locales/tl.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Petsa
 editor-property-kind-list = Listahan
 editor-property-kind-link = Link
 editor-property-kind-tags = Mga tag
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/tr.ftl
+++ b/crates/vmux_ui/locales/tr.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Tarih
 editor-property-kind-list = Liste
 editor-property-kind-link = Bağlantı
 editor-property-kind-tags = Etiketler
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/tt.ftl
+++ b/crates/vmux_ui/locales/tt.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Дата
 editor-property-kind-list = Исемлек
 editor-property-kind-link = Ссылка
 editor-property-kind-tags = Теги
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ug.ftl
+++ b/crates/vmux_ui/locales/ug.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = چېسلا
 editor-property-kind-list = تىزىملىك
 editor-property-kind-link = ئۇلىنىش
 editor-property-kind-tags = خەتكۈچ
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/uk.ftl
+++ b/crates/vmux_ui/locales/uk.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Дата
 editor-property-kind-list = Список
 editor-property-kind-link = Посилання
 editor-property-kind-tags = Теги
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/ur.ftl
+++ b/crates/vmux_ui/locales/ur.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = تاریخ
 editor-property-kind-list = فہرست
 editor-property-kind-link = لنک
 editor-property-kind-tags = ٹیگز
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/uz.ftl
+++ b/crates/vmux_ui/locales/uz.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Sana
 editor-property-kind-list = Roʻyxat
 editor-property-kind-link = Havola
 editor-property-kind-tags = Teglar
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/vi.ftl
+++ b/crates/vmux_ui/locales/vi.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Ngày
 editor-property-kind-list = Danh sách
 editor-property-kind-link = liên kết
 editor-property-kind-tags = Thẻ
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/xh.ftl
+++ b/crates/vmux_ui/locales/xh.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Umhla
 editor-property-kind-list = Uluhlu
 editor-property-kind-link = Ikhonkco
 editor-property-kind-tags = Iithegi
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/yi.ftl
+++ b/crates/vmux_ui/locales/yi.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = טאָג
 editor-property-kind-list = רשימה
 editor-property-kind-link = לינק
 editor-property-kind-tags = טאַגס
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/yo.ftl
+++ b/crates/vmux_ui/locales/yo.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Ọjọ
 editor-property-kind-list = Akojọ
 editor-property-kind-link = Ọna asopọ
 editor-property-kind-tags = Awọn afi
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/zh-Hans.ftl
+++ b/crates/vmux_ui/locales/zh-Hans.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = 日期
 editor-property-kind-list = 列表
 editor-property-kind-link = 关联
 editor-property-kind-tags = 标签
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/zh-Hant.ftl
+++ b/crates/vmux_ui/locales/zh-Hant.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = 日期
 editor-property-kind-list = 清單
 editor-property-kind-link = 關聯
 editor-property-kind-tags = 標籤
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/zh-TW.ftl
+++ b/crates/vmux_ui/locales/zh-TW.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = 日期
 editor-property-kind-list = 清單
 editor-property-kind-link = 關聯
 editor-property-kind-tags = 標籤
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/zh.ftl
+++ b/crates/vmux_ui/locales/zh.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = 日期
 editor-property-kind-list = 列表
 editor-property-kind-link = 关联
 editor-property-kind-tags = 标签
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_ui/locales/zu.ftl
+++ b/crates/vmux_ui/locales/zu.ftl
@@ -727,3 +727,7 @@ editor-property-kind-date = Usuku
 editor-property-kind-list = Uhlu
 editor-property-kind-link = Isixhumanisi
 editor-property-kind-tags = Omaka
+
+agent-effort = Effort
+agent-effort-default = Default
+agent-effort-tooltip = Reasoning effort (applies to new sessions)

--- a/crates/vmux_wire/src/protocol.rs
+++ b/crates/vmux_wire/src/protocol.rs
@@ -675,6 +675,9 @@ pub enum ClientMessage {
         resume_acp_session_id: Option<String>,
         /// MCP servers imported into vmux Registry and managed for every launched agent.
         managed_mcp_servers: Vec<ManagedMcpServer>,
+        /// Launch-time reasoning-effort level for this session (agent-specific; e.g. Claude
+        /// forwards it through `claudeCode.options.effort`). `None` = the agent's own default.
+        effort: Option<String>,
     },
     Status,
     AgentInputWithAttachments {
@@ -1755,6 +1758,7 @@ mod tests {
                 url: Some("https://example.com/mcp".into()),
                 headers: Vec::new(),
             }],
+            effort: Some("high".into()),
         };
         let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&client).unwrap();
         let decoded = rkyv::from_bytes::<ClientMessage, rkyv::rancor::Error>(&bytes).unwrap();


### PR DESCRIPTION
## Context
Claude/Codex expose a reasoning-**effort** knob (Claude `--effort` / Agent SDK `effort`, Codex `model_reasoning_effort`), but vmux had no way to set it. This adds an **Effort** pill beside the model pill in the chat composer.

## Behavior
Effort is a **per-agent launch-time default**, persisted in settings (`agent.effort`) and applied when the agent next starts a session/process:
- **CLI claude** → `--effort <level>` (prepended, so `--resume` stays last)
- **CLI codex** → `-c model_reasoning_effort=<level>`
- **ACP claude** → injected into the existing `claudeCode.options` session `_meta` (`driver.rs`), which the adapter forwards to the Agent SDK `effort` option

Levels are per-agent — claude `low/medium/high/max`, codex `minimal/low/medium/high`; agents with no vmux-drivable effort knob hide the pill (`vmux_core::agent::effort_levels`).

## Why next-session, not live
Investigated `@zed-industries/claude-code-acp` 0.16.2 + `@anthropic-ai/claude-agent-sdk`: the adapter fixes query options at session creation and the SDK exposes `setModel`/`setPermissionMode`/`setMaxThinkingTokens` but **no `setEffort`**. So true mid-session switching is impossible upstream for ACP claude; the pill applies to the next session. (The standalone CLI has a live `/effort` command users can still use.)

## Plumbing
`SpawnAcpAgent` gains an `effort` field (GUI → server → driver). CLI effort threads through `build_agent_launch` → `CliAgentStrategy::effort_args`. The composer pushes the current effort via `ModelState`; selecting emits `SetAgentEffort`, which persists to settings.

## i18n
Added `agent-effort` / `agent-effort-default` / `agent-effort-tooltip` to all 115 bundled locales (parity test passes). **Non-English values are English placeholders pending translation.**

## Tests
`effort_levels` contract (incl. deliberate empties for ACP codex/gemini), claude/codex `effort_args` flag contracts, and driver `session_meta` effort injection (set / unset / invalid dropped / non-claude ignored). Targeted tests + fmt + clippy + pre-push workspace gate all green.

## QA (needs app run)
Open a Claude ACP agent → the **Effort** pill appears beside the model pill; pick a level; the next session launches with `claudeCode.options.effort`. For CLI, the chosen level is passed as `--effort` / `-c model_reasoning_effort=` on the next spawn.

## Follow-ups
- Effort pill on the `vmux://start` composer (set effort before launching).
- Real translations for the 3 new strings.
- ACP codex/gemini effort once their runtimes expose a control.
