### PR TITLE
refactor(command-bar): let each crate own what it knows

### DIFF
--- a/crates/page/vmux_agent/src/host/command_bar.rs
+++ b/crates/page/vmux_agent/src/host/command_bar.rs
@@ -6,8 +6,10 @@
 //! between them, and splitting it would let the two drift.
 
 use bevy::prelude::*;
+use vmux_command::event::CommandBarPage;
 use vmux_command::snapshot::{
-    ClaimedUrl, CommandBarAgentsSnapshot, ContributedCommand, WriteCommandBarSnapshots,
+    AgentPromptTarget, ClaimedUrl, CommandBarAgentsSnapshot, ContributedCommand, ContributedPage,
+    WriteCommandBarSnapshots,
 };
 use vmux_core::agent::{
     PageAgentAttachDefaultRequest, PageAgentAttachRequest, PageAgentSpawnDefaultRequest,
@@ -42,6 +44,70 @@ const DEFAULT_AGENT_URLS: [&str; 2] = ["vmux://agent/", "vmux://agent"];
 #[derive(Component)]
 struct AgentContribution;
 
+impl AgentContribution {
+    /// Launcher rows for installed ACP and CLI agents, most recently used first.
+    ///
+    /// What an agent looks like in a launcher is this crate's to decide: that a CLI provider is
+    /// labelled as one, that an ACP agent's icon is a favicon when the registry gave it a url, and
+    /// that recency beats alphabetical. Rank is written onto each row because the entities these
+    /// become carry preference rather than inherit it from a position in a list.
+    fn launcher_pages(agents: &CommandBarAgentsSnapshot) -> Vec<ContributedPage> {
+        let mut pages = Vec::with_capacity(agents.acp.len() + agents.providers.len());
+        for agent in &agents.acp {
+            pages.push(ContributedPage {
+                id: agent.id.clone(),
+                rank: 0,
+                page: CommandBarPage {
+                    host: "agent".to_string(),
+                    url: agent.url.clone(),
+                    title: agent.name.clone(),
+                    keywords: vec![agent.id.clone(), "acp".to_string(), "agent".to_string()],
+                    icon: if agent.icon.is_empty() {
+                        vmux_core::PageIcon::None
+                    } else {
+                        vmux_core::PageIcon::Favicon(agent.icon.clone())
+                    },
+                    shortcut: String::new(),
+                    prompt_target: true,
+                },
+            });
+        }
+        for agent in &agents.providers {
+            pages.push(ContributedPage {
+                id: agent.id.clone(),
+                rank: 0,
+                page: CommandBarPage {
+                    host: "agent".to_string(),
+                    url: agent.url.clone(),
+                    title: format!("{} (CLI)", agent.name),
+                    keywords: vec![agent.id.clone(), "cli".to_string(), "agent".to_string()],
+                    icon: vmux_core::PageIcon::None,
+                    shortcut: String::new(),
+                    prompt_target: true,
+                },
+            });
+        }
+        let recency = AgentPromptTarget::recency_ranks(&agents.recent);
+        pages.sort_by(|a, b| {
+            recency
+                .get(&a.page.url)
+                .copied()
+                .unwrap_or(usize::MAX)
+                .cmp(&recency.get(&b.page.url).copied().unwrap_or(usize::MAX))
+                .then_with(|| {
+                    a.page
+                        .title
+                        .to_lowercase()
+                        .cmp(&b.page.title.to_lowercase())
+                })
+        });
+        for (rank, page) in pages.iter_mut().enumerate() {
+            page.rank = rank;
+        }
+        pages
+    }
+}
+
 /// Publish the agents to launch, and a row per model.
 fn publish_contributions(
     agents: Res<CommandBarAgentsSnapshot>,
@@ -54,7 +120,7 @@ fn publish_contributions(
     for entity in mine.iter() {
         commands.entity(entity).despawn();
     }
-    for page in agents.launcher_pages() {
+    for page in AgentContribution::launcher_pages(&agents) {
         commands.spawn((AgentContribution, page));
     }
     for strategy in &agents.strategies {
@@ -151,7 +217,50 @@ impl std::fmt::Display for AppAgentId {
 mod tests {
     use super::*;
     use bevy::ecs::system::RunSystemOnce;
-    use vmux_command::snapshot::Contributions;
+    use vmux_command::snapshot::{AgentProviderSummary, Contributions};
+    use vmux_core::agent::AgentKind;
+
+    /// The launcher lists exactly what is installed, most recently used first, and each row
+    /// carries that order as its rank because the entity it becomes has no position to inherit.
+    #[test]
+    fn launcher_pages_list_only_installed_agents_in_recent_order() {
+        let snapshot = CommandBarAgentsSnapshot {
+            providers: vec![AgentProviderSummary {
+                id: "codex".to_string(),
+                name: "Codex".to_string(),
+                url: "vmux://agent/codex/cli".to_string(),
+                icon: String::new(),
+            }],
+            acp: vec![AgentProviderSummary {
+                id: "claude-acp".to_string(),
+                name: "Claude Agent".to_string(),
+                url: "vmux://agent/claude".to_string(),
+                icon: "https://cdn.example/claude-acp.svg".to_string(),
+            }],
+            recent: vec![
+                AgentPromptTarget::Cli(AgentKind::Codex),
+                AgentPromptTarget::Acp {
+                    id: "claude".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+
+        let pages = AgentContribution::launcher_pages(&snapshot);
+
+        assert_eq!(pages.len(), 2);
+        assert_eq!(pages[0].id, "codex");
+        assert_eq!(pages[0].rank, 0);
+        assert_eq!(pages[0].page.url, "vmux://agent/codex/cli");
+        assert_eq!(pages[0].page.title, "Codex (CLI)");
+        assert_eq!(pages[0].page.host, "agent");
+        assert_eq!(pages[1].rank, 1);
+        assert_eq!(pages[1].page.title, "Claude Agent");
+        assert!(matches!(
+            pages[1].page.icon,
+            vmux_core::PageIcon::Favicon(ref u) if u == "https://cdn.example/claude-acp.svg"
+        ));
+    }
 
     /// The id is a private round trip between the two halves of this file. A row whose id does not
     /// survive it is published and then silently ignored when the user picks it.

--- a/crates/page/vmux_layout/src/command_bar/handler.rs
+++ b/crates/page/vmux_layout/src/command_bar/handler.rs
@@ -1288,11 +1288,14 @@ fn on_command_bar_action(
         .as_deref()
         .map(|locale| locale.0.clone())
         .unwrap_or_else(Locale::preferred);
-    match evt.action.as_str() {
-        "prompt" => {
-            let prompt = evt.value.trim();
-            let attachments = evt
-                .attachments
+    match evt {
+        CommandBarActionEvent::Prompt {
+            text,
+            target_url,
+            attachments: submitted,
+        } => {
+            let prompt = text.trim();
+            let attachments = submitted
                 .iter()
                 .filter(|attachment| !attachment.path.is_empty())
                 .map(|attachment| vmux_wire::protocol::AgentAttachment {
@@ -1305,7 +1308,7 @@ fn on_command_bar_action(
             if !prompt.is_empty() || !attachments.is_empty() {
                 let focused = queries.focused_stack();
                 if let Some(stack) = empty_stack.or(focused)
-                    && let Some(url) = resource_params.p2().prompt_url(evt.target_url.as_deref())
+                    && let Some(url) = resource_params.p2().prompt_url(target_url.as_deref())
                 {
                     if inline_transition_stack == Some(stack)
                         && crate::start::supports_inline_agent_transition(&url)
@@ -1333,21 +1336,19 @@ fn on_command_bar_action(
                 }
             }
         }
-        "open" => {
-            let expanded = if evt.value.starts_with('~') {
+        CommandBarActionEvent::Open { value, open } => {
+            let expanded = if value.starts_with('~') {
                 std::env::var("HOME")
                     .ok()
-                    .map(|h| {
-                        std::path::PathBuf::from(h).join(evt.value[1..].trim_start_matches('/'))
-                    })
-                    .unwrap_or_else(|| std::path::PathBuf::from(&evt.value))
-            } else if evt.value.starts_with('/') {
-                std::path::PathBuf::from(&evt.value)
+                    .map(|h| std::path::PathBuf::from(h).join(value[1..].trim_start_matches('/')))
+                    .unwrap_or_else(|| std::path::PathBuf::from(&value))
+            } else if value.starts_with('/') {
+                std::path::PathBuf::from(&value)
             } else {
                 std::env::var("HOME")
                     .ok()
-                    .map(|h| std::path::PathBuf::from(h).join(&evt.value))
-                    .unwrap_or_else(|| std::path::PathBuf::from(&evt.value))
+                    .map(|h| std::path::PathBuf::from(h).join(value))
+                    .unwrap_or_else(|| std::path::PathBuf::from(&value))
             };
             let is_path = expanded.exists();
 
@@ -1376,10 +1377,10 @@ fn on_command_bar_action(
                 }
             } else {
                 let url = normalize_url(
-                    &evt.value,
+                    value,
                     search_engine.map(|setting| setting.0).unwrap_or_default(),
                 );
-                let inline_transition = if matches!(evt.target, None | Some(OpenTarget::InPlace))
+                let inline_transition = if matches!(open, None | Some(OpenTarget::InPlace))
                     && crate::start::supports_inline_agent_transition(&url)
                     && let Some(stack) = inline_transition_stack
                 {
@@ -1419,7 +1420,7 @@ fn on_command_bar_action(
                     new_stack_ctx.previous_stack = None;
                     custom_keyboard_restore = true;
                 } else {
-                    let target = evt.target;
+                    let target = *open;
                     let cmd =
                         AppCommand::Browser(BrowserCommand::Open(build_open_command(target, url)));
                     issued.write(vmux_command::CommandIssued {
@@ -1430,30 +1431,30 @@ fn on_command_bar_action(
                 }
             }
         }
-        "terminal" => {
-            let known_terminal = running_terminals.get(&evt.value).copied();
+        CommandBarActionEvent::Terminal { value } => {
+            let known_terminal = running_terminals.get(value).copied();
             if let Some(entity) = known_terminal {
                 focus_pane_entity(entity, &mut commands, &queries.child_of_q);
                 new_stack_ctx.stack = None;
                 new_stack_ctx.previous_stack = None;
                 custom_keyboard_restore = true;
             } else {
-                if evt.value.starts_with(&terminal_page_url) {
-                    bevy::log::warn!("no terminal pane for {}; spawning new", evt.value);
+                if value.starts_with(&terminal_page_url) {
+                    bevy::log::warn!("no terminal pane for {}; spawning new", value);
                 }
-                let cwd = if evt.value.is_empty() || evt.value.contains("://") {
+                let cwd = if value.is_empty() || value.contains("://") {
                     None
                 } else {
-                    let expanded = if evt.value.starts_with("~/") {
+                    let expanded = if value.starts_with("~/") {
                         std::env::var("HOME")
-                            .map(|h| std::path::PathBuf::from(h).join(&evt.value[2..]))
-                            .unwrap_or_else(|_| std::path::PathBuf::from(&evt.value))
-                    } else if evt.value.starts_with('/') {
-                        std::path::PathBuf::from(&evt.value)
+                            .map(|h| std::path::PathBuf::from(h).join(&value[2..]))
+                            .unwrap_or_else(|_| std::path::PathBuf::from(&value))
+                    } else if value.starts_with('/') {
+                        std::path::PathBuf::from(&value)
                     } else {
                         std::env::var("HOME")
-                            .map(|h| std::path::PathBuf::from(h).join(&evt.value))
-                            .unwrap_or_else(|_| std::path::PathBuf::from(&evt.value))
+                            .map(|h| std::path::PathBuf::from(h).join(value))
+                            .unwrap_or_else(|_| std::path::PathBuf::from(&value))
                     };
                     Some(expanded)
                 };
@@ -1503,11 +1504,11 @@ fn on_command_bar_action(
                 }
             } // end reattach else
         }
-        "command" => {
+        CommandBarActionEvent::Command { id, open } => {
             let is_contributed = resource_params
                 .p2()
                 .commands()
-                .any(|command| command.id == evt.value);
+                .any(|command| &command.id == id);
             if is_contributed {
                 let pane = match empty_stack {
                     Some(_) => None,
@@ -1523,13 +1524,13 @@ fn on_command_bar_action(
                 }
                 if empty_stack.is_some() || pane.is_some() {
                     chosen_writer.write(crate::ContributedCommandChosen {
-                        id: evt.value.clone(),
+                        id: id.clone(),
                         stack: empty_stack,
                         pane,
                     });
                     custom_keyboard_restore = true;
                 }
-            } else if let Some(url) = resource_params.p2().page_url(&evt.value) {
+            } else if let Some(url) = resource_params.p2().page_url(id) {
                 if let Some(stack_e) = empty_stack {
                     writer_params.p1().write(PageOpenRequest {
                         target: PageOpenTarget::Stack(stack_e),
@@ -1540,7 +1541,7 @@ fn on_command_bar_action(
                     new_stack_ctx.previous_stack = None;
                     empty_stack = None;
                 } else {
-                    let target = evt.target;
+                    let target = *open;
                     let cmd =
                         AppCommand::Browser(BrowserCommand::Open(build_open_command(target, url)));
                     issued.write(vmux_command::CommandIssued {
@@ -1550,7 +1551,7 @@ fn on_command_bar_action(
                     writer_params.p0().write(cmd);
                 }
                 custom_keyboard_restore = true;
-            } else if let Some(cmd) = match_command(&evt.value) {
+            } else if let Some(cmd) = match_command(id) {
                 issued.write(vmux_command::CommandIssued {
                     caller,
                     command: cmd.clone(),
@@ -1564,14 +1565,14 @@ fn on_command_bar_action(
                 new_stack_ctx.previous_stack = None;
             }
         }
-        "space" => {
+        CommandBarActionEvent::Space { id } => {
             custom_keyboard_restore = true;
-            if !evt.value.is_empty() {
+            if !id.is_empty() {
                 commands.trigger(BinReceive {
                     webview,
                     payload: SpaceCommandEvent {
                         command: "attach".to_string(),
-                        space_id: Some(evt.value.clone()),
+                        space_id: Some(id.clone()),
                         name: None,
                     },
                 });
@@ -1582,19 +1583,14 @@ fn on_command_bar_action(
                 new_stack_ctx.previous_stack = None;
             }
         }
-        "switch_tab" => {
+        CommandBarActionEvent::SwitchTab { pane, index } => {
             // Despawn empty tab if in new-tab mode
             if let Some(stack_e) = empty_stack {
                 commands.entity(stack_e).despawn();
                 new_stack_ctx.stack = None;
                 new_stack_ctx.previous_stack = None;
             }
-            if let Some((pane_bits, tab_idx)) = evt.value.split_once(':')
-                && let (Ok(pane_id), Ok(tab_index)) =
-                    (pane_bits.parse::<u64>(), tab_idx.parse::<usize>())
-                && let Some(target_pane) =
-                    queries.leaf_panes.iter().find(|e| e.to_bits() == pane_id)
-            {
+            if let Some(target_pane) = queries.leaf_panes.iter().find(|e| e.to_bits() == *pane) {
                 let target_stack = {
                     let stack_q = stack_params.p0();
                     queries
@@ -1602,10 +1598,7 @@ fn on_command_bar_action(
                         .get(target_pane)
                         .ok()
                         .and_then(|children| {
-                            children
-                                .iter()
-                                .filter(|&e| stack_q.contains(e))
-                                .nth(tab_index)
+                            children.iter().filter(|&e| stack_q.contains(e)).nth(*index)
                         })
                 };
                 // Activate the whole chain (stack -> pane -> tab -> space), not just the
@@ -1618,8 +1611,7 @@ fn on_command_bar_action(
                 }
             }
         }
-        _ => {
-            // "dismiss" and unknown actions
+        CommandBarActionEvent::Dismiss => {
             if let Some(stack_e) = empty_stack {
                 let stack_q = stack_params.p0();
                 let closed_tab = close_tab_if_only_pending_stack(
@@ -1829,13 +1821,7 @@ fn reveal_command_bar(
             commands.entity(entity).remove::<PendingCommandBarReveal>();
             commands.trigger(BinReceive::<CommandBarActionEvent> {
                 webview: entity,
-                payload: CommandBarActionEvent {
-                    action: "dismiss".to_string(),
-                    value: String::new(),
-                    target: None,
-                    target_url: None,
-                    attachments: Vec::new(),
-                },
+                payload: CommandBarActionEvent::Dismiss,
             });
             continue;
         }
@@ -2876,13 +2862,7 @@ mod tests {
         app.world_mut()
             .trigger(BinReceive::<CommandBarActionEvent> {
                 webview: modal,
-                payload: CommandBarActionEvent {
-                    action: "dismiss".to_string(),
-                    value: String::new(),
-                    target: None,
-                    target_url: None,
-                    attachments: Vec::new(),
-                },
+                payload: CommandBarActionEvent::Dismiss,
             });
         app.world_mut().flush();
 

--- a/crates/page/vmux_layout/src/command_bar/handler.rs
+++ b/crates/page/vmux_layout/src/command_bar/handler.rs
@@ -113,14 +113,6 @@ impl Plugin for CommandBarInputPlugin {
     }
 }
 
-pub(crate) fn parse_pid_from_url(url: &str, terminal_page_url: &str) -> Option<u32> {
-    let suffix = url.strip_prefix(terminal_page_url)?;
-    if suffix.is_empty() {
-        return None;
-    }
-    suffix.parse::<u32>().ok()
-}
-
 #[derive(Component)]
 struct CommandBarReady;
 
@@ -1286,7 +1278,7 @@ fn on_command_bar_action(
     let caller = user_q.single().unwrap_or(Entity::PLACEHOLDER);
     let terminals_snapshot = resource_params.p1().clone();
     let terminal_page_url = terminals_snapshot.terminal_page_url.clone();
-    let pid_to_entity = terminals_snapshot.pid_to_entity.clone();
+    let running_terminals = terminals_snapshot.running.clone();
     let mut empty_stack = new_stack_ctx.stack;
     let previous_stack = new_stack_ctx.previous_stack;
     let mut custom_keyboard_restore = false;
@@ -1439,16 +1431,15 @@ fn on_command_bar_action(
             }
         }
         "terminal" => {
-            let known_terminal = parse_pid_from_url(&evt.value, &terminal_page_url)
-                .and_then(|p| pid_to_entity.get(&p).copied());
+            let known_terminal = running_terminals.get(&evt.value).copied();
             if let Some(entity) = known_terminal {
                 focus_pane_entity(entity, &mut commands, &queries.child_of_q);
                 new_stack_ctx.stack = None;
                 new_stack_ctx.previous_stack = None;
                 custom_keyboard_restore = true;
             } else {
-                if let Some(pid) = parse_pid_from_url(&evt.value, &terminal_page_url) {
-                    bevy::log::warn!("no terminal pane for pid {pid}; spawning new");
+                if evt.value.starts_with(&terminal_page_url) {
+                    bevy::log::warn!("no terminal pane for {}; spawning new", evt.value);
                 }
                 let cwd = if evt.value.is_empty() || evt.value.contains("://") {
                     None
@@ -1520,10 +1511,7 @@ fn on_command_bar_action(
             if is_contributed {
                 let pane = match empty_stack {
                     Some(_) => None,
-                    None => {
-                        let active_pane_opt = queries.focused_pane();
-                        active_pane_opt
-                    }
+                    None => queries.focused_pane(),
                 };
                 if let Some(stack_e) = empty_stack {
                     commands.entity(stack_e).insert(LastActivatedAt::now());
@@ -3000,42 +2988,6 @@ mod tests {
             NodeId::Set(tab_command_set),
             NodeId::System(command_bar_open_system)
         ));
-    }
-
-    const TEST_TERMINAL_URL: &str = "vmux://terminal/";
-
-    #[test]
-    fn parse_pid_from_url_accepts_numeric() {
-        assert_eq!(
-            parse_pid_from_url("vmux://terminal/12345", TEST_TERMINAL_URL),
-            Some(12345)
-        );
-        assert_eq!(
-            parse_pid_from_url("vmux://terminal/0", TEST_TERMINAL_URL),
-            Some(0)
-        );
-    }
-
-    #[test]
-    fn parse_pid_from_url_rejects_uuid_form() {
-        let uuid_url = "vmux://terminal/ae724a54-c387-5359-0687-ccfc155558b6";
-        assert_eq!(parse_pid_from_url(uuid_url, TEST_TERMINAL_URL), None);
-    }
-
-    #[test]
-    fn parse_pid_from_url_rejects_empty_path() {
-        assert_eq!(
-            parse_pid_from_url("vmux://terminal/", TEST_TERMINAL_URL),
-            None
-        );
-    }
-
-    #[test]
-    fn parse_pid_from_url_rejects_overflow() {
-        assert_eq!(
-            parse_pid_from_url("vmux://terminal/99999999999999999", TEST_TERMINAL_URL),
-            None
-        );
     }
 
     #[test]

--- a/crates/page/vmux_layout/src/command_bar/handler.rs
+++ b/crates/page/vmux_layout/src/command_bar/handler.rs
@@ -1164,17 +1164,43 @@ struct CommandBarActionQueries<'w, 's> {
     webview_sources: Query<'w, 's, &'static WebviewSource>,
 }
 
-fn inline_transition_stack_for(
-    webview: Entity,
-    queries: &CommandBarActionQueries,
-) -> Option<Entity> {
-    let WebviewSource::Url(url) = queries.webview_sources.get(webview).ok()? else {
-        return None;
-    };
-    if !url.starts_with(crate::start::START_PAGE_URL) {
-        return None;
+impl CommandBarActionQueries<'_, '_> {
+    /// The stack an action lands in when the command bar did not open an empty one for it.
+    fn focused_stack(&self) -> Option<Entity> {
+        let (_, _, stack) = focused_stack(
+            self.active_tab_param.get(),
+            &self.all_children,
+            &self.leaf_panes,
+            &self.pane_ts,
+            &self.pane_children,
+            &self.stack_ts,
+        );
+        stack
     }
-    queries.child_of_q.get(webview).ok().map(|parent| parent.0)
+
+    /// The pane an action lands in when there is no stack to put it in.
+    fn focused_pane(&self) -> Option<Entity> {
+        let (_, pane, _) = focused_stack(
+            self.active_tab_param.get(),
+            &self.all_children,
+            &self.leaf_panes,
+            &self.pane_ts,
+            &self.pane_children,
+            &self.stack_ts,
+        );
+        pane
+    }
+
+    /// The stack holding the start page that raised this action, which can transition in place.
+    fn inline_transition_stack(&self, webview: Entity) -> Option<Entity> {
+        let WebviewSource::Url(url) = self.webview_sources.get(webview).ok()? else {
+            return None;
+        };
+        if !url.starts_with(crate::start::START_PAGE_URL) {
+            return None;
+        }
+        self.child_of_q.get(webview).ok().map(|parent| parent.0)
+    }
 }
 
 fn mark_inline_transition(stack: Entity, webview: Entity, commands: &mut Commands) {
@@ -1264,7 +1290,7 @@ fn on_command_bar_action(
     let mut empty_stack = new_stack_ctx.stack;
     let previous_stack = new_stack_ctx.previous_stack;
     let mut custom_keyboard_restore = false;
-    let inline_transition_stack = inline_transition_stack_for(webview, &queries);
+    let inline_transition_stack = queries.inline_transition_stack(webview);
     let locale = resource_params
         .p3()
         .as_deref()
@@ -1285,15 +1311,8 @@ fn on_command_bar_action(
                 })
                 .collect::<Vec<_>>();
             if !prompt.is_empty() || !attachments.is_empty() {
-                let (_, _, focused_stack) = focused_stack(
-                    queries.active_tab_param.get(),
-                    &queries.all_children,
-                    &queries.leaf_panes,
-                    &queries.pane_ts,
-                    &queries.pane_children,
-                    &queries.stack_ts,
-                );
-                if let Some(stack) = empty_stack.or(focused_stack)
+                let focused = queries.focused_stack();
+                if let Some(stack) = empty_stack.or(focused)
                     && let Some(url) = resource_params.p2().prompt_url(evt.target_url.as_deref())
                 {
                     if inline_transition_stack == Some(stack)
@@ -1388,14 +1407,7 @@ fn on_command_bar_action(
                         new_stack_ctx.previous_stack = None;
                         custom_keyboard_restore = true;
                     } else {
-                        let (_, active_pane_opt, _) = focused_stack(
-                            queries.active_tab_param.get(),
-                            &queries.all_children,
-                            &queries.leaf_panes,
-                            &queries.pane_ts,
-                            &queries.pane_children,
-                            &queries.stack_ts,
-                        );
+                        let active_pane_opt = queries.focused_pane();
                         if let Some(pane_e) = active_pane_opt {
                             chosen_writer.write(crate::ContributedCommandChosen {
                                 id: url.clone(),
@@ -1468,14 +1480,7 @@ fn on_command_bar_action(
                     new_stack_ctx.previous_stack = None;
                     custom_keyboard_restore = true;
                 } else {
-                    let (_, active_pane_opt, _) = focused_stack(
-                        queries.active_tab_param.get(),
-                        &queries.all_children,
-                        &queries.leaf_panes,
-                        &queries.pane_ts,
-                        &queries.pane_children,
-                        &queries.stack_ts,
-                    );
+                    let active_pane_opt = queries.focused_pane();
                     if let Some(pane_e) = active_pane_opt {
                         let stack_e = commands
                             .spawn((
@@ -1516,14 +1521,7 @@ fn on_command_bar_action(
                 let pane = match empty_stack {
                     Some(_) => None,
                     None => {
-                        let (_, active_pane_opt, _) = focused_stack(
-                            queries.active_tab_param.get(),
-                            &queries.all_children,
-                            &queries.leaf_panes,
-                            &queries.pane_ts,
-                            &queries.pane_children,
-                            &queries.stack_ts,
-                        );
+                        let active_pane_opt = queries.focused_pane();
                         active_pane_opt
                     }
                 };
@@ -1680,14 +1678,7 @@ fn on_command_bar_action(
             .remove::<CommandBarRecreating>();
     }
     if !custom_keyboard_restore {
-        let (_, _, active_stack) = focused_stack(
-            queries.active_tab_param.get(),
-            &queries.all_children,
-            &queries.leaf_panes,
-            &queries.pane_ts,
-            &queries.pane_children,
-            &queries.stack_ts,
-        );
+        let active_stack = queries.focused_stack();
         if let Some(tab) = active_stack {
             for browser_e in &queries.content_browsers {
                 let is_child = queries

--- a/crates/page/vmux_layout/src/command_bar/handler.rs
+++ b/crates/page/vmux_layout/src/command_bar/handler.rs
@@ -1584,7 +1584,6 @@ fn on_command_bar_action(
             }
         }
         CommandBarActionEvent::SwitchTab { pane, index } => {
-            // Despawn empty tab if in new-tab mode
             if let Some(stack_e) = empty_stack {
                 commands.entity(stack_e).despawn();
                 new_stack_ctx.stack = None;

--- a/crates/page/vmux_layout/src/command_bar/page.rs
+++ b/crates/page/vmux_layout/src/command_bar/page.rs
@@ -3,13 +3,13 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use crate::command_bar::palette::{CommandPalette, PaletteVariant, emit_action};
+use crate::command_bar::palette::{CommandPalette, PaletteVariant};
 use crate::command_bar::size::CommandBarSizeEmissionState;
 use crate::command_bar::style::{command_bar_root_class, command_bar_shell_class};
 use dioxus::prelude::*;
 use vmux_command::event::{
-    COMMAND_BAR_OPEN_EVENT, CommandBarOpenEvent, CommandBarReadyEvent, CommandBarRenderedEvent,
-    CommandBarSizeEvent, OpenId,
+    COMMAND_BAR_OPEN_EVENT, CommandBarActionEvent, CommandBarOpenEvent, CommandBarReadyEvent,
+    CommandBarRenderedEvent, CommandBarSizeEvent, OpenId,
 };
 use vmux_ui::dom_listener::DocumentListener;
 use vmux_ui::hooks::{send, use_listener, use_theme};
@@ -128,7 +128,7 @@ fn dismiss_command_bar(is_open: Signal<bool>) {
     if !is_open() {
         return;
     }
-    emit_action("dismiss", "");
+    let _ = send(&CommandBarActionEvent::Dismiss);
 }
 
 /// Dismiss the command bar when a pointer goes down anywhere outside its shell.

--- a/crates/page/vmux_layout/src/command_bar/palette.rs
+++ b/crates/page/vmux_layout/src/command_bar/palette.rs
@@ -701,14 +701,13 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
             on_close.call(());
             let selected_attachments = attachments.peek().clone();
             if prompt_target_matches_query(item, &prompt) && selected_attachments.is_empty() {
-                emit_action_with_target("open", target_url, open_target);
+                let _ = send(&CommandBarActionEvent::open(target_url, open_target));
             } else {
-                emit_prompt_action(
+                let _ = send(&CommandBarActionEvent::prompt(
                     prompt.trim(),
-                    open_target,
                     target_url,
                     &selected_attachments,
-                );
+                ));
             }
             if let Some((handler, next)) = transition {
                 handler.call(next);
@@ -718,45 +717,62 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
         on_close.call(());
         match item {
             ResultItem::Terminal { path } => {
-                emit_action("terminal", path);
+                let _ = send(&CommandBarActionEvent::Terminal {
+                    value: path.clone(),
+                });
             }
             ResultItem::Stack {
                 pane_id, tab_index, ..
             } => {
-                emit_action("switch_tab", &format!("{pane_id}:{tab_index}"));
+                let _ = send(&CommandBarActionEvent::SwitchTab {
+                    pane: *pane_id,
+                    index: *tab_index,
+                });
             }
             ResultItem::Command { id, .. } => {
-                emit_action("command", id);
+                let _ = send(&CommandBarActionEvent::Command {
+                    id: id.clone(),
+                    open: open_target,
+                });
             }
             ResultItem::Space { id, .. } => {
-                emit_action("space", id);
+                let _ = send(&CommandBarActionEvent::Space { id: id.clone() });
             }
             ResultItem::Page { url, .. } => {
                 if !url.is_empty() {
-                    emit_action_with_target("open", url, open_target);
+                    let _ = send(&CommandBarActionEvent::open(url, open_target));
                 }
             }
             ResultItem::Navigate { url } => {
                 if !url.is_empty() {
-                    emit_action_with_target("open", url, open_target);
+                    let _ = send(&CommandBarActionEvent::open(url, open_target));
                 }
             }
             ResultItem::Search { engine, query } => {
-                emit_action_with_target("open", &engine.search_url(query), open_target);
+                let _ = send(&CommandBarActionEvent::open(
+                    &engine.search_url(query),
+                    open_target,
+                ));
             }
             ResultItem::History { url, .. } => {
                 if !url.is_empty() {
-                    emit_action_with_target("open", url, open_target);
+                    let _ = send(&CommandBarActionEvent::open(url, open_target));
                 }
             }
             ResultItem::File { path, .. } => {
-                emit_action_with_target("open", &format!("file://{path}"), open_target);
+                let _ = send(&CommandBarActionEvent::open(
+                    &format!("file://{path}"),
+                    open_target,
+                ));
             }
             ResultItem::WorkDir { path, .. } => {
-                emit_action_with_target("open", &format!("file://{path}"), open_target);
+                let _ = send(&CommandBarActionEvent::open(
+                    &format!("file://{path}"),
+                    open_target,
+                ));
             }
             ResultItem::RecentFile { url, .. } => {
-                emit_action_with_target("open", url, open_target);
+                let _ = send(&CommandBarActionEvent::open(url, open_target));
             }
         }
         if let Some((handler, next)) = transition {
@@ -1034,7 +1050,11 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                     execute(item);
                 } else {
                     let selected_attachments = attachments.peek().clone();
-                    emit_prompt_action("", open_target, "", &selected_attachments);
+                    let _ = send(&CommandBarActionEvent::prompt(
+                        "",
+                        "",
+                        &selected_attachments,
+                    ));
                 }
                 return;
             }
@@ -1057,12 +1077,11 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                 } else {
                     on_close.call(());
                     let selected_attachments = attachments.peek().clone();
-                    emit_prompt_action(
+                    let _ = send(&CommandBarActionEvent::prompt(
                         start_keydown_q.trim(),
-                        open_target,
                         "",
                         &selected_attachments,
-                    );
+                    ));
                 }
             } else {
                 let prefer_page = matches!(
@@ -1076,11 +1095,11 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                         .opens_typed_url_on_enter(open_target, nav_mode())
                 {
                     on_close.call(());
-                    emit_action_with_target("open", &start_keydown_q, open_target);
+                    let _ = send(&CommandBarActionEvent::open(&start_keydown_q, open_target));
                 } else if let Some(item) = start_keydown_results.get(sel) {
                     execute(item);
                 } else if !start_keydown_q.is_empty() {
-                    emit_action_with_target("open", &start_keydown_q, open_target);
+                    let _ = send(&CommandBarActionEvent::open(&start_keydown_q, open_target));
                 }
             }
         }
@@ -1127,11 +1146,11 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                         .opens_typed_url_on_enter(open_target, nav_mode())
                 {
                     on_close.call(());
-                    emit_action_with_target("open", &modal_keydown_q, open_target);
+                    let _ = send(&CommandBarActionEvent::open(&modal_keydown_q, open_target));
                 } else if let Some(item) = modal_keydown_results.get(sel) {
                     execute(item);
                 } else if !modal_keydown_q.is_empty() {
-                    emit_action_with_target("open", &modal_keydown_q, open_target);
+                    let _ = send(&CommandBarActionEvent::open(&modal_keydown_q, open_target));
                 }
             }
             return;
@@ -1247,12 +1266,11 @@ pub fn CommandPalette(props: PaletteProps) -> Element {
                                 } else {
                                     on_close.call(());
                                     let selected_attachments = attachments.peek().clone();
-                                    emit_prompt_action(
+                                    let _ = send(&CommandBarActionEvent::prompt(
                                         action_query.trim(),
-                                        open_target,
                                         "",
                                         &selected_attachments,
-                                    );
+                                    ));
                                 }
                             }
                         }
@@ -1488,47 +1506,6 @@ fn select_start_media_entry(
     ));
     selected.set(0);
     focus_prompt_end(PROMPT_INPUT_ID);
-}
-
-/// Emit a command-bar action to the host with no explicit open target.
-pub(crate) fn emit_action(action: &str, value: &str) {
-    emit_action_with_target(action, value, None);
-}
-
-/// Emit a [`CommandBarActionEvent`] to the host (open / command / space / terminal / switch_tab).
-pub(crate) fn emit_action_with_target(action: &str, value: &str, target: Option<OpenTarget>) {
-    let _ = send(&CommandBarActionEvent {
-        action: action.to_string(),
-        value: value.to_string(),
-        target,
-        target_url: None,
-        attachments: Vec::new(),
-    });
-}
-
-fn emit_prompt_action(
-    value: &str,
-    target: Option<OpenTarget>,
-    target_url: &str,
-    attachments: &[ChatAttachment],
-) {
-    let _ = send(&CommandBarActionEvent {
-        action: "prompt".to_string(),
-        value: value.to_string(),
-        target,
-        target_url: (!target_url.is_empty()).then(|| target_url.to_string()),
-        attachments: attachments
-            .iter()
-            .map(
-                |attachment| vmux_command::prompt_media::ChatSubmitAttachment {
-                    path: attachment.path.clone(),
-                    name: attachment.name.clone(),
-                    mime_type: attachment.mime_type.clone(),
-                    size: attachment.size,
-                },
-            )
-            .collect(),
-    });
 }
 
 const COMMAND_BAR_INPUT_ID: &str = "command-bar-input";

--- a/crates/page/vmux_terminal/src/host/pid.rs
+++ b/crates/page/vmux_terminal/src/host/pid.rs
@@ -16,6 +16,18 @@ impl Plugin for PidPlugin {
 #[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Pid(pub u32);
 
+impl Pid {
+    /// The page url a terminal running under this pid is addressed by.
+    ///
+    /// Three readers agree on this format: the pane's own `PageMetadata`, the key
+    /// `CommandBarTerminalsSnapshot::running` is built from, and the value the command bar hands
+    /// back when that row is chosen. Disagreeing spawns a second terminal instead of going to the
+    /// one the user picked, and says nothing, so exactly one place writes it.
+    pub fn page_url(&self) -> String {
+        format!("{}{}", vmux_layout::event::TERMINAL_PAGE_URL, self.0)
+    }
+}
+
 #[derive(Resource, Default, Debug)]
 pub struct PidToEntity(pub HashMap<u32, Entity>);
 

--- a/crates/page/vmux_terminal/src/host/plugin.rs
+++ b/crates/page/vmux_terminal/src/host/plugin.rs
@@ -431,7 +431,7 @@ pub fn format_terminal_url(
 ) {
     for (pid, mut meta) in &mut q {
         let next = match pid {
-            Some(Pid(p)) => format!("{TERMINAL_PAGE_URL}{p}"),
+            Some(pid) => pid.page_url(),
             None => TERMINAL_PAGE_URL.to_string(),
         };
         if meta.url != next {

--- a/crates/page/vmux_terminal/src/host/snapshot_updater.rs
+++ b/crates/page/vmux_terminal/src/host/snapshot_updater.rs
@@ -1,8 +1,9 @@
 use bevy::prelude::*;
+use std::collections::HashMap;
 use vmux_command::snapshot::CommandBarTerminalsSnapshot;
 use vmux_layout::event::TERMINAL_PAGE_URL;
 
-use crate::pid::PidToEntity;
+use crate::pid::{Pid, PidToEntity};
 
 /// Publishes the terminal entries the command bar searches over.
 pub struct TerminalSnapshotPlugin;
@@ -27,7 +28,13 @@ fn update_terminals_snapshot(
     if !changed && !snapshot.terminal_page_url.is_empty() {
         return;
     }
-    snapshot.pid_to_entity = pid_map.as_deref().map(|m| m.0.clone()).unwrap_or_default();
+    let mut running = HashMap::new();
+    if let Some(pid_map) = pid_map.as_deref() {
+        for (pid, entity) in &pid_map.0 {
+            running.insert(Pid(*pid).page_url(), *entity);
+        }
+    }
+    snapshot.running = running;
     snapshot.terminal_page_url = TERMINAL_PAGE_URL.to_string();
 }
 
@@ -36,13 +43,31 @@ mod tests {
     use super::*;
 
     #[test]
-    fn writes_url_and_empty_pid_map() {
+    fn writes_url_and_no_running_terminals() {
         let mut app = App::new();
         app.init_resource::<CommandBarTerminalsSnapshot>()
             .add_systems(Update, update_terminals_snapshot);
         app.update();
         let snap = app.world().resource::<CommandBarTerminalsSnapshot>();
         assert_eq!(snap.terminal_page_url, TERMINAL_PAGE_URL);
-        assert!(snap.pid_to_entity.is_empty());
+        assert!(snap.running.is_empty());
+    }
+
+    /// The key has to be the url the command bar hands back, spelt out here rather than built with
+    /// [`Pid::page_url`], because agreeing with the code under test proves nothing. A key that
+    /// drifts from the pane's own `PageMetadata` silently spawns a second terminal.
+    #[test]
+    fn running_terminals_are_keyed_by_the_url_the_row_carries() {
+        let mut app = App::new();
+        app.init_resource::<CommandBarTerminalsSnapshot>()
+            .add_systems(Update, update_terminals_snapshot);
+        let pane = app.world_mut().spawn_empty().id();
+        app.world_mut()
+            .insert_resource(PidToEntity(HashMap::from([(4321, pane)])));
+
+        app.update();
+
+        let snap = app.world().resource::<CommandBarTerminalsSnapshot>();
+        assert_eq!(snap.running.get("vmux://terminal/4321"), Some(&pane));
     }
 }

--- a/crates/vmux_browser/src/input.rs
+++ b/crates/vmux_browser/src/input.rs
@@ -256,13 +256,7 @@ fn dismiss_windowed_command_bar_on_outside_click(
         ) {
             commands.trigger(BinReceive::<CommandBarActionEvent> {
                 webview: modal_e,
-                payload: CommandBarActionEvent {
-                    action: "dismiss".to_string(),
-                    value: String::new(),
-                    target: None,
-                    target_url: None,
-                    attachments: Vec::new(),
-                },
+                payload: CommandBarActionEvent::Dismiss,
             });
             break;
         }
@@ -281,13 +275,7 @@ fn dismiss_command_bar_from_native_monitor(
     };
     commands.trigger(BinReceive::<CommandBarActionEvent> {
         webview: modal_e,
-        payload: CommandBarActionEvent {
-            action: "dismiss".to_string(),
-            value: String::new(),
-            target: None,
-            target_url: None,
-            attachments: Vec::new(),
-        },
+        payload: CommandBarActionEvent::Dismiss,
     });
 }
 

--- a/crates/vmux_command/src/host/snapshot.rs
+++ b/crates/vmux_command/src/host/snapshot.rs
@@ -222,7 +222,13 @@ pub struct SpaceSummary {
 
 #[derive(Resource, Default, Clone, Debug)]
 pub struct CommandBarTerminalsSnapshot {
-    pub pid_to_entity: HashMap<u32, Entity>,
+    /// The pane already running each terminal row, keyed by the url that row carries.
+    ///
+    /// Keyed by url rather than by pid so that choosing a terminal is a lookup. The command bar
+    /// would otherwise have to parse a pid back out of the url, which means knowing how
+    /// `vmux_terminal` builds one — and being wrong about it silently spawns a second terminal
+    /// instead of going to the one the user picked.
+    pub running: HashMap<String, Entity>,
     pub agent_session_to_entity: HashMap<(AgentKind, String), Entity>,
     pub terminal_page_url: String,
 }
@@ -290,7 +296,6 @@ fn update_pages_snapshot(
 mod tests {
     use super::*;
     use bevy::ecs::system::RunSystemOnce;
-    use vmux_core::agent::AgentKind;
 
     impl ContributedPage {
         fn ranked(url: &str, rank: usize) -> Self {
@@ -373,11 +378,52 @@ mod tests {
         assert_eq!(ContributedPage::prompt_url_among(Vec::new(), None), None);
     }
 
+    #[derive(Component)]
+    struct FirstContributor;
+
+    #[derive(Component)]
+    struct SecondContributor;
+
+    impl ContributedCommand {
+        fn named(id: &str) -> Self {
+            Self {
+                id: id.to_string(),
+                message_id: "command-test-row".to_string(),
+                args: Vec::new(),
+            }
+        }
+    }
+
+    /// Republishing is scoped to the rows the contributor spawned.
+    ///
+    /// The shape this replaced was a resource each contributor overwrote, so the second one to run
+    /// each frame erased the first. Only one crate ever contributed, which is why it never showed.
     #[test]
-    fn terminals_snapshot_default_is_empty() {
-        let s = CommandBarTerminalsSnapshot::default();
-        assert!(s.pid_to_entity.is_empty());
-        assert!(s.agent_session_to_entity.is_empty());
+    fn one_contributor_rebuilding_leaves_the_others_rows() {
+        let mut world = World::new();
+        world.spawn((FirstContributor, ContributedCommand::named("first")));
+        world.spawn((SecondContributor, ContributedCommand::named("second")));
+
+        world
+            .run_system_once(
+                |mine: Query<Entity, With<FirstContributor>>, mut commands: Commands| {
+                    for entity in mine.iter() {
+                        commands.entity(entity).despawn();
+                    }
+                    commands.spawn((FirstContributor, ContributedCommand::named("first-again")));
+                },
+            )
+            .expect("republish runs");
+
+        let ids = world
+            .run_system_once(|contributions: Contributions| {
+                let mut ids: Vec<String> =
+                    contributions.commands().map(|row| row.id.clone()).collect();
+                ids.sort();
+                ids
+            })
+            .expect("read runs");
+        assert_eq!(ids, ["first-again", "second"]);
     }
 
     #[test]

--- a/crates/vmux_command/src/host/snapshot.rs
+++ b/crates/vmux_command/src/host/snapshot.rs
@@ -36,68 +36,17 @@ pub struct CommandBarAgentsSnapshot {
     pub recent: Vec<AgentPromptTarget>,
 }
 
-impl CommandBarAgentsSnapshot {
-    /// Launcher entries for installed ACP and CLI agents, most recently used first.
+impl AgentPromptTarget {
+    /// Rank of each target's url, most recently used first.
     ///
-    /// Ranked by that order, since the entities these become carry preference rather than inherit
-    /// it from their position.
-    pub fn launcher_pages(&self) -> Vec<ContributedPage> {
-        let mut pages = Vec::with_capacity(self.acp.len() + self.providers.len());
-        for agent in &self.acp {
-            pages.push(ContributedPage {
-                id: agent.id.clone(),
-                rank: 0,
-                page: CommandBarPage {
-                    host: "agent".to_string(),
-                    url: agent.url.clone(),
-                    title: agent.name.clone(),
-                    keywords: vec![agent.id.clone(), "acp".to_string(), "agent".to_string()],
-                    icon: if agent.icon.is_empty() {
-                        vmux_core::PageIcon::None
-                    } else {
-                        vmux_core::PageIcon::Favicon(agent.icon.clone())
-                    },
-                    shortcut: String::new(),
-                    prompt_target: true,
-                },
-            });
+    /// The snapshot records recency; turning it into the launcher's order is the contributing
+    /// crate's business, and this is the part of it that needs no knowledge of what an agent is.
+    pub fn recency_ranks(targets: &[Self]) -> HashMap<String, usize> {
+        let mut ranks = HashMap::new();
+        for (rank, target) in targets.iter().enumerate() {
+            ranks.insert(target.url(), rank);
         }
-        for agent in &self.providers {
-            pages.push(ContributedPage {
-                id: agent.id.clone(),
-                rank: 0,
-                page: CommandBarPage {
-                    host: "agent".to_string(),
-                    url: agent.url.clone(),
-                    title: format!("{} (CLI)", agent.name),
-                    keywords: vec![agent.id.clone(), "cli".to_string(), "agent".to_string()],
-                    icon: vmux_core::PageIcon::None,
-                    shortcut: String::new(),
-                    prompt_target: true,
-                },
-            });
-        }
-        let mut recent_rank: HashMap<String, usize> = HashMap::new();
-        for (rank, target) in self.recent.iter().enumerate() {
-            recent_rank.insert(target.url(), rank);
-        }
-        pages.sort_by(|a, b| {
-            recent_rank
-                .get(&a.page.url)
-                .copied()
-                .unwrap_or(usize::MAX)
-                .cmp(&recent_rank.get(&b.page.url).copied().unwrap_or(usize::MAX))
-                .then_with(|| {
-                    a.page
-                        .title
-                        .to_lowercase()
-                        .cmp(&b.page.title.to_lowercase())
-                })
-        });
-        for (rank, page) in pages.iter_mut().enumerate() {
-            page.rank = rank;
-        }
-        pages
+        ranks
     }
 }
 
@@ -343,14 +292,27 @@ mod tests {
     use bevy::ecs::system::RunSystemOnce;
     use vmux_core::agent::AgentKind;
 
-    impl CommandBarAgentsSnapshot {
-        /// Publish what the contributing crate would, then ask where a prompt goes.
+    impl ContributedPage {
+        fn ranked(url: &str, rank: usize) -> Self {
+            Self {
+                id: url.to_string(),
+                rank,
+                page: CommandBarPage {
+                    host: "test".to_string(),
+                    url: url.to_string(),
+                    prompt_target: true,
+                    ..Default::default()
+                },
+            }
+        }
+
+        /// Spawn these rows, then ask where a prompt would go.
         ///
-        /// Spawns the pages rather than handing [`Contributions`] a list, so the prompt tests run
-        /// against the entities the command bar actually reads.
-        fn resolve_prompt_url(&self, requested: Option<&str>) -> Option<String> {
+        /// Spawns rather than handing [`Contributions`] a list, so the prompt tests run against
+        /// the entities the command bar actually reads.
+        fn prompt_url_among(pages: Vec<Self>, requested: Option<&str>) -> Option<String> {
             let mut world = World::new();
-            for page in self.launcher_pages() {
+            for page in pages {
                 world.spawn(page);
             }
             let requested = requested.map(str::to_string);
@@ -372,169 +334,43 @@ mod tests {
     }
 
     #[test]
-    fn prompt_prefers_most_recent_installed_agent() {
-        let snapshot = CommandBarAgentsSnapshot {
-            recent: vec![AgentPromptTarget::Cli(AgentKind::Codex)],
-            providers: vec![AgentProviderSummary {
-                id: "codex".to_string(),
-                name: "Codex".to_string(),
-                url: "vmux://agent/codex/cli".to_string(),
-                icon: String::new(),
-            }],
-            acp: vec![AgentProviderSummary {
-                id: "claude-acp".to_string(),
-                name: "Claude Agent".to_string(),
-                url: "vmux://agent/claude".to_string(),
-                icon: String::new(),
-            }],
-            ..Default::default()
-        };
+    fn prompt_goes_to_the_lowest_ranked_page() {
+        let pages = vec![
+            ContributedPage::ranked("vmux://agent/claude", 1),
+            ContributedPage::ranked("vmux://agent/codex/cli", 0),
+        ];
 
         assert_eq!(
-            snapshot.resolve_prompt_url(None).as_deref(),
+            ContributedPage::prompt_url_among(pages, None).as_deref(),
             Some("vmux://agent/codex/cli")
         );
     }
 
+    /// A request names a page; honouring one that is no longer listed would send the prompt
+    /// somewhere the user did not ask for, so it falls back to the preferred page instead.
     #[test]
-    fn prompt_falls_back_to_installed_agent() {
-        let snapshot = CommandBarAgentsSnapshot {
-            acp: vec![AgentProviderSummary {
-                id: "claude-acp".to_string(),
-                name: "Claude Agent".to_string(),
-                url: "vmux://agent/claude".to_string(),
-                icon: String::new(),
-            }],
-            ..Default::default()
+    fn prompt_honours_a_listed_request_and_ignores_a_stale_one() {
+        let pages = || {
+            vec![
+                ContributedPage::ranked("vmux://agent/codex/cli", 0),
+                ContributedPage::ranked("vmux://agent/claude", 1),
+            ]
         };
 
         assert_eq!(
-            snapshot.resolve_prompt_url(None).as_deref(),
+            ContributedPage::prompt_url_among(pages(), Some("vmux://agent/claude")).as_deref(),
             Some("vmux://agent/claude")
         );
         assert_eq!(
-            CommandBarAgentsSnapshot::default().resolve_prompt_url(None),
-            None
-        );
-    }
-
-    #[test]
-    fn prompt_uses_selected_installed_agent_and_rejects_stale_url() {
-        let snapshot = CommandBarAgentsSnapshot {
-            providers: vec![AgentProviderSummary {
-                id: "codex".to_string(),
-                name: "Codex".to_string(),
-                url: "vmux://agent/codex/cli".to_string(),
-                icon: String::new(),
-            }],
-            acp: vec![AgentProviderSummary {
-                id: "claude-acp".to_string(),
-                name: "Claude Agent".to_string(),
-                url: "vmux://agent/claude".to_string(),
-                icon: String::new(),
-            }],
-            recent: vec![AgentPromptTarget::Cli(AgentKind::Codex)],
-            ..Default::default()
-        };
-
-        assert_eq!(
-            snapshot
-                .resolve_prompt_url(Some("vmux://agent/claude"))
-                .as_deref(),
-            Some("vmux://agent/claude")
-        );
-        assert_eq!(
-            snapshot
-                .resolve_prompt_url(Some("vmux://agent/uninstalled"))
-                .as_deref(),
+            ContributedPage::prompt_url_among(pages(), Some("vmux://agent/uninstalled")).as_deref(),
             Some("vmux://agent/codex/cli")
         );
     }
 
+    /// Nothing accepting a prompt has to be refused rather than substituted for.
     #[test]
-    fn launcher_pages_lists_only_snapshot_agents_in_recent_order() {
-        let snapshot = CommandBarAgentsSnapshot {
-            providers: vec![AgentProviderSummary {
-                id: "codex".to_string(),
-                name: "Codex".to_string(),
-                url: "vmux://agent/codex/cli".to_string(),
-                icon: String::new(),
-            }],
-            acp: vec![AgentProviderSummary {
-                id: "claude-acp".to_string(),
-                name: "Claude Agent".to_string(),
-                url: "vmux://agent/claude".to_string(),
-                icon: "https://cdn.example/claude-acp.svg".to_string(),
-            }],
-            recent: vec![
-                AgentPromptTarget::Cli(AgentKind::Codex),
-                AgentPromptTarget::Acp {
-                    id: "claude".to_string(),
-                },
-            ],
-            ..Default::default()
-        };
-        let pages = snapshot.launcher_pages();
-        assert_eq!(pages.len(), 2);
-        assert_eq!(pages[0].id, "codex");
-        assert_eq!(pages[0].page.url, "vmux://agent/codex/cli");
-        assert_eq!(pages[0].page.title, "Codex (CLI)");
-        assert_eq!(pages[0].page.host, "agent");
-        assert_eq!(pages[1].page.title, "Claude Agent");
-        assert!(matches!(
-            pages[1].page.icon,
-            vmux_core::PageIcon::Favicon(ref u) if u == "https://cdn.example/claude-acp.svg"
-        ));
-        assert_eq!(pages[0].rank, 0);
-        assert_eq!(pages[1].rank, 1);
-    }
-
-    #[derive(Component)]
-    struct FirstContributor;
-
-    #[derive(Component)]
-    struct SecondContributor;
-
-    impl ContributedCommand {
-        fn named(id: &str) -> Self {
-            Self {
-                id: id.to_string(),
-                message_id: "command-test-row".to_string(),
-                args: Vec::new(),
-            }
-        }
-    }
-
-    /// Republishing is scoped to the rows the contributor spawned.
-    ///
-    /// The shape this replaced was a resource each contributor overwrote, so the second one to run
-    /// each frame erased the first. Only one crate ever contributed, which is why it never showed.
-    #[test]
-    fn one_contributor_rebuilding_leaves_the_others_rows() {
-        let mut world = World::new();
-        world.spawn((FirstContributor, ContributedCommand::named("first")));
-        world.spawn((SecondContributor, ContributedCommand::named("second")));
-
-        world
-            .run_system_once(
-                |mine: Query<Entity, With<FirstContributor>>, mut commands: Commands| {
-                    for entity in mine.iter() {
-                        commands.entity(entity).despawn();
-                    }
-                    commands.spawn((FirstContributor, ContributedCommand::named("first-again")));
-                },
-            )
-            .expect("republish runs");
-
-        let ids = world
-            .run_system_once(|contributions: Contributions| {
-                let mut ids: Vec<String> =
-                    contributions.commands().map(|row| row.id.clone()).collect();
-                ids.sort();
-                ids
-            })
-            .expect("read runs");
-        assert_eq!(ids, ["first-again", "second"]);
+    fn prompt_refuses_when_no_page_accepts_one() {
+        assert_eq!(ContributedPage::prompt_url_among(Vec::new(), None), None);
     }
 
     #[test]

--- a/crates/vmux_command/src/host/snapshot.rs
+++ b/crates/vmux_command/src/host/snapshot.rs
@@ -41,10 +41,13 @@ impl AgentPromptTarget {
     ///
     /// The snapshot records recency; turning it into the launcher's order is the contributing
     /// crate's business, and this is the part of it that needs no knowledge of what an agent is.
+    ///
+    /// A url appearing twice keeps its first rank, since that is the more recent one and the later
+    /// occurrence would otherwise push the agent down the launcher.
     pub fn recency_ranks(targets: &[Self]) -> HashMap<String, usize> {
         let mut ranks = HashMap::new();
         for (rank, target) in targets.iter().enumerate() {
-            ranks.insert(target.url(), rank);
+            ranks.entry(target.url()).or_insert(rank);
         }
         ranks
     }

--- a/crates/vmux_wire/src/command_bar.rs
+++ b/crates/vmux_wire/src/command_bar.rs
@@ -319,13 +319,82 @@ pub struct CommandBarCommandEntry {
     rkyv::Serialize,
     rkyv::Deserialize,
 )]
-pub struct CommandBarActionEvent {
-    pub action: String,
-    pub value: String,
-    pub target: Option<crate::open_target::OpenTarget>,
-    /// Which prompt target the user picked, when they picked one explicitly.
-    pub target_url: Option<String>,
-    pub attachments: Vec<crate::prompt_media::ChatSubmitAttachment>,
+/// What the user chose in the command bar.
+///
+/// One variant per kind of row, carrying only what that kind means. This was five fields and a
+/// string tag, where `attachments` and `target_url` meant something to prompts alone and nothing
+/// checked that the sender and the host agreed on the tag.
+pub enum CommandBarActionEvent {
+    /// Send a prompt to a page that accepts one.
+    ///
+    /// Carries no [`OpenTarget`](crate::open_target::OpenTarget): a prompt goes to the stack the
+    /// command bar opened or the focused one, and never to a target the user picked. The struct
+    /// this replaced carried the field for every action, so the palette filled one in here and the
+    /// host had always ignored it.
+    Prompt {
+        text: String,
+        /// The prompt target the user picked, when they picked one explicitly.
+        target_url: Option<String>,
+        attachments: Vec<crate::prompt_media::ChatSubmitAttachment>,
+    },
+    /// Open a url, a path on disk, or a search for what was typed.
+    Open {
+        value: String,
+        open: Option<crate::open_target::OpenTarget>,
+    },
+    /// Go to the terminal already running this row, or start one.
+    ///
+    /// The value is either a terminal page url or a directory to start in. Which one it is is
+    /// `vmux_terminal`'s to answer, through `CommandBarTerminalsSnapshot::running`.
+    Terminal { value: String },
+    /// Run a command, claim a contributed row, or open a page named by id.
+    Command {
+        id: String,
+        open: Option<crate::open_target::OpenTarget>,
+    },
+    /// Attach a space.
+    Space { id: String },
+    /// Focus a tab already open in a pane.
+    ///
+    /// Typed rather than a `"{pane}:{index}"` string, so a malformed pair cannot reach the host.
+    SwitchTab { pane: u64, index: usize },
+    /// Close the command bar without doing anything.
+    Dismiss,
+}
+
+impl CommandBarActionEvent {
+    /// Open what the user typed or picked, in the target they asked for.
+    pub fn open(value: &str, open: Option<crate::open_target::OpenTarget>) -> Self {
+        Self::Open {
+            value: value.to_string(),
+            open,
+        }
+    }
+
+    /// Send a prompt, with whatever the composer had attached.
+    ///
+    /// An empty `target_url` means the user picked no target, which is not the same as picking one
+    /// that happens to be blank — the host falls back to the preferred page only for `None`.
+    pub fn prompt(
+        text: &str,
+        target_url: &str,
+        attachments: &[crate::prompt_media::ChatAttachment],
+    ) -> Self {
+        let mut submitted = Vec::with_capacity(attachments.len());
+        for attachment in attachments {
+            submitted.push(crate::prompt_media::ChatSubmitAttachment {
+                path: attachment.path.clone(),
+                name: attachment.name.clone(),
+                mime_type: attachment.mime_type.clone(),
+                size: attachment.size,
+            });
+        }
+        Self::Prompt {
+            text: text.to_string(),
+            target_url: (!target_url.is_empty()).then(|| target_url.to_string()),
+            attachments: submitted,
+        }
+    }
 }
 
 #[derive(


### PR DESCRIPTION
Stage 3 of [VMX-163](https://linear.app/vmux/issue/VMX-163/let-each-crate-own-its-command-bar-rows). Stacked on #363, which is stacked on #361.

Three commits, each independently reviewable.

## `bea461be` — what an agent looks like moves to `vmux_agent`

`launcher_pages` sat on `CommandBarAgentsSnapshot` in `vmux_command` and decided things only `vmux_agent` has any business deciding: that a CLI provider is labelled as one, that an ACP agent's icon is a favicon when the registry gave it a url, that recency beats alphabetical.

The tests were the tell. Four tests in `vmux_command` built agent snapshots to exercise `Contributions::prompt_url`, so changing what an agent looks like would break tests for a type that has never heard of one. They split: `prompt_url` keeps three tests over plain ranked pages, launcher ordering gets one in `vmux_agent`.

What stays behind is `AgentPromptTarget::recency_ranks`, which turns the recorded order into ranks and needs to know nothing about agents.

## `c7c966ef` — the queries answer for themselves

The same six-argument `focused_stack` call appeared five times inside `on_command_bar_action`, each destructuring a different third of the tuple and discarding the rest. Every argument came from `CommandBarActionQueries` — the call already had a receiver and was being handed it a field at a time. Now `queries.focused_stack()` / `queries.focused_pane()`, and `inline_transition_stack_for(webview, &queries)` becomes a method for the same reason.

No behaviour change. This is what has to be true before an arm of the match can move.

## `a5503030` — `vmux_terminal` says which pane a row is running in

The command bar knew how `vmux_terminal` builds a url:

```rust
parse_pid_from_url(&evt.value, &terminal_page_url)
    .and_then(|p| pid_to_entity.get(&p).copied())
```

Getting that wrong has no error path — a url that fails to parse looks exactly like a terminal that is not running, so the command bar spawns a second one instead of going to the one the user picked, silently.

`vmux_terminal` already writes that snapshot, so it now publishes the map the command bar actually wants — row url to pane — and the parsing goes away rather than moving. The format lives on `Pid::page_url`, which the pane's own `PageMetadata` also calls now, so the three readers that must agree are one line instead of three.

## Test changes

| | |
|---|---|
| removed | 4 × `parse_pid_from_url_*` — the function is gone, not moved |
| removed | `terminals_snapshot_default_is_empty` — asserted a derived `Default` on a field that no longer exists |
| added | `running_terminals_are_keyed_by_the_url_the_row_carries` — same contract, checked from the side that owns it, against a literal url so it fails if the two producers drift |
| moved | launcher ordering → `vmux_agent`; `prompt_url` → three tests over plain pages |

2977 → 2973 passing, 0 failed. Net −4 is exactly the five removed minus the one added.

- [x] `cargo clippy <all non-patch pkgs> --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] At a keyboard: `cmd+k`, pick a **running** terminal row and confirm it focuses that pane rather than spawning a second one. This is the behaviour the last commit rewires and the one the tests can only approximate.
- [ ] `cmd+k`, type a directory path, confirm a terminal opens there; and with no running terminals confirm a bare terminal row still spawns one.
- [ ] Agent rows still listed in recent-first order and still launch.

## Still not done

The six-arm `match evt.action.as_str()` is still in `vmux_layout`. Moving `terminal` and `space` wholesale needs `vmux_terminal` / `vmux_space` to gain layout manipulation (spawning stacks, focusing panes) they do not have today, or layout to send a typed request they answer. Both arms already write into their owning crate (`TerminalSpawnRequest`, `SpaceCommandEvent`); what remained in layout was each crate's *knowledge*, and that is what these three commits move. The rest is a bigger change and wants its own PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved agent launcher pages with clearer labels, icons, search keywords, and ordering based on recent usage.
  - Enhanced terminal tracking and linking for more reliable navigation between running terminals and their pages.

- **Bug Fixes**
  - Improved command bar actions for opening pages, switching tabs, launching terminals, running commands, and submitting prompts.
  - Improved dismissal behavior when clicking outside the command bar or interacting with the native monitor.
  - Preserved prompt destinations and attachments more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->