### PR TITLE
fix(mobile): handle a denied camera in the QR scanner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11538,6 +11538,7 @@ dependencies = [
 name = "vmux_mobile"
 version = "0.0.30"
 dependencies = [
+ "block2 0.6.2",
  "dioxus",
  "dispatch2",
  "futures-util",

--- a/crates/app/vmux_mobile/Cargo.toml
+++ b/crates/app/vmux_mobile/Cargo.toml
@@ -36,10 +36,13 @@ vmux_team = { path = "../../page/vmux_team" }
 vmux_ui = { path = "../../vmux_ui" }
 
 [target.'cfg(target_os = "ios")'.dependencies]
+block2 = "0.6"
 dispatch2 = "0.3"
 objc2 = "0.6"
 objc2-av-foundation = { version = "0.3", default-features = false, features = [
     "std",
+    # requestAccessForMediaType takes a completion block.
+    "block2",
     "AVAnimation",
     "AVCaptureDevice",
     "AVCaptureInput",
@@ -61,9 +64,12 @@ objc2-core-foundation = { version = "0.3", default-features = false, features = 
 objc2-foundation = { version = "0.3", default-features = false, features = [
     "std",
     "NSArray",
+    "NSDictionary",
     "NSError",
+    "NSNotification",
     "NSObject",
     "NSString",
+    "NSURL",
 ] }
 objc2-quartz-core = { version = "0.3", default-features = false, features = [
     "std",
@@ -77,6 +83,8 @@ objc2-ui-kit = { version = "0.3", default-features = false, features = [
     "NSText",
     "objc2-core-foundation",
     "objc2-quartz-core",
+    # openSettingsURLString, so a denied camera can be re-granted without hunting through Settings.
+    "UIApplication",
     "UIButton",
     "UIColor",
     "UIControl",

--- a/crates/app/vmux_mobile/src/main.rs
+++ b/crates/app/vmux_mobile/src/main.rs
@@ -1662,6 +1662,10 @@ struct PairCardProps {
 #[component]
 fn PairCard(props: PairCardProps) -> Element {
     let mut show_link = use_signal(|| !props.value.trim().is_empty());
+    let unavailable = use_hook(|| match qr_scanner::ScannerSupport::detect() {
+        qr_scanner::ScannerSupport::Available => None,
+        qr_scanner::ScannerSupport::Unavailable(reason) => Some(reason),
+    });
 
     rsx! {
         div { class: "w-full",
@@ -1670,8 +1674,9 @@ fn PairCard(props: PairCardProps) -> Element {
                 p { class: "mt-1 text-xs leading-5 text-muted-foreground", {translate("mobile-pair-subtitle")} }
             }
             button {
-                class: "flex h-14 w-full items-center justify-center gap-2.5 rounded-2xl bg-primary text-sm font-semibold text-primary-foreground shadow-xl shadow-black/20 active:scale-[0.99] active:bg-primary/90",
+                class: "flex h-14 w-full items-center justify-center gap-2.5 rounded-2xl bg-primary text-sm font-semibold text-primary-foreground shadow-xl shadow-black/20 disabled:pointer-events-none disabled:opacity-40 disabled:shadow-none active:scale-[0.99] active:bg-primary/90",
                 r#type: "button",
+                disabled: unavailable.is_some(),
                 onclick: move |_| props.on_scan.call(()),
                 svg {
                     class: "h-5 w-5",
@@ -1697,6 +1702,9 @@ fn PairCard(props: PairCardProps) -> Element {
                 r#type: "button",
                 onclick: move |_| show_link.set(!show_link()),
                 {if show_link() { translate("mobile-pair-hide-link") } else { translate("mobile-pair-show-link") }}
+            }
+            if let Some(reason) = unavailable.clone() {
+                p { class: "mt-3 text-center text-xs leading-5 text-muted-foreground", "{reason}" }
             }
             if show_link() {
                 form {

--- a/crates/app/vmux_mobile/src/qr_scanner.rs
+++ b/crates/app/vmux_mobile/src/qr_scanner.rs
@@ -268,6 +268,37 @@ mod platform {
         ROOT_CONTROLLER.set(window.window.ui_view_controller().cast());
     }
 
+    /// Whether a camera exists to scan with, so the button can be dead rather than dead-ended.
+    ///
+    /// Permission is deliberately not part of this. A denied camera can be turned back on and
+    /// [`open`] presents the screen that does it, so the button stays live; a device with no
+    /// camera at all has no such route and a tap can only ever produce an error.
+    pub enum ScannerSupport {
+        Available,
+        Unavailable(String),
+    }
+
+    impl ScannerSupport {
+        pub fn detect() -> Self {
+            let Some(media_type) = (unsafe { AVMediaTypeVideo }) else {
+                return Self::Unavailable(translate("mobile-qr-camera-unavailable"));
+            };
+            // Checked before the device probe: a denied camera can report no default device, and
+            // that must not read as absent hardware.
+            let status = unsafe { AVCaptureDevice::authorizationStatusForMediaType(media_type) };
+            if matches!(
+                status,
+                AVAuthorizationStatus::Denied | AVAuthorizationStatus::Restricted
+            ) {
+                return Self::Available;
+            }
+            match unsafe { AVCaptureDevice::defaultDeviceWithMediaType(media_type) } {
+                Some(_) => Self::Available,
+                None => Self::Unavailable(translate("mobile-qr-camera-unavailable")),
+            }
+        }
+    }
+
     pub fn open() -> Result<(), String> {
         if ACTIVE.get() || REQUESTING.get() {
             return Ok(());
@@ -405,6 +436,17 @@ mod platform {
     use vmux_ui::i18n::translate;
 
     pub fn install(_: &dioxus::mobile::DesktopContext) {}
+
+    pub enum ScannerSupport {
+        Available,
+        Unavailable(String),
+    }
+
+    impl ScannerSupport {
+        pub fn detect() -> Self {
+            Self::Unavailable(translate("mobile-qr-unsupported-platform"))
+        }
+    }
 
     pub fn open() -> Result<(), String> {
         Err(translate("mobile-qr-unsupported-platform"))

--- a/crates/app/vmux_mobile/src/qr_scanner.rs
+++ b/crates/app/vmux_mobile/src/qr_scanner.rs
@@ -5,38 +5,59 @@ mod platform {
     use std::ptr;
     use std::sync::{LazyLock, Mutex};
 
+    use block2::RcBlock;
     use dioxus::mobile::tao::platform::ios::WindowExtIOS;
     use dispatch2::DispatchQueue;
     use objc2::rc::Retained;
-    use objc2::runtime::{NSObjectProtocol, ProtocolObject};
+    use objc2::runtime::{Bool, NSObjectProtocol, ProtocolObject};
     use objc2::{DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel};
     use objc2_av_foundation::{
-        AVCaptureDevice, AVCaptureDeviceInput, AVCaptureMetadataOutput,
-        AVCaptureMetadataOutputObjectsDelegate, AVCaptureSession, AVCaptureVideoPreviewLayer,
+        AVAuthorizationStatus, AVCaptureDevice, AVCaptureDeviceInput, AVCaptureMetadataOutput,
+        AVCaptureMetadataOutputObjectsDelegate, AVCaptureSession,
+        AVCaptureSessionRuntimeErrorNotification, AVCaptureVideoPreviewLayer,
         AVLayerVideoGravityResizeAspectFill, AVMediaTypeVideo, AVMetadataMachineReadableCodeObject,
         AVMetadataObject, AVMetadataObjectTypeQRCode,
     };
     use objc2_core_foundation::{CGPoint, CGRect, CGSize};
-    use objc2_foundation::{NSArray, NSString};
+    use objc2_foundation::{
+        NSArray, NSDictionary, NSNotification, NSNotificationCenter, NSString, NSURL,
+    };
     use objc2_ui_kit::{
-        NSTextAlignment, UIButton, UIButtonType, UIColor, UIControlEvents, UIControlState, UIFont,
-        UILabel, UIModalPresentationStyle, UIViewController,
+        NSTextAlignment, UIApplication, UIApplicationOpenSettingsURLString, UIButton, UIButtonType,
+        UIColor, UIControlEvents, UIControlState, UIFont, UILabel, UIModalPresentationStyle,
+        UIViewController,
     };
     use vmux_ui::i18n::{TranslationValue, translate, translate_with};
 
     thread_local! {
         static ROOT_CONTROLLER: Cell<*mut UIViewController> = const { Cell::new(ptr::null_mut()) };
         static ACTIVE: Cell<bool> = const { Cell::new(false) };
+        /// Set the moment a permission prompt goes up, before any controller exists.
+        ///
+        /// `ACTIVE` cannot cover this: `requestAccessForMediaType` returns immediately and answers
+        /// on another queue, so between the tap and the answer there is nothing presented and a
+        /// second tap would raise a second prompt.
+        static REQUESTING: Cell<bool> = const { Cell::new(false) };
     }
 
     static RESULTS: LazyLock<Mutex<VecDeque<Result<String, String>>>> =
         LazyLock::new(|| Mutex::new(VecDeque::new()));
 
+    /// The live scanner and the denied-permission screen are the same controller.
+    ///
+    /// They share the modal, the title and the cancel button; only the capture half differs, and
+    /// there is nothing to capture when the camera was refused.
     struct ScannerIvars {
-        session: Retained<AVCaptureSession>,
-        preview: Retained<AVCaptureVideoPreviewLayer>,
+        capture: Option<Capture>,
         title: Retained<UILabel>,
         cancel: Retained<UIButton>,
+        /// Shown only when the camera was refused.
+        settings: Retained<UIButton>,
+    }
+
+    struct Capture {
+        session: Retained<AVCaptureSession>,
+        preview: Retained<AVCaptureVideoPreviewLayer>,
     }
 
     define_class!(
@@ -54,7 +75,10 @@ mod platform {
                 }
                 let Some(view) = self.view() else { return };
                 view.setBackgroundColor(Some(&UIColor::blackColor()));
-                view.layer().addSublayer(&self.ivars().preview);
+                match &self.ivars().capture {
+                    Some(capture) => view.layer().addSublayer(&capture.preview),
+                    None => view.addSubview(&self.ivars().settings),
+                }
                 view.addSubview(&self.ivars().title);
                 view.addSubview(&self.ivars().cancel);
             }
@@ -67,20 +91,66 @@ mod platform {
                 let Some(view) = self.view() else { return };
                 let bounds = view.bounds();
                 let safe = view.safeAreaInsets();
-                self.ivars().preview.setFrame(bounds);
+                let width = (bounds.size.width - 64.0).max(0.0);
+                if let Some(capture) = &self.ivars().capture {
+                    capture.preview.setFrame(bounds);
+                }
+                // The refusal needs room to explain itself, so it gets the middle of the screen
+                // rather than the strip a scanning hint sits in.
+                let title_top = if self.ivars().capture.is_some() {
+                    safe.top + 54.0
+                } else {
+                    (bounds.size.height * 0.32).max(safe.top + 54.0)
+                };
+                let title_height = if self.ivars().capture.is_some() {
+                    56.0
+                } else {
+                    140.0
+                };
                 self.ivars().title.setFrame(CGRect::new(
-                    CGPoint::new(32.0, safe.top + 54.0),
-                    CGSize::new((bounds.size.width - 64.0).max(0.0), 56.0),
+                    CGPoint::new(32.0, title_top),
+                    CGSize::new(width, title_height),
                 ));
                 self.ivars().cancel.setFrame(CGRect::new(
                     CGPoint::new(18.0, safe.top + 8.0),
                     CGSize::new(76.0, 40.0),
                 ));
+                if self.ivars().capture.is_none() {
+                    self.ivars().settings.setFrame(CGRect::new(
+                        CGPoint::new(32.0, title_top + title_height + 24.0),
+                        CGSize::new(width, 48.0),
+                    ));
+                }
             }
 
             #[unsafe(method(cancel))]
             fn cancel(&self) {
                 self.close(None);
+            }
+
+            #[unsafe(method(openSettings))]
+            fn open_settings(&self) {
+                let Some(marker) = MainThreadMarker::new() else {
+                    return;
+                };
+                let Some(url) = (unsafe { NSURL::URLWithString(UIApplicationOpenSettingsURLString) })
+                else {
+                    return;
+                };
+                unsafe {
+                    UIApplication::sharedApplication(marker)
+                        .openURL_options_completionHandler(&url, &NSDictionary::new(), None);
+                }
+                // Leaving for Settings means coming back to a fresh authorization status, which
+                // only the next open() can act on.
+                self.close(None);
+            }
+
+            /// The session can fail after it started — the camera is taken by another app, or the
+            /// hardware is interrupted. Without this the preview freezes and says nothing.
+            #[unsafe(method(sessionRuntimeError:))]
+            fn session_runtime_error(&self, _notification: &NSNotification) {
+                self.close(Some(Err(translate("mobile-qr-session-error"))));
             }
         }
 
@@ -112,17 +182,19 @@ mod platform {
     impl ScannerController {
         fn new(
             marker: MainThreadMarker,
-            session: Retained<AVCaptureSession>,
-            preview: Retained<AVCaptureVideoPreviewLayer>,
+            capture: Option<Capture>,
+            message: &str,
         ) -> Retained<Self> {
+            let denied = capture.is_none();
+
             let title = UILabel::initWithFrame(UILabel::alloc(marker), CGRect::ZERO);
-            title.setText(Some(&NSString::from_str(&translate("mobile-qr-title"))));
+            title.setText(Some(&NSString::from_str(message)));
             unsafe {
                 title.setTextColor(Some(&UIColor::whiteColor()));
                 title.setFont(Some(&UIFont::boldSystemFontOfSize(17.0)));
             }
             title.setTextAlignment(NSTextAlignment(1));
-            title.setNumberOfLines(2);
+            title.setNumberOfLines(if denied { 0 } else { 2 });
 
             let cancel = UIButton::buttonWithType(UIButtonType::System, marker);
             cancel.setTitle_forState(
@@ -133,11 +205,20 @@ mod platform {
             cancel.setBackgroundColor(Some(&UIColor::colorWithWhite_alpha(0.0, 0.45)));
             cancel.layer().setCornerRadius(16.0);
 
+            let settings = UIButton::buttonWithType(UIButtonType::System, marker);
+            settings.setTitle_forState(
+                Some(&NSString::from_str(&translate("mobile-qr-open-settings"))),
+                UIControlState::Normal,
+            );
+            settings.setTitleColor_forState(Some(&UIColor::blackColor()), UIControlState::Normal);
+            settings.setBackgroundColor(Some(&UIColor::whiteColor()));
+            settings.layer().setCornerRadius(16.0);
+
             let this = Self::alloc(marker).set_ivars(ScannerIvars {
-                session,
-                preview,
+                capture,
                 title,
                 cancel,
+                settings,
             });
             let this: Retained<Self> = unsafe { msg_send![super(this), init] };
             unsafe {
@@ -146,6 +227,19 @@ mod platform {
                     sel!(cancel),
                     UIControlEvents::TouchUpInside,
                 );
+                this.ivars().settings.addTarget_action_forControlEvents(
+                    Some(&this),
+                    sel!(openSettings),
+                    UIControlEvents::TouchUpInside,
+                );
+                if let Some(capture) = &this.ivars().capture {
+                    NSNotificationCenter::defaultCenter().addObserver_selector_name_object(
+                        &this,
+                        sel!(sessionRuntimeError:),
+                        Some(AVCaptureSessionRuntimeErrorNotification),
+                        Some(&capture.session),
+                    );
+                }
             }
             this
         }
@@ -154,8 +248,11 @@ mod platform {
             if !ACTIVE.replace(false) {
                 return;
             }
-            unsafe {
-                self.ivars().session.stopRunning();
+            if let Some(capture) = &self.ivars().capture {
+                unsafe {
+                    NSNotificationCenter::defaultCenter().removeObserver(self);
+                    capture.session.stopRunning();
+                }
             }
             if let Some(result) = result {
                 RESULTS
@@ -172,11 +269,69 @@ mod platform {
     }
 
     pub fn open() -> Result<(), String> {
-        if ACTIVE.get() {
+        if ACTIVE.get() || REQUESTING.get() {
             return Ok(());
         }
         let marker = MainThreadMarker::new()
             .ok_or_else(|| "QR scanner must be opened from the main thread.".to_string())?;
+        let media_type =
+            unsafe { AVMediaTypeVideo }.ok_or_else(|| translate("mobile-qr-camera-unavailable"))?;
+
+        // Nothing below asks the system for the camera, so without this the session builds and
+        // starts against a device that will never deliver frames — a black screen with no reason
+        // given. Reviewers deny permissions as a matter of course.
+        match unsafe { AVCaptureDevice::authorizationStatusForMediaType(media_type) } {
+            AVAuthorizationStatus::Authorized => present(marker),
+            AVAuthorizationStatus::Denied | AVAuthorizationStatus::Restricted => {
+                present_denied(marker)
+            }
+            // NotDetermined, and anything a later iOS adds: ask, then act on the answer.
+            _ => {
+                REQUESTING.set(true);
+                let handler = RcBlock::new(move |granted: Bool| {
+                    // The completion runs on an arbitrary queue; every UIKit call below needs the
+                    // main one.
+                    DispatchQueue::main().exec_async(move || {
+                        REQUESTING.set(false);
+                        let Some(marker) = MainThreadMarker::new() else {
+                            return;
+                        };
+                        let outcome = if granted.as_bool() {
+                            present(marker)
+                        } else {
+                            present_denied(marker)
+                        };
+                        if let Err(message) = outcome {
+                            RESULTS
+                                .lock()
+                                .unwrap_or_else(|error| error.into_inner())
+                                .push_back(Err(message));
+                        }
+                    });
+                });
+                unsafe {
+                    AVCaptureDevice::requestAccessForMediaType_completionHandler(
+                        media_type, &handler,
+                    );
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// The screen a refusal gets: what happened, how to undo it, and a way back to the manual link.
+    fn present_denied(marker: MainThreadMarker) -> Result<(), String> {
+        let root = ROOT_CONTROLLER
+            .with(|pointer| unsafe { Retained::retain(pointer.get()) })
+            .ok_or_else(|| translate("mobile-qr-unavailable"))?;
+        let controller = ScannerController::new(marker, None, &translate("mobile-qr-denied"));
+        controller.setModalPresentationStyle(UIModalPresentationStyle::FullScreen);
+        ACTIVE.set(true);
+        root.presentViewController_animated_completion(&controller, true, None);
+        Ok(())
+    }
+
+    fn present(marker: MainThreadMarker) -> Result<(), String> {
         let root = ROOT_CONTROLLER
             .with(|pointer| unsafe { Retained::retain(pointer.get()) })
             .ok_or_else(|| translate("mobile-qr-unavailable"))?;
@@ -214,7 +369,14 @@ mod platform {
                 preview.setVideoGravity(gravity);
             }
         }
-        let controller = ScannerController::new(marker, session.clone(), preview);
+        let controller = ScannerController::new(
+            marker,
+            Some(Capture {
+                session: session.clone(),
+                preview,
+            }),
+            &translate("mobile-qr-title"),
+        );
         unsafe {
             output.setMetadataObjectsDelegate_queue(
                 Some(ProtocolObject::from_ref(&*controller)),

--- a/crates/vmux_ui/locales/af.ftl
+++ b/crates/vmux_ui/locales/af.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Die verbinding met jou Mac het verlore gegaan.
 mobile-error-connection-closed = Jou Mac het die verbinding gesluit.
 mobile-error-address-invalid = Daardie koppeladres is ongeldig.
 mobile-error-address-no-port = Daardie koppeladres het geen poort nie.
+mobile-qr-denied = Vmux kan nie die kamera gebruik nie. Skakel dit in Instellings aan om die QR-kode te skandeer, of gaan terug en plak eerder die koppelskakel.
+mobile-qr-open-settings = Maak Instellings oop
+mobile-qr-session-error = Die kamera het gestop. Probeer weer, of plak eerder die koppelskakel.

--- a/crates/vmux_ui/locales/am.ftl
+++ b/crates/vmux_ui/locales/am.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = ከMac ዎ ጋር ያለው ግንኙነት �
 mobile-error-connection-closed = Mac ዎ ግንኙነቱን ዘግቷል።
 mobile-error-address-invalid = ያ የማጣመሪያ አድራሻ ልክ አይደለም።
 mobile-error-address-no-port = ያ የማጣመሪያ አድራሻ ወደብ የለውም።
+mobile-qr-denied = Vmux ካሜራውን መጠቀም አይችልም። QR ኮዱን ለመቃኘት በቅንብሮች ውስጥ ያብሩት፣ ወይም ተመልሰው የማጣመሪያ አገናኙን ይለጥፉ።
+mobile-qr-open-settings = ቅንብሮችን ይክፈቱ
+mobile-qr-session-error = ካሜራው ቆሟል። እንደገና ይሞክሩ፣ ወይም በምትኩ የማጣመሪያ አገናኙን ይለጥፉ።

--- a/crates/vmux_ui/locales/ar.ftl
+++ b/crates/vmux_ui/locales/ar.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = انقطع الاتصال بجهاز Mac.
 mobile-error-connection-closed = أغلق جهاز Mac الاتصال.
 mobile-error-address-invalid = عنوان الإقران هذا غير صالح.
 mobile-error-address-no-port = عنوان الإقران هذا لا يحتوي على منفذ.
+mobile-qr-denied = لا يستطيع Vmux استخدام الكاميرا. فعّلها في الإعدادات لمسح رمز QR، أو ارجع والصق رابط الإقران بدلاً من ذلك.
+mobile-qr-open-settings = فتح الإعدادات
+mobile-qr-session-error = توقّفت الكاميرا. أعد المحاولة، أو الصق رابط الإقران بدلاً من ذلك.

--- a/crates/vmux_ui/locales/az.ftl
+++ b/crates/vmux_ui/locales/az.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Mac-inizlə bağlantı kəsildi.
 mobile-error-connection-closed = Mac-iniz bağlantını bağladı.
 mobile-error-address-invalid = Həmin qoşulma ünvanı yanlışdır.
 mobile-error-address-no-port = Həmin qoşulma ünvanında port yoxdur.
+mobile-qr-denied = Vmux kameradan istifadə edə bilmir. QR kodu skan etmək üçün onu Ayarlar bölməsində aktivləşdirin, ya da geri qayıdıb qoşulma linkini yapışdırın.
+mobile-qr-open-settings = Ayarları aç
+mobile-qr-session-error = Kamera dayandı. Yenidən cəhd edin, ya da əvəzinə qoşulma linkini yapışdırın.

--- a/crates/vmux_ui/locales/be.ftl
+++ b/crates/vmux_ui/locales/be.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Падключэнне да вашага Mac �
 mobile-error-connection-closed = Ваш Mac закрыў падключэнне.
 mobile-error-address-invalid = Няправільны адрас спалучэння.
 mobile-error-address-no-port = У адрасе спалучэння няма порта.
+mobile-qr-denied = Vmux не можа выкарыстоўваць камеру. Уключыце яе ў Наладах, каб адсканіраваць QR-код, або вярніцеся і ўстаўце спасылку спалучэння.
+mobile-qr-open-settings = Адкрыць Налады
+mobile-qr-session-error = Камера спынілася. Паспрабуйце зноў або ўстаўце спасылку спалучэння.

--- a/crates/vmux_ui/locales/bg.ftl
+++ b/crates/vmux_ui/locales/bg.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Връзката с вашия Mac прекъ�
 mobile-error-connection-closed = Вашият Mac затвори връзката.
 mobile-error-address-invalid = Невалиден адрес за сдвояване.
 mobile-error-address-no-port = Адресът за сдвояване няма порт.
+mobile-qr-denied = Vmux не може да използва камерата. Включете я в Настройки, за да сканирате QR кода, или се върнете и поставете връзката за сдвояване.
+mobile-qr-open-settings = Отваряне на Настройки
+mobile-qr-session-error = Камерата спря. Опитайте отново или поставете връзката за сдвояване.

--- a/crates/vmux_ui/locales/bn.ftl
+++ b/crates/vmux_ui/locales/bn.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = আপনার Mac-এর সাথে সং
 mobile-error-connection-closed = আপনার Mac সংযোগটি বন্ধ করে দিয়েছে।
 mobile-error-address-invalid = সেই পেয়ারিং ঠিকানা বৈধ নয়।
 mobile-error-address-no-port = সেই পেয়ারিং ঠিকানায় কোনো পোর্ট নেই।
+mobile-qr-denied = Vmux ক্যামেরা ব্যবহার করতে পারছে না। QR কোড স্ক্যান করতে সেটিংসে এটি চালু করুন, অথবা ফিরে গিয়ে পেয়ারিং লিঙ্ক পেস্ট করুন।
+mobile-qr-open-settings = সেটিংস খুলুন
+mobile-qr-session-error = ক্যামেরা বন্ধ হয়ে গেছে। আবার চেষ্টা করুন, অথবা বদলে পেয়ারিং লিঙ্ক পেস্ট করুন।

--- a/crates/vmux_ui/locales/bs.ftl
+++ b/crates/vmux_ui/locales/bs.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Veza s tvojim Mac-om je prekinuta.
 mobile-error-connection-closed = Tvoj Mac je zatvorio vezu.
 mobile-error-address-invalid = Ta adresa za uparivanje nije ispravna.
 mobile-error-address-no-port = Ta adresa za uparivanje nema port.
+mobile-qr-denied = Vmux ne može koristiti kameru. Uključi je u Postavkama da skeniraš QR kod ili se vrati i umjesto toga zalijepi link za uparivanje.
+mobile-qr-open-settings = Otvori Postavke
+mobile-qr-session-error = Kamera se zaustavila. Pokušaj ponovo ili umjesto toga zalijepi link za uparivanje.

--- a/crates/vmux_ui/locales/ca.ftl
+++ b/crates/vmux_ui/locales/ca.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = S’ha perdut la connexió amb el teu Mac.
 mobile-error-connection-closed = El teu Mac ha tancat la connexió.
 mobile-error-address-invalid = Aquesta adreça d’aparellament no és vàlida.
 mobile-error-address-no-port = Aquesta adreça d’aparellament no té port.
+mobile-qr-denied = Vmux no pot utilitzar la càmera. Activa-la a Configuració per escanejar el codi QR, o torna enrere i enganxa l’enllaç d’aparellament.
+mobile-qr-open-settings = Obre Configuració
+mobile-qr-session-error = La càmera s’ha aturat. Torna-ho a provar o enganxa l’enllaç d’aparellament.

--- a/crates/vmux_ui/locales/ceb.ftl
+++ b/crates/vmux_ui/locales/ceb.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Naputol ang koneksyon sa imong Mac.
 mobile-error-connection-closed = Gisirhan sa imong Mac ang koneksyon.
 mobile-error-address-invalid = Dili balido kana nga pairing address.
 mobile-error-address-no-port = Kana nga pairing address walay port.
+mobile-qr-denied = Dili magamit sa Vmux ang camera. I-on kini sa Settings aron ma-scan ang QR code, o balik ug i-paste na lang ang pairing link.
+mobile-qr-open-settings = Ablihi ang Settings
+mobile-qr-session-error = Mihunong ang camera. Sulayi pag-usab, o i-paste na lang ang pairing link.

--- a/crates/vmux_ui/locales/co.ftl
+++ b/crates/vmux_ui/locales/co.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = A cunnessione cù u to Mac s’hè interrotta.
 mobile-error-connection-closed = U to Mac hà chjusu a cunnessione.
 mobile-error-address-invalid = St’indirizzu d’appaghjamentu ùn hè micca validu.
 mobile-error-address-no-port = St’indirizzu d’appaghjamentu ùn hà nisun portu.
+mobile-qr-denied = Vmux ùn pò micca aduprà a camera. Attivala in Impostazioni per scannà u codice QR, o torna indietru è incolla piuttostu u ligame d’appaghjamentu.
+mobile-qr-open-settings = Apre Impostazioni
+mobile-qr-session-error = A camera s’hè firmata. Prova torna, o incolla piuttostu u ligame d’appaghjamentu.

--- a/crates/vmux_ui/locales/cs.ftl
+++ b/crates/vmux_ui/locales/cs.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Připojení k tvému Macu se přerušilo.
 mobile-error-connection-closed = Tvůj Mac připojení ukončil.
 mobile-error-address-invalid = Tato párovací adresa je neplatná.
 mobile-error-address-no-port = Tato párovací adresa neobsahuje port.
+mobile-qr-denied = Vmux nemůže použít kameru. Zapni ji v Nastavení, abys naskenoval QR kód, nebo se vrať a vlož místo toho odkaz pro párování.
+mobile-qr-open-settings = Otevřít Nastavení
+mobile-qr-session-error = Kamera se zastavila. Zkus to znovu, nebo vlož místo toho odkaz pro párování.

--- a/crates/vmux_ui/locales/cy.ftl
+++ b/crates/vmux_ui/locales/cy.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Mae’r cysylltiad â’ch Mac wedi torri.
 mobile-error-connection-closed = Caeodd eich Mac y cysylltiad.
 mobile-error-address-invalid = Mae’r cyfeiriad pario hwnnw yn annilys.
 mobile-error-address-no-port = Nid oes porth yn y cyfeiriad pario hwnnw.
+mobile-qr-denied = Ni all Vmux ddefnyddio’r camera. Trowch ef ymlaen yn Gosodiadau i sganio’r cod QR, neu ewch yn ôl a gludo’r ddolen bario yn lle hynny.
+mobile-qr-open-settings = Agor Gosodiadau
+mobile-qr-session-error = Mae’r camera wedi stopio. Rhowch gynnig arall arni, neu gludwch y ddolen bario yn lle hynny.

--- a/crates/vmux_ui/locales/da.ftl
+++ b/crates/vmux_ui/locales/da.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Forbindelsen til din Mac gik tabt.
 mobile-error-connection-closed = Din Mac lukkede forbindelsen.
 mobile-error-address-invalid = Den parringsadresse er ugyldig.
 mobile-error-address-no-port = Den parringsadresse har ingen port.
+mobile-qr-denied = Vmux kan ikke bruge kameraet. Slå det til i Indstillinger for at scanne QR-koden, eller gå tilbage og indsæt parringslinket i stedet.
+mobile-qr-open-settings = Åbn Indstillinger
+mobile-qr-session-error = Kameraet stoppede. Prøv igen, eller indsæt parringslinket i stedet.

--- a/crates/vmux_ui/locales/de.ftl
+++ b/crates/vmux_ui/locales/de.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Die Verbindung zu Ihrem Mac ist abgebrochen.
 mobile-error-connection-closed = Ihr Mac hat die Verbindung geschlossen.
 mobile-error-address-invalid = Diese Kopplungsadresse ist ungültig.
 mobile-error-address-no-port = Diese Kopplungsadresse enthält keinen Port.
+mobile-qr-denied = Vmux kann die Kamera nicht verwenden. Aktivieren Sie sie in den Einstellungen, um den QR-Code zu scannen, oder gehen Sie zurück und fügen Sie stattdessen den Kopplungslink ein.
+mobile-qr-open-settings = Einstellungen öffnen
+mobile-qr-session-error = Die Kamera wurde gestoppt. Versuchen Sie es erneut, oder fügen Sie stattdessen den Kopplungslink ein.

--- a/crates/vmux_ui/locales/el.ftl
+++ b/crates/vmux_ui/locales/el.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Η σύνδεση με το Mac σας δια�
 mobile-error-connection-closed = Το Mac σας έκλεισε τη σύνδεση.
 mobile-error-address-invalid = Αυτή η διεύθυνση σύζευξης δεν είναι έγκυρη.
 mobile-error-address-no-port = Αυτή η διεύθυνση σύζευξης δεν έχει θύρα.
+mobile-qr-denied = Το Vmux δεν μπορεί να χρησιμοποιήσει την κάμερα. Ενεργοποιήστε την στις Ρυθμίσεις για να σαρώσετε τον κωδικό QR ή επιστρέψτε και επικολλήστε τον σύνδεσμο σύζευξης.
+mobile-qr-open-settings = Άνοιγμα Ρυθμίσεων
+mobile-qr-session-error = Η κάμερα σταμάτησε. Δοκιμάστε ξανά ή επικολλήστε τον σύνδεσμο σύζευξης.

--- a/crates/vmux_ui/locales/en-US.ftl
+++ b/crates/vmux_ui/locales/en-US.ftl
@@ -789,3 +789,6 @@ mobile-error-connection-dropped = The connection to your Mac dropped.
 mobile-error-connection-closed = Your Mac closed the connection.
 mobile-error-address-invalid = That pairing address is not valid.
 mobile-error-address-no-port = That pairing address has no port.
+mobile-qr-denied = Vmux cannot use the camera. Turn it on in Settings to scan the QR code, or go back and paste the pairing link instead.
+mobile-qr-open-settings = Open Settings
+mobile-qr-session-error = The camera stopped. Try again, or paste the pairing link instead.

--- a/crates/vmux_ui/locales/eo.ftl
+++ b/crates/vmux_ui/locales/eo.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = La konekto al via Mac rompiĝis.
 mobile-error-connection-closed = Via Mac fermis la konekton.
 mobile-error-address-invalid = Tiu pariga adreso estas nevalida.
 mobile-error-address-no-port = Tiu pariga adreso ne havas pordon.
+mobile-qr-denied = Vmux ne povas uzi la fotilon. Ŝaltu ĝin en Agordoj por skani la QR-kodon, aŭ reiru kaj anstataŭe algluu la parigan ligilon.
+mobile-qr-open-settings = Malfermi Agordojn
+mobile-qr-session-error = La fotilo haltis. Provu denove, aŭ anstataŭe algluu la parigan ligilon.

--- a/crates/vmux_ui/locales/es.ftl
+++ b/crates/vmux_ui/locales/es.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Se perdió la conexión con tu Mac.
 mobile-error-connection-closed = Tu Mac cerró la conexión.
 mobile-error-address-invalid = Esa dirección de emparejamiento no es válida.
 mobile-error-address-no-port = Esa dirección de emparejamiento no tiene puerto.
+mobile-qr-denied = Vmux no puede usar la cámara. Actívala en Ajustes para escanear el código QR, o vuelve atrás y pega el enlace de emparejamiento.
+mobile-qr-open-settings = Abrir Ajustes
+mobile-qr-session-error = La cámara se detuvo. Inténtalo de nuevo o pega el enlace de emparejamiento.

--- a/crates/vmux_ui/locales/et.ftl
+++ b/crates/vmux_ui/locales/et.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Ühendus sinu Maciga katkes.
 mobile-error-connection-closed = Sinu Mac sulges ühenduse.
 mobile-error-address-invalid = See sidumisaadress on vigane.
 mobile-error-address-no-port = Sellel sidumisaadressil puudub port.
+mobile-qr-denied = Vmux ei saa kaamerat kasutada. Lülita see rakenduses Seaded sisse, et QR-koodi skannida, või mine tagasi ja kleebi selle asemel sidumislink.
+mobile-qr-open-settings = Ava Seaded
+mobile-qr-session-error = Kaamera peatus. Proovi uuesti või kleebi selle asemel sidumislink.

--- a/crates/vmux_ui/locales/eu.ftl
+++ b/crates/vmux_ui/locales/eu.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Zure Mac-arekiko konexioa eten da.
 mobile-error-connection-closed = Zure Mac-ek konexioa itxi du.
 mobile-error-address-invalid = Parekatze-helbide hori ez da baliozkoa.
 mobile-error-address-no-port = Parekatze-helbide horrek ez du atakarik.
+mobile-qr-denied = Vmux-ek ezin du kamera erabili. Aktibatu Ezarpenak atalean QR kodea eskaneatzeko, edo itzuli atzera eta itsatsi parekatze-esteka horren ordez.
+mobile-qr-open-settings = Ireki Ezarpenak
+mobile-qr-session-error = Kamera gelditu da. Saiatu berriro, edo itsatsi parekatze-esteka horren ordez.

--- a/crates/vmux_ui/locales/fa.ftl
+++ b/crates/vmux_ui/locales/fa.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = اتصال به Mac شما قطع شد.
 mobile-error-connection-closed = Mac شما اتصال را بست.
 mobile-error-address-invalid = آن آدرس جفت‌سازی معتبر نیست.
 mobile-error-address-no-port = آن آدرس جفت‌سازی درگاه ندارد.
+mobile-qr-denied = Vmux نمی‌تواند از دوربین استفاده کند. برای اسکن کد QR آن را در تنظیمات روشن کنید، یا برگردید و به‌جای آن پیوند جفت‌سازی را جای‌گذاری کنید.
+mobile-qr-open-settings = باز کردن تنظیمات
+mobile-qr-session-error = دوربین متوقف شد. دوباره تلاش کنید، یا به‌جای آن پیوند جفت‌سازی را جای‌گذاری کنید.

--- a/crates/vmux_ui/locales/fi.ftl
+++ b/crates/vmux_ui/locales/fi.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Yhteys Maciisi katkesi.
 mobile-error-connection-closed = Macisi sulki yhteyden.
 mobile-error-address-invalid = Tämä pariliitososoite on virheellinen.
 mobile-error-address-no-port = Tästä pariliitososoitteesta puuttuu portti.
+mobile-qr-denied = Vmux ei voi käyttää kameraa. Ota se käyttöön Asetuksissa, jotta voit skannata QR-koodin, tai palaa takaisin ja liitä sen sijaan pariliitoslinkki.
+mobile-qr-open-settings = Avaa Asetukset
+mobile-qr-session-error = Kamera pysähtyi. Yritä uudelleen tai liitä sen sijaan pariliitoslinkki.

--- a/crates/vmux_ui/locales/fil.ftl
+++ b/crates/vmux_ui/locales/fil.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Naputol ang koneksyon sa iyong Mac.
 mobile-error-connection-closed = Isinara ng iyong Mac ang koneksyon.
 mobile-error-address-invalid = Hindi wasto ang pairing address na iyon.
 mobile-error-address-no-port = Walang port ang pairing address na iyon.
+mobile-qr-denied = Hindi magamit ng Vmux ang camera. I-on ito sa Settings para ma-scan ang QR code, o bumalik at i-paste na lang ang pairing link.
+mobile-qr-open-settings = Buksan ang Settings
+mobile-qr-session-error = Huminto ang camera. Subukan ulit, o i-paste na lang ang pairing link.

--- a/crates/vmux_ui/locales/fr.ftl
+++ b/crates/vmux_ui/locales/fr.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = La connexion à votre Mac a été perdue.
 mobile-error-connection-closed = Votre Mac a fermé la connexion.
 mobile-error-address-invalid = Cette adresse d’appairage n’est pas valide.
 mobile-error-address-no-port = Cette adresse d’appairage ne contient pas de port.
+mobile-qr-denied = Vmux ne peut pas utiliser la caméra. Activez-la dans Réglages pour scanner le code QR, ou revenez en arrière et collez plutôt le lien d’appairage.
+mobile-qr-open-settings = Ouvrir Réglages
+mobile-qr-session-error = La caméra s’est arrêtée. Réessayez, ou collez plutôt le lien d’appairage.

--- a/crates/vmux_ui/locales/fy.ftl
+++ b/crates/vmux_ui/locales/fy.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = De ferbining mei jo Mac is ferlern gien.
 mobile-error-connection-closed = Jo Mac hat de ferbining sluten.
 mobile-error-address-invalid = Dat keppeladres is ûnjildich.
 mobile-error-address-no-port = Dat keppeladres hat gjin poarte.
+mobile-qr-denied = Vmux kin de kamera net brûke. Set him oan yn Ynstellings om de QR-koade te scannen, of gean werom en plak ynstee de keppellink.
+mobile-qr-open-settings = Ynstellings iepenje
+mobile-qr-session-error = De kamera is stoppe. Besykje it nochris, of plak ynstee de keppellink.

--- a/crates/vmux_ui/locales/ga.ftl
+++ b/crates/vmux_ui/locales/ga.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Cailleadh an ceangal le do Mac.
 mobile-error-connection-closed = Dhún do Mac an ceangal.
 mobile-error-address-invalid = Tá an seoladh péireála sin neamhbhailí.
 mobile-error-address-no-port = Níl port sa seoladh péireála sin.
+mobile-qr-denied = Ní féidir le Vmux an ceamara a úsáid. Cuir ar siúl é i Socruithe chun an cód QR a scanadh, nó fill ar ais agus greamaigh an nasc péireála ina áit.
+mobile-qr-open-settings = Oscail Socruithe
+mobile-qr-session-error = Stop an ceamara. Bain triail eile as, nó greamaigh an nasc péireála ina áit.

--- a/crates/vmux_ui/locales/gd.ftl
+++ b/crates/vmux_ui/locales/gd.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Chaidh an ceangal ris a’ Mac agad a chall.
 mobile-error-connection-closed = Dhùin a’ Mac agad an ceangal.
 mobile-error-address-invalid = Chan eil an seòladh paidhreachaidh sin dligheach.
 mobile-error-address-no-port = Chan eil port anns an t-seòladh paidhreachaidh sin.
+mobile-qr-denied = Chan urrainn dha Vmux an camara a chleachdadh. Cuir air e ann an Roghainnean gus an còd QR a sganadh, no till air ais agus cuir a-steach an ceangal paidhreachaidh na àite.
+mobile-qr-open-settings = Fosgail Roghainnean
+mobile-qr-session-error = Sguir an camara. Feuch ris a-rithist, no cuir a-steach an ceangal paidhreachaidh na àite.

--- a/crates/vmux_ui/locales/gl.ftl
+++ b/crates/vmux_ui/locales/gl.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Perdeuse a conexión co teu Mac.
 mobile-error-connection-closed = O teu Mac pechou a conexión.
 mobile-error-address-invalid = Ese enderezo de emparellamento non é válido.
 mobile-error-address-no-port = Ese enderezo de emparellamento non ten porto.
+mobile-qr-denied = Vmux non pode usar a cámara. Actívaa en Axustes para escanear o código QR, ou volve atrás e pega a ligazón de emparellamento.
+mobile-qr-open-settings = Abrir Axustes
+mobile-qr-session-error = A cámara detívose. Téntao de novo ou pega a ligazón de emparellamento.

--- a/crates/vmux_ui/locales/gu.ftl
+++ b/crates/vmux_ui/locales/gu.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = તમારા Mac સાથેનું ક�
 mobile-error-connection-closed = તમારા Macએ કનેક્શન બંધ કર્યું.
 mobile-error-address-invalid = એ પેરિંગ સરનામું અમાન્ય છે.
 mobile-error-address-no-port = એ પેરિંગ સરનામામાં પોર્ટ નથી.
+mobile-qr-denied = Vmux કૅમેરાનો ઉપયોગ કરી શકતું નથી. QR કોડ સ્કૅન કરવા સેટિંગ્સમાં તેને ચાલુ કરો, અથવા પાછા જઈને પેરિંગ લિંક પેસ્ટ કરો.
+mobile-qr-open-settings = સેટિંગ્સ ખોલો
+mobile-qr-session-error = કૅમેરા બંધ થઈ ગયો. ફરી પ્રયાસ કરો, અથવા તેના બદલે પેરિંગ લિંક પેસ્ટ કરો.

--- a/crates/vmux_ui/locales/ha.ftl
+++ b/crates/vmux_ui/locales/ha.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Haɗin da Mac ɗinka ya katse.
 mobile-error-connection-closed = Mac ɗinka ya rufe haɗin.
 mobile-error-address-invalid = Wannan adireshin haɗi ba shi da inganci.
 mobile-error-address-no-port = Wannan adireshin haɗi ba shi da port.
+mobile-qr-denied = Vmux ba zai iya amfani da kyamara ba. Kunna ta a Saituna don duba QR code, ko ka koma baya ka manna hanyar haɗi maimakon.
+mobile-qr-open-settings = Buɗe Saituna
+mobile-qr-session-error = Kyamara ta tsaya. Sake gwadawa, ko manna hanyar haɗi maimakon.

--- a/crates/vmux_ui/locales/haw.ftl
+++ b/crates/vmux_ui/locales/haw.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Ua moku ka pilina me kāu Mac.
 mobile-error-connection-closed = Ua pani kāu Mac i ka pilina.
 mobile-error-address-invalid = ʻAʻole kūpono kēlā helu hoʻohui.
 mobile-error-address-no-port = ʻAʻohe awa ma kēlā helu hoʻohui.
+mobile-qr-denied = ʻAʻole hiki iā Vmux ke hoʻohana i ke paʻi kiʻi. E hoʻā iā ia ma Hoʻonohonoho e kālai ai i ka QR code, a i ʻole e hoʻi i hope a hoʻopili i ka loulou hoʻohui.
+mobile-qr-open-settings = E wehe iā Hoʻonohonoho
+mobile-qr-session-error = Ua kū ke paʻi kiʻi. E hoʻāʻo hou, a i ʻole e hoʻopili i ka loulou hoʻohui.

--- a/crates/vmux_ui/locales/he.ftl
+++ b/crates/vmux_ui/locales/he.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = החיבור ל-Mac שלך נותק.
 mobile-error-connection-closed = ה-Mac שלך סגר את החיבור.
 mobile-error-address-invalid = כתובת ההתחברות הזו אינה תקינה.
 mobile-error-address-no-port = בכתובת ההתחברות הזו אין פורט.
+mobile-qr-denied = Vmux לא יכול להשתמש במצלמה. הפעל אותה בהגדרות כדי לסרוק את קוד ה-QR, או חזור והדבק את קישור ההתחברות במקום זאת.
+mobile-qr-open-settings = פתח הגדרות
+mobile-qr-session-error = המצלמה הפסיקה לפעול. נסה שוב, או הדבק את קישור ההתחברות במקום זאת.

--- a/crates/vmux_ui/locales/hi.ftl
+++ b/crates/vmux_ui/locales/hi.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = आपके Mac से कनेक्शन 
 mobile-error-connection-closed = आपके Mac ने कनेक्शन बंद कर दिया।
 mobile-error-address-invalid = वह पेयरिंग पता अमान्य है।
 mobile-error-address-no-port = उस पेयरिंग पते में पोर्ट नहीं है।
+mobile-qr-denied = Vmux कैमरे का उपयोग नहीं कर सकता। QR कोड स्कैन करने के लिए सेटिंग्स में इसे चालू करें, या वापस जाकर पेयरिंग लिंक पेस्ट करें।
+mobile-qr-open-settings = सेटिंग्स खोलें
+mobile-qr-session-error = कैमरा बंद हो गया। दोबारा कोशिश करें, या इसके बजाय पेयरिंग लिंक पेस्ट करें।

--- a/crates/vmux_ui/locales/hmn.ftl
+++ b/crates/vmux_ui/locales/hmn.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Qhov txuas mus rau koj lub Mac tu lawm.
 mobile-error-connection-closed = Koj lub Mac kaw qhov txuas lawm.
 mobile-error-address-invalid = Qhov chaw nyob txuas ntawd tsis raug.
 mobile-error-address-no-port = Qhov chaw nyob txuas ntawd tsis muaj port.
+mobile-qr-denied = Vmux siv tsis tau koob yees duab. Qhib nws hauv Chaw Teeb Tsa kom luam tau QR code, los sis rov qab mus thiab ntaus txoj link txuas hloov chaw.
+mobile-qr-open-settings = Qhib Chaw Teeb Tsa
+mobile-qr-session-error = Koob yees duab tau nres. Sim dua, los sis ntaus txoj link txuas hloov chaw.

--- a/crates/vmux_ui/locales/hr.ftl
+++ b/crates/vmux_ui/locales/hr.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Veza s tvojim Mac uređajem je izgubljena.
 mobile-error-connection-closed = Tvoj Mac je zatvorio vezu.
 mobile-error-address-invalid = Ta adresa za uparivanje nije valjana.
 mobile-error-address-no-port = Ta adresa za uparivanje nema port.
+mobile-qr-denied = Vmux ne može koristiti kameru. Uključi je u Postavkama kako bi skenirao QR kod ili se vrati i umjesto toga zalijepi poveznicu za uparivanje.
+mobile-qr-open-settings = Otvori Postavke
+mobile-qr-session-error = Kamera se zaustavila. Pokušaj ponovno ili umjesto toga zalijepi poveznicu za uparivanje.

--- a/crates/vmux_ui/locales/ht.ftl
+++ b/crates/vmux_ui/locales/ht.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Konesyon an ak Mac ou a koupe.
 mobile-error-connection-closed = Mac ou a fèmen konesyon an.
 mobile-error-address-invalid = Adrès konesyon sa a pa valab.
 mobile-error-address-no-port = Adrès konesyon sa a pa gen port.
+mobile-qr-denied = Vmux pa ka itilize kamera a. Aktive li nan Paramèt pou eskane kòd QR a, oswa retounen epi kole lyen konesyon an pito.
+mobile-qr-open-settings = Louvri Paramèt
+mobile-qr-session-error = Kamera a sispann. Eseye ankò, oswa kole lyen konesyon an pito.

--- a/crates/vmux_ui/locales/hu.ftl
+++ b/crates/vmux_ui/locales/hu.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = A Mac gépével való kapcsolat megszakadt.
 mobile-error-connection-closed = A Mac gépe bontotta a kapcsolatot.
 mobile-error-address-invalid = Ez a párosítási cím érvénytelen.
 mobile-error-address-no-port = Ez a párosítási cím nem tartalmaz portot.
+mobile-qr-denied = A Vmux nem tudja használni a kamerát. Kapcsolja be a Beállításokban a QR-kód beolvasásához, vagy lépjen vissza, és illessze be inkább a párosítási hivatkozást.
+mobile-qr-open-settings = Beállítások megnyitása
+mobile-qr-session-error = A kamera leállt. Próbálja újra, vagy illessze be inkább a párosítási hivatkozást.

--- a/crates/vmux_ui/locales/hy.ftl
+++ b/crates/vmux_ui/locales/hy.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Ձեր Mac-ի հետ կապը խզվեց:
 mobile-error-connection-closed = Ձեր Mac-ը փակեց կապը:
 mobile-error-address-invalid = Այդ զուգակցման հասցեն վավեր չէ:
 mobile-error-address-no-port = Այդ զուգակցման հասցեում port չկա:
+mobile-qr-denied = Vmux-ը չի կարող օգտագործել տեսախցիկը: Միացրեք այն Կարգավորումներում՝ QR կոդը սկանավորելու համար, կամ վերադարձեք և փոխարենը տեղադրեք զուգակցման հղումը:
+mobile-qr-open-settings = Բացել Կարգավորումները
+mobile-qr-session-error = Տեսախցիկը դադարեց: Փորձեք նորից կամ փոխարենը տեղադրեք զուգակցման հղումը:

--- a/crates/vmux_ui/locales/id.ftl
+++ b/crates/vmux_ui/locales/id.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Koneksi ke Mac Anda terputus.
 mobile-error-connection-closed = Mac Anda menutup koneksi.
 mobile-error-address-invalid = Alamat pemasangan itu tidak valid.
 mobile-error-address-no-port = Alamat pemasangan itu tidak memiliki port.
+mobile-qr-denied = Vmux tidak dapat menggunakan kamera. Aktifkan di Pengaturan untuk memindai kode QR, atau kembali dan tempel tautan pemasangan saja.
+mobile-qr-open-settings = Buka Pengaturan
+mobile-qr-session-error = Kamera berhenti. Coba lagi, atau tempel tautan pemasangan saja.

--- a/crates/vmux_ui/locales/ig.ftl
+++ b/crates/vmux_ui/locales/ig.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Njikọ na Mac gị adaala.
 mobile-error-connection-closed = Mac gị mechiri njikọ ahụ.
 mobile-error-address-invalid = Adreesị njikọta ahụ ezighi ezi.
 mobile-error-address-no-port = Adreesị njikọta ahụ enweghị port.
+mobile-qr-denied = Vmux enweghị ike iji igwefoto. Gbanye ya na Ntọala iji nyochaa koodu QR, ma ọ bụ laghachi azụ tinye njikọ njikọta kama.
+mobile-qr-open-settings = Mepee Ntọala
+mobile-qr-session-error = Igwefoto kwụsịrị. Nwaa ọzọ, ma ọ bụ tinye njikọ njikọta kama.

--- a/crates/vmux_ui/locales/is.ftl
+++ b/crates/vmux_ui/locales/is.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Tengingin við Mac-tölvuna þína rofnaði.
 mobile-error-connection-closed = Mac-tölvan þín lokaði tengingunni.
 mobile-error-address-invalid = Þetta pörunarvistfang er ógilt.
 mobile-error-address-no-port = Þetta pörunarvistfang hefur enga gátt.
+mobile-qr-denied = Vmux getur ekki notað myndavélina. Kveiktu á henni í Stillingum til að skanna QR-kóðann, eða farðu til baka og límdu inn pörunartengilinn í staðinn.
+mobile-qr-open-settings = Opna Stillingar
+mobile-qr-session-error = Myndavélin stöðvaðist. Reyndu aftur eða límdu inn pörunartengilinn í staðinn.

--- a/crates/vmux_ui/locales/it.ftl
+++ b/crates/vmux_ui/locales/it.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = La connessione al tuo Mac è caduta.
 mobile-error-connection-closed = Il tuo Mac ha chiuso la connessione.
 mobile-error-address-invalid = Quell'indirizzo di abbinamento non è valido.
 mobile-error-address-no-port = Quell'indirizzo di abbinamento non contiene la porta.
+mobile-qr-denied = Vmux non può usare la fotocamera. Attivala in Impostazioni per scansionare il codice QR, oppure torna indietro e incolla il link di abbinamento.
+mobile-qr-open-settings = Apri Impostazioni
+mobile-qr-session-error = La fotocamera si è interrotta. Riprova oppure incolla il link di abbinamento.

--- a/crates/vmux_ui/locales/ja.ftl
+++ b/crates/vmux_ui/locales/ja.ftl
@@ -783,3 +783,6 @@ mobile-error-connection-dropped = Mac との接続が切れました。
 mobile-error-connection-closed = Mac が接続を終了しました。
 mobile-error-address-invalid = そのペアリングアドレスは正しくありません。
 mobile-error-address-no-port = そのペアリングアドレスにポートがありません。
+mobile-qr-denied = Vmux はカメラを使用できません。QRコードをスキャンするには設定でカメラをオンにするか、前の画面に戻ってペアリングリンクを貼り付けてください。
+mobile-qr-open-settings = 設定を開く
+mobile-qr-session-error = カメラが停止しました。もう一度お試しいただくか、代わりにペアリングリンクを貼り付けてください。

--- a/crates/vmux_ui/locales/jv.ftl
+++ b/crates/vmux_ui/locales/jv.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Sambungan menyang Mac panjenengan wis pedhot.
 mobile-error-connection-closed = Mac panjenengan nutup sambungan.
 mobile-error-address-invalid = Alamat pasangan kuwi ora sah.
 mobile-error-address-no-port = Alamat pasangan kuwi ora duwe port.
+mobile-qr-denied = Vmux ora bisa nggunakake kamera. Uripake ing Setelan supaya bisa mindhai kode QR, utawa bali mundur banjur tempel link pasangan wae.
+mobile-qr-open-settings = Bukak Setelan
+mobile-qr-session-error = Kamera mandheg. Coba maneh, utawa tempel link pasangan wae.

--- a/crates/vmux_ui/locales/ka.ftl
+++ b/crates/vmux_ui/locales/ka.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = თქვენს Mac-თან კავშ�
 mobile-error-connection-closed = თქვენმა Mac-მა კავშირი დახურა.
 mobile-error-address-invalid = ეს დაწყვილების მისამართი არასწორია.
 mobile-error-address-no-port = ამ დაწყვილების მისამართს პორტი არ აქვს.
+mobile-qr-denied = Vmux ვერ იყენებს კამერას. ჩართეთ ის პარამეტრებში QR კოდის დასასკანირებლად, ან დაბრუნდით უკან და ამის ნაცვლად ჩასვით დაწყვილების ბმული.
+mobile-qr-open-settings = პარამეტრების გახსნა
+mobile-qr-session-error = კამერა გაჩერდა. სცადეთ ხელახლა, ან ამის ნაცვლად ჩასვით დაწყვილების ბმული.

--- a/crates/vmux_ui/locales/kk.ftl
+++ b/crates/vmux_ui/locales/kk.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Mac-іңізбен байланыс үзілд
 mobile-error-connection-closed = Mac-іңіз байланысты жапты.
 mobile-error-address-invalid = Бұл жұптау адресі жарамсыз.
 mobile-error-address-no-port = Бұл жұптау адресінде порт жоқ.
+mobile-qr-denied = Vmux камераны пайдалана алмайды. QR кодын сканерлеу үшін оны Параметрлерде қосыңыз немесе артқа қайтып, оның орнына жұптау сілтемесін қойыңыз.
+mobile-qr-open-settings = Параметрлерді ашу
+mobile-qr-session-error = Камера тоқтады. Қайталап көріңіз немесе оның орнына жұптау сілтемесін қойыңыз.

--- a/crates/vmux_ui/locales/km.ftl
+++ b/crates/vmux_ui/locales/km.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = ការភ្ជាប់ទៅ Mac រប�
 mobile-error-connection-closed = Mac របស់អ្នកបានបិទការភ្ជាប់។
 mobile-error-address-invalid = អាសយដ្ឋានភ្ជាប់នោះមិនត្រឹមត្រូវ។
 mobile-error-address-no-port = អាសយដ្ឋានភ្ជាប់នោះគ្មានច្រក។
+mobile-qr-denied = Vmux មិនអាចប្រើកាមេរ៉ាបានទេ។ សូមបើកវានៅក្នុងការកំណត់ ដើម្បីស្កេនកូដ QR ឬត្រឡប់ក្រោយ រួចបិទភ្ជាប់តំណភ្ជាប់ជំនួសវិញ។
+mobile-qr-open-settings = បើកការកំណត់
+mobile-qr-session-error = កាមេរ៉ាបានឈប់ដំណើរការ។ សូមព្យាយាមម្ដងទៀត ឬបិទភ្ជាប់តំណភ្ជាប់ជំនួសវិញ។

--- a/crates/vmux_ui/locales/kn.ftl
+++ b/crates/vmux_ui/locales/kn.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = ನಿಮ್ಮ Mac ನೊಂದಿಗಿನ �
 mobile-error-connection-closed = ನಿಮ್ಮ Mac ಸಂಪರ್ಕವನ್ನು ಮುಚ್ಚಿತು.
 mobile-error-address-invalid = ಆ ಜೋಡಣೆ ವಿಳಾಸ ಅಮಾನ್ಯವಾಗಿದೆ.
 mobile-error-address-no-port = ಆ ಜೋಡಣೆ ವಿಳಾಸದಲ್ಲಿ ಪೋರ್ಟ್ ಇಲ್ಲ.
+mobile-qr-denied = Vmux ಕ್ಯಾಮೆರಾ ಬಳಸಲಾಗುತ್ತಿಲ್ಲ. QR ಕೋಡ್ ಸ್ಕ್ಯಾನ್ ಮಾಡಲು ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ಅದನ್ನು ಆನ್ ಮಾಡಿ, ಅಥವಾ ಹಿಂತಿರುಗಿ ಬದಲಿಗೆ ಜೋಡಣೆ ಲಿಂಕ್ ಅಂಟಿಸಿ.
+mobile-qr-open-settings = ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ತೆರೆಯಿರಿ
+mobile-qr-session-error = ಕ್ಯಾಮೆರಾ ನಿಂತುಹೋಯಿತು. ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ, ಅಥವಾ ಬದಲಿಗೆ ಜೋಡಣೆ ಲಿಂಕ್ ಅಂಟಿಸಿ.

--- a/crates/vmux_ui/locales/ko.ftl
+++ b/crates/vmux_ui/locales/ko.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Mac과의 연결이 끊어졌습니다.
 mobile-error-connection-closed = Mac이 연결을 종료했습니다.
 mobile-error-address-invalid = 페어링 주소가 올바르지 않습니다.
 mobile-error-address-no-port = 페어링 주소에 포트가 없습니다.
+mobile-qr-denied = Vmux에서 카메라를 사용할 수 없습니다. QR 코드를 스캔하려면 설정에서 카메라를 켜거나, 뒤로 돌아가 페어링 링크를 붙여넣으세요.
+mobile-qr-open-settings = 설정 열기
+mobile-qr-session-error = 카메라가 중지되었습니다. 다시 시도하거나 대신 페어링 링크를 붙여넣으세요.

--- a/crates/vmux_ui/locales/ku.ftl
+++ b/crates/vmux_ui/locales/ku.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = پەیوەندی بە Mac-ەکەتەوە پچ�
 mobile-error-connection-closed = Mac-ەکەت پەیوەندییەکەی داخست.
 mobile-error-address-invalid = ناونیشانی جووتکردن نادروستە.
 mobile-error-address-no-port = ناونیشانی جووتکردن پۆرتی تێدا نییە.
+mobile-qr-denied = Vmux ناتوانێت کامێرا بەکاربهێنێت. لە ڕێکخستنەکاندا بیکەرەوە بۆ سکانکردنی کۆدی QR، یان بگەڕێوە دواوە و لە جیاتی ئەوە بەستەری جووتکردن بلکێنە.
+mobile-qr-open-settings = ڕێکخستنەکان بکەرەوە
+mobile-qr-session-error = کامێرا وەستا. دووبارە هەوڵ بدەوە، یان لە جیاتی ئەوە بەستەری جووتکردن بلکێنە.

--- a/crates/vmux_ui/locales/ky.ftl
+++ b/crates/vmux_ui/locales/ky.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Mac-иңиз менен туташуу үзү�
 mobile-error-connection-closed = Mac-иңиз туташууну жапты.
 mobile-error-address-invalid = Жупташтыруу дареги жараксыз.
 mobile-error-address-no-port = Жупташтыруу дарегинде порт жок.
+mobile-qr-denied = Vmux камераны колдоно албайт. QR кодун сканерлөө үчүн аны Жөндөөлөрдөн күйгүзүңүз же артка кайтып, анын ордуна жупташтыруу шилтемесин коюңуз.
+mobile-qr-open-settings = Жөндөөлөрдү ачуу
+mobile-qr-session-error = Камера токтоп калды. Кайра аракет кылыңыз же анын ордуна жупташтыруу шилтемесин коюңуз.

--- a/crates/vmux_ui/locales/la.ftl
+++ b/crates/vmux_ui/locales/la.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Coniunctio cum Mac tuo intercidit.
 mobile-error-connection-closed = Mac tuum coniunctionem clausit.
 mobile-error-address-invalid = Inscriptio coniunctionis invalida est.
 mobile-error-address-no-port = Inscriptio coniunctionis portum non habet.
+mobile-qr-denied = Vmux camera uti non potest. Eam in Optionibus accende ut codicem QR legas, vel redi et nexum coniunctionis potius insere.
+mobile-qr-open-settings = Optiones aperire
+mobile-qr-session-error = Camera destitit. Iterum conare, vel nexum coniunctionis potius insere.

--- a/crates/vmux_ui/locales/lb.ftl
+++ b/crates/vmux_ui/locales/lb.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = D'Verbindung mat dengem Mac ass ofgebrach.
 mobile-error-connection-closed = Däi Mac huet d'Verbindung zougemaach.
 mobile-error-address-invalid = D'Koppeladress ass ongëlteg.
 mobile-error-address-no-port = D'Koppeladress huet kee Port.
+mobile-qr-denied = Vmux kann d'Camera net benotzen. Schalt se an den Astellungen un, fir de QR-Code ze scannen, oder géi zréck a setz amplaz de Koppellink an.
+mobile-qr-open-settings = Astellungen opmaachen
+mobile-qr-session-error = D'Camera huet opgehalen. Probéier nach eng Kéier, oder setz amplaz de Koppellink an.

--- a/crates/vmux_ui/locales/lo.ftl
+++ b/crates/vmux_ui/locales/lo.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = ການເຊື່ອມຕໍ່ກັບ 
 mobile-error-connection-closed = Mac ຂອງທ່ານໄດ້ປິດການເຊື່ອມຕໍ່.
 mobile-error-address-invalid = ທີ່ຢູ່ຈັບຄູ່ບໍ່ຖືກຕ້ອງ.
 mobile-error-address-no-port = ທີ່ຢູ່ຈັບຄູ່ບໍ່ມີພອດ.
+mobile-qr-denied = Vmux ບໍ່ສາມາດໃຊ້ກ້ອງໄດ້. ເປີດໃຊ້ມັນໃນການຕັ້ງຄ່າເພື່ອສະແກນລະຫັດ QR, ຫຼືກັບຄືນໄປແລ້ວວາງລິ້ງຈັບຄູ່ແທນ.
+mobile-qr-open-settings = ເປີດການຕັ້ງຄ່າ
+mobile-qr-session-error = ກ້ອງຢຸດເຮັດວຽກ. ລອງໃໝ່ອີກຄັ້ງ, ຫຼືວາງລິ້ງຈັບຄູ່ແທນ.

--- a/crates/vmux_ui/locales/lt.ftl
+++ b/crates/vmux_ui/locales/lt.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Ryšys su jūsų Mac nutrūko.
 mobile-error-connection-closed = Jūsų Mac uždarė ryšį.
 mobile-error-address-invalid = Susiejimo adresas netinkamas.
 mobile-error-address-no-port = Susiejimo adrese nėra prievado.
+mobile-qr-denied = Vmux negali naudoti kameros. Įjunkite ją Nustatymuose, kad nuskaitytumėte QR kodą, arba grįžkite atgal ir vietoj to įklijuokite susiejimo nuorodą.
+mobile-qr-open-settings = Atidaryti Nustatymus
+mobile-qr-session-error = Kamera sustojo. Bandykite dar kartą arba vietoj to įklijuokite susiejimo nuorodą.

--- a/crates/vmux_ui/locales/lv.ftl
+++ b/crates/vmux_ui/locales/lv.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Savienojums ar jūsu Mac pārtrūka.
 mobile-error-connection-closed = Jūsu Mac aizvēra savienojumu.
 mobile-error-address-invalid = Savienošanas adrese nav derīga.
 mobile-error-address-no-port = Savienošanas adresē nav porta.
+mobile-qr-denied = Vmux nevar izmantot kameru. Ieslēdziet to Iestatījumos, lai skenētu QR kodu, vai atgriezieties un tā vietā ielīmējiet savienošanas saiti.
+mobile-qr-open-settings = Atvērt Iestatījumus
+mobile-qr-session-error = Kamera apstājās. Mēģiniet vēlreiz vai tā vietā ielīmējiet savienošanas saiti.

--- a/crates/vmux_ui/locales/mg.ftl
+++ b/crates/vmux_ui/locales/mg.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Tapaka ny fifandraisana amin’ny Mac-nao.
 mobile-error-connection-closed = Nakaton’ny Mac-nao ny fifandraisana.
 mobile-error-address-invalid = Tsy mety ny adiresy fampifandraisana.
 mobile-error-address-no-port = Tsy misy port ny adiresy fampifandraisana.
+mobile-qr-denied = Tsy afaka mampiasa ny fakan-tsary i Vmux. Alefaso ao amin’ny Settings izy mba hahafahana mi-scan ny QR code, na miverena ka apetaho ny rohy fampifandraisana.
+mobile-qr-open-settings = Sokafy ny Settings
+mobile-qr-session-error = Nijanona ny fakan-tsary. Andramo indray, na apetaho ny rohy fampifandraisana.

--- a/crates/vmux_ui/locales/mi.ftl
+++ b/crates/vmux_ui/locales/mi.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Kua motu te tūhonotanga ki tō Mac.
 mobile-error-connection-closed = Kua katia e tō Mac te tūhonotanga.
 mobile-error-address-invalid = He muhu te wāhitau tūhono.
 mobile-error-address-no-port = Kāore he tauranga i te wāhitau tūhono.
+mobile-qr-denied = Kāore e taea e Vmux te whakamahi i te kāmera. Whakahohea i roto i Settings kia taea ai te matawai i te QR code, hoki rānei ki muri ka whakapiri i te hono tūhono.
+mobile-qr-open-settings = Huakina Settings
+mobile-qr-session-error = Kua mutu te kāmera. Ngana anō, whakapirihia rānei te hono tūhono.

--- a/crates/vmux_ui/locales/mk.ftl
+++ b/crates/vmux_ui/locales/mk.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Врската со твојот Mac се пр
 mobile-error-connection-closed = Твојот Mac ја затвори врската.
 mobile-error-address-invalid = Адресата за поврзување е невалидна.
 mobile-error-address-no-port = Адресата за поврзување нема порта.
+mobile-qr-denied = Vmux не може да ја користи камерата. Вклучи ја во Поставки за да го скенираш QR кодот или врати се назад и залепи го линкот за поврзување.
+mobile-qr-open-settings = Отвори Поставки
+mobile-qr-session-error = Камерата запре. Обиди се повторно или залепи го линкот за поврзување.

--- a/crates/vmux_ui/locales/ml.ftl
+++ b/crates/vmux_ui/locales/ml.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = നിങ്ങളുടെ Mac-മായു�
 mobile-error-connection-closed = നിങ്ങളുടെ Mac കണക്ഷൻ അടച്ചു.
 mobile-error-address-invalid = പെയറിംഗ് വിലാസം അസാധുവാണ്.
 mobile-error-address-no-port = പെയറിംഗ് വിലാസത്തിൽ പോർട്ടില്ല.
+mobile-qr-denied = Vmux-ന് ക്യാമറ ഉപയോഗിക്കാനാകുന്നില്ല. QR കോഡ് സ്കാൻ ചെയ്യാൻ ക്രമീകരണങ്ങളിൽ അത് ഓണാക്കുക, അല്ലെങ്കിൽ തിരികെ പോയി പെയറിംഗ് ലിങ്ക് ഒട്ടിക്കുക.
+mobile-qr-open-settings = ക്രമീകരണങ്ങൾ തുറക്കുക
+mobile-qr-session-error = ക്യാമറ നിലച്ചു. വീണ്ടും ശ്രമിക്കുക, അല്ലെങ്കിൽ പെയറിംഗ് ലിങ്ക് ഒട്ടിക്കുക.

--- a/crates/vmux_ui/locales/mn.ftl
+++ b/crates/vmux_ui/locales/mn.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Таны Mac-тай холбоо тасарл�
 mobile-error-connection-closed = Таны Mac холбоог хаалаа.
 mobile-error-address-invalid = Тэр холболтын хаяг буруу байна.
 mobile-error-address-no-port = Тэр холболтын хаягт порт алга.
+mobile-qr-denied = Vmux камерыг ашиглаж чадахгүй байна. QR код уншуулахын тулд Тохиргоо хэсэгт үүнийг асаана уу, эсвэл буцаж очоод холбох линкийг буулгана уу.
+mobile-qr-open-settings = Тохиргоог нээх
+mobile-qr-session-error = Камер зогслоо. Дахин оролдоно уу, эсвэл холбох линкийг буулгана уу.

--- a/crates/vmux_ui/locales/mr.ftl
+++ b/crates/vmux_ui/locales/mr.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = तुमच्या Mac शी कनेक�
 mobile-error-connection-closed = तुमच्या Mac ने कनेक्शन बंद केले.
 mobile-error-address-invalid = तो पेअरिंग पत्ता अवैध आहे.
 mobile-error-address-no-port = त्या पेअरिंग पत्त्यात पोर्ट नाही.
+mobile-qr-denied = Vmux कॅमेरा वापरू शकत नाही. QR कोड स्कॅन करण्यासाठी सेटिंग्जमध्ये तो चालू करा, किंवा मागे जाऊन पेअरिंग लिंक पेस्ट करा.
+mobile-qr-open-settings = सेटिंग्ज उघडा
+mobile-qr-session-error = कॅमेरा थांबला. पुन्हा प्रयत्न करा, किंवा पेअरिंग लिंक पेस्ट करा.

--- a/crates/vmux_ui/locales/ms.ftl
+++ b/crates/vmux_ui/locales/ms.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Sambungan ke Mac anda terputus.
 mobile-error-connection-closed = Mac anda menutup sambungan.
 mobile-error-address-invalid = Alamat pasangan itu tidak sah.
 mobile-error-address-no-port = Alamat pasangan itu tiada port.
+mobile-qr-denied = Vmux tidak boleh menggunakan kamera. Hidupkannya dalam Tetapan untuk mengimbas kod QR, atau kembali dan tampal pautan pasangan sebaliknya.
+mobile-qr-open-settings = Buka Tetapan
+mobile-qr-session-error = Kamera terhenti. Cuba lagi, atau tampal pautan pasangan sebaliknya.

--- a/crates/vmux_ui/locales/mt.ftl
+++ b/crates/vmux_ui/locales/mt.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Il-konnessjoni mal-Mac tiegħek inqatgħet.
 mobile-error-connection-closed = Il-Mac tiegħek għalaq il-konnessjoni.
 mobile-error-address-invalid = Dak l-indirizz tal-pairing mhuwiex validu.
 mobile-error-address-no-port = Dak l-indirizz tal-pairing m’għandux port.
+mobile-qr-denied = Vmux ma jistax juża l-kamera. Ixgħelha f’Settings biex tiskennja l-kodiċi QR, jew mur lura u paste il-link tal-pairing minflok.
+mobile-qr-open-settings = Iftaħ Settings
+mobile-qr-session-error = Il-kamera waqfet. Erġa’ pprova, jew paste il-link tal-pairing minflok.

--- a/crates/vmux_ui/locales/my.ftl
+++ b/crates/vmux_ui/locales/my.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = သင့် Mac နှင့် ချိတ�
 mobile-error-connection-closed = သင့် Mac က ချိတ်ဆက်မှုကို ပိတ်လိုက်သည်။
 mobile-error-address-invalid = ထို ချိတ်ဆက် လိပ်စာ မမှန်ကန်ပါ။
 mobile-error-address-no-port = ထို ချိတ်ဆက် လိပ်စာတွင် port မပါပါ။
+mobile-qr-denied = Vmux သည် ကင်မရာကို အသုံးမပြုနိုင်ပါ။ QR ကုဒ်ကို စကင်ဖတ်ရန် ဆက်တင်များတွင် ၎င်းကို ဖွင့်ပါ၊ သို့မဟုတ် နောက်သို့ပြန်သွား၍ ချိတ်ဆက်လင့်ခ်ကို ကူးထည့်ပါ။
+mobile-qr-open-settings = ဆက်တင်များ ဖွင့်ရန်
+mobile-qr-session-error = ကင်မရာ ရပ်သွားပါပြီ။ ထပ်စမ်းကြည့်ပါ၊ သို့မဟုတ် ချိတ်ဆက်လင့်ခ်ကို ကူးထည့်ပါ။

--- a/crates/vmux_ui/locales/nb.ftl
+++ b/crates/vmux_ui/locales/nb.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Tilkoblingen til Mac-en din ble brutt.
 mobile-error-connection-closed = Mac-en din lukket tilkoblingen.
 mobile-error-address-invalid = Den koblingsadressen er ugyldig.
 mobile-error-address-no-port = Den koblingsadressen mangler port.
+mobile-qr-denied = Vmux får ikke tilgang til kameraet. Slå det på i Innstillinger for å skanne QR-koden, eller gå tilbake og lim inn koblingslenken i stedet.
+mobile-qr-open-settings = Åpne Innstillinger
+mobile-qr-session-error = Kameraet stoppet. Prøv igjen, eller lim inn koblingslenken i stedet.

--- a/crates/vmux_ui/locales/ne.ftl
+++ b/crates/vmux_ui/locales/ne.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = तपाईंको Mac सँगको ज�
 mobile-error-connection-closed = तपाईंको Mac ले जडान बन्द गर्‍यो।
 mobile-error-address-invalid = त्यो पेयरिङ ठेगाना अवैध छ।
 mobile-error-address-no-port = त्यो पेयरिङ ठेगानामा पोर्ट छैन।
+mobile-qr-denied = Vmux ले क्यामेरा प्रयोग गर्न सक्दैन। QR कोड स्क्यान गर्न सेटिङमा यसलाई खोल्नुहोस्, वा पछाडि गएर पेयरिङ लिंक टाँस्नुहोस्।
+mobile-qr-open-settings = सेटिङ खोल्नुहोस्
+mobile-qr-session-error = क्यामेरा रोकियो। फेरि प्रयास गर्नुहोस्, वा पेयरिङ लिंक टाँस्नुहोस्।

--- a/crates/vmux_ui/locales/nl.ftl
+++ b/crates/vmux_ui/locales/nl.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = De verbinding met je Mac is weggevallen.
 mobile-error-connection-closed = Je Mac heeft de verbinding gesloten.
 mobile-error-address-invalid = Dat koppelingsadres is ongeldig.
 mobile-error-address-no-port = Dat koppelingsadres bevat geen poort.
+mobile-qr-denied = Vmux kan de camera niet gebruiken. Zet die aan in Instellingen om de QR-code te scannen, of ga terug en plak de koppelingslink.
+mobile-qr-open-settings = Open Instellingen
+mobile-qr-session-error = De camera is gestopt. Probeer het opnieuw of plak de koppelingslink.

--- a/crates/vmux_ui/locales/no.ftl
+++ b/crates/vmux_ui/locales/no.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Tilkoblingen til Mac-en din ble brutt.
 mobile-error-connection-closed = Mac-en din lukket tilkoblingen.
 mobile-error-address-invalid = Den koblingsadressen er ugyldig.
 mobile-error-address-no-port = Den koblingsadressen mangler port.
+mobile-qr-denied = Vmux får ikke tilgang til kameraet. Slå det på i Innstillinger for å skanne QR-koden, eller gå tilbake og lim inn koblingslenken i stedet.
+mobile-qr-open-settings = Åpne Innstillinger
+mobile-qr-session-error = Kameraet stoppet. Prøv igjen, eller lim inn koblingslenken i stedet.

--- a/crates/vmux_ui/locales/ny.ftl
+++ b/crates/vmux_ui/locales/ny.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Kulumikizana ndi Mac yanu kwadulika.
 mobile-error-connection-closed = Mac yanu yatseka kulumikizana.
 mobile-error-address-invalid = Adilesi yolumikizira imeneyo si yolondola.
 mobile-error-address-no-port = Adilesi yolumikizira imeneyo ilibe port.
+mobile-qr-denied = Vmux singathe kugwiritsa ntchito kamera. Iyatseni mu Settings kuti muskane QR code, kapena bwererani ndi kumata ulalo wolumikizira m'malo mwake.
+mobile-qr-open-settings = Tsegulani Settings
+mobile-qr-session-error = Kamera yaima. Yesaninso, kapena matani ulalo wolumikizira m'malo mwake.

--- a/crates/vmux_ui/locales/or.ftl
+++ b/crates/vmux_ui/locales/or.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = ଆପଣଙ୍କ Mac ସହ ସଂଯୋଗ 
 mobile-error-connection-closed = ଆପଣଙ୍କ Mac ସଂଯୋଗ ବନ୍ଦ କରିଦେଲା।
 mobile-error-address-invalid = ସେହି ପେୟାରିଂ ଠିକଣା ଅବୈଧ।
 mobile-error-address-no-port = ସେହି ପେୟାରିଂ ଠିକଣାରେ ପୋର୍ଟ ନାହିଁ।
+mobile-qr-denied = Vmux କ୍ୟାମେରା ବ୍ୟବହାର କରିପାରୁନାହିଁ। QR କୋଡ୍ ସ୍କାନ୍ କରିବାକୁ ସେଟିଂସ୍ ରେ ଏହାକୁ ଚାଲୁ କରନ୍ତୁ, କିମ୍ବା ପଛକୁ ଯାଇ ପେୟାରିଂ ଲିଙ୍କ୍ ପେଷ୍ଟ କରନ୍ତୁ।
+mobile-qr-open-settings = ସେଟିଂସ୍ ଖୋଲନ୍ତୁ
+mobile-qr-session-error = କ୍ୟାମେରା ବନ୍ଦ ହୋଇଗଲା। ପୁନଃ ଚେଷ୍ଟା କରନ୍ତୁ, କିମ୍ବା ପେୟାରିଂ ଲିଙ୍କ୍ ପେଷ୍ଟ କରନ୍ତୁ।

--- a/crates/vmux_ui/locales/pa.ftl
+++ b/crates/vmux_ui/locales/pa.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = ਤੁਹਾਡੇ Mac ਨਾਲ ਕਨੈਕ�
 mobile-error-connection-closed = ਤੁਹਾਡੇ Mac ਨੇ ਕਨੈਕਸ਼ਨ ਬੰਦ ਕਰ ਦਿੱਤਾ।
 mobile-error-address-invalid = ਉਹ ਪੇਅਰਿੰਗ ਪਤਾ ਗਲਤ ਹੈ।
 mobile-error-address-no-port = ਉਸ ਪੇਅਰਿੰਗ ਪਤੇ ਵਿੱਚ ਪੋਰਟ ਨਹੀਂ ਹੈ।
+mobile-qr-denied = Vmux ਕੈਮਰਾ ਨਹੀਂ ਵਰਤ ਸਕਦਾ। QR ਕੋਡ ਸਕੈਨ ਕਰਨ ਲਈ ਸੈਟਿੰਗਾਂ ਵਿੱਚ ਇਸਨੂੰ ਚਾਲੂ ਕਰੋ, ਜਾਂ ਵਾਪਸ ਜਾ ਕੇ ਪੇਅਰਿੰਗ ਲਿੰਕ ਪੇਸਟ ਕਰੋ।
+mobile-qr-open-settings = ਸੈਟਿੰਗਾਂ ਖੋਲ੍ਹੋ
+mobile-qr-session-error = ਕੈਮਰਾ ਰੁਕ ਗਿਆ। ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰੋ, ਜਾਂ ਪੇਅਰਿੰਗ ਲਿੰਕ ਪੇਸਟ ਕਰੋ।

--- a/crates/vmux_ui/locales/pl.ftl
+++ b/crates/vmux_ui/locales/pl.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Połączenie z komputerem Mac zostało zerwane
 mobile-error-connection-closed = Twój Mac zamknął połączenie.
 mobile-error-address-invalid = Adres parowania jest nieprawidłowy.
 mobile-error-address-no-port = Adres parowania nie zawiera portu.
+mobile-qr-denied = Vmux nie może korzystać z aparatu. Włącz dostęp w Ustawieniach, aby zeskanować kod QR, albo wróć i wklej link parowania.
+mobile-qr-open-settings = Otwórz Ustawienia
+mobile-qr-session-error = Aparat przestał działać. Spróbuj ponownie albo wklej link parowania.

--- a/crates/vmux_ui/locales/ps.ftl
+++ b/crates/vmux_ui/locales/ps.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = له ستاسو Mac سره اړیکه پرې �
 mobile-error-connection-closed = ستاسو Mac اړیکه بنده کړه.
 mobile-error-address-invalid = د پیرنګ پته ناسمه ده.
 mobile-error-address-no-port = د پیرنګ په پته کې پورټ نشته.
+mobile-qr-denied = Vmux کامره نشي کارولی. د QR کوډ سکن کولو لپاره یې په تنظیماتو کې فعاله کړئ، یا شاته ولاړ شئ او د پیرنګ لینک پیست کړئ.
+mobile-qr-open-settings = تنظیمات پرانیزئ
+mobile-qr-session-error = کامره ودرېده. بیا هڅه وکړئ، یا د پیرنګ لینک پیست کړئ.

--- a/crates/vmux_ui/locales/pt-BR.ftl
+++ b/crates/vmux_ui/locales/pt-BR.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = A conexão com o seu Mac caiu.
 mobile-error-connection-closed = Seu Mac encerrou a conexão.
 mobile-error-address-invalid = O endereço de pareamento é inválido.
 mobile-error-address-no-port = O endereço de pareamento não tem porta.
+mobile-qr-denied = O Vmux não pode usar a câmera. Ative-a nos Ajustes para escanear o código QR ou volte e cole o link de pareamento.
+mobile-qr-open-settings = Abrir Ajustes
+mobile-qr-session-error = A câmera parou. Tente de novo ou cole o link de pareamento.

--- a/crates/vmux_ui/locales/pt-PT.ftl
+++ b/crates/vmux_ui/locales/pt-PT.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = A ligação ao seu Mac caiu.
 mobile-error-connection-closed = O seu Mac encerrou a ligação.
 mobile-error-address-invalid = O endereço de emparelhamento é inválido.
 mobile-error-address-no-port = O endereço de emparelhamento não tem porta.
+mobile-qr-denied = O Vmux não consegue utilizar a câmara. Ative-a nas Definições para ler o código QR ou volte atrás e cole antes a ligação de emparelhamento.
+mobile-qr-open-settings = Abrir Definições
+mobile-qr-session-error = A câmara parou. Tente novamente ou cole antes a ligação de emparelhamento.

--- a/crates/vmux_ui/locales/pt.ftl
+++ b/crates/vmux_ui/locales/pt.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = A conexão com o seu Mac foi perdida.
 mobile-error-connection-closed = O seu Mac encerrou a conexão.
 mobile-error-address-invalid = O endereço de emparelhamento é inválido.
 mobile-error-address-no-port = O endereço de emparelhamento não indica uma porta.
+mobile-qr-denied = O Vmux não pode aceder à câmara. Ative-a nas Definições para ler o código QR ou regresse e cole o link de emparelhamento.
+mobile-qr-open-settings = Abrir as Definições
+mobile-qr-session-error = A câmara deixou de funcionar. Tente de novo ou cole o link de emparelhamento.

--- a/crates/vmux_ui/locales/ro.ftl
+++ b/crates/vmux_ui/locales/ro.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Conexiunea cu Mac-ul tău s-a întrerupt.
 mobile-error-connection-closed = Mac-ul tău a închis conexiunea.
 mobile-error-address-invalid = Adresa de asociere nu este validă.
 mobile-error-address-no-port = Adresa de asociere nu conține un port.
+mobile-qr-denied = Vmux nu poate folosi camera. Activeaz-o din Setări ca să scanezi codul QR sau întoarce-te și lipește în schimb linkul de asociere.
+mobile-qr-open-settings = Deschide Setările
+mobile-qr-session-error = Camera s-a oprit. Încearcă din nou sau lipește în schimb linkul de asociere.

--- a/crates/vmux_ui/locales/ru.ftl
+++ b/crates/vmux_ui/locales/ru.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Соединение с вашим Mac раз�
 mobile-error-connection-closed = Ваш Mac закрыл соединение.
 mobile-error-address-invalid = Адрес сопряжения недействителен.
 mobile-error-address-no-port = В адресе сопряжения нет порта.
+mobile-qr-denied = Vmux не может использовать камеру. Включите доступ в Настройках, чтобы отсканировать QR-код, или вернитесь и вставьте ссылку сопряжения.
+mobile-qr-open-settings = Открыть Настройки
+mobile-qr-session-error = Камера остановилась. Повторите попытку или вставьте ссылку сопряжения.

--- a/crates/vmux_ui/locales/rw.ftl
+++ b/crates/vmux_ui/locales/rw.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Guhuza na Mac yawe byaciwe.
 mobile-error-connection-closed = Mac yawe yahagaritse guhuza.
 mobile-error-address-invalid = Aderesi yo guhuza ntiyemewe.
 mobile-error-address-no-port = Aderesi yo guhuza nta port irimo.
+mobile-qr-denied = Vmux ntishobora gukoresha kamera. Yifungurire muri Settings kugira ngo usikane kode QR, cyangwa usubire inyuma womeke ihuriro ryo guhuza.
+mobile-qr-open-settings = Fungura Settings
+mobile-qr-session-error = Kamera yahagaze. Ongera ugerageze, cyangwa omeka ihuriro ryo guhuza.

--- a/crates/vmux_ui/locales/sd.ftl
+++ b/crates/vmux_ui/locales/sd.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = توهانجي Mac سان رابطو ٽٽي و
 mobile-error-connection-closed = توهانجي Mac رابطو بند ڪري ڇڏيو.
 mobile-error-address-invalid = ڳنڍڻ وارو پتو غلط آهي.
 mobile-error-address-no-port = ڳنڍڻ واري پتي ۾ پورٽ ناهي.
+mobile-qr-denied = Vmux ڪئميرا استعمال نٿو ڪري سگهي. QR ڪوڊ اسڪين ڪرڻ لاءِ سيٽنگون ۾ ان کي آن ڪريو، يا واپس وڃي ڳنڍڻ جو لنڪ پيسٽ ڪريو.
+mobile-qr-open-settings = سيٽنگون کوليو
+mobile-qr-session-error = ڪئميرا بند ٿي وئي. ٻيهر ڪوشش ڪريو، يا ڳنڍڻ جو لنڪ پيسٽ ڪريو.

--- a/crates/vmux_ui/locales/si.ftl
+++ b/crates/vmux_ui/locales/si.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = ඔබේ Mac වෙත වූ සම්බන
 mobile-error-connection-closed = ඔබේ Mac සම්බන්ධතාවය වසා දැමීය.
 mobile-error-address-invalid = යුගල කිරීමේ ලිපිනය වලංගු නැත.
 mobile-error-address-no-port = යුගල කිරීමේ ලිපිනයේ පෝට් එකක් නැත.
+mobile-qr-denied = Vmux හට කැමරාව භාවිත කළ නොහැක. QR කේතය පරිලෝකනය කිරීමට සැකසුම් තුළ එය සක්‍රිය කරන්න, නැතහොත් ආපසු ගොස් යුගල කිරීමේ සබැඳිය අලවන්න.
+mobile-qr-open-settings = සැකසුම් විවෘත කරන්න
+mobile-qr-session-error = කැමරාව නැවතුණි. නැවත උත්සාහ කරන්න, නැතහොත් යුගල කිරීමේ සබැඳිය අලවන්න.

--- a/crates/vmux_ui/locales/sk.ftl
+++ b/crates/vmux_ui/locales/sk.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Spojenie s vaším Mac sa prerušilo.
 mobile-error-connection-closed = Váš Mac ukončil spojenie.
 mobile-error-address-invalid = Párovacia adresa je neplatná.
 mobile-error-address-no-port = Párovacia adresa neobsahuje port.
+mobile-qr-denied = Vmux nemôže použiť fotoaparát. Povoľte ho v Nastaveniach, aby ste naskenovali QR kód, alebo sa vráťte späť a vložte párovací odkaz.
+mobile-qr-open-settings = Otvoriť Nastavenia
+mobile-qr-session-error = Fotoaparát sa zastavil. Skúste to znova alebo vložte párovací odkaz.

--- a/crates/vmux_ui/locales/sl.ftl
+++ b/crates/vmux_ui/locales/sl.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Povezava z vašim Mac se je prekinila.
 mobile-error-connection-closed = Vaš Mac je zaprl povezavo.
 mobile-error-address-invalid = Naslov za seznanitev ni veljaven.
 mobile-error-address-no-port = Naslov za seznanitev nima vrat.
+mobile-qr-denied = Vmux ne more uporabljati kamere. Vklopite jo v Nastavitvah, da skenirate kodo QR, ali pa se vrnite in prilepite povezavo za seznanitev.
+mobile-qr-open-settings = Odpri Nastavitve
+mobile-qr-session-error = Kamera se je ustavila. Poskusite znova ali prilepite povezavo za seznanitev.

--- a/crates/vmux_ui/locales/sm.ftl
+++ b/crates/vmux_ui/locales/sm.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Ua motu le so‘otaga i lau Mac.
 mobile-error-connection-closed = Ua tapunia e lau Mac le so‘otaga.
 mobile-error-address-invalid = E lē aogā lena tuatusi feso‘ota‘i.
 mobile-error-address-no-port = E leai se port i lena tuatusi feso‘ota‘i.
+mobile-qr-denied = E le mafai e Vmux ona fa‘aoga le mea pu‘eata. Ki i luga i Settings e siaki ai le QR code, pe toe fo‘i i tua ma fa‘apipi‘i le so‘otaga feso‘ota‘i.
+mobile-qr-open-settings = Tatala Settings
+mobile-qr-session-error = Ua tu le mea pu‘eata. Toe taumafai, pe fa‘apipi‘i le so‘otaga feso‘ota‘i.

--- a/crates/vmux_ui/locales/sn.ftl
+++ b/crates/vmux_ui/locales/sn.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Kubatana neMac yako kwadambuka.
 mobile-error-connection-closed = Mac yako yavhara kubatana.
 mobile-error-address-invalid = Kero yekubatanidza iyoyo haina kururama.
 mobile-error-address-no-port = Kero yekubatanidza iyoyo haina poti.
+mobile-qr-denied = Vmux haigoni kushandisa kamera. Ivhurei muSettings kuti muskene QR code, kana kudzokera shure momunamira link yekubatanidza.
+mobile-qr-open-settings = Vhura Settings
+mobile-qr-session-error = Kamera yamira. Edzai zvakare, kana kunamira link yekubatanidza.

--- a/crates/vmux_ui/locales/so.ftl
+++ b/crates/vmux_ui/locales/so.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Xidhiidhka Mac-kaaga wuu go'ay.
 mobile-error-connection-closed = Mac-kaagu xidhiidhka wuu xidhay.
 mobile-error-address-invalid = Cinwaankaas isku xidhka waa khaldan yahay.
 mobile-error-address-no-port = Cinwaankaas isku xidhka ma laha port.
+mobile-qr-denied = Vmux ma isticmaali karo kamarada. Ka shid Settings si aad u iskaanto QR code-ka, ama dib u noqo oo ku dheji linkiga isku xidhka.
+mobile-qr-open-settings = Fur Settings
+mobile-qr-session-error = Kamaradu way joogsatay. Isku day mar kale, ama ku dheji linkiga isku xidhka.

--- a/crates/vmux_ui/locales/sq.ftl
+++ b/crates/vmux_ui/locales/sq.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Lidhja me Mac-un tënd u ndërpre.
 mobile-error-connection-closed = Mac-u yt e mbylli lidhjen.
 mobile-error-address-invalid = Ajo adresë çiftimi nuk është e vlefshme.
 mobile-error-address-no-port = Ajo adresë çiftimi nuk ka portë.
+mobile-qr-denied = Vmux nuk mund ta përdorë kamerën. Aktivizoje te Settings për të skanuar kodin QR, ose kthehu pas dhe ngjit lidhjen e çiftimit.
+mobile-qr-open-settings = Hap Settings
+mobile-qr-session-error = Kamera u ndal. Provo sërish ose ngjit lidhjen e çiftimit.

--- a/crates/vmux_ui/locales/sr.ftl
+++ b/crates/vmux_ui/locales/sr.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Веза са Mac-ом је прекинута
 mobile-error-connection-closed = Ваш Mac је затворио везу.
 mobile-error-address-invalid = Та адреса за упаривање није исправна.
 mobile-error-address-no-port = Та адреса за упаривање нема порт.
+mobile-qr-denied = Vmux не може да користи камеру. Укључите је у Settings да бисте скенирали QR код или се вратите назад и налепите везу за упаривање.
+mobile-qr-open-settings = Отвори Settings
+mobile-qr-session-error = Камера је престала да ради. Покушајте поново или налепите везу за упаривање.

--- a/crates/vmux_ui/locales/st.ftl
+++ b/crates/vmux_ui/locales/st.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Kgokahano le Mac ya hao e kgaohile.
 mobile-error-connection-closed = Mac ya hao e kwetse kgokahano.
 mobile-error-address-invalid = Aterese eo ya ho kopanya ha e nepahala.
 mobile-error-address-no-port = Aterese eo ya ho kopanya ha e na port.
+mobile-qr-denied = Vmux e ke ke ya sebedisa khamera. E bulele ho Settings hore o skene khoutu ya QR, kapa o khutlele morao mme o momahanye sehokelo sa ho kopanya.
+mobile-qr-open-settings = Bula Settings
+mobile-qr-session-error = Khamera e emisitse. Leka hape, kapa o momahanye sehokelo sa ho kopanya.

--- a/crates/vmux_ui/locales/su.ftl
+++ b/crates/vmux_ui/locales/su.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Sambungan ka Mac anjeun pegat.
 mobile-error-connection-closed = Mac anjeun nutup sambungan.
 mobile-error-address-invalid = Alamat pasangan éta teu valid.
 mobile-error-address-no-port = Alamat pasangan éta teu boga port.
+mobile-qr-denied = Vmux teu bisa maké kaméra. Hurungkeun di Settings pikeun mindai kode QR, atawa balik deui terus témpélkeun tautan pasangan.
+mobile-qr-open-settings = Buka Settings
+mobile-qr-session-error = Kaméra eureun. Cobaan deui, atawa témpélkeun tautan pasangan.

--- a/crates/vmux_ui/locales/sv.ftl
+++ b/crates/vmux_ui/locales/sv.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Anslutningen till din Mac bröts.
 mobile-error-connection-closed = Din Mac stängde anslutningen.
 mobile-error-address-invalid = Den parkopplingsadressen är ogiltig.
 mobile-error-address-no-port = Den parkopplingsadressen saknar port.
+mobile-qr-denied = Vmux kan inte använda kameran. Aktivera den i Inställningar för att skanna QR-koden, eller gå tillbaka och klistra in parkopplingslänken i stället.
+mobile-qr-open-settings = Öppna Inställningar
+mobile-qr-session-error = Kameran stoppades. Försök igen eller klistra in parkopplingslänken i stället.

--- a/crates/vmux_ui/locales/sw.ftl
+++ b/crates/vmux_ui/locales/sw.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Muunganisho na Mac yako umekatika.
 mobile-error-connection-closed = Mac yako imefunga muunganisho.
 mobile-error-address-invalid = Anwani hiyo ya kuoanisha si sahihi.
 mobile-error-address-no-port = Anwani hiyo ya kuoanisha haina poti.
+mobile-qr-denied = Vmux haiwezi kutumia kamera. Iwashe katika Settings ili kuchanganua msimbo wa QR, au urudi nyuma na ubandike kiungo cha kuoanisha.
+mobile-qr-open-settings = Fungua Settings
+mobile-qr-session-error = Kamera imesimama. Jaribu tena, au ubandike kiungo cha kuoanisha.

--- a/crates/vmux_ui/locales/ta.ftl
+++ b/crates/vmux_ui/locales/ta.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = உங்கள் Mac உடனான இண�
 mobile-error-connection-closed = உங்கள் Mac இணைப்பை மூடியது.
 mobile-error-address-invalid = அந்த இணைப்பு முகவரி செல்லாது.
 mobile-error-address-no-port = அந்த இணைப்பு முகவரியில் போர்ட் இல்லை.
+mobile-qr-denied = Vmux ஆல் கேமராவைப் பயன்படுத்த முடியவில்லை. QR குறியீட்டை ஸ்கேன் செய்ய அமைப்புகளில் கேமராவை இயக்கவும், அல்லது திரும்பிச் சென்று இணைப்புச் சுட்டியை ஒட்டவும்.
+mobile-qr-open-settings = அமைப்புகளைத் திற
+mobile-qr-session-error = கேமரா நின்றுவிட்டது. மீண்டும் முயலவும், அல்லது இணைப்புச் சுட்டியை ஒட்டவும்.

--- a/crates/vmux_ui/locales/te.ftl
+++ b/crates/vmux_ui/locales/te.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = మీ Mac తో కనెక్షన్ త
 mobile-error-connection-closed = మీ Mac కనెక్షన్‌ను మూసివేసింది.
 mobile-error-address-invalid = ఆ పెయిరింగ్ చిరునామా చెల్లదు.
 mobile-error-address-no-port = ఆ పెయిరింగ్ చిరునామాలో పోర్ట్ లేదు.
+mobile-qr-denied = Vmux కెమెరాను ఉపయోగించలేదు. QR కోడ్‌ను స్కాన్ చేయడానికి సెట్టింగ్‌లలో దాన్ని ఆన్ చేయండి, లేదా వెనక్కి వెళ్లి పెయిరింగ్ లింక్‌ను అతికించండి.
+mobile-qr-open-settings = సెట్టింగ్‌లు తెరవండి
+mobile-qr-session-error = కెమెరా ఆగిపోయింది. మళ్లీ ప్రయత్నించండి, లేదా పెయిరింగ్ లింక్‌ను అతికించండి.

--- a/crates/vmux_ui/locales/tg.ftl
+++ b/crates/vmux_ui/locales/tg.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Пайваст бо Mac-и шумо қатъ �
 mobile-error-connection-closed = Mac-и шумо пайвастро баст.
 mobile-error-address-invalid = Он суроғаи ҷуфтшавӣ нодуруст аст.
 mobile-error-address-no-port = Он суроғаи ҷуфтшавӣ порт надорад.
+mobile-qr-denied = Vmux наметавонад камераро истифода барад. Барои скани QR-код онро дар Settings фаъол кунед ё бозгашта пайванди ҷуфтшавиро гузоред.
+mobile-qr-open-settings = Settings-ро кушоед
+mobile-qr-session-error = Камера қатъ шуд. Аз нав кӯшиш кунед ё пайванди ҷуфтшавиро гузоред.

--- a/crates/vmux_ui/locales/th.ftl
+++ b/crates/vmux_ui/locales/th.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = การเชื่อมต่อกับ 
 mobile-error-connection-closed = Mac ของคุณปิดการเชื่อมต่อ
 mobile-error-address-invalid = ที่อยู่การจับคู่ไม่ถูกต้อง
 mobile-error-address-no-port = ที่อยู่การจับคู่ไม่มีพอร์ต
+mobile-qr-denied = Vmux ใช้กล้องไม่ได้ เปิดสิทธิ์กล้องในการตั้งค่าเพื่อสแกน QR code หรือย้อนกลับแล้ววางลิงก์จับคู่แทน
+mobile-qr-open-settings = เปิดการตั้งค่า
+mobile-qr-session-error = กล้องหยุดทำงาน ลองใหม่อีกครั้ง หรือวางลิงก์จับคู่แทน

--- a/crates/vmux_ui/locales/tk.ftl
+++ b/crates/vmux_ui/locales/tk.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Mac-yňyz bilen birikme üzüldi.
 mobile-error-connection-closed = Mac-yňyz birikmäni ýapdy.
 mobile-error-address-invalid = Jübütleme salgysy nädogry.
 mobile-error-address-no-port = Jübütleme salgysynda port ýok.
+mobile-qr-denied = Vmux kamerany ulanyp bilmeýär. QR kody skanerlemek üçin ony Settings-de açyň ýa-da yzyna gaýdyp jübütleme salgysyny goýuň.
+mobile-qr-open-settings = Settings-i aç
+mobile-qr-session-error = Kamera durdy. Täzeden synanyşyň ýa-da jübütleme salgysyny goýuň.

--- a/crates/vmux_ui/locales/tl.ftl
+++ b/crates/vmux_ui/locales/tl.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Naputol ang koneksyon sa iyong Mac.
 mobile-error-connection-closed = Isinara ng iyong Mac ang koneksyon.
 mobile-error-address-invalid = Hindi wasto ang pairing address.
 mobile-error-address-no-port = Walang port ang pairing address.
+mobile-qr-denied = Hindi magamit ng Vmux ang camera. I-on ito sa Settings para ma-scan ang QR code, o bumalik at i-paste na lang ang pairing link.
+mobile-qr-open-settings = Buksan ang Settings
+mobile-qr-session-error = Huminto ang camera. Subukan ulit, o i-paste na lang ang pairing link.

--- a/crates/vmux_ui/locales/tr.ftl
+++ b/crates/vmux_ui/locales/tr.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Mac’inizle bağlantı koptu.
 mobile-error-connection-closed = Mac’iniz bağlantıyı kapattı.
 mobile-error-address-invalid = Eşleştirme adresi geçersiz.
 mobile-error-address-no-port = Eşleştirme adresinde port yok.
+mobile-qr-denied = Vmux kamerayı kullanamıyor. QR kodu taramak için Ayarlar’dan kamerayı açın ya da geri dönüp eşleştirme bağlantısını yapıştırın.
+mobile-qr-open-settings = Ayarlar’ı aç
+mobile-qr-session-error = Kamera durdu. Yeniden deneyin ya da eşleştirme bağlantısını yapıştırın.

--- a/crates/vmux_ui/locales/tt.ftl
+++ b/crates/vmux_ui/locales/tt.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Mac’ыгыз белән тоташу өзе�
 mobile-error-connection-closed = Mac’ыгыз тоташуны япты.
 mobile-error-address-invalid = Парлау адресы дөрес түгел.
 mobile-error-address-no-port = Парлау адресында порт юк.
+mobile-qr-denied = Vmux камераны куллана алмый. QR-кодны сканерлау өчен аны Settings’та кабызыгыз яки артка кайтып парлау сылтамасын куегыз.
+mobile-qr-open-settings = Settings’ны ачу
+mobile-qr-session-error = Камера туктады. Кабат карап карагыз яки парлау сылтамасын куегыз.

--- a/crates/vmux_ui/locales/ug.ftl
+++ b/crates/vmux_ui/locales/ug.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Mac ئۈسكۈنىڭىز بىلەن ئۇلىن
 mobile-error-connection-closed = Mac ئۈسكۈنىڭىز ئۇلىنىشنى تاقىۋەتتى.
 mobile-error-address-invalid = جۈپلەش ئادرېسى ئىناۋەتسىز.
 mobile-error-address-no-port = جۈپلەش ئادرېسىدا پورت يوق.
+mobile-qr-denied = Vmux كامېرانى ئىشلىتەلمەيدۇ. QR كودىنى سىكانېرلاش ئۈچۈن Settings تىن كامېرانى قوزغىتىڭ ياكى قايتىپ بېرىپ جۈپلەش ئۇلانمىسىنى چاپلاڭ.
+mobile-qr-open-settings = Settings نى ئېچىش
+mobile-qr-session-error = كامېرا توختىدى. قايتا سىناڭ ياكى جۈپلەش ئۇلانمىسىنى چاپلاڭ.

--- a/crates/vmux_ui/locales/uk.ftl
+++ b/crates/vmux_ui/locales/uk.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = З’єднання з вашим Mac розі
 mobile-error-connection-closed = Ваш Mac закрив з’єднання.
 mobile-error-address-invalid = Недійсна адреса для сполучення.
 mobile-error-address-no-port = В адресі для сполучення немає порту.
+mobile-qr-denied = Vmux не може використати камеру. Увімкніть її в Параметрах, щоб відсканувати QR-код, або поверніться назад і вставте посилання для сполучення.
+mobile-qr-open-settings = Відкрити Параметри
+mobile-qr-session-error = Камера зупинилася. Спробуйте ще раз або вставте посилання для сполучення.

--- a/crates/vmux_ui/locales/ur.ftl
+++ b/crates/vmux_ui/locales/ur.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = آپ کے Mac سے کنکشن منقطع ہو 
 mobile-error-connection-closed = آپ کے Mac نے کنکشن بند کر دیا۔
 mobile-error-address-invalid = پیئرنگ کا پتہ غلط ہے۔
 mobile-error-address-no-port = پیئرنگ کے پتے میں پورٹ نہیں ہے۔
+mobile-qr-denied = Vmux کیمرہ استعمال نہیں کر سکتا۔ QR کوڈ اسکین کرنے کے لیے ترتیبات میں اسے آن کریں، یا واپس جا کر پیئرنگ لنک چسپاں کریں۔
+mobile-qr-open-settings = ترتیبات کھولیں
+mobile-qr-session-error = کیمرہ رک گیا۔ دوبارہ کوشش کریں، یا پیئرنگ لنک چسپاں کریں۔

--- a/crates/vmux_ui/locales/uz.ftl
+++ b/crates/vmux_ui/locales/uz.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Mac kompyuteringiz bilan ulanish uzildi.
 mobile-error-connection-closed = Mac kompyuteringiz ulanishni yopdi.
 mobile-error-address-invalid = Juftlash manzili yaroqsiz.
 mobile-error-address-no-port = Juftlash manzilida port yo‘q.
+mobile-qr-denied = Vmux kameradan foydalana olmaydi. QR kodni skanerlash uchun uni Settings da yoqing yoki orqaga qaytib juftlash havolasini joylashtiring.
+mobile-qr-open-settings = Settings ni ochish
+mobile-qr-session-error = Kamera to‘xtadi. Qayta urinib ko‘ring yoki juftlash havolasini joylashtiring.

--- a/crates/vmux_ui/locales/vi.ftl
+++ b/crates/vmux_ui/locales/vi.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Kết nối tới máy Mac của bạn đã b�
 mobile-error-connection-closed = Máy Mac của bạn đã đóng kết nối.
 mobile-error-address-invalid = Địa chỉ ghép nối không hợp lệ.
 mobile-error-address-no-port = Địa chỉ ghép nối không có cổng.
+mobile-qr-denied = Vmux không thể dùng máy ảnh. Hãy bật trong Cài đặt để quét mã QR, hoặc quay lại và dán liên kết ghép nối.
+mobile-qr-open-settings = Mở Cài đặt
+mobile-qr-session-error = Máy ảnh đã dừng. Hãy thử lại, hoặc dán liên kết ghép nối.

--- a/crates/vmux_ui/locales/xh.ftl
+++ b/crates/vmux_ui/locales/xh.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Uqhagamshelo kwi-Mac yakho luqhawukile.
 mobile-error-connection-closed = I-Mac yakho ivale uqhagamshelo.
 mobile-error-address-invalid = Idilesi yokudibanisa ayisebenzi.
 mobile-error-address-no-port = Idilesi yokudibanisa ayinaphothi.
+mobile-qr-denied = I-Vmux ayikwazi ukusebenzisa ikhamera. Yivule kwi-Settings ukuze uskene ikhowudi ye-QR, okanye ubuyele umva uze ucole ikhonkco lokudibanisa.
+mobile-qr-open-settings = Vula i-Settings
+mobile-qr-session-error = Ikhamera imisile. Zama kwakhona, okanye ucole ikhonkco lokudibanisa.

--- a/crates/vmux_ui/locales/yi.ftl
+++ b/crates/vmux_ui/locales/yi.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = די פֿאַרבינדונג מיט אײַע�
 mobile-error-connection-closed = אײַער Mac האָט פֿאַרמאַכט די פֿאַרבינדונג.
 mobile-error-address-invalid = דער פּערינג־אַדרעס איז אומגילטיק.
 mobile-error-address-no-port = דער פּערינג־אַדרעס האָט נישט קיין פּאָרט.
+mobile-qr-denied = Vmux קען נישט נוצן די קאַמערע. שאַלט זי אָן אין Settings כּדי צו סקאַנירן דעם QR־קאָד, אָדער גייט צוריק און לייגט אַרײַן דעם פּערינג־לינק.
+mobile-qr-open-settings = עפֿנט Settings
+mobile-qr-session-error = די קאַמערע האָט זיך אָפּגעשטעלט. פּרוּווט נאָך אַ מאָל, אָדער לייגט אַרײַן דעם פּערינג־לינק.

--- a/crates/vmux_ui/locales/yo.ftl
+++ b/crates/vmux_ui/locales/yo.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Ìsopọ̀ sí Mac rẹ ti já.
 mobile-error-connection-closed = Mac rẹ ti pa ìsopọ̀ náà.
 mobile-error-address-invalid = Àdírẹ́sì ìsopọ̀ yẹn kò tọ́.
 mobile-error-address-no-port = Àdírẹ́sì ìsopọ̀ yẹn kò ní port.
+mobile-qr-denied = Vmux kò lè lo kámẹ́rà. Tan án ní Settings láti ṣàyẹ̀wò kóòdù QR, tàbí padà sẹ́yìn kí o sì lẹ̀ ọ̀nà ìsopọ̀ mọ́.
+mobile-qr-open-settings = Ṣí Settings
+mobile-qr-session-error = Kámẹ́rà dúró. Gbìyànjú lẹ́ẹ̀kansi, tàbí lẹ̀ ọ̀nà ìsopọ̀ mọ́.

--- a/crates/vmux_ui/locales/zh-Hans.ftl
+++ b/crates/vmux_ui/locales/zh-Hans.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = 与你的 Mac 的连接已断开。
 mobile-error-connection-closed = 你的 Mac 关闭了连接。
 mobile-error-address-invalid = 此配对地址无效。
 mobile-error-address-no-port = 此配对地址中没有端口。
+mobile-qr-denied = Vmux 无法使用摄像头。请在设置中开启摄像头权限以扫描 QR 码，或者返回上一步粘贴配对链接。
+mobile-qr-open-settings = 打开设置
+mobile-qr-session-error = 摄像头已停止。请重试，或者改为粘贴配对链接。

--- a/crates/vmux_ui/locales/zh-Hant.ftl
+++ b/crates/vmux_ui/locales/zh-Hant.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = 與你的 Mac 的連線已中斷。
 mobile-error-connection-closed = 你的 Mac 關閉了連線。
 mobile-error-address-invalid = 這個配對位址無效。
 mobile-error-address-no-port = 這個配對位址沒有連接埠。
+mobile-qr-denied = Vmux 無法使用相機。請在設定中開啟相機權限以掃描 QR 碼，或返回上一步貼上配對連結。
+mobile-qr-open-settings = 開啟設定
+mobile-qr-session-error = 相機已停止。請重試，或改為貼上配對連結。

--- a/crates/vmux_ui/locales/zh-TW.ftl
+++ b/crates/vmux_ui/locales/zh-TW.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = 和你的 Mac 的連線中斷了。
 mobile-error-connection-closed = 你的 Mac 主動關閉了連線。
 mobile-error-address-invalid = 這組配對位址無效。
 mobile-error-address-no-port = 這組配對位址缺少連接埠。
+mobile-qr-denied = Vmux 沒有相機權限。請到設定開啟相機才能掃描 QR 碼，或是返回上一頁貼上配對連結。
+mobile-qr-open-settings = 前往設定
+mobile-qr-session-error = 相機中斷了。請再試一次，或改用配對連結。

--- a/crates/vmux_ui/locales/zh.ftl
+++ b/crates/vmux_ui/locales/zh.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = 与你的 Mac 的连接断开了。
 mobile-error-connection-closed = 你的 Mac 主动关闭了连接。
 mobile-error-address-invalid = 该配对地址无效。
 mobile-error-address-no-port = 该配对地址缺少端口号。
+mobile-qr-denied = Vmux 没有摄像头权限。请到设置里开启摄像头才能扫描 QR 码，或者返回上一步改用配对链接。
+mobile-qr-open-settings = 前往设置
+mobile-qr-session-error = 摄像头中断了。请重试，或者改用配对链接。

--- a/crates/vmux_ui/locales/zu.ftl
+++ b/crates/vmux_ui/locales/zu.ftl
@@ -798,3 +798,6 @@ mobile-error-connection-dropped = Uxhumano ne-Mac yakho lunqamukile.
 mobile-error-connection-closed = I-Mac yakho ivale uxhumano.
 mobile-error-address-invalid = Lelo kheli lokubhangqa alivumelekile.
 mobile-error-address-no-port = Lelo kheli lokubhangqa alinayo iphothi.
+mobile-qr-denied = I-Vmux ayikwazi ukusebenzisa ikhamera. Yivule ku-Settings ukuze uskene ikhodi ye-QR, noma ubuyele emuva bese unamathisela isixhumanisi sokubhangqa.
+mobile-qr-open-settings = Vula i-Settings
+mobile-qr-session-error = Ikhamera imile. Zama futhi, noma unamathisele isixhumanisi sokubhangqa.

--- a/packaging/ios/Info.plist
+++ b/packaging/ios/Info.plist
@@ -5,7 +5,7 @@
 	rendering assets/ios/ios.plist.hbs. `[ios.plist]` cannot be used for the keys below, because
 	the template writes them first and a duplicate key loses on parse.
 
-	Keep in sync with crates/vmux_mobile/Dioxus.toml. CFBundleExecutable is the [[bin]] name.
+	Keep in sync with crates/app/vmux_mobile/Dioxus.toml. CFBundleExecutable is the [[bin]] name.
 
 	The two version keys below are placeholders: scripts/inject-ios-resources.sh stamps the built
 	copy from the workspace version and the CI run number. Editing them here has no effect.

--- a/scripts/inject-ios-resources.sh
+++ b/scripts/inject-ios-resources.sh
@@ -113,8 +113,12 @@ set_plist() {
 
 SDK_VERSION="$(xcrun --sdk iphoneos --show-sdk-version)"
 SDK_BUILD="$(xcrun --sdk iphoneos --show-sdk-build-version)"
-XCODE_VERSION="$(xcodebuild -version | head -1 | awk '{print $2}')"
-XCODE_BUILD="$(xcodebuild -version | tail -1 | awk '{print $3}')"
+# Read once, and without `head`: it closes the pipe after the first line, xcodebuild takes
+# SIGPIPE for the second, and `set -o pipefail` surfaces that as exit 141. It only loses the
+# race when xcodebuild is still writing, so it fails intermittently under load.
+XCODE_INFO="$(xcodebuild -version)"
+XCODE_VERSION="$(awk 'NR == 1 { print $2 }' <<<"$XCODE_INFO")"
+XCODE_BUILD="$(awk 'END { print $3 }' <<<"$XCODE_INFO")"
 XCODE_PADDED="$(printf '%d%d0' "${XCODE_VERSION%%.*}" "$(echo "$XCODE_VERSION" | cut -d. -f2)")"
 
 set_plist CFBundleIconName AppIcon


### PR DESCRIPTION
## Context

The QR scanner never asks iOS for camera access and never checks whether it has it ([VMX-132](https://linear.app/vmux/issue/VMX-132)). Denial does not fail loudly — `deviceInputWithDevice_error` still succeeds, `startRunning` still returns without error — so the user gets a **black full-screen modal** with a title and a Cancel button and no explanation. App Store reviewers deny permissions as a matter of course, so this is a likely rejection as well as a bad experience.

Fifth of six on `feat/mobile-remote`. Stacked on #350 → #349 → #348 → #347 — **review those first**; this diff is against #350.

## Implementation

`open()` now reads `authorizationStatusForMediaType` before building anything, calls `requestAccessForMediaType_completionHandler` on first use, and hops back to `DispatchQueue::main()` — the completion runs on an arbitrary queue and everything after it is UIKit.

**The denied screen is the same controller.** `ScannerIvars.capture` became an `Option`; when it is `None` there is no session, no preview layer, and the settings button is shown instead. That keeps the modal, title and cancel button in one place rather than growing a second near-identical view controller for a screen that differs only by its capture half. `close()` skips the session teardown when there is nothing to tear down.

The refusal screen gives the reviewer all three things they need: what happened, a button into `UIApplicationOpenSettingsURLString`, and a pointer back to the manual pairing link — which already works without a camera, so the app is never a dead end.

**`AVCaptureSessionRuntimeError` is now observed.** A session can die after it starts, most commonly when another app takes the camera. Until now the preview just froze and said nothing. The handler routes through the existing `close(Some(Err(..)))`, so dismissal and error plumbing are reused rather than duplicated.

**The re-entry guard needed a second flag.** `ACTIVE` is only set once a controller exists, but `requestAccess` returns immediately and answers later — between the tap and the answer nothing is presented, so a double tap raised two system prompts. `REQUESTING` covers exactly that window.

Feature gates added: `block2` on `objc2-av-foundation` (the completion handler is a block), `UIApplication` on `objc2-ui-kit` (for `openSettingsURLString`), and `NSURL`/`NSDictionary`/`NSNotification` on `objc2-foundation`. `block2` also had to become a direct dependency — enabling the feature does not put the crate in scope.

Three new strings, translated into all 115 catalogs.

## Checks / QA

- `cargo clippy -p vmux_mobile --features mobile --target aarch64-apple-ios --all-targets` — clean.
- `cargo test -p vmux_ui --lib i18n` — 7 passed; all 115 catalogs at 63 `mobile-` IDs.
- `make mobile-ios` — builds, injects, bundle layout test passes.
- `cargo fmt --check` — clean.

**Not verified on a device.** The whole point of this change is behaviour under a denied permission, and I cannot grant or deny a camera on real hardware. Reviewer steps:

1. Simulator or device → Settings → Vmux → Camera **off**.
2. Open the app unpaired, tap **Scan QR code**. Expect the explanation, not a black screen.
3. Tap **Open Settings** — should land in the Vmux settings pane.
4. Re-enable Camera, return, tap Scan again — should now show the live preview.
5. Delete and reinstall to get back to *not determined*, tap Scan, and confirm the system prompt appears once even if you tap twice quickly.
6. While scanning, open the Camera app to steal the device and confirm the scanner closes with a message rather than freezing.

## Not closed here

- "Manually verified on a physical device with camera access denied, then re-granted" — needs hardware.
