### PR TITLE
feat(mobile): build and ship a signed iOS release

### DIFF
--- a/.agents/skills/vmux-release/SKILL.md
+++ b/.agents/skills/vmux-release/SKILL.md
@@ -11,6 +11,7 @@ description: Use when releasing a new vmux version, cutting a vmux release, vali
 - Main is clean and current enough to branch from.
 - All recent CI runs green.
 - Apple signing secrets configured in repo Actions secrets: `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_ID`, `APPLE_APP_PASSWORD`, `APPLE_TEAM_ID`.
+- iOS App Store secrets configured: `APPLE_IOS_SIGNING_IDENTITY`, `APPLE_IOS_CERTIFICATE`, `APPLE_IOS_CERTIFICATE_PASSWORD`, `APPLE_IOS_PROVISIONING_PROFILE`. Distinct from the macOS pair above — `APPLE_CERTIFICATE` is a Developer ID certificate and cannot sign for the App Store, so this needs an Apple Distribution certificate and a provisioning profile for `ai.vmux.mobile`. `APPLE_ID`, `APPLE_APP_PASSWORD` and `APPLE_TEAM_ID` are shared with macOS.
 - Update signing secrets configured: `VMUX_UPDATE_PUBLIC_KEY`, `VMUX_UPDATE_PRIVATE_KEY`, `VMUX_UPDATE_PRIVATE_KEY_PASSWORD`.
 
 ## Steps

--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@
 # APPLE_CERTIFICATE is a Developer ID certificate and cannot sign for the App Store. These need
 # an Apple Distribution certificate and a provisioning profile for ai.vmux.mobile, each base64
 # of the raw file. APPLE_ID, APPLE_APP_PASSWORD and APPLE_TEAM_ID are shared with macOS.
+#
+# Encode each on ONE line — `base64 -i file | tr -d '\n'`. This file is read line by line, so a
+# wrapped value is silently truncated at the first newline and fails later as a bad certificate
+# or a profile that will not decode, nowhere near the paste that caused it.
 # APPLE_IOS_SIGNING_IDENTITY=Apple Distribution: Your Name (XXXXXXXXXX)
 # APPLE_IOS_CERTIFICATE=
 # APPLE_IOS_CERTIFICATE_PASSWORD=

--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,12 @@
 # APPLE_CERTIFICATE_PASSWORD=
 # VMUX_UPDATE_PRIVATE_KEY=
 # VMUX_UPDATE_PRIVATE_KEY_PASSWORD=
+
+# iOS App Store signing, used by scripts/build-ios-release.sh. Separate from the pair above:
+# APPLE_CERTIFICATE is a Developer ID certificate and cannot sign for the App Store. These need
+# an Apple Distribution certificate and a provisioning profile for ai.vmux.mobile, each base64
+# of the raw file. APPLE_ID, APPLE_APP_PASSWORD and APPLE_TEAM_ID are shared with macOS.
+# APPLE_IOS_SIGNING_IDENTITY=Apple Distribution: Your Name (XXXXXXXXXX)
+# APPLE_IOS_CERTIFICATE=
+# APPLE_IOS_CERTIFICATE_PASSWORD=
+# APPLE_IOS_PROVISIONING_PROFILE=

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,9 @@ jobs:
           # version alone cannot carry a resubmission. run_number is monotonic and needs no
           # committed state, which would otherwise trip update-release-metadata.sh --check.
           VMUX_IOS_BUILD_NUMBER: ${{ github.run_number }}
+          # The script builds and signs but will not send unless asked. This is the only place
+          # that asks, so an upload can only come from a release run.
+          VMUX_IOS_UPLOAD: "1"
         run: ./scripts/build-ios-release.sh
 
       - name: Verify bundle layout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,43 @@ jobs:
             echo "tag=v$VERSION"
           } >> "$GITHUB_OUTPUT"
 
+  testflight:
+    name: Upload iOS to TestFlight
+    needs: detect-version
+    if: needs.detect-version.outputs.should_release == 'true'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@1.95.0
+        with:
+          targets: aarch64-apple-ios
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ios-release
+
+      - name: Install dioxus CLI
+        run: ./scripts/install-dioxus-cli.sh
+
+      - name: Build, sign and upload
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+          APPLE_IOS_SIGNING_IDENTITY: ${{ secrets.APPLE_IOS_SIGNING_IDENTITY }}
+          APPLE_IOS_CERTIFICATE: ${{ secrets.APPLE_IOS_CERTIFICATE }}
+          APPLE_IOS_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_IOS_CERTIFICATE_PASSWORD }}
+          APPLE_IOS_PROVISIONING_PROFILE: ${{ secrets.APPLE_IOS_PROVISIONING_PROFILE }}
+          # App Store Connect refuses a CFBundleVersion it has already seen, and the marketing
+          # version alone cannot carry a resubmission. run_number is monotonic and needs no
+          # committed state, which would otherwise trip update-release-metadata.sh --check.
+          VMUX_IOS_BUILD_NUMBER: ${{ github.run_number }}
+        run: ./scripts/build-ios-release.sh
+
+      - name: Verify bundle layout
+        run: ./scripts/test-ios-bundle-layout.sh --signed
+
   publish:
     name: Publish Release
     needs: detect-version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,12 @@ jobs:
     if: needs.detect-version.outputs.should_release == 'true'
     runs-on: macos-latest
     steps:
