### PR TITLE
feat(mobile): fold the phone transcript with the shared grouping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11556,6 +11556,7 @@ dependencies = [
  "url",
  "vmux_chat",
  "vmux_remote",
+ "vmux_service",
  "vmux_start",
  "vmux_team",
  "vmux_ui",

--- a/crates/app/vmux_mobile/Cargo.toml
+++ b/crates/app/vmux_mobile/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { workspace = true, features = ["time"] }
 url = { workspace = true }
 quinn = { workspace = true }
 vmux_remote = { path = "../../host/vmux_remote" }
+vmux_service = { path = "../../host/vmux_service" }
 vmux_wire = { path = "../../vmux_wire" }
 vmux_chat = { path = "../../page/vmux_chat" }
 vmux_start = { path = "../../page/vmux_start" }

--- a/crates/app/vmux_mobile/src/main.rs
+++ b/crates/app/vmux_mobile/src/main.rs
@@ -21,6 +21,7 @@ use vmux_chat::page::approval::ApprovalPanel;
 use vmux_chat::page::composer::ComposerStatus;
 use vmux_chat::page::composer::options::{EffortMenu, ModelMenu, ModelPill};
 use vmux_chat::transcript::{AssistantTurn, ChatItemRow, MD_CSS, WorkingIndicator};
+use vmux_service::chat::group_turns_tail;
 use vmux_start::results::CommandBarResultItem;
 use vmux_start::row::ResultRow;
 use vmux_ui::components::prompt_box::{PromptPopup, PromptPopupPlacement};
@@ -33,10 +34,8 @@ use vmux_ui::favicon::Favicon;
 use vmux_ui::hooks::{MenuDirection, move_selection};
 use vmux_ui::i18n::translate;
 use vmux_wire::PageIcon;
-use vmux_wire::chat::{
-    ChatBlock, ChatItem, ChatPlanStep, ChatSubagent, ChatTurn, latest_tool_location,
-};
-use vmux_wire::prompt_media::{ChatAttachment, ChatSubmitAttachment};
+use vmux_wire::chat::{ChatItem, latest_tool_location};
+use vmux_wire::prompt_media::ChatAttachment;
 use vmux_wire::protocol::{AgentAction, SharedAgentCommand, SharedMessage, SharedResponse};
 use vmux_wire::room::{
     AgentAttachment, ApprovalRequest, AssistantBlock, ClientOpId, Message, ModelOptionEntry,
@@ -143,6 +142,26 @@ struct MobileRoomProjection {
     room_id: Option<RoomId>,
     through_seq: u64,
     events: Vec<RoomEvent>,
+}
+
+impl MobileRoomProjection {
+    /// Fold the replayed log into rendered chat items, with any streaming delta as the tail of
+    /// the live turn.
+    ///
+    /// The phone has no imported history and no per-turn durations, so it always asks for the
+    /// whole transcript and lets every turn resolve its duration to `None`.
+    fn chat_items(&self, live_delta: &str, running: bool) -> Vec<ChatItem> {
+        let mut messages = Vec::with_capacity(self.events.len() + 1);
+        for event in &self.events {
+            messages.push(event.message.clone());
+        }
+        if !live_delta.is_empty() {
+            messages.push(Message::Assistant {
+                blocks: vec![AssistantBlock::Text(live_delta.to_string())],
+            });
+        }
+        group_turns_tail(&[], &messages, &[], running, usize::MAX).items
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -1145,7 +1164,7 @@ fn AppBody() -> Element {
     let approval_value = approval();
     let live_delta_value = live_delta();
     let room_value = room();
-    let transcript_items = group_messages(room_value.events, &live_delta_value, is_streaming);
+    let transcript_items = room_value.chat_items(&live_delta_value, is_streaming);
     let latest_tool = latest_tool_location(&transcript_items);
     let activity = vmux_wire::chat::activity_counts(&transcript_items);
     let attachment_previews = use_signal(HashMap::<String, ChatAttachment>::new);
@@ -1740,126 +1759,6 @@ fn PairCard(props: PairCardProps) -> Element {
 
 /// Fold the room's event log into the shared transcript model. The desktop gets this from
 /// `group_turns` on the daemon side; the relay does not pre-group yet, so mobile folds locally.
-fn group_messages(events: Vec<RoomEvent>, live_delta: &str, running: bool) -> Vec<ChatItem> {
-    let mut items: Vec<ChatItem> = Vec::new();
-    let mut turn: Vec<ChatBlock> = Vec::new();
-    for event in events {
-        match event.message {
-            Message::User { text, attachments } => {
-                if !turn.is_empty() {
-                    items.push(ChatItem::Turn(chat_turn(std::mem::take(&mut turn), false)));
-                }
-                items.push(ChatItem::User {
-                    text,
-                    context: None,
-                    attachments: attachments
-                        .into_iter()
-                        .map(|attachment| ChatSubmitAttachment {
-                            path: attachment.path,
-                            name: attachment.name,
-                            mime_type: attachment.mime_type,
-                            size: attachment.size,
-                        })
-                        .collect(),
-                });
-            }
-            Message::Assistant { blocks } => turn.extend(blocks.into_iter().map(chat_block)),
-            Message::ToolResult {
-                call_id,
-                content,
-                is_error,
-            } => turn.push(ChatBlock::ToolResult {
-                call_id,
-                content,
-                is_error,
-            }),
-        }
-    }
-    if !live_delta.is_empty() {
-        turn.push(ChatBlock::Text(live_delta.to_string()));
-    }
-    if !turn.is_empty() {
-        items.push(ChatItem::Turn(chat_turn(turn, running)));
-    }
-    items
-}
-
-fn chat_turn(blocks: Vec<ChatBlock>, running: bool) -> ChatTurn {
-    let step_count = blocks
-        .iter()
-        .enumerate()
-        .filter(|(index, block)| {
-            !matches!(block, ChatBlock::Text(_))
-                && ChatTurn {
-                    blocks: blocks.clone(),
-                    ..ChatTurn::default()
-                }
-                .parent_tool_index(*index)
-                .is_none()
-        })
-        .count() as u32;
-    ChatTurn {
-        blocks,
-        running,
-        duration_secs: None,
-        step_count,
-    }
-}
-
-fn chat_block(block: AssistantBlock) -> ChatBlock {
-    match block {
-        AssistantBlock::Text(text) => ChatBlock::Text(text),
-        AssistantBlock::Thinking(text) => ChatBlock::Thinking(text),
-        AssistantBlock::ToolUse {
-            call_id,
-            name,
-            args,
-            parent_call_id,
-        } => ChatBlock::ToolUse {
-            call_id,
-            name,
-            args,
-            parent_call_id,
-        },
-        AssistantBlock::Subagent(subagent) => ChatBlock::Subagent(Box::new(ChatSubagent {
-            call_id: subagent.call_id,
-            provider: subagent.provider,
-            title: subagent.title,
-            status: subagent.status,
-            action: subagent.action,
-            agent_name: subagent.agent_name,
-            thread_id: subagent.thread_id,
-            parent_thread_id: subagent.parent_thread_id,
-            child_thread_ids: subagent.child_thread_ids,
-            parent_call_id: subagent.parent_call_id,
-            prompt: subagent.prompt,
-            model: subagent.model,
-            reasoning_effort: subagent.reasoning_effort,
-            raw_input: subagent.raw_input,
-        })),
-        AssistantBlock::Diff {
-            call_id,
-            path,
-            old_text,
-            new_text,
-        } => ChatBlock::Diff {
-            call_id,
-            path,
-            old_text,
-            new_text,
-        },
-        AssistantBlock::Plan { steps } => ChatBlock::Plan {
-            steps: steps
-                .into_iter()
-                .map(|step| ChatPlanStep {
-                    content: step.content,
-                    status: step.status,
-                })
-                .collect(),
-        },
-    }
-}
-
 #[allow(clippy::too_many_arguments)]
 fn open_session(
     api: Api,
@@ -2147,6 +2046,7 @@ fn session_result_item(session: &RemoteSession) -> CommandBarResultItem {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use vmux_wire::chat::ChatBlock;
 
     /// The fingerprint is the whole basis for trusting the desktop's certificate. If it were
     /// dropped while parsing, the phone would silently fall back to an unpinned connection —
@@ -2226,30 +2126,36 @@ mod tests {
         );
     }
 
-    fn sample_events() -> Vec<RoomEvent> {
-        vmux_wire::room::RoomEvent::from_messages(
-            "s",
-            0,
-            &[
-                Message::user("hello"),
-                Message::Assistant {
-                    blocks: vec![AssistantBlock::Thinking("working".to_string())],
-                },
-                Message::ToolResult {
-                    call_id: "tool-1".to_string(),
-                    content: "done".to_string(),
-                    is_error: false,
-                },
-                Message::Assistant {
-                    blocks: vec![AssistantBlock::Text("answer".to_string())],
-                },
-            ],
-        )
+    impl MobileRoomProjection {
+        fn sample() -> Self {
+            Self {
+                room_id: None,
+                through_seq: 0,
+                events: RoomEvent::from_messages(
+                    "s",
+                    0,
+                    &[
+                        Message::user("hello"),
+                        Message::Assistant {
+                            blocks: vec![AssistantBlock::Thinking("working".to_string())],
+                        },
+                        Message::ToolResult {
+                            call_id: "tool-1".to_string(),
+                            content: "done".to_string(),
+                            is_error: false,
+                        },
+                        Message::Assistant {
+                            blocks: vec![AssistantBlock::Text("answer".to_string())],
+                        },
+                    ],
+                ),
+            }
+        }
     }
 
     #[test]
     fn groups_agent_activity_into_one_turn() {
-        let items = group_messages(sample_events(), "", false);
+        let items = MobileRoomProjection::sample().chat_items("", false);
 
         assert_eq!(items.len(), 2);
         assert!(matches!(items[0], ChatItem::User { .. }));
@@ -2261,7 +2167,7 @@ mod tests {
 
     #[test]
     fn streaming_delta_extends_the_live_turn() {
-        let items = group_messages(sample_events(), "partial", true);
+        let items = MobileRoomProjection::sample().chat_items("partial", true);
 
         let ChatItem::Turn(turn) = &items[1] else {
             panic!("expected a turn");

--- a/docs/specs/2026-08-13-mobile-ecs-host-design.md
+++ b/docs/specs/2026-08-13-mobile-ecs-host-design.md
@@ -132,17 +132,29 @@ Each stage ships on its own.
 
 1. **Delete the duplicate projection.** Depend on `vmux_service` from `vmux_mobile`, call `group_turns_tail`, delete `main.rs:1743-1861`. No ECS. Landed with this spec.
 2. **Give the phone a `World`.** `MinimalPlugins`, the wake-driven pump, nothing in it. Answer the `Reflect`-on-iOS question first. Record idle CPU and battery — the baseline every later stage is judged against.
-3. **Move the QUIC client in.** `Api` becomes a resource, the subscribe loop at `main.rs:1888` becomes a system draining into components, and `AppBody`'s session signals become reads.
+3. **Move the QUIC client in.** `Api` becomes a resource, the subscribe loop at `main.rs:1888` becomes a system draining into components, and `AppBody`'s session signals become reads. This stage owns the connection and the projection across a suspend, so it carries the resume criteria below and cannot land without them.
 4. **Make `PageHost` real.** `send` queues, `listen` registers, `PostUpdate` pushes. `TEAM_EVENT` stops polling and `POLL_INTERVAL_MS` goes.
 5. **Camera as a capability.** Port the QR scanner onto `CameraPlugin`, preserving VMX-132's denied-permission behaviour.
 6. **Retire the rest of `AppBody`.** Composer, media, pairing.
 
 Stages 1 and 2 are independent of each other. Stage 3 is where behaviour can actually regress, and is the one to land alone.
 
-## Open
+### Suspend and resume, which stage 3 must preserve
 
-- **Backgrounding.** iOS suspends the process; the QUIC connection dies and the World stops being pumped. Today `RESUMED` (`main.rs:104`) triggers a re-read. What the World does across suspend — reconnect, refetch, or restore — is undecided.
-- **Persistence.** The desktop persists ECS state through `moonshine-save`. Whether the phone persists a transcript or refetches it is open, and depends on the above.
+The phone already answers this, and moving the connection into the World must not quietly drop the answer. Both rules are current behaviour, not new design.
+
+**The connection is suspect after a resume, not dead.** iOS tears down the UDP socket while the process is suspended without closing the QUIC connection, so a connection that still looks alive usually is not (`main.rs:60-65`). `RESUMED` records the resume and the next call redials, which is cheaper than discovering it through a stalled request. In the World this becomes a wake source that marks the `Api` resource stale; the redial stays lazy.
+
+**The Mac is the authoritative transcript, always.** Nothing is persisted on the phone today, and stage 3 does not change that. The World's session components are a cache of a projection whose record lives on the host, so the recovery path after a suspend is to reattach and re-project — never to trust what the World was holding when it was frozen.
+
+Acceptance criteria for the stage:
+
+- [ ] Background for longer than the QUIC idle timeout, foreground, and send a prompt — it arrives, with no stalled request and no manual retry
+- [ ] Background mid-stream and foreground — the transcript reconciles to what the Mac has, with no duplicated or truncated turn
+- [ ] The World stops being pumped while suspended and resumes without a burst of catch-up updates
+- [ ] Reattach failure is visible in the UI rather than presenting stale state as live
+
+**Persistence stays open**, and is deliberately not a stage 3 concern. The desktop persists ECS state through `moonshine-save`; whether the phone ever caches a transcript for offline reading is a stage 6+ question, and the answer above — host authoritative, phone refetches — is what makes it safe to defer.
 
 ## Dependencies
 

--- a/docs/specs/2026-08-13-mobile-ecs-host-design.md
+++ b/docs/specs/2026-08-13-mobile-ecs-host-design.md
@@ -120,6 +120,14 @@ So adding a capability is adding a plugin, not editing a central `match`, and `U
 
 A device capability owns its slice whole, per the by-feature split rule: `CameraPlugin` holds permission state, the `AVCaptureSession` and the scan result together. Because the World is on the main thread, its systems call UIKit directly — the `dispatch2` hop `qr_scanner.rs` needs today goes away along with `RESULTS`, `ACTIVE` and `REQUESTING`.
 
+### A registration outlives the scope that made it
+
+Today `listen` spawns a Dioxus task bound to the subscribing component, so the subscription dies with the page and nothing accumulates. A registration held in the World has no such owner, which raises two separate questions with two different answers.
+
+**Delivery into a dead scope is already prevented, and not by anything mobile.** `use_listener` wraps the callback in a `GuardedListener` and deactivates it from `use_drop` (`hooks/use_listener.rs:21-23`); `GuardedListener::call` returns `false` once deactivated (`listener_guard.rs:62`). The desktop relies on this too. Nothing here needs to be invented.
+
+**Reclamation does have to be added.** A registration the World keeps forever is a leak even when it is inert, so `PostUpdate` drops any whose `call` returned `false`. That returned bool is the prune signal and there is no need for a subscription token on top of it — which is fortunate, because `PageHost::listen` returns `Result<(), EventListenerError>` and cannot hand one back without changing the CEF side too.
+
 ## What does not move
 
 Sessions execute on the Mac or a cloud host. The phone's World owns device state and a projection; it never owns a PTY, an ACP process or a provider stream.
@@ -133,11 +141,19 @@ Each stage ships on its own.
 1. **Delete the duplicate projection.** Depend on `vmux_service` from `vmux_mobile`, call `group_turns_tail`, delete `main.rs:1743-1861`. No ECS. Landed with this spec.
 2. **Give the phone a `World`.** `MinimalPlugins`, the wake-driven pump, nothing in it. Answer the `Reflect`-on-iOS question first. Record idle CPU and battery — the baseline every later stage is judged against.
 3. **Move the QUIC client in.** `Api` becomes a resource, the subscribe loop at `main.rs:1888` becomes a system draining into components, and `AppBody`'s session signals become reads. This stage owns the connection and the projection across a suspend, so it carries the resume criteria below and cannot land without them.
-4. **Make `PageHost` real.** `send` queues, `listen` registers, `PostUpdate` pushes. `TEAM_EVENT` stops polling and `POLL_INTERVAL_MS` goes.
+4. **Make `PageHost` real.** `send` queues, `listen` registers, `PostUpdate` pushes and prunes. Moving the roster poll into a system is this stage; deleting it is not — see below.
 5. **Camera as a capability.** Port the QR scanner onto `CameraPlugin`, preserving VMX-132's denied-permission behaviour.
 6. **Retire the rest of `AppBody`.** Composer, media, pairing.
 
 Stages 1 and 2 are independent of each other. Stage 3 is where behaviour can actually regress, and is the one to land alone.
+
+### `TEAM_EVENT` cannot stop polling in stage 4
+
+The roster is the one event id the phone serves today, and it serves it by re-reading `api.team()` every three seconds and diffing the snapshot (`page_host.rs:44-71`). Deleting `POLL_INTERVAL_MS` needs something to push instead, and there is nothing: `StreamKind` is `Control` and `SessionEvents` only (`vmux_remote/src/quic.rs:67-72`), so every push route in the protocol is scoped to one session.
+
+VMX-140 moved the roster into the service, so the state to push exists. What is missing is a stream to push it down — a `StreamKind::WorkspaceEvents`, opened client-side like `subscribe(sid)` because the relay only routes streams the client opened, carrying the roster and anything else that is not per-session.
+
+Until that lands, stage 4 moves the poll into a system and stops there. That is still worth doing — one owner instead of one task per subscriber, and change detection in one place — but a stage that deletes the poll without replacing it makes `listen(TEAM_EVENT, …)` go quiet, which is the failure this note exists to prevent.
 
 ### Suspend and resume, which stage 3 must preserve
 

--- a/docs/specs/2026-08-13-mobile-ecs-host-design.md
+++ b/docs/specs/2026-08-13-mobile-ecs-host-design.md
@@ -19,7 +19,7 @@ More than the issue assumed.
 - **The page/host seam is two methods.** `PageHost` (`vmux_ui/src/transport.rs:27`) is `send(id, bytes)` and `listen(id, on_bytes)`. `transport/cef.rs` answers it for the desktop, `vmux_mobile/src/page_host.rs:30` for the phone. A page does not know which it has.
 - **Pages already compile for iOS.** `ui` means wasm *or* iOS (`crates/build_platform_cfg.rs:31`), so `vmux_chat::page` and its leaves are already built on the phone.
 - **The push channel exists.** `quic_api.rs:238` opens the stream client-side and writes once, because the relay only routes streams the client opened. The constraint is real and the workaround is built.
-- **The session model is render-free and phone-linkable.** VMX-140 landed `vmux_session`, whose whole dependency list is `bevy_app`, `bevy_ecs`, `bevy_reflect`, `serde`, `vmux_wire`. `room.rs` is 485 lines of it.
+- **The session model is render-free.** VMX-140 landed `vmux_session`, whose whole dependency list is `bevy_app`, `bevy_ecs`, `bevy_reflect`, `serde`, `vmux_wire`. It is not, however, phone-linkable — see the seam section below.
 
 ## The duplicate projection is a missing dependency, not a missing ECS
 
@@ -29,7 +29,16 @@ This issue claimed 1078 lines the phone "cannot call because it has no ECS". Tha
 
 The phone re-implements them at `main.rs:1743`, `:1787` and `:1809` because `vmux_mobile` does not list `vmux_service` as a dependency. Nothing else stops it.
 
-So deleting the duplicate is a manifest line and a call-site change. **It should land first and alone, and it does not need any of the rest of this design.**
+So deleting the duplicate is a manifest line and a call-site change, and **it does not need any of the rest of this design.** It lands with this spec.
+
+It is not free of behaviour change, though, because the shared fold does more than the phone's copy did. Four differences, all of them the desktop's existing behaviour:
+
+- Private context is split out of a user prompt into `ChatItem::User.context` (`chat.rs:121`). The phone rendered the composed prompt raw and always set `context: None`.
+- A user message with no text and no attachments is skipped rather than rendered empty.
+- A turn that has started but produced nothing yet renders, instead of being suppressed until its first block.
+- Prose is trimmed, and `reconnect_progress` lines fold into a reconnect block instead of showing as text.
+
+Each is a fix in the phone's favour, but together they are a visible change to the chat surface and need eyeballing on device.
 
 That removes the strongest-sounding argument for the World, so the honest justification is what remains:
 
@@ -39,13 +48,15 @@ That removes the strongest-sounding argument for the World, so the honest justif
 
 The World is for those. The projection is a dependency line.
 
-### Where the grouping should live
+### The grouping stays where it is
 
-`vmux_session`, not `vmux_service`. It is pure, three surfaces consume it, and `host/` means "runtime that runs with no UI and owns state" — a fold over a slice is not that. Move it beside `room.rs` and re-export from `vmux_service::chat` so no caller changes, exactly as stage 1 of the sibling spec moved the components.
+Moving it to `vmux_session`, beside `room.rs`, was tried first and is wrong — `vmux_session` does not compile for iOS at all, for the reason in the seam section below.
+
+`vmux_service::chat` is already the correct home, and `app/vmux_mobile` depending on `host/vmux_service` is the established shape: `page/vmux_agent` already does exactly that, because the crate cfg-splits and a non-host target links only the non-host half. `cargo tree --target aarch64-apple-ios -p vmux_mobile -i bevy_cef` finds nothing after the dependency is added, and neither does the same query for `bevy_ecs`.
 
 ## Ownership after
 
-- `vmux_session` — session and room components, plus transcript grouping. No `App`, no CEF, no target gate.
+- `vmux_service` — the transcript grouping, in the half that survives the iOS cfg gate. Unchanged by this design.
 - `app/vmux_mobile` — the `World`, the device capability plugins, the QUIC forwarder, and `MobileHost`.
 
 **No new crate.** One consumer, and the seam that would justify one is already enforced by the target (below). A `vmux_mobile_host` crate earns its place when a second thing links it.
@@ -54,13 +65,19 @@ The World is for those. The projection is a dependency line.
 
 The sibling spec needed a crate boundary because cloud Linux and desktop Linux are the same triple, so no cfg could separate them. Here the discriminator is `aarch64-apple-ios`, and `build_platform_cfg.rs` already resolves it to `ui`.
 
-The risk is therefore inverted, and worth stating because it reads backwards. `vmux_agent` and `vmux_service` both gate their Bevy halves with `cfg(not(any(target_arch = "wasm32", target_os = "ios")))`. That is correct — it is what keeps CEF off the phone — but it also means **those crates compile without Bevy on iOS**. The phone cannot reuse their plugins. It links `vmux_session` and writes its own.
+The risk is therefore inverted, and worth stating because it reads backwards. `vmux_agent` and `vmux_service` both gate their Bevy halves with `cfg(not(any(target_arch = "wasm32", target_os = "ios")))`. That is correct — it is what keeps CEF off the phone — but it also means **those crates compile without Bevy on iOS**. The phone cannot reuse their plugins; it writes its own.
+
+**`vmux_session` goes further: it does not compile for iOS at all.** `vmux_wire` declares `bevy_ecs` and `bevy_reflect` for host targets only, and `vmux_wire/build.rs:26` emits `bevy_linked` only when the feature is on *and* the target is neither wasm nor iOS — so on the phone the wire types carry no `Reflect` derive. `vmux_session` derives `Reflect` unconditionally on structs holding those types, and eleven trait bounds fail. Confirmed with `cargo check -p vmux_session --target aarch64-apple-ios`.
+
+This is the single most important constraint on the client ECS, and it is not a bug to fix in passing. Anything the phone's World stores must either avoid `Reflect` or the wire types must gain derives on iOS — which means linking `bevy_reflect` there, the very thing the gate exists to prevent. **Stage 2 has to answer this before any component is written.**
 
 CI asserts the direction that can still break:
 
 ```text
 cargo tree --target aarch64-apple-ios -p vmux_mobile -i bevy_cef   # must find nothing
 ```
+
+Nothing in CI builds `vmux_mobile` at all today — only `make ios` does, locally. That is how a 226-line duplicate of a shared function survived unnoticed, and it is worth closing independently of this design.
 
 ## Topology: one host, two legs
 
@@ -113,8 +130,8 @@ Native navigation — the `UINavigationController` stack, the back gesture, per-
 
 Each stage ships on its own.
 
-1. **Delete the duplicate projection.** Move the grouping to `vmux_session`, re-export from `vmux_service::chat`, depend on it from `vmux_mobile`, delete `main.rs:1743-1861`. No ECS, no behaviour change. Worth landing whether or not the rest happens.
-2. **Give the phone a `World`.** `MinimalPlugins`, the wake-driven pump, nothing in it. Record idle CPU and battery — the baseline every later stage is judged against.
+1. **Delete the duplicate projection.** Depend on `vmux_service` from `vmux_mobile`, call `group_turns_tail`, delete `main.rs:1743-1861`. No ECS. Landed with this spec.
+2. **Give the phone a `World`.** `MinimalPlugins`, the wake-driven pump, nothing in it. Answer the `Reflect`-on-iOS question first. Record idle CPU and battery — the baseline every later stage is judged against.
 3. **Move the QUIC client in.** `Api` becomes a resource, the subscribe loop at `main.rs:1888` becomes a system draining into components, and `AppBody`'s session signals become reads.
 4. **Make `PageHost` real.** `send` queues, `listen` registers, `PostUpdate` pushes. `TEAM_EVENT` stops polling and `POLL_INTERVAL_MS` goes.
 5. **Camera as a capability.** Port the QR scanner onto `CameraPlugin`, preserving VMX-132's denied-permission behaviour.

--- a/docs/specs/2026-08-13-mobile-ecs-host-design.md
+++ b/docs/specs/2026-08-13-mobile-ecs-host-design.md
@@ -1,0 +1,132 @@
+# Mobile ECS host design
+
+## Goal
+
+Give the phone a client-side Bevy `World` that owns device state and projects service state, and make `PageHost` its only door. Pages then render on the phone the way they render on the desktop, and a phone feature stops costing a wire change.
+
+## Why now
+
+[Service as ECS host](2026-08-11-service-ecs-host-design.md) made the service own the work and demoted the local client to a renderer. The phone is the other client, and it is not a renderer of anything — it is a second implementation.
+
+`crates/app/vmux_mobile/src/main.rs` is 2275 lines. `AppBody` (`:698`) is 787 of them and declares thirty `use_signal`s in its first forty lines: auth, pairing, sessions, agents, the open session, the transcript, the composer draft, staged attachments, media queries, three generation counters used as stale-guards. One component holding routing, connection state, chat state and the composer, with no owner for any of it.
+
+The cost compounds. Every feature the phone wants needs a `SharedAgentCommand` variant, a payload mirrored into `vmux_wire`, an answering system and a dispatch arm — the five-step change written out in VMX-150 for one struct.
+
+## What already holds
+
+More than the issue assumed.
+
+- **The page/host seam is two methods.** `PageHost` (`vmux_ui/src/transport.rs:27`) is `send(id, bytes)` and `listen(id, on_bytes)`. `transport/cef.rs` answers it for the desktop, `vmux_mobile/src/page_host.rs:30` for the phone. A page does not know which it has.
+- **Pages already compile for iOS.** `ui` means wasm *or* iOS (`crates/build_platform_cfg.rs:31`), so `vmux_chat::page` and its leaves are already built on the phone.
+- **The push channel exists.** `quic_api.rs:238` opens the stream client-side and writes once, because the relay only routes streams the client opened. The constraint is real and the workaround is built.
+- **The session model is render-free and phone-linkable.** VMX-140 landed `vmux_session`, whose whole dependency list is `bevy_app`, `bevy_ecs`, `bevy_reflect`, `serde`, `vmux_wire`. `room.rs` is 485 lines of it.
+
+## The duplicate projection is a missing dependency, not a missing ECS
+
+This issue claimed 1078 lines the phone "cannot call because it has no ECS". That was wrong twice, and the correction changes what the ECS is for.
+
+`vmux_service::chat` is 729 lines of transcript grouping — `group_turns_tail`, `group_turns_before`, `grouped_item_count` — declared `pub mod chat` unconditionally at `vmux_service/src/lib.rs:4`, outside the `#[cfg(host)]` block below it. It imports `crate::message`, and `vmux_service/src/message.rs` is one line re-exporting `vmux_wire::room::{AssistantBlock, Message, PlanStep, SubagentBlock}`. Pure functions over wire types, unit-tested, no Bevy anywhere near them.
+
+The phone re-implements them at `main.rs:1743`, `:1787` and `:1809` because `vmux_mobile` does not list `vmux_service` as a dependency. Nothing else stops it.
+
+So deleting the duplicate is a manifest line and a call-site change. **It should land first and alone, and it does not need any of the rest of this design.**
+
+That removes the strongest-sounding argument for the World, so the honest justification is what remains:
+
+- **Device state has no owner.** Three global queues drained by polling futures: `OPENED_URLS` (`main.rs:49`, polled at `:854`), `qr_scanner::RESULTS` (`qr_scanner.rs:43`, polled at `main.rs:867`) and `RESUMED` (`main.rs:104`). Each is a thread-local or a `Mutex` plus a loop, invented once per capability.
+- **`PageHost::send` has nothing to send to.** It returns `Unsupported` for every id (`page_host.rs:40`) because there is no local state a page could address. `listen` serves exactly `TEAM_EVENT`, by re-reading the Mac every three seconds (`page_host.rs:28`).
+- **Thirty signals in one component** is the shape state takes when nothing owns it.
+
+The World is for those. The projection is a dependency line.
+
+### Where the grouping should live
+
+`vmux_session`, not `vmux_service`. It is pure, three surfaces consume it, and `host/` means "runtime that runs with no UI and owns state" — a fold over a slice is not that. Move it beside `room.rs` and re-export from `vmux_service::chat` so no caller changes, exactly as stage 1 of the sibling spec moved the components.
+
+## Ownership after
+
+- `vmux_session` — session and room components, plus transcript grouping. No `App`, no CEF, no target gate.
+- `app/vmux_mobile` — the `World`, the device capability plugins, the QUIC forwarder, and `MobileHost`.
+
+**No new crate.** One consumer, and the seam that would justify one is already enforced by the target (below). A `vmux_mobile_host` crate earns its place when a second thing links it.
+
+## The seam is the target, not a crate
+
+The sibling spec needed a crate boundary because cloud Linux and desktop Linux are the same triple, so no cfg could separate them. Here the discriminator is `aarch64-apple-ios`, and `build_platform_cfg.rs` already resolves it to `ui`.
+
+The risk is therefore inverted, and worth stating because it reads backwards. `vmux_agent` and `vmux_service` both gate their Bevy halves with `cfg(not(any(target_arch = "wasm32", target_os = "ios")))`. That is correct — it is what keeps CEF off the phone — but it also means **those crates compile without Bevy on iOS**. The phone cannot reuse their plugins. It links `vmux_session` and writes its own.
+
+CI asserts the direction that can still break:
+
+```text
+cargo tree --target aarch64-apple-ios -p vmux_mobile -i bevy_cef   # must find nothing
+```
+
+## Topology: one host, two legs
+
+```text
+page ↔ mobile host ↔ relay ↔ desktop or cloud host
+                   ↔ device (camera, photos, biometrics, notifications)
+```
+
+A page talks to exactly one host, because `PageHost` is a singleton by construction: `install_host` writes into a `thread_local!` holding one `Option<Rc<dyn PageHost>>` (`transport.rs:42`, `:100`) and `Host::with_installed` (`:63`) resolves every call through it. Giving a page two hosts means a registry and a rule in each page about which id belongs to which — topology knowledge in the one place the trait exists to keep it out of.
+
+It also matches the desktop, where a page likewise talks to one host that fans out: CEF → desktop ECS → `vmux_service`.
+
+The phone's World is therefore not purely a projection. Sessions project from the service — a PTY is never going to run on a phone — but device state is authoritative here and nowhere else. That is what makes it a host.
+
+## Where the World lives, and who pumps it
+
+The desktop is Bevy hosting a webview. The phone is the inverse: Dioxus and tao own the run loop (`main.rs:106`), and UIKit requires the main thread. Bevy is a guest.
+
+**Reject a worker thread.** It looks like the service's headless runner and buys nothing here. `PageHost` is `Rc<dyn PageHost>` and `BytesListener` is `Box<dyn FnMut(&[u8])>` — neither is `Send`, so listeners run on the Dioxus thread whatever the World does. Every device capability is a UIKit call that must reach the main thread anyway. A worker thread adds two marshalling hops to buy parallelism the phone has no work for.
+
+**Take the main thread, pumped by a wake-driven future.** Same wake discipline as the service runner, for a different reason: there an idle tick is a bill, here it is a blocked UI thread. Wake sources are the ones that already exist — a frame decoded off the QUIC subscription, a `PageHost::send`, a capability result, `Event::Resumed` (`main.rs:124`).
+
+The budget is what makes this safe. The phone's World has no PTYs, no terminal grid, no compositing and no tiling. One update is a transcript fold over the tail.
+
+**Idle CPU and battery are acceptance numbers.** Measure a paired phone with an open session and no traffic, before and after.
+
+### Schedules
+
+One pass per wake, matching the service so the two read the same:
+
+- `PreUpdate` — drain the tokio channels and the capability results into components. The only place the outside world is read.
+- `Update` — decide. Fold the transcript, answer page requests, forward what belongs to the Mac.
+- `PostUpdate` — fan out. Push payloads to the listeners `MobileHost` registered.
+
+## Routing is registration, not a match
+
+`MobileHost` decides nothing. `send` queues the `(id, bytes)` into the World; `listen` records the callback. Whichever plugin claimed that id answers it, and forwarding to the Mac is itself just the plugin that owns `Api`.
+
+So adding a capability is adding a plugin, not editing a central `match`, and `Unsupported` becomes its honest meaning — no plugin claimed this id — which is what `event_listener.rs:25` already documents it as.
+
+A device capability owns its slice whole, per the by-feature split rule: `CameraPlugin` holds permission state, the `AVCaptureSession` and the scan result together. Because the World is on the main thread, its systems call UIKit directly — the `dispatch2` hop `qr_scanner.rs` needs today goes away along with `RESULTS`, `ACTIVE` and `REQUESTING`.
+
+## What does not move
+
+Sessions execute on the Mac or a cloud host. The phone's World owns device state and a projection; it never owns a PTY, an ACP process or a provider stream.
+
+Native navigation — the `UINavigationController` stack, the back gesture, per-screen state — is VMX-161 and is deliberately not here. This design decides where state lives; that one decides how screens are presented.
+
+## Migration path
+
+Each stage ships on its own.
+
+1. **Delete the duplicate projection.** Move the grouping to `vmux_session`, re-export from `vmux_service::chat`, depend on it from `vmux_mobile`, delete `main.rs:1743-1861`. No ECS, no behaviour change. Worth landing whether or not the rest happens.
+2. **Give the phone a `World`.** `MinimalPlugins`, the wake-driven pump, nothing in it. Record idle CPU and battery — the baseline every later stage is judged against.
+3. **Move the QUIC client in.** `Api` becomes a resource, the subscribe loop at `main.rs:1888` becomes a system draining into components, and `AppBody`'s session signals become reads.
+4. **Make `PageHost` real.** `send` queues, `listen` registers, `PostUpdate` pushes. `TEAM_EVENT` stops polling and `POLL_INTERVAL_MS` goes.
+5. **Camera as a capability.** Port the QR scanner onto `CameraPlugin`, preserving VMX-132's denied-permission behaviour.
+6. **Retire the rest of `AppBody`.** Composer, media, pairing.
+
+Stages 1 and 2 are independent of each other. Stage 3 is where behaviour can actually regress, and is the one to land alone.
+
+## Open
+
+- **Backgrounding.** iOS suspends the process; the QUIC connection dies and the World stops being pumped. Today `RESUMED` (`main.rs:104`) triggers a re-read. What the World does across suspend — reconnect, refetch, or restore — is undecided.
+- **Persistence.** The desktop persists ECS state through `moonshine-save`. Whether the phone persists a transcript or refetches it is open, and depends on the above.
+
+## Dependencies
+
+**VMX-151** blocks anything still `cfg(web)` — the palette and the start page cannot mount on the phone until the command-bar input is controlled. **VMX-127** is QUIC parity on the deployed relay, which the forwarding leg rides on. **VMX-132** overlaps stage 5 and lands first. **VMX-161** owns navigation.


### PR DESCRIPTION
Closes VMX-152.

Design plus the first stage of it.

## The finding

The issue was scoped on "1078 lines the phone cannot call because it has no ECS". That was wrong, and the correction is most of the value here.

`vmux_service::chat` — `group_turns_tail`, `group_turns_before`, `grouped_item_count` — is declared at `vmux_service/src/lib.rs:4`, *outside* the `#[cfg(host)]` block below it. It imports `crate::message` and `crate::protocol`, both one-line re-exports of `vmux_wire`. Its lib compiles for `aarch64-apple-ios` today.

The phone re-implemented it at `main.rs:1743`/`:1787`/`:1809` because `vmux_mobile` never listed `vmux_service` as a dependency. Nothing else stopped it.

So stage 1 is a manifest line and a call site. 154 deletions, 79 insertions.

## What the spec decides

**Topology.** A page talks to exactly one host; the mobile host owns both legs — device capabilities locally, session traffic forwarded over QUIC. `PageHost` is a singleton by construction (`transport.rs:42`, `:100`), so two hosts means a registry plus a rule in every page about which id belongs where.

**Where the World lives.** Dioxus and tao own the iOS run loop, so Bevy is a guest on the main thread pumped by a wake-driven future, not a headless worker. `Rc<dyn PageHost>` and `Box<dyn FnMut>` are non-`Send`, and every capability is a main-thread UIKit call.

**Routing is registration.** `MobileHost` decides nothing: `send` queues, `listen` records, whichever plugin claimed the id answers.

**The seam is the target, not a crate** — and the risk runs the opposite way from the service spec. Which brings us to:

## vmux_session cannot compile for iOS

Worth its own heading, because it shapes everything after stage 1 and it is not obvious.

`vmux_wire` declares `bevy_ecs`/`bevy_reflect` for host targets only, and `vmux_wire/build.rs:26` emits `bevy_linked` only when the feature is on *and* the target is neither wasm nor iOS. So on the phone the wire types carry no `Reflect` derive. `vmux_session` derives `Reflect` unconditionally on structs holding them, and eleven trait bounds fail.

I found this by moving the grouping into `vmux_session` first, which seemed the natural home beside `room.rs`. It is not, and the move is reverted. Stage 2 now has to answer the `Reflect`-on-iOS question before writing a single component, rather than discovering it midway.

## Behaviour changes

Four, all of them the desktop behaviour the phone was missing:

- Private context is split out of a user prompt into `ChatItem::User.context` (`chat.rs:121`); the phone rendered the composed prompt raw with `context: None`.
- A user message with no text and no attachments is skipped rather than rendered empty.
- A started-but-empty turn renders, instead of being suppressed until its first block.
- Prose is trimmed, and `reconnect_progress` lines fold into a reconnect block instead of showing as text.

Each is a fix, but together they are a visible change to the chat surface.

## Verification, and its limit

- `cargo check -p vmux_mobile --features mobile --target aarch64-apple-ios` — clean.
- `cargo tree --target aarch64-apple-ios -p vmux_mobile -i bevy_cef` — nothing. Same for `bevy_ecs`. The `vmux_service` dependency does not drag Bevy onto the phone.
- `cargo test -p vmux_service --lib chat::` — 16 passed. This is the suite that now covers the phone transcript.
- `cargo fmt`, `cargo clippy` — clean.

**The phone's own two tests cannot run anywhere.** `ui` is wasm-or-iOS, so `vmux_chat::page` does not exist for the host triple and `cargo test -p vmux_mobile` fails to compile. They are preserved and repointed at `MobileRoomProjection::chat_items`, but nothing executes them. Nothing in CI builds `vmux_mobile` at all — only `make ios` does, locally. That is how the duplicate survived, and it is worth closing separately.

## Test plan

- [ ] `make ios` and read a transcript with tool calls and a subagent — grouping unchanged
- [ ] Watch a live response stream — the delta still grows the turn, no flicker or duplicate block
- [ ] Send a prompt carrying private context — it renders as context, not inline in the prompt
- [ ] Confirm no empty turn artefacts at the tail of a finished conversation
