### PR TITLE
refactor(wire): carve the remote-legal subset out of the message enums

### DIFF
--- a/crates/vmux_agent/src/chat_page.rs
+++ b/crates/vmux_agent/src/chat_page.rs
@@ -64,6 +64,7 @@ use vmux_service::client::ServiceClient;
 #[cfg(not(any(target_arch = "wasm32", target_os = "ios")))]
 use vmux_service::protocol::{
     AgentAttachment, AgentCommand as ServiceAgentCommand, AgentRequestId, ClientMessage,
+    SharedMessage,
 };
 
 #[cfg(not(any(target_arch = "wasm32", target_os = "ios")))]
@@ -1575,7 +1576,9 @@ fn cancel_session(
     else {
         return;
     };
-    service.0.send(ClientMessage::AgentCancel { sid });
+    service
+        .0
+        .send(ClientMessage::Shared(SharedMessage::AgentCancel { sid }));
 }
 
 #[cfg(not(any(target_arch = "wasm32", target_os = "ios")))]

--- a/crates/vmux_agent/src/client/acp.rs
+++ b/crates/vmux_agent/src/client/acp.rs
@@ -11,7 +11,7 @@ use vmux_layout::event::TERMINAL_PAGE_URL;
 use vmux_layout::pane::{PlacementCtx, resolve_spiral_pane};
 use vmux_layout::stack::stack_bundle;
 use vmux_service::client::ServiceClient;
-use vmux_service::protocol::ClientMessage;
+use vmux_service::protocol::{ClientMessage, SharedMessage};
 use vmux_setting::AppSettings;
 use vmux_terminal::reattach_terminal_bundle;
 