+      # The job builds and uploads to Apple; it never pushes. The workflow token carries
+      # contents: write for the publish job, so leaving it in the checkout would hand a
+      # write-capable credential to every build step for no reason.
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@1.95.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev dev-full dev-player dev-rust web-bundle test-app local release build-local build-release build setup-cef install-debug-render-process seed-target doctor ensure-mac-deps ensure-native-deps ensure-web-deps ensure-dioxus-deps ensure-mobile-ios-deps ensure-mobile-android-deps ios android mobile-ios mobile-android mobile-ios-run mobile-android-run ensure-package-deps ensure-codesign-deps website build-website-release build-website-css api-docs lint lint-fix test setup-hooks cleanup cleanup-local
+.PHONY: dev dev-full dev-player dev-rust web-bundle test-app local release build-local build-release build setup-cef install-debug-render-process seed-target doctor ensure-mac-deps ensure-native-deps ensure-web-deps ensure-dioxus-deps ensure-mobile-ios-deps ensure-mobile-android-deps ios android mobile-ios mobile-android mobile-ios-run mobile-android-run build-mobile-ios-release mobile-ios-release ensure-ios-release-deps ensure-package-deps ensure-codesign-deps website build-website-release build-website-css api-docs lint lint-fix test setup-hooks cleanup cleanup-local
 
 .DEFAULT_GOAL := dev
 
@@ -86,6 +86,13 @@ android: mobile-android-run
 mobile-ios: ensure-mobile-ios-deps
 	"$(DX_BIN)" build --ios -p vmux_mobile $(if $(filter release,$(VMUX_IOS_PROFILE)),--release)
 	./scripts/inject-ios-resources.sh
+	./scripts/test-ios-bundle-layout.sh
+
+build-mobile-ios-release: ensure-ios-release-deps
+	./scripts/build-ios-release.sh
+
+mobile-ios-release: build-mobile-ios-release
+	./scripts/test-ios-bundle-layout.sh --signed
 
 # The icon, launch screen and privacy manifest exist only in a bundle the injector has been over,
 # and `mobile-ios-run` cannot be that bundle: `dx serve` installs what it just built and reinstalls
@@ -352,6 +359,15 @@ ensure-package-deps:
 		echo "Installing bevy_cef_bundle_app $(BEVY_CEF_BUNDLE_APP_VERSION) (found: $${bcb_version:-missing})..."; \
 		"$(CARGO_BIN)" install bevy_cef_bundle_app --locked --version "$(BEVY_CEF_BUNDLE_APP_VERSION)"; \
 	fi
+
+ensure-ios-release-deps: ensure-mobile-ios-deps ensure-codesign-deps
+	@echo "Checking iOS release dependencies..."
+	@for tool in actool ibtool altool; do \
+		if ! xcrun --find "$$tool" >/dev/null 2>&1; then \
+			echo "$$tool not found. Install Xcode, not just the Command Line Tools."; \
+			exit 1; \
+		fi; \
+	done
 
 ensure-codesign-deps:
 	@echo "Checking codesigning dependencies..."

--- a/Makefile
+++ b/Makefile
@@ -360,9 +360,12 @@ ensure-package-deps:
 		"$(CARGO_BIN)" install bevy_cef_bundle_app --locked --version "$(BEVY_CEF_BUNDLE_APP_VERSION)"; \
 	fi
 
+# altool is not here: it is only reached when VMUX_IOS_UPLOAD asks for an upload, and requiring
+# it up front would refuse a build-and-sign on a machine that can do one. The script checks for
+# it where it uses it.
 ensure-ios-release-deps: ensure-mobile-ios-deps ensure-codesign-deps
 	@echo "Checking iOS release dependencies..."
-	@for tool in actool ibtool altool; do \
+	@for tool in actool ibtool; do \
 		if ! xcrun --find "$$tool" >/dev/null 2>&1; then \
 			echo "$$tool not found. Install Xcode, not just the Command Line Tools."; \
 			exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev dev-full dev-player dev-rust web-bundle test-app local release build-local build-release build setup-cef install-debug-render-process seed-target doctor ensure-mac-deps ensure-native-deps ensure-web-deps ensure-dioxus-deps ensure-mobile-ios-deps ensure-mobile-android-deps ios android mobile-ios mobile-android mobile-ios-run mobile-android-run build-mobile-ios-release mobile-ios-release ensure-ios-release-deps ensure-package-deps ensure-codesign-deps website build-website-release build-website-css api-docs lint lint-fix test setup-hooks cleanup cleanup-local
