### PR TITLE
Docs: the relay routes by identity, not by an allocated port

### DIFF
--- a/docs/architecture/mobile-remote.md
+++ b/docs/architecture/mobile-remote.md
@@ -42,8 +42,8 @@ make ios
 ```
 
 Open the left side sheet in Vmux and enable **Remote** in the space card. The desktop registers
-with the relay and waits for it to allocate a port; the pairing link cannot be shown until it has,
-because the link has to name that port.
+with the relay and waits for it to accept; the pairing link cannot be shown until it has, because
+a link offered first would name a pairing the relay would refuse.
 
 The first time, scan the QR code with the phone. It opens Vmux Remote through the
 `vmux://pair` deep link, verifies the endpoint, and stores the credentials. After the first
@@ -112,7 +112,8 @@ nothing and reports only a timeout, so an untagged value is logged and ignored r
 inherited. The tag is what is checked and never the port number, so a relay deliberately stood up
 somewhere other than the default survives the upgrade. Enabling Remote rewrites the file tagged.
 
-The port the relay allocates is recorded beside it and lives exactly as long as the registration
-does: written when the daemon registers, removed when that session ends and again at daemon
-startup. Every reader treats a missing port as "not registered yet", so the app offers no pairing
-link during that window rather than one naming a port the relay has already freed.
+The device id the relay accepted is recorded beside it and lives exactly as long as the
+registration does: written when the relay admits the desktop, removed when that session ends.
+It is not the same as the desktop's own id, which exists whether or not anything is registered.
+Every reader treats its absence as "not registered yet", so the app offers no pairing link during
+that window rather than one the relay would refuse.

--- a/docs/architecture/topology.md
+++ b/docs/architecture/topology.md
@@ -37,23 +37,25 @@ flowchart LR
     relay(["relay<br/>vmux-cloud"])
 
     service <-->|"QUIC control · held open"| relay
-    remote <-->|"QUIC · allocated UDP port"| relay
+    remote <-->|"QUIC · the same UDP port"| relay
 
     style relay stroke-dasharray: 4 4
 ```
 
-Neither end of the relay listens for the other. The server dials out and holds one QUIC connection
-open; the relay allocates it a UDP port and tells it which. The pairing link names that port, so a
-remote client reaches a host behind NAT without either side opening one.
+Neither end of the relay listens for the other. Both dial the same UDP port and are told apart by
+the hello they open with, which names the desktop and presents the pairing token. The pairing link
+names that desktop, so a remote client reaches a host behind NAT without either side opening a
+port.
 
 **The relay cannot read any of it.** A remote client's packets belong to a second QUIC session that
 terminates on the *host*, and cross the relay as DATAGRAM frames on the control connection. TLS 1.3
 is end to end; the relay holds no key for it and links no crate that could decode a payload even
 with one. What it does see is metadata — which device talks when, and how much.
 
-Forwarding only works in that direction. The desktop's NAT mapping was opened toward the control
-port, and a port-restricted NAT — most consumer routers — drops anything arriving from a different
-source port, so replies cannot be sent straight from the allocated port.
+Forwarding only works in that direction. The desktop's NAT mapping was opened by its own dial and
+a port-restricted NAT — most consumer routers — admits only what comes back on that same pairing,
+so the relay cannot start a fresh flow toward the desktop. Everything rides the connection the
+desktop already holds open.
 
 Nothing is dialled until Remote is switched on. The server checks that before connecting and a
 single watcher closes every live connection the moment it goes off.
@@ -107,7 +109,7 @@ named that way precisely because it resolves on its own, unlike `NotFound`.
 | page ↔ local client | `window.cef` binEmit/binListen | rkyv; page→host adds a `vmux-bin-ipc-v1` envelope, host→page bare |
 | local client ↔ server | unix socket | `u32`-length-prefixed rkyv frames, 64 MiB cap |
 | remote client ↔ server | QUIC, one bidirectional stream per request | rkyv `SharedMessage` / `SharedResponse`, after a JSON hello |
-| server ↔ relay | QUIC control connection | JSON `RelayHello` / `RelayAllocation`, then opaque DATAGRAM frames |
+| server ↔ relay | QUIC control connection | JSON `RelayHello` / `RelayAccepted`, then opaque DATAGRAM frames |
 
 The last row is the one worth reading twice. Only the hello is the relay's business; everything
 after it is a remote client's own QUIC session in transit.


### PR DESCRIPTION
Found while working through [VMX-127](https://linear.app/vmux/issue/VMX-127/land-quic-transport-end-to-end-for-ios). `#360` changed the relay to route by identity on one port, but four passages still describe the old design — and someone following them would set up the wrong test.

`grep` finds no `relay_port` anywhere in the client, and `RelayAllocation` no longer exists, so these are documentation describing code that was deleted.

## What was wrong

**`mobile-remote.md:45`** — "waits for it to allocate a port; the pairing link cannot be shown until it has, because the link has to name that port." The link never names a port now. The wait is real, but it is on the relay *accepting the registration*: `Relay::base_url` returns `None` until `recorded_device()` is set, because a link handed out first names a pairing the relay would refuse.

**`mobile-remote.md:115-118`** — described the allocated port as the thing recorded beside the relay URL. What is actually recorded is the device id the relay accepted (`remote-relay-registration`), which is *not* the same as this desktop's own id (`remote-device`) — the second exists whether or not anything is registered, and confusing them is what the paths doc-comment warns about.

**`topology.md:40,46,56`** — the diagram edge, the prose, and the NAT explanation. Both ends dial the same port and are told apart by the hello. The NAT paragraph's conclusion still holds but its reasoning did not: it argued from a *different source port*, which no longer exists. Rewritten to argue from the mapping the desktop's own dial opened.

**`topology.md:112`** — the wire table still named `RelayAllocation`. It is `RelayAccepted`.

## Test plan

- [x] `grep -rn 'allocat' docs/architecture/` returns only the unrelated CEF line in `why-rust-cef.md`
- [x] `grep -rn 'RelayAllocation' docs/ crates/` returns nothing
- [x] Claims checked against `pairing.rs:122-146`, `paths.rs:155-175`, `quic.rs:281`

Docs only; no code changes.