### PR TITLE
fix(mobile): complete the iOS Info.plist for App Store submission

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ android: mobile-android-run
 
 mobile-ios: ensure-mobile-ios-deps
 	"$(DX_BIN)" build --ios -p vmux_mobile
+	./scripts/inject-ios-resources.sh
 
 mobile-android: ensure-mobile-android-deps
 	"$(DX_BIN)" build --android -p vmux_mobile

--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,10 @@ ios: mobile-ios-run
 
 android: mobile-android-run
 
+# `inject-ios-resources.sh` reads VMUX_IOS_PROFILE to decide which bundle to write into, so the
+# build has to be told the same thing or the script looks for a bundle dx never produced.
 mobile-ios: ensure-mobile-ios-deps
-	"$(DX_BIN)" build --ios -p vmux_mobile
+	"$(DX_BIN)" build --ios -p vmux_mobile $(if $(filter release,$(VMUX_IOS_PROFILE)),--release)
 	./scripts/inject-ios-resources.sh
 
 mobile-android: ensure-mobile-android-deps

--- a/crates/vmux_client/src/pairing.rs
+++ b/crates/vmux_client/src/pairing.rs
@@ -224,7 +224,7 @@ impl PersistedRelay {
 pub struct PairingInfo {
     /// Carried by the QR code.
     pub url: String,
-    /// Carried by the `vmuxremote://` deep link, for a phone already holding the device.
+    /// Carried by the `vmux://` deep link, for a phone already holding the device.
     pub deep_link: String,
 }
 
@@ -242,8 +242,7 @@ impl PairingInfo {
             format!("token={token}&fp={fingerprint}")
         }));
 
-        let mut deep_link =
-            url::Url::parse("vmuxremote://pair").map_err(|error| error.to_string())?;
+        let mut deep_link = url::Url::parse("vmux://pair").map_err(|error| error.to_string())?;
         deep_link
             .query_pairs_mut()
             .append_pair("base", base_url)
@@ -311,7 +310,7 @@ mod tests {
         );
         assert_eq!(
             pairing.deep_link,
-            "vmuxremote://pair?base=https%3A%2F%2Flocalhost%3A41003&token=secret&fp=abc123"
+            "vmux://pair?base=https%3A%2F%2Flocalhost%3A41003&token=secret&fp=abc123"
         );
     }
 
@@ -322,7 +321,7 @@ mod tests {
         assert_eq!(pairing.url, "https://localhost:41003/#token=secret");
         assert_eq!(
             pairing.deep_link,
-            "vmuxremote://pair?base=https%3A%2F%2Flocalhost%3A41003&token=secret"
+            "vmux://pair?base=https%3A%2F%2Flocalhost%3A41003&token=secret"
         );
     }
 

--- a/crates/vmux_mobile/Dioxus.toml
+++ b/crates/vmux_mobile/Dioxus.toml
@@ -4,9 +4,14 @@ default_platform = "ios"
 public_dir = "assets"
 tailwind_input = "assets/tailwind.css"
 tailwind_output = "assets/tailwind.out.css"
+# Supplies the whole plist rather than merging. `[ios.plist]` is appended after the keys dx
+# hardcodes and a duplicate key loses on parse, so UIDeviceFamily, the orientations and
+# CFBundleVersion cannot be set that way. Read relative to the working directory, so dx has to
+# be invoked from the repo root — `make mobile-ios` is.
+ios_info_plist = "packaging/ios/Info.plist"
 
 [bundle]
-identifier = "ai.vmux.remote"
+identifier = "ai.vmux.mobile"
 publisher = "Vmux"
 short_description = "Continue Vmux agent chats from your phone."
 icon = ["../../icon.png"]
@@ -16,20 +21,14 @@ schemes = ["vmuxremote"]
 
 [ios]
 deployment_target = "15.0"
-identifier = "ai.vmux.remote"
+identifier = "ai.vmux.mobile"
 icon = ["../../icon.png"]
-
-[ios.plist]
-CFBundleDisplayName = "Vmux"
-CFBundleName = "Vmux"
-NSAppTransportSecurity = { NSAllowsLocalNetworking = true }
-NSCameraUsageDescription = "Scan the pairing QR code shown by Vmux on your Mac."
 
 [android]
 min_sdk = 24
 target_sdk = 35
 compile_sdk = 35