+.PHONY: dev dev-full dev-player dev-rust web-bundle test-app local release build-local build-release build setup-cef install-debug-render-process seed-target doctor ensure-mac-deps ensure-native-deps ensure-web-deps ensure-dioxus-deps ensure-mobile-ios-deps ensure-mobile-android-deps ios android mobile-ios mobile-android mobile-ios-run mobile-android-run build-ios-release ios-release ensure-ios-release-deps ensure-package-deps ensure-codesign-deps website build-website-release build-website-css api-docs lint lint-fix test setup-hooks cleanup cleanup-local
 
 .DEFAULT_GOAL := dev
 
@@ -88,10 +88,10 @@ mobile-ios: ensure-mobile-ios-deps
 	./scripts/inject-ios-resources.sh
 	./scripts/test-ios-bundle-layout.sh
 
-build-mobile-ios-release: ensure-ios-release-deps
+build-ios-release: ensure-ios-release-deps
 	./scripts/build-ios-release.sh
 
-mobile-ios-release: build-mobile-ios-release
+ios-release: build-ios-release
 	./scripts/test-ios-bundle-layout.sh --signed
 
 # The icon, launch screen and privacy manifest exist only in a bundle the injector has been over,

--- a/packaging/ios/Vmux.entitlements
+++ b/packaging/ios/Vmux.entitlements
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+	App Store distribution entitlements. {{TEAM_ID}} is substituted by
+	scripts/build-ios-release.sh from APPLE_TEAM_ID, the same placeholder convention
+	packaging/macos/ai.vmux.service.plist uses for {{PROFILE}}.
+
+	Nothing here beyond identity: the app talks to a relay over QUIC and to a paired Mac, which
+	needs no entitlement. get-task-allow must be false or App Store Connect rejects the upload.
+-->
+<plist version="1.0">
+<dict>
+	<key>application-identifier</key>
+	<string>{{TEAM_ID}}.ai.vmux.mobile</string>
+	<key>com.apple.developer.team-identifier</key>
+	<string>{{TEAM_ID}}</string>
+	<key>get-task-allow</key>
+	<false/>
+</dict>
+</plist>

