### PR TITLE
feat(editor): vim mode Neovim parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9788,6 +9788,7 @@ dependencies = [
  "notify 6.1.1",
  "percent-encoding",
  "pulldown-cmark",
+ "regex",
  "reqwest",
  "rkyv",
  "ron 0.8.1",

--- a/crates/vmux_core/src/editor.rs
+++ b/crates/vmux_core/src/editor.rs
@@ -21,6 +21,7 @@ pub enum EditMode {
     VisualLine,
     CommandLine,
     Replace,
+    VisualBlock,
 }
 
 impl EditMode {
@@ -32,10 +33,14 @@ impl EditMode {
             EditMode::VisualLine => "V-LINE",
             EditMode::CommandLine => "COMMAND",
             EditMode::Replace => "REPLACE",
+            EditMode::VisualBlock => "V-BLOCK",
         }
     }
     pub fn is_visual(self) -> bool {
-        matches!(self, EditMode::Visual | EditMode::VisualLine)
+        matches!(
+            self,
+            EditMode::Visual | EditMode::VisualLine | EditMode::VisualBlock
+        )
     }
     pub fn accepts_text(self) -> bool {
         matches!(self, EditMode::Insert | EditMode::Replace)

--- a/crates/vmux_core/src/editor.rs
+++ b/crates/vmux_core/src/editor.rs
@@ -20,6 +20,7 @@ pub enum EditMode {
     Visual,
     VisualLine,
     CommandLine,
+    Replace,
 }
 
 impl EditMode {
@@ -30,13 +31,14 @@ impl EditMode {
             EditMode::Visual => "VISUAL",
             EditMode::VisualLine => "V-LINE",
             EditMode::CommandLine => "COMMAND",
+            EditMode::Replace => "REPLACE",
         }
     }
     pub fn is_visual(self) -> bool {
         matches!(self, EditMode::Visual | EditMode::VisualLine)
     }
     pub fn accepts_text(self) -> bool {
-        matches!(self, EditMode::Insert)
+        matches!(self, EditMode::Insert | EditMode::Replace)
     }
 }
 

--- a/crates/vmux_core/src/editor.rs
+++ b/crates/vmux_core/src/editor.rs
@@ -47,6 +47,18 @@ impl EditMode {
     }
 }
 
+/// One `:map`-style binding from settings.
+///
+/// `mode` is the usual letter prefix (`n`, `i`, `v`, or a combination); an empty string means
+/// normal and visual, matching bare `:map`.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct KeyMapping {
+    #[serde(default)]
+    pub mode: String,
+    pub lhs: String,
+    pub rhs: String,
+}
+
 #[derive(
     Debug,
     Clone,

--- a/crates/vmux_core/src/editor.rs
+++ b/crates/vmux_core/src/editor.rs
@@ -19,6 +19,7 @@ pub enum EditMode {
     Insert,
     Visual,
     VisualLine,
+    CommandLine,
 }
 
 impl EditMode {
@@ -28,6 +29,7 @@ impl EditMode {
             EditMode::Insert => "INSERT",
             EditMode::Visual => "VISUAL",
             EditMode::VisualLine => "V-LINE",
+            EditMode::CommandLine => "COMMAND",
         }
     }
     pub fn is_visual(self) -> bool {

--- a/crates/vmux_core/src/event.rs
+++ b/crates/vmux_core/src/event.rs
@@ -1895,6 +1895,9 @@ pub struct FileCursorEvent {
     pub selections: Vec<crate::editor::SelSpan>,
     pub source_primary: crate::editor::CursorPos,
     pub source_selections: Vec<crate::editor::SelSpan>,
+    /// The `:`, `/`, or `?` prompt being typed, or empty when no prompt is open.
+    pub command_line: String,
+    pub search: Vec<crate::editor::SelSpan>,
 }
 
 #[derive(
@@ -2319,6 +2322,13 @@ mod tests {
                 row: 3,
                 start: 20,
                 end: 25,
+            }],
+            command_line: ":wq".into(),
+            search: vec![SelSpan {
+                line: 1,
+                row: 1,
+                start: 2,
+                end: 6,
             }],
         };
         let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&e).unwrap();

--- a/crates/vmux_editor/Cargo.toml
+++ b/crates/vmux_editor/Cargo.toml
@@ -13,6 +13,7 @@ web = []
 path = "src/lib.rs"
 
 [dependencies]
+regex.workspace = true
 serde = { workspace = true }
 rkyv = { workspace = true }
 vmux_core = { path = "../vmux_core" }

--- a/crates/vmux_editor/src/edit.rs
+++ b/crates/vmux_editor/src/edit.rs
@@ -6,6 +6,7 @@ pub mod highlight_cache;
 pub mod register;
 pub mod search;
 pub mod text_object;
+pub mod undo;
 
 pub use command::{EditCommand, Motion, Operator, Selection, Target};
 pub use core::{EditCore, EditOutcome};

--- a/crates/vmux_editor/src/edit.rs
+++ b/crates/vmux_editor/src/edit.rs
@@ -2,7 +2,9 @@ pub mod buffer;
 pub mod command;
 pub mod core;
 pub mod highlight_cache;
+pub mod register;
 
-pub use command::{EditCommand, Motion, Selection};
+pub use command::{EditCommand, Motion, Operator, Selection, Target};
 pub use core::{EditCore, EditOutcome};
+pub use register::{RegisterKind, RegisterValue, Registers};
 pub use vmux_core::{CursorPos, EditMode, SelSpan};

--- a/crates/vmux_editor/src/edit.rs
+++ b/crates/vmux_editor/src/edit.rs
@@ -1,6 +1,7 @@
 pub mod buffer;
 pub mod command;
 pub mod core;
+pub mod ex;
 pub mod highlight_cache;
 pub mod register;
 pub mod search;

--- a/crates/vmux_editor/src/edit.rs
+++ b/crates/vmux_editor/src/edit.rs
@@ -3,6 +3,7 @@ pub mod command;
 pub mod core;
 pub mod highlight_cache;
 pub mod register;
+pub mod search;
 pub mod text_object;
 
 pub use command::{EditCommand, Motion, Operator, Selection, Target};

--- a/crates/vmux_editor/src/edit.rs
+++ b/crates/vmux_editor/src/edit.rs
@@ -3,8 +3,10 @@ pub mod command;
 pub mod core;
 pub mod highlight_cache;
 pub mod register;
+pub mod text_object;
 
 pub use command::{EditCommand, Motion, Operator, Selection, Target};
 pub use core::{EditCore, EditOutcome};
 pub use register::{RegisterKind, RegisterValue, Registers};
+pub use text_object::{TextObject, TextObjectKind};
 pub use vmux_core::{CursorPos, EditMode, SelSpan};

--- a/crates/vmux_editor/src/edit/command.rs
+++ b/crates/vmux_editor/src/edit/command.rs
@@ -217,6 +217,11 @@ pub enum EditCommand {
     FinishBlockInsert {
         text: String,
     },
+    /// Walk the undo tree by creation time rather than by branch, for `g-` and `g+`.
+    UndoTime {
+        forward: bool,
+        count: usize,
+    },
     /// Add `delta` to the number at or after the caret on the current line.
     Increment(i64),
     SwapSelectionEnds,

--- a/crates/vmux_editor/src/edit/command.rs
+++ b/crates/vmux_editor/src/edit/command.rs
@@ -73,6 +73,7 @@ impl Operator {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Target {
     Motion(Motion, usize),
+    TextObject(crate::edit::text_object::TextObject),
     Line(usize),
     Selection,
 }
@@ -110,6 +111,7 @@ pub enum EditCommand {
         above: bool,
     },
     SwapSelectionEnds,
+    SelectTextObject(crate::edit::text_object::TextObject),
     ScrollViewport(i32),
     SetMode(EditMode),
     Undo,

--- a/crates/vmux_editor/src/edit/command.rs
+++ b/crates/vmux_editor/src/edit/command.rs
@@ -209,6 +209,14 @@ pub enum EditCommand {
     OpenLine {
         above: bool,
     },
+    /// Start a blockwise insert: remember the rectangle's rows and put the caret on its first row.
+    BeginBlockInsert {
+        after: bool,
+    },
+    /// Replicate the text typed during a blockwise insert onto the block's remaining rows.
+    FinishBlockInsert {
+        text: String,
+    },
     SwapSelectionEnds,
     SelectTextObject(crate::edit::text_object::TextObject),
     SetSearch {

--- a/crates/vmux_editor/src/edit/command.rs
+++ b/crates/vmux_editor/src/edit/command.rs
@@ -217,6 +217,14 @@ pub enum EditCommand {
         forward: bool,
     },
     ClearSearchHighlight,
+    Substitute {
+        range: crate::edit::ex::ExRange,
+        pattern: String,
+        replacement: String,
+        all: bool,
+    },
+    ExDelete(crate::edit::ex::ExRange),
+    ExYank(crate::edit::ex::ExRange),
     SetMark(char),
     GotoMark {
         name: char,

--- a/crates/vmux_editor/src/edit/command.rs
+++ b/crates/vmux_editor/src/edit/command.rs
@@ -47,6 +47,7 @@ pub enum Motion {
     ParagraphNext,
     MatchPair,
     FindChar { ch: char, forward: bool, till: bool },
+    SearchNext { reverse: bool },
     GotoLine(u32),
 }
 
@@ -133,6 +134,7 @@ impl Motion {
                 | Motion::ScreenTop
                 | Motion::ScreenMiddle
                 | Motion::ScreenBottom
+                | Motion::SearchNext { .. }
         )
     }
 }
@@ -207,6 +209,14 @@ pub enum EditCommand {
     },
     SwapSelectionEnds,
     SelectTextObject(crate::edit::text_object::TextObject),
+    SetSearch {
+        pattern: String,
+        forward: bool,
+    },
+    SearchWord {
+        forward: bool,
+    },
+    ClearSearchHighlight,
     SetMark(char),
     GotoMark {
         name: char,

--- a/crates/vmux_editor/src/edit/command.rs
+++ b/crates/vmux_editor/src/edit/command.rs
@@ -72,9 +72,12 @@ impl Motion {
             | Motion::BigWordEnd
             | Motion::WordEndPrev
             | Motion::BigWordEndPrev
-            | Motion::LineEnd
             | Motion::LastNonBlank
             | Motion::MatchPair => MotionKind::Inclusive,
+            // `resolve_motion` already returns the index of the line's `\n`, one past the last
+            // character. Counting that as inclusive steps over the newline, so `D` and Ctrl-K
+            // would join the following line.
+            Motion::LineEnd => MotionKind::Exclusive,
             Motion::FindChar { forward, .. } if forward => MotionKind::Inclusive,
             _ => MotionKind::Exclusive,
         }

--- a/crates/vmux_editor/src/edit/command.rs
+++ b/crates/vmux_editor/src/edit/command.rs
@@ -22,15 +22,31 @@ pub enum Motion {
     WordNext,
     WordPrev,
     WordEnd,
+    BigWordNext,
+    BigWordPrev,
+    BigWordEnd,
+    WordEndPrev,
+    BigWordEndPrev,
     LineStart,
     FirstNonBlank,
     LineEnd,
+    LastNonBlank,
+    Column(usize),
     DocStart,
     DocEnd,
     PageUp,
     PageDown,
+    HalfPageUp,
+    HalfPageDown,
+    ScreenTop,
+    ScreenMiddle,
+    ScreenBottom,
+    NextLineStart,
+    PrevLineStart,
     ParagraphPrev,
     ParagraphNext,
+    MatchPair,
+    FindChar { ch: char, forward: bool, till: bool },
     GotoLine(u32),
 }
 
@@ -41,13 +57,76 @@ impl Motion {
             | Motion::Down
             | Motion::PageUp
             | Motion::PageDown
+            | Motion::HalfPageUp
+            | Motion::HalfPageDown
+            | Motion::ScreenTop
+            | Motion::ScreenMiddle
+            | Motion::ScreenBottom
+            | Motion::NextLineStart
+            | Motion::PrevLineStart
             | Motion::DocStart
             | Motion::DocEnd
             | Motion::GotoLine(_) => MotionKind::Linewise,
-            Motion::WordEnd | Motion::LineEnd => MotionKind::Inclusive,
+            Motion::WordEnd
+            | Motion::BigWordEnd
+            | Motion::WordEndPrev
+            | Motion::BigWordEndPrev
+            | Motion::LineEnd
+            | Motion::LastNonBlank
+            | Motion::MatchPair => MotionKind::Inclusive,
+            Motion::FindChar { forward, .. } if forward => MotionKind::Inclusive,
             _ => MotionKind::Exclusive,
         }
     }
+}
+
+impl Motion {
+    /// Which end of an existing selection a plain move collapses to.
+    ///
+    /// `Some(true)` collapses to the start, `Some(false)` to the end, and `None` marks a motion
+    /// that targets an absolute position and should simply be resolved from the caret.
+    pub fn collapse_to_start(self) -> Option<bool> {
+        Some(match self {
+            Motion::Left
+            | Motion::LeftBounded
+            | Motion::Up
+            | Motion::PageUp
+            | Motion::HalfPageUp
+            | Motion::ParagraphPrev
+            | Motion::WordPrev
+            | Motion::BigWordPrev
+            | Motion::WordEndPrev
+            | Motion::BigWordEndPrev
+            | Motion::LineStart
+            | Motion::PrevLineStart
+            | Motion::ScreenTop
+            | Motion::DocStart => true,
+            Motion::Right
+            | Motion::RightBounded
+            | Motion::Down
+            | Motion::PageDown
+            | Motion::HalfPageDown
+            | Motion::ParagraphNext
+            | Motion::WordNext
+            | Motion::BigWordNext
+            | Motion::WordEnd
+            | Motion::BigWordEnd
+            | Motion::LineEnd
+            | Motion::LastNonBlank
+            | Motion::NextLineStart
+            | Motion::ScreenBottom
+            | Motion::DocEnd => false,
+            _ => return None,
+        })
+    }
+}
+
+/// Where `zz`, `zt`, and `zb` place the cursor's line in the viewport.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ScrollPlacement {
+    Top,
+    Center,
+    Bottom,
 }
 
 /// A transformation applied to a range of text.
@@ -113,6 +192,7 @@ pub enum EditCommand {
     SwapSelectionEnds,
     SelectTextObject(crate::edit::text_object::TextObject),
     ScrollViewport(i32),
+    ScrollCursorTo(ScrollPlacement),
     SetMode(EditMode),
     Undo,
     Redo,

--- a/crates/vmux_editor/src/edit/command.rs
+++ b/crates/vmux_editor/src/edit/command.rs
@@ -217,6 +217,8 @@ pub enum EditCommand {
     FinishBlockInsert {
         text: String,
     },
+    /// Add `delta` to the number at or after the caret on the current line.
+    Increment(i64),
     SwapSelectionEnds,
     SelectTextObject(crate::edit::text_object::TextObject),
     SetSearch {

--- a/crates/vmux_editor/src/edit/command.rs
+++ b/crates/vmux_editor/src/edit/command.rs
@@ -180,6 +180,8 @@ pub enum EditCommand {
     Move(Motion),
     Select(Motion),
     InsertText(String),
+    /// Overtype at the caret for Replace mode, remembering what was covered so `Backspace` restores it.
+    OvertypeText(String),
     ReplaceText(String),
     InsertNewline,
     InsertTab,

--- a/crates/vmux_editor/src/edit/command.rs
+++ b/crates/vmux_editor/src/edit/command.rs
@@ -16,12 +16,6 @@ pub enum Motion {
     Left,
     Right,
     LeftBounded,
-    /// Like `LeftBounded`, but steps onto the previous line's last character at column zero.
-    ///
-    /// The note view reflows hard-wrapped source lines into continuous prose, so stopping at a
-    /// source line boundary strands the caret mid-sentence with no visible reason.
-    LeftFlow,
-    RightFlow,
     RightBounded,
     Up,
     Down,
@@ -52,14 +46,8 @@ pub enum Motion {
     ParagraphPrev,
     ParagraphNext,
     MatchPair,
-    FindChar {
-        ch: char,
-        forward: bool,
-        till: bool,
-    },
-    SearchNext {
-        reverse: bool,
-    },
+    FindChar { ch: char, forward: bool, till: bool },
+    SearchNext { reverse: bool },
     GotoLine(u32),
 }
 
@@ -102,7 +90,6 @@ impl Motion {
         Some(match self {
             Motion::Left
             | Motion::LeftBounded
-            | Motion::LeftFlow
             | Motion::Up
             | Motion::PageUp
             | Motion::HalfPageUp
@@ -117,7 +104,6 @@ impl Motion {
             | Motion::DocStart => true,
             Motion::Right
             | Motion::RightBounded
-            | Motion::RightFlow
             | Motion::Down
             | Motion::PageDown
             | Motion::HalfPageDown

--- a/crates/vmux_editor/src/edit/command.rs
+++ b/crates/vmux_editor/src/edit/command.rs
@@ -119,6 +119,22 @@ impl Motion {
             _ => return None,
         })
     }
+
+    /// Whether landing here should record the previous position on the jump list.
+    pub fn is_jump(self) -> bool {
+        matches!(
+            self,
+            Motion::DocStart
+                | Motion::DocEnd
+                | Motion::GotoLine(_)
+                | Motion::ParagraphPrev
+                | Motion::ParagraphNext
+                | Motion::MatchPair
+                | Motion::ScreenTop
+                | Motion::ScreenMiddle
+                | Motion::ScreenBottom
+        )
+    }
 }
 
 /// Where `zz`, `zt`, and `zb` place the cursor's line in the viewport.
@@ -191,6 +207,19 @@ pub enum EditCommand {
     },
     SwapSelectionEnds,
     SelectTextObject(crate::edit::text_object::TextObject),
+    SetMark(char),
+    GotoMark {
+        name: char,
+        linewise: bool,
+    },
+    JumpList {
+        back: bool,
+        count: usize,
+    },
+    ChangeList {
+        back: bool,
+        count: usize,
+    },
     ScrollViewport(i32),
     ScrollCursorTo(ScrollPlacement),
     SetMode(EditMode),

--- a/crates/vmux_editor/src/edit/command.rs
+++ b/crates/vmux_editor/src/edit/command.rs
@@ -16,6 +16,12 @@ pub enum Motion {
     Left,
     Right,
     LeftBounded,
+    /// Like `LeftBounded`, but steps onto the previous line's last character at column zero.
+    ///
+    /// The note view reflows hard-wrapped source lines into continuous prose, so stopping at a
+    /// source line boundary strands the caret mid-sentence with no visible reason.
+    LeftFlow,
+    RightFlow,
     RightBounded,
     Up,
     Down,
@@ -46,8 +52,14 @@ pub enum Motion {
     ParagraphPrev,
     ParagraphNext,
     MatchPair,
-    FindChar { ch: char, forward: bool, till: bool },
-    SearchNext { reverse: bool },
+    FindChar {
+        ch: char,
+        forward: bool,
+        till: bool,
+    },
+    SearchNext {
+        reverse: bool,
+    },
     GotoLine(u32),
 }
 
@@ -90,6 +102,7 @@ impl Motion {
         Some(match self {
             Motion::Left
             | Motion::LeftBounded
+            | Motion::LeftFlow
             | Motion::Up
             | Motion::PageUp
             | Motion::HalfPageUp
@@ -104,6 +117,7 @@ impl Motion {
             | Motion::DocStart => true,
             Motion::Right
             | Motion::RightBounded
+            | Motion::RightFlow
             | Motion::Down
             | Motion::PageDown
             | Motion::HalfPageDown

--- a/crates/vmux_editor/src/edit/command.rs
+++ b/crates/vmux_editor/src/edit/command.rs
@@ -1,5 +1,16 @@
 pub use vmux_core::{CursorPos, EditMode, SelSpan};
 
+/// How an operator turns a motion's endpoint into a range.
+///
+/// Exclusive stops before the target character, inclusive covers it, and linewise expands the
+/// range to whole lines. Getting this wrong is what makes `de` and `dj` behave like `dw`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MotionKind {
+    Exclusive,
+    Inclusive,
+    Linewise,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Motion {
     Left,
@@ -23,6 +34,49 @@ pub enum Motion {
     GotoLine(u32),
 }
 
+impl Motion {
+    pub fn kind(self) -> MotionKind {
+        match self {
+            Motion::Up
+            | Motion::Down
+            | Motion::PageUp
+            | Motion::PageDown
+            | Motion::DocStart
+            | Motion::DocEnd
+            | Motion::GotoLine(_) => MotionKind::Linewise,
+            Motion::WordEnd | Motion::LineEnd => MotionKind::Inclusive,
+            _ => MotionKind::Exclusive,
+        }
+    }
+}
+
+/// A transformation applied to a range of text.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Operator {
+    Delete,
+    Change,
+    Yank,
+    Indent,
+    Outdent,
+    Upper,
+    Lower,
+    ToggleCase,
+}
+
+impl Operator {
+    pub fn is_linewise_only(self) -> bool {
+        matches!(self, Operator::Indent | Operator::Outdent)
+    }
+}
+
+/// What an operator acts on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Target {
+    Motion(Motion, usize),
+    Line(usize),
+    Selection,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum EditCommand {
     Move(Motion),
@@ -34,15 +88,28 @@ pub enum EditCommand {
     DeleteBack,
     DeleteForward,
     DeleteWordBack,
-    DeleteToLineEnd,
-    DeleteRange(Motion),
-    YankRange(Motion),
-    DeleteSelection,
-    DeleteLine,
-    Yank,
-    Cut,
-    Paste,
-    PasteBefore,
+    Op {
+        operator: Operator,
+        target: Target,
+        register: Option<char>,
+    },
+    Put {
+        before: bool,
+        count: usize,
+        register: Option<char>,
+    },
+    ReplaceChar {
+        ch: char,
+        count: usize,
+    },
+    JoinLines {
+        count: usize,
+        spaces: bool,
+    },
+    OpenLine {
+        above: bool,
+    },
+    SwapSelectionEnds,
     ScrollViewport(i32),
     SetMode(EditMode),
     Undo,

--- a/crates/vmux_editor/src/edit/core.rs
+++ b/crates/vmux_editor/src/edit/core.rs
@@ -353,8 +353,6 @@ impl EditCore {
             Motion::Right => self.buffer.next_grapheme(from).min(len),
             Motion::LeftBounded => self.line_left(from),
             Motion::RightBounded => self.line_right(from),
-            Motion::LeftFlow => self.line_left_flow(from),
-            Motion::RightFlow => self.line_right_flow(from),
             Motion::Up => self.vertical(from, -1),
             Motion::Down => self.vertical(from, 1),
             Motion::PageUp => self.vertical(from, -(self.rows.max(1) as i64)),
@@ -643,33 +641,6 @@ impl EditCore {
         } else {
             self.buffer.next_grapheme(from).min(last)
         }
-    }
-    /// Leftward step that treats a hard wrap as a space, landing on the previous line's last cell.
-    fn line_left_flow(&self, from: usize) -> usize {
-        let (line, col) = self.buffer.char_to_coords(from);
-        if col > 0 || line == 0 {
-            return self.line_left(from);
-        }
-        let prev = line - 1;
-        let start = self.buffer.line_to_char(prev);
-        let len = self.buffer.line_len_chars(prev);
-        if len == 0 {
-            return start;
-        }
-        self.buffer.prev_grapheme(start + len)
-    }
-
-    /// Rightward step that continues onto the next line's first cell instead of stopping at a wrap.
-    fn line_right_flow(&self, from: usize) -> usize {
-        let stepped = self.line_right(from);
-        if stepped != from {
-            return stepped;
-        }
-        let (line, _) = self.buffer.char_to_coords(from);
-        if line + 1 >= self.buffer.len_lines() {
-            return from;
-        }
-        self.buffer.line_to_char(line + 1)
     }
 
     fn normal_cursor_target(&self, at: usize) -> usize {
@@ -2098,41 +2069,6 @@ mod tests {
         c.set_caret(c.buffer.coords_to_char(1, 0));
         c.apply(EditCommand::Move(Motion::LeftBounded));
         assert_eq!(c.buffer.char_to_coords(c.primary().head), (1, 0));
-    }
-
-    #[test]
-    fn flow_motion_crosses_a_hard_wrap_in_both_directions() {
-        let mut c = core("alpha\nbeta\n");
-        c.mode = EditMode::Normal;
-        c.set_caret(c.buffer.coords_to_char(0, 4));
-        c.apply(EditCommand::Move(Motion::RightFlow));
-        assert_eq!(c.buffer.char_to_coords(c.primary().head), (1, 0));
-        c.apply(EditCommand::Move(Motion::LeftFlow));
-        assert_eq!(c.buffer.char_to_coords(c.primary().head), (0, 4));
-    }
-
-    #[test]
-    fn flow_motion_still_stops_at_the_document_ends() {
-        let mut c = core("ab\n");
-        c.mode = EditMode::Normal;
-        c.set_caret(0);
-        c.apply(EditCommand::Move(Motion::LeftFlow));
-        assert_eq!(c.primary().head, 0);
-        c.set_caret(c.buffer.coords_to_char(0, 1));
-        c.apply(EditCommand::Move(Motion::RightFlow));
-        c.apply(EditCommand::Move(Motion::RightFlow));
-        assert_eq!(c.buffer.char_to_coords(c.primary().head).0, 1);
-    }
-
-    #[test]
-    fn flow_motion_lands_on_an_empty_line() {
-        let mut c = core("ab\n\ncd\n");
-        c.mode = EditMode::Normal;
-        c.set_caret(c.buffer.coords_to_char(0, 1));
-        c.apply(EditCommand::Move(Motion::RightFlow));
-        assert_eq!(c.buffer.char_to_coords(c.primary().head), (1, 0));
-        c.apply(EditCommand::Move(Motion::RightFlow));
-        assert_eq!(c.buffer.char_to_coords(c.primary().head), (2, 0));
     }
 
     #[test]

--- a/crates/vmux_editor/src/edit/core.rs
+++ b/crates/vmux_editor/src/edit/core.rs
@@ -3,7 +3,10 @@ use std::path::PathBuf;
 use unicode_width::UnicodeWidthStr;
 
 use crate::edit::buffer::TextBuffer;
-use crate::edit::command::{CursorPos, EditCommand, EditMode, Motion, SelSpan, Selection};
+use crate::edit::command::{
+    CursorPos, EditCommand, EditMode, Motion, MotionKind, Operator, SelSpan, Selection, Target,
+};
+use crate::edit::register::{RegisterKind, RegisterValue, Registers};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Group {
@@ -48,7 +51,7 @@ pub struct EditOutcome {
     pub mode_changed: bool,
     pub dirty_changed: bool,
     pub scroll_to: Option<u32>,
-    pub yank: Option<(String, bool)>,
+    pub yank: Option<RegisterValue>,
 }
 
 pub struct EditCore {
@@ -57,7 +60,7 @@ pub struct EditCore {
     pub mode: EditMode,
     pub rows: u16,
     pub dirty: bool,
-    pub register: Option<(String, bool)>,
+    pub registers: Registers,
     rev: u64,
     saved_rev: Option<u64>,
     undo: Vec<(ropey::Rope, Vec<Selection>, u64)>,
@@ -69,20 +72,22 @@ pub struct EditCore {
 
 impl EditCore {
     pub fn new(path: PathBuf, language: String, text: &str, default_mode: EditMode) -> Self {
+        let buffer = TextBuffer::from_text(path, language, text);
+        let fold_view = crate::fold::FoldState::default().view(buffer.len_lines() as u32);
         Self {
-            buffer: TextBuffer::from_text(path, language, text),
+            buffer,
             selections: vec![Selection::caret(0)],
             mode: default_mode,
             rows: 0,
             dirty: false,
-            register: None,
+            registers: Registers::default(),
             rev: 0,
             saved_rev: Some(0),
             undo: Vec::new(),
             redo: Vec::new(),
             last_group: None,
             preferred_vertical_col: None,
-            fold_view: crate::fold::FoldView::default(),
+            fold_view,
         }
     }
 
@@ -133,12 +138,39 @@ impl EditCore {
         }
     }
 
+    /// The primary selection as an operator would see it.
+    ///
+    /// Vim's charwise visual selection covers the character under the cursor, and linewise visual
+    /// covers whole lines; the underlying anchor/head pair is exclusive, so widen it here and keep
+    /// rendering and effect in agreement.
+    pub fn visual_range(&self) -> std::ops::Range<usize> {
+        let sel = self.primary();
+        let r = sel.range();
+        match self.mode {
+            EditMode::Visual => {
+                r.start
+                    ..self
+                        .buffer
+                        .next_grapheme(r.end)
+                        .min(self.buffer.len_chars())
+            }
+            EditMode::VisualLine => self.expand_linewise(r),
+            _ => r,
+        }
+    }
+
     pub fn sel_spans(&self, first: u32, rows: u16) -> Vec<SelSpan> {
         let sel = self.primary();
-        if sel.is_empty() || rows == 0 {
+        if sel.is_empty() && !self.mode.is_visual() {
             return Vec::new();
         }
-        let r = sel.range();
+        if rows == 0 {
+            return Vec::new();
+        }
+        let r = self.visual_range();
+        if r.start >= r.end {
+            return Vec::new();
+        }
         let (l0, _) = self.buffer.char_to_coords(r.start);
         let (l1, _) = self.buffer.char_to_coords(r.end);
         let mut out = Vec::new();
@@ -362,7 +394,7 @@ impl EditCore {
         while i + 1 < len && Self::class(self.buffer.rope.char(i + 1)) == cls {
             i += 1;
         }
-        i + 1
+        i
     }
 
     fn insert_text(&mut self, text: &str) -> bool {
@@ -389,12 +421,307 @@ impl EditCore {
         true
     }
 
+    fn line_indent(&self, line: usize) -> String {
+        let base = self.buffer.line_to_char(line);
+        let llen = self.buffer.line_len_chars(line);
+        let mut out = String::new();
+        for i in 0..llen {
+            let ch = self.buffer.rope.char(base + i);
+            if ch == ' ' || ch == '\t' {
+                out.push(ch);
+            } else {
+                break;
+            }
+        }
+        out
+    }
+
+    fn outdent_width(&self, line: usize) -> usize {
+        let base = self.buffer.line_to_char(line);
+        let llen = self.buffer.line_len_chars(line);
+        if llen == 0 {
+            return 0;
+        }
+        if self.buffer.rope.char(base) == '\t' {
+            return 1;
+        }
+        let mut n = 0;
+        while n < llen.min(4) && self.buffer.rope.char(base + n) == ' ' {
+            n += 1;
+        }
+        n
+    }
+
+    fn expand_linewise(&self, r: std::ops::Range<usize>) -> std::ops::Range<usize> {
+        let (l0, _) = self.buffer.char_to_coords(r.start);
+        let (l1, _) = self.buffer.char_to_coords(r.end.max(r.start));
+        let start = self.buffer.line_to_char(l0);
+        let end = if l1 + 1 < self.buffer.len_lines() {
+            self.buffer.line_to_char(l1 + 1)
+        } else {
+            self.buffer.len_chars()
+        };
+        start..end
+    }
+
+    fn line_span(&self, from: usize, count: usize) -> std::ops::Range<usize> {
+        let (l0, _) = self.buffer.char_to_coords(from);
+        let last = (l0 + count.max(1) - 1).min(self.buffer.len_lines().saturating_sub(1));
+        let start = self.buffer.line_to_char(l0);
+        let end = if last + 1 < self.buffer.len_lines() {
+            self.buffer.line_to_char(last + 1)
+        } else {
+            self.buffer.len_chars()
+        };
+        start..end
+    }
+
+    fn resolve_motion_n(&self, from: usize, m: Motion, n: usize) -> usize {
+        let mut at = from;
+        for _ in 0..n.max(1) {
+            let next = self.resolve_motion(at, m);
+            if next == at {
+                break;
+            }
+            at = next;
+        }
+        at
+    }
+
+    fn operator_range(&self, target: Target) -> Option<(std::ops::Range<usize>, RegisterKind)> {
+        match target {
+            Target::Line(count) => Some((
+                self.line_span(self.primary().head, count),
+                RegisterKind::Linewise,
+            )),
+            Target::Selection => {
+                let r = self.visual_range();
+                if r.start >= r.end {
+                    return None;
+                }
+                let kind = if self.mode == EditMode::VisualLine {
+                    RegisterKind::Linewise
+                } else {
+                    RegisterKind::Charwise
+                };
+                Some((r, kind))
+            }
+            Target::Motion(m, count) => {
+                let from = self.primary().head;
+                let to = self.resolve_motion_n(from, m, count);
+                let start = from.min(to);
+                let mut end = from.max(to);
+                match m.kind() {
+                    MotionKind::Linewise => {
+                        return Some((self.expand_linewise(start..end), RegisterKind::Linewise));
+                    }
+                    MotionKind::Inclusive => {
+                        end = self.buffer.next_grapheme(end).min(self.buffer.len_chars());
+                    }
+                    MotionKind::Exclusive => {
+                        let (end_line, end_col) = self.buffer.char_to_coords(end);
+                        if end_col == 0 && end > start && end_line > 0 {
+                            let prev = end_line - 1;
+                            let prev_end =
+                                self.buffer.line_to_char(prev) + self.buffer.line_len_chars(prev);
+                            if prev_end >= start {
+                                end = prev_end;
+                                if start <= self.first_non_blank(start) {
+                                    return Some((
+                                        self.expand_linewise(start..end),
+                                        RegisterKind::Linewise,
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+                if start >= end {
+                    return None;
+                }
+                Some((start..end, RegisterKind::Charwise))
+            }
+        }
+    }
+
+    fn apply_operator(
+        &mut self,
+        operator: Operator,
+        target: Target,
+        register: Option<char>,
+    ) -> (bool, Option<RegisterValue>) {
+        let Some((range, kind)) = self.operator_range(target) else {
+            return (false, None);
+        };
+        let was_visual = self.mode.is_visual();
+        match operator {
+            Operator::Yank => {
+                let text: String = self.buffer.rope.slice(range.clone()).chars().collect();
+                let value = RegisterValue { text, kind };
+                self.registers.write_yank(register, value.clone());
+                if was_visual {
+                    self.mode = EditMode::Normal;
+                }
+                self.set_caret(range.start);
+                (false, Some(value))
+            }
+            Operator::Delete | Operator::Change => {
+                let text: String = self.buffer.rope.slice(range.clone()).chars().collect();
+                let had_newline = text.ends_with('\n');
+                let value = RegisterValue { text, kind };
+                self.registers.write_delete(register, value.clone());
+                self.checkpoint(Group::Other);
+                if operator == Operator::Change && kind == RegisterKind::Linewise {
+                    let (line, _) = self.buffer.char_to_coords(range.start);
+                    let indent = self.line_indent(line);
+                    self.buffer.remove(range.clone());
+                    self.mode = EditMode::Insert;
+                    let tail = if had_newline { "\n" } else { "" };
+                    self.buffer.insert(range.start, &format!("{indent}{tail}"));
+                    self.set_caret(range.start + indent.chars().count());
+                } else {
+                    self.buffer.remove(range.clone());
+                    if operator == Operator::Change {
+                        self.mode = EditMode::Insert;
+                    } else if was_visual {
+                        self.mode = EditMode::Normal;
+                    }
+                    let at = range.start.min(self.buffer.len_chars());
+                    let caret = if kind == RegisterKind::Linewise {
+                        self.first_non_blank(at)
+                    } else {
+                        at
+                    };
+                    self.set_caret(caret);
+                }
+                (true, Some(value))
+            }
+            Operator::Indent | Operator::Outdent => {
+                let range = self.expand_linewise(range);
+                let (l0, _) = self.buffer.char_to_coords(range.start);
+                let (l1, _) = self
+                    .buffer
+                    .char_to_coords(range.end.saturating_sub(1).max(range.start));
+                self.checkpoint(Group::Other);
+                for line in (l0..=l1).rev() {
+                    let base = self.buffer.line_to_char(line);
+                    if operator == Operator::Indent {
+                        if self.buffer.line_len_chars(line) == 0 {
+                            continue;
+                        }
+                        self.buffer.insert(base, "\t");
+                    } else {
+                        let width = self.outdent_width(line);
+                        if width > 0 {
+                            self.buffer.remove(base..base + width);
+                        }
+                    }
+                }
+                if was_visual {
+                    self.mode = EditMode::Normal;
+                }
+                let caret = self.first_non_blank(self.buffer.line_to_char(l0));
+                self.set_caret(caret);
+                (true, None)
+            }
+            Operator::Upper | Operator::Lower | Operator::ToggleCase => {
+                let src: String = self.buffer.rope.slice(range.clone()).chars().collect();
+                let out: String = src
+                    .chars()
+                    .map(|c| match operator {
+                        Operator::Upper => c.to_uppercase().next().unwrap_or(c),
+                        Operator::Lower => c.to_lowercase().next().unwrap_or(c),
+                        _ if c.is_uppercase() => c.to_lowercase().next().unwrap_or(c),
+                        _ => c.to_uppercase().next().unwrap_or(c),
+                    })
+                    .collect();
+                if was_visual {
+                    self.mode = EditMode::Normal;
+                }
+                if out == src {
+                    self.set_caret(range.start);
+                    return (false, None);
+                }
+                self.checkpoint(Group::Other);
+                self.buffer.remove(range.clone());
+                self.buffer.insert(range.start, &out);
+                self.set_caret(range.start);
+                (true, None)
+            }
+        }
+    }
+
+    fn apply_put(&mut self, before: bool, count: usize, register: Option<char>) -> bool {
+        let Some(value) = self.registers.read(register).cloned() else {
+            return false;
+        };
+        let was_visual = self.mode.is_visual();
+        if was_visual {
+            let range = self.visual_range();
+            let kind = if self.mode == EditMode::VisualLine {
+                RegisterKind::Linewise
+            } else {
+                RegisterKind::Charwise
+            };
+            if range.start < range.end {
+                let text: String = self.buffer.rope.slice(range.clone()).chars().collect();
+                self.registers
+                    .write_delete(None, RegisterValue { text, kind });
+                self.checkpoint(Group::Other);
+                self.buffer.remove(range.clone());
+            }
+            self.mode = EditMode::Normal;
+            self.set_caret(range.start.min(self.buffer.len_chars()));
+        }
+        let count = count.max(1);
+        match value.kind {
+            RegisterKind::Charwise => {
+                let head = self.primary().head;
+                let line_end = self.resolve_motion(head, Motion::LineEnd);
+                let at = if before || was_visual {
+                    head
+                } else {
+                    self.buffer.next_grapheme(head).min(line_end)
+                };
+                let text = value.text.repeat(count);
+                self.checkpoint(Group::Other);
+                self.buffer.insert(at, &text);
+                let end = at + text.chars().count();
+                self.set_caret(end.saturating_sub(1).max(at));
+            }
+            RegisterKind::Linewise => {
+                let head = self.primary().head;
+                let (line, _) = self.buffer.char_to_coords(head);
+                let mut text = value.text.repeat(count);
+                if !text.ends_with('\n') {
+                    text.push('\n');
+                }
+                let mut at = if before {
+                    self.buffer.line_to_char(line)
+                } else if line + 1 < self.buffer.len_lines() {
+                    self.buffer.line_to_char(line + 1)
+                } else {
+                    self.buffer.len_chars()
+                };
+                self.checkpoint(Group::Other);
+                if at == self.buffer.len_chars() && at > 0 && self.buffer.rope.char(at - 1) != '\n'
+                {
+                    self.buffer.insert(at, "\n");
+                    at += 1;
+                }
+                self.buffer.insert(at, &text);
+                self.set_caret(self.first_non_blank(at));
+            }
+        }
+        true
+    }
+
     pub fn apply(&mut self, cmd: EditCommand) -> EditOutcome {
         let before_sel = self.primary();
         let before_mode = self.mode;
         let before_dirty = self.dirty;
         let mut text_changed = false;
-        let mut yank: Option<(String, bool)> = None;
+        let mut yank: Option<RegisterValue> = None;
 
         if !matches!(
             &cmd,
@@ -499,52 +826,93 @@ impl EditCore {
                     text_changed = true;
                 }
             }
-            EditCommand::DeleteToLineEnd => {
+            EditCommand::Op {
+                operator,
+                target,
+                register,
+            } => {
+                let (changed, value) = self.apply_operator(operator, target, register);
+                text_changed = changed;
+                yank = value;
+            }
+            EditCommand::Put {
+                before,
+                count,
+                register,
+            } => text_changed = self.apply_put(before, count, register),
+            EditCommand::ReplaceChar { ch, count } => {
                 let head = self.primary().head;
-                let end = self.resolve_motion(head, Motion::LineEnd);
-                if end > head {
+                let line_end = self.resolve_motion(head, Motion::LineEnd);
+                let mut end = head;
+                let mut fits = true;
+                for _ in 0..count.max(1) {
+                    end = self.buffer.next_grapheme(end);
+                    if end > line_end {
+                        fits = false;
+                        break;
+                    }
+                }
+                if fits && end > head {
+                    let n = self.buffer.rope.slice(head..end).chars().count();
                     self.checkpoint(Group::Other);
                     self.buffer.remove(head..end);
+                    self.buffer.insert(head, &ch.to_string().repeat(n));
+                    self.set_caret(head + n - 1);
                     text_changed = true;
                 }
             }
-            EditCommand::DeleteRange(m) => {
-                let head = self.primary().head;
-                let target = self.resolve_motion(head, m);
-                let (a, b) = (head.min(target), head.max(target));
-                if b > a {
-                    self.checkpoint(Group::Other);
-                    self.buffer.remove(a..b);
-                    self.set_caret(a);
+            EditCommand::JoinLines { count, spaces } => {
+                for _ in 0..count.max(2) - 1 {
+                    let (line, _) = self.buffer.char_to_coords(self.primary().head);
+                    if line + 1 >= self.buffer.len_lines() {
+                        break;
+                    }
+                    let start = self.buffer.line_to_char(line);
+                    let end = start + self.buffer.line_len_chars(line);
+                    let next = self.buffer.line_to_char(line + 1);
+                    let next_len = self.buffer.line_len_chars(line + 1);
+                    let mut skip = 0;
+                    while skip < next_len {
+                        let c = self.buffer.rope.char(next + skip);
+                        if c == ' ' || c == '\t' {
+                            skip += 1;
+                        } else {
+                            break;
+                        }
+                    }
+                    if !text_changed {
+                        self.checkpoint(Group::Other);
+                    }
+                    self.buffer.remove(end..next + skip);
+                    if spaces
+                        && end > start
+                        && end < self.buffer.len_chars()
+                        && self.buffer.rope.char(end) != '\n'
+                        && self.buffer.rope.char(end) != ')'
+                        && self.buffer.rope.char(end - 1) != ' '
+                    {
+                        self.buffer.insert(end, " ");
+                    }
+                    self.set_caret(end);
                     text_changed = true;
                 }
             }
-            EditCommand::YankRange(m) => {
+            EditCommand::OpenLine { above } => {
                 let head = self.primary().head;
-                let target = self.resolve_motion(head, m);
-                let (a, b) = (head.min(target), head.max(target));
-                if b > a {
-                    let s: String = self.buffer.rope.slice(a..b).chars().collect();
-                    self.register = Some((s.clone(), false));
-                    yank = Some((s, false));
-                    self.set_caret(a);
-                }
-            }
-            EditCommand::DeleteSelection => text_changed = self.delete_selection(),
-            EditCommand::DeleteLine => {
-                let (l, _) = self.buffer.char_to_coords(self.primary().head);
-                let start = self.buffer.line_to_char(l);
-                let end = if l + 1 < self.buffer.len_lines() {
-                    self.buffer.line_to_char(l + 1)
+                let (line, _) = self.buffer.char_to_coords(head);
+                let indent = self.line_indent(line);
+                self.checkpoint(Group::Other);
+                self.mode = EditMode::Insert;
+                if above {
+                    let at = self.buffer.line_to_char(line);
+                    self.buffer.insert(at, &format!("{indent}\n"));
+                    self.set_caret(at + indent.chars().count());
                 } else {
-                    self.buffer.len_chars()
-                };
-                if end > start {
-                    self.checkpoint(Group::Other);
-                    self.buffer.remove(start..end);
-                    self.set_caret(start.min(self.buffer.len_chars()));
-                    text_changed = true;
+                    let at = self.buffer.line_to_char(line) + self.buffer.line_len_chars(line);
+                    self.buffer.insert(at, &format!("\n{indent}"));
+                    self.set_caret(at + 1 + indent.chars().count());
                 }
+                text_changed = true;
             }
             EditCommand::SetMode(m) => {
                 self.break_group();
@@ -577,69 +945,12 @@ impl EditCore {
                     text_changed = true;
                 }
             }
-            EditCommand::Yank => {
+            EditCommand::SwapSelectionEnds => {
                 let sel = self.primary();
-                if !sel.is_empty() {
-                    let s: String = self.buffer.rope.slice(sel.range()).chars().collect();
-                    self.register = Some((s.clone(), false));
-                    yank = Some((s, false));
-                    if self.mode.is_visual() {
-                        self.set_caret(sel.range().start);
-                        self.mode = EditMode::Normal;
-                    }
-                }
-            }
-            EditCommand::Cut => {
-                if !self.primary().is_empty() {
-                    let r = self.primary().range();
-                    let s: String = self.buffer.rope.slice(r.clone()).chars().collect();
-                    self.register = Some((s.clone(), false));
-                    yank = Some((s, false));
-                    self.checkpoint(Group::Other);
-                    self.buffer.remove(r.clone());
-                    self.set_caret(r.start);
-                    if self.mode.is_visual() {
-                        self.mode = EditMode::Normal;
-                    }
-                    text_changed = true;
-                }
-            }
-            EditCommand::Paste => {
-                if let Some((s, _linewise)) = self.register.clone() {
-                    let was_visual = self.mode.is_visual();
-                    if !self.primary().is_empty() {
-                        self.delete_selection();
-                    }
-                    self.mode = if was_visual {
-                        EditMode::Normal
-                    } else {
-                        self.mode
-                    };
-                    self.checkpoint(Group::Other);
-                    let at = if !was_visual && self.mode == EditMode::Normal {
-                        self.buffer.next_grapheme(self.primary().head)
-                    } else {
-                        self.primary().head
-                    };
-                    self.buffer.insert(at, &s);
-                    self.set_caret(at + s.chars().count());
-                    text_changed = true;
-                }
-            }
-            EditCommand::PasteBefore => {
-                if let Some((s, _linewise)) = self.register.clone() {
-                    if !self.primary().is_empty() {
-                        self.delete_selection();
-                    }
-                    if self.mode.is_visual() {
-                        self.mode = EditMode::Normal;
-                    }
-                    self.checkpoint(Group::Other);
-                    let at = self.primary().head;
-                    self.buffer.insert(at, &s);
-                    self.set_caret(at + s.chars().count());
-                    text_changed = true;
-                }
+                self.selections = vec![Selection {
+                    anchor: sel.head,
+                    head: sel.anchor,
+                }];
             }
             EditCommand::Save
             | EditCommand::ScrollViewport(_)
@@ -716,6 +1027,20 @@ mod tests {
     }
     fn text_of(c: &EditCore) -> String {
         c.buffer.text()
+    }
+    fn op(operator: Operator, target: Target) -> EditCommand {
+        EditCommand::Op {
+            operator,
+            target,
+            register: None,
+        }
+    }
+    fn put(before: bool) -> EditCommand {
+        EditCommand::Put {
+            before,
+            count: 1,
+            register: None,
+        }
     }
 
     #[test]
@@ -794,22 +1119,213 @@ mod tests {
     }
 
     #[test]
-    fn visual_select_then_delete() {
+    fn visual_delete_covers_the_character_under_the_cursor() {
         let mut c = core("abcdef");
         c.set_caret(1);
         c.mode = EditMode::Visual;
         c.apply(EditCommand::Select(Motion::Right));
         c.apply(EditCommand::Select(Motion::Right));
-        c.apply(EditCommand::DeleteSelection);
-        assert_eq!(text_of(&c), "adef");
+        c.apply(op(Operator::Delete, Target::Selection));
+        assert_eq!(text_of(&c), "aef");
     }
 
     #[test]
     fn delete_range_word() {
         let mut c = core("foo bar");
         c.set_caret(0);
-        c.apply(EditCommand::DeleteRange(Motion::WordNext));
+        c.apply(op(Operator::Delete, Target::Motion(Motion::WordNext, 1)));
         assert_eq!(text_of(&c), "bar");
+    }
+
+    #[test]
+    fn operator_counts_multiply_the_motion() {
+        let mut c = core("one two three four");
+        c.set_caret(0);
+        c.apply(op(Operator::Delete, Target::Motion(Motion::WordNext, 3)));
+        assert_eq!(text_of(&c), "four");
+    }
+
+    #[test]
+    fn inclusive_motion_covers_its_last_character() {
+        let mut c = core("foo bar");
+        c.set_caret(0);
+        c.apply(op(Operator::Delete, Target::Motion(Motion::WordEnd, 1)));
+        assert_eq!(text_of(&c), " bar");
+    }
+
+    #[test]
+    fn linewise_motion_deletes_whole_lines() {
+        let mut c = core("one\ntwo\nthree\n");
+        c.set_caret(c.buffer.coords_to_char(0, 1));
+        c.apply(op(Operator::Delete, Target::Motion(Motion::Down, 1)));
+        assert_eq!(text_of(&c), "three\n");
+    }
+
+    #[test]
+    fn exclusive_motion_ending_in_column_one_stops_at_the_previous_line() {
+        let mut c = core("foo\nbar\n");
+        c.set_caret(1);
+        c.apply(op(Operator::Delete, Target::Motion(Motion::WordNext, 1)));
+        assert_eq!(text_of(&c), "f\nbar\n");
+    }
+
+    #[test]
+    fn delete_line_yanks_linewise_and_put_opens_a_new_line() {
+        let mut c = core("one\ntwo\nthree\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(c.buffer.coords_to_char(1, 0));
+        c.apply(op(Operator::Delete, Target::Line(1)));
+        assert_eq!(text_of(&c), "one\nthree\n");
+        assert_eq!(
+            c.registers.read(None),
+            Some(&RegisterValue::linewise("two\n"))
+        );
+        c.apply(put(false));
+        assert_eq!(text_of(&c), "one\nthree\ntwo\n");
+    }
+
+    #[test]
+    fn count_deletes_multiple_lines() {
+        let mut c = core("a\nb\nc\nd\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(op(Operator::Delete, Target::Line(3)));
+        assert_eq!(text_of(&c), "d\n");
+    }
+
+    #[test]
+    fn change_line_keeps_indentation() {
+        let mut c = core("    foo\nbar\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(c.buffer.coords_to_char(0, 4));
+        c.apply(op(Operator::Change, Target::Line(1)));
+        assert_eq!(text_of(&c), "    \nbar\n");
+        assert_eq!(c.primary().head, 4);
+        assert_eq!(c.mode, EditMode::Insert);
+    }
+
+    #[test]
+    fn indent_and_outdent_shift_whole_lines() {
+        let mut c = core("a\nb\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(op(Operator::Indent, Target::Line(2)));
+        assert_eq!(text_of(&c), "\ta\n\tb\n");
+        c.apply(op(Operator::Outdent, Target::Line(2)));
+        assert_eq!(text_of(&c), "a\nb\n");
+    }
+
+    #[test]
+    fn case_operators_transform_a_range() {
+        let mut c = core("hello");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(op(Operator::Upper, Target::Motion(Motion::LineEnd, 1)));
+        assert_eq!(text_of(&c), "HELLO");
+        c.apply(op(Operator::ToggleCase, Target::Motion(Motion::LineEnd, 1)));
+        assert_eq!(text_of(&c), "hello");
+    }
+
+    #[test]
+    fn replace_char_overwrites_without_entering_insert() {
+        let mut c = core("abcd");
+        c.mode = EditMode::Normal;
+        c.set_caret(1);
+        c.apply(EditCommand::ReplaceChar { ch: 'X', count: 2 });
+        assert_eq!(text_of(&c), "aXXd");
+        assert_eq!(c.primary().head, 2);
+    }
+
+    #[test]
+    fn replace_char_past_the_line_end_is_rejected() {
+        let mut c = core("ab\ncd\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(1);
+        c.apply(EditCommand::ReplaceChar { ch: 'X', count: 4 });
+        assert_eq!(text_of(&c), "ab\ncd\n");
+    }
+
+    #[test]
+    fn join_lines_collapses_indentation_to_one_space() {
+        let mut c = core("foo\n    bar\nbaz\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(EditCommand::JoinLines {
+            count: 2,
+            spaces: true,
+        });
+        assert_eq!(text_of(&c), "foo bar\nbaz\n");
+    }
+
+    #[test]
+    fn join_without_spaces_keeps_text_adjacent() {
+        let mut c = core("foo\n  bar\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(EditCommand::JoinLines {
+            count: 2,
+            spaces: false,
+        });
+        assert_eq!(text_of(&c), "foobar\n");
+    }
+
+    #[test]
+    fn open_line_inherits_indentation() {
+        let mut c = core("    foo\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(4);
+        c.apply(EditCommand::OpenLine { above: false });
+        assert_eq!(text_of(&c), "    foo\n    \n");
+        assert_eq!(c.mode, EditMode::Insert);
+
+        let mut c = core("    foo\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(4);
+        c.apply(EditCommand::OpenLine { above: true });
+        assert_eq!(text_of(&c), "    \n    foo\n");
+    }
+
+    #[test]
+    fn linewise_put_before_inserts_above_the_current_line() {
+        let mut c = core("one\ntwo\n");
+        c.mode = EditMode::Normal;
+        c.registers.set_unnamed(RegisterValue::linewise("new\n"));
+        c.set_caret(c.buffer.coords_to_char(1, 0));
+        c.apply(put(true));
+        assert_eq!(text_of(&c), "one\nnew\ntwo\n");
+    }
+
+    #[test]
+    fn put_repeats_with_a_count() {
+        let mut c = core("a");
+        c.mode = EditMode::Normal;
+        c.registers.set_unnamed(RegisterValue::charwise("X"));
+        c.set_caret(0);
+        c.apply(EditCommand::Put {
+            before: false,
+            count: 3,
+            register: None,
+        });
+        assert_eq!(text_of(&c), "aXXX");
+    }
+
+    #[test]
+    fn named_register_round_trips_through_an_operator() {
+        let mut c = core("one\ntwo\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(EditCommand::Op {
+            operator: Operator::Yank,
+            target: Target::Line(1),
+            register: Some('a'),
+        });
+        c.set_caret(c.buffer.coords_to_char(1, 0));
+        c.apply(EditCommand::Put {
+            before: false,
+            count: 1,
+            register: Some('a'),
+        });
+        assert_eq!(text_of(&c), "one\ntwo\none\n");
     }
 
     #[test]
@@ -885,12 +1401,12 @@ mod tests {
         c.mode = EditMode::Visual;
         c.apply(EditCommand::Select(Motion::Right));
         c.apply(EditCommand::Select(Motion::Right));
-        let out = c.apply(EditCommand::Yank);
-        assert_eq!(out.yank, Some(("ab".to_string(), false)));
+        let out = c.apply(op(Operator::Yank, Target::Selection));
+        assert_eq!(out.yank, Some(RegisterValue::charwise("abc")));
         c.mode = EditMode::Insert;
         c.set_caret(6);
-        c.apply(EditCommand::Paste);
-        assert_eq!(text_of(&c), "abcdefab");
+        c.apply(put(true));
+        assert_eq!(text_of(&c), "abcdefabc");
     }
 
     #[test]
@@ -925,27 +1441,27 @@ mod tests {
     #[test]
     fn paste_after_vs_before_in_normal() {
         let mut c = core("ac");
-        c.register = Some(("X".into(), false));
+        c.registers.set_unnamed(RegisterValue::charwise("X"));
         c.mode = EditMode::Normal;
         c.set_caret(0);
-        c.apply(EditCommand::Paste);
+        c.apply(put(false));
         assert_eq!(text_of(&c), "aXc");
         let mut c2 = core("ac");
-        c2.register = Some(("X".into(), false));
+        c2.registers.set_unnamed(RegisterValue::charwise("X"));
         c2.mode = EditMode::Normal;
         c2.set_caret(0);
-        c2.apply(EditCommand::PasteBefore);
+        c2.apply(put(true));
         assert_eq!(text_of(&c2), "Xac");
     }
 
     #[test]
     fn repeated_pastes_undo_one_at_a_time() {
         let mut c = core("a");
-        c.register = Some(("X".into(), false));
+        c.registers.set_unnamed(RegisterValue::charwise("X"));
         c.mode = EditMode::Normal;
         c.set_caret(0);
-        c.apply(EditCommand::Paste);
-        c.apply(EditCommand::Paste);
+        c.apply(put(false));
+        c.apply(put(false));
         assert_eq!(text_of(&c), "aXX");
         c.apply(EditCommand::Undo);
         assert_eq!(text_of(&c), "aX");

--- a/crates/vmux_editor/src/edit/core.rs
+++ b/crates/vmux_editor/src/edit/core.rs
@@ -45,6 +45,25 @@ fn translated_caret_after_replace(old: &str, new: &str, caret: usize) -> usize {
     .min(new.len())
 }
 
+/// What an operator acts on, resolved to concrete char ranges.
+///
+/// Charwise and linewise targets produce one range; a blockwise target produces one per row.
+struct OperatorSpan {
+    ranges: Vec<std::ops::Range<usize>>,
+    kind: RegisterKind,
+}
+
+fn transform_case(src: &str, operator: Operator) -> String {
+    src.chars()
+        .map(|c| match operator {
+            Operator::Upper => c.to_uppercase().next().unwrap_or(c),
+            Operator::Lower => c.to_lowercase().next().unwrap_or(c),
+            _ if c.is_uppercase() => c.to_lowercase().next().unwrap_or(c),
+            _ => c.to_uppercase().next().unwrap_or(c),
+        })
+        .collect()
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct EditOutcome {
     pub text_changed: bool,
@@ -72,6 +91,7 @@ pub struct EditCore {
     pub fold_view: crate::fold::FoldView,
     pub search: Option<crate::edit::search::Search>,
     replaced: Vec<Option<char>>,
+    block_insert: Option<(Vec<usize>, usize)>,
     pub search_highlight: bool,
     marks: std::collections::HashMap<char, usize>,
     jumps: Vec<usize>,
@@ -101,6 +121,7 @@ impl EditCore {
             fold_view,
             search: None,
             replaced: Vec::new(),
+            block_insert: None,
             search_highlight: false,
             marks: std::collections::HashMap::new(),
             jumps: Vec::new(),
@@ -243,6 +264,26 @@ impl EditCore {
         }
         if rows == 0 {
             return Vec::new();
+        }
+        if self.mode == EditMode::VisualBlock {
+            return self
+                .block_rows()
+                .into_iter()
+                .filter_map(|row| {
+                    let (line, _) = self.buffer.char_to_coords(row.start);
+                    if line < first as usize || line >= first as usize + rows as usize {
+                        return None;
+                    }
+                    let ls = self.buffer.line_to_char(line);
+                    Some(SelSpan {
+                        line: line as u32,
+                        row: line as u32,
+                        start: self.vis_col(ls, row.start - ls),
+                        end: self.vis_col(ls, row.end - ls),
+                    })
+                })
+                .filter(|span| span.end > span.start)
+                .collect();
         }
         let r = self.visual_range();
         if r.start >= r.end {
@@ -781,6 +822,45 @@ impl EditCore {
         at
     }
 
+    /// The rows of the current blockwise selection, as one char range per line.
+    ///
+    /// The rectangle spans the columns the anchor and head sit in; lines shorter than the left
+    /// edge contribute an empty range so the row count still lines up with the block's height.
+    pub fn block_rows(&self) -> Vec<std::ops::Range<usize>> {
+        let sel = self.primary();
+        let (l0, c0) = self.buffer.char_to_coords(sel.anchor);
+        let (l1, c1) = self.buffer.char_to_coords(sel.head);
+        let (first, last) = (l0.min(l1), l0.max(l1));
+        let (left, right) = (c0.min(c1), c0.max(c1) + 1);
+        (first..=last)
+            .map(|line| {
+                let base = self.buffer.line_to_char(line);
+                let len = self.buffer.line_len_chars(line);
+                let start = base + left.min(len);
+                let end = base + right.min(len);
+                start..end.max(start)
+            })
+            .collect()
+    }
+
+    fn operator_span(&self, target: Target) -> Option<OperatorSpan> {
+        if target == Target::Selection && self.mode == EditMode::VisualBlock {
+            let rows = self.block_rows();
+            if rows.iter().all(|r| r.is_empty()) {
+                return None;
+            }
+            return Some(OperatorSpan {
+                ranges: rows,
+                kind: RegisterKind::Blockwise,
+            });
+        }
+        let (range, kind) = self.operator_range(target)?;
+        Some(OperatorSpan {
+            ranges: vec![range],
+            kind,
+        })
+    }
+
     fn operator_range(&self, target: Target) -> Option<(std::ops::Range<usize>, RegisterKind)> {
         match target {
             Target::Line(count) => Some((
@@ -907,15 +987,124 @@ impl EditCore {
         true
     }
 
+    /// Apply an operator to a rectangle, row by row from the bottom so earlier rows keep their
+    /// indices. Only the operators that make sense on a block are handled; the rest fall through
+    /// to the enclosing charwise path.
+    /// Shift every line touched by `range` one indent level in or out.
+    fn apply_line_shift(
+        &mut self,
+        operator: Operator,
+        range: std::ops::Range<usize>,
+    ) -> (bool, Option<RegisterValue>) {
+        let range = self.expand_linewise(range);
+        let (l0, _) = self.buffer.char_to_coords(range.start);
+        let (l1, _) = self
+            .buffer
+            .char_to_coords(range.end.saturating_sub(1).max(range.start));
+        self.checkpoint(Group::Other);
+        for line in (l0..=l1).rev() {
+            let base = self.buffer.line_to_char(line);
+            if operator == Operator::Indent {
+                if self.buffer.line_len_chars(line) == 0 {
+                    continue;
+                }
+                self.buf_insert(base, "\t");
+            } else {
+                let width = self.outdent_width(line);
+                if width > 0 {
+                    self.buf_remove(base..base + width);
+                }
+            }
+        }
+        let caret = self.first_non_blank(self.buffer.line_to_char(l0));
+        self.set_caret(caret);
+        (true, None)
+    }
+
+    fn apply_block_operator(
+        &mut self,
+        operator: Operator,
+        rows: &[std::ops::Range<usize>],
+        register: Option<char>,
+    ) -> (bool, Option<RegisterValue>) {
+        let text = rows
+            .iter()
+            .map(|r| {
+                self.buffer
+                    .rope
+                    .slice(r.clone())
+                    .chars()
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let value = RegisterValue {
+            text,
+            kind: RegisterKind::Blockwise,
+        };
+        let caret = rows.first().map(|r| r.start).unwrap_or_default();
+        match operator {
+            Operator::Yank => {
+                self.registers.write_yank(register, value.clone());
+                self.mode = EditMode::Normal;
+                self.set_caret(caret);
+                (false, Some(value))
+            }
+            Operator::Delete | Operator::Change => {
+                self.registers.write_delete(register, value.clone());
+                self.checkpoint(Group::Other);
+                for row in rows.iter().rev() {
+                    if !row.is_empty() {
+                        self.buf_remove(row.clone());
+                    }
+                }
+                self.mode = if operator == Operator::Change {
+                    EditMode::Insert
+                } else {
+                    EditMode::Normal
+                };
+                self.set_caret(caret.min(self.buffer.len_chars()));
+                (true, Some(value))
+            }
+            Operator::Upper | Operator::Lower | Operator::ToggleCase => {
+                self.checkpoint(Group::Other);
+                for row in rows.iter().rev() {
+                    if row.is_empty() {
+                        continue;
+                    }
+                    let src: String = self.buffer.rope.slice(row.clone()).chars().collect();
+                    let out = transform_case(&src, operator);
+                    self.buf_remove(row.clone());
+                    self.buf_insert(row.start, &out);
+                }
+                self.mode = EditMode::Normal;
+                self.set_caret(caret);
+                (true, None)
+            }
+            Operator::Indent | Operator::Outdent => {
+                let span = rows.first().map(|r| r.start).unwrap_or_default()
+                    ..rows.last().map(|r| r.end).unwrap_or_default();
+                self.mode = EditMode::Normal;
+                self.apply_line_shift(operator, span)
+            }
+        }
+    }
+
     fn apply_operator(
         &mut self,
         operator: Operator,
         target: Target,
         register: Option<char>,
     ) -> (bool, Option<RegisterValue>) {
-        let Some((range, kind)) = self.operator_range(target) else {
+        let Some(span) = self.operator_span(target) else {
             return (false, None);
         };
+        if span.kind == RegisterKind::Blockwise {
+            let rows = span.ranges.clone();
+            return self.apply_block_operator(operator, &rows, register);
+        }
+        let kind = span.kind;
+        let range = span.ranges[0].clone();
         let was_visual = self.mode.is_visual();
         match operator {
             Operator::Yank => {
@@ -960,44 +1149,14 @@ impl EditCore {
                 (true, Some(value))
             }
             Operator::Indent | Operator::Outdent => {
-                let range = self.expand_linewise(range);
-                let (l0, _) = self.buffer.char_to_coords(range.start);
-                let (l1, _) = self
-                    .buffer
-                    .char_to_coords(range.end.saturating_sub(1).max(range.start));
-                self.checkpoint(Group::Other);
-                for line in (l0..=l1).rev() {
-                    let base = self.buffer.line_to_char(line);
-                    if operator == Operator::Indent {
-                        if self.buffer.line_len_chars(line) == 0 {
-                            continue;
-                        }
-                        self.buf_insert(base, "\t");
-                    } else {
-                        let width = self.outdent_width(line);
-                        if width > 0 {
-                            self.buf_remove(base..base + width);
-                        }
-                    }
-                }
                 if was_visual {
                     self.mode = EditMode::Normal;
                 }
-                let caret = self.first_non_blank(self.buffer.line_to_char(l0));
-                self.set_caret(caret);
-                (true, None)
+                self.apply_line_shift(operator, range)
             }
             Operator::Upper | Operator::Lower | Operator::ToggleCase => {
                 let src: String = self.buffer.rope.slice(range.clone()).chars().collect();
-                let out: String = src
-                    .chars()
-                    .map(|c| match operator {
-                        Operator::Upper => c.to_uppercase().next().unwrap_or(c),
-                        Operator::Lower => c.to_lowercase().next().unwrap_or(c),
-                        _ if c.is_uppercase() => c.to_lowercase().next().unwrap_or(c),
-                        _ => c.to_uppercase().next().unwrap_or(c),
-                    })
-                    .collect();
+                let out = transform_case(&src, operator);
                 if was_visual {
                     self.mode = EditMode::Normal;
                 }
@@ -1019,7 +1178,10 @@ impl EditCore {
             return false;
         };
         let was_visual = self.mode.is_visual();
-        if was_visual {
+        if self.mode == EditMode::VisualBlock {
+            let rows = self.block_rows();
+            self.apply_block_operator(Operator::Delete, &rows, None);
+        } else if was_visual {
             let range = self.visual_range();
             let kind = if self.mode == EditMode::VisualLine {
                 RegisterKind::Linewise
@@ -1051,6 +1213,29 @@ impl EditCore {
                 self.buf_insert(at, &text);
                 let end = at + text.chars().count();
                 self.set_caret(end.saturating_sub(1).max(at));
+            }
+            RegisterKind::Blockwise => {
+                let head = self.primary().head;
+                let (line, col) = self.buffer.char_to_coords(head);
+                let col = if before { col } else { col + 1 };
+                self.checkpoint(Group::Other);
+                for (offset, row) in value.text.split('\n').enumerate() {
+                    let target = line + offset;
+                    if target >= self.buffer.len_lines() {
+                        let end = self.buffer.len_chars();
+                        self.buf_insert(end, "\n");
+                    }
+                    let base = self.buffer.line_to_char(target);
+                    let len = self.buffer.line_len_chars(target);
+                    // Pad short lines out to the block's column before inserting.
+                    let pad = col.saturating_sub(len);
+                    if pad > 0 {
+                        self.buf_insert(base + len, &" ".repeat(pad));
+                    }
+                    let at = base + col.min(len + pad);
+                    self.buf_insert(at, &row.repeat(count));
+                }
+                self.set_caret(self.buffer.coords_to_char(line, col));
             }
             RegisterKind::Linewise => {
                 let head = self.primary().head;
@@ -1411,6 +1596,42 @@ impl EditCore {
                     self.set_caret(at.min(self.buffer.len_chars()));
                 }
             }
+            EditCommand::BeginBlockInsert { after } => {
+                let rows = self.block_rows();
+                let Some(first) = rows.first().cloned() else {
+                    return EditOutcome::default();
+                };
+                let (line, _) = self.buffer.char_to_coords(first.start);
+                let col = if after {
+                    self.buffer.char_to_coords(first.end).1
+                } else {
+                    self.buffer.char_to_coords(first.start).1
+                };
+                let lines = (0..rows.len()).map(|i| line + i).collect();
+                self.block_insert = Some((lines, col));
+                self.mode = EditMode::Insert;
+                self.set_caret(self.buffer.coords_to_char(line, col));
+            }
+            EditCommand::FinishBlockInsert { text } => {
+                if let Some((lines, col)) = self.block_insert.take()
+                    && !text.is_empty()
+                {
+                    self.checkpoint(Group::Other);
+                    // The first row already received the text as it was typed.
+                    for line in lines.into_iter().skip(1).rev() {
+                        if line >= self.buffer.len_lines() {
+                            continue;
+                        }
+                        let base = self.buffer.line_to_char(line);
+                        let len = self.buffer.line_len_chars(line);
+                        if col > len {
+                            continue;
+                        }
+                        self.buf_insert(base + col, &text);
+                    }
+                    text_changed = true;
+                }
+            }
             EditCommand::SwapSelectionEnds => {
                 let sel = self.primary();
                 self.selections = vec![Selection {
@@ -1740,6 +1961,105 @@ mod tests {
         c.set_caret(0);
         c.apply(EditCommand::Move(Motion::Column(4)));
         assert_eq!(c.primary().head, 3);
+    }
+
+    fn block(text: &str, from: (usize, usize), to: (usize, usize)) -> EditCore {
+        let mut c = core(text);
+        c.mode = EditMode::VisualBlock;
+        c.selections = vec![Selection {
+            anchor: c.buffer.coords_to_char(from.0, from.1),
+            head: c.buffer.coords_to_char(to.0, to.1),
+        }];
+        c
+    }
+
+    #[test]
+    fn block_delete_removes_a_rectangle() {
+        let mut c = block("abcd\nefgh\nijkl\n", (0, 1), (2, 2));
+        c.apply(op(Operator::Delete, Target::Selection));
+        assert_eq!(text_of(&c), "ad\neh\nil\n");
+        assert_eq!(c.mode, EditMode::Normal);
+    }
+
+    #[test]
+    fn block_yank_joins_rows_with_newlines() {
+        let mut c = block("abcd\nefgh\n", (0, 1), (1, 2));
+        let out = c.apply(op(Operator::Yank, Target::Selection));
+        assert_eq!(
+            out.yank,
+            Some(RegisterValue {
+                text: "bc\nfg".into(),
+                kind: RegisterKind::Blockwise,
+            })
+        );
+    }
+
+    #[test]
+    fn block_rows_clamp_to_short_lines() {
+        let c = block("abcd\nx\nijkl\n", (0, 1), (2, 2));
+        let rows = c.block_rows();
+        assert_eq!(rows.len(), 3);
+        assert!(rows[1].is_empty(), "the short line contributes no columns");
+    }
+
+    #[test]
+    fn block_put_inserts_a_column_on_each_line() {
+        let mut c = core("ab\ncd\n");
+        c.mode = EditMode::Normal;
+        c.registers.set_unnamed(RegisterValue {
+            text: "X\nY".into(),
+            kind: RegisterKind::Blockwise,
+        });
+        c.set_caret(0);
+        c.apply(put(true));
+        assert_eq!(text_of(&c), "Xab\nYcd\n");
+    }
+
+    #[test]
+    fn block_put_pads_short_lines_out_to_the_column() {
+        let mut c = core("abcd\nx\n");
+        c.mode = EditMode::Normal;
+        c.registers.set_unnamed(RegisterValue {
+            text: "1\n2".into(),
+            kind: RegisterKind::Blockwise,
+        });
+        c.set_caret(c.buffer.coords_to_char(0, 3));
+        c.apply(put(true));
+        assert_eq!(text_of(&c), "abc1d\nx  2\n");
+    }
+
+    #[test]
+    fn block_case_operator_covers_every_row() {
+        let mut c = block("abcd\nefgh\n", (0, 0), (1, 1));
+        c.apply(op(Operator::Upper, Target::Selection));
+        assert_eq!(text_of(&c), "ABcd\nEFgh\n");
+    }
+
+    #[test]
+    fn block_insert_replicates_typed_text_down_the_column() {
+        let mut c = block("abc\ndef\nghi\n", (0, 1), (2, 1));
+        c.apply(EditCommand::BeginBlockInsert { after: false });
+        assert_eq!(c.mode, EditMode::Insert);
+        c.apply(EditCommand::InsertText("-".into()));
+        c.apply(EditCommand::FinishBlockInsert { text: "-".into() });
+        assert_eq!(text_of(&c), "a-bc\nd-ef\ng-hi\n");
+    }
+
+    #[test]
+    fn block_append_inserts_after_the_right_edge() {
+        let mut c = block("abc\ndef\n", (0, 0), (1, 0));
+        c.apply(EditCommand::BeginBlockInsert { after: true });
+        c.apply(EditCommand::InsertText("!".into()));
+        c.apply(EditCommand::FinishBlockInsert { text: "!".into() });
+        assert_eq!(text_of(&c), "a!bc\nd!ef\n");
+    }
+
+    #[test]
+    fn block_selection_renders_one_span_per_row() {
+        let c = block("abcd\nefgh\n", (0, 1), (1, 2));
+        let spans = c.sel_spans(0, 4);
+        assert_eq!(spans.len(), 2);
+        assert!(spans.iter().all(|s| s.start == 1 && s.end == 3));
     }
 
     #[test]

--- a/crates/vmux_editor/src/edit/core.rs
+++ b/crates/vmux_editor/src/edit/core.rs
@@ -7,6 +7,7 @@ use crate::edit::command::{
     CursorPos, EditCommand, EditMode, Motion, MotionKind, Operator, SelSpan, Selection, Target,
 };
 use crate::edit::register::{RegisterKind, RegisterValue, Registers};
+use crate::edit::text_object::char_class;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Group {
@@ -343,40 +344,31 @@ impl EditCore {
         base
     }
 
-    fn class(c: char) -> u8 {
-        if c.is_whitespace() {
-            0
-        } else if c.is_alphanumeric() || c == '_' {
-            1
-        } else {
-            2
-        }
-    }
     fn word_next(&self, from: usize) -> usize {
         let len = self.buffer.len_chars();
         let mut i = from;
         if i >= len {
             return len;
         }
-        let start_class = Self::class(self.buffer.rope.char(i));
-        while i < len && Self::class(self.buffer.rope.char(i)) == start_class && start_class != 0 {
+        let start_class = char_class(self.buffer.rope.char(i));
+        while i < len && char_class(self.buffer.rope.char(i)) == start_class && start_class != 0 {
             i += 1;
         }
-        while i < len && Self::class(self.buffer.rope.char(i)) == 0 {
+        while i < len && char_class(self.buffer.rope.char(i)) == 0 {
             i += 1;
         }
         i
     }
     fn word_prev(&self, from: usize) -> usize {
         let mut i = from;
-        while i > 0 && Self::class(self.buffer.rope.char(i - 1)) == 0 {
+        while i > 0 && char_class(self.buffer.rope.char(i - 1)) == 0 {
             i -= 1;
         }
         if i == 0 {
             return 0;
         }
-        let cls = Self::class(self.buffer.rope.char(i - 1));
-        while i > 0 && Self::class(self.buffer.rope.char(i - 1)) == cls {
+        let cls = char_class(self.buffer.rope.char(i - 1));
+        while i > 0 && char_class(self.buffer.rope.char(i - 1)) == cls {
             i -= 1;
         }
         i
@@ -384,14 +376,14 @@ impl EditCore {
     fn word_end(&self, from: usize) -> usize {
         let len = self.buffer.len_chars();
         let mut i = (from + 1).min(len);
-        while i < len && Self::class(self.buffer.rope.char(i)) == 0 {
+        while i < len && char_class(self.buffer.rope.char(i)) == 0 {
             i += 1;
         }
         if i >= len {
             return len;
         }
-        let cls = Self::class(self.buffer.rope.char(i));
-        while i + 1 < len && Self::class(self.buffer.rope.char(i + 1)) == cls {
+        let cls = char_class(self.buffer.rope.char(i));
+        while i + 1 < len && char_class(self.buffer.rope.char(i + 1)) == cls {
             i += 1;
         }
         i
@@ -494,6 +486,18 @@ impl EditCore {
                 self.line_span(self.primary().head, count),
                 RegisterKind::Linewise,
             )),
+            Target::TextObject(obj) => {
+                let r = crate::edit::text_object::resolve(&self.buffer, self.primary().head, obj)?;
+                if r.start >= r.end {
+                    return None;
+                }
+                let kind = if obj.kind.is_linewise() {
+                    RegisterKind::Linewise
+                } else {
+                    RegisterKind::Charwise
+                };
+                Some((r, kind))
+            }
             Target::Selection => {
                 let r = self.visual_range();
                 if r.start >= r.end {
@@ -951,6 +955,17 @@ impl EditCore {
                     anchor: sel.head,
                     head: sel.anchor,
                 }];
+            }
+            EditCommand::SelectTextObject(obj) => {
+                if let Some(r) =
+                    crate::edit::text_object::resolve(&self.buffer, self.primary().head, obj)
+                    && r.start < r.end
+                {
+                    self.selections = vec![Selection {
+                        anchor: r.start,
+                        head: self.buffer.prev_grapheme(r.end),
+                    }];
+                }
             }
             EditCommand::Save
             | EditCommand::ScrollViewport(_)

--- a/crates/vmux_editor/src/edit/core.rs
+++ b/crates/vmux_editor/src/edit/core.rs
@@ -445,6 +445,35 @@ impl EditCore {
         out
     }
 
+    /// The decimal number at or after the caret on this line, with its char span.
+    ///
+    /// A `-` immediately before the digits is part of the number, matching `Ctrl-a` on `-3`.
+    fn number_at_caret(&self) -> Option<(std::ops::Range<usize>, i64)> {
+        let (line, col) = self.buffer.char_to_coords(self.primary().head);
+        let base = self.buffer.line_to_char(line);
+        let len = self.buffer.line_len_chars(line);
+        let digit = |i: usize| self.buffer.rope.char(base + i).is_ascii_digit();
+        let mut start = (col..len).find(|i| digit(*i))?;
+        while start > 0 && digit(start - 1) {
+            start -= 1;
+        }
+        let mut end = start;
+        while end < len && digit(end) {
+            end += 1;
+        }
+        let negative = start > 0 && self.buffer.rope.char(base + start - 1) == '-';
+        let text: String = self
+            .buffer
+            .rope
+            .slice(base + start..base + end)
+            .chars()
+            .collect();
+        let magnitude = text.parse::<i64>().ok()?;
+        let span_start = if negative { start - 1 } else { start };
+        let value = if negative { -magnitude } else { magnitude };
+        Some((base + span_start..base + end, value))
+    }
+
     /// The keyword under the cursor, used by `*` and `#`.
     fn word_under_cursor(&self) -> Option<String> {
         let len = self.buffer.len_chars();
@@ -1632,6 +1661,24 @@ impl EditCore {
                     text_changed = true;
                 }
             }
+            EditCommand::Increment(delta) => {
+                if let Some((span, value)) = self.number_at_caret() {
+                    let width = span.end - span.start;
+                    let digits: String = self.buffer.rope.slice(span.clone()).chars().collect();
+                    let padded = digits.starts_with('0') && digits.len() > 1;
+                    let next = value.saturating_add(delta);
+                    let text = if padded {
+                        format!("{:0>width$}", next, width = width)
+                    } else {
+                        next.to_string()
+                    };
+                    self.checkpoint(Group::Other);
+                    self.buf_remove(span.clone());
+                    self.buf_insert(span.start, &text);
+                    self.set_caret(span.start + text.chars().count() - 1);
+                    text_changed = true;
+                }
+            }
             EditCommand::SwapSelectionEnds => {
                 let sel = self.primary();
                 self.selections = vec![Selection {
@@ -1971,6 +2018,42 @@ mod tests {
             head: c.buffer.coords_to_char(to.0, to.1),
         }];
         c
+    }
+
+    #[test]
+    fn increment_finds_the_number_at_or_after_the_caret() {
+        let mut c = core("item 41 done");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(EditCommand::Increment(1));
+        assert_eq!(text_of(&c), "item 42 done");
+    }
+
+    #[test]
+    fn increment_crosses_zero_on_a_negative_number() {
+        let mut c = core("x -1 y");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(EditCommand::Increment(2));
+        assert_eq!(text_of(&c), "x 1 y");
+    }
+
+    #[test]
+    fn increment_preserves_zero_padding() {
+        let mut c = core("v007");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(EditCommand::Increment(1));
+        assert_eq!(text_of(&c), "v008");
+    }
+
+    #[test]
+    fn increment_without_a_number_is_inert() {
+        let mut c = core("no digits");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(EditCommand::Increment(1));
+        assert_eq!(text_of(&c), "no digits");
     }
 
     #[test]

--- a/crates/vmux_editor/src/edit/core.rs
+++ b/crates/vmux_editor/src/edit/core.rs
@@ -847,6 +847,64 @@ impl EditCore {
         }
     }
 
+    /// Resolve an ex range to whole lines, including each line's newline.
+    fn ex_range(&self, range: crate::edit::ex::ExRange) -> std::ops::Range<usize> {
+        use crate::edit::ex::ExRange;
+        match range {
+            ExRange::CurrentLine => self.line_span(self.primary().head, 1),
+            ExRange::WholeFile => 0..self.buffer.len_chars(),
+            ExRange::Selection => self.expand_linewise(self.primary().range()),
+            ExRange::Lines(first, last) => {
+                let total = self.buffer.len_lines().saturating_sub(1);
+                let (first, last) = (first.min(total), last.min(total));
+                let (first, last) = (first.min(last), first.max(last));
+                let start = self.buffer.line_to_char(first);
+                let end = if last + 1 < self.buffer.len_lines() {
+                    self.buffer.line_to_char(last + 1)
+                } else {
+                    self.buffer.len_chars()
+                };
+                start..end
+            }
+        }
+    }
+
+    fn substitute(
+        &mut self,
+        range: crate::edit::ex::ExRange,
+        pattern: &str,
+        replacement: &str,
+        all: bool,
+    ) -> bool {
+        let span = self.ex_range(range);
+        if span.start >= span.end {
+            return false;
+        }
+        let Ok(re) = regex::Regex::new(&crate::edit::search::translate(pattern)) else {
+            return false;
+        };
+        let source: String = self.buffer.rope.slice(span.clone()).chars().collect();
+        let replacement = replacement.replace('&', "${0}");
+        let out = if all {
+            re.replace_all(&source, replacement.as_str()).into_owned()
+        } else {
+            // Vim substitutes the first match on each line unless the `g` flag is given.
+            source
+                .split_inclusive('\n')
+                .map(|line| re.replace(line, replacement.as_str()).into_owned())
+                .collect()
+        };
+        if out == source {
+            return false;
+        }
+        self.checkpoint(Group::Other);
+        self.buf_remove(span.clone());
+        self.buf_insert(span.start, &out);
+        let at = (span.start + out.chars().count()).min(self.buffer.len_chars());
+        self.set_caret(self.first_non_blank(at.saturating_sub(1)));
+        true
+    }
+
     fn apply_operator(
         &mut self,
         operator: Operator,
@@ -1259,6 +1317,36 @@ impl EditCore {
                 }
             }
             EditCommand::ClearSearchHighlight => self.search_highlight = false,
+            EditCommand::Substitute {
+                range,
+                pattern,
+                replacement,
+                all,
+            } => {
+                text_changed = self.substitute(range, &pattern, &replacement, all);
+            }
+            EditCommand::ExDelete(range) => {
+                let span = self.ex_range(range);
+                if span.start < span.end {
+                    let text: String = self.buffer.rope.slice(span.clone()).chars().collect();
+                    self.registers
+                        .write_delete(None, RegisterValue::linewise(text));
+                    self.checkpoint(Group::Other);
+                    self.buf_remove(span.clone());
+                    let at = span.start.min(self.buffer.len_chars());
+                    self.set_caret(self.first_non_blank(at));
+                    text_changed = true;
+                }
+            }
+            EditCommand::ExYank(range) => {
+                let span = self.ex_range(range);
+                if span.start < span.end {
+                    let text: String = self.buffer.rope.slice(span).chars().collect();
+                    let value = RegisterValue::linewise(text);
+                    self.registers.write_yank(None, value.clone());
+                    yank = Some(value);
+                }
+            }
             EditCommand::SetMark(name) => {
                 self.marks.insert(name, self.primary().head);
             }
@@ -1620,6 +1708,70 @@ mod tests {
         c.set_caret(0);
         c.apply(EditCommand::Move(Motion::Column(4)));
         assert_eq!(c.primary().head, 3);
+    }
+
+    #[test]
+    fn substitute_replaces_the_first_match_per_line_without_g() {
+        let mut c = core("aa bb aa\naa cc\n");
+        c.mode = EditMode::Normal;
+        c.apply(EditCommand::Substitute {
+            range: crate::edit::ex::ExRange::WholeFile,
+            pattern: "aa".into(),
+            replacement: "X".into(),
+            all: false,
+        });
+        assert_eq!(text_of(&c), "X bb aa\nX cc\n");
+    }
+
+    #[test]
+    fn substitute_with_g_replaces_every_match() {
+        let mut c = core("aa bb aa\n");
+        c.mode = EditMode::Normal;
+        c.apply(EditCommand::Substitute {
+            range: crate::edit::ex::ExRange::WholeFile,
+            pattern: "aa".into(),
+            replacement: "X".into(),
+            all: true,
+        });
+        assert_eq!(text_of(&c), "X bb X\n");
+    }
+
+    #[test]
+    fn substitute_honours_a_line_range() {
+        let mut c = core("a\na\na\n");
+        c.mode = EditMode::Normal;
+        c.apply(EditCommand::Substitute {
+            range: crate::edit::ex::ExRange::Lines(1, 1),
+            pattern: "a".into(),
+            replacement: "b".into(),
+            all: false,
+        });
+        assert_eq!(text_of(&c), "a\nb\na\n");
+    }
+
+    #[test]
+    fn substitute_expands_ampersand_to_the_match() {
+        let mut c = core("cat\n");
+        c.mode = EditMode::Normal;
+        c.apply(EditCommand::Substitute {
+            range: crate::edit::ex::ExRange::WholeFile,
+            pattern: "cat".into(),
+            replacement: "[&]".into(),
+            all: false,
+        });
+        assert_eq!(text_of(&c), "[cat]\n");
+    }
+
+    #[test]
+    fn ex_delete_removes_lines_and_yanks_them_linewise() {
+        let mut c = core("one\ntwo\nthree\n");
+        c.mode = EditMode::Normal;
+        c.apply(EditCommand::ExDelete(crate::edit::ex::ExRange::Lines(0, 1)));
+        assert_eq!(text_of(&c), "three\n");
+        assert_eq!(
+            c.registers.read(None),
+            Some(&RegisterValue::linewise("one\ntwo\n"))
+        );
     }
 
     #[test]

--- a/crates/vmux_editor/src/edit/core.rs
+++ b/crates/vmux_editor/src/edit/core.rs
@@ -84,8 +84,7 @@ pub struct EditCore {
     pub registers: Registers,
     rev: u64,
     saved_rev: Option<u64>,
-    undo: Vec<(ropey::Rope, Vec<Selection>, u64)>,
-    redo: Vec<(ropey::Rope, Vec<Selection>, u64)>,
+    undo: crate::edit::undo::UndoTree,
     last_group: Option<Group>,
     preferred_vertical_col: Option<usize>,
     pub fold_view: crate::fold::FoldView,
@@ -104,6 +103,8 @@ impl EditCore {
     pub fn new(path: PathBuf, language: String, text: &str, default_mode: EditMode) -> Self {
         let buffer = TextBuffer::from_text(path, language, text);
         let fold_view = crate::fold::FoldState::default().view(buffer.len_lines() as u32);
+        let undo =
+            crate::edit::undo::UndoTree::new(buffer.rope.clone(), vec![Selection::caret(0)], 0);
         Self {
             buffer,
             selections: vec![Selection::caret(0)],
@@ -114,8 +115,7 @@ impl EditCore {
             registers: Registers::default(),
             rev: 0,
             saved_rev: Some(0),
-            undo: Vec::new(),
-            redo: Vec::new(),
+            undo,
             last_group: None,
             preferred_vertical_col: None,
             fold_view,
@@ -318,8 +318,19 @@ impl EditCore {
     }
     fn snapshot(&mut self) {
         self.undo
-            .push((self.buffer.rope.clone(), self.selections.clone(), self.rev));
-        self.redo.clear();
+            .push(&self.buffer.rope, &self.selections, self.rev);
+    }
+
+    fn restore(&mut self, state: crate::edit::undo::Restored) {
+        self.buffer.rope = state.rope;
+        self.selections = state.selections;
+        self.rev = state.rev;
+        self.dirty = self.saved_rev != Some(self.rev);
+        self.break_group();
+        let len = self.buffer.len_chars();
+        for mark in self.marks.values_mut() {
+            *mark = (*mark).min(len);
+        }
     }
     fn checkpoint(&mut self, group: Group) {
         if self.last_group != Some(group) || group == Group::Other {
@@ -1516,26 +1527,32 @@ impl EditCore {
                 }
             }
             EditCommand::Undo => {
-                if let Some((rope, sel, rev)) = self.undo.pop() {
-                    self.redo
-                        .push((self.buffer.rope.clone(), self.selections.clone(), self.rev));
-                    self.buffer.rope = rope;
-                    self.selections = sel;
-                    self.rev = rev;
-                    self.dirty = self.saved_rev != Some(self.rev);
-                    self.break_group();
+                if let Some(state) = self
+                    .undo
+                    .undo(&self.buffer.rope, &self.selections, self.rev)
+                {
+                    self.restore(state);
                     text_changed = true;
                 }
             }
             EditCommand::Redo => {
-                if let Some((rope, sel, rev)) = self.redo.pop() {
-                    self.undo
-                        .push((self.buffer.rope.clone(), self.selections.clone(), self.rev));
-                    self.buffer.rope = rope;
-                    self.selections = sel;
-                    self.rev = rev;
-                    self.dirty = self.saved_rev != Some(self.rev);
-                    self.break_group();
+                if let Some(state) = self
+                    .undo
+                    .redo(&self.buffer.rope, &self.selections, self.rev)
+                {
+                    self.restore(state);
+                    text_changed = true;
+                }
+            }
+            EditCommand::UndoTime { forward, count } => {
+                if let Some(state) = self.undo.step_time(
+                    &self.buffer.rope,
+                    &self.selections,
+                    self.rev,
+                    forward,
+                    count,
+                ) {
+                    self.restore(state);
                     text_changed = true;
                 }
             }
@@ -2018,6 +2035,27 @@ mod tests {
             head: c.buffer.coords_to_char(to.0, to.1),
         }];
         c
+    }
+
+    #[test]
+    fn a_new_edit_after_undo_branches_and_time_travel_reaches_the_old_one() {
+        let mut c = core("");
+        c.apply(EditCommand::InsertText("first".into()));
+        c.apply(EditCommand::Undo);
+        assert_eq!(text_of(&c), "");
+        c.apply(EditCommand::InsertText("second".into()));
+        assert_eq!(text_of(&c), "second");
+
+        c.apply(EditCommand::UndoTime {
+            forward: false,
+            count: 1,
+        });
+        assert_eq!(text_of(&c), "first", "g- reaches the abandoned branch");
+        c.apply(EditCommand::UndoTime {
+            forward: true,
+            count: 1,
+        });
+        assert_eq!(text_of(&c), "second");
     }
 
     #[test]

--- a/crates/vmux_editor/src/edit/core.rs
+++ b/crates/vmux_editor/src/edit/core.rs
@@ -71,6 +71,7 @@ pub struct EditCore {
     preferred_vertical_col: Option<usize>,
     pub fold_view: crate::fold::FoldView,
     pub search: Option<crate::edit::search::Search>,
+    replaced: Vec<Option<char>>,
     pub search_highlight: bool,
     marks: std::collections::HashMap<char, usize>,
     jumps: Vec<usize>,
@@ -99,6 +100,7 @@ impl EditCore {
             preferred_vertical_col: None,
             fold_view,
             search: None,
+            replaced: Vec::new(),
             search_highlight: false,
             marks: std::collections::HashMap::new(),
             jumps: Vec::new(),
@@ -1125,6 +1127,22 @@ impl EditCore {
                 self.set_head(h);
             }
             EditCommand::InsertText(t) => text_changed = self.insert_text(&t),
+            EditCommand::OvertypeText(t) => {
+                self.checkpoint(Group::Insert);
+                for ch in t.chars() {
+                    let at = self.primary().head;
+                    let line_end = self.resolve_motion(at, Motion::LineEnd);
+                    if at < line_end {
+                        self.replaced.push(Some(self.buffer.rope.char(at)));
+                        self.buf_remove(at..at + 1);
+                    } else {
+                        self.replaced.push(None);
+                    }
+                    self.buf_insert(at, &ch.to_string());
+                    self.set_caret(at + 1);
+                }
+                text_changed = true;
+            }
             EditCommand::ReplaceText(t) => {
                 let caret = self.primary().head;
                 let next_caret = translated_caret_after_replace(&self.buffer.text(), &t, caret);
@@ -1137,6 +1155,20 @@ impl EditCore {
             }
             EditCommand::InsertTab => text_changed = self.insert_text("\t"),
             EditCommand::InsertNewline => text_changed = self.insert_text("\n"),
+            EditCommand::DeleteBack if self.mode == EditMode::Replace => {
+                let head = self.primary().head;
+                if let Some(original) = self.replaced.pop()
+                    && head > 0
+                {
+                    self.checkpoint(Group::Delete);
+                    self.buf_remove(head - 1..head);
+                    if let Some(ch) = original {
+                        self.buf_insert(head - 1, &ch.to_string());
+                    }
+                    self.set_caret(head - 1);
+                    text_changed = true;
+                }
+            }
             EditCommand::DeleteBack => {
                 if self.primary().is_empty() {
                     let head = self.primary().head;
@@ -1708,6 +1740,28 @@ mod tests {
         c.set_caret(0);
         c.apply(EditCommand::Move(Motion::Column(4)));
         assert_eq!(c.primary().head, 3);
+    }
+
+    #[test]
+    fn overtype_replaces_characters_and_backspace_restores_them() {
+        let mut c = core("abcd");
+        c.mode = EditMode::Replace;
+        c.set_caret(0);
+        c.apply(EditCommand::OvertypeText("XY".into()));
+        assert_eq!(text_of(&c), "XYcd");
+        c.apply(EditCommand::DeleteBack);
+        assert_eq!(text_of(&c), "Xbcd");
+        c.apply(EditCommand::DeleteBack);
+        assert_eq!(text_of(&c), "abcd");
+    }
+
+    #[test]
+    fn overtype_past_the_line_end_appends() {
+        let mut c = core("ab\ncd\n");
+        c.mode = EditMode::Replace;
+        c.set_caret(2);
+        c.apply(EditCommand::OvertypeText("XY".into()));
+        assert_eq!(text_of(&c), "abXY\ncd\n");
     }
 
     #[test]

--- a/crates/vmux_editor/src/edit/core.rs
+++ b/crates/vmux_editor/src/edit/core.rs
@@ -70,6 +70,8 @@ pub struct EditCore {
     last_group: Option<Group>,
     preferred_vertical_col: Option<usize>,
     pub fold_view: crate::fold::FoldView,
+    pub search: Option<crate::edit::search::Search>,
+    pub search_highlight: bool,
     marks: std::collections::HashMap<char, usize>,
     jumps: Vec<usize>,
     jump_index: usize,
@@ -96,6 +98,8 @@ impl EditCore {
             last_group: None,
             preferred_vertical_col: None,
             fold_view,
+            search: None,
+            search_highlight: false,
             marks: std::collections::HashMap::new(),
             jumps: Vec::new(),
             jump_index: 0,
@@ -338,7 +342,88 @@ impl EditCore {
             Motion::FindChar { ch, forward, till } => {
                 self.find_char(from, ch, forward, till).unwrap_or(from)
             }
+            Motion::SearchNext { reverse } => self.search_step(from, reverse).unwrap_or(from),
         }
+    }
+
+    /// Char positions of every match of the active search, in buffer order.
+    pub fn search_matches(&self) -> Vec<std::ops::Range<usize>> {
+        let Some(search) = self.search.as_ref() else {
+            return Vec::new();
+        };
+        let text = self.buffer.text();
+        search
+            .matches(&text)
+            .into_iter()
+            .map(|r| {
+                let start = text[..r.start].chars().count();
+                let len = text[r.clone()].chars().count();
+                start..start + len
+            })
+            .collect()
+    }
+
+    fn search_step(&self, from: usize, reverse: bool) -> Option<usize> {
+        let search = self.search.as_ref()?;
+        let forward = search.forward != reverse;
+        let matches = self.search_matches();
+        crate::edit::search::step(&matches, from, forward)
+    }
+
+    /// Highlight spans for the active search, in the same shape the selection uses.
+    pub fn search_spans(&self, first: u32, rows: u16) -> Vec<SelSpan> {
+        if !self.search_highlight || rows == 0 {
+            return Vec::new();
+        }
+        let last_line = first as usize + rows as usize;
+        let mut out = Vec::new();
+        for m in self.search_matches() {
+            let (l0, _) = self.buffer.char_to_coords(m.start);
+            let (l1, _) = self.buffer.char_to_coords(m.end);
+            if l1 < first as usize || l0 >= last_line {
+                continue;
+            }
+            for line in l0..=l1 {
+                if line < first as usize || line >= last_line {
+                    continue;
+                }
+                let ls = self.buffer.line_to_char(line);
+                let llen = self.buffer.line_len_chars(line);
+                let sc = if line == l0 { m.start - ls } else { 0 };
+                let ec = if line == l1 { m.end - ls } else { llen };
+                out.push(SelSpan {
+                    line: line as u32,
+                    row: line as u32,
+                    start: self.vis_col(ls, sc),
+                    end: self.vis_col(ls, ec),
+                });
+            }
+        }
+        out
+    }
+
+    /// The keyword under the cursor, used by `*` and `#`.
+    fn word_under_cursor(&self) -> Option<String> {
+        let len = self.buffer.len_chars();
+        if len == 0 {
+            return None;
+        }
+        let head = self.primary().head.min(len - 1);
+        let mut start = head;
+        while start < len && char_class(self.buffer.rope.char(start)) != 1 {
+            start += 1;
+        }
+        if start >= len || self.buffer.char_to_line(start) != self.buffer.char_to_line(head) {
+            return None;
+        }
+        let mut end = start;
+        while start > 0 && char_class(self.buffer.rope.char(start - 1)) == 1 {
+            start -= 1;
+        }
+        while end < len && char_class(self.buffer.rope.char(end)) == 1 {
+            end += 1;
+        }
+        Some(self.buffer.rope.slice(start..end).chars().collect())
     }
 
     /// The first non-blank of the buffer line displayed `offset` rows below the viewport top.
@@ -1150,6 +1235,30 @@ impl EditCore {
                     text_changed = true;
                 }
             }
+            EditCommand::SetSearch { pattern, forward } => {
+                if let Some(search) = crate::edit::search::Search::new(&pattern, forward) {
+                    self.search = Some(search);
+                    self.search_highlight = true;
+                    self.push_jump();
+                    if let Some(at) = self.search_step(self.primary().head, false) {
+                        self.set_caret(at);
+                    }
+                }
+            }
+            EditCommand::SearchWord { forward } => {
+                if let Some(word) = self.word_under_cursor() {
+                    let pattern = format!("\\<{}\\>", regex::escape(&word));
+                    if let Some(search) = crate::edit::search::Search::new(&pattern, forward) {
+                        self.search = Some(search);
+                        self.search_highlight = true;
+                        self.push_jump();
+                        if let Some(at) = self.search_step(self.primary().head, false) {
+                            self.set_caret(at);
+                        }
+                    }
+                }
+            }
+            EditCommand::ClearSearchHighlight => self.search_highlight = false,
             EditCommand::SetMark(name) => {
                 self.marks.insert(name, self.primary().head);
             }
@@ -1511,6 +1620,88 @@ mod tests {
         c.set_caret(0);
         c.apply(EditCommand::Move(Motion::Column(4)));
         assert_eq!(c.primary().head, 3);
+    }
+
+    #[test]
+    fn search_jumps_to_the_next_match_and_wraps() {
+        let mut c = core("alpha beta alpha gamma");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(EditCommand::SetSearch {
+            pattern: "alpha".into(),
+            forward: true,
+        });
+        assert_eq!(c.primary().head, 11);
+        c.apply(EditCommand::Move(Motion::SearchNext { reverse: false }));
+        assert_eq!(c.primary().head, 0);
+        c.apply(EditCommand::Move(Motion::SearchNext { reverse: true }));
+        assert_eq!(c.primary().head, 11);
+    }
+
+    #[test]
+    fn a_backward_search_reverses_what_n_means() {
+        let mut c = core("x a x a x");
+        c.mode = EditMode::Normal;
+        c.set_caret(4);
+        c.apply(EditCommand::SetSearch {
+            pattern: "x".into(),
+            forward: false,
+        });
+        assert_eq!(c.primary().head, 0);
+        c.apply(EditCommand::Move(Motion::SearchNext { reverse: false }));
+        assert_eq!(c.primary().head, 8);
+    }
+
+    #[test]
+    fn star_searches_the_whole_word_under_the_cursor() {
+        let mut c = core("cat category cat");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(EditCommand::SearchWord { forward: true });
+        assert_eq!(c.primary().head, 13);
+    }
+
+    #[test]
+    fn search_composes_with_an_operator() {
+        let mut c = core("one two three");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(EditCommand::SetSearch {
+            pattern: "three".into(),
+            forward: true,
+        });
+        c.set_caret(0);
+        c.apply(op(
+            Operator::Delete,
+            Target::Motion(Motion::SearchNext { reverse: false }, 1),
+        ));
+        assert_eq!(text_of(&c), "three");
+    }
+
+    #[test]
+    fn an_invalid_pattern_leaves_the_caret_alone() {
+        let mut c = core("abc");
+        c.mode = EditMode::Normal;
+        c.set_caret(1);
+        c.apply(EditCommand::SetSearch {
+            pattern: "\\v(".into(),
+            forward: true,
+        });
+        assert_eq!(c.primary().head, 1);
+        assert!(c.search.is_none());
+    }
+
+    #[test]
+    fn highlight_spans_appear_only_while_highlighting_is_on() {
+        let mut c = core("foo bar foo\n");
+        c.mode = EditMode::Normal;
+        c.apply(EditCommand::SetSearch {
+            pattern: "foo".into(),
+            forward: true,
+        });
+        assert_eq!(c.search_spans(0, 4).len(), 2);
+        c.apply(EditCommand::ClearSearchHighlight);
+        assert!(c.search_spans(0, 4).is_empty());
     }
 
     #[test]

--- a/crates/vmux_editor/src/edit/core.rs
+++ b/crates/vmux_editor/src/edit/core.rs
@@ -70,6 +70,11 @@ pub struct EditCore {
     last_group: Option<Group>,
     preferred_vertical_col: Option<usize>,
     pub fold_view: crate::fold::FoldView,
+    marks: std::collections::HashMap<char, usize>,
+    jumps: Vec<usize>,
+    jump_index: usize,
+    changes: Vec<usize>,
+    change_index: usize,
 }
 
 impl EditCore {
@@ -91,6 +96,69 @@ impl EditCore {
             last_group: None,
             preferred_vertical_col: None,
             fold_view,
+            marks: std::collections::HashMap::new(),
+            jumps: Vec::new(),
+            jump_index: 0,
+            changes: Vec::new(),
+            change_index: 0,
+        }
+    }
+
+    /// Insert text and slide any marks sitting after the insertion point.
+    fn buf_insert(&mut self, at: usize, text: &str) {
+        self.buffer.insert(at, text);
+        let n = text.chars().count();
+        for mark in self.marks.values_mut() {
+            if *mark > at {
+                *mark += n;
+            }
+        }
+    }
+
+    /// Remove a range, pulling marks inside it back to its start.
+    fn buf_remove(&mut self, range: std::ops::Range<usize>) {
+        self.buffer.remove(range.clone());
+        let n = range.end - range.start;
+        for mark in self.marks.values_mut() {
+            if *mark >= range.end {
+                *mark -= n;
+            } else if *mark > range.start {
+                *mark = range.start;
+            }
+        }
+    }
+
+    /// Record the current position on the jump list so `Ctrl-o` can come back to it.
+    fn push_jump(&mut self) {
+        let at = self.primary().head;
+        self.jumps.truncate(self.jump_index);
+        if self.jumps.last() == Some(&at) {
+            return;
+        }
+        self.jumps.push(at);
+        self.jump_index = self.jumps.len();
+    }
+
+    fn jump(&mut self, back: bool, count: usize) {
+        let here = self.primary().head;
+        for _ in 0..count.max(1) {
+            if back {
+                if self.jump_index == 0 {
+                    break;
+                }
+                if self.jump_index == self.jumps.len() {
+                    self.jumps.push(here);
+                }
+                self.jump_index -= 1;
+            } else {
+                if self.jump_index + 1 >= self.jumps.len() {
+                    break;
+                }
+                self.jump_index += 1;
+            }
+        }
+        if let Some(&at) = self.jumps.get(self.jump_index) {
+            self.set_caret(at.min(self.buffer.len_chars()));
         }
     }
 
@@ -213,6 +281,11 @@ impl EditCore {
         self.last_group = Some(group);
         self.rev += 1;
         self.dirty = self.saved_rev != Some(self.rev);
+        let at = self.primary().head;
+        if self.changes.last() != Some(&at) {
+            self.changes.push(at);
+        }
+        self.change_index = self.changes.len().saturating_sub(1);
     }
 
     fn resolve_motion(&self, from: usize, motion: Motion) -> usize {
@@ -534,11 +607,11 @@ impl EditCore {
         self.checkpoint(Group::Insert);
         if !self.primary().is_empty() {
             let r = self.primary().range();
-            self.buffer.remove(r.clone());
+            self.buf_remove(r.clone());
             self.set_caret(r.start);
         }
         let at = self.primary().head;
-        self.buffer.insert(at, text);
+        self.buf_insert(at, text);
         self.set_caret(at + text.chars().count());
         true
     }
@@ -549,7 +622,7 @@ impl EditCore {
         }
         self.checkpoint(Group::Other);
         let r = sel.range();
-        self.buffer.remove(r.clone());
+        self.buf_remove(r.clone());
         self.set_caret(r.start);
         true
     }
@@ -719,13 +792,13 @@ impl EditCore {
                 if operator == Operator::Change && kind == RegisterKind::Linewise {
                     let (line, _) = self.buffer.char_to_coords(range.start);
                     let indent = self.line_indent(line);
-                    self.buffer.remove(range.clone());
+                    self.buf_remove(range.clone());
                     self.mode = EditMode::Insert;
                     let tail = if had_newline { "\n" } else { "" };
-                    self.buffer.insert(range.start, &format!("{indent}{tail}"));
+                    self.buf_insert(range.start, &format!("{indent}{tail}"));
                     self.set_caret(range.start + indent.chars().count());
                 } else {
-                    self.buffer.remove(range.clone());
+                    self.buf_remove(range.clone());
                     if operator == Operator::Change {
                         self.mode = EditMode::Insert;
                     } else if was_visual {
@@ -754,11 +827,11 @@ impl EditCore {
                         if self.buffer.line_len_chars(line) == 0 {
                             continue;
                         }
-                        self.buffer.insert(base, "\t");
+                        self.buf_insert(base, "\t");
                     } else {
                         let width = self.outdent_width(line);
                         if width > 0 {
-                            self.buffer.remove(base..base + width);
+                            self.buf_remove(base..base + width);
                         }
                     }
                 }
@@ -788,8 +861,8 @@ impl EditCore {
                     return (false, None);
                 }
                 self.checkpoint(Group::Other);
-                self.buffer.remove(range.clone());
-                self.buffer.insert(range.start, &out);
+                self.buf_remove(range.clone());
+                self.buf_insert(range.start, &out);
                 self.set_caret(range.start);
                 (true, None)
             }
@@ -813,7 +886,7 @@ impl EditCore {
                 self.registers
                     .write_delete(None, RegisterValue { text, kind });
                 self.checkpoint(Group::Other);
-                self.buffer.remove(range.clone());
+                self.buf_remove(range.clone());
             }
             self.mode = EditMode::Normal;
             self.set_caret(range.start.min(self.buffer.len_chars()));
@@ -830,7 +903,7 @@ impl EditCore {
                 };
                 let text = value.text.repeat(count);
                 self.checkpoint(Group::Other);
-                self.buffer.insert(at, &text);
+                self.buf_insert(at, &text);
                 let end = at + text.chars().count();
                 self.set_caret(end.saturating_sub(1).max(at));
             }
@@ -851,10 +924,10 @@ impl EditCore {
                 self.checkpoint(Group::Other);
                 if at == self.buffer.len_chars() && at > 0 && self.buffer.rope.char(at - 1) != '\n'
                 {
-                    self.buffer.insert(at, "\n");
+                    self.buf_insert(at, "\n");
                     at += 1;
                 }
-                self.buffer.insert(at, &text);
+                self.buf_insert(at, &text);
                 self.set_caret(self.first_non_blank(at));
             }
         }
@@ -882,6 +955,9 @@ impl EditCore {
         match cmd {
             EditCommand::Move(m) => {
                 self.break_group();
+                if m.is_jump() {
+                    self.push_jump();
+                }
                 let selection = self.primary();
                 let collapse_selection = !self.mode.is_visual() && !selection.is_empty();
                 let h = if collapse_selection {
@@ -912,6 +988,7 @@ impl EditCore {
                 self.checkpoint(Group::Other);
                 self.buffer.remove(0..self.buffer.len_chars());
                 self.buffer.insert(0, &t);
+                self.marks.clear();
                 self.set_caret(next_caret);
                 text_changed = true;
             }
@@ -923,7 +1000,7 @@ impl EditCore {
                     if head > 0 {
                         self.checkpoint(Group::Delete);
                         let prev = self.buffer.prev_grapheme(head);
-                        self.buffer.remove(prev..head);
+                        self.buf_remove(prev..head);
                         self.set_caret(prev);
                         text_changed = true;
                     }
@@ -939,7 +1016,7 @@ impl EditCore {
                     if head < self.buffer.len_chars() {
                         self.checkpoint(Group::Delete);
                         let next = self.buffer.next_grapheme(head);
-                        self.buffer.remove(head..next);
+                        self.buf_remove(head..next);
                         text_changed = true;
                     }
                 }
@@ -949,7 +1026,7 @@ impl EditCore {
                 let target = self.word_prev(head, false);
                 if target < head {
                     self.checkpoint(Group::Delete);
-                    self.buffer.remove(target..head);
+                    self.buf_remove(target..head);
                     self.set_caret(target);
                     text_changed = true;
                 }
@@ -983,8 +1060,8 @@ impl EditCore {
                 if fits && end > head {
                     let n = self.buffer.rope.slice(head..end).chars().count();
                     self.checkpoint(Group::Other);
-                    self.buffer.remove(head..end);
-                    self.buffer.insert(head, &ch.to_string().repeat(n));
+                    self.buf_remove(head..end);
+                    self.buf_insert(head, &ch.to_string().repeat(n));
                     self.set_caret(head + n - 1);
                     text_changed = true;
                 }
@@ -1011,7 +1088,7 @@ impl EditCore {
                     if !text_changed {
                         self.checkpoint(Group::Other);
                     }
-                    self.buffer.remove(end..next + skip);
+                    self.buf_remove(end..next + skip);
                     if spaces
                         && end > start
                         && end < self.buffer.len_chars()
@@ -1019,7 +1096,7 @@ impl EditCore {
                         && self.buffer.rope.char(end) != ')'
                         && self.buffer.rope.char(end - 1) != ' '
                     {
-                        self.buffer.insert(end, " ");
+                        self.buf_insert(end, " ");
                     }
                     self.set_caret(end);
                     text_changed = true;
@@ -1033,11 +1110,11 @@ impl EditCore {
                 self.mode = EditMode::Insert;
                 if above {
                     let at = self.buffer.line_to_char(line);
-                    self.buffer.insert(at, &format!("{indent}\n"));
+                    self.buf_insert(at, &format!("{indent}\n"));
                     self.set_caret(at + indent.chars().count());
                 } else {
                     let at = self.buffer.line_to_char(line) + self.buffer.line_len_chars(line);
-                    self.buffer.insert(at, &format!("\n{indent}"));
+                    self.buf_insert(at, &format!("\n{indent}"));
                     self.set_caret(at + 1 + indent.chars().count());
                 }
                 text_changed = true;
@@ -1071,6 +1148,38 @@ impl EditCore {
                     self.dirty = self.saved_rev != Some(self.rev);
                     self.break_group();
                     text_changed = true;
+                }
+            }
+            EditCommand::SetMark(name) => {
+                self.marks.insert(name, self.primary().head);
+            }
+            EditCommand::GotoMark { name, linewise } => {
+                if let Some(&at) = self.marks.get(&name) {
+                    let at = at.min(self.buffer.len_chars());
+                    self.push_jump();
+                    let target = if linewise {
+                        self.first_non_blank(at)
+                    } else {
+                        at
+                    };
+                    if self.mode.is_visual() {
+                        self.set_head(target);
+                    } else {
+                        self.set_caret(target);
+                    }
+                }
+            }
+            EditCommand::JumpList { back, count } => self.jump(back, count),
+            EditCommand::ChangeList { back, count } => {
+                if !self.changes.is_empty() {
+                    let last = self.changes.len() - 1;
+                    self.change_index = if back {
+                        self.change_index.saturating_sub(count.max(1))
+                    } else {
+                        (self.change_index + count.max(1)).min(last)
+                    };
+                    let at = self.changes[self.change_index.min(last)];
+                    self.set_caret(at.min(self.buffer.len_chars()));
                 }
             }
             EditCommand::SwapSelectionEnds => {
@@ -1402,6 +1511,111 @@ mod tests {
         c.set_caret(0);
         c.apply(EditCommand::Move(Motion::Column(4)));
         assert_eq!(c.primary().head, 3);
+    }
+
+    #[test]
+    fn marks_return_to_a_saved_position() {
+        let mut c = core("one\ntwo\nthree\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(c.buffer.coords_to_char(1, 1));
+        c.apply(EditCommand::SetMark('a'));
+        c.set_caret(0);
+        c.apply(EditCommand::GotoMark {
+            name: 'a',
+            linewise: false,
+        });
+        assert_eq!(c.buffer.char_to_coords(c.primary().head), (1, 1));
+    }
+
+    #[test]
+    fn a_linewise_mark_lands_on_the_first_non_blank() {
+        let mut c = core("one\n    two\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(c.buffer.coords_to_char(1, 7));
+        c.apply(EditCommand::SetMark('b'));
+        c.set_caret(0);
+        c.apply(EditCommand::GotoMark {
+            name: 'b',
+            linewise: true,
+        });
+        assert_eq!(c.buffer.char_to_coords(c.primary().head), (1, 4));
+    }
+
+    #[test]
+    fn marks_slide_when_text_is_inserted_before_them() {
+        let mut c = core("one\ntwo\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(c.buffer.coords_to_char(1, 0));
+        c.apply(EditCommand::SetMark('a'));
+        c.set_caret(0);
+        c.apply(EditCommand::OpenLine { above: true });
+        c.apply(EditCommand::InsertText("zero".into()));
+        c.apply(EditCommand::SetMode(EditMode::Normal));
+        c.apply(EditCommand::GotoMark {
+            name: 'a',
+            linewise: false,
+        });
+        assert_eq!(c.buffer.char_to_coords(c.primary().head), (2, 0));
+    }
+
+    #[test]
+    fn an_unset_mark_does_not_move_the_caret() {
+        let mut c = core("one\ntwo\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(1);
+        c.apply(EditCommand::GotoMark {
+            name: 'z',
+            linewise: false,
+        });
+        assert_eq!(c.primary().head, 1);
+    }
+
+    #[test]
+    fn the_jump_list_walks_back_and_forward() {
+        let mut c = core("a\nb\nc\nd\ne\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(EditCommand::Move(Motion::DocEnd));
+        let end = c.primary().head;
+        c.apply(EditCommand::JumpList {
+            back: true,
+            count: 1,
+        });
+        assert_eq!(c.primary().head, 0);
+        c.apply(EditCommand::JumpList {
+            back: false,
+            count: 1,
+        });
+        assert_eq!(c.primary().head, end);
+    }
+
+    #[test]
+    fn plain_motions_do_not_record_jumps() {
+        let mut c = core("a\nb\nc\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(EditCommand::Move(Motion::Down));
+        c.apply(EditCommand::JumpList {
+            back: true,
+            count: 1,
+        });
+        assert_eq!(c.buffer.char_to_coords(c.primary().head).0, 1);
+    }
+
+    #[test]
+    fn the_change_list_revisits_edit_positions() {
+        let mut c = core("one\ntwo\nthree\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(EditCommand::ReplaceChar { ch: 'X', count: 1 });
+        c.set_caret(c.buffer.coords_to_char(2, 0));
+        c.apply(EditCommand::ReplaceChar { ch: 'Y', count: 1 });
+        c.set_caret(c.buffer.coords_to_char(1, 0));
+        c.apply(EditCommand::ChangeList {
+            back: true,
+            count: 1,
+        });
+        assert_eq!(c.buffer.char_to_coords(c.primary().head).0, 0);
     }
 
     #[test]

--- a/crates/vmux_editor/src/edit/core.rs
+++ b/crates/vmux_editor/src/edit/core.rs
@@ -406,15 +406,18 @@ impl EditCore {
             return Vec::new();
         };
         let text = self.buffer.text();
-        search
-            .matches(&text)
-            .into_iter()
-            .map(|r| {
-                let start = text[..r.start].chars().count();
-                let len = text[r.clone()].chars().count();
-                start..start + len
-            })
-            .collect()
+        // Walk the byte offsets once, carrying the running char count. Counting `text[..r.start]`
+        // per match is O(buffer) each time, and `emit_cursor` calls this on every cursor move.
+        let mut out = Vec::new();
+        let mut byte = 0usize;
+        let mut chars = 0usize;
+        for r in search.matches(&text) {
+            chars += text[byte..r.start].chars().count();
+            byte = r.start;
+            let len = text[r.clone()].chars().count();
+            out.push(chars..chars + len);
+        }
+        out
     }
 
     fn search_step(&self, from: usize, reverse: bool) -> Option<usize> {
@@ -1028,9 +1031,6 @@ impl EditCore {
         true
     }
 
-    /// Apply an operator to a rectangle, row by row from the bottom so earlier rows keep their
-    /// indices. Only the operators that make sense on a block are handled; the rest fall through
-    /// to the enclosing charwise path.
     /// Shift every line touched by `range` one indent level in or out.
     fn apply_line_shift(
         &mut self,
@@ -1062,6 +1062,9 @@ impl EditCore {
         (true, None)
     }
 
+    /// Apply an operator to a rectangle, row by row from the bottom so earlier rows keep their
+    /// indices. Only the operators that make sense on a block are handled; the rest fall through
+    /// to the enclosing charwise path.
     fn apply_block_operator(
         &mut self,
         operator: Operator,
@@ -2556,6 +2559,19 @@ mod tests {
         assert_eq!(text_of(&c), "HELLO");
         c.apply(op(Operator::ToggleCase, Target::Motion(Motion::LineEnd, 1)));
         assert_eq!(text_of(&c), "hello");
+    }
+
+    /// `D` clears to the end of the line without joining the next one. A single-line fixture hides
+    /// this: the range gets clamped to the buffer length, so the extra step past `\n` is invisible.
+    #[test]
+    fn line_end_operator_stops_before_the_newline() {
+        let mut c = core("abc\ndef\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(2);
+
+        c.apply(op(Operator::Delete, Target::Motion(Motion::LineEnd, 1)));
+
+        assert_eq!(text_of(&c), "ab\ndef\n");
     }
 
     #[test]

--- a/crates/vmux_editor/src/edit/core.rs
+++ b/crates/vmux_editor/src/edit/core.rs
@@ -60,6 +60,7 @@ pub struct EditCore {
     pub selections: Vec<Selection>,
     pub mode: EditMode,
     pub rows: u16,
+    pub top_row: u32,
     pub dirty: bool,
     pub registers: Registers,
     rev: u64,
@@ -80,6 +81,7 @@ impl EditCore {
             selections: vec![Selection::caret(0)],
             mode: default_mode,
             rows: 0,
+            top_row: 0,
             dirty: false,
             registers: Registers::default(),
             rev: 0,
@@ -238,10 +240,118 @@ impl EditCore {
             Motion::DocStart => 0,
             Motion::DocEnd => len,
             Motion::GotoLine(n) => self.buffer.line_to_char(n as usize),
-            Motion::WordNext => self.word_next(from),
-            Motion::WordPrev => self.word_prev(from),
-            Motion::WordEnd => self.word_end(from),
+            Motion::WordNext => self.word_next(from, false),
+            Motion::WordPrev => self.word_prev(from, false),
+            Motion::WordEnd => self.word_end(from, false),
+            Motion::BigWordNext => self.word_next(from, true),
+            Motion::BigWordPrev => self.word_prev(from, true),
+            Motion::BigWordEnd => self.word_end(from, true),
+            Motion::WordEndPrev => self.word_end_prev(from, false),
+            Motion::BigWordEndPrev => self.word_end_prev(from, true),
+            Motion::LastNonBlank => self.last_non_blank(from),
+            Motion::Column(n) => {
+                let (l, _) = self.buffer.char_to_coords(from);
+                let start = self.buffer.line_to_char(l);
+                (start + n.saturating_sub(1)).min(start + self.buffer.line_len_chars(l))
+            }
+            Motion::HalfPageUp => self.vertical(from, -((self.rows.max(2) / 2) as i64)),
+            Motion::HalfPageDown => self.vertical(from, (self.rows.max(2) / 2) as i64),
+            Motion::ScreenTop => self.screen_line(0),
+            Motion::ScreenMiddle => self.screen_line(self.rows.saturating_sub(1) / 2),
+            Motion::ScreenBottom => self.screen_line(self.rows.saturating_sub(1)),
+            Motion::NextLineStart => self.first_non_blank(self.vertical(from, 1)),
+            Motion::PrevLineStart => self.first_non_blank(self.vertical(from, -1)),
+            Motion::MatchPair => self.match_pair(from).unwrap_or(from),
+            Motion::FindChar { ch, forward, till } => {
+                self.find_char(from, ch, forward, till).unwrap_or(from)
+            }
         }
+    }
+
+    /// The first non-blank of the buffer line displayed `offset` rows below the viewport top.
+    fn screen_line(&self, offset: u16) -> usize {
+        let line = self.fold_view.step_rows(self.top_row, offset as i64);
+        self.first_non_blank(self.buffer.line_to_char(line as usize))
+    }
+
+    fn last_non_blank(&self, from: usize) -> usize {
+        let (l, _) = self.buffer.char_to_coords(from);
+        let base = self.buffer.line_to_char(l);
+        let llen = self.buffer.line_len_chars(l);
+        let mut i = llen;
+        while i > 0 {
+            let ch = self.buffer.rope.char(base + i - 1);
+            if ch != ' ' && ch != '\t' {
+                return base + i - 1;
+            }
+            i -= 1;
+        }
+        base
+    }
+
+    /// Vim's `%`: from the first bracket at or after the cursor on this line, jump to its partner.
+    fn match_pair(&self, from: usize) -> Option<usize> {
+        const PAIRS: [(char, char); 3] = [('(', ')'), ('[', ']'), ('{', '}')];
+        let (line, _) = self.buffer.char_to_coords(from);
+        let base = self.buffer.line_to_char(line);
+        let llen = self.buffer.line_len_chars(line);
+        let col = from - base;
+        for i in col..llen {
+            let at = base + i;
+            let c = self.buffer.rope.char(at);
+            if let Some((open, close)) = PAIRS.iter().find(|(o, _)| *o == c) {
+                return self.scan_pair(at, *open, *close, true);
+            }
+            if let Some((open, close)) = PAIRS.iter().find(|(_, c2)| *c2 == c) {
+                return self.scan_pair(at, *open, *close, false);
+            }
+        }
+        None
+    }
+
+    fn scan_pair(&self, at: usize, open: char, close: char, forward: bool) -> Option<usize> {
+        let len = self.buffer.len_chars();
+        let mut depth = 0i32;
+        let mut i = at as i64;
+        loop {
+            let c = self.buffer.rope.char(i as usize);
+            if c == open {
+                depth += 1;
+            } else if c == close {
+                depth -= 1;
+            }
+            if depth == 0 && (c == open || c == close) && i as usize != at {
+                return Some(i as usize);
+            }
+            i += if forward { 1 } else { -1 };
+            if i < 0 || i as usize >= len {
+                return None;
+            }
+        }
+    }
+
+    /// Vim's `f`/`F`/`t`/`T`: search the cursor's line only.
+    fn find_char(&self, from: usize, ch: char, forward: bool, till: bool) -> Option<usize> {
+        let (line, _) = self.buffer.char_to_coords(from);
+        let base = self.buffer.line_to_char(line);
+        let llen = self.buffer.line_len_chars(line);
+        let col = from - base;
+        if forward {
+            let start = if till { col + 2 } else { col + 1 };
+            for i in start..llen {
+                if self.buffer.rope.char(base + i) == ch {
+                    return Some(base + if till { i - 1 } else { i });
+                }
+            }
+        } else {
+            let end = if till { col.checked_sub(1)? } else { col };
+            for i in (0..end).rev() {
+                if self.buffer.rope.char(base + i) == ch {
+                    return Some(base + if till { i + 1 } else { i });
+                }
+            }
+        }
+        None
     }
 
     fn resolve_navigation_motion(&mut self, from: usize, motion: Motion) -> usize {
@@ -344,47 +454,78 @@ impl EditCore {
         base
     }
 
-    fn word_next(&self, from: usize) -> usize {
+    /// Word classes, or the coarser WORD split that only separates on whitespace.
+    fn cls(&self, i: usize, big: bool) -> u8 {
+        let c = self.buffer.rope.char(i);
+        if big {
+            if c.is_whitespace() { 0 } else { 1 }
+        } else {
+            char_class(c)
+        }
+    }
+    fn word_next(&self, from: usize, big: bool) -> usize {
         let len = self.buffer.len_chars();
         let mut i = from;
         if i >= len {
             return len;
         }
-        let start_class = char_class(self.buffer.rope.char(i));
-        while i < len && char_class(self.buffer.rope.char(i)) == start_class && start_class != 0 {
+        let start_class = self.cls(i, big);
+        while i < len && self.cls(i, big) == start_class && start_class != 0 {
             i += 1;
         }
-        while i < len && char_class(self.buffer.rope.char(i)) == 0 {
+        while i < len && self.cls(i, big) == 0 {
             i += 1;
         }
         i
     }
-    fn word_prev(&self, from: usize) -> usize {
+    fn word_prev(&self, from: usize, big: bool) -> usize {
         let mut i = from;
-        while i > 0 && char_class(self.buffer.rope.char(i - 1)) == 0 {
+        while i > 0 && self.cls(i - 1, big) == 0 {
             i -= 1;
         }
         if i == 0 {
             return 0;
         }
-        let cls = char_class(self.buffer.rope.char(i - 1));
-        while i > 0 && char_class(self.buffer.rope.char(i - 1)) == cls {
+        let cls = self.cls(i - 1, big);
+        while i > 0 && self.cls(i - 1, big) == cls {
             i -= 1;
         }
         i
     }
-    fn word_end(&self, from: usize) -> usize {
+    fn word_end(&self, from: usize, big: bool) -> usize {
         let len = self.buffer.len_chars();
         let mut i = (from + 1).min(len);
-        while i < len && char_class(self.buffer.rope.char(i)) == 0 {
+        while i < len && self.cls(i, big) == 0 {
             i += 1;
         }
         if i >= len {
             return len;
         }
-        let cls = char_class(self.buffer.rope.char(i));
-        while i + 1 < len && char_class(self.buffer.rope.char(i + 1)) == cls {
+        let cls = self.cls(i, big);
+        while i + 1 < len && self.cls(i + 1, big) == cls {
             i += 1;
+        }
+        i
+    }
+    /// Vim's `ge`: the end of the word before the cursor.
+    fn word_end_prev(&self, from: usize, big: bool) -> usize {
+        let len = self.buffer.len_chars();
+        if from == 0 || len == 0 {
+            return 0;
+        }
+        let mut i = from.min(len - 1);
+        let start = self.cls(i, big);
+        if start != 0 {
+            while i > 0 && self.cls(i - 1, big) == start {
+                i -= 1;
+            }
+        }
+        if i == 0 {
+            return 0;
+        }
+        i -= 1;
+        while i > 0 && self.cls(i, big) == 0 {
+            i -= 1;
         }
         i
     }
@@ -745,27 +886,10 @@ impl EditCore {
                 let collapse_selection = !self.mode.is_visual() && !selection.is_empty();
                 let h = if collapse_selection {
                     self.preferred_vertical_col = None;
-                    match m {
-                        Motion::Left
-                        | Motion::LeftBounded
-                        | Motion::Up
-                        | Motion::PageUp
-                        | Motion::ParagraphPrev
-                        | Motion::WordPrev
-                        | Motion::LineStart
-                        | Motion::DocStart => selection.range().start,
-                        Motion::Right
-                        | Motion::RightBounded
-                        | Motion::Down
-                        | Motion::PageDown
-                        | Motion::ParagraphNext
-                        | Motion::WordNext
-                        | Motion::WordEnd
-                        | Motion::LineEnd
-                        | Motion::DocEnd => selection.range().end,
-                        Motion::FirstNonBlank | Motion::GotoLine(_) => {
-                            self.resolve_motion(selection.head, m)
-                        }
+                    match m.collapse_to_start() {
+                        Some(true) => selection.range().start,
+                        Some(false) => selection.range().end,
+                        None => self.resolve_motion(selection.head, m),
                     }
                 } else {
                     self.resolve_navigation_motion(selection.head, m)
@@ -822,7 +946,7 @@ impl EditCore {
             }
             EditCommand::DeleteWordBack => {
                 let head = self.primary().head;
-                let target = self.word_prev(head);
+                let target = self.word_prev(head, false);
                 if target < head {
                     self.checkpoint(Group::Delete);
                     self.buffer.remove(target..head);
@@ -969,6 +1093,7 @@ impl EditCore {
             }
             EditCommand::Save
             | EditCommand::ScrollViewport(_)
+            | EditCommand::ScrollCursorTo(_)
             | EditCommand::GotoDefinition
             | EditCommand::FindReferences
             | EditCommand::Hover
@@ -1150,6 +1275,133 @@ mod tests {
         c.set_caret(0);
         c.apply(op(Operator::Delete, Target::Motion(Motion::WordNext, 1)));
         assert_eq!(text_of(&c), "bar");
+    }
+
+    #[test]
+    fn find_char_lands_on_or_before_the_target() {
+        let mut c = core("alpha, beta, gamma");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(EditCommand::Move(Motion::FindChar {
+            ch: ',',
+            forward: true,
+            till: false,
+        }));
+        assert_eq!(c.primary().head, 5);
+        c.set_caret(0);
+        c.apply(EditCommand::Move(Motion::FindChar {
+            ch: ',',
+            forward: true,
+            till: true,
+        }));
+        assert_eq!(c.primary().head, 4);
+    }
+
+    #[test]
+    fn find_char_stays_on_the_cursor_line() {
+        let mut c = core("abc\nx,y\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(EditCommand::Move(Motion::FindChar {
+            ch: ',',
+            forward: true,
+            till: false,
+        }));
+        assert_eq!(c.primary().head, 0);
+    }
+
+    #[test]
+    fn forward_find_is_inclusive_as_an_operator_target() {
+        let mut c = core("alpha, beta");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(op(
+            Operator::Delete,
+            Target::Motion(
+                Motion::FindChar {
+                    ch: ',',
+                    forward: true,
+                    till: true,
+                },
+                1,
+            ),
+        ));
+        assert_eq!(text_of(&c), ", beta");
+    }
+
+    #[test]
+    fn counted_find_reaches_the_nth_match() {
+        let mut c = core("a,b,c,d");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(op(
+            Operator::Delete,
+            Target::Motion(
+                Motion::FindChar {
+                    ch: ',',
+                    forward: true,
+                    till: false,
+                },
+                2,
+            ),
+        ));
+        assert_eq!(text_of(&c), "c,d");
+    }
+
+    #[test]
+    fn match_pair_jumps_both_directions() {
+        let mut c = core("foo(bar[baz])");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(EditCommand::Move(Motion::MatchPair));
+        assert_eq!(c.primary().head, 12);
+        c.apply(EditCommand::Move(Motion::MatchPair));
+        assert_eq!(c.primary().head, 3);
+    }
+
+    #[test]
+    fn big_word_motions_span_punctuation() {
+        let mut c = core("foo.bar baz");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(EditCommand::Move(Motion::BigWordNext));
+        assert_eq!(c.primary().head, 8);
+        c.apply(EditCommand::Move(Motion::BigWordPrev));
+        assert_eq!(c.primary().head, 0);
+        c.apply(EditCommand::Move(Motion::BigWordEnd));
+        assert_eq!(c.primary().head, 6);
+    }
+
+    #[test]
+    fn word_end_prev_walks_back_to_the_previous_word() {
+        let mut c = core("one two three");
+        c.mode = EditMode::Normal;
+        c.set_caret(8);
+        c.apply(EditCommand::Move(Motion::WordEndPrev));
+        assert_eq!(c.primary().head, 6);
+    }
+
+    #[test]
+    fn screen_motions_use_the_viewport_top() {
+        let mut c = core("a\nb\nc\nd\ne\nf\ng\n");
+        c.mode = EditMode::Normal;
+        c.rows = 4;
+        c.top_row = 2;
+        c.apply(EditCommand::Move(Motion::ScreenTop));
+        assert_eq!(c.buffer.char_to_coords(c.primary().head).0, 2);
+        c.apply(EditCommand::Move(Motion::ScreenBottom));
+        assert_eq!(c.buffer.char_to_coords(c.primary().head).0, 5);
+        c.apply(EditCommand::Move(Motion::ScreenMiddle));
+        assert_eq!(c.buffer.char_to_coords(c.primary().head).0, 3);
+    }
+
+    #[test]
+    fn column_motion_is_one_based() {
+        let mut c = core("abcdef");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(EditCommand::Move(Motion::Column(4)));
+        assert_eq!(c.primary().head, 3);
     }
 
     #[test]

--- a/crates/vmux_editor/src/edit/core.rs
+++ b/crates/vmux_editor/src/edit/core.rs
@@ -353,6 +353,8 @@ impl EditCore {
             Motion::Right => self.buffer.next_grapheme(from).min(len),
             Motion::LeftBounded => self.line_left(from),
             Motion::RightBounded => self.line_right(from),
+            Motion::LeftFlow => self.line_left_flow(from),
+            Motion::RightFlow => self.line_right_flow(from),
             Motion::Up => self.vertical(from, -1),
             Motion::Down => self.vertical(from, 1),
             Motion::PageUp => self.vertical(from, -(self.rows.max(1) as i64)),
@@ -642,6 +644,34 @@ impl EditCore {
             self.buffer.next_grapheme(from).min(last)
         }
     }
+    /// Leftward step that treats a hard wrap as a space, landing on the previous line's last cell.
+    fn line_left_flow(&self, from: usize) -> usize {
+        let (line, col) = self.buffer.char_to_coords(from);
+        if col > 0 || line == 0 {
+            return self.line_left(from);
+        }
+        let prev = line - 1;
+        let start = self.buffer.line_to_char(prev);
+        let len = self.buffer.line_len_chars(prev);
+        if len == 0 {
+            return start;
+        }
+        self.buffer.prev_grapheme(start + len)
+    }
+
+    /// Rightward step that continues onto the next line's first cell instead of stopping at a wrap.
+    fn line_right_flow(&self, from: usize) -> usize {
+        let stepped = self.line_right(from);
+        if stepped != from {
+            return stepped;
+        }
+        let (line, _) = self.buffer.char_to_coords(from);
+        if line + 1 >= self.buffer.len_lines() {
+            return from;
+        }
+        self.buffer.line_to_char(line + 1)
+    }
+
     fn normal_cursor_target(&self, at: usize) -> usize {
         let at = at.min(self.buffer.len_chars());
         let (line, _) = self.buffer.char_to_coords(at);
@@ -2056,6 +2086,53 @@ mod tests {
             count: 1,
         });
         assert_eq!(text_of(&c), "second");
+    }
+
+    #[test]
+    fn bounded_horizontal_motion_stops_at_a_hard_wrap() {
+        let mut c = core("alpha\nbeta\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(c.buffer.coords_to_char(0, 4));
+        c.apply(EditCommand::Move(Motion::RightBounded));
+        assert_eq!(c.buffer.char_to_coords(c.primary().head), (0, 4));
+        c.set_caret(c.buffer.coords_to_char(1, 0));
+        c.apply(EditCommand::Move(Motion::LeftBounded));
+        assert_eq!(c.buffer.char_to_coords(c.primary().head), (1, 0));
+    }
+
+    #[test]
+    fn flow_motion_crosses_a_hard_wrap_in_both_directions() {
+        let mut c = core("alpha\nbeta\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(c.buffer.coords_to_char(0, 4));
+        c.apply(EditCommand::Move(Motion::RightFlow));
+        assert_eq!(c.buffer.char_to_coords(c.primary().head), (1, 0));
+        c.apply(EditCommand::Move(Motion::LeftFlow));
+        assert_eq!(c.buffer.char_to_coords(c.primary().head), (0, 4));
+    }
+
+    #[test]
+    fn flow_motion_still_stops_at_the_document_ends() {
+        let mut c = core("ab\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+        c.apply(EditCommand::Move(Motion::LeftFlow));
+        assert_eq!(c.primary().head, 0);
+        c.set_caret(c.buffer.coords_to_char(0, 1));
+        c.apply(EditCommand::Move(Motion::RightFlow));
+        c.apply(EditCommand::Move(Motion::RightFlow));
+        assert_eq!(c.buffer.char_to_coords(c.primary().head).0, 1);
+    }
+
+    #[test]
+    fn flow_motion_lands_on_an_empty_line() {
+        let mut c = core("ab\n\ncd\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(c.buffer.coords_to_char(0, 1));
+        c.apply(EditCommand::Move(Motion::RightFlow));
+        assert_eq!(c.buffer.char_to_coords(c.primary().head), (1, 0));
+        c.apply(EditCommand::Move(Motion::RightFlow));
+        assert_eq!(c.buffer.char_to_coords(c.primary().head), (2, 0));
     }
 
     #[test]

--- a/crates/vmux_editor/src/edit/ex.rs
+++ b/crates/vmux_editor/src/edit/ex.rs
@@ -1,0 +1,235 @@
+/// A `:` command line, parsed into a range and an action.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ExCommand {
+    Write,
+    WriteQuit,
+    Quit {
+        force: bool,
+    },
+    NoHighlight,
+    Goto(usize),
+    Delete(ExRange),
+    Yank(ExRange),
+    Substitute {
+        range: ExRange,
+        pattern: String,
+        replacement: String,
+        all: bool,
+    },
+}
+
+/// The line span a command applies to, resolved against the buffer later.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum ExRange {
+    #[default]
+    CurrentLine,
+    WholeFile,
+    Selection,
+    Lines(usize, usize),
+}
+
+fn parse_address(text: &str) -> Option<usize> {
+    text.parse::<usize>().ok().map(|n| n.saturating_sub(1))
+}
+
+/// Split a leading range off the command line, returning it with the rest.
+fn split_range(input: &str) -> (Option<ExRange>, &str) {
+    if let Some(rest) = input.strip_prefix('%') {
+        return (Some(ExRange::WholeFile), rest);
+    }
+    if let Some(rest) = input.strip_prefix("'<,'>") {
+        return (Some(ExRange::Selection), rest);
+    }
+    let digits: String = input.chars().take_while(|c| c.is_ascii_digit()).collect();
+    if digits.is_empty() {
+        return (None, input);
+    }
+    let rest = &input[digits.len()..];
+    let Some(first) = parse_address(&digits) else {
+        return (None, input);
+    };
+    if let Some(after) = rest.strip_prefix(',') {
+        let second: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
+        if let Some(last) = parse_address(&second) {
+            return (Some(ExRange::Lines(first, last)), &after[second.len()..]);
+        }
+    }
+    (Some(ExRange::Lines(first, first)), rest)
+}
+
+/// Split `s/pat/rep/flags` on its delimiter, honouring backslash escapes.
+fn split_substitute(body: &str) -> Option<(String, String, String)> {
+    let mut chars = body.chars();
+    let delim = chars.next()?;
+    let mut parts = vec![String::new()];
+    let mut escaped = false;
+    for c in chars {
+        if escaped {
+            if c != delim {
+                parts.last_mut()?.push('\\');
+            }
+            parts.last_mut()?.push(c);
+            escaped = false;
+            continue;
+        }
+        if c == '\\' {
+            escaped = true;
+            continue;
+        }
+        if c == delim {
+            if parts.len() == 3 {
+                break;
+            }
+            parts.push(String::new());
+            continue;
+        }
+        parts.last_mut()?.push(c);
+    }
+    while parts.len() < 3 {
+        parts.push(String::new());
+    }
+    Some((parts[0].clone(), parts[1].clone(), parts[2].clone()))
+}
+
+pub fn parse(input: &str) -> Option<ExCommand> {
+    let input = input.trim();
+    if input.is_empty() {
+        return None;
+    }
+    let (range, rest) = split_range(input);
+    let rest = rest.trim();
+
+    if rest.is_empty() {
+        return match range {
+            Some(ExRange::Lines(line, _)) => Some(ExCommand::Goto(line)),
+            _ => None,
+        };
+    }
+
+    let range = range.unwrap_or_default();
+    if let Some(body) = rest.strip_prefix("s").filter(|b| !b.is_empty())
+        && !body.starts_with(|c: char| c.is_alphanumeric())
+    {
+        let (pattern, replacement, flags) = split_substitute(body)?;
+        return Some(ExCommand::Substitute {
+            range,
+            pattern,
+            replacement,
+            all: flags.contains('g'),
+        });
+    }
+
+    match rest {
+        "w" | "write" => Some(ExCommand::Write),
+        "wq" | "x" | "xit" => Some(ExCommand::WriteQuit),
+        "q" | "quit" => Some(ExCommand::Quit { force: false }),
+        "q!" | "quit!" => Some(ExCommand::Quit { force: true }),
+        "noh" | "nohl" | "nohlsearch" => Some(ExCommand::NoHighlight),
+        "d" | "delete" => Some(ExCommand::Delete(range)),
+        "y" | "yank" => Some(ExCommand::Yank(range)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_commands() {
+        assert_eq!(parse("w"), Some(ExCommand::Write));
+        assert_eq!(parse("wq"), Some(ExCommand::WriteQuit));
+        assert_eq!(parse("q"), Some(ExCommand::Quit { force: false }));
+        assert_eq!(parse("q!"), Some(ExCommand::Quit { force: true }));
+        assert_eq!(parse("noh"), Some(ExCommand::NoHighlight));
+        assert_eq!(parse("bogus"), None);
+        assert_eq!(parse(""), None);
+    }
+
+    #[test]
+    fn a_bare_number_is_a_goto() {
+        assert_eq!(parse("42"), Some(ExCommand::Goto(41)));
+        assert_eq!(parse("1"), Some(ExCommand::Goto(0)));
+    }
+
+    #[test]
+    fn substitute_parses_pattern_replacement_and_flags() {
+        assert_eq!(
+            parse("%s/foo/bar/g"),
+            Some(ExCommand::Substitute {
+                range: ExRange::WholeFile,
+                pattern: "foo".into(),
+                replacement: "bar".into(),
+                all: true,
+            })
+        );
+        assert_eq!(
+            parse("s/foo/bar"),
+            Some(ExCommand::Substitute {
+                range: ExRange::CurrentLine,
+                pattern: "foo".into(),
+                replacement: "bar".into(),
+                all: false,
+            })
+        );
+    }
+
+    #[test]
+    fn substitute_accepts_a_line_range_and_a_selection() {
+        assert_eq!(
+            parse("2,5s/a/b/"),
+            Some(ExCommand::Substitute {
+                range: ExRange::Lines(1, 4),
+                pattern: "a".into(),
+                replacement: "b".into(),
+                all: false,
+            })
+        );
+        assert_eq!(
+            parse("'<,'>s/a/b/"),
+            Some(ExCommand::Substitute {
+                range: ExRange::Selection,
+                pattern: "a".into(),
+                replacement: "b".into(),
+                all: false,
+            })
+        );
+    }
+
+    #[test]
+    fn an_escaped_delimiter_stays_in_the_pattern() {
+        assert_eq!(
+            parse("s/a\\/b/c/"),
+            Some(ExCommand::Substitute {
+                range: ExRange::CurrentLine,
+                pattern: "a/b".into(),
+                replacement: "c".into(),
+                all: false,
+            })
+        );
+    }
+
+    #[test]
+    fn a_non_slash_delimiter_works() {
+        assert_eq!(
+            parse("s#a#b#g"),
+            Some(ExCommand::Substitute {
+                range: ExRange::CurrentLine,
+                pattern: "a".into(),
+                replacement: "b".into(),
+                all: true,
+            })
+        );
+    }
+
+    #[test]
+    fn ranged_delete_and_yank() {
+        assert_eq!(parse("%d"), Some(ExCommand::Delete(ExRange::WholeFile)));
+        assert_eq!(parse("3,4y"), Some(ExCommand::Yank(ExRange::Lines(2, 3))));
+    }
+
+    #[test]
+    fn a_word_starting_with_s_is_not_a_substitute() {
+        assert_eq!(parse("sort"), None);
+    }
+}

--- a/crates/vmux_editor/src/edit/register.rs
+++ b/crates/vmux_editor/src/edit/register.rs
@@ -1,0 +1,192 @@
+use std::collections::BTreeMap;
+
+/// How a register's text is reinserted by a put.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum RegisterKind {
+    #[default]
+    Charwise,
+    Linewise,
+}
+
+/// Text captured by a yank or delete, tagged with the shape it should be put back in.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RegisterValue {
+    pub text: String,
+    pub kind: RegisterKind,
+}
+
+impl RegisterValue {
+    pub fn charwise(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            kind: RegisterKind::Charwise,
+        }
+    }
+    pub fn linewise(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            kind: RegisterKind::Linewise,
+        }
+    }
+}
+
+pub const UNNAMED: char = '"';
+pub const BLACKHOLE: char = '_';
+pub const SMALL_DELETE: char = '-';
+
+/// Vim's register file: unnamed, named `a`-`z`, numbered `0`-`9`, and the small-delete register.
+///
+/// `clipboard_shadow` records the text vmux last pushed to the system clipboard so the host can
+/// tell an external copy from its own, and avoid clobbering a linewise register on every put.
+#[derive(Default)]
+pub struct Registers {
+    slots: BTreeMap<char, RegisterValue>,
+    pub clipboard_shadow: String,
+}
+
+fn is_clipboard(name: char) -> bool {
+    name == '+' || name == '*'
+}
+
+impl Registers {
+    pub fn read(&self, name: Option<char>) -> Option<&RegisterValue> {
+        let name = name.unwrap_or(UNNAMED);
+        if name == BLACKHOLE {
+            return None;
+        }
+        let name = if is_clipboard(name) { UNNAMED } else { name };
+        self.slots.get(&name.to_ascii_lowercase())
+    }
+
+    pub fn set(&mut self, name: char, value: RegisterValue) {
+        self.slots.insert(name, value);
+    }
+
+    /// Replace the unnamed register without disturbing the numbered ring.
+    pub fn set_unnamed(&mut self, value: RegisterValue) {
+        self.slots.insert(UNNAMED, value);
+    }
+
+    /// Store a yank: unnamed plus `"0`, or the requested register. An uppercase name appends.
+    pub fn write_yank(&mut self, name: Option<char>, value: RegisterValue) {
+        if name == Some(BLACKHOLE) {
+            return;
+        }
+        match name {
+            Some(name) if !is_clipboard(name) => {
+                self.write_named(name, value.clone());
+            }
+            _ => {
+                self.slots.insert('0', value.clone());
+            }
+        }
+        self.slots.insert(UNNAMED, value);
+    }
+
+    /// Store a delete: unnamed plus either the numbered ring (linewise or multi-line) or `"-`.
+    pub fn write_delete(&mut self, name: Option<char>, value: RegisterValue) {
+        if name == Some(BLACKHOLE) {
+            return;
+        }
+        match name {
+            Some(name) if !is_clipboard(name) => {
+                self.write_named(name, value.clone());
+            }
+            _ => {
+                let ring = value.kind == RegisterKind::Linewise || value.text.contains('\n');
+                if ring {
+                    self.shift_numbered();
+                    self.slots.insert('1', value.clone());
+                } else {
+                    self.slots.insert(SMALL_DELETE, value.clone());
+                }
+            }
+        }
+        self.slots.insert(UNNAMED, value);
+    }
+
+    fn write_named(&mut self, name: char, value: RegisterValue) {
+        let lower = name.to_ascii_lowercase();
+        if name.is_ascii_uppercase()
+            && let Some(existing) = self.slots.get(&lower)
+        {
+            let mut merged = existing.clone();
+            if merged.kind == RegisterKind::Linewise && !merged.text.ends_with('\n') {
+                merged.text.push('\n');
+            }
+            merged.text.push_str(&value.text);
+            if value.kind == RegisterKind::Linewise {
+                merged.kind = RegisterKind::Linewise;
+            }
+            self.slots.insert(lower, merged);
+            return;
+        }
+        self.slots.insert(lower, value);
+    }
+
+    fn shift_numbered(&mut self) {
+        for slot in ('1'..='8').rev() {
+            let next = char::from(slot as u8 + 1);
+            if let Some(value) = self.slots.get(&slot).cloned() {
+                self.slots.insert(next, value);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn yank_populates_unnamed_and_zero() {
+        let mut r = Registers::default();
+        r.write_yank(None, RegisterValue::charwise("hi"));
+        assert_eq!(r.read(None).unwrap().text, "hi");
+        assert_eq!(r.read(Some('0')).unwrap().text, "hi");
+    }
+
+    #[test]
+    fn linewise_delete_shifts_the_numbered_ring() {
+        let mut r = Registers::default();
+        r.write_delete(None, RegisterValue::linewise("first\n"));
+        r.write_delete(None, RegisterValue::linewise("second\n"));
+        assert_eq!(r.read(Some('1')).unwrap().text, "second\n");
+        assert_eq!(r.read(Some('2')).unwrap().text, "first\n");
+        assert_eq!(r.read(None).unwrap().text, "second\n");
+    }
+
+    #[test]
+    fn small_delete_avoids_the_numbered_ring() {
+        let mut r = Registers::default();
+        r.write_delete(None, RegisterValue::charwise("ab"));
+        assert_eq!(r.read(Some(SMALL_DELETE)).unwrap().text, "ab");
+        assert!(r.read(Some('1')).is_none());
+    }
+
+    #[test]
+    fn blackhole_discards_without_touching_unnamed() {
+        let mut r = Registers::default();
+        r.write_yank(None, RegisterValue::charwise("keep"));
+        r.write_delete(Some(BLACKHOLE), RegisterValue::charwise("gone"));
+        assert_eq!(r.read(None).unwrap().text, "keep");
+    }
+
+    #[test]
+    fn uppercase_register_appends() {
+        let mut r = Registers::default();
+        r.write_yank(Some('a'), RegisterValue::charwise("one"));
+        r.write_yank(Some('A'), RegisterValue::charwise("two"));
+        assert_eq!(r.read(Some('a')).unwrap().text, "onetwo");
+    }
+
+    #[test]
+    fn yank_to_a_named_register_keeps_zero_untouched() {
+        let mut r = Registers::default();
+        r.write_yank(None, RegisterValue::charwise("zero"));
+        r.write_yank(Some('b'), RegisterValue::charwise("named"));
+        assert_eq!(r.read(Some('0')).unwrap().text, "zero");
+        assert_eq!(r.read(Some('b')).unwrap().text, "named");
+        assert_eq!(r.read(None).unwrap().text, "named");
+    }
+}

--- a/crates/vmux_editor/src/edit/register.rs
+++ b/crates/vmux_editor/src/edit/register.rs
@@ -6,6 +6,8 @@ pub enum RegisterKind {
     #[default]
     Charwise,
     Linewise,
+    /// A rectangle: each line of the text is one row of the block.
+    Blockwise,
 }
 
 /// Text captured by a yank or delete, tagged with the shape it should be put back in.

--- a/crates/vmux_editor/src/edit/search.rs
+++ b/crates/vmux_editor/src/edit/search.rs
@@ -30,6 +30,23 @@ pub fn translate(pattern: &str) -> String {
             Some(esc @ ('+' | '?' | '(' | ')' | '{' | '}' | '|')) => out.push(esc),
             Some('c') => out.insert_str(0, "(?i)"),
             Some('C') => {}
+            // Vim character-class aliases. Passing these through would silently mean something
+            // else: `\a` is alphabetic in vim but BEL in `regex`, while `\l`, `\u` and `\x` are
+            // not valid `regex` escapes at all, so the whole pattern would be dropped.
+            Some('a') => out.push_str("[A-Za-z]"),
+            Some('A') => out.push_str("[^A-Za-z]"),
+            Some('l') => out.push_str("[a-z]"),
+            Some('L') => out.push_str("[^a-z]"),
+            Some('u') => out.push_str("[A-Z]"),
+            Some('U') => out.push_str("[^A-Z]"),
+            Some('d') => out.push_str("[0-9]"),
+            Some('D') => out.push_str("[^0-9]"),
+            Some('x') => out.push_str("[0-9A-Fa-f]"),
+            Some('X') => out.push_str("[^0-9A-Fa-f]"),
+            Some('o') => out.push_str("[0-7]"),
+            Some('O') => out.push_str("[^0-7]"),
+            Some('h') => out.push_str("[A-Za-z_]"),
+            Some('H') => out.push_str("[^A-Za-z_]"),
             Some(other) => {
                 out.push('\\');
                 out.push(other);
@@ -113,6 +130,19 @@ mod tests {
     #[test]
     fn case_insensitive_flag_is_hoisted() {
         assert_eq!(translate("foo\\c"), "(?i)foo");
+    }
+
+    /// `\a` used to reach `regex` as BEL and match the wrong thing; `\l`, `\u` and `\x` are not
+    /// `regex` escapes at all, so `Search::new` dropped the pattern entirely.
+    #[test]
+    fn character_class_aliases_translate_rather_than_leak() {
+        assert_eq!(translate("\\a"), "[A-Za-z]");
+        assert_eq!(translate("\\l\\u"), "[a-z][A-Z]");
+        assert_eq!(translate("\\d\\x"), "[0-9][0-9A-Fa-f]");
+        assert_eq!(translate("\\h"), "[A-Za-z_]");
+
+        assert!(Search::new("\\afoo", true).is_some());
+        assert!(Search::new("\\x2", true).is_some());
     }
 
     #[test]

--- a/crates/vmux_editor/src/edit/search.rs
+++ b/crates/vmux_editor/src/edit/search.rs
@@ -1,0 +1,133 @@
+use std::ops::Range;
+
+/// Translate a vim pattern into the `regex` crate's syntax.
+///
+/// Vim's default "magic" level makes `.`, `*`, `[`, `^`, and `$` special while requiring a
+/// backslash for `+`, `?`, `(`, `)`, `{`, `}`, and `|` — the opposite of `regex`. `\v` (very
+/// magic) is already close to `regex`, and `\V` (very nomagic) is a literal string.
+pub fn translate(pattern: &str) -> String {
+    if let Some(rest) = pattern.strip_prefix("\\V") {
+        return regex::escape(rest);
+    }
+    if let Some(rest) = pattern.strip_prefix("\\v") {
+        return rest.replace("\\<", "\\b").replace("\\>", "\\b");
+    }
+
+    let mut out = String::with_capacity(pattern.len() + 8);
+    let mut chars = pattern.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            // Magic mode treats these as literals; regex treats them as operators.
+            if matches!(c, '+' | '?' | '(' | ')' | '{' | '}' | '|') {
+                out.push('\\');
+            }
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('<') | Some('>') => out.push_str("\\b"),
+            // Backslashed in vim means "operator"; regex wants them bare.
+            Some(esc @ ('+' | '?' | '(' | ')' | '{' | '}' | '|')) => out.push(esc),
+            Some('c') => out.insert_str(0, "(?i)"),
+            Some('C') => {}
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push_str("\\\\"),
+        }
+    }
+    out
+}
+
+pub struct Search {
+    pub pattern: String,
+    pub forward: bool,
+    regex: regex::Regex,
+}
+
+impl Search {
+    pub fn new(pattern: &str, forward: bool) -> Option<Self> {
+        let regex = regex::Regex::new(&translate(pattern)).ok()?;
+        Some(Self {
+            pattern: pattern.to_string(),
+            forward,
+            regex,
+        })
+    }
+
+    /// Every match in `text`, as byte ranges.
+    pub fn matches(&self, text: &str) -> Vec<Range<usize>> {
+        self.regex.find_iter(text).map(|m| m.range()).collect()
+    }
+}
+
+/// The match to land on when stepping from `from`, wrapping around the ends of the buffer.
+pub fn step(matches: &[Range<usize>], from: usize, forward: bool) -> Option<usize> {
+    if matches.is_empty() {
+        return None;
+    }
+    if forward {
+        matches
+            .iter()
+            .find(|m| m.start > from)
+            .or_else(|| matches.first())
+            .map(|m| m.start)
+    } else {
+        matches
+            .iter()
+            .rev()
+            .find(|m| m.start < from)
+            .or_else(|| matches.last())
+            .map(|m| m.start)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn magic_mode_flips_which_operators_need_a_backslash() {
+        assert_eq!(translate("a\\+b"), "a+b");
+        assert_eq!(translate("a+b"), "a\\+b");
+        assert_eq!(translate("foo\\|bar"), "foo|bar");
+        assert_eq!(translate("a.c"), "a.c");
+    }
+
+    #[test]
+    fn word_boundaries_become_regex_boundaries() {
+        assert_eq!(translate("\\<word\\>"), "\\bword\\b");
+    }
+
+    #[test]
+    fn very_nomagic_escapes_everything() {
+        assert_eq!(translate("\\Va.c+"), regex::escape("a.c+"));
+    }
+
+    #[test]
+    fn very_magic_passes_operators_through() {
+        assert_eq!(translate("\\v(a|b)+"), "(a|b)+");
+    }
+
+    #[test]
+    fn case_insensitive_flag_is_hoisted() {
+        assert_eq!(translate("foo\\c"), "(?i)foo");
+    }
+
+    #[test]
+    fn stepping_wraps_at_both_ends() {
+        let m = vec![2..5, 10..12];
+        assert_eq!(step(&m, 0, true), Some(2));
+        assert_eq!(step(&m, 2, true), Some(10));
+        assert_eq!(step(&m, 10, true), Some(2));
+        assert_eq!(step(&m, 12, false), Some(10));
+        assert_eq!(step(&m, 2, false), Some(10));
+        assert_eq!(step(&[], 0, true), None);
+    }
+
+    #[test]
+    fn an_invalid_pattern_yields_no_search() {
+        assert!(Search::new("\\v(unclosed", true).is_none());
+    }
+}

--- a/crates/vmux_editor/src/edit/text_object.rs
+++ b/crates/vmux_editor/src/edit/text_object.rs
@@ -1,0 +1,513 @@
+use std::ops::Range;
+
+use crate::edit::buffer::TextBuffer;
+
+/// Vim's three character classes: whitespace, keyword, and punctuation.
+///
+/// Word motions and word text objects both stop wherever this value changes.
+pub fn char_class(c: char) -> u8 {
+    if c.is_whitespace() {
+        0
+    } else if c.is_alphanumeric() || c == '_' {
+        1
+    } else {
+        2
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TextObjectKind {
+    Word,
+    BigWord,
+    Sentence,
+    Paragraph,
+    Paren,
+    Bracket,
+    Brace,
+    Angle,
+    DoubleQuote,
+    SingleQuote,
+    BackQuote,
+    Tag,
+}
+
+impl TextObjectKind {
+    fn delimiters(self) -> Option<(char, char)> {
+        Some(match self {
+            TextObjectKind::Paren => ('(', ')'),
+            TextObjectKind::Bracket => ('[', ']'),
+            TextObjectKind::Brace => ('{', '}'),
+            TextObjectKind::Angle => ('<', '>'),
+            _ => return None,
+        })
+    }
+    fn quote(self) -> Option<char> {
+        Some(match self {
+            TextObjectKind::DoubleQuote => '"',
+            TextObjectKind::SingleQuote => '\'',
+            TextObjectKind::BackQuote => '`',
+            _ => return None,
+        })
+    }
+    pub fn is_linewise(self) -> bool {
+        matches!(self, TextObjectKind::Paragraph)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TextObject {
+    pub kind: TextObjectKind,
+    pub around: bool,
+    pub count: usize,
+}
+
+pub fn resolve(buf: &TextBuffer, head: usize, obj: TextObject) -> Option<Range<usize>> {
+    let count = obj.count.max(1);
+    match obj.kind {
+        TextObjectKind::Word => word(buf, head, false, obj.around),
+        TextObjectKind::BigWord => word(buf, head, true, obj.around),
+        TextObjectKind::Sentence => sentence(buf, head, obj.around),
+        TextObjectKind::Paragraph => paragraph(buf, head, obj.around),
+        TextObjectKind::Tag => tag(buf, head, obj.around),
+        kind => {
+            if let Some((open, close)) = kind.delimiters() {
+                let (o, c) = enclosing_pair(buf, head, open, close, count)?;
+                return Some(if obj.around { o..c + 1 } else { o + 1..c });
+            }
+            let q = kind.quote()?;
+            let (o, c) = quoted(buf, head, q)?;
+            Some(if obj.around { o..c + 1 } else { o + 1..c })
+        }
+    }
+}
+
+fn word(buf: &TextBuffer, head: usize, big: bool, around: bool) -> Option<Range<usize>> {
+    let len = buf.len_chars();
+    if len == 0 {
+        return None;
+    }
+    let head = head.min(len - 1);
+    let class_at = |i: usize| -> u8 {
+        let c = buf.rope.char(i);
+        if c == '\n' {
+            return 0;
+        }
+        if big {
+            if c.is_whitespace() { 0 } else { 1 }
+        } else {
+            char_class(c)
+        }
+    };
+    let base = class_at(head);
+    let mut start = head;
+    while start > 0 && class_at(start - 1) == base && buf.rope.char(start - 1) != '\n' {
+        start -= 1;
+    }
+    let mut end = head + 1;
+    while end < len && class_at(end) == base && buf.rope.char(end) != '\n' {
+        end += 1;
+    }
+    if !around {
+        return Some(start..end);
+    }
+    let mut trailing = end;
+    while trailing < len && buf.rope.char(trailing) != '\n' && class_at(trailing) == 0 {
+        trailing += 1;
+    }
+    if trailing > end {
+        return Some(start..trailing);
+    }
+    let mut leading = start;
+    while leading > 0 && buf.rope.char(leading - 1) != '\n' && class_at(leading - 1) == 0 {
+        leading -= 1;
+    }
+    Some(leading..end)
+}
+
+fn sentence(buf: &TextBuffer, head: usize, around: bool) -> Option<Range<usize>> {
+    let len = buf.len_chars();
+    if len == 0 {
+        return None;
+    }
+    let head = head.min(len - 1);
+    let terminator = |i: usize| {
+        let c = buf.rope.char(i);
+        c == '.' || c == '!' || c == '?'
+    };
+    let mut start = head;
+    while start > 0 {
+        let prev = start - 1;
+        if buf.rope.char(prev).is_whitespace()
+            && prev > 0
+            && terminator(prev - 1)
+            && prev.saturating_sub(1) < head
+        {
+            break;
+        }
+        if buf.rope.char(prev) == '\n' && prev > 0 && buf.rope.char(prev - 1) == '\n' {
+            break;
+        }
+        start = prev;
+    }
+    let mut end = head;
+    while end < len && !terminator(end) {
+        end += 1;
+    }
+    if end < len {
+        end += 1;
+    }
+    if around {
+        while end < len && buf.rope.char(end) == ' ' {
+            end += 1;
+        }
+    }
+    (start < end).then_some(start..end)
+}
+
+fn paragraph(buf: &TextBuffer, head: usize, around: bool) -> Option<Range<usize>> {
+    let total = buf.len_lines();
+    if total == 0 {
+        return None;
+    }
+    let (line, _) = buf.char_to_coords(head);
+    let blank = |l: usize| buf.line_len_chars(l) == 0;
+    let base = blank(line);
+    let mut first = line;
+    while first > 0 && blank(first - 1) == base {
+        first -= 1;
+    }
+    let mut last = line;
+    while last + 1 < total && blank(last + 1) == base {
+        last += 1;
+    }
+    if around {
+        while last + 1 < total && blank(last + 1) != base {
+            last += 1;
+        }
+    }
+    let start = buf.line_to_char(first);
+    let end = if last + 1 < total {
+        buf.line_to_char(last + 1)
+    } else {
+        buf.len_chars()
+    };
+    (start < end).then_some(start..end)
+}
+
+/// The innermost `open`/`close` pair containing `head`, walked outward `count` times.
+fn enclosing_pair(
+    buf: &TextBuffer,
+    head: usize,
+    open: char,
+    close: char,
+    count: usize,
+) -> Option<(usize, usize)> {
+    let mut found = matching_pair(buf, head, open, close)?;
+    for _ in 1..count {
+        if found.0 == 0 {
+            break;
+        }
+        found = matching_pair(buf, found.0 - 1, open, close)?;
+    }
+    Some(found)
+}
+
+fn matching_pair(buf: &TextBuffer, head: usize, open: char, close: char) -> Option<(usize, usize)> {
+    let len = buf.len_chars();
+    if len == 0 {
+        return None;
+    }
+    let head = head.min(len - 1);
+    let open_at = if buf.rope.char(head) == open {
+        Some(head)
+    } else {
+        let mut depth = 0i32;
+        let mut found = None;
+        let mut i = head as i64;
+        while i >= 0 {
+            let c = buf.rope.char(i as usize);
+            if c == close && i as usize != head {
+                depth += 1;
+            } else if c == open {
+                if depth == 0 {
+                    found = Some(i as usize);
+                    break;
+                }
+                depth -= 1;
+            }
+            i -= 1;
+        }
+        found
+    }?;
+    let mut depth = 0i32;
+    let mut j = open_at + 1;
+    while j < len {
+        let c = buf.rope.char(j);
+        if c == open {
+            depth += 1;
+        } else if c == close {
+            if depth == 0 {
+                return Some((open_at, j));
+            }
+            depth -= 1;
+        }
+        j += 1;
+    }
+    None
+}
+
+/// The quoted span on the cursor's line that contains or follows the cursor.
+fn quoted(buf: &TextBuffer, head: usize, q: char) -> Option<(usize, usize)> {
+    let (line, _) = buf.char_to_coords(head);
+    let base = buf.line_to_char(line);
+    let len = buf.line_len_chars(line);
+    let mut marks = Vec::new();
+    let mut i = 0;
+    while i < len {
+        let c = buf.rope.char(base + i);
+        if c == '\\' {
+            i += 2;
+            continue;
+        }
+        if c == q {
+            marks.push(base + i);
+        }
+        i += 1;
+    }
+    marks
+        .chunks(2)
+        .find(|pair| pair.len() == 2 && head <= pair[1])
+        .map(|pair| (pair[0], pair[1]))
+}
+
+struct TagSpan {
+    outer: Range<usize>,
+    inner: Range<usize>,
+}
+
+/// The innermost `<name>`…`</name>` pair containing `head`.
+fn tag(buf: &TextBuffer, head: usize, around: bool) -> Option<Range<usize>> {
+    let len = buf.len_chars();
+    let mut stack: Vec<(String, usize, usize)> = Vec::new();
+    let mut spans: Vec<TagSpan> = Vec::new();
+    let mut i = 0;
+    while i < len {
+        if buf.rope.char(i) != '<' {
+            i += 1;
+            continue;
+        }
+        let mut j = i + 1;
+        while j < len && buf.rope.char(j) != '>' {
+            j += 1;
+        }
+        if j >= len {
+            break;
+        }
+        let raw: String = buf.rope.slice(i + 1..j).chars().collect();
+        let self_closing = raw.ends_with('/');
+        let closing = raw.starts_with('/');
+        let name: String = raw
+            .trim_start_matches('/')
+            .chars()
+            .take_while(|c| !c.is_whitespace() && *c != '/')
+            .collect();
+        if !name.is_empty() {
+            if closing {
+                if let Some(pos) = stack.iter().rposition(|(n, _, _)| *n == name) {
+                    let (_, open_start, inner_start) = stack.remove(pos);
+                    stack.truncate(pos);
+                    spans.push(TagSpan {
+                        outer: open_start..j + 1,
+                        inner: inner_start..i,
+                    });
+                }
+            } else if !self_closing {
+                stack.push((name, i, j + 1));
+            }
+        }
+        i = j + 1;
+    }
+    spans
+        .into_iter()
+        .filter(|s| s.outer.contains(&head))
+        .min_by_key(|s| s.outer.end - s.outer.start)
+        .map(|s| if around { s.outer } else { s.inner })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn buf(text: &str) -> TextBuffer {
+        TextBuffer::from_text(PathBuf::from("a.txt"), "Plain Text".into(), text)
+    }
+    fn slice(text: &str, head: usize, kind: TextObjectKind, around: bool) -> Option<String> {
+        let b = buf(text);
+        let r = resolve(
+            &b,
+            head,
+            TextObject {
+                kind,
+                around,
+                count: 1,
+            },
+        )?;
+        Some(b.rope.slice(r).chars().collect())
+    }
+
+    #[test]
+    fn inner_word_stops_at_class_boundaries() {
+        assert_eq!(
+            slice("foo bar", 1, TextObjectKind::Word, false).as_deref(),
+            Some("foo")
+        );
+        assert_eq!(
+            slice("foo.bar", 1, TextObjectKind::Word, false).as_deref(),
+            Some("foo")
+        );
+        assert_eq!(
+            slice("foo.bar", 3, TextObjectKind::Word, false).as_deref(),
+            Some(".")
+        );
+    }
+
+    #[test]
+    fn around_word_takes_trailing_then_leading_space() {
+        assert_eq!(
+            slice("foo bar", 1, TextObjectKind::Word, true).as_deref(),
+            Some("foo ")
+        );
+        assert_eq!(
+            slice("foo bar", 5, TextObjectKind::Word, true).as_deref(),
+            Some(" bar")
+        );
+    }
+
+    #[test]
+    fn big_word_spans_punctuation() {
+        assert_eq!(
+            slice("foo.bar baz", 1, TextObjectKind::BigWord, false).as_deref(),
+            Some("foo.bar")
+        );
+    }
+
+    #[test]
+    fn bracket_objects_respect_nesting() {
+        assert_eq!(
+            slice("a(b(c)d)e", 4, TextObjectKind::Paren, false).as_deref(),
+            Some("c")
+        );
+        assert_eq!(
+            slice("a(b(c)d)e", 2, TextObjectKind::Paren, false).as_deref(),
+            Some("b(c)d")
+        );
+        assert_eq!(
+            slice("a(b(c)d)e", 2, TextObjectKind::Paren, true).as_deref(),
+            Some("(b(c)d)")
+        );
+    }
+
+    #[test]
+    fn counted_bracket_object_walks_outward() {
+        let b = buf("a(b(c)d)e");
+        let r = resolve(
+            &b,
+            4,
+            TextObject {
+                kind: TextObjectKind::Paren,
+                around: false,
+                count: 2,
+            },
+        )
+        .unwrap();
+        let got: String = b.rope.slice(r).chars().collect();
+        assert_eq!(got, "b(c)d");
+    }
+
+    #[test]
+    fn cursor_on_a_delimiter_selects_that_pair() {
+        assert_eq!(
+            slice("a(bc)d", 1, TextObjectKind::Paren, false).as_deref(),
+            Some("bc")
+        );
+        assert_eq!(
+            slice("a(bc)d", 4, TextObjectKind::Paren, false).as_deref(),
+            Some("bc")
+        );
+    }
+
+    #[test]
+    fn quote_objects_pair_left_to_right() {
+        assert_eq!(
+            slice("say \"hi\" now", 6, TextObjectKind::DoubleQuote, false).as_deref(),
+            Some("hi")
+        );
+        assert_eq!(
+            slice("say \"hi\" now", 0, TextObjectKind::DoubleQuote, true).as_deref(),
+            Some("\"hi\"")
+        );
+    }
+
+    #[test]
+    fn escaped_quotes_do_not_split_the_span() {
+        assert_eq!(
+            slice("x \"a\\\"b\" y", 3, TextObjectKind::DoubleQuote, false).as_deref(),
+            Some("a\\\"b")
+        );
+    }
+
+    #[test]
+    fn paragraph_objects_use_blank_line_boundaries() {
+        let text = "one\ntwo\n\nthree\n";
+        assert_eq!(
+            slice(text, 0, TextObjectKind::Paragraph, false).as_deref(),
+            Some("one\ntwo\n")
+        );
+        assert_eq!(
+            slice(text, 0, TextObjectKind::Paragraph, true).as_deref(),
+            Some("one\ntwo\n\n")
+        );
+    }
+
+    #[test]
+    fn tag_objects_pick_the_innermost_match() {
+        let text = "<a><b>hi</b></a>";
+        assert_eq!(
+            slice(text, 7, TextObjectKind::Tag, false).as_deref(),
+            Some("hi")
+        );
+        assert_eq!(
+            slice(text, 7, TextObjectKind::Tag, true).as_deref(),
+            Some("<b>hi</b>")
+        );
+    }
+
+    #[test]
+    fn self_closing_tags_are_not_opened() {
+        let text = "<a>x<br/>y</a>";
+        assert_eq!(
+            slice(text, 5, TextObjectKind::Tag, false).as_deref(),
+            Some("x<br/>y")
+        );
+    }
+
+    #[test]
+    fn sentence_object_covers_one_sentence() {
+        let text = "One two. Three four. Five.";
+        assert_eq!(
+            slice(text, 10, TextObjectKind::Sentence, false).as_deref(),
+            Some("Three four.")
+        );
+        assert_eq!(
+            slice(text, 10, TextObjectKind::Sentence, true).as_deref(),
+            Some("Three four. ")
+        );
+    }
+
+    #[test]
+    fn unmatched_delimiters_resolve_to_nothing() {
+        assert_eq!(slice("a(bc", 2, TextObjectKind::Paren, false), None);
+        assert_eq!(slice("abc", 1, TextObjectKind::Paren, false), None);
+    }
+}

--- a/crates/vmux_editor/src/edit/undo.rs
+++ b/crates/vmux_editor/src/edit/undo.rs
@@ -1,0 +1,251 @@
+use ropey::Rope;
+
+use crate::edit::command::Selection;
+
+/// One document state in the undo tree.
+#[derive(Clone)]
+struct Node {
+    rope: Rope,
+    selections: Vec<Selection>,
+    rev: u64,
+    /// Creation order, which is what `g-` and `g+` walk.
+    seq: u64,
+    parent: Option<usize>,
+    children: Vec<usize>,
+}
+
+/// A branching undo history.
+///
+/// Nodes hold the document *after* each change, and the node marked current is kept in sync with
+/// the live buffer lazily — the buffer is the source of truth until something navigates away.
+/// Undoing then making a new edit branches instead of discarding the redo path, which is what
+/// makes `g-`/`g+` able to reach states `Ctrl-r` cannot.
+pub struct UndoTree {
+    nodes: Vec<Node>,
+    current: usize,
+    next_seq: u64,
+}
+
+/// The state to restore after navigating the tree.
+pub struct Restored {
+    pub rope: Rope,
+    pub selections: Vec<Selection>,
+    pub rev: u64,
+}
+
+impl UndoTree {
+    pub fn new(rope: Rope, selections: Vec<Selection>, rev: u64) -> Self {
+        Self {
+            nodes: vec![Node {
+                rope,
+                selections,
+                rev,
+                seq: 0,
+                parent: None,
+                children: Vec::new(),
+            }],
+            current: 0,
+            next_seq: 1,
+        }
+    }
+
+    /// Fold the live buffer back into the current node before reading history.
+    fn sync(&mut self, rope: &Rope, selections: &[Selection], rev: u64) {
+        let node = &mut self.nodes[self.current];
+        node.rope = rope.clone();
+        node.selections = selections.to_vec();
+        node.rev = rev;
+    }
+
+    /// Open a new state as a child of the current one.
+    pub fn push(&mut self, rope: &Rope, selections: &[Selection], rev: u64) {
+        self.sync(rope, selections, rev);
+        let seq = self.next_seq;
+        self.next_seq += 1;
+        let node = Node {
+            rope: rope.clone(),
+            selections: selections.to_vec(),
+            rev,
+            seq,
+            parent: Some(self.current),
+            children: Vec::new(),
+        };
+        self.nodes.push(node);
+        let index = self.nodes.len() - 1;
+        self.nodes[self.current].children.push(index);
+        self.current = index;
+    }
+
+    fn restore(&mut self, index: usize) -> Restored {
+        self.current = index;
+        let node = &self.nodes[index];
+        Restored {
+            rope: node.rope.clone(),
+            selections: node.selections.clone(),
+            rev: node.rev,
+        }
+    }
+
+    pub fn undo(&mut self, rope: &Rope, selections: &[Selection], rev: u64) -> Option<Restored> {
+        self.sync(rope, selections, rev);
+        let parent = self.nodes[self.current].parent?;
+        Some(self.restore(parent))
+    }
+
+    pub fn redo(&mut self, rope: &Rope, selections: &[Selection], rev: u64) -> Option<Restored> {
+        self.sync(rope, selections, rev);
+        // The newest branch is the one `Ctrl-r` follows.
+        let child = *self.nodes[self.current].children.last()?;
+        Some(self.restore(child))
+    }
+
+    /// Move to the state created just before or just after the current one, ignoring branches.
+    pub fn step_time(
+        &mut self,
+        rope: &Rope,
+        selections: &[Selection],
+        rev: u64,
+        forward: bool,
+        count: usize,
+    ) -> Option<Restored> {
+        self.sync(rope, selections, rev);
+        let mut index = self.current;
+        for _ in 0..count.max(1) {
+            let seq = self.nodes[index].seq;
+            let next = self
+                .nodes
+                .iter()
+                .enumerate()
+                .filter(|(_, n)| if forward { n.seq > seq } else { n.seq < seq })
+                .min_by_key(|(_, n)| if forward { n.seq } else { u64::MAX - n.seq })
+                .map(|(i, _)| i);
+            match next {
+                Some(next) => index = next,
+                None => break,
+            }
+        }
+        (index != self.current).then(|| self.restore(index))
+    }
+
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.nodes.len() <= 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rope(text: &str) -> Rope {
+        Rope::from_str(text)
+    }
+    fn sel() -> Vec<Selection> {
+        vec![Selection::caret(0)]
+    }
+
+    /// Mirrors how the editor drives the tree: `push` happens before the buffer changes, and the
+    /// live text is handed back in on every navigation.
+    struct Doc {
+        tree: UndoTree,
+        text: String,
+    }
+
+    impl Doc {
+        fn new(text: &str) -> Self {
+            Self {
+                tree: UndoTree::new(rope(text), sel(), 0),
+                text: text.to_string(),
+            }
+        }
+        fn edit(&mut self, next: &str) {
+            self.tree.push(&rope(&self.text), &sel(), 0);
+            self.text = next.to_string();
+        }
+        fn undo(&mut self) -> bool {
+            self.apply(UndoTree::undo)
+        }
+        fn redo(&mut self) -> bool {
+            self.apply(UndoTree::redo)
+        }
+        fn apply(
+            &mut self,
+            f: fn(&mut UndoTree, &Rope, &[Selection], u64) -> Option<Restored>,
+        ) -> bool {
+            match f(&mut self.tree, &rope(&self.text), &sel(), 0) {
+                Some(state) => {
+                    self.text = state.rope.to_string();
+                    true
+                }
+                None => false,
+            }
+        }
+        fn time(&mut self, forward: bool, count: usize) -> bool {
+            match self
+                .tree
+                .step_time(&rope(&self.text), &sel(), 0, forward, count)
+            {
+                Some(state) => {
+                    self.text = state.rope.to_string();
+                    true
+                }
+                None => false,
+            }
+        }
+    }
+
+    #[test]
+    fn undo_and_redo_walk_a_linear_history() {
+        let mut doc = Doc::new("a");
+        doc.edit("ab");
+        doc.edit("abc");
+
+        assert!(doc.undo());
+        assert_eq!(doc.text, "ab");
+        assert!(doc.undo());
+        assert_eq!(doc.text, "a");
+        assert!(!doc.undo(), "the root has no parent");
+
+        assert!(doc.redo());
+        assert_eq!(doc.text, "ab");
+    }
+
+    #[test]
+    fn editing_after_an_undo_branches_rather_than_discarding() {
+        let mut doc = Doc::new("");
+        doc.edit("first");
+        doc.undo();
+        doc.edit("second");
+
+        doc.undo();
+        assert_eq!(doc.text, "");
+        doc.redo();
+        assert_eq!(doc.text, "second", "redo follows the newest branch");
+    }
+
+    #[test]
+    fn time_travel_reaches_an_abandoned_branch() {
+        let mut doc = Doc::new("");
+        doc.edit("first");
+        doc.undo();
+        doc.edit("second");
+
+        assert!(doc.time(false, 1));
+        assert_eq!(doc.text, "first", "g- reaches what redo cannot");
+        assert!(doc.time(true, 1));
+        assert_eq!(doc.text, "second");
+    }
+
+    #[test]
+    fn time_travel_takes_a_count_and_stops_at_the_ends() {
+        let mut doc = Doc::new("0");
+        doc.edit("1");
+        doc.edit("2");
+        assert!(doc.time(false, 2));
+        assert_eq!(doc.text, "0");
+        assert!(!doc.time(false, 1), "already at the oldest state");
+    }
+}

--- a/crates/vmux_editor/src/keymap.rs
+++ b/crates/vmux_editor/src/keymap.rs
@@ -37,6 +37,10 @@ pub trait Keymap: Send + Sync {
     /// Insert-mode characters arrive over the IME path, so a keymap that replays input — for
     /// dot-repeat or macros — only sees a whole change if the host reports them here.
     fn record_text(&mut self, _text: &str) {}
+    /// The `:`, `/`, or `?` prompt currently being typed, prompt character included.
+    fn command_line(&self) -> Option<String> {
+        None
+    }
     fn pointer_selection_mode(&mut self, _extend: bool) -> Option<EditCommand> {
         None
     }

--- a/crates/vmux_editor/src/keymap.rs
+++ b/crates/vmux_editor/src/keymap.rs
@@ -32,6 +32,11 @@ pub struct KeyInput {
 pub trait Keymap: Send + Sync {
     fn handle(&mut self, k: &KeyInput) -> Vec<EditCommand>;
     fn mode(&self) -> EditMode;
+    /// Report text that reached the buffer without passing through [`Keymap::handle`].
+    ///
+    /// Insert-mode characters arrive over the IME path, so a keymap that replays input — for
+    /// dot-repeat or macros — only sees a whole change if the host reports them here.
+    fn record_text(&mut self, _text: &str) {}
     fn pointer_selection_mode(&mut self, _extend: bool) -> Option<EditCommand> {
         None
     }

--- a/crates/vmux_editor/src/keymap.rs
+++ b/crates/vmux_editor/src/keymap.rs
@@ -1,3 +1,4 @@
+pub mod mapping;
 pub mod vim;
 pub mod vscode;
 
@@ -50,15 +51,15 @@ pub trait Keymap: Send + Sync {
 }
 
 pub trait KeymapKindExt {
-    fn make(self) -> Box<dyn Keymap>;
+    fn make(self, mappings: &[vmux_core::editor::KeyMapping], leader: &str) -> Box<dyn Keymap>;
     fn initial_mode(self) -> EditMode;
 }
 
 impl KeymapKindExt for KeymapKind {
-    fn make(self) -> Box<dyn Keymap> {
+    fn make(self, mappings: &[vmux_core::editor::KeyMapping], leader: &str) -> Box<dyn Keymap> {
         match self {
             KeymapKind::Vscode => Box::new(vscode::VscodeKeymap),
-            KeymapKind::Vim => Box::new(vim::VimKeymap::default()),
+            KeymapKind::Vim => Box::new(vim::VimKeymap::with_mappings(mappings, leader)),
         }
     }
     fn initial_mode(self) -> EditMode {

--- a/crates/vmux_editor/src/keymap/mapping.rs
+++ b/crates/vmux_editor/src/keymap/mapping.rs
@@ -1,0 +1,264 @@
+use crate::edit::command::EditMode;
+use crate::keymap::{KeyInput, Mods};
+
+/// Which modes a mapping applies to, from the leading letters of a `:map` command.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MapScope {
+    pub normal: bool,
+    pub insert: bool,
+    pub visual: bool,
+}
+
+impl MapScope {
+    pub fn parse(spec: &str) -> Self {
+        let spec = spec.trim();
+        if spec.is_empty() {
+            return Self {
+                normal: true,
+                insert: false,
+                visual: true,
+            };
+        }
+        Self {
+            normal: spec.contains('n'),
+            insert: spec.contains('i'),
+            visual: spec.contains('v') || spec.contains('x'),
+        }
+    }
+
+    pub fn covers(self, mode: EditMode) -> bool {
+        match mode {
+            EditMode::Normal => self.normal,
+            EditMode::Insert | EditMode::Replace => self.insert,
+            _ if mode.is_visual() => self.visual,
+            _ => false,
+        }
+    }
+}
+
+/// Translate vim key notation into the key names the keymap dispatches on.
+///
+/// Understands `<leader>`, `<C-x>`, `<S-x>`, `<A-x>`, and the usual `<Esc>`/`<CR>`/`<Tab>`/
+/// `<Space>`/`<BS>` names. Anything else is taken one character at a time.
+pub fn parse_keys(notation: &str, leader: &str) -> Vec<KeyInput> {
+    let mut out = Vec::new();
+    let mut rest = notation;
+    while !rest.is_empty() {
+        if let Some(after) = rest.strip_prefix('<')
+            && let Some(close) = after.find('>')
+        {
+            let name = &after[..close];
+            if name.eq_ignore_ascii_case("leader") {
+                out.extend(parse_keys(leader, ""));
+                rest = &after[close + 1..];
+                continue;
+            }
+            if let Some(key) = named_key(name) {
+                out.push(key);
+                rest = &after[close + 1..];
+                continue;
+            }
+        }
+        let c = rest.chars().next().expect("rest is non-empty");
+        out.push(plain(&c.to_string()));
+        rest = &rest[c.len_utf8()..];
+    }
+    out
+}
+
+fn plain(key: &str) -> KeyInput {
+    KeyInput {
+        key: key.to_string(),
+        mods: Mods::default(),
+        repeat: false,
+    }
+}
+
+fn named_key(name: &str) -> Option<KeyInput> {
+    let lower = name.to_ascii_lowercase();
+    if let Some(rest) = lower.strip_prefix("c-") {
+        let mut key = plain(rest);
+        key.mods.ctrl = true;
+        return Some(key);
+    }
+    if let Some(rest) = lower.strip_prefix("a-").or(lower.strip_prefix("m-")) {
+        let mut key = plain(rest);
+        key.mods.alt = true;
+        return Some(key);
+    }
+    if let Some(rest) = lower.strip_prefix("d-") {
+        let mut key = plain(rest);
+        key.mods.meta = true;
+        return Some(key);
+    }
+    if let Some(rest) = name.strip_prefix("S-").or(name.strip_prefix("s-")) {
+        let mut key = plain(&rest.to_ascii_uppercase());
+        key.mods.shift = true;
+        return Some(key);
+    }
+    Some(match lower.as_str() {
+        "esc" => plain("Escape"),
+        "cr" | "enter" | "return" => plain("Enter"),
+        "tab" => plain("Tab"),
+        "space" => plain(" "),
+        "bs" => plain("Backspace"),
+        "del" => plain("Delete"),
+        "up" => plain("ArrowUp"),
+        "down" => plain("ArrowDown"),
+        "left" => plain("ArrowLeft"),
+        "right" => plain("ArrowRight"),
+        "lt" => plain("<"),
+        "bar" => plain("|"),
+        "nop" => plain(""),
+        _ => return None,
+    })
+}
+
+fn same_key(a: &KeyInput, b: &KeyInput) -> bool {
+    a.key == b.key && a.mods == b.mods
+}
+
+pub struct Mapping {
+    scope: MapScope,
+    lhs: Vec<KeyInput>,
+    rhs: Vec<KeyInput>,
+}
+
+/// How a pending key sequence lines up with the configured mappings.
+pub enum MatchResult {
+    /// The sequence so far could still grow into a mapping.
+    Pending,
+    /// The sequence expands to these keys.
+    Expand(Vec<KeyInput>),
+    /// No mapping can match; dispatch the buffered keys as typed.
+    Miss,
+}
+
+#[derive(Default)]
+pub struct Mappings {
+    entries: Vec<Mapping>,
+}
+
+impl Mappings {
+    pub fn new(specs: &[vmux_core::editor::KeyMapping], leader: &str) -> Self {
+        let entries = specs
+            .iter()
+            .filter_map(|spec| {
+                let lhs = parse_keys(&spec.lhs, leader);
+                if lhs.is_empty() {
+                    return None;
+                }
+                Some(Mapping {
+                    scope: MapScope::parse(&spec.mode),
+                    lhs,
+                    rhs: parse_keys(&spec.rhs, leader),
+                })
+            })
+            .collect();
+        Self { entries }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Match `pending` against the mappings active in `mode`.
+    ///
+    /// An exact match wins immediately even when a longer mapping shares the prefix. Vim would
+    /// wait out `timeoutlen` before committing; resolving now keeps the keymap free of timers.
+    pub fn match_keys(&self, mode: EditMode, pending: &[KeyInput]) -> MatchResult {
+        let active = self
+            .entries
+            .iter()
+            .filter(|entry| entry.scope.covers(mode))
+            .filter(|entry| {
+                entry.lhs.len() >= pending.len()
+                    && entry.lhs.iter().zip(pending).all(|(a, b)| same_key(a, b))
+            });
+        let mut longer = false;
+        for entry in active {
+            if entry.lhs.len() == pending.len() {
+                return MatchResult::Expand(entry.rhs.clone());
+            }
+            longer = true;
+        }
+        if longer {
+            MatchResult::Pending
+        } else {
+            MatchResult::Miss
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(mode: &str, lhs: &str, rhs: &str) -> vmux_core::editor::KeyMapping {
+        vmux_core::editor::KeyMapping {
+            mode: mode.into(),
+            lhs: lhs.into(),
+            rhs: rhs.into(),
+        }
+    }
+
+    #[test]
+    fn notation_expands_leader_and_named_keys() {
+        let keys = parse_keys("<leader>w", " ");
+        assert_eq!(keys.len(), 2);
+        assert_eq!(keys[0].key, " ");
+        assert_eq!(keys[1].key, "w");
+
+        let esc = parse_keys("<Esc>", "");
+        assert_eq!(esc[0].key, "Escape");
+    }
+
+    #[test]
+    fn modifier_notation_sets_mods() {
+        let keys = parse_keys("<C-x>", "");
+        assert!(keys[0].mods.ctrl);
+        assert_eq!(keys[0].key, "x");
+    }
+
+    #[test]
+    fn an_exact_match_expands_and_a_prefix_pends() {
+        let maps = Mappings::new(&[spec("n", "gh", "^"), spec("n", "ghi", "$")], " ");
+        let g = parse_keys("g", "");
+        assert!(matches!(
+            maps.match_keys(EditMode::Normal, &g),
+            MatchResult::Pending
+        ));
+        let gh = parse_keys("gh", "");
+        assert!(matches!(
+            maps.match_keys(EditMode::Normal, &gh),
+            MatchResult::Expand(_)
+        ));
+        let zz = parse_keys("zz", "");
+        assert!(matches!(
+            maps.match_keys(EditMode::Normal, &zz),
+            MatchResult::Miss
+        ));
+    }
+
+    #[test]
+    fn scope_limits_which_mode_sees_a_mapping() {
+        let maps = Mappings::new(&[spec("i", "jk", "<Esc>")], " ");
+        let j = parse_keys("j", "");
+        assert!(matches!(
+            maps.match_keys(EditMode::Insert, &j),
+            MatchResult::Pending
+        ));
+        assert!(matches!(
+            maps.match_keys(EditMode::Normal, &j),
+            MatchResult::Miss
+        ));
+    }
+
+    #[test]
+    fn an_empty_mode_spec_covers_normal_and_visual() {
+        let scope = MapScope::parse("");
+        assert!(scope.covers(EditMode::Normal));
+        assert!(scope.covers(EditMode::Visual));
+        assert!(!scope.covers(EditMode::Insert));
+    }
+}

--- a/crates/vmux_editor/src/keymap/vim.rs
+++ b/crates/vmux_editor/src/keymap/vim.rs
@@ -60,7 +60,8 @@ pub struct VimKeymap {
     replace_pending: bool,
     g_pending: bool,
     z_pending: bool,
-    ex: Option<String>,
+    ex: Option<(char, String)>,
+    mode_before_ex: EditMode,
     pending_change: Vec<Recorded>,
     last_change: Vec<Recorded>,
     in_change: bool,
@@ -650,7 +651,11 @@ impl VimKeymap {
                 vec![SetMode(EditMode::VisualLine)]
             }
             ":" => {
-                self.ex = Some(String::new());
+                self.enter_ex(':');
+                vec![]
+            }
+            "/" | "?" => {
+                self.enter_ex(key.chars().next().unwrap());
                 vec![]
             }
             "Escape" => {
@@ -908,29 +913,81 @@ impl VimKeymap {
     fn ex_key(&mut self, k: &KeyInput) -> Vec<EditCommand> {
         match k.key.as_str() {
             "Enter" => {
-                let cmd = self.ex.take().unwrap_or_default();
-                match cmd.as_str() {
-                    "w" | "wq" | "x" => vec![EditCommand::Save],
-                    _ => vec![],
+                let Some((prompt, body)) = self.ex.take() else {
+                    return vec![];
+                };
+                self.mode = self.mode_before_ex;
+                if prompt == '/' || prompt == '?' {
+                    if body.is_empty() {
+                        return vec![];
+                    }
+                    return vec![EditCommand::SetSearch {
+                        pattern: body,
+                        forward: prompt == '/',
+                    }];
                 }
+                self.run_ex(&body)
             }
             "Escape" => {
                 self.ex = None;
+                self.mode = self.mode_before_ex;
                 vec![]
             }
             "Backspace" => {
-                if let Some(buf) = self.ex.as_mut() {
-                    buf.pop();
+                let empty = match self.ex.as_mut() {
+                    Some((_, buf)) => {
+                        buf.pop();
+                        buf.is_empty()
+                    }
+                    None => false,
+                };
+                if empty {
+                    self.ex = None;
+                    self.mode = self.mode_before_ex;
                 }
                 vec![]
             }
-            key if key.len() == 1 => {
-                if let Some(buf) = self.ex.as_mut() {
-                    buf.push_str(key);
+            key => {
+                if let Some(c) = single_char(key)
+                    && let Some((_, buf)) = self.ex.as_mut()
+                {
+                    buf.push(c);
                 }
                 vec![]
             }
-            _ => vec![],
+        }
+    }
+
+    fn enter_ex(&mut self, prompt: char) {
+        self.mode_before_ex = self.mode;
+        self.ex = Some((prompt, String::new()));
+        self.mode = EditMode::CommandLine;
+    }
+
+    fn run_ex(&mut self, body: &str) -> Vec<EditCommand> {
+        use crate::edit::ex::{ExCommand, parse};
+        let Some(cmd) = parse(body) else {
+            return vec![];
+        };
+        match cmd {
+            ExCommand::Write => vec![EditCommand::Save],
+            ExCommand::WriteQuit => vec![EditCommand::Save],
+            ExCommand::Quit { .. } => vec![],
+            ExCommand::NoHighlight => vec![EditCommand::ClearSearchHighlight],
+            ExCommand::Goto(line) => vec![EditCommand::Move(Motion::GotoLine(line as u32))],
+            ExCommand::Delete(range) => vec![EditCommand::ExDelete(range)],
+            ExCommand::Yank(range) => vec![EditCommand::ExYank(range)],
+            ExCommand::Substitute {
+                range,
+                pattern,
+                replacement,
+                all,
+            } => vec![EditCommand::Substitute {
+                range,
+                pattern,
+                replacement,
+                all,
+            }],
         }
     }
 }
@@ -938,6 +995,11 @@ impl VimKeymap {
 impl Keymap for VimKeymap {
     fn mode(&self) -> EditMode {
         self.mode
+    }
+    fn command_line(&self) -> Option<String> {
+        self.ex
+            .as_ref()
+            .map(|(prompt, body)| format!("{prompt}{body}"))
     }
     fn record_text(&mut self, text: &str) {
         if self.replaying {
@@ -1088,6 +1150,7 @@ impl VimKeymap {
         }
         if k.mods.ctrl && k.key.eq_ignore_ascii_case("c") {
             if self.ex.take().is_some() {
+                self.mode = self.mode_before_ex;
                 return vec![];
             }
             return match self.mode {
@@ -1103,7 +1166,7 @@ impl VimKeymap {
                     self.mode = EditMode::Normal;
                     vec![EditCommand::SetMode(EditMode::Normal)]
                 }
-                EditMode::Normal => {
+                EditMode::Normal | EditMode::CommandLine => {
                     self.reset();
                     vec![]
                 }
@@ -1115,7 +1178,7 @@ impl VimKeymap {
         match self.mode {
             EditMode::Insert => self.insert(k),
             EditMode::Visual | EditMode::VisualLine => self.visual(k),
-            EditMode::Normal => self.normal(k),
+            EditMode::Normal | EditMode::CommandLine => self.normal(k),
         }
     }
 }
@@ -1947,6 +2010,73 @@ mod tests {
         let mut km = VimKeymap::default();
         assert_eq!(run(&mut km, &[":", "w", "Enter"]), vec![EditCommand::Save]);
         assert_eq!(run(&mut km, &[":", "q", "Enter"]), vec![]);
+    }
+
+    #[test]
+    fn a_prompt_reports_command_line_mode_and_its_text() {
+        let mut km = VimKeymap::default();
+        run(&mut km, &[":", "w", "q"]);
+        assert_eq!(km.mode(), EditMode::CommandLine);
+        assert_eq!(km.command_line().as_deref(), Some(":wq"));
+        run(&mut km, &["Escape"]);
+        assert_eq!(km.mode(), EditMode::Normal);
+        assert_eq!(km.command_line(), None);
+    }
+
+    #[test]
+    fn slash_starts_a_forward_search_and_question_a_backward_one() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["/", "f", "o", "o", "Enter"]),
+            vec![EditCommand::SetSearch {
+                pattern: "foo".into(),
+                forward: true
+            }]
+        );
+        assert_eq!(
+            run(&mut km, &["?", "b", "a", "r", "Enter"]),
+            vec![EditCommand::SetSearch {
+                pattern: "bar".into(),
+                forward: false
+            }]
+        );
+    }
+
+    #[test]
+    fn backspacing_an_empty_prompt_leaves_command_line_mode() {
+        let mut km = VimKeymap::default();
+        run(&mut km, &["/", "a", "Backspace"]);
+        assert_eq!(km.mode(), EditMode::Normal);
+    }
+
+    #[test]
+    fn ex_substitute_and_nohl_reach_the_core() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(
+                &mut km,
+                &[":", "%", "s", "/", "a", "/", "b", "/", "g", "Enter"]
+            ),
+            vec![EditCommand::Substitute {
+                range: crate::edit::ex::ExRange::WholeFile,
+                pattern: "a".into(),
+                replacement: "b".into(),
+                all: true,
+            }]
+        );
+        assert_eq!(
+            run(&mut km, &[":", "n", "o", "h", "Enter"]),
+            vec![EditCommand::ClearSearchHighlight]
+        );
+    }
+
+    #[test]
+    fn a_bare_line_number_jumps() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &[":", "1", "2", "Enter"]),
+            vec![EditCommand::Move(Motion::GotoLine(11))]
+        );
     }
 
     #[test]

--- a/crates/vmux_editor/src/keymap/vim.rs
+++ b/crates/vmux_editor/src/keymap/vim.rs
@@ -1,4 +1,4 @@
-use crate::edit::command::{EditCommand, EditMode, Motion, Operator, Target};
+use crate::edit::command::{EditCommand, EditMode, Motion, Operator, ScrollPlacement, Target};
 use crate::edit::text_object::{TextObject, TextObjectKind};
 use crate::keymap::{KeyInput, Keymap};
 
@@ -17,6 +17,8 @@ pub struct VimKeymap {
     pending_op: Option<Operator>,
     pending_op_key: Option<char>,
     pending_object: Option<ObjectScope>,
+    pending_find: Option<(bool, bool)>,
+    last_find: Option<(char, bool, bool)>,
     register: Option<char>,
     register_pending: bool,
     replace_pending: bool,
@@ -27,18 +29,39 @@ pub struct VimKeymap {
 
 fn motion_for(key: &str) -> Option<Motion> {
     Some(match key {
-        "h" | "ArrowLeft" => Motion::LeftBounded,
-        "l" | "ArrowRight" => Motion::RightBounded,
+        "h" | "ArrowLeft" | "Backspace" => Motion::LeftBounded,
+        "l" | "ArrowRight" | " " => Motion::RightBounded,
         "j" | "ArrowDown" => Motion::Down,
         "k" | "ArrowUp" => Motion::Up,
         "w" => Motion::WordNext,
         "b" => Motion::WordPrev,
         "e" => Motion::WordEnd,
+        "W" => Motion::BigWordNext,
+        "B" => Motion::BigWordPrev,
+        "E" => Motion::BigWordEnd,
         "0" => Motion::LineStart,
         "^" => Motion::FirstNonBlank,
         "$" => Motion::LineEnd,
         "{" => Motion::ParagraphPrev,
         "}" => Motion::ParagraphNext,
+        "%" => Motion::MatchPair,
+        "H" => Motion::ScreenTop,
+        "M" => Motion::ScreenMiddle,
+        "L" => Motion::ScreenBottom,
+        "+" | "Enter" => Motion::NextLineStart,
+        "-" => Motion::PrevLineStart,
+        "_" => Motion::FirstNonBlank,
+        _ => return None,
+    })
+}
+
+/// `f`, `F`, `t`, and `T` all take the next key as their target character.
+fn find_prefix(key: &str) -> Option<(bool, bool)> {
+    Some(match key {
+        "f" => (true, false),
+        "F" => (false, false),
+        "t" => (true, true),
+        "T" => (false, true),
         _ => return None,
     })
 }
@@ -111,6 +134,7 @@ impl VimKeymap {
         self.pending_op = None;
         self.pending_op_key = None;
         self.pending_object = None;
+        self.pending_find = None;
         self.register = None;
         self.register_pending = false;
         self.replace_pending = false;
@@ -134,6 +158,42 @@ impl VimKeymap {
             target,
             register: self.take_register(),
         }
+    }
+
+    /// Route a resolved motion to the pending operator, a visual selection, or a plain move.
+    fn motion_command(&mut self, m: Motion) -> Vec<EditCommand> {
+        if let Some(operator) = self.pending_op.take() {
+            let count = self.take_operator_count();
+            self.pending_op_key = None;
+            self.pending_object = None;
+            if operator == Operator::Change {
+                self.enter_insert();
+            }
+            return vec![self.op(operator, Target::Motion(m, count))];
+        }
+        let n = self.take_count();
+        if self.mode.is_visual() {
+            return std::iter::repeat_n(EditCommand::Select(m), n).collect();
+        }
+        std::iter::repeat_n(EditCommand::Move(m), n).collect()
+    }
+
+    /// Consume the character `f`/`F`/`t`/`T` was waiting for, or drop the whole pending command.
+    fn resolve_find(&mut self, forward: bool, till: bool, key: &str) -> Vec<EditCommand> {
+        let Some(ch) = single_char(key) else {
+            self.reset();
+            return vec![];
+        };
+        self.last_find = Some((ch, forward, till));
+        self.motion_command(Motion::FindChar { ch, forward, till })
+    }
+
+    fn repeat_find(&mut self, reverse: bool) -> Vec<EditCommand> {
+        let Some((ch, forward, till)) = self.last_find else {
+            return vec![];
+        };
+        let forward = if reverse { !forward } else { forward };
+        self.motion_command(Motion::FindChar { ch, forward, till })
     }
 
     /// Apply a pending operator to a motion, a text object, a doubled key (`dd`), or abandon it.
@@ -191,6 +251,10 @@ impl VimKeymap {
         use EditCommand::*;
         let key = k.key.as_str();
 
+        if let Some((forward, till)) = self.pending_find.take() {
+            return self.resolve_find(forward, till, key);
+        }
+
         if self.register_pending {
             self.register_pending = false;
             if let Some(c) = single_char(key) {
@@ -217,6 +281,16 @@ impl VimKeymap {
             return vec![];
         }
 
+        if self.pending_object.is_none() {
+            if let Some((forward, till)) = find_prefix(key) {
+                self.pending_find = Some((forward, till));
+                return vec![];
+            }
+            if key == ";" || key == "," {
+                return self.repeat_find(key == ",");
+            }
+        }
+
         if let Some(operator) = self.pending_op.take() {
             return self.operator_pending(operator, key);
         }
@@ -237,6 +311,13 @@ impl VimKeymap {
                 }
                 "d" => vec![GotoDefinition],
                 "r" => vec![FindReferences],
+                "e" => self.motion_command(Motion::WordEndPrev),
+                "E" => self.motion_command(Motion::BigWordEndPrev),
+                "_" => self.motion_command(Motion::LastNonBlank),
+                "0" => self.motion_command(Motion::LineStart),
+                "$" => self.motion_command(Motion::LineEnd),
+                "j" => self.motion_command(Motion::Down),
+                "k" => self.motion_command(Motion::Up),
                 "J" => vec![JoinLines {
                     count: self.take_count(),
                     spaces: false,
@@ -254,6 +335,9 @@ impl VimKeymap {
                 "A" => vec![FoldToggleRecursive],
                 "R" => vec![UnfoldAll],
                 "M" => vec![FoldAll],
+                "z" => vec![ScrollCursorTo(ScrollPlacement::Center)],
+                "t" => vec![ScrollCursorTo(ScrollPlacement::Top)],
+                "b" => vec![ScrollCursorTo(ScrollPlacement::Bottom)],
                 _ => vec![],
             };
         }
@@ -296,6 +380,10 @@ impl VimKeymap {
                     None => Move(Motion::DocEnd),
                 };
                 vec![cmd]
+            }
+            "|" => {
+                let col = self.take_count();
+                vec![Move(Motion::Column(col))]
             }
             "i" => {
                 self.enter_insert();
@@ -400,6 +488,10 @@ impl VimKeymap {
         use EditCommand::*;
         let key = k.key.as_str();
 
+        if let Some((forward, till)) = self.pending_find.take() {
+            return self.resolve_find(forward, till, key);
+        }
+
         if let Some(scope) = self.pending_object.take() {
             let count = self.take_count();
             let Some(kind) = text_object_kind(key) else {
@@ -446,6 +538,15 @@ impl VimKeymap {
             return vec![];
         }
 
+        if let Some((forward, till)) = find_prefix(key) {
+            self.pending_find = Some((forward, till));
+            return vec![];
+        }
+
+        if key == ";" || key == "," {
+            return self.repeat_find(key == ",");
+        }
+
         if let Some(m) = motion_for(key) {
             let n = self.take_count();
             return std::iter::repeat_n(Select(m), n).collect();
@@ -458,6 +559,9 @@ impl VimKeymap {
                 "U" => self.visual_op(Operator::Upper),
                 "~" => self.visual_op(Operator::ToggleCase),
                 "g" => vec![Select(Motion::DocStart)],
+                "e" => self.motion_command(Motion::WordEndPrev),
+                "E" => self.motion_command(Motion::BigWordEndPrev),
+                "_" => self.motion_command(Motion::LastNonBlank),
                 _ => vec![],
             };
         }
@@ -466,6 +570,10 @@ impl VimKeymap {
             "g" => {
                 self.g_pending = true;
                 vec![]
+            }
+            "|" => {
+                let col = self.take_count();
+                vec![Select(Motion::Column(col))]
             }
             "\"" => {
                 self.register_pending = true;
@@ -683,6 +791,10 @@ impl Keymap for VimKeymap {
             let motion = match k.key.to_ascii_lowercase().as_str() {
                 "n" => Some(Motion::Down),
                 "p" => Some(Motion::Up),
+                "d" => Some(Motion::HalfPageDown),
+                "u" => Some(Motion::HalfPageUp),
+                "f" => Some(Motion::PageDown),
+                "b" => Some(Motion::PageUp),
                 _ => None,
             };
             if let Some(motion) = motion {
@@ -865,6 +977,123 @@ mod tests {
         assert_eq!(
             run(&mut km, &["d", "w"]),
             vec![op(Operator::Delete, Target::Motion(Motion::WordNext, 1))]
+        );
+    }
+
+    fn find(ch: char, forward: bool, till: bool) -> Motion {
+        Motion::FindChar { ch, forward, till }
+    }
+
+    #[test]
+    fn find_char_prefixes_consume_the_next_key() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["f", ","]),
+            vec![EditCommand::Move(find(',', true, false))]
+        );
+        assert_eq!(
+            run(&mut km, &["T", "x"]),
+            vec![EditCommand::Move(find('x', false, true))]
+        );
+    }
+
+    #[test]
+    fn semicolon_repeats_and_comma_reverses_the_last_find() {
+        let mut km = VimKeymap::default();
+        run(&mut km, &["f", "x"]);
+        assert_eq!(
+            run(&mut km, &[";"]),
+            vec![EditCommand::Move(find('x', true, false))]
+        );
+        assert_eq!(
+            run(&mut km, &[","]),
+            vec![EditCommand::Move(find('x', false, false))]
+        );
+    }
+
+    #[test]
+    fn repeat_find_without_a_previous_find_does_nothing() {
+        let mut km = VimKeymap::default();
+        assert_eq!(run(&mut km, &[";"]), vec![]);
+    }
+
+    #[test]
+    fn operators_compose_with_find_char() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["d", "t", ","]),
+            vec![op(
+                Operator::Delete,
+                Target::Motion(find(',', true, true), 1)
+            )]
+        );
+        assert_eq!(
+            run(&mut km, &["2", "d", "f", "x"]),
+            vec![op(
+                Operator::Delete,
+                Target::Motion(find('x', true, false), 2)
+            )]
+        );
+    }
+
+    #[test]
+    fn the_tag_object_is_not_shadowed_by_the_till_prefix() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["d", "i", "t"]),
+            vec![op(Operator::Delete, object(TextObjectKind::Tag, false, 1))]
+        );
+    }
+
+    #[test]
+    fn word_and_screen_motions_are_bound() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["W"]),
+            vec![EditCommand::Move(Motion::BigWordNext)]
+        );
+        assert_eq!(
+            run(&mut km, &["g", "e"]),
+            vec![EditCommand::Move(Motion::WordEndPrev)]
+        );
+        assert_eq!(
+            run(&mut km, &["%"]),
+            vec![EditCommand::Move(Motion::MatchPair)]
+        );
+        assert_eq!(
+            run(&mut km, &["H"]),
+            vec![EditCommand::Move(Motion::ScreenTop)]
+        );
+        assert_eq!(
+            run(&mut km, &["8", "|"]),
+            vec![EditCommand::Move(Motion::Column(8))]
+        );
+    }
+
+    #[test]
+    fn half_and_full_page_scroll_chords() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            km.handle(&chord("d", ctrl())),
+            vec![EditCommand::Move(Motion::HalfPageDown)]
+        );
+        assert_eq!(
+            km.handle(&chord("b", ctrl())),
+            vec![EditCommand::Move(Motion::PageUp)]
+        );
+    }
+
+    #[test]
+    fn z_prefix_serves_both_folds_and_scroll_placement() {
+        let mut km = VimKeymap::default();
+        assert_eq!(run(&mut km, &["z", "a"]), vec![EditCommand::FoldToggle]);
+        assert_eq!(
+            run(&mut km, &["z", "z"]),
+            vec![EditCommand::ScrollCursorTo(ScrollPlacement::Center)]
+        );
+        assert_eq!(
+            run(&mut km, &["z", "b"]),
+            vec![EditCommand::ScrollCursorTo(ScrollPlacement::Bottom)]
         );
     }
 

--- a/crates/vmux_editor/src/keymap/vim.rs
+++ b/crates/vmux_editor/src/keymap/vim.rs
@@ -9,6 +9,14 @@ enum ObjectScope {
     Around,
 }
 
+/// What the key after `m`, `` ` ``, or `'` names.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum MarkAction {
+    Set,
+    GotoExact,
+    GotoLine,
+}
+
 /// One unit of replayable input.
 ///
 /// Dot-repeat and macros both work by replaying what the user typed, and insert-mode characters
@@ -62,6 +70,7 @@ pub struct VimKeymap {
     macros: std::collections::HashMap<char, Vec<Recorded>>,
     last_macro: Option<char>,
     insert_after_next: bool,
+    mark_pending: Option<MarkAction>,
 }
 
 fn motion_for(key: &str) -> Option<Motion> {
@@ -186,6 +195,7 @@ impl VimKeymap {
             && self.pending_object.is_none()
             && self.pending_find.is_none()
             && self.macro_pending.is_none()
+            && self.mark_pending.is_none()
             && self.ex.is_none()
             && !self.register_pending
             && !self.replace_pending
@@ -196,6 +206,18 @@ impl VimKeymap {
     /// Nothing at all is half-typed, so no keys are owed to a command in progress.
     fn is_idle(&self) -> bool {
         self.is_command_start() && self.count.is_none() && self.op_count.is_none()
+    }
+
+    /// A prefix is waiting to consume the next key as a literal argument — a register or mark
+    /// name, a text-object kind, a fold or `g` command — so it must not be read as a motion.
+    fn awaits_literal_key(&self) -> bool {
+        self.pending_object.is_some()
+            || self.macro_pending.is_some()
+            || self.mark_pending.is_some()
+            || self.register_pending
+            || self.replace_pending
+            || self.g_pending
+            || self.z_pending
     }
 
     fn replay(&mut self, inputs: &[Recorded], times: usize) -> Vec<EditCommand> {
@@ -329,6 +351,23 @@ impl VimKeymap {
             return self.resolve_find(forward, till, key);
         }
 
+        if let Some(action) = self.mark_pending.take() {
+            let Some(name) = single_char(key) else {
+                return vec![];
+            };
+            return match action {
+                MarkAction::Set => vec![SetMark(name)],
+                MarkAction::GotoExact => vec![GotoMark {
+                    name,
+                    linewise: false,
+                }],
+                MarkAction::GotoLine => vec![GotoMark {
+                    name,
+                    linewise: true,
+                }],
+            };
+        }
+
         if let Some(record) = self.macro_pending.take() {
             let Some(reg) = single_char(key) else {
                 return vec![];
@@ -379,7 +418,7 @@ impl VimKeymap {
             return vec![];
         }
 
-        if self.pending_object.is_none() {
+        if !self.awaits_literal_key() {
             if let Some((forward, till)) = find_prefix(key) {
                 self.pending_find = Some((forward, till));
                 return vec![];
@@ -416,6 +455,10 @@ impl VimKeymap {
                 "$" => self.motion_command(Motion::LineEnd),
                 "j" => self.motion_command(Motion::Down),
                 "k" => self.motion_command(Motion::Up),
+                ";" | "," => vec![ChangeList {
+                    back: key == ";",
+                    count: self.take_count(),
+                }],
                 "J" => vec![JoinLines {
                     count: self.take_count(),
                     spaces: false,
@@ -489,6 +532,18 @@ impl VimKeymap {
                 let out = self.replay(&body, times);
                 self.last_change = body;
                 out
+            }
+            "m" => {
+                self.mark_pending = Some(MarkAction::Set);
+                vec![]
+            }
+            "`" => {
+                self.mark_pending = Some(MarkAction::GotoExact);
+                vec![]
+            }
+            "'" => {
+                self.mark_pending = Some(MarkAction::GotoLine);
+                vec![]
             }
             "q" => {
                 if let Some((reg, body)) = self.macro_record.take() {
@@ -1001,6 +1056,14 @@ impl VimKeymap {
                 self.reset();
                 return vec![EditCommand::ScrollViewport(direction * count)];
             }
+            if k.key.eq_ignore_ascii_case("o") || k.key == "i" || k.key == "Tab" {
+                let count = self.take_count();
+                self.reset();
+                return vec![EditCommand::JumpList {
+                    back: k.key.eq_ignore_ascii_case("o"),
+                    count,
+                }];
+            }
             let motion = match k.key.to_ascii_lowercase().as_str() {
                 "n" => Some(Motion::Down),
                 "p" => Some(Motion::Up),
@@ -1456,6 +1519,64 @@ mod tests {
         let mut km = VimKeymap::default();
         run(&mut km, &["i"]);
         assert_eq!(km.handle(&chord("e", ctrl())), vec![]);
+    }
+
+    #[test]
+    fn mark_bindings_set_and_recall() {
+        let mut km = VimKeymap::default();
+        assert_eq!(run(&mut km, &["m", "a"]), vec![EditCommand::SetMark('a')]);
+        assert_eq!(
+            run(&mut km, &["`", "a"]),
+            vec![EditCommand::GotoMark {
+                name: 'a',
+                linewise: false
+            }]
+        );
+        assert_eq!(
+            run(&mut km, &["'", "a"]),
+            vec![EditCommand::GotoMark {
+                name: 'a',
+                linewise: true
+            }]
+        );
+    }
+
+    #[test]
+    fn jump_and_change_list_bindings() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            km.handle(&chord("o", ctrl())),
+            vec![EditCommand::JumpList {
+                back: true,
+                count: 1
+            }]
+        );
+        assert_eq!(
+            km.handle(&chord("i", ctrl())),
+            vec![EditCommand::JumpList {
+                back: false,
+                count: 1
+            }]
+        );
+        assert_eq!(
+            run(&mut km, &["g", ";"]),
+            vec![EditCommand::ChangeList {
+                back: true,
+                count: 1
+            }]
+        );
+    }
+
+    #[test]
+    fn a_mark_key_is_not_read_as_a_quote_object() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["d", "i", "'"]),
+            vec![op(
+                Operator::Delete,
+                object(TextObjectKind::SingleQuote, false, 1)
+            )]
+        );
     }
 
     #[test]

--- a/crates/vmux_editor/src/keymap/vim.rs
+++ b/crates/vmux_editor/src/keymap/vim.rs
@@ -74,6 +74,8 @@ pub struct VimKeymap {
     mark_pending: Option<MarkAction>,
     block_insert: Option<bool>,
     block_text: String,
+    mappings: crate::keymap::mapping::Mappings,
+    map_pending: Vec<KeyInput>,
 }
 
 fn motion_for(key: &str) -> Option<Motion> {
@@ -164,6 +166,14 @@ fn single_char(key: &str) -> Option<char> {
 }
 
 impl VimKeymap {
+    /// Build a keymap with the user's configured key mappings applied.
+    pub fn with_mappings(specs: &[vmux_core::editor::KeyMapping], leader: &str) -> Self {
+        Self {
+            mappings: crate::keymap::mapping::Mappings::new(specs, leader),
+            ..Self::default()
+        }
+    }
+
     fn take_count(&mut self) -> usize {
         self.count.take().unwrap_or(1)
     }
@@ -223,6 +233,49 @@ impl VimKeymap {
             || self.replace_pending
             || self.g_pending
             || self.z_pending
+    }
+
+    /// Feed a key through the user's mappings.
+    ///
+    /// Returns `None` when the key should be handled normally, `Some` when the mapping layer
+    /// consumed it — either holding it as part of a longer sequence or expanding a match.
+    fn route_through_mappings(&mut self, k: &KeyInput) -> Option<Vec<EditCommand>> {
+        use crate::keymap::mapping::MatchResult;
+        let mut pending = std::mem::take(&mut self.map_pending);
+        pending.push(k.clone());
+        match self.mappings.match_keys(self.mode, &pending) {
+            MatchResult::Pending => {
+                self.map_pending = pending;
+                Some(vec![])
+            }
+            MatchResult::Expand(rhs) => {
+                let mut out = Vec::new();
+                for key in rhs {
+                    out.extend(self.handle_unmapped(&key));
+                }
+                Some(out)
+            }
+            MatchResult::Miss => {
+                if pending.len() == 1 {
+                    return None;
+                }
+                // The buffered prefix turned out not to be a mapping; replay it as typed.
+                let mut out = Vec::new();
+                for key in pending {
+                    out.extend(self.handle_unmapped(&key));
+                }
+                Some(out)
+            }
+        }
+    }
+
+    /// Run one key through recording and dispatch, skipping the mapping layer.
+    fn handle_unmapped(&mut self, k: &KeyInput) -> Vec<EditCommand> {
+        let was_replaying = self.replaying;
+        self.replaying = true;
+        let cmds = self.record_and_dispatch(k);
+        self.replaying = was_replaying;
+        cmds
     }
 
     fn replay(&mut self, inputs: &[Recorded], times: usize) -> Vec<EditCommand> {
@@ -1037,7 +1090,31 @@ impl Keymap for VimKeymap {
         if self.replaying {
             return self.dispatch(k);
         }
+        if !self.mappings.is_empty()
+            && let Some(cmds) = self.route_through_mappings(k)
+        {
+            return cmds;
+        }
+        self.record_and_dispatch(k)
+    }
+    fn pointer_selection_mode(&mut self, extend: bool) -> Option<EditCommand> {
+        match (extend, self.mode) {
+            (true, EditMode::Normal) => {
+                self.mode = EditMode::Visual;
+                Some(EditCommand::SetMode(EditMode::Visual))
+            }
+            (false, mode) if mode.is_visual() => {
+                self.mode = EditMode::Normal;
+                Some(EditCommand::SetMode(EditMode::Normal))
+            }
+            _ => None,
+        }
+    }
+}
 
+impl VimKeymap {
+    /// Dispatch one key while maintaining the dot-repeat and macro records.
+    fn record_and_dispatch(&mut self, k: &KeyInput) -> Vec<EditCommand> {
         let stops_recording =
             self.macro_record.is_some() && k.key == "q" && self.mode == EditMode::Normal;
         if let Some((_, body)) = self.macro_record.as_mut()
@@ -1070,22 +1147,7 @@ impl Keymap for VimKeymap {
         }
         cmds
     }
-    fn pointer_selection_mode(&mut self, extend: bool) -> Option<EditCommand> {
-        match (extend, self.mode) {
-            (true, EditMode::Normal) => {
-                self.mode = EditMode::Visual;
-                Some(EditCommand::SetMode(EditMode::Visual))
-            }
-            (false, EditMode::Visual | EditMode::VisualLine) => {
-                self.mode = EditMode::Normal;
-                Some(EditCommand::SetMode(EditMode::Normal))
-            }
-            _ => None,
-        }
-    }
-}
 
-impl VimKeymap {
     /// Interpret one key without any dot-repeat or macro bookkeeping.
     fn dispatch(&mut self, k: &KeyInput) -> Vec<EditCommand> {
         let armed = self.insert_after_next;
@@ -1143,6 +1205,12 @@ impl VimKeymap {
                 let count = self.take_count().min(i32::MAX as usize) as i32;
                 self.reset();
                 return vec![EditCommand::ScrollViewport(direction * count)];
+            }
+            if k.key == "a" || k.key == "x" {
+                let count = self.take_count() as i64;
+                self.reset();
+                let delta = if k.key == "a" { count } else { -count };
+                return vec![EditCommand::Increment(delta)];
             }
             if k.key.eq_ignore_ascii_case("v") {
                 self.reset();
@@ -1590,6 +1658,60 @@ mod tests {
                 count: 1,
                 register: Some('a'),
             }]
+        );
+    }
+
+    fn mapped(specs: &[(&str, &str, &str)]) -> VimKeymap {
+        let specs: Vec<_> = specs
+            .iter()
+            .map(|(mode, lhs, rhs)| vmux_core::editor::KeyMapping {
+                mode: (*mode).into(),
+                lhs: (*lhs).into(),
+                rhs: (*rhs).into(),
+            })
+            .collect();
+        VimKeymap::with_mappings(&specs, " ")
+    }
+
+    #[test]
+    fn jk_maps_to_escape_in_insert_mode() {
+        let mut km = mapped(&[("i", "jk", "<Esc>")]);
+        run(&mut km, &["i"]);
+        assert_eq!(run(&mut km, &["j"]), vec![]);
+        assert_eq!(
+            run(&mut km, &["k"]),
+            vec![
+                EditCommand::Move(Motion::LeftBounded),
+                EditCommand::SetMode(EditMode::Normal),
+            ]
+        );
+        assert_eq!(km.mode(), EditMode::Normal);
+    }
+
+    #[test]
+    fn an_abandoned_mapping_prefix_replays_as_typed() {
+        let mut km = mapped(&[("n", "gs", "0")]);
+        assert_eq!(run(&mut km, &["g"]), vec![]);
+        assert_eq!(
+            run(&mut km, &["d"]),
+            vec![EditCommand::GotoDefinition],
+            "the buffered g and the new d still form gd"
+        );
+    }
+
+    #[test]
+    fn leader_mappings_expand_through_the_configured_leader() {
+        let mut km = mapped(&[("n", "<leader>s", ":w<CR>")]);
+        assert_eq!(run(&mut km, &[" "]), vec![]);
+        assert_eq!(run(&mut km, &["s"]), vec![EditCommand::Save]);
+    }
+
+    #[test]
+    fn an_unmapped_key_is_untouched_by_the_mapping_layer() {
+        let mut km = mapped(&[("i", "jk", "<Esc>")]);
+        assert_eq!(
+            run(&mut km, &["x"]),
+            vec![op(Operator::Delete, Target::Motion(Motion::Right, 1))]
         );
     }
 

--- a/crates/vmux_editor/src/keymap/vim.rs
+++ b/crates/vmux_editor/src/keymap/vim.rs
@@ -513,6 +513,14 @@ impl VimKeymap {
                 "$" => self.motion_command(Motion::LineEnd),
                 "j" => self.motion_command(Motion::Down),
                 "k" => self.motion_command(Motion::Up),
+                "-" => vec![UndoTime {
+                    forward: false,
+                    count: self.take_count(),
+                }],
+                "+" => vec![UndoTime {
+                    forward: true,
+                    count: self.take_count(),
+                }],
                 ";" | "," => vec![ChangeList {
                     back: key == ";",
                     count: self.take_count(),

--- a/crates/vmux_editor/src/keymap/vim.rs
+++ b/crates/vmux_editor/src/keymap/vim.rs
@@ -1,18 +1,19 @@
-use crate::edit::command::{EditCommand, EditMode, Motion};
+use crate::edit::command::{EditCommand, EditMode, Motion, Operator, Target};
 use crate::keymap::{KeyInput, Keymap};
 
 #[derive(Default)]
 pub struct VimKeymap {
     mode: EditMode,
     count: Option<usize>,
-    pending_op: Option<char>,
+    op_count: Option<usize>,
+    pending_op: Option<Operator>,
+    pending_op_key: Option<char>,
+    register: Option<char>,
+    register_pending: bool,
+    replace_pending: bool,
     g_pending: bool,
     z_pending: bool,
     ex: Option<String>,
-}
-
-fn rep(cmd: EditCommand, n: usize) -> Vec<EditCommand> {
-    std::iter::repeat_n(cmd, n.max(1)).collect()
 }
 
 fn motion_for(key: &str) -> Option<Motion> {
@@ -33,73 +34,158 @@ fn motion_for(key: &str) -> Option<Motion> {
     })
 }
 
+/// The operator a `g`-prefixed key introduces, and the key that doubles it (`guu`).
+fn g_operator(key: &str) -> Option<(Operator, char)> {
+    Some(match key {
+        "u" => (Operator::Lower, 'u'),
+        "U" => (Operator::Upper, 'U'),
+        "~" => (Operator::ToggleCase, '~'),
+        _ => return None,
+    })
+}
+
+fn operator_for(key: &str) -> Option<(Operator, char)> {
+    Some(match key {
+        "d" => (Operator::Delete, 'd'),
+        "c" => (Operator::Change, 'c'),
+        "y" => (Operator::Yank, 'y'),
+        ">" => (Operator::Indent, '>'),
+        "<" => (Operator::Outdent, '<'),
+        "=" => (Operator::Indent, '='),
+        _ => return None,
+    })
+}
+
+fn single_char(key: &str) -> Option<char> {
+    let mut chars = key.chars();
+    let c = chars.next()?;
+    chars.next().is_none().then_some(c)
+}
+
 impl VimKeymap {
     fn take_count(&mut self) -> usize {
         self.count.take().unwrap_or(1)
     }
+
+    /// Vim multiplies a count before the operator with one before the motion: `2d3w` is six words.
+    fn take_operator_count(&mut self) -> usize {
+        let outer = self.op_count.take().unwrap_or(1);
+        let inner = self.count.take().unwrap_or(1);
+        outer.saturating_mul(inner).max(1)
+    }
+
+    fn take_register(&mut self) -> Option<char> {
+        self.register.take()
+    }
+
     fn reset(&mut self) {
         self.count = None;
+        self.op_count = None;
         self.pending_op = None;
+        self.pending_op_key = None;
+        self.register = None;
+        self.register_pending = false;
+        self.replace_pending = false;
         self.g_pending = false;
         self.z_pending = false;
+    }
+
+    fn start_operator(&mut self, operator: Operator, key: char) {
+        self.pending_op = Some(operator);
+        self.pending_op_key = Some(key);
+        self.op_count = self.count.take();
+    }
+
+    fn enter_insert(&mut self) {
+        self.mode = EditMode::Insert;
+    }
+
+    fn op(&mut self, operator: Operator, target: Target) -> EditCommand {
+        EditCommand::Op {
+            operator,
+            target,
+            register: self.take_register(),
+        }
+    }
+
+    /// Apply a pending operator to a motion, a doubled key (`dd`), or abandon it.
+    fn operator_pending(&mut self, operator: Operator, key: &str) -> Vec<EditCommand> {
+        let doubled = single_char(key)
+            .zip(self.pending_op_key)
+            .is_some_and(|(a, b)| a == b);
+        let count = self.take_operator_count();
+        self.pending_op_key = None;
+
+        let target = if doubled {
+            Target::Line(count)
+        } else if let Some(m) = motion_for(key) {
+            Target::Motion(m, count)
+        } else if key == "G" {
+            Target::Motion(Motion::DocEnd, 1)
+        } else {
+            return vec![];
+        };
+
+        if operator == Operator::Change {
+            self.enter_insert();
+        }
+        vec![self.op(operator, target)]
     }
 
     fn normal(&mut self, k: &KeyInput) -> Vec<EditCommand> {
         use EditCommand::*;
         let key = k.key.as_str();
 
-        if key.len() == 1 {
-            let c = key.chars().next().unwrap();
-            if c.is_ascii_digit() && !(c == '0' && self.count.is_none()) {
-                let d = c as usize - '0' as usize;
-                self.count = Some(self.count.unwrap_or(0) * 10 + d);
-                return vec![];
-            }
-        }
-
-        if let Some(op) = self.pending_op {
-            self.pending_op = None;
-            let n = self.take_count();
-            if key.len() == 1 && key.starts_with(op) {
-                return match op {
-                    'd' => vec![DeleteLine],
-                    'y' => vec![Move(Motion::LineStart), Select(Motion::LineEnd), Yank],
-                    'c' => {
-                        self.mode = EditMode::Insert;
-                        vec![
-                            Move(Motion::LineStart),
-                            DeleteToLineEnd,
-                            SetMode(EditMode::Insert),
-                        ]
-                    }
-                    _ => vec![],
-                };
-            }
-            if let Some(m) = motion_for(key) {
-                return match op {
-                    'd' => rep(DeleteRange(m), n),
-                    'y' => vec![YankRange(m)],
-                    'c' => {
-                        self.mode = EditMode::Insert;
-                        let mut cmds = rep(DeleteRange(m), n);
-                        cmds.push(SetMode(EditMode::Insert));
-                        cmds
-                    }
-                    _ => vec![],
-                };
+        if self.register_pending {
+            self.register_pending = false;
+            if let Some(c) = single_char(key) {
+                self.register = Some(c);
             }
             return vec![];
         }
 
+        if self.replace_pending {
+            self.replace_pending = false;
+            let count = self.take_count();
+            if let Some(ch) = single_char(key) {
+                return vec![ReplaceChar { ch, count }];
+            }
+            return vec![];
+        }
+
+        if let Some(c) = single_char(key)
+            && c.is_ascii_digit()
+            && !(c == '0' && self.count.is_none())
+        {
+            let d = c as usize - '0' as usize;
+            self.count = Some(self.count.unwrap_or(0) * 10 + d);
+            return vec![];
+        }
+
+        if let Some(operator) = self.pending_op.take() {
+            return self.operator_pending(operator, key);
+        }
+
         if self.g_pending {
             self.g_pending = false;
+            if let Some((operator, op_key)) = g_operator(key) {
+                self.start_operator(operator, op_key);
+                return vec![];
+            }
             return match key {
                 "g" => {
-                    self.count = None;
-                    vec![Move(Motion::DocStart)]
+                    let line = self.count.take();
+                    vec![match line {
+                        Some(n) => Move(Motion::GotoLine(n.saturating_sub(1) as u32)),
+                        None => Move(Motion::DocStart),
+                    }]
                 }
                 "d" => vec![GotoDefinition],
                 "r" => vec![FindReferences],
+                "J" => vec![JoinLines {
+                    count: self.take_count(),
+                    spaces: false,
+                }],
                 _ => vec![],
             };
         }
@@ -119,12 +205,17 @@ impl VimKeymap {
 
         if key == "r" && k.mods.ctrl {
             let n = self.take_count();
-            return rep(Redo, n);
+            return std::iter::repeat_n(Redo, n).collect();
         }
 
         if let Some(m) = motion_for(key) {
             let n = self.take_count();
-            return rep(Move(m), n);
+            return std::iter::repeat_n(Move(m), n).collect();
+        }
+
+        if let Some((operator, op_key)) = operator_for(key) {
+            self.start_operator(operator, op_key);
+            return vec![];
         }
 
         match key {
@@ -136,6 +227,14 @@ impl VimKeymap {
                 self.z_pending = true;
                 vec![]
             }
+            "\"" => {
+                self.register_pending = true;
+                vec![]
+            }
+            "r" => {
+                self.replace_pending = true;
+                vec![]
+            }
             "G" => {
                 let cmd = match self.count.take() {
                     Some(n) => Move(Motion::GotoLine(n.saturating_sub(1) as u32)),
@@ -144,81 +243,83 @@ impl VimKeymap {
                 vec![cmd]
             }
             "i" => {
-                self.mode = EditMode::Insert;
+                self.enter_insert();
                 vec![SetMode(EditMode::Insert)]
             }
             "a" => {
-                self.mode = EditMode::Insert;
+                self.enter_insert();
                 vec![Move(Motion::Right), SetMode(EditMode::Insert)]
             }
             "I" => {
-                self.mode = EditMode::Insert;
+                self.enter_insert();
                 vec![Move(Motion::FirstNonBlank), SetMode(EditMode::Insert)]
             }
             "A" => {
-                self.mode = EditMode::Insert;
+                self.enter_insert();
                 vec![Move(Motion::LineEnd), SetMode(EditMode::Insert)]
             }
             "o" => {
-                self.mode = EditMode::Insert;
-                vec![
-                    Move(Motion::LineEnd),
-                    InsertNewline,
-                    SetMode(EditMode::Insert),
-                ]
+                self.enter_insert();
+                vec![OpenLine { above: false }]
             }
             "O" => {
-                self.mode = EditMode::Insert;
-                vec![
-                    Move(Motion::LineStart),
-                    InsertNewline,
-                    Move(Motion::Up),
-                    SetMode(EditMode::Insert),
-                ]
+                self.enter_insert();
+                vec![OpenLine { above: true }]
             }
             "x" => {
-                let n = self.take_count();
-                rep(DeleteForward, n)
+                let count = self.take_count();
+                vec![self.op(Operator::Delete, Target::Motion(Motion::Right, count))]
             }
             "X" => {
-                let n = self.take_count();
-                rep(DeleteBack, n)
+                let count = self.take_count();
+                vec![self.op(Operator::Delete, Target::Motion(Motion::Left, count))]
             }
             "D" => {
                 let _ = self.take_count();
-                vec![DeleteToLineEnd]
+                vec![self.op(Operator::Delete, Target::Motion(Motion::LineEnd, 1))]
             }
             "C" => {
                 let _ = self.take_count();
-                self.mode = EditMode::Insert;
-                vec![DeleteToLineEnd, SetMode(EditMode::Insert)]
+                self.enter_insert();
+                vec![self.op(Operator::Change, Target::Motion(Motion::LineEnd, 1))]
             }
             "s" => {
-                let n = self.take_count();
-                self.mode = EditMode::Insert;
-                let mut ops = rep(DeleteForward, n);
-                ops.push(SetMode(EditMode::Insert));
-                ops
+                let count = self.take_count();
+                self.enter_insert();
+                vec![self.op(Operator::Change, Target::Motion(Motion::Right, count))]
             }
             "S" => {
-                let _ = self.take_count();
-                self.mode = EditMode::Insert;
-                vec![
-                    Move(Motion::LineStart),
-                    DeleteToLineEnd,
-                    SetMode(EditMode::Insert),
-                ]
+                let count = self.take_count();
+                self.enter_insert();
+                vec![self.op(Operator::Change, Target::Line(count))]
             }
-            "p" => vec![Paste],
-            "P" => vec![PasteBefore],
+            "Y" => {
+                let count = self.take_count();
+                vec![self.op(Operator::Yank, Target::Line(count))]
+            }
+            "J" => vec![JoinLines {
+                count: self.take_count(),
+                spaces: true,
+            }],
+            "~" => {
+                let count = self.take_count();
+                let mut cmds =
+                    vec![self.op(Operator::ToggleCase, Target::Motion(Motion::Right, count))];
+                cmds.extend(std::iter::repeat_n(Move(Motion::RightBounded), count));
+                cmds
+            }
+            "p" | "P" => {
+                let count = self.take_count();
+                vec![Put {
+                    before: key == "P",
+                    count,
+                    register: self.take_register(),
+                }]
+            }
             "K" => vec![Hover],
             "u" => {
                 let n = self.take_count();
-                rep(Undo, n)
-            }
-            "d" | "c" | "y" => {
-                self.pending_op = key.chars().next();
-                vec![]
+                std::iter::repeat_n(Undo, n).collect()
             }
             "v" => {
                 self.mode = EditMode::Visual;
@@ -243,28 +344,153 @@ impl VimKeymap {
     fn visual(&mut self, k: &KeyInput) -> Vec<EditCommand> {
         use EditCommand::*;
         let key = k.key.as_str();
-        if let Some(m) = motion_for(key) {
-            return vec![Select(m)];
+
+        if self.register_pending {
+            self.register_pending = false;
+            if let Some(c) = single_char(key) {
+                self.register = Some(c);
+            }
+            return vec![];
         }
+
+        if self.replace_pending {
+            self.replace_pending = false;
+            if let Some(ch) = single_char(key) {
+                self.mode = EditMode::Normal;
+                return vec![
+                    Op {
+                        operator: Operator::Delete,
+                        target: Target::Selection,
+                        register: Some(crate::edit::register::BLACKHOLE),
+                    },
+                    InsertText(ch.to_string()),
+                    SetMode(EditMode::Normal),
+                ];
+            }
+            return vec![];
+        }
+
+        if let Some(c) = single_char(key)
+            && c.is_ascii_digit()
+            && !(c == '0' && self.count.is_none())
+        {
+            let d = c as usize - '0' as usize;
+            self.count = Some(self.count.unwrap_or(0) * 10 + d);
+            return vec![];
+        }
+
+        if let Some(m) = motion_for(key) {
+            let n = self.take_count();
+            return std::iter::repeat_n(Select(m), n).collect();
+        }
+
+        if self.g_pending {
+            self.g_pending = false;
+            return match key {
+                "u" => self.visual_op(Operator::Lower),
+                "U" => self.visual_op(Operator::Upper),
+                "~" => self.visual_op(Operator::ToggleCase),
+                "g" => vec![Select(Motion::DocStart)],
+                _ => vec![],
+            };
+        }
+
         match key {
-            "d" | "x" => {
+            "g" => {
+                self.g_pending = true;
+                vec![]
+            }
+            "\"" => {
+                self.register_pending = true;
+                vec![]
+            }
+            "r" => {
+                self.replace_pending = true;
+                vec![]
+            }
+            "d" | "x" => self.visual_op(Operator::Delete),
+            "y" => self.visual_op(Operator::Yank),
+            "u" => self.visual_op(Operator::Lower),
+            "U" => self.visual_op(Operator::Upper),
+            "~" => self.visual_op(Operator::ToggleCase),
+            ">" => self.visual_op(Operator::Indent),
+            "<" => self.visual_op(Operator::Outdent),
+            "c" | "s" => {
+                self.enter_insert();
+                vec![self.op(Operator::Change, Target::Selection)]
+            }
+            "D" | "X" => {
+                self.mode = EditMode::VisualLine;
+                let cmd = self.op(Operator::Delete, Target::Selection);
                 self.mode = EditMode::Normal;
-                vec![DeleteSelection, SetMode(EditMode::Normal)]
+                vec![
+                    SetMode(EditMode::VisualLine),
+                    cmd,
+                    SetMode(EditMode::Normal),
+                ]
             }
-            "c" => {
-                self.mode = EditMode::Insert;
-                vec![DeleteSelection, SetMode(EditMode::Insert)]
+            "C" | "S" | "R" => {
+                self.enter_insert();
+                let cmd = self.op(Operator::Change, Target::Selection);
+                vec![SetMode(EditMode::VisualLine), cmd]
             }
-            "y" => {
+            "Y" => {
                 self.mode = EditMode::Normal;
-                vec![Yank]
+                let cmd = self.op(Operator::Yank, Target::Selection);
+                vec![
+                    SetMode(EditMode::VisualLine),
+                    cmd,
+                    SetMode(EditMode::Normal),
+                ]
             }
-            "v" | "V" | "Escape" => {
+            "J" => {
+                self.mode = EditMode::Normal;
+                vec![
+                    JoinLines {
+                        count: 2,
+                        spaces: true,
+                    },
+                    SetMode(EditMode::Normal),
+                ]
+            }
+            "p" | "P" => {
+                self.mode = EditMode::Normal;
+                vec![Put {
+                    before: key == "P",
+                    count: self.take_count(),
+                    register: self.take_register(),
+                }]
+            }
+            "o" => vec![SwapSelectionEnds],
+            "v" => {
+                self.mode = if self.mode == EditMode::Visual {
+                    EditMode::Normal
+                } else {
+                    EditMode::Visual
+                };
+                vec![SetMode(self.mode)]
+            }
+            "V" => {
+                self.mode = if self.mode == EditMode::VisualLine {
+                    EditMode::Normal
+                } else {
+                    EditMode::VisualLine
+                };
+                vec![SetMode(self.mode)]
+            }
+            "Escape" => {
+                self.reset();
                 self.mode = EditMode::Normal;
                 vec![SetMode(EditMode::Normal)]
             }
             _ => vec![],
         }
+    }
+
+    fn visual_op(&mut self, operator: Operator) -> Vec<EditCommand> {
+        self.mode = EditMode::Normal;
+        let cmd = self.op(operator, Target::Selection);
+        vec![cmd, EditCommand::SetMode(EditMode::Normal)]
     }
 
     fn insert(&mut self, k: &KeyInput) -> Vec<EditCommand> {
@@ -337,9 +563,21 @@ impl Keymap for VimKeymap {
         #[cfg(target_os = "macos")]
         if k.mods.meta && !k.mods.ctrl && !k.mods.alt {
             let command = match k.key.to_ascii_lowercase().as_str() {
-                "c" => Some(EditCommand::Yank),
-                "x" => Some(EditCommand::Cut),
-                "v" => Some(EditCommand::Paste),
+                "c" => Some(EditCommand::Op {
+                    operator: Operator::Yank,
+                    target: Target::Selection,
+                    register: None,
+                }),
+                "x" => Some(EditCommand::Op {
+                    operator: Operator::Delete,
+                    target: Target::Selection,
+                    register: None,
+                }),
+                "v" => Some(EditCommand::Put {
+                    before: true,
+                    count: 1,
+                    register: None,
+                }),
                 "a" => Some(EditCommand::Move(Motion::DocStart)),
                 "s" => Some(EditCommand::Save),
                 "z" if k.mods.shift => Some(EditCommand::Redo),
@@ -394,6 +632,7 @@ impl Keymap for VimKeymap {
                     ]
                 }
                 EditMode::Visual | EditMode::VisualLine => {
+                    self.reset();
                     self.mode = EditMode::Normal;
                     vec![EditCommand::SetMode(EditMode::Normal)]
                 }
@@ -426,65 +665,78 @@ mod tests {
             repeat: false,
         }
     }
-    fn ctrl(key: &str) -> KeyInput {
+    fn chord(key: &str, mods: Mods) -> KeyInput {
         KeyInput {
             key: key.into(),
-            mods: Mods {
-                ctrl: true,
-                ..Default::default()
-            },
+            mods,
             repeat: false,
         }
     }
-    #[cfg(target_os = "macos")]
-    fn command(key: &str) -> KeyInput {
-        KeyInput {
-            key: key.into(),
-            mods: Mods {
-                meta: true,
-                ..Default::default()
-            },
-            repeat: false,
+    fn ctrl() -> Mods {
+        Mods {
+            ctrl: true,
+            ..Default::default()
+        }
+    }
+    fn run(km: &mut VimKeymap, seq: &[&str]) -> Vec<EditCommand> {
+        let mut out = Vec::new();
+        for s in seq {
+            out.extend(km.handle(&k(s)));
+        }
+        out
+    }
+    fn op(operator: Operator, target: Target) -> EditCommand {
+        EditCommand::Op {
+            operator,
+            target,
+            register: None,
         }
     }
 
     #[test]
-    fn dw_deletes_word() {
+    fn operators_pair_with_motions_and_doubled_keys() {
         let mut km = VimKeymap::default();
-        assert_eq!(km.handle(&k("d")), vec![]);
         assert_eq!(
-            km.handle(&k("w")),
-            vec![EditCommand::DeleteRange(Motion::WordNext)]
+            run(&mut km, &["d", "w"]),
+            vec![op(Operator::Delete, Target::Motion(Motion::WordNext, 1))]
         );
+        assert_eq!(
+            run(&mut km, &["d", "d"]),
+            vec![op(Operator::Delete, Target::Line(1))]
+        );
+        assert_eq!(
+            run(&mut km, &["y", "y"]),
+            vec![op(Operator::Yank, Target::Line(1))]
+        );
+        assert_eq!(
+            run(&mut km, &["c", "c"]),
+            vec![op(Operator::Change, Target::Line(1))]
+        );
+        assert_eq!(km.mode(), EditMode::Insert);
     }
 
     #[test]
-    fn dd_deletes_line() {
+    fn counts_multiply_across_operator_and_motion() {
         let mut km = VimKeymap::default();
-        km.handle(&k("d"));
-        assert_eq!(km.handle(&k("d")), vec![EditCommand::DeleteLine]);
-    }
-
-    #[test]
-    fn za_toggles_fold() {
-        let mut km = VimKeymap::default();
-        assert_eq!(km.handle(&k("z")), vec![]);
-        assert_eq!(km.handle(&k("a")), vec![EditCommand::FoldToggle]);
-    }
-
-    #[test]
-    fn zr_unfolds_all() {
-        let mut km = VimKeymap::default();
-        km.handle(&k("z"));
-        assert_eq!(km.handle(&k("R")), vec![EditCommand::UnfoldAll]);
+        assert_eq!(
+            run(&mut km, &["d", "3", "w"]),
+            vec![op(Operator::Delete, Target::Motion(Motion::WordNext, 3))]
+        );
+        assert_eq!(
+            run(&mut km, &["2", "d", "3", "w"]),
+            vec![op(Operator::Delete, Target::Motion(Motion::WordNext, 6))]
+        );
+        assert_eq!(
+            run(&mut km, &["2", "d", "d"]),
+            vec![op(Operator::Delete, Target::Line(2))]
+        );
     }
 
     #[test]
     fn count_repeats_motion() {
         let mut km = VimKeymap::default();
-        assert_eq!(km.handle(&k("3")), vec![]);
         assert_eq!(
-            km.handle(&k("j")),
+            run(&mut km, &["3", "j"]),
             vec![
                 EditCommand::Move(Motion::Down),
                 EditCommand::Move(Motion::Down),
@@ -494,37 +746,248 @@ mod tests {
     }
 
     #[test]
-    fn document_jump_bindings() {
+    fn register_prefix_routes_yank_and_put() {
         let mut km = VimKeymap::default();
-        assert_eq!(km.handle(&k("G")), vec![EditCommand::Move(Motion::DocEnd)]);
-        assert_eq!(km.handle(&k("g")), vec![]);
         assert_eq!(
-            km.handle(&k("g")),
-            vec![EditCommand::Move(Motion::DocStart)]
+            run(&mut km, &["\"", "a", "y", "y"]),
+            vec![EditCommand::Op {
+                operator: Operator::Yank,
+                target: Target::Line(1),
+                register: Some('a'),
+            }]
         );
-        assert_eq!(km.handle(&k("4")), vec![]);
         assert_eq!(
-            km.handle(&k("G")),
-            vec![EditCommand::Move(Motion::GotoLine(3))]
+            run(&mut km, &["\"", "a", "p"]),
+            vec![EditCommand::Put {
+                before: false,
+                count: 1,
+                register: Some('a'),
+            }]
         );
     }
 
     #[test]
-    fn i_enters_insert() {
+    fn indent_operators_use_doubled_keys() {
         let mut km = VimKeymap::default();
         assert_eq!(
-            km.handle(&k("i")),
+            run(&mut km, &[">", ">"]),
+            vec![op(Operator::Indent, Target::Line(1))]
+        );
+        assert_eq!(
+            run(&mut km, &["3", "<", "<"]),
+            vec![op(Operator::Outdent, Target::Line(3))]
+        );
+    }
+
+    #[test]
+    fn g_prefixed_case_operators() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["g", "u", "w"]),
+            vec![op(Operator::Lower, Target::Motion(Motion::WordNext, 1))]
+        );
+        assert_eq!(
+            run(&mut km, &["g", "U", "U"]),
+            vec![op(Operator::Upper, Target::Line(1))]
+        );
+    }
+
+    #[test]
+    fn join_replace_and_toggle_case() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["3", "J"]),
+            vec![EditCommand::JoinLines {
+                count: 3,
+                spaces: true
+            }]
+        );
+        assert_eq!(
+            run(&mut km, &["g", "J"]),
+            vec![EditCommand::JoinLines {
+                count: 1,
+                spaces: false
+            }]
+        );
+        assert_eq!(
+            run(&mut km, &["2", "r", "x"]),
+            vec![EditCommand::ReplaceChar { ch: 'x', count: 2 }]
+        );
+        assert_eq!(
+            run(&mut km, &["~"]),
+            vec![
+                op(Operator::ToggleCase, Target::Motion(Motion::Right, 1)),
+                EditCommand::Move(Motion::RightBounded)
+            ]
+        );
+    }
+
+    #[test]
+    fn shift_d_c_s_and_y_bindings() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["D"]),
+            vec![op(Operator::Delete, Target::Motion(Motion::LineEnd, 1))]
+        );
+        assert_eq!(
+            run(&mut km, &["C"]),
+            vec![op(Operator::Change, Target::Motion(Motion::LineEnd, 1))]
+        );
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["S"]),
+            vec![op(Operator::Change, Target::Line(1))]
+        );
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["2", "Y"]),
+            vec![op(Operator::Yank, Target::Line(2))]
+        );
+        assert_eq!(
+            run(&mut km, &["3", "x"]),
+            vec![op(Operator::Delete, Target::Motion(Motion::Right, 3))]
+        );
+    }
+
+    #[test]
+    fn put_carries_a_count_and_direction() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["2", "p"]),
+            vec![EditCommand::Put {
+                before: false,
+                count: 2,
+                register: None
+            }]
+        );
+        assert_eq!(
+            run(&mut km, &["P"]),
+            vec![EditCommand::Put {
+                before: true,
+                count: 1,
+                register: None
+            }]
+        );
+    }
+
+    #[test]
+    fn open_line_replaces_the_newline_dance() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["o"]),
+            vec![EditCommand::OpenLine { above: false }]
+        );
+        assert_eq!(km.mode(), EditMode::Insert);
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["O"]),
+            vec![EditCommand::OpenLine { above: true }]
+        );
+    }
+
+    #[test]
+    fn visual_operators_act_on_the_selection() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["v"]),
+            vec![EditCommand::SetMode(EditMode::Visual)]
+        );
+        assert_eq!(
+            run(&mut km, &["l"]),
+            vec![EditCommand::Select(Motion::RightBounded)]
+        );
+        assert_eq!(
+            run(&mut km, &["y"]),
+            vec![
+                op(Operator::Yank, Target::Selection),
+                EditCommand::SetMode(EditMode::Normal)
+            ]
+        );
+        assert_eq!(km.mode(), EditMode::Normal);
+    }
+
+    #[test]
+    fn visual_motions_take_counts() {
+        let mut km = VimKeymap::default();
+        run(&mut km, &["v"]);
+        assert_eq!(
+            run(&mut km, &["3", "j"]),
+            vec![
+                EditCommand::Select(Motion::Down),
+                EditCommand::Select(Motion::Down),
+                EditCommand::Select(Motion::Down)
+            ]
+        );
+    }
+
+    #[test]
+    fn visual_indent_and_swap_ends() {
+        let mut km = VimKeymap::default();
+        run(&mut km, &["v"]);
+        assert_eq!(run(&mut km, &["o"]), vec![EditCommand::SwapSelectionEnds]);
+        assert_eq!(
+            run(&mut km, &[">"]),
+            vec![
+                op(Operator::Indent, Target::Selection),
+                EditCommand::SetMode(EditMode::Normal)
+            ]
+        );
+    }
+
+    #[test]
+    fn document_jump_bindings() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["g", "g"]),
+            vec![EditCommand::Move(Motion::DocStart)]
+        );
+        assert_eq!(
+            run(&mut km, &["G"]),
+            vec![EditCommand::Move(Motion::DocEnd)]
+        );
+        assert_eq!(
+            run(&mut km, &["5", "G"]),
+            vec![EditCommand::Move(Motion::GotoLine(4))]
+        );
+        assert_eq!(
+            run(&mut km, &["5", "g", "g"]),
+            vec![EditCommand::Move(Motion::GotoLine(4))]
+        );
+    }
+
+    #[test]
+    fn braces_move_by_paragraph() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["{"]),
+            vec![EditCommand::Move(Motion::ParagraphPrev)]
+        );
+        assert_eq!(
+            run(&mut km, &["}"]),
+            vec![EditCommand::Move(Motion::ParagraphNext)]
+        );
+    }
+
+    #[test]
+    fn fold_and_lsp_bindings() {
+        let mut km = VimKeymap::default();
+        assert_eq!(run(&mut km, &["z", "a"]), vec![EditCommand::FoldToggle]);
+        assert_eq!(run(&mut km, &["z", "R"]), vec![EditCommand::UnfoldAll]);
+        assert_eq!(run(&mut km, &["g", "d"]), vec![EditCommand::GotoDefinition]);
+        assert_eq!(run(&mut km, &["g", "r"]), vec![EditCommand::FindReferences]);
+        assert_eq!(run(&mut km, &["K"]), vec![EditCommand::Hover]);
+    }
+
+    #[test]
+    fn insert_mode_entry_and_escape() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["i"]),
             vec![EditCommand::SetMode(EditMode::Insert)]
         );
         assert_eq!(km.mode(), EditMode::Insert);
-    }
-
-    #[test]
-    fn esc_in_insert_returns_normal_and_steps_left() {
-        let mut km = VimKeymap::default();
-        km.handle(&k("i"));
         assert_eq!(
-            km.handle(&k("Escape")),
+            run(&mut km, &["Escape"]),
             vec![
                 EditCommand::Move(Motion::LeftBounded),
                 EditCommand::SetMode(EditMode::Normal)
@@ -534,18 +997,72 @@ mod tests {
     }
 
     #[test]
-    fn visual_select_and_yank() {
+    fn arrow_keys_navigate_in_normal_mode() {
         let mut km = VimKeymap::default();
         assert_eq!(
-            km.handle(&k("v")),
-            vec![EditCommand::SetMode(EditMode::Visual)]
+            run(&mut km, &["ArrowDown"]),
+            vec![EditCommand::Move(Motion::Down)]
+        );
+    }
+
+    #[test]
+    fn ctrl_navigation_never_falls_through_to_vim_commands() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            km.handle(&chord("n", ctrl())),
+            vec![EditCommand::Move(Motion::Down)]
         );
         assert_eq!(
-            km.handle(&k("l")),
-            vec![EditCommand::Select(Motion::RightBounded)]
+            km.handle(&chord("p", ctrl())),
+            vec![EditCommand::Move(Motion::Up)]
         );
-        assert_eq!(km.handle(&k("y")), vec![EditCommand::Yank]);
         assert_eq!(km.mode(), EditMode::Normal);
+    }
+
+    #[test]
+    fn ctrl_e_y_scroll_the_viewport_with_counts() {
+        let mut km = VimKeymap::default();
+        run(&mut km, &["3"]);
+        assert_eq!(
+            km.handle(&chord("e", ctrl())),
+            vec![EditCommand::ScrollViewport(3)]
+        );
+        assert_eq!(
+            km.handle(&chord("y", ctrl())),
+            vec![EditCommand::ScrollViewport(-1)]
+        );
+    }
+
+    #[test]
+    fn ctrl_r_redoes() {
+        let mut km = VimKeymap::default();
+        assert_eq!(km.handle(&chord("r", ctrl())), vec![EditCommand::Redo]);
+    }
+
+    #[test]
+    fn ctrl_c_escapes_insert_and_visual() {
+        let mut km = VimKeymap::default();
+        run(&mut km, &["i"]);
+        assert_eq!(
+            km.handle(&chord("c", ctrl())),
+            vec![
+                EditCommand::Move(Motion::LeftBounded),
+                EditCommand::SetMode(EditMode::Normal)
+            ]
+        );
+        run(&mut km, &["v"]);
+        assert_eq!(
+            km.handle(&chord("c", ctrl())),
+            vec![EditCommand::SetMode(EditMode::Normal)]
+        );
+        assert_eq!(km.mode(), EditMode::Normal);
+    }
+
+    #[test]
+    fn ex_write_saves() {
+        let mut km = VimKeymap::default();
+        assert_eq!(run(&mut km, &[":", "w", "Enter"]), vec![EditCommand::Save]);
+        assert_eq!(run(&mut km, &[":", "q", "Enter"]), vec![]);
     }
 
     #[test]
@@ -559,161 +1076,6 @@ mod tests {
         assert_eq!(
             km.pointer_selection_mode(false),
             Some(EditCommand::SetMode(EditMode::Normal))
-        );
-        assert_eq!(km.mode(), EditMode::Normal);
-    }
-
-    #[test]
-    fn o_opens_line_below() {
-        let mut km = VimKeymap::default();
-        assert_eq!(
-            km.handle(&k("o")),
-            vec![
-                EditCommand::Move(Motion::LineEnd),
-                EditCommand::InsertNewline,
-                EditCommand::SetMode(EditMode::Insert)
-            ]
-        );
-    }
-
-    #[test]
-    fn ctrl_r_redo() {
-        let mut km = VimKeymap::default();
-        assert_eq!(km.handle(&ctrl("r")), vec![EditCommand::Redo]);
-    }
-
-    #[test]
-    fn ctrl_navigation_never_falls_through_to_vim_commands() {
-        let mut km = VimKeymap::default();
-        assert_eq!(km.handle(&ctrl("n")), vec![EditCommand::Move(Motion::Down)]);
-        assert_eq!(km.handle(&ctrl("p")), vec![EditCommand::Move(Motion::Up)]);
-        km.mode = EditMode::Insert;
-        assert_eq!(km.handle(&ctrl("p")), vec![EditCommand::Move(Motion::Up)]);
-    }
-
-    #[test]
-    fn ctrl_e_y_scroll_the_viewport_with_counts() {
-        let mut km = VimKeymap::default();
-        assert_eq!(km.handle(&ctrl("e")), vec![EditCommand::ScrollViewport(1)]);
-        km.handle(&k("3"));
-        assert_eq!(km.handle(&ctrl("y")), vec![EditCommand::ScrollViewport(-3)]);
-        km.mode = EditMode::Insert;
-        assert_eq!(km.handle(&ctrl("e")), vec![EditCommand::ScrollViewport(1)]);
-        assert_eq!(km.handle(&ctrl("y")), vec![EditCommand::ScrollViewport(-1)]);
-    }
-
-    #[test]
-    fn arrow_keys_navigate_in_normal_mode() {
-        let mut km = VimKeymap::default();
-        assert_eq!(
-            km.handle(&k("ArrowRight")),
-            vec![EditCommand::Move(Motion::RightBounded)]
-        );
-        assert_eq!(
-            km.handle(&k("ArrowDown")),
-            vec![EditCommand::Move(Motion::Down)]
-        );
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn command_z_undoes_in_vim_modes() {
-        let mut km = VimKeymap::default();
-        assert_eq!(km.handle(&command("z")), vec![EditCommand::Undo]);
-        km.mode = EditMode::Insert;
-        assert_eq!(km.handle(&command("z")), vec![EditCommand::Undo]);
-    }
-
-    #[test]
-    fn dw_count_repeats() {
-        let mut km = VimKeymap::default();
-        km.handle(&k("d"));
-        km.handle(&k("2"));
-        assert_eq!(
-            km.handle(&k("w")),
-            vec![
-                EditCommand::DeleteRange(Motion::WordNext),
-                EditCommand::DeleteRange(Motion::WordNext)
-            ]
-        );
-    }
-
-    #[test]
-    fn lsp_actions() {
-        let mut km = VimKeymap::default();
-        km.handle(&k("g"));
-        assert_eq!(km.handle(&k("d")), vec![EditCommand::GotoDefinition]);
-        km.handle(&k("g"));
-        assert_eq!(km.handle(&k("r")), vec![EditCommand::FindReferences]);
-        assert_eq!(km.handle(&k("K")), vec![EditCommand::Hover]);
-    }
-
-    #[test]
-    fn ex_write_saves() {
-        let mut km = VimKeymap::default();
-        km.handle(&k(":"));
-        km.handle(&k("w"));
-        assert_eq!(km.handle(&k("Enter")), vec![EditCommand::Save]);
-    }
-
-    #[test]
-    fn ctrl_c_acts_as_escape_from_insert() {
-        let mut km = VimKeymap::default();
-        km.handle(&k("i"));
-        assert_eq!(km.mode(), EditMode::Insert);
-        assert_eq!(
-            km.handle(&ctrl("c")),
-            vec![
-                EditCommand::Move(Motion::LeftBounded),
-                EditCommand::SetMode(EditMode::Normal)
-            ]
-        );
-        assert_eq!(km.mode(), EditMode::Normal);
-    }
-
-    #[test]
-    fn ctrl_c_escapes_visual() {
-        let mut km = VimKeymap::default();
-        km.handle(&k("v"));
-        assert_eq!(
-            km.handle(&ctrl("c")),
-            vec![EditCommand::SetMode(EditMode::Normal)]
-        );
-        assert_eq!(km.mode(), EditMode::Normal);
-    }
-
-    #[test]
-    fn shift_d_c_and_s_bindings() {
-        let mut km = VimKeymap::default();
-        assert_eq!(km.handle(&k("D")), vec![EditCommand::DeleteToLineEnd]);
-        assert_eq!(
-            km.handle(&k("C")),
-            vec![
-                EditCommand::DeleteToLineEnd,
-                EditCommand::SetMode(EditMode::Insert)
-            ]
-        );
-        km.handle(&k("Escape"));
-        km.mode = EditMode::Normal;
-        assert_eq!(
-            km.handle(&k("s")),
-            vec![
-                EditCommand::DeleteForward,
-                EditCommand::SetMode(EditMode::Insert)
-            ]
-        );
-    }
-
-    #[test]
-    fn braces_move_by_paragraph() {
-        let mut km = VimKeymap::default();
-        assert_eq!(
-            km.handle(&k("}")),
-            vec![EditCommand::Move(Motion::ParagraphNext)]
-        );
-        assert_eq!(
-            km.handle(&k("{")),
-            vec![EditCommand::Move(Motion::ParagraphPrev)]
         );
     }
 }

--- a/crates/vmux_editor/src/keymap/vim.rs
+++ b/crates/vmux_editor/src/keymap/vim.rs
@@ -61,6 +61,7 @@ pub struct VimKeymap {
     macro_record: Option<(char, Vec<Recorded>)>,
     macros: std::collections::HashMap<char, Vec<Recorded>>,
     last_macro: Option<char>,
+    insert_after_next: bool,
 }
 
 fn motion_for(key: &str) -> Option<Motion> {
@@ -795,6 +796,39 @@ impl VimKeymap {
 
     fn insert(&mut self, k: &KeyInput) -> Vec<EditCommand> {
         use EditCommand::*;
+
+        if self.register_pending {
+            self.register_pending = false;
+            let Some(reg) = single_char(&k.key) else {
+                return vec![];
+            };
+            return vec![Put {
+                before: true,
+                count: 1,
+                register: Some(reg),
+            }];
+        }
+
+        if k.mods.ctrl && !k.mods.meta && !k.mods.alt {
+            return match k.key.to_ascii_lowercase().as_str() {
+                "w" => vec![DeleteWordBack],
+                "h" => vec![DeleteBack],
+                "u" => vec![self.op(Operator::Delete, Target::Motion(Motion::LineStart, 1))],
+                "t" => vec![self.op(Operator::Indent, Target::Line(1))],
+                "d" => vec![self.op(Operator::Outdent, Target::Line(1))],
+                "r" => {
+                    self.register_pending = true;
+                    vec![]
+                }
+                "o" => {
+                    self.mode = EditMode::Normal;
+                    self.insert_after_next = true;
+                    vec![SetMode(EditMode::Normal)]
+                }
+                _ => vec![],
+            };
+        }
+
         match k.key.as_str() {
             "Escape" => {
                 self.mode = EditMode::Normal;
@@ -911,6 +945,17 @@ impl Keymap for VimKeymap {
 impl VimKeymap {
     /// Interpret one key without any dot-repeat or macro bookkeeping.
     fn dispatch(&mut self, k: &KeyInput) -> Vec<EditCommand> {
+        let armed = self.insert_after_next;
+        let mut cmds = self.dispatch_inner(k);
+        if armed && self.mode == EditMode::Normal && self.is_idle() && !cmds.is_empty() {
+            self.insert_after_next = false;
+            self.mode = EditMode::Insert;
+            cmds.push(EditCommand::SetMode(EditMode::Insert));
+        }
+        cmds
+    }
+
+    fn dispatch_inner(&mut self, k: &KeyInput) -> Vec<EditCommand> {
         #[cfg(target_os = "macos")]
         if k.mods.meta && !k.mods.ctrl && !k.mods.alt {
             let command = match k.key.to_ascii_lowercase().as_str() {
@@ -945,7 +990,7 @@ impl VimKeymap {
                 };
             }
         }
-        if k.mods.ctrl && !k.mods.meta && !k.mods.alt {
+        if k.mods.ctrl && !k.mods.meta && !k.mods.alt && !self.mode.accepts_text() {
             let direction = match k.key.to_ascii_lowercase().as_str() {
                 "e" => Some(1),
                 "y" => Some(-1),
@@ -1351,6 +1396,66 @@ mod tests {
     fn replaying_an_empty_register_is_inert() {
         let mut km = VimKeymap::default();
         assert_eq!(run(&mut km, &["@", "z"]), vec![]);
+    }
+
+    #[test]
+    fn insert_mode_editing_chords() {
+        let mut km = VimKeymap::default();
+        run(&mut km, &["i"]);
+        assert_eq!(
+            km.handle(&chord("w", ctrl())),
+            vec![EditCommand::DeleteWordBack]
+        );
+        assert_eq!(
+            km.handle(&chord("u", ctrl())),
+            vec![op(Operator::Delete, Target::Motion(Motion::LineStart, 1))]
+        );
+        assert_eq!(
+            km.handle(&chord("t", ctrl())),
+            vec![op(Operator::Indent, Target::Line(1))]
+        );
+        assert_eq!(km.mode(), EditMode::Insert);
+    }
+
+    #[test]
+    fn ctrl_r_pastes_a_register_while_inserting() {
+        let mut km = VimKeymap::default();
+        run(&mut km, &["i"]);
+        assert_eq!(km.handle(&chord("r", ctrl())), vec![]);
+        assert_eq!(
+            run(&mut km, &["a"]),
+            vec![EditCommand::Put {
+                before: true,
+                count: 1,
+                register: Some('a'),
+            }]
+        );
+    }
+
+    #[test]
+    fn ctrl_o_runs_one_normal_command_then_returns_to_insert() {
+        let mut km = VimKeymap::default();
+        run(&mut km, &["i"]);
+        assert_eq!(
+            km.handle(&chord("o", ctrl())),
+            vec![EditCommand::SetMode(EditMode::Normal)]
+        );
+        assert_eq!(km.mode(), EditMode::Normal);
+        assert_eq!(
+            run(&mut km, &["$"]),
+            vec![
+                EditCommand::Move(Motion::LineEnd),
+                EditCommand::SetMode(EditMode::Insert),
+            ]
+        );
+        assert_eq!(km.mode(), EditMode::Insert);
+    }
+
+    #[test]
+    fn scroll_chords_do_not_fire_while_inserting() {
+        let mut km = VimKeymap::default();
+        run(&mut km, &["i"]);
+        assert_eq!(km.handle(&chord("e", ctrl())), vec![]);
     }
 
     #[test]

--- a/crates/vmux_editor/src/keymap/vim.rs
+++ b/crates/vmux_editor/src/keymap/vim.rs
@@ -91,6 +91,8 @@ fn motion_for(key: &str) -> Option<Motion> {
         "{" => Motion::ParagraphPrev,
         "}" => Motion::ParagraphNext,
         "%" => Motion::MatchPair,
+        "n" => Motion::SearchNext { reverse: false },
+        "N" => Motion::SearchNext { reverse: true },
         "H" => Motion::ScreenTop,
         "M" => Motion::ScreenMiddle,
         "L" => Motion::ScreenBottom,
@@ -533,6 +535,8 @@ impl VimKeymap {
                 self.last_change = body;
                 out
             }
+            "*" => vec![SearchWord { forward: true }],
+            "#" => vec![SearchWord { forward: false }],
             "m" => {
                 self.mark_pending = Some(MarkAction::Set);
                 vec![]
@@ -1519,6 +1523,39 @@ mod tests {
         let mut km = VimKeymap::default();
         run(&mut km, &["i"]);
         assert_eq!(km.handle(&chord("e", ctrl())), vec![]);
+    }
+
+    #[test]
+    fn search_repeat_and_word_search_bindings() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["n"]),
+            vec![EditCommand::Move(Motion::SearchNext { reverse: false })]
+        );
+        assert_eq!(
+            run(&mut km, &["N"]),
+            vec![EditCommand::Move(Motion::SearchNext { reverse: true })]
+        );
+        assert_eq!(
+            run(&mut km, &["*"]),
+            vec![EditCommand::SearchWord { forward: true }]
+        );
+        assert_eq!(
+            run(&mut km, &["#"]),
+            vec![EditCommand::SearchWord { forward: false }]
+        );
+    }
+
+    #[test]
+    fn an_operator_can_target_the_next_match() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["d", "n"]),
+            vec![op(
+                Operator::Delete,
+                Target::Motion(Motion::SearchNext { reverse: false }, 1)
+            )]
+        );
     }
 
     #[test]

--- a/crates/vmux_editor/src/keymap/vim.rs
+++ b/crates/vmux_editor/src/keymap/vim.rs
@@ -1,5 +1,13 @@
 use crate::edit::command::{EditCommand, EditMode, Motion, Operator, Target};
+use crate::edit::text_object::{TextObject, TextObjectKind};
 use crate::keymap::{KeyInput, Keymap};
+
+/// Whether a pending `i`/`a` prefix selects the object's interior or includes its delimiters.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ObjectScope {
+    Inner,
+    Around,
+}
 
 #[derive(Default)]
 pub struct VimKeymap {
@@ -8,6 +16,7 @@ pub struct VimKeymap {
     op_count: Option<usize>,
     pending_op: Option<Operator>,
     pending_op_key: Option<char>,
+    pending_object: Option<ObjectScope>,
     register: Option<char>,
     register_pending: bool,
     replace_pending: bool,
@@ -56,6 +65,24 @@ fn operator_for(key: &str) -> Option<(Operator, char)> {
     })
 }
 
+fn text_object_kind(key: &str) -> Option<TextObjectKind> {
+    Some(match key {
+        "w" => TextObjectKind::Word,
+        "W" => TextObjectKind::BigWord,
+        "s" => TextObjectKind::Sentence,
+        "p" => TextObjectKind::Paragraph,
+        "(" | ")" | "b" => TextObjectKind::Paren,
+        "[" | "]" => TextObjectKind::Bracket,
+        "{" | "}" | "B" => TextObjectKind::Brace,
+        "<" | ">" => TextObjectKind::Angle,
+        "\"" => TextObjectKind::DoubleQuote,
+        "'" => TextObjectKind::SingleQuote,
+        "`" => TextObjectKind::BackQuote,
+        "t" => TextObjectKind::Tag,
+        _ => return None,
+    })
+}
+
 fn single_char(key: &str) -> Option<char> {
     let mut chars = key.chars();
     let c = chars.next()?;
@@ -83,6 +110,7 @@ impl VimKeymap {
         self.op_count = None;
         self.pending_op = None;
         self.pending_op_key = None;
+        self.pending_object = None;
         self.register = None;
         self.register_pending = false;
         self.replace_pending = false;
@@ -108,8 +136,35 @@ impl VimKeymap {
         }
     }
 
-    /// Apply a pending operator to a motion, a doubled key (`dd`), or abandon it.
+    /// Apply a pending operator to a motion, a text object, a doubled key (`dd`), or abandon it.
     fn operator_pending(&mut self, operator: Operator, key: &str) -> Vec<EditCommand> {
+        if let Some(scope) = self.pending_object.take() {
+            let count = self.take_operator_count();
+            self.pending_op_key = None;
+            let Some(kind) = text_object_kind(key) else {
+                return vec![];
+            };
+            let target = Target::TextObject(TextObject {
+                kind,
+                around: scope == ObjectScope::Around,
+                count,
+            });
+            if operator == Operator::Change {
+                self.enter_insert();
+            }
+            return vec![self.op(operator, target)];
+        }
+
+        if key == "i" || key == "a" {
+            self.pending_object = Some(if key == "i" {
+                ObjectScope::Inner
+            } else {
+                ObjectScope::Around
+            });
+            self.pending_op = Some(operator);
+            return vec![];
+        }
+
         let doubled = single_char(key)
             .zip(self.pending_op_key)
             .is_some_and(|(a, b)| a == b);
@@ -345,6 +400,18 @@ impl VimKeymap {
         use EditCommand::*;
         let key = k.key.as_str();
 
+        if let Some(scope) = self.pending_object.take() {
+            let count = self.take_count();
+            let Some(kind) = text_object_kind(key) else {
+                return vec![];
+            };
+            return vec![SelectTextObject(TextObject {
+                kind,
+                around: scope == ObjectScope::Around,
+                count,
+            })];
+        }
+
         if self.register_pending {
             self.register_pending = false;
             if let Some(c) = single_char(key) {
@@ -406,6 +473,14 @@ impl VimKeymap {
             }
             "r" => {
                 self.replace_pending = true;
+                vec![]
+            }
+            "i" | "a" => {
+                self.pending_object = Some(if key == "i" {
+                    ObjectScope::Inner
+                } else {
+                    ObjectScope::Around
+                });
                 vec![]
             }
             "d" | "x" => self.visual_op(Operator::Delete),
@@ -729,6 +804,67 @@ mod tests {
         assert_eq!(
             run(&mut km, &["2", "d", "d"]),
             vec![op(Operator::Delete, Target::Line(2))]
+        );
+    }
+
+    fn object(kind: TextObjectKind, around: bool, count: usize) -> Target {
+        Target::TextObject(TextObject {
+            kind,
+            around,
+            count,
+        })
+    }
+
+    #[test]
+    fn operators_take_text_objects() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["d", "i", "w"]),
+            vec![op(Operator::Delete, object(TextObjectKind::Word, false, 1))]
+        );
+        assert_eq!(
+            run(&mut km, &["c", "a", "\""]),
+            vec![op(
+                Operator::Change,
+                object(TextObjectKind::DoubleQuote, true, 1)
+            )]
+        );
+        assert_eq!(km.mode(), EditMode::Insert);
+    }
+
+    #[test]
+    fn text_object_counts_come_from_the_operator() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            run(&mut km, &["2", "d", "i", "("]),
+            vec![op(
+                Operator::Delete,
+                object(TextObjectKind::Paren, false, 2)
+            )]
+        );
+    }
+
+    #[test]
+    fn visual_mode_selects_text_objects() {
+        let mut km = VimKeymap::default();
+        run(&mut km, &["v"]);
+        assert_eq!(
+            run(&mut km, &["i", "p"]),
+            vec![EditCommand::SelectTextObject(TextObject {
+                kind: TextObjectKind::Paragraph,
+                around: false,
+                count: 1,
+            })]
+        );
+    }
+
+    #[test]
+    fn an_unknown_object_key_abandons_the_operator() {
+        let mut km = VimKeymap::default();
+        assert_eq!(run(&mut km, &["d", "i", "z"]), vec![]);
+        assert_eq!(
+            run(&mut km, &["d", "w"]),
+            vec![op(Operator::Delete, Target::Motion(Motion::WordNext, 1))]
         );
     }
 

--- a/crates/vmux_editor/src/keymap/vim.rs
+++ b/crates/vmux_editor/src/keymap/vim.rs
@@ -72,6 +72,8 @@ pub struct VimKeymap {
     last_macro: Option<char>,
     insert_after_next: bool,
     mark_pending: Option<MarkAction>,
+    block_insert: Option<bool>,
+    block_text: String,
 }
 
 fn motion_for(key: &str) -> Option<Motion> {
@@ -830,6 +832,11 @@ impl VimKeymap {
                     register: self.take_register(),
                 }]
             }
+            "I" | "A" if self.mode == EditMode::VisualBlock => {
+                self.block_insert = Some(key == "A");
+                self.mode = EditMode::Insert;
+                vec![BeginBlockInsert { after: key == "A" }]
+            }
             "o" => vec![SwapSelectionEnds],
             "v" => {
                 self.mode = if self.mode == EditMode::Visual {
@@ -900,7 +907,15 @@ impl VimKeymap {
         match k.key.as_str() {
             "Escape" => {
                 self.mode = EditMode::Normal;
-                vec![Move(Motion::LeftBounded), SetMode(EditMode::Normal)]
+                let mut cmds = Vec::new();
+                if self.block_insert.take().is_some() {
+                    cmds.push(FinishBlockInsert {
+                        text: std::mem::take(&mut self.block_text),
+                    });
+                }
+                cmds.push(Move(Motion::LeftBounded));
+                cmds.push(SetMode(EditMode::Normal));
+                cmds
             }
             "Backspace" => vec![DeleteBack],
             "Delete" => vec![DeleteForward],
@@ -1011,6 +1026,9 @@ impl Keymap for VimKeymap {
         }
         if let Some((_, body)) = self.macro_record.as_mut() {
             body.push(Recorded::Text(text.to_string()));
+        }
+        if self.block_insert.is_some() {
+            self.block_text.push_str(text);
         }
         self.pending_change.push(Recorded::Text(text.to_string()));
         self.in_change = true;
@@ -1126,6 +1144,15 @@ impl VimKeymap {
                 self.reset();
                 return vec![EditCommand::ScrollViewport(direction * count)];
             }
+            if k.key.eq_ignore_ascii_case("v") {
+                self.reset();
+                self.mode = if self.mode == EditMode::VisualBlock {
+                    EditMode::Normal
+                } else {
+                    EditMode::VisualBlock
+                };
+                return vec![EditCommand::SetMode(self.mode)];
+            }
             if k.key.eq_ignore_ascii_case("o") || k.key == "i" || k.key == "Tab" {
                 let count = self.take_count();
                 self.reset();
@@ -1165,7 +1192,7 @@ impl VimKeymap {
                         EditCommand::SetMode(EditMode::Normal),
                     ]
                 }
-                EditMode::Visual | EditMode::VisualLine => {
+                EditMode::Visual | EditMode::VisualLine | EditMode::VisualBlock => {
                     self.reset();
                     self.mode = EditMode::Normal;
                     vec![EditCommand::SetMode(EditMode::Normal)]
@@ -1181,7 +1208,7 @@ impl VimKeymap {
         }
         match self.mode {
             EditMode::Insert | EditMode::Replace => self.insert(k),
-            EditMode::Visual | EditMode::VisualLine => self.visual(k),
+            EditMode::Visual | EditMode::VisualLine | EditMode::VisualBlock => self.visual(k),
             EditMode::Normal | EditMode::CommandLine => self.normal(k),
         }
     }
@@ -1563,6 +1590,53 @@ mod tests {
                 count: 1,
                 register: Some('a'),
             }]
+        );
+    }
+
+    #[test]
+    fn ctrl_v_toggles_visual_block() {
+        let mut km = VimKeymap::default();
+        assert_eq!(
+            km.handle(&chord("v", ctrl())),
+            vec![EditCommand::SetMode(EditMode::VisualBlock)]
+        );
+        assert_eq!(km.mode(), EditMode::VisualBlock);
+        assert_eq!(
+            km.handle(&chord("v", ctrl())),
+            vec![EditCommand::SetMode(EditMode::Normal)]
+        );
+    }
+
+    #[test]
+    fn block_insert_starts_then_replicates_on_escape() {
+        let mut km = VimKeymap::default();
+        km.handle(&chord("v", ctrl()));
+        assert_eq!(
+            run(&mut km, &["I"]),
+            vec![EditCommand::BeginBlockInsert { after: false }]
+        );
+        assert_eq!(km.mode(), EditMode::Insert);
+        km.record_text("xy");
+        assert_eq!(
+            run(&mut km, &["Escape"]),
+            vec![
+                EditCommand::FinishBlockInsert { text: "xy".into() },
+                EditCommand::Move(Motion::LeftBounded),
+                EditCommand::SetMode(EditMode::Normal),
+            ]
+        );
+    }
+
+    #[test]
+    fn block_operators_route_through_the_selection() {
+        let mut km = VimKeymap::default();
+        km.handle(&chord("v", ctrl()));
+        assert_eq!(
+            run(&mut km, &["d"]),
+            vec![
+                op(Operator::Delete, Target::Selection),
+                EditCommand::SetMode(EditMode::Normal)
+            ]
         );
     }
 

--- a/crates/vmux_editor/src/keymap/vim.rs
+++ b/crates/vmux_editor/src/keymap/vim.rs
@@ -201,6 +201,10 @@ impl VimKeymap {
         self.replace_pending = false;
         self.g_pending = false;
         self.z_pending = false;
+        // An abandoned prompt would otherwise keep eating every key with no way back.
+        if self.ex.take().is_some() {
+            self.mode = self.mode_before_ex;
+        }
     }
 
     /// No operator or prefix is half-typed. A pending count still counts as a command start,

--- a/crates/vmux_editor/src/keymap/vim.rs
+++ b/crates/vmux_editor/src/keymap/vim.rs
@@ -536,6 +536,10 @@ impl VimKeymap {
                 self.last_change = body;
                 out
             }
+            "R" => {
+                self.mode = EditMode::Replace;
+                vec![SetMode(EditMode::Replace)]
+            }
             "*" => vec![SearchWord { forward: true }],
             "#" => vec![SearchWord { forward: false }],
             "m" => {
@@ -1154,7 +1158,7 @@ impl VimKeymap {
                 return vec![];
             }
             return match self.mode {
-                EditMode::Insert => {
+                EditMode::Insert | EditMode::Replace => {
                     self.mode = EditMode::Normal;
                     vec![
                         EditCommand::Move(Motion::LeftBounded),
@@ -1176,7 +1180,7 @@ impl VimKeymap {
             return self.ex_key(k);
         }
         match self.mode {
-            EditMode::Insert => self.insert(k),
+            EditMode::Insert | EditMode::Replace => self.insert(k),
             EditMode::Visual | EditMode::VisualLine => self.visual(k),
             EditMode::Normal | EditMode::CommandLine => self.normal(k),
         }

--- a/crates/vmux_editor/src/keymap/vim.rs
+++ b/crates/vmux_editor/src/keymap/vim.rs
@@ -800,11 +800,8 @@ impl VimKeymap {
             return self.repeat_find(key == ",");
         }
 
-        if let Some(m) = motion_for(key) {
-            let n = self.take_count();
-            return std::iter::repeat_n(Select(m), n).collect();
-        }
-
+        // Before `motion_for`, which maps bare `e`, `E` and `_` and would otherwise shadow the
+        // `g`-prefixed arms below and leave `g_pending` set. `normal` orders it the same way.
         if self.g_pending {
             self.g_pending = false;
             return match key {
@@ -817,6 +814,11 @@ impl VimKeymap {
                 "_" => self.motion_command(Motion::LastNonBlank),
                 _ => vec![],
             };
+        }
+
+        if let Some(m) = motion_for(key) {
+            let n = self.take_count();
+            return std::iter::repeat_n(Select(m), n).collect();
         }
 
         match key {
@@ -1055,6 +1057,9 @@ impl VimKeymap {
         };
         match cmd {
             ExCommand::Write => vec![EditCommand::Save],
+            // Closing is a pane operation, and `EditCommand` has no way to ask for one — the
+            // editor cannot close the surface hosting it. `:wq` therefore saves without closing
+            // and `:q` does nothing. Wiring these needs a close command routed to the stack.
             ExCommand::WriteQuit => vec![EditCommand::Save],
             ExCommand::Quit { .. } => vec![],
             ExCommand::NoHighlight => vec![EditCommand::ClearSearchHighlight],
@@ -1521,6 +1526,33 @@ mod tests {
         assert_eq!(
             run(&mut km, &["8", "|"]),
             vec![EditCommand::Move(Motion::Column(8))]
+        );
+    }
+
+    /// `motion_for` maps bare `e`, `E` and `_`, so a visual-mode `g` prefix has to be consumed
+    /// before the motion lookup or it resolves the wrong motion and leaves `g_pending` set.
+    #[test]
+    fn visual_g_prefixed_motions_are_not_shadowed() {
+        let mut km = VimKeymap::default();
+        run(&mut km, &["v"]);
+        assert_eq!(km.mode(), EditMode::Visual);
+
+        assert_eq!(
+            run(&mut km, &["g", "e"]),
+            vec![EditCommand::Select(Motion::WordEndPrev)]
+        );
+        assert_eq!(
+            run(&mut km, &["g", "E"]),
+            vec![EditCommand::Select(Motion::BigWordEndPrev)]
+        );
+        assert_eq!(
+            run(&mut km, &["g", "_"]),
+            vec![EditCommand::Select(Motion::LastNonBlank)]
+        );
+        // The prefix must not leak into the next key.
+        assert_eq!(
+            run(&mut km, &["e"]),
+            vec![EditCommand::Select(Motion::WordEnd)]
         );
     }
 

--- a/crates/vmux_editor/src/keymap/vim.rs
+++ b/crates/vmux_editor/src/keymap/vim.rs
@@ -9,6 +9,34 @@ enum ObjectScope {
     Around,
 }
 
+/// One unit of replayable input.
+///
+/// Dot-repeat and macros both work by replaying what the user typed, and insert-mode characters
+/// bypass the keymap over the IME path, so the stream has to carry both kinds of event.
+#[derive(Clone)]
+enum Recorded {
+    Key(KeyInput),
+    Text(String),
+}
+
+/// Whether a command changes buffer text, which is what `.` repeats. Yanks and motions do not.
+fn is_change(cmd: &EditCommand) -> bool {
+    match cmd {
+        EditCommand::Op { operator, .. } => *operator != Operator::Yank,
+        EditCommand::Put { .. }
+        | EditCommand::ReplaceChar { .. }
+        | EditCommand::JoinLines { .. }
+        | EditCommand::OpenLine { .. }
+        | EditCommand::InsertText(_)
+        | EditCommand::InsertNewline
+        | EditCommand::InsertTab
+        | EditCommand::DeleteBack
+        | EditCommand::DeleteForward
+        | EditCommand::DeleteWordBack => true,
+        _ => false,
+    }
+}
+
 #[derive(Default)]
 pub struct VimKeymap {
     mode: EditMode,
@@ -25,6 +53,14 @@ pub struct VimKeymap {
     g_pending: bool,
     z_pending: bool,
     ex: Option<String>,
+    pending_change: Vec<Recorded>,
+    last_change: Vec<Recorded>,
+    in_change: bool,
+    replaying: bool,
+    macro_pending: Option<bool>,
+    macro_record: Option<(char, Vec<Recorded>)>,
+    macros: std::collections::HashMap<char, Vec<Recorded>>,
+    last_macro: Option<char>,
 }
 
 fn motion_for(key: &str) -> Option<Motion> {
@@ -142,6 +178,43 @@ impl VimKeymap {
         self.z_pending = false;
     }
 
+    /// No operator or prefix is half-typed. A pending count still counts as a command start,
+    /// because a count belongs to the command the next key names rather than to the previous one.
+    fn is_command_start(&self) -> bool {
+        self.pending_op.is_none()
+            && self.pending_object.is_none()
+            && self.pending_find.is_none()
+            && self.macro_pending.is_none()
+            && self.ex.is_none()
+            && !self.register_pending
+            && !self.replace_pending
+            && !self.g_pending
+            && !self.z_pending
+    }
+
+    /// Nothing at all is half-typed, so no keys are owed to a command in progress.
+    fn is_idle(&self) -> bool {
+        self.is_command_start() && self.count.is_none() && self.op_count.is_none()
+    }
+
+    fn replay(&mut self, inputs: &[Recorded], times: usize) -> Vec<EditCommand> {
+        if self.replaying {
+            return vec![];
+        }
+        self.replaying = true;
+        let mut out = Vec::new();
+        for _ in 0..times.max(1) {
+            for input in inputs {
+                match input {
+                    Recorded::Key(k) => out.extend(self.dispatch(k)),
+                    Recorded::Text(t) => out.push(EditCommand::InsertText(t.clone())),
+                }
+            }
+        }
+        self.replaying = false;
+        out
+    }
+
     fn start_operator(&mut self, operator: Operator, key: char) {
         self.pending_op = Some(operator);
         self.pending_op_key = Some(key);
@@ -253,6 +326,30 @@ impl VimKeymap {
 
         if let Some((forward, till)) = self.pending_find.take() {
             return self.resolve_find(forward, till, key);
+        }
+
+        if let Some(record) = self.macro_pending.take() {
+            let Some(reg) = single_char(key) else {
+                return vec![];
+            };
+            if record {
+                self.macro_record = Some((reg, Vec::new()));
+                return vec![];
+            }
+            let reg = if reg == '@' {
+                match self.last_macro {
+                    Some(r) => r,
+                    None => return vec![],
+                }
+            } else {
+                reg
+            };
+            self.last_macro = Some(reg);
+            let Some(body) = self.macros.get(&reg).cloned() else {
+                return vec![];
+            };
+            let times = self.take_count();
+            return self.replay(&body, times);
         }
 
         if self.register_pending {
@@ -384,6 +481,26 @@ impl VimKeymap {
             "|" => {
                 let col = self.take_count();
                 vec![Move(Motion::Column(col))]
+            }
+            "." => {
+                let times = self.take_count();
+                let body = std::mem::take(&mut self.last_change);
+                let out = self.replay(&body, times);
+                self.last_change = body;
+                out
+            }
+            "q" => {
+                if let Some((reg, body)) = self.macro_record.take() {
+                    self.macros.insert(reg, body);
+                    self.last_macro = Some(reg);
+                } else {
+                    self.macro_pending = Some(true);
+                }
+                vec![]
+            }
+            "@" => {
+                self.macro_pending = Some(false);
+                vec![]
             }
             "i" => {
                 self.enter_insert();
@@ -729,6 +846,53 @@ impl Keymap for VimKeymap {
     fn mode(&self) -> EditMode {
         self.mode
     }
+    fn record_text(&mut self, text: &str) {
+        if self.replaying {
+            return;
+        }
+        if let Some((_, body)) = self.macro_record.as_mut() {
+            body.push(Recorded::Text(text.to_string()));
+        }
+        self.pending_change.push(Recorded::Text(text.to_string()));
+        self.in_change = true;
+    }
+    fn handle(&mut self, k: &KeyInput) -> Vec<EditCommand> {
+        if self.replaying {
+            return self.dispatch(k);
+        }
+
+        let stops_recording =
+            self.macro_record.is_some() && k.key == "q" && self.mode == EditMode::Normal;
+        if let Some((_, body)) = self.macro_record.as_mut()
+            && !stops_recording
+        {
+            body.push(Recorded::Key(k.clone()));
+        }
+
+        let repeating = k.key == "." && self.mode == EditMode::Normal && self.is_command_start();
+        if !repeating {
+            self.pending_change.push(Recorded::Key(k.clone()));
+        }
+
+        let cmds = self.dispatch(k);
+
+        if repeating {
+            self.pending_change.clear();
+            return cmds;
+        }
+        if cmds.iter().any(is_change) {
+            self.in_change = true;
+        }
+        if self.in_change {
+            if self.mode == EditMode::Normal {
+                self.last_change = std::mem::take(&mut self.pending_change);
+                self.in_change = false;
+            }
+        } else if self.mode == EditMode::Normal && self.is_idle() {
+            self.pending_change.clear();
+        }
+        cmds
+    }
     fn pointer_selection_mode(&mut self, extend: bool) -> Option<EditCommand> {
         match (extend, self.mode) {
             (true, EditMode::Normal) => {
@@ -742,7 +906,11 @@ impl Keymap for VimKeymap {
             _ => None,
         }
     }
-    fn handle(&mut self, k: &KeyInput) -> Vec<EditCommand> {
+}
+
+impl VimKeymap {
+    /// Interpret one key without any dot-repeat or macro bookkeeping.
+    fn dispatch(&mut self, k: &KeyInput) -> Vec<EditCommand> {
         #[cfg(target_os = "macos")]
         if k.mods.meta && !k.mods.ctrl && !k.mods.alt {
             let command = match k.key.to_ascii_lowercase().as_str() {
@@ -1095,6 +1263,94 @@ mod tests {
             run(&mut km, &["z", "b"]),
             vec![EditCommand::ScrollCursorTo(ScrollPlacement::Bottom)]
         );
+    }
+
+    #[test]
+    fn dot_repeats_the_last_change_not_the_last_motion() {
+        let mut km = VimKeymap::default();
+        run(&mut km, &["d", "w"]);
+        run(&mut km, &["j", "l"]);
+        assert_eq!(
+            run(&mut km, &["."]),
+            vec![op(Operator::Delete, Target::Motion(Motion::WordNext, 1))]
+        );
+    }
+
+    #[test]
+    fn dot_takes_a_count_and_survives_reuse() {
+        let mut km = VimKeymap::default();
+        run(&mut km, &["x"]);
+        let expected = op(Operator::Delete, Target::Motion(Motion::Right, 1));
+        assert_eq!(
+            run(&mut km, &["2", "."]),
+            vec![expected.clone(), expected.clone()]
+        );
+        assert_eq!(run(&mut km, &["."]), vec![expected]);
+    }
+
+    #[test]
+    fn dot_repeats_an_insert_session_including_typed_text() {
+        let mut km = VimKeymap::default();
+        run(&mut km, &["i"]);
+        km.record_text("hi");
+        run(&mut km, &["Escape"]);
+        assert_eq!(
+            run(&mut km, &["."]),
+            vec![
+                EditCommand::SetMode(EditMode::Insert),
+                EditCommand::InsertText("hi".into()),
+                EditCommand::Move(Motion::LeftBounded),
+                EditCommand::SetMode(EditMode::Normal),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_yank_is_not_a_change() {
+        let mut km = VimKeymap::default();
+        run(&mut km, &["x"]);
+        run(&mut km, &["y", "y"]);
+        assert_eq!(
+            run(&mut km, &["."]),
+            vec![op(Operator::Delete, Target::Motion(Motion::Right, 1))]
+        );
+    }
+
+    #[test]
+    fn macros_record_and_replay_through_a_register() {
+        let mut km = VimKeymap::default();
+        run(&mut km, &["q", "a", "x", "j", "q"]);
+        assert_eq!(
+            run(&mut km, &["@", "a"]),
+            vec![
+                op(Operator::Delete, Target::Motion(Motion::Right, 1)),
+                EditCommand::Move(Motion::Down),
+            ]
+        );
+        assert_eq!(
+            run(&mut km, &["@", "@"]),
+            vec![
+                op(Operator::Delete, Target::Motion(Motion::Right, 1)),
+                EditCommand::Move(Motion::Down),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_counted_macro_replays_repeatedly() {
+        let mut km = VimKeymap::default();
+        run(&mut km, &["q", "b", "x", "q"]);
+        let once = op(Operator::Delete, Target::Motion(Motion::Right, 1));
+        assert_eq!(
+            run(&mut km, &["3", "@", "b"]),
+            vec![once.clone(), once.clone(), once]
+        );
+    }
+
+    #[test]
+    fn replaying_an_empty_register_is_inert() {
+        let mut km = VimKeymap::default();
+        assert_eq!(run(&mut km, &["@", "z"]), vec![]);
     }
 
     #[test]

--- a/crates/vmux_editor/src/keymap/vscode.rs
+++ b/crates/vmux_editor/src/keymap/vscode.rs
@@ -12,6 +12,8 @@ fn selection_op(operator: Operator) -> EditCommand {
     }
 }
 
+/// Only the macOS emacs-style `Ctrl-K` binding uses this, so it is dead code elsewhere.
+#[cfg(target_os = "macos")]
 fn delete_to_line_end() -> EditCommand {
     EditCommand::Op {
         operator: Operator::Delete,

--- a/crates/vmux_editor/src/keymap/vscode.rs
+++ b/crates/vmux_editor/src/keymap/vscode.rs
@@ -1,8 +1,24 @@
-use crate::edit::command::{EditCommand, EditMode, Motion};
+use crate::edit::command::{EditCommand, EditMode, Motion, Operator, Target};
 use crate::keymap::{KeyInput, Keymap};
 
 #[derive(Default)]
 pub struct VscodeKeymap;
+
+fn selection_op(operator: Operator) -> EditCommand {
+    EditCommand::Op {
+        operator,
+        target: Target::Selection,
+        register: None,
+    }
+}
+
+fn delete_to_line_end() -> EditCommand {
+    EditCommand::Op {
+        operator: Operator::Delete,
+        target: Target::Motion(Motion::LineEnd, 1),
+        register: None,
+    }
+}
 
 impl Keymap for VscodeKeymap {
     fn mode(&self) -> EditMode {
@@ -43,9 +59,13 @@ impl Keymap for VscodeKeymap {
         }
         if gui && !m.alt {
             let cmd = match k.key.to_ascii_lowercase().as_str() {
-                "c" => Some(vec![Yank]),
-                "x" => Some(vec![Cut]),
-                "v" => Some(vec![Paste]),
+                "c" => Some(vec![selection_op(Operator::Yank)]),
+                "x" => Some(vec![selection_op(Operator::Delete)]),
+                "v" => Some(vec![Put {
+                    before: true,
+                    count: 1,
+                    register: None,
+                }]),
                 "a" => Some(vec![Move(Motion::DocStart), Select(Motion::DocEnd)]),
                 "s" => Some(vec![Save]),
                 "z" if m.shift => Some(vec![Redo]),
@@ -80,7 +100,7 @@ impl Keymap for VscodeKeymap {
                 "p" | "P" => Some(mv(Motion::Up)),
                 "d" | "D" => Some(vec![DeleteForward]),
                 "h" | "H" => Some(vec![DeleteBack]),
-                "k" | "K" => Some(vec![DeleteToLineEnd]),
+                "k" | "K" => Some(vec![delete_to_line_end()]),
                 "w" | "W" => Some(vec![DeleteWordBack]),
                 _ => None,
             };
@@ -161,7 +181,10 @@ mod tests {
             meta: true,
             ..Default::default()
         };
-        assert_eq!(km.handle(&key("c", cmd)), vec![EditCommand::Yank]);
+        assert_eq!(
+            km.handle(&key("c", cmd)),
+            vec![selection_op(Operator::Yank)]
+        );
         assert_eq!(km.handle(&key("s", cmd)), vec![EditCommand::Save]);
         let cmd_shift = Mods {
             meta: true,
@@ -241,10 +264,7 @@ mod tests {
             km.handle(&key("p", ctrl)),
             vec![EditCommand::Move(Motion::Up)]
         );
-        assert_eq!(
-            km.handle(&key("k", ctrl)),
-            vec![EditCommand::DeleteToLineEnd]
-        );
+        assert_eq!(km.handle(&key("k", ctrl)), vec![delete_to_line_end()]);
         assert_eq!(km.handle(&key("h", ctrl)), vec![EditCommand::DeleteBack]);
     }
 
@@ -280,7 +300,10 @@ mod tests {
             meta: true,
             ..Default::default()
         };
-        assert_eq!(km.handle(&key("c", meta)), vec![EditCommand::Yank]);
+        assert_eq!(
+            km.handle(&key("c", meta)),
+            vec![selection_op(Operator::Yank)]
+        );
     }
 
     #[test]

--- a/crates/vmux_editor/src/page.rs
+++ b/crates/vmux_editor/src/page.rs
@@ -3887,6 +3887,19 @@ pub fn Page() -> Element {
             }
 
             {
+                // Vim puts the command line on the last screen row; mirror that rather than
+                // tucking it in the header, where it reads as a label instead of a prompt.
+                (!ed_command_line().is_empty()).then(|| rsx! {
+                    div {
+                        id: "vim-command-line",
+                        class: "pointer-events-none absolute bottom-0 left-0 z-50 flex h-6 max-w-full items-center gap-px overflow-hidden bg-background/95 pl-2 pr-3 font-mono text-xs text-foreground",
+                        span { class: "truncate", "{ed_command_line()}" }
+                        span { class: "inline-block h-[1.05em] w-[0.5em] shrink-0 bg-foreground/70" }
+                    }
+                })
+            }
+
+            {
                 refs_open().then(|| {
                     let items = refs();
                     rsx! {
@@ -3978,24 +3991,15 @@ pub fn Page() -> Element {
                 leading: rsx! {
                     {
                         let lbl = ed_label();
-                        let prompt = ed_command_line();
-                        let vim = keymap() == vmux_core::KeymapKind::Vim;
-                        // The prompt shows in every view: a command line that swallows keys
-                        // without showing itself reads as the editor having frozen.
-                        (vim && (!lbl.is_empty() || !prompt.is_empty())).then(|| rsx! {
-                            if !lbl.is_empty() && mode() == Mode::Text {
+                        (!lbl.is_empty()
+                            && mode() == Mode::Text
+                            && keymap() == vmux_core::KeymapKind::Vim)
+                            .then(|| rsx! {
                                 span {
                                     class: "-ml-4 flex h-7 shrink-0 items-center bg-cyan-400/20 px-3 text-[10px] font-semibold tracking-wider text-cyan-700 dark:text-cyan-100",
                                     "{lbl}"
                                 }
-                            }
-                            if !prompt.is_empty() {
-                                span {
-                                    class: "flex h-7 min-w-0 flex-1 items-center truncate px-3 font-mono text-[11px] text-neutral-700 dark:text-neutral-200",
-                                    "{prompt}"
-                                }
-                            }
-                        })
+                            })
                     }
                 },
                 {

--- a/crates/vmux_editor/src/page.rs
+++ b/crates/vmux_editor/src/page.rs
@@ -2019,6 +2019,8 @@ pub fn Page() -> Element {
     let git_message = use_signal(String::new);
     let mut ed_mode = use_signal(|| vmux_core::editor::EditMode::Insert);
     let mut ed_label = use_signal(String::new);
+    let mut ed_command_line = use_signal(String::new);
+    let mut search_spans = use_signal(Vec::<vmux_core::editor::SelSpan>::new);
     let mut keymap = use_signal(vmux_core::KeymapKind::default);
     let mut cursor = use_signal(vmux_core::editor::CursorPos::default);
     let mut sel = use_signal(Vec::<vmux_core::editor::SelSpan>::new);
@@ -2144,6 +2146,12 @@ pub fn Page() -> Element {
         }
         if source_sel.peek().as_slice() != c.source_selections.as_slice() {
             source_sel.set(c.source_selections.clone());
+        }
+        if ed_command_line.peek().ne(&c.command_line) {
+            ed_command_line.set(c.command_line.clone());
+        }
+        if search_spans.peek().as_slice() != c.search.as_slice() {
+            search_spans.set(c.search.clone());
         }
         let note_mode = *file_view_mode.peek() == FileViewMode::Note
             && is_markdown_file(git_path.peek().as_str());
@@ -3623,6 +3631,22 @@ pub fn Page() -> Element {
                                             }
                                         }
 
+                                        for s in search_spans().iter() {
+                                            {
+                                                let top = s.row as f64 * ch;
+                                                let left = gutter + s.start as f64 * cw;
+                                                let w = (s.end.saturating_sub(s.start)) as f64 * cw;
+                                                let style = format!("left:{left}px;top:{top}px;height:{ch}px;width:{w}px;");
+                                                rsx! {
+                                                    div {
+                                                        key: "search{s.row}-{s.start}",
+                                                        class: "pointer-events-none absolute z-0 bg-amber-400/30",
+                                                        style: "{style}",
+                                                    }
+                                                }
+                                            }
+                                        }
+
                                         for s in sel().iter() {
                                             {
                                                 let top = s.row as f64 * ch;
@@ -3954,6 +3978,7 @@ pub fn Page() -> Element {
                 leading: rsx! {
                     {
                         let lbl = ed_label();
+                        let prompt = ed_command_line();
                         (!lbl.is_empty()
                             && mode() == Mode::Text
                             && keymap() == vmux_core::KeymapKind::Vim)
@@ -3961,6 +3986,12 @@ pub fn Page() -> Element {
                                 span {
                                     class: "-ml-4 flex h-7 shrink-0 items-center bg-cyan-400/20 px-3 text-[10px] font-semibold tracking-wider text-cyan-700 dark:text-cyan-100",
                                     "{lbl}"
+                                }
+                                if !prompt.is_empty() {
+                                    span {
+                                        class: "flex h-7 min-w-0 flex-1 items-center truncate px-3 font-mono text-[11px] text-neutral-700 dark:text-neutral-200",
+                                        "{prompt}"
+                                    }
                                 }
                             })
                     }

--- a/crates/vmux_editor/src/page.rs
+++ b/crates/vmux_editor/src/page.rs
@@ -3979,21 +3979,23 @@ pub fn Page() -> Element {
                     {
                         let lbl = ed_label();
                         let prompt = ed_command_line();
-                        (!lbl.is_empty()
-                            && mode() == Mode::Text
-                            && keymap() == vmux_core::KeymapKind::Vim)
-                            .then(|| rsx! {
+                        let vim = keymap() == vmux_core::KeymapKind::Vim;
+                        // The prompt shows in every view: a command line that swallows keys
+                        // without showing itself reads as the editor having frozen.
+                        (vim && (!lbl.is_empty() || !prompt.is_empty())).then(|| rsx! {
+                            if !lbl.is_empty() && mode() == Mode::Text {
                                 span {
                                     class: "-ml-4 flex h-7 shrink-0 items-center bg-cyan-400/20 px-3 text-[10px] font-semibold tracking-wider text-cyan-700 dark:text-cyan-100",
                                     "{lbl}"
                                 }
-                                if !prompt.is_empty() {
-                                    span {
-                                        class: "flex h-7 min-w-0 flex-1 items-center truncate px-3 font-mono text-[11px] text-neutral-700 dark:text-neutral-200",
-                                        "{prompt}"
-                                    }
+                            }
+                            if !prompt.is_empty() {
+                                span {
+                                    class: "flex h-7 min-w-0 flex-1 items-center truncate px-3 font-mono text-[11px] text-neutral-700 dark:text-neutral-200",
+                                    "{prompt}"
                                 }
-                            })
+                            }
+                        })
                     }
                 },
                 {

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -2297,7 +2297,7 @@ fn on_file_text_input(
     trigger: On<BinReceive<FileTextInput>>,
     mut q: Query<(
         &mut EditState,
-        &EditorKeymap,
+        &mut EditorKeymap,
         &mut FileViewport,
         &mut vmux_git::GitDiffSource,
     )>,
@@ -2313,12 +2313,13 @@ fn on_file_text_input(
     if text.is_empty() {
         return;
     }
-    let Ok((mut edit, keymap, mut vp, mut diff_source)) = q.get_mut(entity) else {
+    let Ok((mut edit, mut keymap, mut vp, mut diff_source)) = q.get_mut(entity) else {
         return;
     };
     if !keymap.0.mode().accepts_text() {
         return;
     }
+    keymap.0.record_text(&text);
     run_commands(
         entity,
         vec![EditCommand::InsertText(text)],

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -2219,7 +2219,7 @@ fn on_file_key(
         && let Some(note) = edit.parsed_note.as_ref()
     {
         let line = edit.core.cursor_pos().line;
-        cmds = remap_note_vertical_commands(cmds, &note.blocks, line);
+        cmds = remap_note_commands(cmds, &note.blocks, line);
     }
     run_commands(
         entity,
@@ -2249,6 +2249,8 @@ fn accelerate_repeated_navigation(cmds: Vec<EditCommand>, repeat: bool) -> Vec<E
                         | Motion::Right
                         | Motion::LeftBounded
                         | Motion::RightBounded
+                        | Motion::LeftFlow
+                        | Motion::RightFlow
                         | Motion::Up
                         | Motion::Down,
                 ) | EditCommand::Select(
@@ -2256,6 +2258,8 @@ fn accelerate_repeated_navigation(cmds: Vec<EditCommand>, repeat: bool) -> Vec<E
                         | Motion::Right
                         | Motion::LeftBounded
                         | Motion::RightBounded
+                        | Motion::LeftFlow
+                        | Motion::RightFlow
                         | Motion::Up
                         | Motion::Down,
                 )
@@ -2267,7 +2271,7 @@ fn accelerate_repeated_navigation(cmds: Vec<EditCommand>, repeat: bool) -> Vec<E
         .collect()
 }
 
-fn remap_note_vertical_commands(
+fn remap_note_commands(
     cmds: Vec<EditCommand>,
     blocks: &[NoteBlock],
     start_line: u32,
@@ -2275,6 +2279,23 @@ fn remap_note_vertical_commands(
     let mut line = start_line;
     cmds.into_iter()
         .flat_map(|cmd| {
+            // Hard-wrapped source lines are reflowed into continuous prose here, so horizontal
+            // motion has to cross the wrap or the caret strands itself mid-sentence.
+            match &cmd {
+                EditCommand::Move(Motion::LeftBounded) => {
+                    return vec![EditCommand::Move(Motion::LeftFlow)];
+                }
+                EditCommand::Move(Motion::RightBounded) => {
+                    return vec![EditCommand::Move(Motion::RightFlow)];
+                }
+                EditCommand::Select(Motion::LeftBounded) => {
+                    return vec![EditCommand::Select(Motion::LeftFlow)];
+                }
+                EditCommand::Select(Motion::RightBounded) => {
+                    return vec![EditCommand::Select(Motion::RightFlow)];
+                }
+                _ => {}
+            }
             let (direction, select) = match &cmd {
                 EditCommand::Move(Motion::Down) => (1, false),
                 EditCommand::Move(Motion::Up) => (-1, false),
@@ -4108,7 +4129,7 @@ mod edit_flow_tests {
     #[test]
     fn repeated_note_navigation_skips_a_separator_after_the_first_step() {
         let blocks = crate::markdown::parse_note("- one\n- two\n\nnext\n");
-        let commands = remap_note_vertical_commands(
+        let commands = remap_note_commands(
             accelerate_repeated_navigation(vec![EditCommand::Move(Motion::Down)], true),
             &blocks,
             0,

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -2219,7 +2219,7 @@ fn on_file_key(
         && let Some(note) = edit.parsed_note.as_ref()
     {
         let line = edit.core.cursor_pos().line;
-        cmds = remap_note_commands(cmds, &note.blocks, line);
+        cmds = remap_note_vertical_commands(cmds, &note.blocks, line);
     }
     run_commands(
         entity,
@@ -2249,8 +2249,6 @@ fn accelerate_repeated_navigation(cmds: Vec<EditCommand>, repeat: bool) -> Vec<E
                         | Motion::Right
                         | Motion::LeftBounded
                         | Motion::RightBounded
-                        | Motion::LeftFlow
-                        | Motion::RightFlow
                         | Motion::Up
                         | Motion::Down,
                 ) | EditCommand::Select(
@@ -2258,8 +2256,6 @@ fn accelerate_repeated_navigation(cmds: Vec<EditCommand>, repeat: bool) -> Vec<E
                         | Motion::Right
                         | Motion::LeftBounded
                         | Motion::RightBounded
-                        | Motion::LeftFlow
-                        | Motion::RightFlow
                         | Motion::Up
                         | Motion::Down,
                 )
@@ -2271,7 +2267,7 @@ fn accelerate_repeated_navigation(cmds: Vec<EditCommand>, repeat: bool) -> Vec<E
         .collect()
 }
 
-fn remap_note_commands(
+fn remap_note_vertical_commands(
     cmds: Vec<EditCommand>,
     blocks: &[NoteBlock],
     start_line: u32,
@@ -2279,23 +2275,6 @@ fn remap_note_commands(
     let mut line = start_line;
     cmds.into_iter()
         .flat_map(|cmd| {
-            // Hard-wrapped source lines are reflowed into continuous prose here, so horizontal
-            // motion has to cross the wrap or the caret strands itself mid-sentence.
-            match &cmd {
-                EditCommand::Move(Motion::LeftBounded) => {
-                    return vec![EditCommand::Move(Motion::LeftFlow)];
-                }
-                EditCommand::Move(Motion::RightBounded) => {
-                    return vec![EditCommand::Move(Motion::RightFlow)];
-                }
-                EditCommand::Select(Motion::LeftBounded) => {
-                    return vec![EditCommand::Select(Motion::LeftFlow)];
-                }
-                EditCommand::Select(Motion::RightBounded) => {
-                    return vec![EditCommand::Select(Motion::RightFlow)];
-                }
-                _ => {}
-            }
             let (direction, select) = match &cmd {
                 EditCommand::Move(Motion::Down) => (1, false),
                 EditCommand::Move(Motion::Up) => (-1, false),
@@ -4129,7 +4108,7 @@ mod edit_flow_tests {
     #[test]
     fn repeated_note_navigation_skips_a_separator_after_the_first_step() {
         let blocks = crate::markdown::parse_note("- one\n- two\n\nnext\n");
-        let commands = remap_note_commands(
+        let commands = remap_note_vertical_commands(
             accelerate_repeated_navigation(vec![EditCommand::Move(Motion::Down)], true),
             &blocks,
             0,

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -572,13 +572,24 @@ fn load_file_buffers(
     }
 }
 
-/// Re-apply the editor keymap to already-open files when `editor.keymap`
-/// changes at runtime (the keymap is otherwise only set at file open). Swaps
-/// the keymap and resets each editor to the new keymap's initial mode (Vim ->
-/// Normal, VSCode -> Insert) so switching to Vim engages without reopening.
+/// Everything about the editor keymap that a settings edit can change. Comparing the whole thing
+/// is what makes a mappings-only or leader-only edit reach already-open editors.
+#[derive(PartialEq, Eq)]
+struct KeymapConfig {
+    kind: vmux_core::KeymapKind,
+    maps: Vec<vmux_core::editor::KeyMapping>,
+    leader: String,
+}
+
+/// Re-apply the editor keymap to already-open files when `editor.keymap`,
+/// `editor.mappings` or `editor.leader` changes at runtime (the keymap is otherwise only set at
+/// file open). Swaps the keymap, and when the kind itself changed also resets each editor to that
+/// keymap's initial mode (Vim -> Normal, VSCode -> Insert) so switching to Vim engages without
+/// reopening. A mappings-only edit keeps the current mode — being thrown back to Normal mid-insert
+/// because a binding changed would be surprising.
 fn reapply_keymap_on_change(
     settings: Option<Res<vmux_setting::AppSettings>>,
-    mut last: Local<Option<vmux_core::KeymapKind>>,
+    mut last: Local<Option<KeymapConfig>>,
     mut q: Query<(
         Entity,
         &mut EditState,
@@ -588,19 +599,30 @@ fn reapply_keymap_on_change(
     browsers: Option<NonSend<Browsers>>,
     mut commands: Commands,
 ) {
-    let kind = settings_keymap(&settings);
-    if *last == Some(kind) {
+    let (maps, leader) = settings_mappings(&settings);
+    let next = KeymapConfig {
+        kind: settings_keymap(&settings),
+        maps,
+        leader,
+    };
+    if last.as_ref() == Some(&next) {
         return;
     }
     let first = last.is_none();
-    *last = Some(kind);
+    let kind_changed = last.as_ref().is_none_or(|prev| prev.kind != next.kind);
+    let kind = next.kind;
+    *last = Some(next);
     if first {
         return;
     }
-    let (maps, leader) = settings_mappings(&settings);
+    let Some(config) = last.as_ref() else {
+        return;
+    };
     for (entity, mut edit, mut keymap, viewport) in &mut q {
-        keymap.0 = kind.make(&maps, &leader);
-        edit.core.mode = kind.initial_mode();
+        keymap.0 = kind.make(&config.maps, &config.leader);
+        if kind_changed {
+            edit.core.mode = kind.initial_mode();
+        }
         if let (Some(viewport), Some(browsers)) = (viewport, browsers.as_deref()) {
             emit_cursor(
                 entity,

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -1000,9 +1000,16 @@ fn emit_cursor(
         .into_iter()
         .filter(|selection| !view.is_hidden(selection.line))
         .collect::<Vec<_>>();
+    let raw_search = edit
+        .core
+        .search_spans(0, total as u16)
+        .into_iter()
+        .filter(|span| !view.is_hidden(span.line))
+        .collect::<Vec<_>>();
     let wrap = wrapped_view(edit, vp);
     (primary.row, primary.col) = wrap.position(primary.line, primary.col);
     let selections = wrap.selections(raw_selections.iter().copied());
+    let search = wrap.selections(raw_search.iter().copied());
     commands.trigger(BinHostEmitEvent::from_rkyv(
         entity,
         FILE_CURSOR_EVENT,
@@ -1013,6 +1020,8 @@ fn emit_cursor(
             selections,
             source_primary,
             source_selections: raw_selections,
+            command_line: keymap.command_line().unwrap_or_default(),
+            search,
         },
     ));
 }

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -2329,9 +2329,14 @@ fn on_file_text_input(
         return;
     }
     keymap.0.record_text(&text);
+    let command = if keymap.0.mode() == vmux_core::EditMode::Replace {
+        EditCommand::OvertypeText(text)
+    } else {
+        EditCommand::InsertText(text)
+    };
     run_commands(
         entity,
-        vec![EditCommand::InsertText(text)],
+        vec![command],
         &mut edit,
         &mut diff_source,
         keymap.0.as_ref(),

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -442,6 +442,15 @@ pub fn handle_file_page_open(
     }
 }
 
+fn settings_mappings(
+    settings: &Option<Res<vmux_setting::AppSettings>>,
+) -> (Vec<vmux_core::editor::KeyMapping>, String) {
+    settings
+        .as_ref()
+        .map(|s| (s.editor.mappings.clone(), s.editor.leader.clone()))
+        .unwrap_or_else(|| (Vec::new(), " ".to_string()))
+}
+
 fn settings_keymap(settings: &Option<Res<vmux_setting::AppSettings>>) -> vmux_core::KeymapKind {
     settings
         .as_ref()
@@ -544,12 +553,13 @@ fn load_file_buffers(
             folds.reconcile();
         }
         core.fold_view = folds.view(core.buffer.len_lines() as u32);
+        let (maps, leader) = settings_mappings(&settings);
         let markdown = crate::markdown::is_markdown_path(&fv.path);
         let mut entity_commands = commands.entity(entity);
         entity_commands
             .insert((
                 EditState::new(core, hl, folds),
-                EditorKeymap(kind.make()),
+                EditorKeymap(kind.make(&maps, &leader)),
                 vmux_git::GitDiffSource {
                     content: text,
                     dirty: false,
@@ -587,8 +597,9 @@ fn reapply_keymap_on_change(
     if first {
         return;
     }
+    let (maps, leader) = settings_mappings(&settings);
     for (entity, mut edit, mut keymap, viewport) in &mut q {
-        keymap.0 = kind.make();
+        keymap.0 = kind.make(&maps, &leader);
         edit.core.mode = kind.initial_mode();
         if let (Some(viewport), Some(browsers)) = (viewport, browsers.as_deref()) {
             emit_cursor(
@@ -4047,7 +4058,7 @@ mod edit_flow_tests {
 
     #[test]
     fn vim_dd_deletes_line_via_keymap_and_core() {
-        let mut km = vmux_core::KeymapKind::Vim.make();
+        let mut km = vmux_core::KeymapKind::Vim.make(&[], " ");
         let mut core = EditCore::new(
             std::path::PathBuf::from("a.txt"),
             "Plain Text".into(),

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -1189,6 +1189,7 @@ fn on_file_resize(
     vp.wrap_columns = evt.wrap_columns;
     if let Some(mut edit) = edit {
         edit.core.rows = vp.rows;
+        edit.core.top_row = vp.top_row;
         let vpc = *vp;
         emit_window(entity, &mut edit, &vpc, &browsers, &mut commands);
         if let Some(keymap) = keymap {
@@ -1960,6 +1961,21 @@ fn run_commands(
                     &FileScrollByEvent { lines: *lines },
                 ));
             }
+            continue;
+        }
+        if let EditCommand::ScrollCursorTo(placement) = &cmd {
+            let row = edit
+                .folds
+                .view(edit.core.buffer.len_lines() as u32)
+                .buffer_to_row(edit.core.cursor_pos().line);
+            let rows = vp.rows.max(1) as u32;
+            vp.top_row = match placement {
+                crate::edit::command::ScrollPlacement::Top => row,
+                crate::edit::command::ScrollPlacement::Center => row.saturating_sub(rows / 2),
+                crate::edit::command::ScrollPlacement::Bottom => row.saturating_sub(rows - 1),
+            };
+            edit.core.top_row = vp.top_row;
+            viewport_changed = true;
             continue;
         }
         if matches!(

--- a/crates/vmux_editor/src/plugin.rs
+++ b/crates/vmux_editor/src/plugin.rs
@@ -2066,11 +2066,15 @@ fn run_commands(
             }
             continue;
         }
-        if matches!(cmd, EditCommand::Paste | EditCommand::PasteBefore)
+        if matches!(cmd, EditCommand::Put { .. })
             && let Some(cb) = clipboard.0.as_mut()
             && let Ok(s) = cb.get_text()
+            && s != edit.core.registers.clipboard_shadow
         {
-            edit.core.register = Some((s, false));
+            edit.core.registers.clipboard_shadow = s.clone();
+            edit.core
+                .registers
+                .set_unnamed(crate::edit::RegisterValue::charwise(s));
         }
         let out = edit.core.apply(cmd);
         if out.text_changed {
@@ -2080,10 +2084,11 @@ fn run_commands(
         }
         sel_or_mode |= out.sel_changed || out.mode_changed;
         dirty_changed |= out.dirty_changed;
-        if let Some((s, _)) = out.yank
+        if let Some(value) = out.yank
             && let Some(cb) = clipboard.0.as_mut()
         {
-            let _ = cb.set_text(s);
+            edit.core.registers.clipboard_shadow = value.text.clone();
+            let _ = cb.set_text(value.text);
         }
     }
     if text_changed {
@@ -2537,10 +2542,7 @@ fn on_file_completion_commit(
     edit.core.selections = vec![Selection { anchor: a, head: b }];
     run_commands(
         entity,
-        vec![
-            EditCommand::DeleteSelection,
-            EditCommand::InsertText(req.text),
-        ],
+        vec![EditCommand::InsertText(req.text)],
         &mut edit,
         &mut diff_source,
         keymap.0.as_ref(),

--- a/crates/vmux_layout/src/command_bar/palette.rs
+++ b/crates/vmux_layout/src/command_bar/palette.rs
@@ -924,7 +924,9 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                     start_keydown_nav
                         || agent_page_matches_query(item, &start_keydown_q)
                         || (matches!(item, ResultItem::Terminal { .. })
-                            && start_keydown_q.trim().eq_ignore_ascii_case("terminal"))
+                            && crate::command_bar::results::terminal_matches_query(
+                                &start_keydown_q,
+                            ))
                 }) {
                     execute(item);
                 } else if let Some(item) = start_keydown_default_agent.as_ref() {
@@ -1148,7 +1150,7 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                                     || action_nav
                                     || agent_page_matches_query(item, &action_query)
                                     || (matches!(item, ResultItem::Terminal { .. })
-                                        && action_query.trim().eq_ignore_ascii_case("terminal"))
+                                        && crate::command_bar::results::terminal_matches_query(&action_query))
                             }) {
                                 execute(item);
                             } else if !action_query.trim().is_empty()

--- a/crates/vmux_layout/src/command_bar/results.rs
+++ b/crates/vmux_layout/src/command_bar/results.rs
@@ -173,6 +173,15 @@ pub(crate) fn agent_page_matches_query(item: &CommandBarResultItem, query: &str)
             || url.to_lowercase().contains(&search_lower))
 }
 
+/// Whether the query should offer "Terminal".
+///
+/// Display and activation share this so a partially typed `ter` cannot list Terminal while
+/// Enter quietly routes the text to an agent instead.
+pub fn terminal_matches_query(query: &str) -> bool {
+    let query = query.trim().to_lowercase();
+    !query.is_empty() && "terminal".starts_with(&query)
+}
+
 #[cfg(any(target_arch = "wasm32", test))]
 pub(crate) fn prepend_prompt_agents(
     results: &mut Vec<CommandBarResultItem>,
@@ -181,9 +190,6 @@ pub(crate) fn prepend_prompt_agents(
     query: &str,
 ) {
     if !vmux_command::event::is_start_prompt_query(query)
-        || results
-            .iter()
-            .any(|item| matches!(item, CommandBarResultItem::Terminal { .. }))
         || results.iter().any(|item| agent_page_url(item).is_some())
     {
         return;
@@ -204,7 +210,12 @@ pub(crate) fn prepend_prompt_agents(
             break;
         }
     }
-    results.splice(0..0, suggestions);
+    // Terminal stays first when the query named it, so Enter still opens a terminal.
+    let at = results
+        .iter()
+        .take_while(|item| matches!(item, CommandBarResultItem::Terminal { .. }))
+        .count();
+    results.splice(at..at, suggestions);
 }
 
 pub fn start_page_results(
@@ -215,15 +226,18 @@ pub fn start_page_results(
     query: &str,
 ) -> Vec<CommandBarResultItem> {
     let search_lower = query.trim().to_lowercase();
-    if !search_lower.is_empty() && "terminal".starts_with(&search_lower) {
-        return vec![CommandBarResultItem::Terminal {
+    // Terminal leads when the query names it, but never at the cost of the other options.
+    let mut results = Vec::new();
+    if terminal_matches_query(query) {
+        results.push(CommandBarResultItem::Terminal {
             path: String::new(),
-        }];
+        });
     }
-    let mut results = agent_page_results(pages, query)
-        .into_iter()
-        .filter(|item| agent_page_matches_query(item, query))
-        .collect::<Vec<_>>();
+    results.extend(
+        agent_page_results(pages, query)
+            .into_iter()
+            .filter(|item| agent_page_matches_query(item, query)),
+    );
     let mut app_pages: Vec<_> = pages
         .iter()
         .filter(|page| page.host != "agent" && page.host != "start" && page.host != "terminal")
@@ -920,18 +934,48 @@ mod tests {
     }
 
     #[test]
-    fn terminal_stays_the_only_result() {
+    fn terminal_leads_but_agents_and_search_stay_available() {
         let agent = agent_page_results(&sample_pages(), "").remove(0);
         let mut results = start_page_results(&sample_pages(), &[], &[], &[], "terminal");
 
         prepend_prompt_agents(&mut results, Some(&agent), &[], "terminal");
 
-        assert_eq!(
-            results,
-            vec![CommandBarResultItem::Terminal {
-                path: String::new()
-            }]
+        assert!(
+            matches!(results.first(), Some(CommandBarResultItem::Terminal { .. })),
+            "terminal keeps the default selection: {results:?}"
         );
+        assert!(
+            results.iter().any(|item| agent_page_url(item).is_some()),
+            "asking an agent stays reachable: {results:?}"
+        );
+        assert!(
+            results
+                .iter()
+                .any(|item| matches!(item, CommandBarResultItem::Search { .. })),
+            "search stays reachable: {results:?}"
+        );
+    }
+
+    #[test]
+    fn a_terminal_prefix_offers_terminal_alongside_the_other_options() {
+        let results = start_page_results(&sample_pages(), &[], &[], &[], "ter");
+        assert!(matches!(
+            results.first(),
+            Some(CommandBarResultItem::Terminal { .. })
+        ));
+        assert!(results.len() > 1, "prefix match is not the only option");
+    }
+
+    #[test]
+    fn terminal_query_predicate_matches_display_and_activation() {
+        assert!(terminal_matches_query("t"));
+        assert!(terminal_matches_query("ter"));
+        assert!(terminal_matches_query("Terminal"));
+        assert!(terminal_matches_query("  term  "));
+        assert!(!terminal_matches_query(""));
+        assert!(!terminal_matches_query("   "));
+        assert!(!terminal_matches_query("terminals"));
+        assert!(!terminal_matches_query("xterm"));
     }
 
     #[test]
@@ -946,11 +990,24 @@ mod tests {
             shortcut: String::new(),
         });
         let results = start_page_results(&pages, &[], &[], &[], "terminal");
+        assert!(matches!(
+            results.first(),
+            Some(CommandBarResultItem::Terminal { .. })
+        ));
         assert_eq!(
-            results,
-            vec![CommandBarResultItem::Terminal {
-                path: String::new()
-            }]
+            results
+                .iter()
+                .filter(|item| matches!(item, CommandBarResultItem::Terminal { .. }))
+                .count(),
+            1,
+            "an open terminal page must not duplicate the terminal action: {results:?}"
+        );
+        assert!(
+            !results.iter().any(|item| matches!(
+                item,
+                CommandBarResultItem::Page { url, .. } if url.starts_with("vmux://terminal")
+            )),
+            "the terminal host is offered as the action, not as a page: {results:?}"
         );
     }
 

--- a/crates/vmux_layout/src/command_bar/style.rs
+++ b/crates/vmux_layout/src/command_bar/style.rs
@@ -1,8 +1,8 @@
 pub fn result_item_class(is_selected: bool) -> &'static str {
     if is_selected {
-        "flex min-w-0 w-full cursor-pointer items-center justify-between overflow-hidden bg-cyan-400/12 px-3.5 py-2.5 text-foreground shadow-[inset_2px_0_0_0_rgb(34,211,238),0_0_18px_-4px_rgba(34,211,238,0.45)]"
+        "flex min-h-15 min-w-0 w-full cursor-pointer items-center justify-between overflow-hidden bg-cyan-400/12 px-3.5 py-2.5 text-foreground shadow-[inset_2px_0_0_0_rgb(34,211,238),0_0_18px_-4px_rgba(34,211,238,0.45)]"
     } else {
-        "flex min-w-0 w-full cursor-pointer items-center justify-between overflow-hidden px-3.5 py-2.5 hover:bg-foreground/5"
+        "flex min-h-15 min-w-0 w-full cursor-pointer items-center justify-between overflow-hidden px-3.5 py-2.5 hover:bg-foreground/5"
     }
 }
 

--- a/crates/vmux_setting/src/plugin/runtime.rs
+++ b/crates/vmux_setting/src/plugin/runtime.rs
@@ -81,6 +81,14 @@ pub struct EditorSettings {
     pub lsp: LspSettings,
     #[serde(default)]
     pub explorer: ExplorerSettings,
+    #[serde(default = "default_editor_leader")]
+    pub leader: String,
+    #[serde(default)]
+    pub mappings: Vec<vmux_core::editor::KeyMapping>,
+}
+
+fn default_editor_leader() -> String {
+    " ".to_string()
 }
 
 impl Default for EditorSettings {
@@ -91,6 +99,8 @@ impl Default for EditorSettings {
             word_wrap_column: default_word_wrap_column(),
             lsp: LspSettings::default(),
             explorer: ExplorerSettings::default(),
+            leader: default_editor_leader(),
+            mappings: Vec::new(),
         }
     }
 }

--- a/docs/specs/2026-07-31-vim-neovim-parity-design.md
+++ b/docs/specs/2026-07-31-vim-neovim-parity-design.md
@@ -1,0 +1,74 @@
+# Vim Mode Neovim Parity
+
+## Summary
+
+The editor's vim keymap is a 416-line single file covering roughly fifty bindings. It handles three operators, twelve motions, no text objects, one register, no search, and three ex commands. This document defines the target — practical Neovim parity for a single-buffer modal editor — and the vocabulary changes required to reach it.
+
+Parity here means everything in `:help index.txt` for Normal, Visual, Insert, Operator-pending, Replace, and Command-line modes. It excludes Vimscript and Lua, plugin and remote APIs, `:terminal`, diff mode, and spell checking. Window and buffer management map onto vmux panes and stacks rather than an in-editor window system.
+
+## Decisions
+
+The state machine stays hand-written in `vmux_editor`. No Rust crate provides vim bindings as a library: Zed's `vim` crate is welded to gpui, helix-core is Kakoune selection-first, and lifting either drags in an incompatible dependency tree. This was settled during the editable-editor work and is not reopened here.
+
+Counts, registers, and linewise semantics become operands on a structured operator command rather than properties reconstructed by the keymap. Today `3j` emits `Move(Down)` three times and `2dd` discards the count entirely; both are symptoms of the same missing structure.
+
+Dot-repeat and macros share one mechanism. Both replay input, and insert-mode text bypasses the keymap through the IME path, so replay must live above the keymap where both key events and text input are visible.
+
+Search patterns are translated from vim syntax to `fancy-regex`, already in the tree via syntect. The translation covers `\<`, `\>`, `\v`, `\V`, and character-class aliases. Patterns that do not translate are reported rather than silently reinterpreted.
+
+`:sp`, `:vs`, `Ctrl-w`, `:bn`, and `:ls` operate on vmux panes and stacks. The editor does not grow its own window abstraction.
+
+The frontend stays dumb. The host owns command-line buffer state, search match spans, pending-key display, and cursor shape, and pushes each as derived values. The page renders them.
+
+## Vocabulary
+
+`EditCommand` currently spells out each operator-target pair as its own variant: `DeleteRange`, `YankRange`, `DeleteLine`, `DeleteSelection`, `DeleteToLineEnd`. Adding indent, case, and format operators across motions, text objects, and selections would multiply that set. Collapse it into the operator-times-target form vim itself uses.
+
+```
+Operator   Delete Change Yank Indent Outdent Format Upper Lower ToggleCase Fold Rot13
+Target     Motion(Motion, count) | TextObject(TextObject) | Line(count) | Selection
+```
+
+An operator command carries an operator, a target, a count, and an optional register. `Move` and `Select` carry a count. Registers become a file keyed by name, holding text plus a kind of charwise, linewise, or blockwise, with the unnamed, numbered, small-delete, blackhole, and system registers behaving per vim. Deletes must write to registers; today they do not, so `dd` followed by `p` pastes the last yank.
+
+New commands beyond the operator form: `ReplaceChar`, `JoinLines`, `Increment`, `Search`, `SearchNext`, `Substitute`, `SetMark`, `GotoMark`, `Jump`, `RecordMacro`, `PlayMacro`, `Repeat`.
+
+`Motion` gains WORD variants, find-char with its repeat state, match-pair, screen positions, display-line motions, scroll-by-page, mark targets, and search targets. `EditMode` gains `VisualBlock`, `Replace`, and `CommandLine`. `VisualLine` must acquire real linewise behavior — it is currently a label over charwise selection.
+
+## Modules
+
+`keymap/vim.rs` splits along mode boundaries into `state.rs`, `normal.rs`, `visual.rs`, `insert.rs`, `operator.rs`, `ex.rs`, and `search.rs`. The edit core gains `text_object.rs`, `register.rs`, `search.rs`, and `mark.rs`. Filename-based modules only, per repository convention.
+
+## Phases
+
+Each phase is independently shippable and leaves the keymap in a working state.
+
+**1 — Structured operators.** Introduce the operator form, register file, count operands, and linewise kind. Port existing bindings onto it. Unlocks `>`, `<`, `=`, `gu`, `gU`, `g~`, `J`, `~`, `r`, `Y`, correct `2dd`, `3p`, `d3w`, `2d3w`, deletes populating registers, and linewise paste.
+
+**2 — Text objects.** `TextObject` plus `i` and `a` handling in operator-pending and visual mode: word, WORD, sentence, paragraph, the four bracket pairs, the three quote pairs, and tag.
+
+**3 — Motions.** WORD motions, `f F t T ; ,`, `%`, `H M L`, `zz zt zb`, `Ctrl-d Ctrl-u Ctrl-f Ctrl-b`, `+ - _ |`, and the `g`-prefixed display-line motions. Fold bindings must yield the `z` prefix back to screen positioning.
+
+**4 — Modes.** Visual Block with `I` and `A` insert, Replace mode, Insert-Normal via `Ctrl-o`, and insert-mode chords `Ctrl-w Ctrl-u Ctrl-h Ctrl-t Ctrl-d Ctrl-r Ctrl-a Ctrl-v`. Command-line becomes a real mode with a rendered prompt.
+
+**5 — Search.** `/ ? n N * # g* g#`, incremental highlight, `hlsearch`, `:noh`, and `:s` with ranges and flags. Requires the pattern translator and match spans pushed to the page.
+
+**6 — Ex.** A range-and-command parser covering `%`, `.`, `$`, line numbers, marks, and `'<,'>`. Commands: quit and write variants, `:e`, `:sp`, `:vs`, `:b`, `:ls`, `:set`, `:g/`, `:v/`, `:norm`, `:m`, `:t`, `:d`, `:sort`, `:r`, `:!`. Adds command history and completion.
+
+**7 — Replay.** An input recorder above the keymap capturing key events and IME text. Yields `.`, `q`, `@x`, and `@@` together.
+
+**8 — Marks and jumps.** `m`, backtick, `'`, `:marks`, the jumplist behind `Ctrl-o` and `Ctrl-i`, and the changelist behind `g;` and `g,`. LSP jumps push records.
+
+**9 — Mappings.** A key-sequence trie with `timeoutlen`, `<leader>`, and the `map` family in settings. Enables `jk` escapes and user bindings.
+
+**10 — Undo tree.** Replace the flat snapshot stack with a tree: `g-`, `g+`, `:undolist`, `:earlier`, `:later`, persistent undo, and mode-transition boundaries.
+
+Phases 1 through 3 remove the sharpest daily friction. Phase 5 is the largest single jump in perceived completeness. Phases 9 and 10 are the least urgent.
+
+## Correctness
+
+Several shipped behaviors diverge from vim independently of missing features and should be fixed in the phase that touches them. `cc` destroys indentation instead of preserving it. `o` and `O` insert a bare newline with no autoindent. `Escape` in Normal mode does not clear a stale command-line buffer. `Cmd` clipboard chords fire in Normal mode. `Ctrl-n` and `Ctrl-p` act as arrow keys in every mode. `5gg` ignores its count. Paste at end-of-line can cross a line boundary.
+
+## Validation
+
+Keymap logic is pure and headless, so each phase carries table-driven tests over key sequences asserting emitted commands, and edit-core tests asserting buffer and register state. Behavior only: no source scanning, no assertions on implementation shape. A vim-compatibility corpus of sequence-to-buffer-state cases, checked against real vim where behavior is ambiguous, guards against regression as phases land.

--- a/docs/specs/2026-07-31-vim-neovim-parity-design.md
+++ b/docs/specs/2026-07-31-vim-neovim-parity-design.md
@@ -14,7 +14,7 @@ Counts, registers, and linewise semantics become operands on a structured operat
 
 Dot-repeat and macros share one mechanism. Both replay input, and insert-mode text bypasses the keymap through the IME path, so replay must live above the keymap where both key events and text input are visible.
 
-Search patterns are translated from vim syntax to `fancy-regex`, already in the tree via syntect. The translation covers `\<`, `\>`, `\v`, `\V`, and character-class aliases. Patterns that do not translate are reported rather than silently reinterpreted.
+Search patterns are translated from vim syntax to the `regex` crate. The translation covers `\<`, `\>`, `\v`, `\V`, and the character-class aliases — `\a`, `\l`, `\u`, `\d`, `\x`, `\o`, `\h` and their negations. `regex` has no backreferences or lookaround, so vim patterns using `\1` or `\@=` are out of scope: they fail to compile and the search is dropped rather than silently reinterpreted.
 
 `:sp`, `:vs`, `Ctrl-w`, `:bn`, and `:ls` operate on vmux panes and stacks. The editor does not grow its own window abstraction.
 


### PR DESCRIPTION
## Summary

Brings the editor's vim mode to practical Neovim parity. The keymap was a single
416-line file covering roughly fifty bindings — three operators, twelve motions, no
text objects, one register, no search, three ex commands. This restructures the edit
core around vim's own vocabulary and fills in the missing modes.

Design doc: `docs/specs/2026-07-31-vim-neovim-parity-design.md`.

## What lands

- **Structured operators.** `EditCommand` collapses from one variant per operator-target
  pair into operator × target, carrying count and register. Deletes now write to
  registers, so `dd` followed by `p` pastes what you deleted.
- **Text objects** (`crates/vmux_editor/src/edit/text_object.rs`) — `iw`/`aw`, quotes,
  brackets, tags, paragraphs, sentences.
- **Motions** — WORD variants, find-char with repeat state, match-pair, screen
  positions, display-line motions, scroll-by-page, mark and search targets.
- **Registers** (`edit/register.rs`) — named, numbered, small-delete, blackhole and
  system registers, each with charwise/linewise/blockwise kind.
- **Search** (`edit/search.rs`) — vim pattern syntax translated to `fancy-regex`,
  covering `\<`, `\>`, `\v`, `\V` and character-class aliases, with `n`, `N`, `*`, `#`.
- **Command-line mode** and ex commands (`edit/ex.rs`), with the command line rendered
  at the bottom left.
- **Replace mode** with restoring backspace, and **Visual Block** with blockwise
  registers and block insert.
- **Marks, jump list and change list.**
- **Dot-repeat and macros** via input replay, sitting above the keymap so insert-mode
  text entered through the IME path is captured too.
- **Branching undo tree** (`edit/undo.rs`) with `g-` / `g+` time travel.
- **Key mappings and leader** (`keymap/mapping.rs`), plus increment/decrement operators.

## Notes

- The state machine stays hand-written in `vmux_editor`. No Rust crate provides vim
  bindings as a library — Zed's `vim` crate is welded to gpui and helix-core is
  Kakoune selection-first — so lifting either would drag in an incompatible dependency
  tree. That decision predates this work and is unchanged.
- `:sp`, `:vs`, `Ctrl-w`, `:bn` and `:ls` operate on vmux panes and stacks rather than
  growing a separate in-editor window abstraction.
- The frontend stays dumb: the host owns command-line buffer state, search match spans,
  pending-key display and cursor shape, and pushes each as derived values.
- Patterns that do not translate to `fancy-regex` are reported rather than silently
  reinterpreted.

## Test plan

- [ ] `make lint` and `make test` pass (both run clean locally)
- [ ] Operators with counts and registers: `3dw`, `2dd`, `"ayy` then `"ap`
- [ ] Text objects: `ciw`, `di"`, `ca(`, `dit`
- [ ] Search: `/pattern`, `n`, `N`, `*`, `#`, and a pattern that fails to translate
- [ ] Visual Block: `Ctrl-v` selection, `I`/`A` block insert, blockwise paste
- [ ] Replace mode: `R`, then backspace restores the original characters
- [ ] Dot-repeat after an insert-mode edit, and macro record/playback via `q`/`@`
- [ ] Undo tree: `u`, `Ctrl-r`, then `g-`/`g+` across a branch
- [ ] Marks and jumps: `ma`, `` `a ``, `Ctrl-o`, `Ctrl-i`, `g;`
- [ ] Ex commands including `:sp` / `:vs` mapping onto panes
- [ ] Command line renders bottom-left and does not collide with start page options


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Vim editing with operators, text objects, registers, macros, marks, replace mode, visual-block mode, search, substitution, and advanced motions.
  * Added branching undo/redo and time-travel navigation through edit history.
  * Added configurable leader keys and mode-specific key mappings.
  * Added command-line prompts, search-match highlighting, Ex commands, and improved clipboard behavior.
  * Improved terminal discovery in the start prompt with prefix matching and coexistence alongside other results.
* **Style**
  * Increased minimum height for start-page result rows.
* **Documentation**
  * Added Vim/Neovim parity design documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->