-identifier = "ai.vmux.remote"
+identifier = "ai.vmux.mobile"
 icon = ["../../icon.png"]
 
 [android.application]

--- a/crates/vmux_mobile/Dioxus.toml
+++ b/crates/vmux_mobile/Dioxus.toml
@@ -17,7 +17,7 @@ short_description = "Continue Vmux agent chats from your phone."
 icon = ["../../icon.png"]
 
 [deep_links]
-schemes = ["vmuxremote"]
+schemes = ["vmux"]
 
 [ios]
 deployment_target = "15.0"

--- a/crates/vmux_mobile/src/main.rs
+++ b/crates/vmux_mobile/src/main.rs
@@ -74,7 +74,7 @@ fn main() {
                     .unwrap_or_else(|error| error.into_inner());
                 opened.extend(
                     urls.iter()
-                        .filter(|url| url.scheme() == "vmux")
+                        .filter(|url| url.scheme() == "vmux" && url.host_str() == Some("pair"))
                         .map(ToString::to_string),
                 );
             }

--- a/crates/vmux_mobile/src/main.rs
+++ b/crates/vmux_mobile/src/main.rs
@@ -74,7 +74,7 @@ fn main() {
                     .unwrap_or_else(|error| error.into_inner());
                 opened.extend(
                     urls.iter()
-                        .filter(|url| url.scheme() == "vmuxremote")
+                        .filter(|url| url.scheme() == "vmux")
                         .map(ToString::to_string),
                 );
             }