--- a/scripts/build-ios-release.sh
+++ b/scripts/build-ios-release.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build, sign and package Vmux for iOS as an App Store .ipa, optionally uploading it to
+# TestFlight. Imports the distribution certificate from APPLE_IOS_CERTIFICATE /
+# APPLE_IOS_CERTIFICATE_PASSWORD (or `.env`) into a temporary keychain so signing works the same
+# way locally and in CI, mirroring scripts/build-mac-release.sh.
+#
+# Required:
+#   APPLE_TEAM_ID                     ten-character team id
+#   APPLE_IOS_SIGNING_IDENTITY        e.g. "Apple Distribution: Name (XXXXXXXXXX)"
+#   APPLE_IOS_PROVISIONING_PROFILE    base64 of the .mobileprovision for ai.vmux.mobile
+# Required unless the identity is already in the login keychain:
+#   APPLE_IOS_CERTIFICATE             base64 of the distribution .p12
+#   APPLE_IOS_CERTIFICATE_PASSWORD    that .p12's export password
+# Required to upload (skip with SKIP_UPLOAD=1):
+#   APPLE_ID, APPLE_APP_PASSWORD
+# Optional:
+#   VMUX_IOS_BUILD_NUMBER             CFBundleVersion; CI passes the run number
+#   SKIP_UPLOAD=1                     build and sign only
+#
+# Usage: ./scripts/build-ios-release.sh
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT/scripts/cargo-target-paths.sh"
+
+if [[ -f "$ROOT/.env" ]]; then
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        [[ -z "$line" || "$line" == \#* ]] && continue
+        [[ "$line" == *=* ]] || continue
+        key="${line%%=*}"
+        value="${line#*=}"
+        [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+        export "$key=$value"
+    done < "$ROOT/.env"
+fi
+
+: "${APPLE_TEAM_ID:?missing APPLE_TEAM_ID}"
+: "${APPLE_IOS_SIGNING_IDENTITY:?missing APPLE_IOS_SIGNING_IDENTITY}"
+: "${APPLE_IOS_PROVISIONING_PROFILE:?missing APPLE_IOS_PROVISIONING_PROFILE}"
+
+DX_BIN="${DX_BIN:-$(command -v dx || echo "$HOME/.cargo/bin/dx")}"
+TARGET_TRIPLE="aarch64-apple-ios"
+BUNDLE_ID="ai.vmux.mobile"
+
+TMP_DIR=""
+KEYCHAIN=""
+ORIGINAL_KEYCHAINS=()
+
+while IFS= read -r keychain; do
+    keychain="${keychain#"${keychain%%[![:space:]]*}"}"
+    keychain="${keychain#\"}"
+    keychain="${keychain%\"}"
+    [[ -n "$keychain" ]] && ORIGINAL_KEYCHAINS+=("$keychain")
+done < <(security list-keychains -d user)
+
+cleanup() {
+    if [[ "${#ORIGINAL_KEYCHAINS[@]}" -gt 0 ]]; then
+        security list-keychains -d user -s "${ORIGINAL_KEYCHAINS[@]}" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "$KEYCHAIN" ]]; then
+        security delete-keychain "$KEYCHAIN" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+trap cleanup EXIT
+
+# BSD mktemp only substitutes X's at the end of the template, so use -t and let it name the dir.
+TMP_DIR="$(mktemp -d -t vmux-ios-build)"
+
+if [[ -n "${APPLE_IOS_CERTIFICATE:-}" || -n "${APPLE_IOS_CERTIFICATE_PASSWORD:-}" ]]; then
+    : "${APPLE_IOS_CERTIFICATE:?missing APPLE_IOS_CERTIFICATE}"
+    : "${APPLE_IOS_CERTIFICATE_PASSWORD:?missing APPLE_IOS_CERTIFICATE_PASSWORD}"
+
+    echo "==> Setting up ephemeral signing keychain"
+    CERT_FILE="$TMP_DIR/cert.p12"
+    KEYCHAIN="$TMP_DIR/signing.keychain-db"
+    KEYCHAIN_PASSWORD="$(uuidgen)"
+
+    echo "$APPLE_IOS_CERTIFICATE" | base64 --decode > "$CERT_FILE"
+    security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+    security set-keychain-settings -lut 21600 "$KEYCHAIN"
+    security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+    if ! security import "$CERT_FILE" -P "$APPLE_IOS_CERTIFICATE_PASSWORD" -A -f pkcs12 -k "$KEYCHAIN"; then
+        echo "Error: failed to import APPLE_IOS_CERTIFICATE. Check APPLE_IOS_CERTIFICATE_PASSWORD matches the .p12 export password." >&2
+        exit 1
+    fi
+    security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+    security list-keychains -d user -s "$KEYCHAIN" "${ORIGINAL_KEYCHAINS[@]}"
+    if ! security find-identity -v -p codesigning "$KEYCHAIN" | grep -Fq "\"$APPLE_IOS_SIGNING_IDENTITY\""; then
+        echo "Error: APPLE_IOS_SIGNING_IDENTITY does not match an imported codesigning identity." >&2
+        echo "       A Developer ID certificate cannot sign for the App Store; this must be an Apple Distribution certificate." >&2
+        exit 1
+    fi
+else
+    echo "==> APPLE_IOS_CERTIFICATE not set; falling back to login keychain"
+fi
+
+CODESIGN_KEYCHAIN_ARGS=()
+if [[ -n "$KEYCHAIN" ]]; then
+    CODESIGN_KEYCHAIN_ARGS=(--keychain "$KEYCHAIN")
+fi
+
+# dx auto-provisioning only ever matches "Apple Development:" identities, so the profile is
+# installed and the signing identity passed explicitly instead of letting dx guess.
+PROFILE_FILE="$TMP_DIR/profile.mobileprovision"
+echo "$APPLE_IOS_PROVISIONING_PROFILE" | base64 --decode > "$PROFILE_FILE"
+
+PROFILE_BUNDLE_ID="$(security cms -D -i "$PROFILE_FILE" 2>/dev/null \
+    | plutil -extract Entitlements.application-identifier raw - 2>/dev/null || true)"
+if [[ "$PROFILE_BUNDLE_ID" != "$APPLE_TEAM_ID.$BUNDLE_ID" ]]; then
+    echo "Error: provisioning profile is for '${PROFILE_BUNDLE_ID:-unknown}', expected '$APPLE_TEAM_ID.$BUNDLE_ID'." >&2
+    exit 1
+fi
+
+echo "==> Building $TARGET_TRIPLE (release)"
+cd "$ROOT"
+"$DX_BIN" build --platform ios --release -p vmux_mobile --target "$TARGET_TRIPLE"
+
+TARGET_DIR="$(vmux_cargo_target_dir "$ROOT")"
+APP_BUNDLE="$TARGET_DIR/dx/vmux_mobile/release/ios/VmuxMobile.app"
+if [[ ! -d "$APP_BUNDLE" ]]; then
+    echo "Error: expected a bundle at $APP_BUNDLE after the build." >&2
+    exit 1
+fi
+
+echo "==> Injecting resources"
+# Must happen between build and signing: the icons, launch screen and privacy manifest are part
+# of what gets sealed. `dx bundle` would rebuild and undo this, which is why the .ipa is
+# assembled below rather than by dx.
+VMUX_IOS_PROFILE=release "$ROOT/scripts/inject-ios-resources.sh" "$APP_BUNDLE"
+
+cp -f "$PROFILE_FILE" "$APP_BUNDLE/embedded.mobileprovision"
+
+ENTITLEMENTS="$TMP_DIR/Vmux.entitlements"
+sed -e "s|{{TEAM_ID}}|$APPLE_TEAM_ID|g" "$ROOT/packaging/ios/Vmux.entitlements" > "$ENTITLEMENTS"
+
+echo "==> Signing"
+codesign --force --timestamp --options runtime \
+    --entitlements "$ENTITLEMENTS" \
+    --sign "$APPLE_IOS_SIGNING_IDENTITY" \
+    ${CODESIGN_KEYCHAIN_ARGS[@]+"${CODESIGN_KEYCHAIN_ARGS[@]}"} \
+    "$APP_BUNDLE"
+
+codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
+
+echo "==> Packaging .ipa"
+VERSION="$(grep -m1 '^version' "$ROOT/Cargo.toml" | sed 's/.*"\(.*\)".*/\1/')"
+OUTPUT_DIR="$TARGET_DIR/dx/vmux_mobile/release/ios/ipa"
+IPA="$OUTPUT_DIR/Vmux_${VERSION}_aarch64.ipa"
+mkdir -p "$OUTPUT_DIR"
+rm -f "$IPA"
+
+PAYLOAD="$TMP_DIR/Payload"
+mkdir -p "$PAYLOAD"
+cp -R "$APP_BUNDLE" "$PAYLOAD/"
+(cd "$TMP_DIR" && ditto -c -k --sequesterRsrc --keepParent Payload "$IPA")
+
+echo "==> Built $IPA"
+
+if [[ "${SKIP_UPLOAD:-}" == "1" ]]; then
+    echo "==> SKIP_UPLOAD=1, not uploading"
+    exit 0
+fi
+
+: "${APPLE_ID:?missing APPLE_ID}"
+: "${APPLE_APP_PASSWORD:?missing APPLE_APP_PASSWORD}"
+
+echo "==> Uploading to App Store Connect"
+xcrun altool --upload-app -f "$IPA" -t ios \
+    -u "$APPLE_ID" -p "$APPLE_APP_PASSWORD" \
+    --team-id "$APPLE_TEAM_ID"
+
+echo "==> Uploaded. It appears in TestFlight once Apple finishes processing."

--- a/scripts/build-ios-release.sh
+++ b/scripts/build-ios-release.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Build, sign and package Vmux for iOS as an App Store .ipa, optionally uploading it to
-# TestFlight. Imports the distribution certificate from APPLE_IOS_CERTIFICATE /
+# Build, sign and package Vmux for iOS as an App Store .ipa. Uploading to TestFlight is opt-in.
+# Imports the distribution certificate from APPLE_IOS_CERTIFICATE /
 # APPLE_IOS_CERTIFICATE_PASSWORD (or `.env`) into a temporary keychain so signing works the same
 # way locally and in CI, mirroring scripts/build-mac-release.sh.
 #
@@ -13,11 +13,11 @@ set -euo pipefail
 # Required unless the identity is already in the login keychain:
 #   APPLE_IOS_CERTIFICATE             base64 of the distribution .p12
 #   APPLE_IOS_CERTIFICATE_PASSWORD    that .p12's export password
-# Required to upload (skip with SKIP_UPLOAD=1):
+# Required only when uploading:
 #   APPLE_ID, APPLE_APP_PASSWORD
 # Optional:
 #   VMUX_IOS_BUILD_NUMBER             CFBundleVersion; CI passes the run number
-#   SKIP_UPLOAD=1                     build and sign only
+#   VMUX_IOS_UPLOAD=1                 send the .ipa to App Store Connect; off by default
 #
 # Usage: ./scripts/build-ios-release.sh
 
@@ -160,8 +160,12 @@ cp -R "$APP_BUNDLE" "$PAYLOAD/"
 
 echo "==> Built $IPA"
 
-if [[ "${SKIP_UPLOAD:-}" == "1" ]]; then
-    echo "==> SKIP_UPLOAD=1, not uploading"
+# Uploading is opt-in rather than opt-out. App Store Connect keeps what it is given: a build
+# cannot be withdrawn once uploaded, and its CFBundleVersion is burned even if the build is
+# rejected, so a mistake here costs a version number rather than a retry. Building and signing
+# are safe to repeat; sending is not, so the sending is what has to be asked for.
+if [[ "${VMUX_IOS_UPLOAD:-}" != "1" ]]; then
+    echo "==> Not uploading. Set VMUX_IOS_UPLOAD=1 to send this to App Store Connect."
     exit 0
 fi
 

--- a/scripts/build-ios-release.sh
+++ b/scripts/build-ios-release.sh
@@ -169,6 +169,11 @@ if [[ "${VMUX_IOS_UPLOAD:-}" != "1" ]]; then
     exit 0
 fi
 
+if ! xcrun --find altool >/dev/null 2>&1; then
+    echo "Error: altool not found. Install Xcode, not just the Command Line Tools." >&2
+    exit 1
+fi
+
 : "${APPLE_ID:?missing APPLE_ID}"
 : "${APPLE_APP_PASSWORD:?missing APPLE_APP_PASSWORD}"
 

--- a/scripts/inject-ios-resources.sh
+++ b/scripts/inject-ios-resources.sh
@@ -96,4 +96,36 @@ fi
 /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "$PLIST"
 /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD_NUMBER" "$PLIST"
 
+# Keys Xcode writes into a built app and dx does not. App Store Connect validates them on upload,
+# so without these the .ipa is rejected before review ever sees it.
+#
+# CFBundleIconName is the one that looks redundant and is not: the copy inside CFBundleIcons says
+# which icon to draw, and this top-level one is what the upload check reads. Only the nested copy
+# existed, so the bundle looked complete and would still have been refused.
+#
+# The DT* keys and BuildMachineOSBuild record which toolchain produced the bundle, so they are
+# asked of the toolchain rather than written down. DTXcode is Xcode's version without the dots,
+# padded — 26.6 is 2660.
+set_plist() {
+    /usr/libexec/PlistBuddy -c "Delete :$1" "$PLIST" >/dev/null 2>&1 || true
+    /usr/libexec/PlistBuddy -c "Add :$1 string $2" "$PLIST"
+}
+
+SDK_VERSION="$(xcrun --sdk iphoneos --show-sdk-version)"
+SDK_BUILD="$(xcrun --sdk iphoneos --show-sdk-build-version)"
+XCODE_VERSION="$(xcodebuild -version | head -1 | awk '{print $2}')"
+XCODE_BUILD="$(xcodebuild -version | tail -1 | awk '{print $3}')"
+XCODE_PADDED="$(printf '%d%d0' "${XCODE_VERSION%%.*}" "$(echo "$XCODE_VERSION" | cut -d. -f2)")"
+
+set_plist CFBundleIconName AppIcon
+set_plist MinimumOSVersion "$DEPLOYMENT_TARGET"
+set_plist DTPlatformName iphoneos
+set_plist DTPlatformVersion "$SDK_VERSION"
+set_plist DTPlatformBuild "$SDK_BUILD"
+set_plist DTSDKName "iphoneos$SDK_VERSION"
+set_plist DTSDKBuild "$SDK_BUILD"
+set_plist DTXcode "$XCODE_PADDED"
+set_plist DTXcodeBuild "$XCODE_BUILD"
+set_plist BuildMachineOSBuild "$(sw_vers -buildVersion)"
+
 echo "inject-ios-resources: $APP_BUNDLE (version $VERSION, build $BUILD_NUMBER)"

--- a/scripts/test-ios-bundle-layout.sh
+++ b/scripts/test-ios-bundle-layout.sh
@@ -76,7 +76,23 @@ if [[ "$(plist_value CFBundleIdentifier)" != "ai.vmux.mobile" ]]; then
 fi
 
 if [[ "$(plist_value 'CFBundleIcons:CFBundlePrimaryIcon:CFBundleIconName')" != "AppIcon" ]]; then
-    echo "Info.plist is missing CFBundleIconName" >&2
+    echo "Info.plist is missing CFBundleIcons:CFBundlePrimaryIcon:CFBundleIconName" >&2
+    exit 1
+fi
+
+# Everything Xcode would have written and dx does not. Checking only the nested icon name above
+# passed while the upload would still have been refused for the top-level one, so each key App
+# Store Connect validates is asserted by the name it validates.
+for key in CFBundleIconName MinimumOSVersion DTPlatformName DTPlatformVersion DTPlatformBuild \
+    DTSDKName DTSDKBuild DTXcode DTXcodeBuild BuildMachineOSBuild; do
+    if [[ -z "$(plist_value "$key")" ]]; then
+        echo "Info.plist is missing $key, which App Store Connect rejects on upload" >&2
+        exit 1
+    fi
+done
+
+if [[ "$(plist_value CFBundleIconName)" != "AppIcon" ]]; then
+    echo "Info.plist CFBundleIconName is not AppIcon" >&2
     exit 1
 fi
 

--- a/scripts/test-ios-bundle-layout.sh
+++ b/scripts/test-ios-bundle-layout.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Asserts the iOS .app bundle has the expected layout. Exits non-zero on failure.
+#
+# Everything checked here is injected after `dx build` rather than produced by it, so a silent
+# regression in inject-ios-resources.sh would otherwise only surface as an App Store rejection.
+#
+# Pass --signed to additionally require the signing artifacts.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT/scripts/cargo-target-paths.sh"
+
+SIGNED=0
+APP=""
+PROFILE="${VMUX_IOS_PROFILE:-debug}"
+for arg in "$@"; do
+    case "$arg" in
+        --signed)
+            SIGNED=1
+            PROFILE="release"
+            ;;
+        *) APP="$arg" ;;
+    esac
+done
+
+if [[ -z "$APP" ]]; then
+    APP="$(vmux_cargo_target_dir "$ROOT")/dx/vmux_mobile/$PROFILE/ios/VmuxMobile.app"
+fi
+
+if [[ ! -d "$APP" ]]; then
+    echo "usage: $0 [--signed] [path-to-VmuxMobile.app]" >&2
+    echo "no bundle at $APP" >&2
+    exit 1
+fi
+
+REQUIRED=(
+    "vmux_mobile"
+    "Info.plist"
+    "Assets.car"
+    "AppIcon60x60@2x.png"
+    "LaunchScreen.storyboardc"
+    "PrivacyInfo.xcprivacy"
+)
+
+if [[ "$SIGNED" == "1" ]]; then
+    REQUIRED+=("embedded.mobileprovision" "_CodeSignature")
+fi
+
+for path in "${REQUIRED[@]}"; do
+    if [[ ! -e "$APP/$path" ]]; then
+        echo "MISSING: $APP/$path" >&2
+        exit 1
+    fi
+done
+
+# UIDeviceFamily is iPhone-only, so an iPad icon in the bundle means actool was run without
+# --target-device iphone.
+FORBIDDEN=(
+    "AppIcon76x76@2x~ipad.png"
+)
+
+for path in "${FORBIDDEN[@]}"; do
+    if [[ -e "$APP/$path" ]]; then
+        echo "FORBIDDEN: $APP/$path" >&2
+        exit 1
+    fi
+done
+
+plist_value() {
+    /usr/libexec/PlistBuddy -c "Print :$1" "$APP/Info.plist" 2>/dev/null || true
+}
+
+if [[ "$(plist_value CFBundleIdentifier)" != "ai.vmux.mobile" ]]; then
+    echo "Info.plist CFBundleIdentifier is not ai.vmux.mobile" >&2
+    exit 1
+fi
+
+if [[ "$(plist_value 'CFBundleIcons:CFBundlePrimaryIcon:CFBundleIconName')" != "AppIcon" ]]; then
+    echo "Info.plist is missing CFBundleIconName" >&2
+    exit 1
+fi
+
+if [[ "$(plist_value ITSAppUsesNonExemptEncryption)" != "false" ]]; then
+    echo "Info.plist is missing ITSAppUsesNonExemptEncryption" >&2
+    exit 1
+fi
+
+# The version keys are stamped onto the built copy, so a mismatch means the injection step did
+# not run and the checked-in placeholders shipped instead.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="$(grep -m1 '^version' "$ROOT/Cargo.toml" | sed 's/.*"\(.*\)".*/\1/')"
+if [[ "$(plist_value CFBundleShortVersionString)" != "$VERSION" ]]; then
+    echo "Info.plist CFBundleShortVersionString does not match Cargo.toml ($VERSION)" >&2
+    exit 1
+fi
+
+echo "OK: iOS bundle layout correct"

