### PR TITLE
refactor(command-bar): spawn contributed rows instead of overwriting a resource

### DIFF
--- a/crates/page/vmux_agent/src/host/command.rs
+++ b/crates/page/vmux_agent/src/host/command.rs
@@ -253,10 +253,10 @@ pub(crate) fn remote_agents(
 /// system-parameter limit.
 #[cfg(not(web))]
 #[derive(bevy::ecs::system::SystemParam)]
-pub(crate) struct DesktopContext<'w> {
+pub(crate) struct DesktopContext<'w, 's> {
     focus: Res<'w, FocusedStack>,
     agents: Res<'w, vmux_command::snapshot::CommandBarAgentsSnapshot>,
-    contributions: Res<'w, vmux_command::snapshot::CommandBarContributions>,
+    contributions: vmux_command::snapshot::Contributions<'w, 's>,
 }
 
 pub(super) fn handle_agent_commands(

--- a/crates/page/vmux_agent/src/host/command_bar.rs
+++ b/crates/page/vmux_agent/src/host/command_bar.rs
@@ -7,7 +7,7 @@
 
 use bevy::prelude::*;
 use vmux_command::snapshot::{
-    CommandBarAgentsSnapshot, CommandBarContributions, ContributedCommand, WriteCommandBarSnapshots,
+    ClaimedUrl, CommandBarAgentsSnapshot, ContributedCommand, WriteCommandBarSnapshots,
 };
 use vmux_core::agent::{
     PageAgentAttachDefaultRequest, PageAgentAttachRequest, PageAgentSpawnDefaultRequest,
@@ -35,31 +35,48 @@ impl Plugin for CommandBarPlugin {
 /// at them until this crate picks one — so it hands them back instead.
 const DEFAULT_AGENT_URLS: [&str; 2] = ["vmux://agent/", "vmux://agent"];
 
+/// Marks a contribution entity as this crate's, so a republish clears only what it published.
+///
+/// Private on purpose: ownership is between a contributor and its own rows, and the command bar
+/// reads every contribution without caring which crate spawned it.
+#[derive(Component)]
+struct AgentContribution;
+
 /// Publish the agents to launch, and a row per model.
 fn publish_contributions(
     agents: Res<CommandBarAgentsSnapshot>,
-    mut contributions: ResMut<CommandBarContributions>,
+    mine: Query<Entity, With<AgentContribution>>,
+    mut commands: Commands,
 ) {
     if !agents.is_changed() {
         return;
     }
-    contributions.pages = agents.launcher_pages();
-    contributions.commands.clear();
+    for entity in mine.iter() {
+        commands.entity(entity).despawn();
+    }
+    for page in agents.launcher_pages() {
+        commands.spawn((AgentContribution, page));
+    }
     for strategy in &agents.strategies {
         let row = AppAgentId {
             provider: strategy.provider.clone(),
             model: strategy.model.clone(),
         };
-        contributions.commands.push(ContributedCommand {
-            id: row.to_string(),
-            message_id: "command-new-app-chat".to_string(),
-            args: vec![
-                ("provider".to_string(), row.provider),
-                ("model".to_string(), row.model),
-            ],
-        });
+        commands.spawn((
+            AgentContribution,
+            ContributedCommand {
+                id: row.to_string(),
+                message_id: "command-new-app-chat".to_string(),
+                args: vec![
+                    ("provider".to_string(), row.provider),
+                    ("model".to_string(), row.model),
+                ],
+            },
+        ));
     }
-    contributions.claimed_urls = DEFAULT_AGENT_URLS.map(str::to_string).to_vec();
+    for url in DEFAULT_AGENT_URLS {
+        commands.spawn((AgentContribution, ClaimedUrl(url.to_string())));
+    }
 }
 
 /// Act on a row or url the command bar handed back.
@@ -133,6 +150,8 @@ impl std::fmt::Display for AppAgentId {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bevy::ecs::system::RunSystemOnce;
+    use vmux_command::snapshot::Contributions;
 
     /// The id is a private round trip between the two halves of this file. A row whose id does not
     /// survive it is published and then silently ignored when the user picks it.
@@ -164,15 +183,22 @@ mod tests {
     /// send the user to whichever agent is default instead of the one they named.
     #[test]
     fn only_the_bare_agent_url_is_claimed() {
-        let contributions = CommandBarContributions {
-            claimed_urls: DEFAULT_AGENT_URLS.map(str::to_string).to_vec(),
-            ..Default::default()
-        };
+        let mut world = World::new();
+        for url in DEFAULT_AGENT_URLS {
+            world.spawn(ClaimedUrl(url.to_string()));
+        }
 
-        assert!(contributions.claims_url("vmux://agent/"));
-        assert!(contributions.claims_url("vmux://agent"));
+        let claimed = world
+            .run_system_once(|contributions: Contributions| {
+                [
+                    contributions.claims_url("vmux://agent/"),
+                    contributions.claims_url("vmux://agent"),
+                    contributions.claims_url("vmux://agent/codex"),
+                    contributions.claims_url("vmux://agent/codex/cli"),
+                ]
+            })
+            .expect("claims_url system runs");
 
-        assert!(!contributions.claims_url("vmux://agent/codex"));
-        assert!(!contributions.claims_url("vmux://agent/codex/cli"));
+        assert_eq!(claimed, [true, true, false, false]);
     }
 }

--- a/crates/page/vmux_layout/src/command_bar/handler.rs
+++ b/crates/page/vmux_layout/src/command_bar/handler.rs
@@ -32,8 +32,8 @@ use vmux_command::event::{
 use vmux_command::open::OpenCommand;
 use vmux_command::open_target::OpenTarget;
 use vmux_command::snapshot::{
-    CommandBarContributions, CommandBarPagesSnapshot, CommandBarSpacesSnapshot,
-    CommandBarTerminalsSnapshot, WriteCommandBarSnapshots,
+    CommandBarPagesSnapshot, CommandBarSpacesSnapshot, CommandBarTerminalsSnapshot, Contributions,
+    WriteCommandBarSnapshots,
 };
 use vmux_command::{
     AppCommand, BrowserBarCommand, BrowserCommand, LayoutCommand, PaneCommand, ReadAppCommands,
@@ -667,8 +667,8 @@ fn handle_open_command_bar(
             Without<Modal>,
         ),
     >,
+    contributions: Contributions,
     mut snapshot_params: ParamSet<(
-        Res<CommandBarContributions>,
         Res<CommandBarSpacesSnapshot>,
         ResMut<NewStackContext>,
         Option<Res<crate::settings::EffectiveStartupUrl>>,
@@ -683,14 +683,13 @@ fn handle_open_command_bar(
         return;
     };
     let active_stack_count = stack_q.iter().count();
-    let spaces_snapshot = snapshot_params.p1().clone();
+    let spaces_snapshot = snapshot_params.p0().clone();
     let space_name = spaces_snapshot.active_space_name.clone();
-    let contributions = snapshot_params.p0().clone();
-    let startup_url = snapshot_params.p3().map(|url| url.0.clone());
-    let pages_snap = snapshot_params.p5().clone();
-    let work_snap = snapshot_params.p6().clone();
+    let startup_url = snapshot_params.p2().map(|url| url.0.clone());
+    let pages_snap = snapshot_params.p4().clone();
+    let work_snap = snapshot_params.p5().clone();
     let locale = snapshot_params
-        .p7()
+        .p6()
         .as_deref()
         .map(|locale| locale.0.clone())
         .unwrap_or_else(Locale::preferred);
@@ -711,7 +710,7 @@ fn handle_open_command_bar(
 
     let mut active_stack_override = None;
     let canceled_pending_stack = {
-        let mut new_stack_ctx = snapshot_params.p2();
+        let mut new_stack_ctx = snapshot_params.p1();
         command_bar_cancel_pending_stack_for_active_open(&mut new_stack_ctx, replace_active_stack)
     };
     if let Some((stack, previous_stack)) = canceled_pending_stack {
@@ -724,7 +723,7 @@ fn handle_open_command_bar(
 
     if (should_dismiss || toggle_closes) && is_open {
         close_command_bar_panel(layout_e, &mut commands);
-        let mut new_stack_ctx = snapshot_params.p2();
+        let mut new_stack_ctx = snapshot_params.p1();
         // Discard empty tab created by a previous Cmd+T
         if let Some(stack_e) = new_stack_ctx.stack.take() {
             commands.entity(stack_e).despawn();
@@ -767,21 +766,21 @@ fn handle_open_command_bar(
     // handle_tab_commands / on_pane_select to clean up.
     if should_dismiss_nav && is_open {
         close_command_bar_panel(layout_e, &mut commands);
-        snapshot_params.p2().needs_open = false;
+        snapshot_params.p1().needs_open = false;
         return;
     }
 
     let startup_request = {
-        let mut new_stack_ctx = snapshot_params.p2();
+        let mut new_stack_ctx = snapshot_params.p1();
         pending_stack_startup_url_request(&mut new_stack_ctx, startup_url.as_deref())
     };
     if let Some(request) = startup_request {
-        snapshot_params.p4().write(request);
+        snapshot_params.p3().write(request);
         return;
     }
 
     let should_open_pending_stack = {
-        let mut new_stack_ctx = snapshot_params.p2();
+        let mut new_stack_ctx = snapshot_params.p1();
         command_bar_should_open_pending_stack(&mut new_stack_ctx, should_toggle)
     };
     if should_open_pending_stack {
@@ -796,7 +795,7 @@ fn handle_open_command_bar(
         return;
     }
 
-    let is_new_stack = snapshot_params.p2().stack.is_some();
+    let is_new_stack = snapshot_params.p1().stack.is_some();
 
     if !is_new_stack {
         let active_stack = active_stack_override.or_else(|| {
@@ -1059,7 +1058,7 @@ pub(crate) fn build_command_bar_open_payload(
     space_name: String,
     url: String,
     spaces_snapshot: &CommandBarSpacesSnapshot,
-    contributions: &CommandBarContributions,
+    contributions: &Contributions,
     pages_snapshot: &CommandBarPagesSnapshot,
     work_snapshot: &vmux_command::snapshot::CommandBarWorkSnapshot,
     locale: &Locale,
@@ -1067,8 +1066,8 @@ pub(crate) fn build_command_bar_open_payload(
     tabs: Vec<CommandBarTab>,
     target: Option<OpenTarget>,
 ) -> CommandBarOpenEvent {
-    let mut contributed = Vec::with_capacity(contributions.commands.len());
-    for command in &contributions.commands {
+    let mut contributed = Vec::new();
+    for command in contributions.commands() {
         let args: Vec<(&str, TranslationValue<'_>)> = command
             .args
             .iter()
@@ -1086,7 +1085,9 @@ pub(crate) fn build_command_bar_open_payload(
             page.title = locale.translate(message_id);
         }
     }
-    pages.extend(contributions.pages.iter().map(|entry| entry.page.clone()));
+    for entry in contributions.pages() {
+        pages.push(entry.page.clone());
+    }
     let history_shortcut = command_shortcut("browser_open_history");
     if !history_shortcut.is_empty()
         && let Some(page) = pages.iter_mut().find(|page| page.host == "history")
@@ -1252,7 +1253,7 @@ fn on_command_bar_action(
     mut resource_params: ParamSet<(
         Res<CommandBarSpacesSnapshot>,
         Res<CommandBarTerminalsSnapshot>,
-        Res<CommandBarContributions>,
+        Contributions,
         Option<Res<ResolvedLocale>>,
     )>,
     mut new_stack_ctx: ResMut<NewStackContext>,
@@ -1521,8 +1522,7 @@ fn on_command_bar_action(
         "command" => {
             let is_contributed = resource_params
                 .p2()
-                .commands
-                .iter()
+                .commands()
                 .any(|command| command.id == evt.value);
             if is_contributed {
                 let pane = match empty_stack {
@@ -2052,29 +2052,31 @@ mod tests {
     use super::*;
     use crate::command_bar::state::CommandBarState;
     use bevy::ecs::schedule::{NodeId, Schedules, SystemSet};
+    use bevy::ecs::system::RunSystemOnce;
     use vmux_command::event::CommandBarSpace;
     use vmux_command::{CommandPlugin, ReadAppCommands};
 
     #[test]
     fn build_payload_includes_commands_and_target() {
-        let pages = CommandBarPagesSnapshot::default();
-        let spaces = CommandBarSpacesSnapshot::default();
-        let agents = CommandBarContributions::default();
-        let work = vmux_command::snapshot::CommandBarWorkSnapshot::default();
-        let payload = build_command_bar_open_payload(
-            OpenId(7),
-            false,
-            String::new(),
-            String::new(),
-            &spaces,
-            &agents,
-            &pages,
-            &work,
-            &Locale::from("en-US"),
-            0,
-            Vec::new(),
-            Some(OpenTarget::InPlace),
-        );
+        let mut world = World::new();
+        let payload = world
+            .run_system_once(|contributions: Contributions| {
+                build_command_bar_open_payload(
+                    OpenId(7),
+                    false,
+                    String::new(),
+                    String::new(),
+                    &CommandBarSpacesSnapshot::default(),
+                    &contributions,
+                    &CommandBarPagesSnapshot::default(),
+                    &vmux_command::snapshot::CommandBarWorkSnapshot::default(),
+                    &Locale::from("en-US"),
+                    0,
+                    Vec::new(),
+                    Some(OpenTarget::InPlace),
+                )
+            })
+            .expect("payload system runs");
         assert_eq!(payload.open_id, OpenId(7));
         assert_eq!(payload.target, Some(OpenTarget::InPlace));
         assert!(!payload.commands.is_empty());
@@ -2663,7 +2665,6 @@ mod tests {
         let mut app = App::new();
         app.add_message::<AppCommand>()
             .add_message::<PageOpenRequest>()
-            .init_resource::<CommandBarContributions>()
             .init_resource::<CommandBarSpacesSnapshot>()
             .init_resource::<CommandBarPagesSnapshot>()
             .init_resource::<vmux_command::snapshot::CommandBarWorkSnapshot>()

--- a/crates/page/vmux_layout/src/start/plugin.rs
+++ b/crates/page/vmux_layout/src/start/plugin.rs
@@ -8,8 +8,8 @@ use bevy_cef::prelude::{
 use vmux_command::event::{CommandBarOpenEvent, CommandBarPromptContext, OpenId};
 use vmux_command::open_target::OpenTarget;
 use vmux_command::snapshot::{
-    CommandBarContributions, CommandBarPagesSnapshot, CommandBarSpacesSnapshot,
-    CommandBarWorkSnapshot,
+    CommandBarPagesSnapshot, CommandBarSpacesSnapshot, CommandBarWorkSnapshot, Contributions,
+    ContributionsChanged,
 };
 use vmux_core::{
     CefPageAttachRequest, PageMetadata, PageOpenError, PageOpenHandled, PageOpenSet, PageOpenTask,
@@ -302,7 +302,8 @@ fn sync_live_start_pages(
     tab_gather: TabGatherParams,
     prompt_context: StartPromptContextParams,
     spaces_snapshot: Res<CommandBarSpacesSnapshot>,
-    contributions: Res<CommandBarContributions>,
+    contributions: Contributions,
+    mut contributions_changed: ContributionsChanged,
     pages_snapshot: Res<CommandBarPagesSnapshot>,
     work_snapshot: Res<CommandBarWorkSnapshot>,
     locale: Option<Res<ResolvedLocale>>,
@@ -339,7 +340,7 @@ fn sync_live_start_pages(
     let focus_changed = focused.is_changed();
     let changed = should_refresh_start_payload(
         spaces_snapshot.is_changed(),
-        contributions.is_changed(),
+        contributions_changed.any(),
         pages_snapshot.is_changed(),
         work_snapshot.is_changed(),
         focus_changed,
@@ -509,7 +510,7 @@ fn on_start_spare_revealed(
     tab_gather: TabGatherParams,
     prompt_context: StartPromptContextParams,
     spaces_snapshot: Res<CommandBarSpacesSnapshot>,
-    contributions: Res<CommandBarContributions>,
+    contributions: Contributions,
     pages_snapshot: Res<CommandBarPagesSnapshot>,
     work_snapshot: Res<CommandBarWorkSnapshot>,
     locale: Option<Res<ResolvedLocale>>,
@@ -553,7 +554,7 @@ fn on_start_data_request(
     tab_gather: TabGatherParams,
     prompt_context: StartPromptContextParams,
     spaces_snapshot: Res<CommandBarSpacesSnapshot>,
-    contributions: Res<CommandBarContributions>,
+    contributions: Contributions,
     pages_snapshot: Res<CommandBarPagesSnapshot>,
     work_snapshot: Res<CommandBarWorkSnapshot>,
     locale: Option<Res<ResolvedLocale>>,
@@ -596,7 +597,7 @@ fn on_start_data_request(
 fn build_start_payload(
     tab_gather: &TabGatherParams,
     spaces_snapshot: &CommandBarSpacesSnapshot,
-    contributions: &CommandBarContributions,
+    contributions: &Contributions,
     pages_snapshot: &CommandBarPagesSnapshot,
     work_snapshot: &CommandBarWorkSnapshot,
     prompt_context: &StartPromptContextParams,
@@ -663,7 +664,6 @@ mod tests {
     fn start_ready_app() -> App {
         let mut app = App::new();
         app.init_resource::<CommandBarSpacesSnapshot>()
-            .init_resource::<CommandBarContributions>()
             .init_resource::<CommandBarPagesSnapshot>()
             .init_resource::<CommandBarWorkSnapshot>()
             .init_resource::<EmittedIds>()

--- a/crates/vmux_command/src/host/snapshot.rs
+++ b/crates/vmux_command/src/host/snapshot.rs
@@ -1,4 +1,5 @@
 use crate::event::{CommandBarPage, CommandBarRecentFile, CommandBarWorkDir, SearchEngine};
+use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 use std::collections::HashMap;
 use vmux_core::agent::AgentKind;
@@ -14,7 +15,6 @@ pub struct CommandBarSnapshotPlugin;
 impl Plugin for CommandBarSnapshotPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<CommandBarAgentsSnapshot>()
-            .init_resource::<CommandBarContributions>()
             .init_resource::<CommandBarSpacesSnapshot>()
             .init_resource::<CommandBarTerminalsSnapshot>()
             .init_resource::<CommandBarPagesSnapshot>()
@@ -38,11 +38,15 @@ pub struct CommandBarAgentsSnapshot {
 
 impl CommandBarAgentsSnapshot {
     /// Launcher entries for installed ACP and CLI agents, most recently used first.
+    ///
+    /// Ranked by that order, since the entities these become carry preference rather than inherit
+    /// it from their position.
     pub fn launcher_pages(&self) -> Vec<ContributedPage> {
         let mut pages = Vec::with_capacity(self.acp.len() + self.providers.len());
         for agent in &self.acp {
             pages.push(ContributedPage {
                 id: agent.id.clone(),
+                rank: 0,
                 page: CommandBarPage {
                     host: "agent".to_string(),
                     url: agent.url.clone(),
@@ -61,6 +65,7 @@ impl CommandBarAgentsSnapshot {
         for agent in &self.providers {
             pages.push(ContributedPage {
                 id: agent.id.clone(),
+                rank: 0,
                 page: CommandBarPage {
                     host: "agent".to_string(),
                     url: agent.url.clone(),
@@ -89,6 +94,9 @@ impl CommandBarAgentsSnapshot {
                         .cmp(&b.page.title.to_lowercase())
                 })
         });
+        for (rank, page) in pages.iter_mut().enumerate() {
+            page.rank = rank;
+        }
         pages
     }
 }
@@ -96,51 +104,50 @@ impl CommandBarAgentsSnapshot {
 /// What other crates add to the command bar.
 ///
 /// The command bar lists pages and commands; it does not know what any of them are for. Whoever
-/// owns a capability describes it here and handles it when it is chosen, so the command bar stays
-/// a launcher rather than growing a branch per feature.
-#[derive(Resource, Default, Clone, Debug)]
-pub struct CommandBarContributions {
-    /// Pages to list, and the targets a prompt can be sent to, most preferred first.
-    pub pages: Vec<ContributedPage>,
-    pub commands: Vec<ContributedCommand>,
-    /// Urls a contributor resolves itself instead of them naming a page to open.
+/// owns a capability spawns it as an entity and handles it when it is chosen, so the command bar
+/// stays a launcher rather than growing a branch per feature.
+///
+/// One entity per row is what lets more than one crate contribute. The list used to be a resource
+/// every contributor overwrote wholesale, so a second one silently erased the first every frame.
+/// A contributor now despawns only the entities it spawned, which it recognises by its own private
+/// marker component — this type never needs to know who owns what.
+#[derive(SystemParam)]
+pub struct Contributions<'w, 's> {
+    pages: Query<'w, 's, &'static ContributedPage>,
+    commands: Query<'w, 's, &'static ContributedCommand>,
+    claimed: Query<'w, 's, &'static ClaimedUrl>,
+}
+
+impl Contributions<'_, '_> {
+    /// Contributed pages, most preferred first.
     ///
-    /// Opening one of these as an ordinary url would land on nothing: they stand for a choice the
-    /// contributor has to make — "the default one" — not for a page that exists yet.
-    pub claimed_urls: Vec<String>,
-}
+    /// Entity iteration order carries no meaning, so preference is [`ContributedPage::rank`] and
+    /// ties break by id. Rank orders one contributor's own pages; between two contributors the id
+    /// is all there is to go on, which is arbitrary but stable.
+    pub fn pages(&self) -> Vec<&ContributedPage> {
+        let mut pages: Vec<&ContributedPage> = self.pages.iter().collect();
+        pages.sort_by(|a, b| a.rank.cmp(&b.rank).then_with(|| a.id.cmp(&b.id)));
+        pages
+    }
 
-/// One contributed page: something the command bar can list, open, and send a prompt to.
-#[derive(Clone, Debug)]
-pub struct ContributedPage {
-    /// Echoed back when this page is chosen by id rather than by url. Opaque to the command bar.
-    pub id: String,
-    pub page: CommandBarPage,
-}
+    /// Contributed command rows, in no particular order.
+    pub fn commands(&self) -> impl Iterator<Item = &ContributedCommand> {
+        self.commands.iter()
+    }
 
-/// One contributed command-bar row.
-#[derive(Clone, Debug)]
-pub struct ContributedCommand {
-    /// Echoed back by the command bar when this row is chosen. Opaque to it.
-    pub id: String,
-    /// Fluent message naming the row, with its arguments. Not a rendered string: the contributor
-    /// has no locale, and the command bar does.
-    pub message_id: String,
-    pub args: Vec<(String, String)>,
-}
-
-impl CommandBarContributions {
     /// Where a prompt should go: `requested` when that page is listed, else the most preferred.
     ///
     /// `None` means nothing accepts a prompt, which a caller has to refuse rather than substitute
     /// for — opening something other than what was asked for would be worse than doing nothing.
     pub fn prompt_url(&self, requested: Option<&str>) -> Option<String> {
         if let Some(requested) = requested
-            && let Some(entry) = self.pages.iter().find(|entry| entry.page.url == requested)
+            && self.pages.iter().any(|entry| entry.page.url == requested)
         {
-            return Some(entry.page.url.clone());
+            return Some(requested.to_string());
         }
-        self.pages.first().map(|entry| entry.page.url.clone())
+        let pages = self.pages();
+        let first = pages.first()?;
+        Some(first.page.url.clone())
     }
 
     /// The page a contributed id names.
@@ -151,9 +158,69 @@ impl CommandBarContributions {
 
     /// Whether a contributor resolves this url itself.
     pub fn claims_url(&self, url: &str) -> bool {
-        self.claimed_urls.iter().any(|claimed| claimed == url)
+        self.claimed.iter().any(|claimed| claimed.0 == url)
     }
 }
+
+/// Matches a contribution entity of any kind whose row was spawned or edited.
+type ContributionTouched = Or<(
+    Changed<ContributedPage>,
+    Changed<ContributedCommand>,
+    Changed<ClaimedUrl>,
+)>;
+
+/// Whether the contributed rows changed since the reading system last ran, despawns included.
+///
+/// Split from [`Contributions`] because reading despawns needs `&mut` and every other reader only
+/// wants to look. Both halves are needed: a republish arrives as spawns, but the last row going
+/// away is a despawn and nothing else.
+#[derive(SystemParam)]
+pub struct ContributionsChanged<'w, 's> {
+    touched: Query<'w, 's, (), ContributionTouched>,
+    pages: RemovedComponents<'w, 's, ContributedPage>,
+    commands: RemovedComponents<'w, 's, ContributedCommand>,
+    claimed: RemovedComponents<'w, 's, ClaimedUrl>,
+}
+
+impl ContributionsChanged<'_, '_> {
+    /// True when a row was spawned, edited or despawned.
+    ///
+    /// Every removal reader is drained even once the answer is known, so a despawn this frame
+    /// cannot be reported again as a change next frame.
+    pub fn any(&mut self) -> bool {
+        let removed =
+            self.pages.read().count() + self.commands.read().count() + self.claimed.read().count();
+        removed > 0 || !self.touched.is_empty()
+    }
+}
+
+/// One contributed page: something the command bar can list, open, and send a prompt to.
+#[derive(Component, Clone, Debug)]
+pub struct ContributedPage {
+    /// Echoed back when this page is chosen by id rather than by url. Opaque to the command bar.
+    pub id: String,
+    pub page: CommandBarPage,
+    /// Preference among this contributor's pages, lowest first.
+    pub rank: usize,
+}
+
+/// One contributed command-bar row.
+#[derive(Component, Clone, Debug)]
+pub struct ContributedCommand {
+    /// Echoed back by the command bar when this row is chosen. Opaque to it.
+    pub id: String,
+    /// Fluent message naming the row, with its arguments. Not a rendered string: the contributor
+    /// has no locale, and the command bar does.
+    pub message_id: String,
+    pub args: Vec<(String, String)>,
+}
+
+/// A url a contributor resolves itself instead of naming a page to open.
+///
+/// Opening one of these as an ordinary url would land on nothing: they stand for a choice the
+/// contributor has to make — "the default one" — not for a page that exists yet.
+#[derive(Component, Clone, Debug)]
+pub struct ClaimedUrl(pub String);
 
 /// Agent identity used for recent-first launcher ordering.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
@@ -255,13 +322,25 @@ fn update_pages_snapshot(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bevy::ecs::system::RunSystemOnce;
     use vmux_core::agent::AgentKind;
 
-    /// What the contributing crate publishes, so the prompt tests run the real path.
-    fn contributions(agents: &CommandBarAgentsSnapshot) -> CommandBarContributions {
-        CommandBarContributions {
-            pages: agents.launcher_pages(),
-            ..Default::default()
+    impl CommandBarAgentsSnapshot {
+        /// Publish what the contributing crate would, then ask where a prompt goes.
+        ///
+        /// Spawns the pages rather than handing [`Contributions`] a list, so the prompt tests run
+        /// against the entities the command bar actually reads.
+        fn resolve_prompt_url(&self, requested: Option<&str>) -> Option<String> {
+            let mut world = World::new();
+            for page in self.launcher_pages() {
+                world.spawn(page);
+            }
+            let requested = requested.map(str::to_string);
+            world
+                .run_system_once(move |contributions: Contributions| {
+                    contributions.prompt_url(requested.as_deref())
+                })
+                .expect("prompt_url system runs")
         }
     }
 
@@ -294,7 +373,7 @@ mod tests {
         };
 
         assert_eq!(
-            contributions(&snapshot).prompt_url(None).as_deref(),
+            snapshot.resolve_prompt_url(None).as_deref(),
             Some("vmux://agent/codex/cli")
         );
     }
@@ -312,11 +391,11 @@ mod tests {
         };
 
         assert_eq!(
-            contributions(&snapshot).prompt_url(None).as_deref(),
+            snapshot.resolve_prompt_url(None).as_deref(),
             Some("vmux://agent/claude")
         );
         assert_eq!(
-            contributions(&CommandBarAgentsSnapshot::default()).prompt_url(None),
+            CommandBarAgentsSnapshot::default().resolve_prompt_url(None),
             None
         );
     }
@@ -341,14 +420,14 @@ mod tests {
         };
 
         assert_eq!(
-            contributions(&snapshot)
-                .prompt_url(Some("vmux://agent/claude"))
+            snapshot
+                .resolve_prompt_url(Some("vmux://agent/claude"))
                 .as_deref(),
             Some("vmux://agent/claude")
         );
         assert_eq!(
-            contributions(&snapshot)
-                .prompt_url(Some("vmux://agent/uninstalled"))
+            snapshot
+                .resolve_prompt_url(Some("vmux://agent/uninstalled"))
                 .as_deref(),
             Some("vmux://agent/codex/cli")
         );
@@ -388,6 +467,56 @@ mod tests {
             pages[1].page.icon,
             vmux_core::PageIcon::Favicon(ref u) if u == "https://cdn.example/claude-acp.svg"
         ));
+        assert_eq!(pages[0].rank, 0);
+        assert_eq!(pages[1].rank, 1);
+    }
+
+    #[derive(Component)]
+    struct FirstContributor;
+
+    #[derive(Component)]
+    struct SecondContributor;
+
+    impl ContributedCommand {
+        fn named(id: &str) -> Self {
+            Self {
+                id: id.to_string(),
+                message_id: "command-test-row".to_string(),
+                args: Vec::new(),
+            }
+        }
+    }
+
+    /// Republishing is scoped to the rows the contributor spawned.
+    ///
+    /// The shape this replaced was a resource each contributor overwrote, so the second one to run
+    /// each frame erased the first. Only one crate ever contributed, which is why it never showed.
+    #[test]
+    fn one_contributor_rebuilding_leaves_the_others_rows() {
+        let mut world = World::new();
+        world.spawn((FirstContributor, ContributedCommand::named("first")));
+        world.spawn((SecondContributor, ContributedCommand::named("second")));
+
+        world
+            .run_system_once(
+                |mine: Query<Entity, With<FirstContributor>>, mut commands: Commands| {
+                    for entity in mine.iter() {
+                        commands.entity(entity).despawn();
+                    }
+                    commands.spawn((FirstContributor, ContributedCommand::named("first-again")));
+                },
+            )
+            .expect("republish runs");
+
+        let ids = world
+            .run_system_once(|contributions: Contributions| {
+                let mut ids: Vec<String> =
+                    contributions.commands().map(|row| row.id.clone()).collect();
+                ids.sort();
+                ids
+            })
+            .expect("read runs");
+        assert_eq!(ids, ["first-again", "second"]);
     }
 
     #[test]


### PR DESCRIPTION
Stage 1 of [VMX-163](https://linear.app/vmux/issue/VMX-163/let-each-crate-own-its-command-bar-rows).

`CommandBarContributions` already documented the rule the command bar is meant to follow:

> The command bar lists pages and commands; it does not know what any of them are for. Whoever owns a capability describes it here and handles it when it is chosen, so the command bar stays a launcher rather than growing a branch per feature.

`vmux_agent` is the only crate that ever used it. The shape is why: it was a `Resource`, and its single writer did

```rust
contributions.pages = agents.launcher_pages();
contributions.commands.clear();
contributions.claimed_urls = DEFAULT_AGENT_URLS.map(str::to_string).to_vec();
```

on every republish. A second contributor would have been erased every frame the agents snapshot changed. The registry was not underused because contributors were lazy — it could not hold two.

## What changed

**One entity per row.** A contributor spawns its own and despawns them by its own private marker (`AgentContribution`, private to `vmux_agent`), so a republish is scoped to what that crate published and any number of crates can write at once.

**Readers take a `Contributions` system param** instead of `Res<CommandBarContributions>`. `prompt_url`, `page_url` and `claims_url` stay on a type rather than becoming loose queries at six call sites.

**Ordering moves onto the row** as `ContributedPage::rank`, because entity iteration order means nothing. `launcher_pages()` assigns it from the order it already sorted into, so preference is unchanged. Ties break by id — arbitrary between two contributors, but stable.

**Change detection splits off** into `ContributionsChanged`. A despawn is only visible through `RemovedComponents`, which needs `&mut`, and the five read-only readers should not have to carry that. Both halves are load-bearing: a republish arrives as spawns, but the last row going away arrives as nothing else — which is the case that would have silently left stale rows on the start page.

`handle_open_command_bar` gets `Contributions` as a direct param rather than a `ParamSet` member, since the old code cloned the resource out of the set and a system param cannot be cloned. The set's remaining indices shift down by one.

## Not in this PR

The six built-in actions still route through the 487-line `match evt.action.as_str()` in `on_command_bar_action`. They move out one at a time in stage 2, now that there is a door wide enough for them.

## Test plan

- [x] `one_contributor_rebuilding_leaves_the_others_rows` — the regression the resource allowed. Two contributors, one republishes, the other's rows survive. Fails under the old shape.
- [x] `only_the_bare_agent_url_is_claimed` and the `prompt_url` suite reworked onto spawned entities, so they run against what the command bar actually reads.
- [x] `cargo test --workspace --exclude bevy_cef_core --exclude bevy_cef` — 2977 passed, 0 failed.
- [x] `cargo clippy <all non-patch pkgs> --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [ ] At a keyboard: `cmd+k`, agent rows still listed and still launch; a prompt with no explicit target still goes to the most recent agent; `vmux://agent/` still resolves to the default rather than 404ing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command-bar pages, commands, and URLs are now dynamically contributed and updated.
  * Recently used agent launcher pages are ranked to improve ordering.
  * Start pages and command-bar actions automatically reflect contribution additions, edits, and removals.

* **Bug Fixes**
  * Improved contributor-specific updates so refreshing one source no longer removes entries from others.
  * Prompt and URL selection now consistently use the latest available contributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->