@@ -1935,9 +1935,9 @@ fn apply_remote_event(
 
 fn parse_pairing_url(input: &str) -> Result<Credentials, String> {
     let input = input.trim();
-    if input.starts_with("vmuxremote://") {
+    if input.starts_with("vmux://") {
         let parsed = Url::parse(input).map_err(|_| "Pairing URL is invalid.".to_string())?;
-        if parsed.scheme() != "vmuxremote" || parsed.host_str() != Some("pair") {
+        if parsed.scheme() != "vmux" || parsed.host_str() != Some("pair") {
             return Err("Pairing URL is invalid.".to_string());
         }
         let params = parsed
@@ -2104,7 +2104,7 @@ mod tests {
         ))
         .unwrap();
         let deep_link = parse_pairing_url(&format!(
-            "vmuxremote://pair?base=https%3A%2F%2Fmac.example.ts.net&token=secret&fp={expected}"
+            "vmux://pair?base=https%3A%2F%2Fmac.example.ts.net&token=secret&fp={expected}"
         ))
         .unwrap();
 
@@ -2147,7 +2147,7 @@ mod tests {
     fn parses_pairing_deep_link() {
         assert_eq!(
             parse_pairing_url(
-                "vmuxremote://pair?base=https%3A%2F%2Fmac.example.ts.net%3A54821&token=secret"
+                "vmux://pair?base=https%3A%2F%2Fmac.example.ts.net%3A54821&token=secret"
             )
             .unwrap(),
             Credentials {

--- a/docs/architecture/mobile-remote.md
+++ b/docs/architecture/mobile-remote.md
@@ -46,7 +46,7 @@ with the relay and waits for it to allocate a port; the pairing link cannot be s
 because the link has to name that port.
 
 The first time, scan the QR code with the phone. It opens Vmux Remote through the
-`vmuxremote://pair` deep link, verifies the endpoint, and stores the credentials. After the first
+`vmux://pair` deep link, verifies the endpoint, and stores the credentials. After the first
 authenticated request, the desktop card switches to **Phone paired**. Use **Pair another** to show
 the QR again. In a simulator, copy the pairing URL from the desktop card and paste it in — a
 simulator cannot scan the screen behind it.

--- a/packaging/ios/Info.plist
+++ b/packaging/ios/Info.plist
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+	Replaces the dx template wholesale: `[ios] info_plist` returns this file verbatim instead of
+	rendering assets/ios/ios.plist.hbs. `[ios.plist]` cannot be used for the keys below, because
+	the template writes them first and a duplicate key loses on parse.
+
+	Keep in sync with crates/vmux_mobile/Dioxus.toml. CFBundleExecutable is the [[bin]] name.
+
+	The two version keys below are placeholders: scripts/inject-ios-resources.sh stamps the built
+	copy from the workspace version and the CI run number. Editing them here has no effect.
+-->
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>Vmux</string>
+
+	<key>CFBundleExecutable</key>
+	<string>vmux_mobile</string>
+
+	<key>CFBundleIdentifier</key>
+	<string>ai.vmux.mobile</string>
+
+	<key>CFBundleName</key>
+	<string>Vmux</string>
+
+	<key>CFBundleShortVersionString</key>
+	<string>0.0.30</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en_US</string>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UISupportsTrueScreenSizeOnMac</key>
+	<true/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+		<string>metal</string>
+	</array>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+	</array>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>ai.vmux.mobile</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>vmuxremote</string>
+			</array>
+		</dict>
+	</array>
+
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
+	<key>NSCameraUsageDescription</key>
+	<string>Scan the pairing QR code shown by Vmux on your Mac.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Connect to Vmux on your Mac when it is on the same network as this iPhone.</string>
+
+	<!-- rustls-tls only: standard HTTPS, exempt. Unset forces a manual prompt on every upload. -->
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+</dict>
+</plist>

--- a/packaging/ios/Info.plist
+++ b/packaging/ios/Info.plist
@@ -62,7 +62,7 @@
 			<string>ai.vmux.mobile</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>vmuxremote</string>
+				<string>vmux</string>
 			</array>
 		</dict>
 	</array>

--- a/packaging/ios/PrivacyInfo.xcprivacy
+++ b/packaging/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+
+	<!--
+		Prompts and transcripts go to the Mac the user paired with, never to us. Nothing is
+		collected by the developer, so this array stays empty.
+	-->
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<!-- credentials.rs writes pairing.json into the app container. -->
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/scripts/inject-ios-resources.sh
+++ b/scripts/inject-ios-resources.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Copy hand-authored resources into a built iOS .app and stamp its version keys.
+#
+# dx never calls copy_resources() for the iOS bundle, so `[ios] resources` in Dioxus.toml is a
+# no-op. Anything that has to ship inside the bundle is copied here instead, after `dx build`
+# and before signing.
+#
+# packaging/ios/Info.plist replaces dx's template wholesale, which means the version keys are no
+# longer derived from Cargo.toml. They are stamped onto the built copy here so the checked-in
+# file cannot drift from the workspace version.
+#
+# Usage: scripts/inject-ios-resources.sh [path/to/App.app]
+#        VMUX_IOS_PROFILE=release VMUX_IOS_BUILD_NUMBER=42 scripts/inject-ios-resources.sh
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT/scripts/cargo-target-paths.sh"
+
+PROFILE="${VMUX_IOS_PROFILE:-debug}"
+case "$PROFILE" in
+    debug | release) ;;
+    *)
+        echo "Error: unknown VMUX_IOS_PROFILE=$PROFILE (expected debug|release)" >&2
+        exit 1
+        ;;
+esac
+
+TARGET_DIR="$(vmux_cargo_target_dir "$ROOT")"
+DEFAULT_BUNDLE="$TARGET_DIR/dx/vmux_mobile/$PROFILE/ios/VmuxMobile.app"
+APP_BUNDLE="${1:-${VMUX_IOS_APP_BUNDLE:-$DEFAULT_BUNDLE}}"
+
+if [[ ! -d "$APP_BUNDLE" ]]; then
+    echo "Error: no .app at $APP_BUNDLE. Run 'make mobile-ios' first." >&2
+    exit 1
+fi
+
+PLIST="$APP_BUNDLE/Info.plist"
+if [[ ! -f "$PLIST" ]]; then
+    echo "Error: no Info.plist in $APP_BUNDLE." >&2
+    exit 1
+fi
+
+# App Store Connect rejects a re-upload that reuses a CFBundleVersion, so CI passes the run
+# number. Locally any constant is fine; nothing local is ever uploaded.
+VERSION="$(grep -m1 '^version' "$ROOT/Cargo.toml" | sed 's/.*"\(.*\)".*/\1/')"
+BUILD_NUMBER="${VMUX_IOS_BUILD_NUMBER:-1}"
+
+if [[ -z "$VERSION" ]]; then
+    echo "Error: could not read version from $ROOT/Cargo.toml" >&2
+    exit 1
+fi
+
+cp -f "$ROOT/packaging/ios/PrivacyInfo.xcprivacy" "$APP_BUNDLE/PrivacyInfo.xcprivacy"
+
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "$PLIST"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD_NUMBER" "$PLIST"
+
+echo "inject-ios-resources: $APP_BUNDLE (version $VERSION, build $BUILD_NUMBER)"


### PR DESCRIPTION
## Context

The iOS bundle is missing four keys that block App Store submission ([VMX-130](https://linear.app/vmux/issue/VMX-130)). Without `ITSAppUsesNonExemptEncryption` every upload stops on a manual encryption prompt; without `NSLocalNetworkUsageDescription` local discovery fails silently on iOS 18 even though `NSAllowsLocalNetworking` is set; shipping `UIDeviceFamily = [1, 2]` makes iPad screenshots mandatory for a UI that is phone-portrait shaped; and there is no privacy manifest anywhere in the repo.

First of a six-PR stack on `feat/mobile-remote` taking the app to a submittable build.

## Implementation

None of those keys can be set from `[ios.plist]`. dx renders its own template first and appends `[ios.plist]` after, and a duplicate key loses on parse — so the entries were silently doing nothing. `[application] ios_info_plist` replaces the plist wholesale instead (note: `[ios] info_plist` looks like the right key but is dead config, never read). It is seeded from the template render so the `vmuxremote` deep link and the device-capability keys survive.

That surfaced a second bug: `CFBundleDisplayName` was resolving to `VmuxMobile`, because the `[ios.plist]` entry setting it to `Vmux` lost the same race. The override fixes the home-screen name.

Owning the plist means the version keys no longer derive from `Cargo.toml`, which would rot the moment the workspace version bumps. `scripts/inject-ios-resources.sh` stamps them onto the built copy instead — `CFBundleShortVersionString` from `Cargo.toml`, `CFBundleVersion` from `VMUX_IOS_BUILD_NUMBER`. The checked-in values are placeholders and say so. The same script copies `PrivacyInfo.xcprivacy` into the bundle, because dx never calls `copy_resources` for iOS and `[ios] resources` is a no-op.

The privacy manifest declares no tracking and no collected data — prompts go to the user's own Mac, never to us. The one required-reason API is file timestamps (`C617.1`), from `credentials.rs` writing `pairing.json`. Nothing in the dependency tree touches `NSUserDefaults`.

The bundle identifier moves to `ai.vmux.mobile`, which is what the distribution certificate and provisioning profile will be issued for in VMX-128.

## Checks / QA

`make mobile-ios` and inspect the built bundle:

```
A=target/dx/vmux_mobile/debug/ios/VmuxMobile.app
/usr/libexec/PlistBuddy -c 'Print :UIDeviceFamily' $A/Info.plist
/usr/libexec/PlistBuddy -c 'Print :CFBundleDisplayName' $A/Info.plist
/usr/libexec/PlistBuddy -c 'Print :CFBundleURLTypes' $A/Info.plist
ls $A/PrivacyInfo.xcprivacy
```

Verified locally: identifier `ai.vmux.mobile`, display name `Vmux`, `UIDeviceFamily` `[1]`, portrait only, `UISupportedInterfaceOrientations~ipad` gone, `vmuxremote` scheme intact, privacy manifest present, versions stamped `0.0.30` / `1`.

Worth a reviewer check that pairing still opens from a `vmuxremote://` link, since this PR owns the plist that declares the scheme.

## Not closed here

Two criteria on VMX-130 stay open until later in the stack:

- `CFBundleVersion` auto-incremented **per upload** — the hook exists (`VMUX_IOS_BUILD_NUMBER`), but nothing passes the CI run number until VMX-128.
- Keys confirmed on a **real archive** — needs the signed release build from VMX-128. Verified on a debug bundle here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the `vmux://` pairing link format for mobile pairing, while continuing to support pasted HTTP(S) pairing URLs.
  * Added iOS privacy disclosures, permissions, capabilities, and URL scheme configuration.
  * iOS builds now include privacy resources and automatically apply app version and build information.

* **Documentation**
  * Updated mobile architecture documentation to reflect the new pairing link format.

* **Bug Fixes**
  * Improved validation and error reporting for iOS packaging when required build resources are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->