--- a/scripts/test-ios-bundle-layout.sh
+++ b/scripts/test-ios-bundle-layout.sh
@@ -103,7 +103,6 @@ fi
 
 # The version keys are stamped onto the built copy, so a mismatch means the injection step did
 # not run and the checked-in placeholders shipped instead.
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VERSION="$(grep -m1 '^version' "$ROOT/Cargo.toml" | sed 's/.*"\(.*\)".*/\1/')"
 if [[ "$(plist_value CFBundleShortVersionString)" != "$VERSION" ]]; then
     echo "Info.plist CFBundleShortVersionString does not match Cargo.toml ($VERSION)" >&2


### PR DESCRIPTION
## Context

There is no path from source to a signed `.ipa` ([VMX-128](https://linear.app/vmux/issue/VMX-128)). `make mobile-ios` builds a debug simulator bundle with no `--release`, `--device` or `--codesign`; there was no `packaging/ios/` before this stack; and neither workflow has ever run an iOS job — both `release.yml` jobs are `ubuntu-latest`.

Third of six on `feat/mobile-remote`. Stacked on #348 → #347 — **review those first**; this diff is against #348.

## Implementation

**Why not `dx bundle --package-types ipa`.** dx does ship an IPA bundler and does codesign when a device target is passed, but not in a usable order: `dx bundle` always runs a full build before packaging (`cli/bundle.rs` — there is no skip-build flag), and the icons, launch screen and privacy manifest from #348 have to be inside the bundle *before* it is sealed. Anything injected first gets rebuilt away; anything injected after breaks the signature. So the script drives the four steps itself — `dx build` for the build, the exact `codesign` invocation dx would have made, then `ditto` around a `Payload/` directory. That last part is all dx's `bundle_ios_ipa` does beyond a verify, and it is not worth a second build system.

**dx cannot find the identity.** `auto_provision_signing_name` regex-matches `"Apple Development: (.+)"` only, so it would never see an Apple Distribution certificate on a hosted runner. The identity and the profile are both passed explicitly, and the profile is validated against `$APPLE_TEAM_ID.ai.vmux.mobile` before the build starts rather than after several minutes of compiling.

**Signing** mirrors `scripts/build-mac-release.sh`: ephemeral keychain, `trap`-based keychain-list restore, the same inline `.env` parser so local and CI take one path. `APPLE_IOS_*` are separate secrets from the macOS ones deliberately — `APPLE_CERTIFICATE` is Developer ID and cannot sign for the App Store. `APPLE_ID`, `APPLE_APP_PASSWORD` and `APPLE_TEAM_ID` are reused.

**`CFBundleVersion`** comes from `github.run_number`. App Store Connect rejects a re-upload that reuses one, and the marketing version alone cannot carry a resubmission. A counter committed to the repo would collide with `update-release-metadata.sh --check`.

**`[ios.entitlements]` is deliberately not set** in `Dioxus.toml`. Since signing is done here with an explicit `--entitlements`, that table would never be read — the same dead-config trap `[ios.plist]` turned out to be in #347.

**`test-ios-bundle-layout.sh`** follows the `REQUIRED[]`/`FORBIDDEN[]` shape of the existing `test-bundle-layout.sh`. It runs on both the debug (`make mobile-ios`) and signed (`make mobile-ios-release`) paths. Everything it asserts is injected after the build rather than produced by it, so without it a regression surfaces as an App Store rejection weeks later.

## Checks / QA

Verified locally:

- `make mobile-ios` → builds, injects, layout test passes.
- Layout test fails correctly on all four negative cases: missing `Assets.car`, a stray `~ipad` icon, an unstamped version, and `--signed` against an unsigned bundle.
- `build-ios-release.sh` fails fast with a named variable on missing env, and rejects a bad provisioning profile *before* building: `Error: provisioning profile is for 'unknown', expected 'ABCDE12345.ai.vmux.mobile'.`
- `release.yml` parses; the `testflight` job wires all seven secrets plus `VMUX_IOS_BUILD_NUMBER`.

**The signing path itself is untested** — see below.

## Before this can work

I cannot do any of these; they need Apple Developer portal access:

- [ ] Register the App ID `ai.vmux.mobile`
- [ ] Issue an **Apple Distribution** certificate, export as `.p12` → `APPLE_IOS_CERTIFICATE` (base64), password → `APPLE_IOS_CERTIFICATE_PASSWORD`
- [ ] Create an **App Store** provisioning profile for `ai.vmux.mobile` → `APPLE_IOS_PROVISIONING_PROFILE` (base64)
- [ ] Set `APPLE_IOS_SIGNING_IDENTITY` to the exact identity string, e.g. `Apple Distribution: Name (TEAMID)`
- [ ] Confirm the `APPLE_ID` app-specific password has App Manager rights for uploads
- [ ] Create the app record in App Store Connect

Then `SKIP_UPLOAD=1 make mobile-ios-release` locally is the cheapest first test, before letting the workflow upload.

## Deliberately out of scope

No iOS job was added to `ci.yml`, so **nothing compiles the iOS target at PR time** — the first signed build happens at release. Adding one would put a `macos-latest` job on every mobile PR, which the issue does not ask for and which is not free. Flagging it as a follow-up rather than deciding it here.

## Not closed here

- A build lands in TestFlight and is installable on a physical iPhone — needs the certificate above.
- Keys confirmed on a real archive (carried over from VMX-130) — same dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated iOS App Store release builds and TestFlight uploads.
  - Added support for validating signing credentials, provisioning profiles, and distribution entitlements.
  - Added iOS bundle checks covering required files, metadata, versions, and signing requirements.
  - Added automatic App Store metadata injection during packaging.

- **Chores**
  - Added configuration guidance and build commands for iOS release tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->