### PR TITLE
refactor(command-bar): let a page name itself and say what it replaces

### DIFF
--- a/crates/app/vmux_desktop/src/tools.rs
+++ b/crates/app/vmux_desktop/src/tools.rs
@@ -173,6 +173,8 @@ impl Plugin for ToolsPlugin {
 const PAGE_MANIFEST: PageManifest = PageManifest {
     host: "tools",
     title: "Tools",
+    title_message_id: Some("tools-title"),
+    replaces_command: None,
     keywords: &[
         "packages", "tools", "dotfiles", "homebrew", "npm", "mcp", "import",
     ],
@@ -183,6 +185,8 @@ const PAGE_MANIFEST: PageManifest = PageManifest {
 const VAULT_PAGE_MANIFEST: PageManifest = PageManifest {
     host: "vault",
     title: "Vault",
+    title_message_id: Some("vault-title"),
+    replaces_command: None,
     keywords: &["vault", "sync", "git", "backup", "dotfiles", "knowledge"],
     icon: Some(vmux_core::BuiltinIcon::Vault),
     command_bar: true,

--- a/crates/host/vmux_service/src/host.rs
+++ b/crates/host/vmux_service/src/host.rs
@@ -34,6 +34,8 @@ pub mod supervisor;
 pub const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
     host: "services",
     title: "Services",
+    title_message_id: Some("services-title"),
+    replaces_command: Some("service_open"),
     keywords: &["processes", "monitor"],
     icon: Some(vmux_core::BuiltinIcon::Activity),
     command_bar: true,

--- a/crates/page/vmux_agent/src/host/agents.rs
+++ b/crates/page/vmux_agent/src/host/agents.rs
@@ -62,6 +62,8 @@ impl Plugin for AgentsManagerPlugin {
 pub const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
     host: "agents",
     title: "Agents",
+    title_message_id: Some("agents-title"),
+    replaces_command: None,
     keywords: &["acp", "agent", "install", "registry"],
     icon: Some(vmux_core::BuiltinIcon::Sparkles),
     command_bar: true,

--- a/crates/page/vmux_agent/src/host/chat.rs
+++ b/crates/page/vmux_agent/src/host/chat.rs
@@ -43,6 +43,8 @@ impl Plugin for AgentChatPagePlugin {
 pub const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
     host: "agent",
     title: "Agent",
+    title_message_id: None,
+    replaces_command: None,
     keywords: &["ai", "chat", "assistant", "agent"],
     icon: Some(vmux_core::BuiltinIcon::Sparkles),
     command_bar: false,

--- a/crates/page/vmux_editor/src/host/lsp/manager_page.rs
+++ b/crates/page/vmux_editor/src/host/lsp/manager_page.rs
@@ -47,6 +47,8 @@ impl Plugin for ManagerPlugin {
 const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
     host: "lsp",
     title: "Language Servers",
+    title_message_id: Some("lsp-title"),
+    replaces_command: None,
     keywords: &["lsp", "language", "server", "install", "mason"],
     icon: Some(vmux_core::BuiltinIcon::Server),
     command_bar: true,

--- a/crates/page/vmux_editor/src/host/plugin.rs
+++ b/crates/page/vmux_editor/src/host/plugin.rs
@@ -3885,6 +3885,8 @@ fn on_explorer_search_open(
 pub const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
     host: "files",
     title: "Files",
+    title_message_id: None,
+    replaces_command: None,
     keywords: &["file", "open"],
     icon: Some(vmux_core::BuiltinIcon::Files),
     command_bar: true,

--- a/crates/page/vmux_history/src/host.rs
+++ b/crates/page/vmux_history/src/host.rs
@@ -37,6 +37,8 @@ impl Plugin for HistoryPlugin {
 pub const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
     host: "history",
     title: "History",
+    title_message_id: Some("history-title"),
+    replaces_command: Some("browser_open_history"),
     keywords: &["recent", "visited"],
     icon: Some(vmux_core::BuiltinIcon::Clock),
     command_bar: true,

--- a/crates/page/vmux_layout/src/command_bar/handler.rs
+++ b/crates/page/vmux_layout/src/command_bar/handler.rs
@@ -173,22 +173,25 @@ pub struct CommandBarEntry {
     pub shortcut: String,
 }
 
-/// Command ids surfaced through a page entry instead of a command row: the
-/// Services page (vmux://services/) replaces "Open Service Monitor", and the
-/// History page shows the History shortcut. Their menu items + shortcuts stay.
-const COMMAND_BAR_SKIP_IDS: &[&str] = &["service_open", "browser_open_history"];
-
 /// Built-in command rows plus whatever other crates contributed, already named.
-pub fn command_list(locale: &Locale, contributed: Vec<CommandBarEntry>) -> Vec<CommandBarEntry> {
-    let mut entries: Vec<CommandBarEntry> = AppCommand::command_bar_entries()
-        .into_iter()
-        .filter(|(id, _, _)| !COMMAND_BAR_SKIP_IDS.contains(id))
-        .map(|(id, name, shortcut)| CommandBarEntry {
+///
+/// `superseded` names commands a registered page stands in for, whose rows the page entry replaces.
+pub fn command_list(
+    locale: &Locale,
+    contributed: Vec<CommandBarEntry>,
+    superseded: &[&str],
+) -> Vec<CommandBarEntry> {
+    let mut entries = Vec::new();
+    for (id, name, shortcut) in AppCommand::command_bar_entries() {
+        if superseded.contains(&id) {
+            continue;
+        }
+        entries.push(CommandBarEntry {
             id: id.to_string(),
             name: localized_command_name(locale.as_str(), id, name),
             shortcut: shortcut.to_string(),
-        })
-        .collect();
+        });
+    }
     entries.extend(contributed);
     entries
 }
@@ -1079,22 +1082,23 @@ pub(crate) fn build_command_bar_open_payload(
             shortcut: String::new(),
         });
     }
-    let mut pages = pages_snapshot.pages.clone();
-    for page in &mut pages {
-        if let Some(message_id) = page_title_message_id(&page.host) {
+    let mut pages = Vec::with_capacity(pages_snapshot.pages.len());
+    let mut superseded = Vec::new();
+    for entry in &pages_snapshot.pages {
+        let mut page = entry.page.clone();
+        if let Some(message_id) = entry.title_message_id {
             page.title = locale.translate(message_id);
         }
+        if let Some(command_id) = entry.replaces_command {
+            page.shortcut = command_shortcut(command_id);
+            superseded.push(command_id);
+        }
+        pages.push(page);
     }
     for entry in contributions.pages() {
         pages.push(entry.page.clone());
     }
-    let history_shortcut = command_shortcut("browser_open_history");
-    if !history_shortcut.is_empty()
-        && let Some(page) = pages.iter_mut().find(|page| page.host == "history")
-    {
-        page.shortcut = history_shortcut;
-    }
-    let commands: Vec<CommandBarCommandEntry> = command_list(locale, contributed)
+    let commands: Vec<CommandBarCommandEntry> = command_list(locale, contributed, &superseded)
         .into_iter()
         .map(|e| CommandBarCommandEntry {
             id: e.id,
@@ -1134,22 +1138,6 @@ pub(crate) fn build_command_bar_open_payload(
         work_snapshot.recent_files.clone(),
         work_snapshot.search_engines.clone(),
     )
-}
-
-fn page_title_message_id(host: &str) -> Option<&'static str> {
-    match host {
-        "agents" => Some("agents-title"),
-        "extensions" => Some("extensions-title"),
-        "history" => Some("history-title"),
-        "lsp" => Some("lsp-title"),
-        "services" => Some("services-title"),
-        "settings" => Some("settings-title"),
-        "spaces" => Some("spaces-title"),
-        "start" => Some("start-title"),
-        "team" => Some("team-title"),
-        "terminal" => Some("command-terminal"),
-        _ => None,
-    }
 }
 
 #[derive(SystemParam)]

--- a/crates/page/vmux_layout/src/host.rs
+++ b/crates/page/vmux_layout/src/host.rs
@@ -63,6 +63,8 @@ pub use crate::command_bar::handler::PendingCommandBarReveal;
 pub const LAYOUT_PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
     host: "layout",
     title: "Layout",
+    title_message_id: None,
+    replaces_command: None,
     keywords: &[],
     icon: None,
     command_bar: false,
@@ -71,6 +73,8 @@ pub const COMMAND_BAR_PAGE_MANIFEST: vmux_core::page::PageManifest =
     vmux_core::page::PageManifest {
         host: "command-bar",
         title: "Command Bar",
+        title_message_id: None,
+        replaces_command: None,
         keywords: &[],
         icon: None,
         command_bar: false,
@@ -78,6 +82,8 @@ pub const COMMAND_BAR_PAGE_MANIFEST: vmux_core::page::PageManifest =
 pub const DEBUG_PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
     host: "debug",
     title: "Debug",
+    title_message_id: None,
+    replaces_command: None,
     keywords: &[],
     icon: None,
     command_bar: false,
@@ -85,6 +91,8 @@ pub const DEBUG_PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::
 pub const ERROR_PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
     host: "error",
     title: "Error",
+    title_message_id: None,
+    replaces_command: None,
     keywords: &[],
     icon: None,
     command_bar: false,

--- a/crates/page/vmux_layout/src/start.rs
+++ b/crates/page/vmux_layout/src/start.rs
@@ -44,6 +44,8 @@ pub const START_PAGE_URL: &str = "vmux://start/";
 pub const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
     host: "start",
     title: "Start",
+    title_message_id: Some("start-title"),
+    replaces_command: None,
     keywords: &["start", "home", "new tab", "launcher"],
     icon: Some(vmux_core::icon::BuiltinIcon::Sparkles),
     command_bar: true,

--- a/crates/page/vmux_setting/src/host.rs
+++ b/crates/page/vmux_setting/src/host.rs
@@ -48,6 +48,8 @@ impl Plugin for SettingsPlugin {
 pub const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
     host: "settings",
     title: "Settings",
+    title_message_id: Some("settings-title"),
+    replaces_command: None,
     keywords: &["preferences", "config"],
     icon: Some(vmux_core::BuiltinIcon::Settings),
     command_bar: true,

--- a/crates/page/vmux_space/src/host.rs
+++ b/crates/page/vmux_space/src/host.rs
@@ -9,6 +9,8 @@ pub mod spaces;
 pub const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
     host: "spaces",
     title: "Spaces",
+    title_message_id: Some("spaces-title"),
+    replaces_command: None,
     keywords: &["space"],
     icon: Some(vmux_core::BuiltinIcon::Layers),
     command_bar: true,

--- a/crates/page/vmux_team/src/host.rs
+++ b/crates/page/vmux_team/src/host.rs
@@ -43,6 +43,8 @@ impl Plugin for TeamPlugin {
 pub const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
     host: "team",
     title: "Team",
+    title_message_id: Some("team-title"),
+    replaces_command: None,
     keywords: &["team", "agents", "profile"],
     icon: Some(vmux_core::BuiltinIcon::Users),
     command_bar: true,

--- a/crates/page/vmux_terminal/src/host.rs
+++ b/crates/page/vmux_terminal/src/host.rs
@@ -26,6 +26,8 @@ pub use plugin::*;
 pub const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
     host: "terminal",
     title: "Terminal",
+    title_message_id: Some("command-terminal"),
+    replaces_command: None,
     keywords: &["shell", "console"],
     icon: Some(vmux_core::BuiltinIcon::Terminal),
     command_bar: true,

--- a/crates/vmux_browser/src/extensions/manager_page.rs
+++ b/crates/vmux_browser/src/extensions/manager_page.rs
@@ -66,6 +66,8 @@ impl Plugin for ExtensionsPlugin {
 const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
     host: "extensions",
     title: "Extensions",
+    title_message_id: Some("extensions-title"),
+    replaces_command: None,
     keywords: &["extension", "extensions", "chrome", "addon", "install"],
     icon: Some(vmux_core::BuiltinIcon::Puzzle),
     command_bar: true,

--- a/crates/vmux_browser/src/page_life.rs
+++ b/crates/vmux_browser/src/page_life.rs
@@ -161,6 +161,8 @@ mod apply_page_icons_tests {
     const TEAM: PageManifest = PageManifest {
         host: "team",
         title: "Team",
+        title_message_id: Some("team-title"),
+        replaces_command: None,
         keywords: &[],
         icon: Some(BuiltinIcon::Users),
         command_bar: true,
@@ -168,6 +170,8 @@ mod apply_page_icons_tests {
     const AGENT: PageManifest = PageManifest {
         host: "agent",
         title: "Agent",
+        title_message_id: None,
+        replaces_command: None,
         keywords: &[],
         icon: Some(BuiltinIcon::Sparkles),
         command_bar: false,

--- a/crates/vmux_command/src/host/snapshot.rs
+++ b/crates/vmux_command/src/host/snapshot.rs
@@ -280,7 +280,19 @@ pub struct CommandBarTerminalsSnapshot {
 
 #[derive(Resource, Default, Clone, Debug)]
 pub struct CommandBarPagesSnapshot {
-    pub pages: Vec<CommandBarPage>,
+    pub pages: Vec<RegisteredPage>,
+}
+
+/// A page the command bar lists, with the parts of its manifest that only resolve per locale.
+///
+/// The title and the superseded command stay unresolved here because the snapshot is built once at
+/// startup and the locale can change after it. Whoever renders the payload holds the locale and
+/// finishes the job.
+#[derive(Clone, Debug)]
+pub struct RegisteredPage {
+    pub page: CommandBarPage,
+    pub title_message_id: Option<&'static str>,
+    pub replaces_command: Option<&'static str>,
 }
 
 /// Command-bar "current work" data: working dirs of open terminal/agent panes and
@@ -299,23 +311,29 @@ fn update_pages_snapshot(
     if !snapshot.pages.is_empty() {
         return;
     }
-    let mut pages: Vec<CommandBarPage> = manifests
-        .iter()
-        .filter(|manifest| manifest.command_bar)
-        .map(|manifest| CommandBarPage {
-            host: manifest.host.to_string(),
-            url: manifest.url(),
-            title: manifest.title.to_string(),
-            keywords: manifest.keywords.iter().map(|k| k.to_string()).collect(),
-            icon: manifest
-                .icon
-                .map(vmux_core::PageIcon::Builtin)
-                .unwrap_or_default(),
-            shortcut: String::new(),
-            prompt_target: false,
-        })
-        .collect();
-    pages.sort_by(|a, b| a.url.cmp(&b.url));
+    let mut pages = Vec::new();
+    for manifest in &manifests {
+        if !manifest.command_bar {
+            continue;
+        }
+        pages.push(RegisteredPage {
+            page: CommandBarPage {
+                host: manifest.host.to_string(),
+                url: manifest.url(),
+                title: manifest.title.to_string(),
+                keywords: manifest.keywords.iter().map(|k| k.to_string()).collect(),
+                icon: manifest
+                    .icon
+                    .map(vmux_core::PageIcon::Builtin)
+                    .unwrap_or_default(),
+                shortcut: String::new(),
+                prompt_target: false,
+            },
+            title_message_id: manifest.title_message_id,
+            replaces_command: manifest.replaces_command,
+        });
+    }
+    pages.sort_by(|a, b| a.page.url.cmp(&b.page.url));
     snapshot.pages = pages;
 }
 
@@ -532,15 +550,19 @@ mod tests {
         app.init_resource::<CommandBarPagesSnapshot>()
             .add_systems(Update, update_pages_snapshot);
         app.world_mut().spawn(PageManifest {
-            host: "settings",
-            title: "Settings",
-            keywords: &["preferences"],
+            host: "services",
+            title: "Services",
+            title_message_id: Some("services-title"),
+            replaces_command: Some("service_open"),
+            keywords: &["daemon"],
             icon: Some(vmux_core::BuiltinIcon::Settings),
             command_bar: true,
         });
         app.world_mut().spawn(PageManifest {
             host: "layout",
             title: "Layout",
+            title_message_id: None,
+            replaces_command: None,
             keywords: &[],
             icon: None,
             command_bar: false,
@@ -550,7 +572,9 @@ mod tests {
 
         let snap = app.world().resource::<CommandBarPagesSnapshot>();
         assert_eq!(snap.pages.len(), 1);
-        assert_eq!(snap.pages[0].host, "settings");
-        assert_eq!(snap.pages[0].url, "vmux://settings/");
+        assert_eq!(snap.pages[0].page.host, "services");
+        assert_eq!(snap.pages[0].page.url, "vmux://services/");
+        assert_eq!(snap.pages[0].title_message_id, Some("services-title"));
+        assert_eq!(snap.pages[0].replaces_command, Some("service_open"));
     }
 }

--- a/crates/vmux_core/src/host/page.rs
+++ b/crates/vmux_core/src/host/page.rs
@@ -27,6 +27,18 @@ pub const PAGE_READY_BIN_EVENT_ID: &str = "vmux-page-ready";
 pub struct PageManifest {
     pub host: &'static str,
     pub title: &'static str,
+    /// Fluent id naming this page in the command bar, resolved against the active locale.
+    ///
+    /// `None` falls back to [`Self::title`], which is untranslated. Declared here rather than
+    /// looked up by host so a page names itself, and adding one does not mean editing the command
+    /// bar.
+    pub title_message_id: Option<&'static str>,
+    /// A command id this page supersedes.
+    ///
+    /// The command's own row is dropped from the command bar and its shortcut is shown on this
+    /// page's entry instead, because reaching the page is what the command did. Its menu item and
+    /// its keybinding are untouched.
+    pub replaces_command: Option<&'static str>,
     pub keywords: &'static [&'static str],
     pub icon: Option<crate::icon::BuiltinIcon>,
     pub command_bar: bool,
@@ -240,6 +252,8 @@ mod tests {
         let manifest = PageManifest {
             host: "settings",
             title: "Settings",
+            title_message_id: Some("settings-title"),
+            replaces_command: None,
             keywords: &["preferences"],
             icon: Some(crate::icon::BuiltinIcon::Settings),
             command_bar: true,
@@ -280,6 +294,8 @@ mod tests {
         app.world_mut().spawn(PageManifest {
             host: "history",
             title: "History",
+            title_message_id: Some("history-title"),
+            replaces_command: Some("browser_open_history"),
             keywords: &["recent", "visited"],
             icon: Some(crate::icon::BuiltinIcon::Clock),
             command_bar: true,
@@ -301,6 +317,8 @@ mod tests {
         let manifest = PageManifest {
             host: "history",
             title: "History",
+            title_message_id: Some("history-title"),
+            replaces_command: Some("browser_open_history"),
             keywords: &["recent", "visited"],
             icon: Some(crate::icon::BuiltinIcon::Clock),
             command_bar: true,


### PR DESCRIPTION
Stage 2 of [VMX-163](https://linear.app/vmux/issue/VMX-163/let-each-crate-own-its-command-bar-rows). Stacked on #361 — review that first.

`vmux_layout` knew three things about other crates' pages that it had no way to learn:

```rust
fn page_title_message_id(host: &str) -> Option<&'static str> {
    match host {
        "agents" => Some("agents-title"),
        "extensions" => Some("extensions-title"),
        "history" => Some("history-title"),
        ...
```

```rust
const COMMAND_BAR_SKIP_IDS: &[&str] = &["service_open", "browser_open_history"];
```

```rust
let history_shortcut = command_shortcut("browser_open_history");
if !history_shortcut.is_empty()
    && let Some(page) = pages.iter_mut().find(|page| page.host == "history")
{ page.shortcut = history_shortcut; }
```

Every one of those pages already translates its own title in its own page component — `vmux_team/src/page.rs` calls `translate("team-title")`. The match was a second copy of that fact, kept in sync by nothing, and adding a page meant editing the command bar to make it speak French.

## What changed

`PageManifest` gains two fields, so a page declares these where it declares everything else:

```rust
pub title_message_id: Option<&'static str>,
pub replaces_command: Option<&'static str>,
```

The skip list and the history shortcut turn out to be **the same fact** — a page stands in for a command — so they collapse into `replaces_command`. Both special cases go, and `command_list` takes the superseded ids rather than owning a const.

`CommandBarPagesSnapshot` now holds `RegisteredPage` rather than the wire type alone. A title cannot be resolved when the snapshot is built at startup, because the locale can change after that; the payload builder holds the locale and finishes the job.

## Behaviour changes

Two, both deliberate:

- **`tools` and `vault` get translated titles for the first time.** Both ids already existed in all 110 bundled locales; only the host match stood between them and being used. Previously these two showed the untranslated English `manifest.title` in every locale.
- **A command is now hidden because a registered page replaces it**, not because it is on a list. In a build without `vmux_service`, `service_open` keeps its row instead of vanishing with nothing to stand in for it.

`command_shortcut("service_open")` is empty (`ServiceCommand::Open` declares no shortcut), so unifying the shortcut path leaves the services entry exactly as it was.

## Test plan

- [x] `pages_snapshot_collects_only_command_bar_pages` extended to assert both new fields survive the manifest → snapshot hop.
- [x] `cargo test --workspace --exclude bevy_cef_core --exclude bevy_cef` — 2977 passed, 0 failed.
- [x] `cargo clippy <all non-patch pkgs> --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [ ] At a keyboard: `cmd+k` and confirm History, Services, Settings, Spaces, Team, Agents, Terminal, LSP, Extensions and Start are all still named correctly; History still shows its shortcut on the page row; neither "Open Service Monitor" nor the History command appears as its own row.
- [ ] Switch to a non-English locale and confirm the ten titles translate, and that Tools and Vault now translate too.