@@ -432,13 +432,13 @@ fn acp_auto_approval_message(
     policy: &AgentApprovalPolicy,
     request: &AgentApprovalRequest,
 ) -> Option<ClientMessage> {
-    policy
-        .allows(&request.name)
-        .then(|| ClientMessage::AgentApprove {
+    policy.allows(&request.name).then(|| {
+        ClientMessage::Shared(SharedMessage::AgentApprove {
             sid: session.sid.clone(),
             call_id: request.call_id.clone(),
             decision: vmux_service::protocol::ApprovalDecision::AllowAlways,
         })
+    })
 }
 
 fn auto_allow_acp_approval(
@@ -1151,7 +1151,7 @@ mod tests {
 
         assert!(matches!(
             acp_auto_approval_message(&session, &policy, &request),
-            Some(ClientMessage::AgentApprove { sid, call_id, decision })
+            Some(ClientMessage::Shared(SharedMessage::AgentApprove { sid, call_id, decision }))
                 if sid == "s1"
                     && call_id == "call-1"
                     && decision == vmux_service::protocol::ApprovalDecision::AllowAlways

--- a/crates/vmux_agent/src/client/page/plugin.rs
+++ b/crates/vmux_agent/src/client/page/plugin.rs
@@ -17,7 +17,7 @@ use vmux_service::agent_events::{
     PageAgentSnapshot,
 };
 use vmux_service::client::ServiceClient;
-use vmux_service::protocol::{AgentRunStatus, ClientMessage};
+use vmux_service::protocol::{AgentRunStatus, ClientMessage, SharedMessage};
 
 pub struct PageAgentPlugin;
 
@@ -110,9 +110,11 @@ fn spawn_page_session_on_add(
             auto_tools,
             tools_json,
         });
-        service.0.send(ClientMessage::AttachPageAgent {
-            sid: session.sid.clone(),
-        });
+        service
+            .0
+            .send(ClientMessage::Shared(SharedMessage::AttachPageAgent {
+                sid: session.sid.clone(),
+            }));
     }
 }
 

--- a/crates/vmux_agent/src/plugin.rs
+++ b/crates/vmux_agent/src/plugin.rs
@@ -22,7 +22,7 @@ use vmux_service::client::ServiceClient;
 use vmux_service::protocol::AgentAttachment;
 use vmux_service::protocol::{
     AgentCommand as ServiceAgentCommand, AgentCommandResult, AgentQuery, AgentQueryResult,
-    AgentRequestId, AgentShellMode, ClientMessage, ProcessId,
+    AgentRequestId, AgentShellMode, ClientMessage, ProcessId, SharedAgentCommand,
 };
 use vmux_setting::AppSettings;
 use vmux_space::ActiveSpace;
@@ -2198,21 +2198,21 @@ fn handle_agent_commands(
                     None => AgentCommandResult::Error("invalid bookmark command".to_string()),
                 }
             }
-            ServiceAgentCommand::NewAgentChat { prompt, agent_url } => {
+            ServiceAgentCommand::Shared(SharedAgentCommand::NewAgentChat { prompt, agent_url }) => {
                 stack_writers.2.write(vmux_layout::NewAgentChatRequest {
                     prompt: prompt.clone(),
                     agent_url: agent_url.clone(),
                 });
                 AgentCommandResult::Ok
             }
-            ServiceAgentCommand::ListAgents => {
+            ServiceAgentCommand::Shared(SharedAgentCommand::ListAgents) => {
                 match serde_json::to_string(&remote_agents(&desktop.agents)) {
                     Ok(json) => AgentCommandResult::Text(json),
                     Err(error) => AgentCommandResult::Error(format!("list_agents: {error}")),
                 }
             }
             // Answered in vmux_team, which already holds the queries the roster is built from.
-            ServiceAgentCommand::ListTeam
+            ServiceAgentCommand::Shared(SharedAgentCommand::ListTeam)
             | ServiceAgentCommand::OpenBeside { .. }
             | ServiceAgentCommand::Run { .. }
             | ServiceAgentCommand::RunWithPlacementOverride { .. }
@@ -5961,6 +5961,7 @@ fn handle_restart_agent_pty(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use vmux_service::protocol::SharedMessage;
 
     fn init_worktree_test_repo() -> tempfile::TempDir {
         let repo = tempfile::tempdir().unwrap();
@@ -6129,7 +6130,7 @@ mod tests {
     fn chat_workspace_continuation_is_private_same_session_input() {
         assert!(matches!(
             chat_agent_continuation_message("sid-1", "continue original request"),
-            ClientMessage::AgentInput { sid, text, context }
+            ClientMessage::Shared(SharedMessage::AgentInput { sid, text, context })
                 if sid == "sid-1"
                     && text.is_empty()
                     && context.as_deref() == Some("continue original request")

--- a/crates/vmux_agent/src/systems/approval.rs
+++ b/crates/vmux_agent/src/systems/approval.rs
@@ -8,7 +8,7 @@ use crate::components::{AgentApprovalPolicy, AgentSession, approval_tool_key};
 use crate::events::{AgentApprovalReply, ApprovalDecision};
 use crate::run_state::AgentRunState;
 use vmux_service::client::ServiceClient;
-use vmux_service::protocol::{ApprovalDecision as ProtoDecision, ClientMessage};
+use vmux_service::protocol::{ApprovalDecision as ProtoDecision, ClientMessage, SharedMessage};
 
 #[derive(Default, Deserialize, Serialize)]
 struct SavedApprovalGrants {
@@ -153,11 +153,13 @@ pub(crate) fn handle_approval_reply(
     }
     let decision = protocol_decision(reply.decision);
     if let Some(service) = service.as_ref() {
-        service.0.send(ClientMessage::AgentApprove {
-            sid,
-            call_id: reply.call_id.clone(),
-            decision,
-        });
+        service
+            .0
+            .send(ClientMessage::Shared(SharedMessage::AgentApprove {
+                sid,
+                call_id: reply.call_id.clone(),
+                decision,
+            }));
     }
     *state = AgentRunState::Streaming;
 }

--- a/crates/vmux_service/src/acp/driver.rs
+++ b/crates/vmux_service/src/acp/driver.rs
@@ -34,7 +34,7 @@ use super::projector::{AcpProjector, Intent, is_conversation_title_tool};
 use crate::process::{ProcessManager, PtyInputWriter};
 use crate::protocol::{
     AgentAttachment, AgentCommand, AgentRequestId, AgentRunStatus, ApprovalDecision,
-    ServiceMessage, compose_agent_prompt,
+    ServiceMessage, SharedEvent, compose_agent_prompt,
 };
 use crate::remote::{RemoteApproval, RemoteSession, RemoteStatus};
 
@@ -204,10 +204,10 @@ impl AcpShared {
         let projector = self.projector.lock().unwrap();
         let messages_json =
             serde_json::to_string(projector.messages()).unwrap_or_else(|_| "[]".to_string());
-        ServiceMessage::AgentMessagesSnapshot {
+        ServiceMessage::Shared(SharedEvent::AgentMessagesSnapshot {
             sid: self.sid.clone(),
             messages_json,
-        }
+        })
     }
 
     fn cwd(&self) -> PathBuf {
@@ -235,24 +235,22 @@ impl AcpShared {
             return;
         };
         *self.cwd.lock().unwrap() = validated.cwd.clone();
-        self.emit(ServiceMessage::AcpWorkspaceChanged {
+        self.emit(ServiceMessage::Shared(SharedEvent::AcpWorkspaceChanged {
             sid: self.sid.clone(),
             name: name.to_string(),
             branch: branch.to_string(),
             cwd: validated.cwd.to_string_lossy().into_owned(),
             workspace_cwd: validated.workspace_cwd.to_string_lossy().into_owned(),
-        });
+        }));
     }
 
     pub fn agent_info_message(&self) -> Option<ServiceMessage> {
-        self.agent_name
-            .lock()
-            .unwrap()
-            .as_ref()
-            .map(|name| ServiceMessage::AcpAgentInfo {
+        self.agent_name.lock().unwrap().as_ref().map(|name| {
+            ServiceMessage::Shared(SharedEvent::AcpAgentInfo {
                 sid: self.sid.clone(),
                 name: name.clone(),
             })
+        })
     }
 
     pub fn model_info_message(&self) -> Option<ServiceMessage> {
@@ -304,19 +302,19 @@ impl AcpShared {
             return false;
         }
         *approval = None;
-        self.emit(ServiceMessage::AgentApprovalResolved {
+        self.emit(ServiceMessage::Shared(SharedEvent::AgentApprovalResolved {
             sid: self.sid.clone(),
             call_id: call_id.to_string(),
-        });
+        }));
         true
     }
 
     fn publish_agent_info(&self, name: String) {
         *self.agent_name.lock().unwrap() = Some(name.clone());
-        self.emit(ServiceMessage::AcpAgentInfo {
+        self.emit(ServiceMessage::Shared(SharedEvent::AcpAgentInfo {
             sid: self.sid.clone(),
             name,
-        });
+        }));
     }
 
     fn publish_model_info(&self, config_options: &[SessionConfigOption]) {
@@ -331,12 +329,12 @@ impl AcpShared {
         if let Some(state) = next {
             self.emit(state.message(&self.sid));
         } else if removed {
-            self.emit(ServiceMessage::AcpModelInfo {
+            self.emit(ServiceMessage::Shared(SharedEvent::AcpModelInfo {
                 sid: self.sid.clone(),
                 config_id: String::new(),
                 current_model_id: String::new(),
                 models: Vec::new(),
-            });
+            }));
         }
     }
 
@@ -378,10 +376,10 @@ impl AcpShared {
             serde_json::to_string(projector.messages()).unwrap_or_else(|_| "[]".to_string());
         self.history_replay_updates.store(0, Ordering::SeqCst);
         self.history_replay.store(false, Ordering::SeqCst);
-        self.emit(ServiceMessage::AgentMessagesSnapshot {
+        self.emit(ServiceMessage::Shared(SharedEvent::AgentMessagesSnapshot {
             sid: self.sid.clone(),
             messages_json,
-        });
+        }));
     }
 
     fn emit(&self, msg: ServiceMessage) {
@@ -393,10 +391,10 @@ impl AcpShared {
             *self.approval.lock().unwrap() = None;
         }
         *self.status.lock().unwrap() = status.clone();
-        self.emit(ServiceMessage::AgentRunStatusChanged {
+        self.emit(ServiceMessage::Shared(SharedEvent::AgentRunStatusChanged {
             sid: self.sid.clone(),
             status,
-        });
+        }));
     }
 
     fn push_stderr(&self, line: String) {
@@ -454,20 +452,20 @@ fn project_session_update(shared: &AcpShared, update: SessionUpdate) {
         if update_count == 1 || update_count.is_multiple_of(HISTORY_REPLAY_SNAPSHOT_INTERVAL) {
             let messages_json =
                 serde_json::to_string(projector.messages()).unwrap_or_else(|_| "[]".to_string());
-            shared.emit(ServiceMessage::AgentMessagesSnapshot {
+            shared.emit(ServiceMessage::Shared(SharedEvent::AgentMessagesSnapshot {
                 sid: shared.sid.clone(),
                 messages_json,
-            });
+            }));
         }
         return;
     }
     drop(projector);
     for intent in intents {
         match intent {
-            Intent::Delta(text) => shared.emit(ServiceMessage::AgentDelta {
+            Intent::Delta(text) => shared.emit(ServiceMessage::Shared(SharedEvent::AgentDelta {
                 sid: shared.sid.clone(),
                 text,
-            }),
+            })),
             Intent::Snapshot => shared.emit(shared.snapshot_message()),
             Intent::ProposedDiff {
                 call_id,
@@ -514,12 +512,12 @@ struct AcpModelInfoState {
 
 impl AcpModelInfoState {
     fn message(&self, sid: &str) -> ServiceMessage {
-        ServiceMessage::AcpModelInfo {
+        ServiceMessage::Shared(SharedEvent::AcpModelInfo {
             sid: sid.to_string(),
             config_id: self.config_id.clone(),
             current_model_id: self.current_model_id.clone(),
             models: self.models.clone(),
-        }
+        })
     }
 }
 
@@ -819,12 +817,12 @@ pub async fn run(
                     name: name.clone(),
                     args_json: args_json.clone(),
                 });
-                perm_shared.emit(ServiceMessage::AgentAwaitingApproval {
+                perm_shared.emit(ServiceMessage::Shared(SharedEvent::AgentAwaitingApproval {
                     sid: perm_shared.sid.clone(),
                     call_id: call_id.clone(),
                     name,
                     args_json,
-                });
+                }));
                 let decision = rx.await.unwrap_or(ApprovalDecision::Deny);
                 *perm_shared.approval.lock().unwrap() = None;
                 let outcome = match pick_permission_option(&req.options, decision) {
@@ -2026,7 +2024,7 @@ mod tests {
         shared.publish_agent_info("Antigravity".into());
 
         match shared.agent_info_message() {
-            Some(ServiceMessage::AcpAgentInfo { sid, name }) => {
+            Some(ServiceMessage::Shared(SharedEvent::AcpAgentInfo { sid, name })) => {
                 assert_eq!(sid, "s1");
                 assert_eq!(name, "Antigravity");
             }
@@ -2099,12 +2097,12 @@ mod tests {
         shared.publish_model_info(&[config]);
 
         match shared.model_info_message() {
-            Some(ServiceMessage::AcpModelInfo {
+            Some(ServiceMessage::Shared(SharedEvent::AcpModelInfo {
                 sid,
                 current_model_id,
                 models,
                 ..
-            }) => {
+            })) => {
                 assert_eq!(sid, "s1");
                 assert_eq!(current_model_id, "sonnet");
                 assert_eq!(models[0].name, "Claude Sonnet");
@@ -2169,9 +2167,9 @@ mod tests {
         shared.publish_selected_model("model", "default", &[stale]);
 
         match stream_rx.try_recv().expect("selected model update") {
-            ServiceMessage::AcpModelInfo {
+            ServiceMessage::Shared(SharedEvent::AcpModelInfo {
                 current_model_id, ..
-            } => assert_eq!(current_model_id, "default"),
+            }) => assert_eq!(current_model_id, "default"),
             other => panic!("expected ACP model info, got {other:?}"),
         }
     }
@@ -2203,11 +2201,11 @@ mod tests {
         shared.publish_selected_model("model", "default", &[]);
 
         match stream_rx.try_recv().expect("selected model update") {
-            ServiceMessage::AcpModelInfo {
+            ServiceMessage::Shared(SharedEvent::AcpModelInfo {
                 current_model_id,
                 models,
                 ..
-            } => {
+            }) => {
                 assert_eq!(current_model_id, "default");
                 assert_eq!(models.len(), 2);
             }
@@ -2234,7 +2232,7 @@ mod tests {
                 TextContent::new("hello"),
             ))),
         );
-        let ServiceMessage::AgentMessagesSnapshot { messages_json, .. } =
+        let ServiceMessage::Shared(SharedEvent::AgentMessagesSnapshot { messages_json, .. }) =
             stream_rx.try_recv().expect("first progressive snapshot")
         else {
             panic!("expected snapshot");
@@ -2256,7 +2254,7 @@ mod tests {
         assert!(snapshots.len() < 64);
         shared.finish_history_replay(true);
 
-        let ServiceMessage::AgentMessagesSnapshot { messages_json, .. } =
+        let ServiceMessage::Shared(SharedEvent::AgentMessagesSnapshot { messages_json, .. }) =
             stream_rx.try_recv().expect("final snapshot")
         else {
             panic!("expected snapshot");
@@ -2293,7 +2291,7 @@ mod tests {
             ))),
         );
 
-        let ServiceMessage::AgentMessagesSnapshot { messages_json, .. } =
+        let ServiceMessage::Shared(SharedEvent::AgentMessagesSnapshot { messages_json, .. }) =
             stream_rx.try_recv().expect("progressive snapshot")
         else {
             panic!("expected snapshot");
@@ -2304,7 +2302,7 @@ mod tests {
         shared.finish_history_replay(false);
 
         assert!(shared.projector.lock().unwrap().messages().is_empty());
-        let ServiceMessage::AgentMessagesSnapshot { messages_json, .. } =
+        let ServiceMessage::Shared(SharedEvent::AgentMessagesSnapshot { messages_json, .. }) =
             stream_rx.try_recv().expect("clearing snapshot")
         else {
             panic!("expected snapshot");
@@ -2798,7 +2796,7 @@ mod tests {
         assert!(shared.resolve_approval("call-1"));
         assert!(matches!(
             receiver.try_recv(),
-            Ok(ServiceMessage::AgentApprovalResolved { sid, call_id })
+            Ok(ServiceMessage::Shared(SharedEvent::AgentApprovalResolved { sid, call_id }))
                 if sid == "s1" && call_id == "call-1"
         ));
         assert!(shared.approval.lock().unwrap().is_none());

--- a/crates/vmux_service/src/acp/projector.rs
+++ b/crates/vmux_service/src/acp/projector.rs
@@ -14,9 +14,9 @@ use agent_client_protocol::schema::v1::{
 /// A side effect the driver performs after feeding a `SessionUpdate` to the projector.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Intent {
-    /// Incremental assistant text → `ServiceMessage::AgentDelta`.
+    /// Incremental assistant text → `ServiceMessage::Shared(SharedEvent::AgentDelta)`.
     Delta(String),
-    /// The transcript changed structurally → `ServiceMessage::AgentMessagesSnapshot`.
+    /// The transcript changed structurally → `ServiceMessage::Shared(SharedEvent::AgentMessagesSnapshot)`.
     Snapshot,
     /// A tool call carries a proposed edit → `ServiceMessage::AcpProposedDiff`.
     ProposedDiff {

--- a/crates/vmux_service/src/agent.rs
+++ b/crates/vmux_service/src/agent.rs
@@ -7,7 +7,7 @@ use tokio::sync::{Mutex, broadcast, mpsc};
 use crate::agent_broker::AgentBroker;
 use crate::message::{AssistantBlock, Message};
 use crate::protocol::{
-    AgentAttachment, AgentRequestId, AgentRunStatus, ApprovalDecision, ServiceMessage,
+    AgentAttachment, AgentRequestId, AgentRunStatus, ApprovalDecision, ServiceMessage, SharedEvent,
 };
 use crate::providers::{anthropic, mistral, openai};
 use crate::remote::{RemoteApproval, RemoteSession, RemoteStatus};
@@ -133,12 +133,12 @@ impl AgentSessionManager {
                     .is_some_and(|pending| pending.call_id == *call_id)
                 {
                     *approval = None;
-                    let _ = handle
-                        .stream_tx
-                        .send(ServiceMessage::AgentApprovalResolved {
+                    let _ = handle.stream_tx.send(ServiceMessage::Shared(
+                        SharedEvent::AgentApprovalResolved {
                             sid: sid.to_string(),
                             call_id: call_id.clone(),
-                        });
+                        },
+                    ));
                 }
             }
             let _ = handle.input_tx.send(input);
@@ -205,10 +205,10 @@ fn remote_session(sid: &str, handle: &SessionHandle) -> RemoteSession {
 async fn snapshot_message(sid: &str, messages: &Arc<Mutex<Vec<Message>>>) -> ServiceMessage {
     let msgs = messages.lock().await;
     let messages_json = serde_json::to_string(&*msgs).unwrap_or_else(|_| "[]".to_string());
-    ServiceMessage::AgentMessagesSnapshot {
+    ServiceMessage::Shared(SharedEvent::AgentMessagesSnapshot {
         sid: sid.to_string(),
         messages_json,
-    }
+    })
 }
 
 fn spawn_sse(
@@ -365,10 +365,10 @@ async fn run_session(
                         match event {
                             StreamEvent::TextDelta(text) => {
                                 append_text(&mut blocks, &text);
-                                let _ = stream_tx.send(ServiceMessage::AgentDelta {
+                                let _ = stream_tx.send(ServiceMessage::Shared(SharedEvent::AgentDelta {
                                     sid: sid.clone(),
                                     text,
-                                });
+                                }));
                             }
                             StreamEvent::ToolUseStart { call_id, name } => {
                                 partial = Some((call_id, name, String::new()));
@@ -454,12 +454,13 @@ async fn run_session(
                     args_json: args_json.clone(),
                 };
                 *approval.lock().unwrap() = Some(next_approval.clone());
-                let _ = stream_tx.send(ServiceMessage::AgentAwaitingApproval {
-                    sid: sid.clone(),
-                    call_id: call_id.clone(),
-                    name: name.clone(),
-                    args_json: args_json.clone(),
-                });
+                let _ =
+                    stream_tx.send(ServiceMessage::Shared(SharedEvent::AgentAwaitingApproval {
+                        sid: sid.clone(),
+                        call_id: call_id.clone(),
+                        name: name.clone(),
+                        args_json: args_json.clone(),
+                    }));
                 match await_decision(&mut input_rx, &call_id).await {
                     Decision::Closed => return,
                     Decision::Cancelled => {
@@ -513,10 +514,10 @@ fn emit_status(
         *approval.lock().unwrap() = None;
     }
     *status.lock().unwrap() = next.clone();
-    let _ = stream_tx.send(ServiceMessage::AgentRunStatusChanged {
+    let _ = stream_tx.send(ServiceMessage::Shared(SharedEvent::AgentRunStatusChanged {
         sid: sid.to_string(),
         status: next,
-    });
+    }));
 }
 
 #[cfg(test)]
@@ -555,7 +556,10 @@ mod tests {
         )
         .unwrap();
         match mgr.snapshot("s").await {
-            Some(ServiceMessage::AgentMessagesSnapshot { messages_json, .. }) => {
+            Some(ServiceMessage::Shared(SharedEvent::AgentMessagesSnapshot {
+                messages_json,
+                ..
+            })) => {
                 assert_eq!(messages_json, "[]");
             }
             other => panic!("expected snapshot, got {other:?}"),
@@ -661,7 +665,7 @@ mod tests {
 
         assert!(matches!(
             receiver.try_recv(),
-            Ok(ServiceMessage::AgentApprovalResolved { sid, call_id })
+            Ok(ServiceMessage::Shared(SharedEvent::AgentApprovalResolved { sid, call_id }))
                 if sid == "s" && call_id == "call-1"
         ));
         assert!(mgr.remote_session("s").unwrap().approval.is_none());

--- a/crates/vmux_service/src/remote/server.rs
+++ b/crates/vmux_service/src/remote/server.rs
@@ -21,7 +21,7 @@ use crate::acp::{AcpInput, AcpSessionManager};
 use crate::agent::{AgentSessionManager, SessionInput};
 use crate::agent_broker::AgentBroker;
 use crate::message::Message;
-use crate::protocol::{AgentAttachment, ApprovalDecision, ServiceMessage};
+use crate::protocol::{AgentAttachment, ApprovalDecision, ServiceMessage, SharedEvent};
 use crate::remote::{
     ApprovalRequest, ClientOpId, NewChatRequest, PromptRequest, RemoteApproval, RemoteEvent,
     RemoteMediaEntry, RemoteSession, RemoteStatus, RoomEvent,
@@ -154,10 +154,11 @@ async fn create_chat(
     {
         return StatusCode::ACCEPTED;
     }
-    let command = crate::protocol::AgentCommand::NewAgentChat {
+    let command = crate::protocol::SharedAgentCommand::NewAgentChat {
         prompt: prompt.to_string(),
         agent_url: request.agent_url.clone(),
-    };
+    }
+    .into();
     match state
         .broker
         .command(crate::protocol::AgentRequestId::new(), None, command)
@@ -223,7 +224,11 @@ async fn broker_json(
 
 /// The installed agents, so a remote client can offer the same launcher rows the desktop does.
 async fn list_agents(State(state): State<RemoteState>) -> Json<Vec<vmux_remote::RemoteAgent>> {
-    let json = broker_json(&state, crate::protocol::AgentCommand::ListAgents).await;
+    let json = broker_json(
+        &state,
+        crate::protocol::SharedAgentCommand::ListAgents.into(),
+    )
+    .await;
     Json(
         json.and_then(|json| serde_json::from_str(&json).ok())
             .unwrap_or_default(),
@@ -233,7 +238,7 @@ async fn list_agents(State(state): State<RemoteState>) -> Json<Vec<vmux_remote::
 /// The active space's team roster, so a remote client can render the same team page the desktop
 /// does.
 async fn list_team(State(state): State<RemoteState>) -> Json<Vec<vmux_wire::team::TeamMemberRow>> {
-    let json = broker_json(&state, crate::protocol::AgentCommand::ListTeam).await;
+    let json = broker_json(&state, crate::protocol::SharedAgentCommand::ListTeam.into()).await;
     Json(
         json.and_then(|json| serde_json::from_str(&json).ok())
             .unwrap_or_default(),
@@ -506,29 +511,31 @@ async fn service_event(
     message: ServiceMessage,
 ) -> Option<RemoteEvent> {
     match message {
-        ServiceMessage::AgentDelta { text, .. } => Some(RemoteEvent::Delta {
+        ServiceMessage::Shared(SharedEvent::AgentDelta { text, .. }) => Some(RemoteEvent::Delta {
             room_id: vmux_remote::room_id_for_session(sid),
             text,
         }),
-        ServiceMessage::AgentRunStatusChanged { status, .. } => Some(RemoteEvent::Status {
-            status: RemoteStatus::from(&status),
-        }),
-        ServiceMessage::AgentAwaitingApproval {
+        ServiceMessage::Shared(SharedEvent::AgentRunStatusChanged { status, .. }) => {
+            Some(RemoteEvent::Status {
+                status: RemoteStatus::from(&status),
+            })
+        }
+        ServiceMessage::Shared(SharedEvent::AgentAwaitingApproval {
             call_id,
             name,
             args_json,
             ..
-        } => Some(RemoteEvent::Approval {
+        }) => Some(RemoteEvent::Approval {
             approval: Some(RemoteApproval {
                 call_id,
                 name,
                 args_json,
             }),
         }),
-        ServiceMessage::AgentApprovalResolved { .. } => {
+        ServiceMessage::Shared(SharedEvent::AgentApprovalResolved { .. }) => {
             Some(RemoteEvent::Approval { approval: None })
         }
-        ServiceMessage::AgentMessagesSnapshot { messages_json, .. } => {
+        ServiceMessage::Shared(SharedEvent::AgentMessagesSnapshot { messages_json, .. }) => {
             let messages = serde_json::from_str::<Vec<Message>>(&messages_json).ok()?;
             let session = current_session(state, sid).await?;
             let events =
@@ -543,11 +550,13 @@ async fn service_event(
                 events,
             })
         }
-        ServiceMessage::AcpAgentInfo { .. }
-        | ServiceMessage::AcpModelInfo { .. }
-        | ServiceMessage::AcpWorkspaceChanged { .. } => current_session(state, sid)
-            .await
-            .map(|session| RemoteEvent::Session { session }),
+        ServiceMessage::Shared(SharedEvent::AcpAgentInfo { .. })
+        | ServiceMessage::Shared(SharedEvent::AcpModelInfo { .. })
+        | ServiceMessage::Shared(SharedEvent::AcpWorkspaceChanged { .. }) => {
+            current_session(state, sid)
+                .await
+                .map(|session| RemoteEvent::Session { session })
+        }
         _ => None,
     }
 }

--- a/crates/vmux_service/src/remote/server/relay.rs
+++ b/crates/vmux_service/src/remote/server/relay.rs
@@ -1,6 +1,6 @@
 use std::{net::IpAddr, time::Duration};
 
-use crate::protocol::AgentCommand;
+use crate::protocol::{AgentCommand, SharedAgentCommand};
 use axum::http::StatusCode;
 use futures_util::StreamExt;
 use serde::Serialize;
@@ -111,10 +111,11 @@ impl DesktopRelayClient {
         let response = match kind {
             DesktopCommandKind::ListSessions => list_sessions_response(self.state.clone()).await,
             DesktopCommandKind::ListAgents => {
-                broker_list_response(self.state.clone(), AgentCommand::ListAgents).await
+                broker_list_response(self.state.clone(), SharedAgentCommand::ListAgents.into())
+                    .await
             }
             DesktopCommandKind::ListTeam => {
-                broker_list_response(self.state.clone(), AgentCommand::ListTeam).await
+                broker_list_response(self.state.clone(), SharedAgentCommand::ListTeam.into()).await
             }
             DesktopCommandKind::CreateChat { body } => {
                 create_chat_response(self.state.clone(), body).await
@@ -301,10 +302,11 @@ async fn create_chat_response(state: RemoteState, body: Value) -> DesktopRespons
     {
         return status_response(StatusCode::ACCEPTED);
     }
-    let command = crate::protocol::AgentCommand::NewAgentChat {
+    let command = crate::protocol::SharedAgentCommand::NewAgentChat {
         prompt: prompt.to_string(),
         agent_url: request.agent_url.clone(),
-    };
+    }
+    .into();
     match state
         .broker
         .command(crate::protocol::AgentRequestId::new(), None, command)

--- a/crates/vmux_service/src/server.rs
+++ b/crates/vmux_service/src/server.rs
@@ -1,7 +1,7 @@
 use crate::process::{Process, ProcessManager, PtyInputWriter};
 use crate::protocol::{
     AgentAttachment, ClientMessage, ManagedMcpServer, ManagedMcpTransport, ProcessId,
-    ServiceMessage, compose_agent_prompt, validate_agent_command,
+    ServiceMessage, SharedMessage, compose_agent_prompt, validate_agent_command,
 };
 use crate::{read_message, write_message};
 use std::collections::HashMap;
@@ -830,7 +830,7 @@ async fn handle_client(
                 }
             }
 
-            ClientMessage::AttachPageAgent { sid } => {
+            ClientMessage::Shared(SharedMessage::AttachPageAgent { sid }) => {
                 let rx = agent_manager.lock().await.subscribe(&sid);
                 if let Some(mut rx) = rx {
                     if let Some(snapshot) = agent_manager.lock().await.snapshot(&sid).await {
@@ -872,17 +872,17 @@ async fn handle_client(
                 }
             }
 
-            ClientMessage::AgentInput { sid, text, context } => {
+            ClientMessage::Shared(SharedMessage::AgentInput { sid, text, context }) => {
                 route_agent_input(&acp_manager, &agent_manager, sid, text, context, Vec::new())
                     .await;
             }
 
-            ClientMessage::AgentInputWithAttachments {
+            ClientMessage::Shared(SharedMessage::AgentInputWithAttachments {
                 sid,
                 text,
                 context,
                 attachments,
-            } => {
+            }) => {
                 route_agent_input(
                     &acp_manager,
                     &agent_manager,
@@ -922,7 +922,7 @@ async fn handle_client(
                 );
             }
 
-            ClientMessage::AgentCancel { sid } => {
+            ClientMessage::Shared(SharedMessage::AgentCancel { sid }) => {
                 if acp_manager.lock().await.contains(&sid) {
                     acp_manager
                         .lock()
@@ -936,11 +936,11 @@ async fn handle_client(
                 }
             }
 
-            ClientMessage::AgentApprove {
+            ClientMessage::Shared(SharedMessage::AgentApprove {
                 sid,
                 call_id,
                 decision,
-            } => {
+            }) => {
                 if acp_manager.lock().await.contains(&sid) {
                     acp_manager
                         .lock()

--- a/crates/vmux_team/src/plugin.rs
+++ b/crates/vmux_team/src/plugin.rs
@@ -16,7 +16,7 @@ use vmux_layout::stack::Stack;
 use vmux_layout::warm_page::{WarmPage, WarmPagePlugin};
 use vmux_service::agent_events::AgentCommandRequest;
 use vmux_service::client::ServiceClient;
-use vmux_service::protocol::{AgentCommand, AgentCommandResult, ClientMessage};
+use vmux_service::protocol::{AgentCommand, AgentCommandResult, ClientMessage, SharedAgentCommand};
 
 #[derive(Component)]
 struct Team;
@@ -219,7 +219,7 @@ fn build_team_members(
     members
 }
 
-/// Answer [`AgentCommand::ListTeam`] for the daemon's remote API.
+/// Answer [`SharedAgentCommand::ListTeam`] for the daemon's remote API.
 ///
 /// `AgentCommandRequest` is a message, so reading it here rather than in `vmux_agent`'s central
 /// handler costs nothing and keeps the roster's seven queries out of a system that is already at
@@ -243,7 +243,10 @@ fn answer_list_team(
     children_q: Query<&Children>,
 ) {
     for request in reader.read() {
-        if !matches!(request.command, AgentCommand::ListTeam) {
+        if !matches!(
+            request.command,
+            AgentCommand::Shared(SharedAgentCommand::ListTeam)
+        ) {
             continue;
         }
         let Some(service) = service.as_ref() else {

--- a/crates/vmux_terminal/src/plugin.rs
+++ b/crates/vmux_terminal/src/plugin.rs
@@ -28,7 +28,7 @@ use vmux_layout::Browser;
 use vmux_layout::{CloseRequiresConfirmation, LayoutSpawnRequest};
 use vmux_service::{
     client::{ServiceHandle, ServiceWake},
-    protocol::{ClientMessage, ProcessId, ServiceMessage},
+    protocol::{ClientMessage, ProcessId, ServiceMessage, SharedEvent},
 };
 use vmux_setting::{AppSettings, SettingsSaveRequest};
 
@@ -1651,22 +1651,22 @@ fn poll_service_messages(
                         args_json,
                     });
             }
-            ServiceMessage::AgentDelta { sid, text } => {
+            ServiceMessage::Shared(SharedEvent::AgentDelta { sid, text }) => {
                 writers
                     .page_agent_delta
                     .write(vmux_service::agent_events::PageAgentDelta { sid, text });
             }
-            ServiceMessage::AgentRunStatusChanged { sid, status } => {
+            ServiceMessage::Shared(SharedEvent::AgentRunStatusChanged { sid, status }) => {
                 writers
                     .page_agent_run_status
                     .write(vmux_service::agent_events::PageAgentRunStatus { sid, status });
             }
-            ServiceMessage::AgentAwaitingApproval {
+            ServiceMessage::Shared(SharedEvent::AgentAwaitingApproval {
                 sid,
                 call_id,
                 name,
                 args_json,
-            } => {
+            }) => {
                 writers.page_agent_awaiting.write(
                     vmux_service::agent_events::PageAgentAwaitingApproval {
                         sid,
@@ -1676,28 +1676,28 @@ fn poll_service_messages(
                     },
                 );
             }
-            ServiceMessage::AgentApprovalResolved { sid, call_id } => {
+            ServiceMessage::Shared(SharedEvent::AgentApprovalResolved { sid, call_id }) => {
                 writers
                     .page_agent_approval_resolved
                     .write(vmux_service::agent_events::PageAgentApprovalResolved { sid, call_id });
             }
-            ServiceMessage::AgentMessagesSnapshot { sid, messages_json } => {
+            ServiceMessage::Shared(SharedEvent::AgentMessagesSnapshot { sid, messages_json }) => {
                 writers
                     .page_agent_snapshot
                     .write(vmux_service::agent_events::PageAgentSnapshot { sid, messages_json });
             }
-            ServiceMessage::AcpAgentInfo { sid, name } => {
+            ServiceMessage::Shared(SharedEvent::AcpAgentInfo { sid, name }) => {
                 writers
                     .page_agent_info
                     .write(vmux_service::agent_events::PageAgentInfo { sid, name });
             }
-            ServiceMessage::AcpWorkspaceChanged {
+            ServiceMessage::Shared(SharedEvent::AcpWorkspaceChanged {
                 sid,
                 name,
                 branch,
                 cwd,
                 workspace_cwd,
-            } => {
+            }) => {
                 writers.page_agent_workspace_changed.write(
                     vmux_service::agent_events::PageAgentWorkspaceChanged {
                         sid,
@@ -1708,12 +1708,12 @@ fn poll_service_messages(
                     },
                 );
             }
-            ServiceMessage::AcpModelInfo {
+            ServiceMessage::Shared(SharedEvent::AcpModelInfo {
                 sid,
                 config_id,
                 current_model_id,
                 models,
-            } => {
+            }) => {
                 writers.page_agent_model_info.write(
                     vmux_service::agent_events::PageAgentModelInfo {
                         sid,
@@ -3928,7 +3928,7 @@ mod tests {
             .split("fn flush_pending_terminal_input")
             .next()
             .expect("service handler body");
-        assert!(handler.contains("ServiceMessage::AcpAgentInfo"));
+        assert!(handler.contains("ServiceMessage::Shared(SharedEvent::AcpAgentInfo"));
         assert!(handler.contains(".page_agent_info"));
     }
 

--- a/crates/vmux_wire/src/protocol.rs
+++ b/crates/vmux_wire/src/protocol.rs
@@ -1,7 +1,9 @@
 pub mod layout;
+pub mod shared;
 pub use layout::{
     Focus, LayoutNode, LayoutSnapshot, NodeKind, SplitDirection, Stack, Tab, format_id, parse_id,
 };
+pub use shared::{SharedAgentCommand, SharedEvent, SharedMessage};
 
 use crate::{TermCursor, TermLine, TermSelectionRange};
 
@@ -290,20 +292,9 @@ pub enum AgentCommand {
         line: u32,
         limit: u32,
     },
-    /// Open a focused desktop tab with the default agent and submit its first prompt.
-    /// Appended to preserve existing positional enum discriminants.
-    NewAgentChat {
-        prompt: String,
-        /// Launch URL of the agent to start with; `None` uses the default.
-        agent_url: Option<String>,
-    },
-    /// Ask the GUI for the installed-agent list. Answered as JSON in
-    /// [`AgentCommandResult::Text`], because only the GUI holds the registry.
-    ListAgents,
-    /// Ask the GUI for the active space's team roster. Answered as JSON in
-    /// [`AgentCommandResult::Text`]; the roster is assembled from ECS state, and the daemon
-    /// serving the remote API runs in a different process from the ECS that holds it.
-    ListTeam,
+    /// The commands a remote peer may also issue. Appended last so the preceding positional
+    /// rkyv discriminants keep their existing values.
+    Shared(SharedAgentCommand),
 }
 
 pub const AGENT_QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
@@ -509,7 +500,9 @@ pub fn validate_agent_command(command: &AgentCommand) -> Result<(), &'static str
         {
             Err("read_knowledge requires a path and limit between 1 and 2000")
         }
-        AgentCommand::NewAgentChat { prompt, .. } if prompt.trim().is_empty() => {
+        AgentCommand::Shared(SharedAgentCommand::NewAgentChat { prompt, .. })
+            if prompt.trim().is_empty() =>
+        {
             Err("new_agent_chat.prompt is empty")
         }
         _ => Ok(()),
@@ -639,16 +632,8 @@ pub enum ClientMessage {
         auto_tools: Vec<String>,
         tools_json: String,
     },
-    AttachPageAgent {
-        sid: String,
-    },
     DetachPageAgent {
         sid: String,
-    },
-    AgentInput {
-        sid: String,
-        text: String,
-        context: Option<String>,
     },
     /// Select a model exposed by an ACP session's model configuration option.
     AcpSetModel {
@@ -656,15 +641,6 @@ pub enum ClientMessage {
         request_id: u64,
         config_id: String,
         model_id: String,
-    },
-    /// Interrupt the session's in-flight turn without tearing the session down.
-    AgentCancel {
-        sid: String,
-    },
-    AgentApprove {
-        sid: String,
-        call_id: String,
-        decision: ApprovalDecision,
     },
     ClosePageAgent {
         sid: String,
@@ -697,17 +673,14 @@ pub enum ClientMessage {
         effort: Option<String>,
     },
     Status,
-    AgentInputWithAttachments {
-        sid: String,
-        text: String,
-        context: Option<String>,
-        attachments: Vec<AgentAttachment>,
-    },
     /// Update the host-side working directory used by an existing ACP session.
     RebindAcpWorkspace {
         sid: String,
         cwd: String,
     },
+    /// The operations a remote peer may also perform. Appended last so the preceding positional
+    /// rkyv discriminants keep their existing values.
+    Shared(SharedMessage),
 }
 
 impl ClientMessage {
@@ -718,16 +691,7 @@ impl ClientMessage {
         context: Option<String>,
         attachments: Vec<AgentAttachment>,
     ) -> Self {
-        if attachments.is_empty() {
-            Self::AgentInput { sid, text, context }
-        } else {
-            Self::AgentInputWithAttachments {
-                sid,
-                text,
-                context,
-                attachments,
-            }
-        }
+        SharedMessage::agent_input(sid, text, context, attachments).into()
     }
 }
 
@@ -962,33 +926,11 @@ pub enum ServiceMessage {
     Bell {
         process_id: ProcessId,
     },
-    AgentDelta {
-        sid: String,
-        text: String,
-    },
-    AgentRunStatusChanged {
-        sid: String,
-        status: AgentRunStatus,
-    },
-    AgentAwaitingApproval {
-        sid: String,
-        call_id: String,
-        name: String,
-        args_json: String,
-    },
-    AgentApprovalResolved {
-        sid: String,
-        call_id: String,
-    },
     AgentToolCall {
         request_id: AgentRequestId,
         sid: String,
         name: String,
         args_json: String,
-    },
-    AgentMessagesSnapshot {
-        sid: String,
-        messages_json: String,
     },
     /// An ACP agent created a terminal; the GUI spawns a visible pane bound to `process_id`.
     AcpTerminalCreated {
@@ -1017,25 +959,6 @@ pub enum ServiceMessage {
         sid: String,
         acp_session_id: String,
     },
-    /// Identity reported by an ACP agent during initialization.
-    AcpAgentInfo {
-        sid: String,
-        name: String,
-    },
-    AcpWorkspaceChanged {
-        sid: String,
-        name: String,
-        branch: String,
-        cwd: String,
-        workspace_cwd: String,
-    },
-    /// Current model and selectable models reported by an ACP session.
-    AcpModelInfo {
-        sid: String,
-        config_id: String,
-        current_model_id: String,
-        models: Vec<AcpModelOption>,
-    },
     /// Completion of a model selection request, correlated by `request_id`.
     AcpModelSelectionResult {
         sid: String,
@@ -1043,6 +966,9 @@ pub enum ServiceMessage {
         model_id: String,
         succeeded: bool,
     },
+    /// The events a remote peer may also receive. Appended last so the preceding positional
+    /// rkyv discriminants keep their existing values.
+    Shared(SharedEvent),
 }
 
 /// One model exposed by an ACP session configuration selector.
@@ -1099,6 +1025,158 @@ mod tests {
         assert!(has_private_context_envelope(&echoed));
     }
 
+    /// The remote surface is exactly this set. A variant reaches a paired phone only by being
+    /// moved into `SharedMessage`, so widening it must be a deliberate edit here and not a
+    /// side effect of adding a variant to `ClientMessage`.
+    #[test]
+    fn shared_message_variants_are_the_whole_remote_surface() {
+        fn name(message: &SharedMessage) -> &'static str {
+            match message {
+                SharedMessage::AttachPageAgent { .. } => "AttachPageAgent",
+                SharedMessage::AgentInput { .. } => "AgentInput",
+                SharedMessage::AgentCancel { .. } => "AgentCancel",
+                SharedMessage::AgentApprove { .. } => "AgentApprove",
+                SharedMessage::AgentInputWithAttachments { .. } => "AgentInputWithAttachments",
+            }
+        }
+
+        let sid = || "s".to_string();
+        let every_variant = [
+            SharedMessage::AttachPageAgent { sid: sid() },
+            SharedMessage::AgentInput {
+                sid: sid(),
+                text: String::new(),
+                context: None,
+            },
+            SharedMessage::AgentCancel { sid: sid() },
+            SharedMessage::AgentApprove {
+                sid: sid(),
+                call_id: "c".into(),
+                decision: ApprovalDecision::Allow,
+            },
+            SharedMessage::AgentInputWithAttachments {
+                sid: sid(),
+                text: String::new(),
+                context: None,
+                attachments: Vec::new(),
+            },
+        ];
+
+        assert_eq!(
+            every_variant.iter().map(name).collect::<Vec<_>>(),
+            [
+                "AttachPageAgent",
+                "AgentInput",
+                "AgentCancel",
+                "AgentApprove",
+                "AgentInputWithAttachments",
+            ]
+        );
+    }
+
+    /// Companion gate to [`shared_message_variants_are_the_whole_remote_surface`], for the
+    /// commands a remote peer may issue.
+    #[test]
+    fn shared_agent_command_variants_are_the_whole_remote_surface() {
+        fn name(command: &SharedAgentCommand) -> &'static str {
+            match command {
+                SharedAgentCommand::NewAgentChat { .. } => "NewAgentChat",
+                SharedAgentCommand::ListAgents => "ListAgents",
+                SharedAgentCommand::ListTeam => "ListTeam",
+            }
+        }
+
+        let every_variant = [
+            SharedAgentCommand::NewAgentChat {
+                prompt: String::new(),
+                agent_url: None,
+            },
+            SharedAgentCommand::ListAgents,
+            SharedAgentCommand::ListTeam,
+        ];
+
+        assert_eq!(
+            every_variant.iter().map(name).collect::<Vec<_>>(),
+            ["NewAgentChat", "ListAgents", "ListTeam"]
+        );
+    }
+
+    /// Companion gate to [`shared_message_variants_are_the_whole_remote_surface`], for the events
+    /// a remote peer may receive. Terminal output, proposed diffs and process lifecycle are
+    /// absent by design.
+    #[test]
+    fn shared_event_variants_are_the_whole_remote_surface() {
+        fn name(event: &SharedEvent) -> &'static str {
+            match event {
+                SharedEvent::AgentDelta { .. } => "AgentDelta",
+                SharedEvent::AgentRunStatusChanged { .. } => "AgentRunStatusChanged",
+                SharedEvent::AgentAwaitingApproval { .. } => "AgentAwaitingApproval",
+                SharedEvent::AgentApprovalResolved { .. } => "AgentApprovalResolved",
+                SharedEvent::AgentMessagesSnapshot { .. } => "AgentMessagesSnapshot",
+                SharedEvent::AcpAgentInfo { .. } => "AcpAgentInfo",
+                SharedEvent::AcpWorkspaceChanged { .. } => "AcpWorkspaceChanged",
+                SharedEvent::AcpModelInfo { .. } => "AcpModelInfo",
+            }
+        }
+
+        let sid = || "s".to_string();
+        let every_variant = [
+            SharedEvent::AgentDelta {
+                sid: sid(),
+                text: String::new(),
+            },
+            SharedEvent::AgentRunStatusChanged {
+                sid: sid(),
+                status: AgentRunStatus::Idle,
+            },
+            SharedEvent::AgentAwaitingApproval {
+                sid: sid(),
+                call_id: String::new(),
+                name: String::new(),
+                args_json: String::new(),
+            },
+            SharedEvent::AgentApprovalResolved {
+                sid: sid(),
+                call_id: String::new(),
+            },
+            SharedEvent::AgentMessagesSnapshot {
+                sid: sid(),
+                messages_json: String::new(),
+            },
+            SharedEvent::AcpAgentInfo {
+                sid: sid(),
+                name: String::new(),
+            },
+            SharedEvent::AcpWorkspaceChanged {
+                sid: sid(),
+                name: String::new(),
+                branch: String::new(),
+                cwd: String::new(),
+                workspace_cwd: String::new(),
+            },
+            SharedEvent::AcpModelInfo {
+                sid: sid(),
+                config_id: String::new(),
+                current_model_id: String::new(),
+                models: Vec::new(),
+            },
+        ];
+
+        assert_eq!(
+            every_variant.iter().map(name).collect::<Vec<_>>(),
+            [
+                "AgentDelta",
+                "AgentRunStatusChanged",
+                "AgentAwaitingApproval",
+                "AgentApprovalResolved",
+                "AgentMessagesSnapshot",
+                "AcpAgentInfo",
+                "AcpWorkspaceChanged",
+                "AcpModelInfo",
+            ]
+        );
+    }
+
     #[test]
     fn agent_request_id_roundtrips() {
         let request_id = AgentRequestId::new();
@@ -1110,10 +1188,12 @@ mod tests {
 
     #[test]
     fn agent_cancel_and_interrupted_roundtrip() {
-        let msg = ClientMessage::AgentCancel { sid: "s1".into() };
+        let msg = ClientMessage::Shared(SharedMessage::AgentCancel { sid: "s1".into() });
         let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&msg).unwrap();
         let back = rkyv::from_bytes::<ClientMessage, rkyv::rancor::Error>(&bytes).unwrap();
-        assert!(matches!(back, ClientMessage::AgentCancel { sid } if sid == "s1"));
+        assert!(
+            matches!(back, ClientMessage::Shared(SharedMessage::AgentCancel { sid }) if sid == "s1")
+        );
 
         let st = AgentRunStatus::Interrupted;
         let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&st).unwrap();
@@ -1123,25 +1203,25 @@ mod tests {
 
     #[test]
     fn acp_workspace_changed_roundtrips() {
-        let message = ServiceMessage::AcpWorkspaceChanged {
+        let message = ServiceMessage::Shared(SharedEvent::AcpWorkspaceChanged {
             sid: "s1".into(),
             name: "quiet-amber-wolf".into(),
             branch: "vibe/quiet-amber-wolf".into(),
             cwd: "/worktrees/quiet-amber-wolf".into(),
             workspace_cwd: "/repo".into(),
-        };
+        });
         let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&message).unwrap();
         let decoded = rkyv::from_bytes::<ServiceMessage, rkyv::rancor::Error>(&bytes).unwrap();
 
         assert!(matches!(
             decoded,
-            ServiceMessage::AcpWorkspaceChanged {
+            ServiceMessage::Shared(SharedEvent::AcpWorkspaceChanged {
                 sid,
                 name,
                 branch,
                 cwd,
                 workspace_cwd,
-            } if sid == "s1"
+            }) if sid == "s1"
                 && name == "quiet-amber-wolf"
                 && branch == "vibe/quiet-amber-wolf"
                 && cwd == "/worktrees/quiet-amber-wolf"
@@ -1186,16 +1266,16 @@ mod tests {
     #[test]
     fn new_agent_chat_requires_prompt_and_roundtrips() {
         assert_eq!(
-            validate_agent_command(&AgentCommand::NewAgentChat {
+            validate_agent_command(&AgentCommand::Shared(SharedAgentCommand::NewAgentChat {
                 prompt: "  ".to_string(),
                 agent_url: None,
-            }),
+            })),
             Err("new_agent_chat.prompt is empty")
         );
-        let command = AgentCommand::NewAgentChat {
+        let command = AgentCommand::Shared(SharedAgentCommand::NewAgentChat {
             prompt: "continue from my phone".to_string(),
             agent_url: Some("vmux://agent/claude".to_string()),
-        };
+        });
         let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&command).unwrap();
         let back: AgentCommand =
             rkyv::from_bytes::<AgentCommand, rkyv::rancor::Error>(&bytes).unwrap();
@@ -1684,14 +1764,14 @@ mod tests {
                 auto_tools: vec!["list_spaces".into()],
                 tools_json: "[]".into(),
             },
-            ClientMessage::AttachPageAgent { sid: "s".into() },
+            ClientMessage::Shared(SharedMessage::AttachPageAgent { sid: "s".into() }),
             ClientMessage::DetachPageAgent { sid: "s".into() },
-            ClientMessage::AgentInput {
+            ClientMessage::Shared(SharedMessage::AgentInput {
                 sid: "s".into(),
                 text: "hi".into(),
                 context: Some("prior conversation".into()),
-            },
-            ClientMessage::AgentInputWithAttachments {
+            }),
+            ClientMessage::Shared(SharedMessage::AgentInputWithAttachments {
                 sid: "s".into(),
                 text: "inspect".into(),
                 context: None,
@@ -1701,23 +1781,23 @@ mod tests {
                     mime_type: "image/png".into(),
                     size: 42,
                 }],
-            },
+            }),
             ClientMessage::AcpSetModel {
                 sid: "s".into(),
                 request_id: 7,
                 config_id: "model".into(),
                 model_id: "sonnet".into(),
             },
-            ClientMessage::AgentApprove {
+            ClientMessage::Shared(SharedMessage::AgentApprove {
                 sid: "s".into(),
                 call_id: "c".into(),
                 decision: ApprovalDecision::Allow,
-            },
-            ClientMessage::AgentApprove {
+            }),
+            ClientMessage::Shared(SharedMessage::AgentApprove {
                 sid: "s".into(),
                 call_id: "ca".into(),
                 decision: ApprovalDecision::AllowAlways,
-            },
+            }),
             ClientMessage::ClosePageAgent { sid: "s".into() },
             ClientMessage::AgentToolResult {
                 request_id: AgentRequestId::new(),
@@ -1732,20 +1812,20 @@ mod tests {
         for msg in messages {
             let expects_allow_always = matches!(
                 &msg,
-                ClientMessage::AgentApprove {
+                ClientMessage::Shared(SharedMessage::AgentApprove {
                     decision: ApprovalDecision::AllowAlways,
                     ..
-                }
+                })
             );
             let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&msg).unwrap();
             let decoded = rkyv::from_bytes::<ClientMessage, rkyv::rancor::Error>(&bytes).unwrap();
             if expects_allow_always {
                 assert!(matches!(
                     decoded,
-                    ClientMessage::AgentApprove {
+                    ClientMessage::Shared(SharedMessage::AgentApprove {
                         decision: ApprovalDecision::AllowAlways,
                         ..
-                    }
+                    })
                 ));
             }
         }
@@ -1755,7 +1835,7 @@ mod tests {
     fn agent_input_builder_preserves_legacy_variant_without_attachments() {
         assert!(matches!(
             ClientMessage::agent_input("s".into(), "hi".into(), None, Vec::new()),
-            ClientMessage::AgentInput { sid, text, context }
+            ClientMessage::Shared(SharedMessage::AgentInput { sid, text, context })
                 if sid == "s" && text == "hi" && context.is_none()
         ));
         assert!(matches!(
@@ -1770,7 +1850,7 @@ mod tests {
                     size: 42,
                 }],
             ),
-            ClientMessage::AgentInputWithAttachments { attachments, .. }
+            ClientMessage::Shared(SharedMessage::AgentInputWithAttachments { attachments, .. })
                 if attachments.len() == 1
         ));
     }
@@ -1843,11 +1923,11 @@ mod tests {
                 sid: "s".into(),
                 acp_session_id: "acp-1".into(),
             },
-            ServiceMessage::AcpAgentInfo {
+            ServiceMessage::Shared(SharedEvent::AcpAgentInfo {
                 sid: "s".into(),
                 name: "Antigravity".into(),
-            },
-            ServiceMessage::AcpModelInfo {
+            }),
+            ServiceMessage::Shared(SharedEvent::AcpModelInfo {
                 sid: "s".into(),
                 config_id: "model".into(),
                 current_model_id: "sonnet".into(),
@@ -1856,7 +1936,7 @@ mod tests {
                     name: "Claude Sonnet".into(),
                     description: Some("Balanced".into()),
                 }],
-            },
+            }),
             ServiceMessage::AcpModelSelectionResult {
                 sid: "s".into(),
                 request_id: 7,
@@ -1873,38 +1953,38 @@ mod tests {
     #[test]
     fn page_agent_service_messages_roundtrip() {
         let messages = [
-            ServiceMessage::AgentDelta {
+            ServiceMessage::Shared(SharedEvent::AgentDelta {
                 sid: "s".into(),
                 text: "hello".into(),
-            },
-            ServiceMessage::AgentRunStatusChanged {
+            }),
+            ServiceMessage::Shared(SharedEvent::AgentRunStatusChanged {
                 sid: "s".into(),
                 status: AgentRunStatus::Streaming,
-            },
-            ServiceMessage::AgentRunStatusChanged {
+            }),
+            ServiceMessage::Shared(SharedEvent::AgentRunStatusChanged {
                 sid: "s".into(),
                 status: AgentRunStatus::Errored("boom".into()),
-            },
-            ServiceMessage::AgentAwaitingApproval {
+            }),
+            ServiceMessage::Shared(SharedEvent::AgentAwaitingApproval {
                 sid: "s".into(),
                 call_id: "c".into(),
                 name: "n".into(),
                 args_json: "{}".into(),
-            },
-            ServiceMessage::AgentApprovalResolved {
+            }),
+            ServiceMessage::Shared(SharedEvent::AgentApprovalResolved {
                 sid: "s".into(),
                 call_id: "c".into(),
-            },
+            }),
             ServiceMessage::AgentToolCall {
                 request_id: AgentRequestId::new(),
                 sid: "s".into(),
                 name: "n".into(),
                 args_json: "{}".into(),
             },
-            ServiceMessage::AgentMessagesSnapshot {
+            ServiceMessage::Shared(SharedEvent::AgentMessagesSnapshot {
                 sid: "s".into(),
                 messages_json: "[]".into(),
-            },
+            }),
         ];
         for msg in messages {
             let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&msg).unwrap();

--- a/crates/vmux_wire/src/protocol/shared.rs
+++ b/crates/vmux_wire/src/protocol/shared.rs
@@ -1,0 +1,153 @@
+//! The subset of the protocol a remote peer may speak.
+//!
+//! Every other variant of [`ClientMessage`](super::ClientMessage) stays flat on that enum and is
+//! therefore local-only: a transport that decodes into [`SharedMessage`] cannot represent
+//! `CreateProcess`, `RunShell`, `Shutdown` or `SubscribeAgentCommands`, so the boundary is enforced
+//! by the type system rather than by a runtime check that someone has to remember to write.
+//!
+//! Adding a variant to a parent enum leaves it local. Widening the remote surface is the deliberate
+//! act of moving a variant in here, which is what makes the failure mode closed.
+
+use super::{
+    AcpModelOption, AgentAttachment, AgentCommand, AgentRunStatus, ApprovalDecision, ClientMessage,
+    ServiceMessage,
+};
+
+/// Operations a remote peer is permitted to perform.
+///
+/// Carried over the local link too, wrapped in [`ClientMessage::Shared`] — "shared" is about which
+/// transports may carry it, not about where it originates.
+#[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub enum SharedMessage {
+    /// Subscribe to a session's transcript and status.
+    AttachPageAgent { sid: String },
+    AgentInput {
+        sid: String,
+        text: String,
+        context: Option<String>,
+    },
+    /// Interrupt the session's in-flight turn without tearing the session down.
+    AgentCancel { sid: String },
+    AgentApprove {
+        sid: String,
+        call_id: String,
+        decision: ApprovalDecision,
+    },
+    AgentInputWithAttachments {
+        sid: String,
+        text: String,
+        context: Option<String>,
+        attachments: Vec<AgentAttachment>,
+    },
+}
+
+impl SharedMessage {
+    /// Build a prompt message, choosing the attachment-carrying variant only when needed.
+    pub fn agent_input(
+        sid: String,
+        text: String,
+        context: Option<String>,
+        attachments: Vec<AgentAttachment>,
+    ) -> Self {
+        if attachments.is_empty() {
+            Self::AgentInput { sid, text, context }
+        } else {
+            Self::AgentInputWithAttachments {
+                sid,
+                text,
+                context,
+                attachments,
+            }
+        }
+    }
+}
+
+impl From<SharedMessage> for ClientMessage {
+    fn from(message: SharedMessage) -> Self {
+        Self::Shared(message)
+    }
+}
+
+/// Agent commands a remote peer is permitted to issue.
+///
+/// All three are answered by the GUI rather than the daemon, because only the ECS holds the
+/// registry and the roster.
+#[derive(Debug, Clone, PartialEq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub enum SharedAgentCommand {
+    /// Open a focused desktop tab with the default agent and submit its first prompt.
+    NewAgentChat {
+        prompt: String,
+        /// Launch URL of the agent to start with; `None` uses the default.
+        agent_url: Option<String>,
+    },
+    /// Ask the GUI for the installed-agent list. Answered as JSON in
+    /// [`AgentCommandResult::Text`](super::AgentCommandResult::Text), because only the GUI holds
+    /// the registry.
+    ListAgents,
+    /// Ask the GUI for the active space's team roster. Answered as JSON in
+    /// [`AgentCommandResult::Text`](super::AgentCommandResult::Text); the roster is assembled from
+    /// ECS state, and the daemon serving the remote API runs in a different process from the ECS
+    /// that holds it.
+    ListTeam,
+}
+
+impl From<SharedAgentCommand> for AgentCommand {
+    fn from(command: SharedAgentCommand) -> Self {
+        Self::Shared(command)
+    }
+}
+
+/// Session events a remote peer is permitted to receive.
+///
+/// Everything else a session emits — terminal output, proposed diffs, process lifecycle — stays
+/// flat on [`ServiceMessage`] and never leaves the machine.
+#[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub enum SharedEvent {
+    AgentDelta {
+        sid: String,
+        text: String,
+    },
+    AgentRunStatusChanged {
+        sid: String,
+        status: AgentRunStatus,
+    },
+    AgentAwaitingApproval {
+        sid: String,
+        call_id: String,
+        name: String,
+        args_json: String,
+    },
+    AgentApprovalResolved {
+        sid: String,
+        call_id: String,
+    },
+    AgentMessagesSnapshot {
+        sid: String,
+        messages_json: String,
+    },
+    /// Identity reported by an ACP agent during initialization.
+    AcpAgentInfo {
+        sid: String,
+        name: String,
+    },
+    AcpWorkspaceChanged {
+        sid: String,
+        name: String,
+        branch: String,
+        cwd: String,
+        workspace_cwd: String,
+    },
+    /// Current model and selectable models reported by an ACP session.
+    AcpModelInfo {
+        sid: String,
+        config_id: String,
+        current_model_id: String,
+        models: Vec<AcpModelOption>,
+    },
+}
+
+impl From<SharedEvent> for ServiceMessage {
+    fn from(event: SharedEvent) -> Self {
+        Self::Shared(event)
+    }
+}


### PR DESCRIPTION
## Summary

Stage 1 of moving the remote transport to QUIC. Pure refactor — no behaviour change, no transport change. HTTP and SSE keep running on top of it.

A paired phone may only speak a fraction of what the local link speaks, but nothing in the type system said so. The remote handlers were *trusted* to construct only the six `AcpInput`/`SessionInput` calls, while `ClientMessage` sat beside them carrying `CreateProcess`, `RunShell`, `Shutdown` and `SubscribeAgentCommands` — the last of which would let a remote peer impersonate the desktop and answer broker requests.

This carves the remote-legal fraction into three new enums and gives each parent one `Shared(..)` door:

| new enum | carved from | variants |
| --- | --- | --- |
| `SharedMessage` | `ClientMessage` (37) | 5 |
| `SharedAgentCommand` | `AgentCommand` (41) | 3 |
| `SharedEvent` | `ServiceMessage` (31) | 8 |

```rust
enum ClientMessage {
    CreateProcess {..},        // flat = local, the majority
    ..,
    Shared(SharedMessage),     // one door to the remote-legal half
}
```

## Why this shape

- **Compiler-enforced, not runtime-checked.** A transport decoding into `SharedMessage` cannot represent a privileged variant. No allowlist to keep in step.
- **Fails safe.** A variant added flat to a parent stays local until someone deliberately moves it across. The alternative — flattening the shared half and nesting `Local(..)` — fails *open*, since a new variant would be remote-reachable by default.
- **Cheap.** Nesting the small half means the flat majority never moves: ~90 call sites touched instead of ~630.
- **Wire-stable.** Each `Shared` door is appended last so existing positional rkyv discriminants hold, and the shared enums own their own discriminant space — adding a local-only variant later won't shift the remote format.

## Not in this PR

Deleting `RemoteEvent`'s 31→5 projection was originally scoped here. `ServiceMessage` is rkyv-only and `RemoteEvent` is serde-only, so removing it now would mean adding serde derives to `SharedEvent` purely to keep SSE alive — work thrown away once the QUIC path lands, plus a JSON shape change forcing a mobile-parser edit in the same PR. Deferred to the stage where `SharedEvent` goes over QUIC as rkyv natively. The projection stays and simply matches through the new door.

## Test plan

- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo test -p vmux_wire -p vmux_service -p vmux_agent -p vmux_team -p vmux_terminal` green
- [x] Three table-driven exact-set gates added, one per shared enum — widening the remote surface fails CI until the expected list is edited, and that edit is the review gate
- [ ] **Needs a real run:** desktop + paired phone, send a prompt, cancel a turn, resolve an approval. Nothing else proves a ~90-site refactor preserved behaviour.