### PR TITLE
Remove the Mesh3d quads nothing renders

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ bevy = { version = "0.19.0", default-features = false, features = [
     "bevy_window",
     "bevy_render",
     "bevy_core_pipeline",
-    "bevy_mesh",
     "bevy_sprite",
     "bevy_ui",
     "bevy_ui_render",

--- a/crates/app/vmux_desktop/src/persistence.rs
+++ b/crates/app/vmux_desktop/src/persistence.rs
@@ -434,7 +434,6 @@ pub(crate) fn rebuild_space_views(
     settings: Res<AppSettings>,
     mut spawn_agent: MessageWriter<vmux_core::agent::SpawnAgentInStackRequest>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     if tabs_need_view.is_empty()
@@ -554,10 +553,7 @@ pub(crate) fn rebuild_space_views(
                 .starts_with(SERVICES_PAGE_URL.trim_end_matches('/'))
             {
                 commands.spawn((
-                    vmux_terminal::processes_monitor::ProcessesMonitor::new(
-                        &mut meshes,
-                        &mut webview_mt,
-                    ),
+                    vmux_terminal::processes_monitor::ProcessesMonitor::new(&mut webview_mt),
                     ChildOf(entity),
                 ));
             } else if meta
@@ -567,12 +563,7 @@ pub(crate) fn rebuild_space_views(
                 let cwd = saved_launch.map(|l| std::path::PathBuf::from(&l.cwd));
                 let term = commands
                     .spawn((
-                        new_terminal_bundle_with_cwd(
-                            &mut meshes,
-                            &mut webview_mt,
-                            &settings,
-                            cwd.as_deref(),
-                        ),
+                        new_terminal_bundle_with_cwd(&mut webview_mt, &settings, cwd.as_deref()),
                         ChildOf(entity),
                     ))
                     .id();
@@ -615,24 +606,21 @@ pub(crate) fn rebuild_space_views(
                     }
                 }
             } else if meta.url.starts_with(SPACES_PAGE_URL.trim_end_matches('/')) {
-                commands.spawn((Spaces::new(&mut meshes, &mut webview_mt), ChildOf(entity)));
+                commands.spawn((Spaces::new(&mut webview_mt), ChildOf(entity)));
             } else if meta
                 .url
                 .starts_with(SETTINGS_PAGE_URL.trim_end_matches('/'))
             {
-                commands.spawn((Settings::new(&mut meshes, &mut webview_mt), ChildOf(entity)));
+                commands.spawn((Settings::new(&mut webview_mt), ChildOf(entity)));
             } else if meta.url.starts_with("file:") {
                 if let Some(bundle) =
-                    vmux_editor::restore_file_view_bundle(&meta.url, &mut meshes, &mut webview_mt)
+                    vmux_editor::restore_file_view_bundle(&meta.url, &mut webview_mt)
                 {
                     commands.spawn((bundle, ChildOf(entity)));
                 }
             } else {
                 let browser = commands
-                    .spawn((
-                        Browser::new(&mut meshes, &mut webview_mt, &meta.url),
-                        ChildOf(entity),
-                    ))
+                    .spawn((Browser::new(&mut webview_mt, &meta.url), ChildOf(entity)))
                     .id();
                 commands.entity(browser).insert(meta.clone());
             }
@@ -1036,7 +1024,6 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .insert_resource(test_settings())
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .init_resource::<vmux_agent::strategy::AgentStrategies>()
             .add_message::<vmux_core::agent::SpawnAgentInStackRequest>()
@@ -1383,7 +1370,6 @@ mod tests {
             .insert_resource(ActiveSpace {
                 record: vmux_space::model::bootstrap_space_record(),
             })
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .init_resource::<vmux_agent::strategy::AgentStrategies>()
             .add_plugins(PersistencePlugin);
@@ -1600,7 +1586,6 @@ mod tests {
             .insert_resource(ActiveSpace {
                 record: vmux_space::model::bootstrap_space_record(),
             })
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .init_resource::<vmux_agent::strategy::AgentStrategies>()
             .add_plugins(PersistencePlugin);

--- a/crates/app/vmux_desktop/tests/release_invariants.rs
+++ b/crates/app/vmux_desktop/tests/release_invariants.rs
@@ -530,7 +530,6 @@ fn workspace_bevy_uses_explicit_feature_allowlist() {
         "bevy_window",
         "bevy_render",
         "bevy_core_pipeline",
-        "bevy_mesh",
         "bevy_sprite",
         "bevy_ui",
         "bevy_ui_render",

--- a/crates/page/vmux_agent/src/host/attach.rs
+++ b/crates/page/vmux_agent/src/host/attach.rs
@@ -45,13 +45,12 @@ pub fn attach_page_agent_to_stack(
     model: &str,
     sid: &str,
     commands: &mut Commands,
-    meshes: &mut ResMut<Assets<Mesh>>,
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
     idx: &crate::client::page::strategy_index::PageStrategyIndex,
     kind_q: &Query<&crate::client::page::strategy_components::StrategyKind>,
 ) -> Option<()> {
     attach_page_agent_to_stack_with_webview(
-        stack, provider, model, sid, None, commands, meshes, webview_mt, idx, kind_q,
+        stack, provider, model, sid, None, commands, webview_mt, idx, kind_q,
     )
 }
 
@@ -63,7 +62,6 @@ pub(crate) fn attach_page_agent_to_stack_with_webview(
     sid: &str,
     webview: Option<Entity>,
     commands: &mut Commands,
-    meshes: &mut ResMut<Assets<Mesh>>,
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
     idx: &crate::client::page::strategy_index::PageStrategyIndex,
     kind_q: &Query<&crate::client::page::strategy_components::StrategyKind>,
@@ -110,7 +108,7 @@ pub(crate) fn attach_page_agent_to_stack_with_webview(
             .remove::<crate::host::chat::ChatSynced>();
     } else {
         commands.spawn((
-            vmux_layout::Browser::new(meshes, webview_mt, &url),
+            vmux_layout::Browser::new(webview_mt, &url),
             crate::host::chat::AgentChatView,
             ChildOf(stack),
         ));
@@ -128,11 +126,10 @@ pub fn attach_acp_agent_to_stack(
     icon: Option<&str>,
     resume: Option<&str>,
     commands: &mut Commands,
-    meshes: &mut ResMut<Assets<Mesh>>,
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     attach_acp_agent_to_stack_with_webview(
-        stack, agent_id, name, sid, cwd, icon, resume, None, commands, meshes, webview_mt,
+        stack, agent_id, name, sid, cwd, icon, resume, None, commands, webview_mt,
     );
 }
 
@@ -147,7 +144,6 @@ pub(crate) fn attach_acp_agent_to_stack_with_webview(
     resume: Option<&str>,
     webview: Option<Entity>,
     commands: &mut Commands,
-    meshes: &mut ResMut<Assets<Mesh>>,
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     let agent_id = crate::acp_install::agent_url_id(agent_id);
@@ -204,7 +200,7 @@ pub(crate) fn attach_acp_agent_to_stack_with_webview(
             .remove::<crate::host::chat::ChatSynced>();
     } else {
         commands.spawn((
-            vmux_layout::Browser::new(meshes, webview_mt, &url),
+            vmux_layout::Browser::new(webview_mt, &url),
             crate::host::chat::AgentChatView,
             ChildOf(stack),
             anchor,
@@ -368,14 +364,12 @@ mod tests {
         use bevy::ecs::system::RunSystemOnce;
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>();
         let stack = app.world_mut().spawn_empty().id();
 
         app.world_mut()
             .run_system_once(
                 move |mut commands: Commands,
-                      mut meshes: ResMut<Assets<Mesh>>,
                       mut mt: ResMut<Assets<WebviewExtendStandardMaterial>>| {
                     attach_acp_agent_to_stack(
                         stack,
@@ -386,7 +380,6 @@ mod tests {
                         Some("https://cdn.example/vibe.svg"),
                         None,
                         &mut commands,
-                        &mut meshes,
                         &mut mt,
                     );
                 },

--- a/crates/page/vmux_agent/src/host/client/acp.rs
+++ b/crates/page/vmux_agent/src/host/client/acp.rs
@@ -993,7 +993,6 @@ fn apply_acp_terminal_created(
     mut reader: MessageReader<vmux_service::agent_events::PageAgentAcpTerminalCreated>,
     sessions: Query<(Entity, &AcpSession)>,
     ctx: PlacementCtx,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
     mut commands: Commands,
 ) {
@@ -1021,7 +1020,7 @@ fn apply_acp_terminal_created(
             .spawn((stack_bundle(), LastActivatedAt(0), ChildOf(target_pane)))
             .id();
         commands.spawn((
-            reattach_terminal_bundle(&mut meshes, &mut webview_mt, ev.process_id),
+            reattach_terminal_bundle(&mut webview_mt, ev.process_id),
             vmux_terminal::RetainOnProcessExit,
             ChildOf(tab),
         ));
@@ -1450,7 +1449,6 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(bevy::app::TaskPoolPlugin::default())
             .add_plugins(AcpAgentPlugin)
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>();
         let matching = app
             .world_mut()
@@ -1514,7 +1512,6 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(bevy::app::TaskPoolPlugin::default())
             .add_plugins(AcpAgentPlugin)
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>();
         let matching = app
             .world_mut()
@@ -1682,7 +1679,6 @@ mod tests {
         let mut app = App::new();
         app.add_message::<PageAgentAcpTerminalCreated>()
             .add_systems(Update, apply_acp_terminal_created)
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>();
         let tab = app.world_mut().spawn(tab_bundle()).id();
         let pane = app
@@ -1894,7 +1890,6 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(bevy::app::TaskPoolPlugin::default())
             .add_plugins(AcpAgentPlugin)
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>();
         app.world_mut().spawn(AcpSession {
             agent_id: "vibe-acp".to_string(),

--- a/crates/page/vmux_agent/src/host/command.rs
+++ b/crates/page/vmux_agent/src/host/command.rs
@@ -722,7 +722,6 @@ mod tests {
         .add_message::<vmux_history::query::HistoryOpenIntent>()
         .insert_resource(FocusedStack::default())
         .insert_resource(test_settings())
-        .init_resource::<Assets<Mesh>>()
         .init_resource::<Assets<WebviewExtendStandardMaterial>>();
 
         let mut agent_value = serde_json::to_value(vmux_setting::AgentSettings::default()).unwrap();
@@ -790,7 +789,6 @@ mod tests {
         .add_systems(Update, vmux_terminal::handle_terminal_send_requests)
         .insert_resource(FocusedStack::default())
         .insert_resource(test_settings())
-        .init_resource::<Assets<Mesh>>()
         .init_resource::<Assets<WebviewExtendStandardMaterial>>();
 
         let pane = app.world_mut().spawn(Pane).id();

--- a/crates/page/vmux_agent/src/host/page_open.rs
+++ b/crates/page/vmux_agent/src/host/page_open.rs
@@ -297,7 +297,6 @@ fn handle_agent_page_open(
     kind_q: Query<&crate::client::page::strategy_components::StrategyKind>,
     mut spawn_agent: MessageWriter<SpawnAgentInStackRequest>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
     settings: Res<AppSettings>,
     workspace: AgentPageOpenWorkspace,
@@ -366,7 +365,6 @@ fn handle_agent_page_open(
             &kind_q,
             &mut spawn_agent,
             &mut commands,
-            &mut meshes,
             &mut webview_mt,
             &default_cwd,
             &settings.agent.acp,
@@ -397,7 +395,6 @@ fn handle_swap_stack_session(
     children_q: Query<&Children>,
     mut spawn_agent: MessageWriter<SpawnAgentInStackRequest>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     for ev in reader.read() {
@@ -499,7 +496,6 @@ fn handle_swap_stack_session(
                     icon.as_deref(),
                     sid.as_deref(),
                     &mut commands,
-                    &mut meshes,
                     &mut webview_mt,
                 );
                 if let Some((imported, pending)) = imported {
@@ -525,7 +521,6 @@ fn handle_agent_page_open_task(
     kind_q: &Query<&crate::client::page::strategy_components::StrategyKind>,
     spawn_agent: &mut MessageWriter<SpawnAgentInStackRequest>,
     commands: &mut Commands,
-    meshes: &mut ResMut<Assets<Mesh>>,
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
     default_cwd: &std::path::Path,
     acp_configs: &[vmux_setting::AcpAgentConfig],
@@ -535,7 +530,7 @@ fn handle_agent_page_open_task(
         .into_iter()
         .find(|k| task.url == k.setup_url())
     {
-        attach_cli_setup_to_stack(kind, task.stack, children_q, commands, meshes, webview_mt);
+        attach_cli_setup_to_stack(kind, task.stack, children_q, commands, webview_mt);
         return Ok(());
     }
     match crate::AgentUrl::parse(&task.url) {
@@ -555,7 +550,6 @@ fn handle_agent_page_open_task(
                 &sid,
                 transition_webview,
                 commands,
-                meshes,
                 webview_mt,
                 idx,
                 kind_q,
@@ -581,7 +575,6 @@ fn handle_agent_page_open_task(
                 &sid,
                 transition_webview,
                 commands,
-                meshes,
                 webview_mt,
                 idx,
                 kind_q,
@@ -678,7 +671,6 @@ fn handle_agent_page_open_task(
                 sid.as_deref(),
                 transition_webview,
                 commands,
-                meshes,
                 webview_mt,
             );
             insert_initial_prompt_queue(task.stack, initial_prompt, initial_attachments, commands);
@@ -768,7 +760,6 @@ pub(crate) fn attach_agent_spawn_error_to_stack(
     message: &str,
     children_q: &Query<&Children>,
     commands: &mut Commands,
-    meshes: &mut ResMut<Assets<Mesh>>,
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     clear_stack_children(stack, children_q, commands);
@@ -789,7 +780,7 @@ pub(crate) fn attach_agent_spawn_error_to_stack(
     });
     let browser = commands
         .spawn((
-            vmux_layout::Browser::new_with_title(meshes, webview_mt, &data_url, title),
+            vmux_layout::Browser::new_with_title(webview_mt, &data_url, title),
             ChildOf(stack),
         ))
         .id();
@@ -801,7 +792,6 @@ pub(crate) fn attach_cli_setup_to_stack(
     stack: Entity,
     children_q: &Query<&Children>,
     commands: &mut Commands,
-    meshes: &mut ResMut<Assets<Mesh>>,
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     clear_stack_children(stack, children_q, commands);
@@ -818,7 +808,7 @@ pub(crate) fn attach_cli_setup_to_stack(
     });
     let browser = commands
         .spawn((
-            vmux_layout::Browser::new_with_title(meshes, webview_mt, &url, &title),
+            vmux_layout::Browser::new_with_title(webview_mt, &url, &title),
             ChildOf(stack),
         ))
         .id();
@@ -864,7 +854,6 @@ mod tests {
             .add_message::<vmux_core::agent::SwapStackSession>()
             .add_message::<SpawnAgentInStackRequest>()
             .insert_resource(test_settings())
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_swap_stack_session);
         app
@@ -1020,7 +1009,6 @@ mod tests {
                 (AgentKind::Vibe, false),
             ])))
             .insert_resource(test_settings())
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(
                 Update,
@@ -1073,7 +1061,6 @@ mod tests {
                     (kind, false),
                 ])))
                 .insert_resource(settings)
-                .init_resource::<Assets<Mesh>>()
                 .init_resource::<Assets<WebviewExtendStandardMaterial>>()
                 .add_systems(
                     Update,
@@ -1124,7 +1111,6 @@ mod tests {
                     distribution: Distribution::default(),
                 }],
             })
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_agent_page_open);
 
@@ -1160,7 +1146,6 @@ mod tests {
             .add_message::<SpawnAgentInStackRequest>()
             .insert_resource(AgentStrategies::default())
             .insert_resource(test_settings())
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_agent_page_open);
 
@@ -1196,7 +1181,6 @@ mod tests {
             .insert_resource(vmux_layout::worktree::ManagedWorktreeRoot(
                 managed_root.path().to_path_buf(),
             ))
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(
                 Update,
@@ -1298,7 +1282,6 @@ mod tests {
             .insert_resource(vmux_layout::worktree::ManagedWorktreeRoot(
                 managed_root.path().to_path_buf(),
             ))
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(
                 Update,
@@ -1363,7 +1346,6 @@ mod tests {
             .insert_resource(vmux_layout::worktree::ManagedWorktreeRoot(
                 managed_root.path().to_path_buf(),
             ))
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(
                 Update,
@@ -1454,7 +1436,6 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .add_message::<SpawnAgentInStackRequest>()
             .insert_resource(settings)
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_agent_page_open);
         let tab = app
@@ -1509,7 +1490,6 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .add_message::<SpawnAgentInStackRequest>()
             .insert_resource(test_settings())
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_agent_page_open);
         let tab = app
@@ -1568,7 +1548,6 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .add_message::<SpawnAgentInStackRequest>()
             .insert_resource(test_settings())
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_agent_page_open);
         let stack = app
@@ -1664,7 +1643,6 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .add_message::<SpawnAgentInStackRequest>()
             .insert_resource(test_settings())
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(
                 Update,
@@ -1747,7 +1725,6 @@ mod tests {
                     profile: "Personal".into(),
                 },
             })
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_agent_page_open);
 
@@ -1809,7 +1786,6 @@ mod tests {
                     profile: "Personal".into(),
                 },
             })
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_agent_page_open);
         let space = app
@@ -1859,7 +1835,6 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .add_message::<SpawnAgentInStackRequest>()
             .insert_resource(settings)
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_agent_page_open);
         let stack = app
@@ -1900,7 +1875,6 @@ mod tests {
                 (AgentKind::Codex, true),
             ])))
             .insert_resource(test_settings())
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_spawn_agent_requests);
         let stack = app
@@ -1956,7 +1930,6 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .add_message::<SpawnAgentInStackRequest>()
             .insert_resource(test_settings())
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_agent_page_open);
         let stack = app
@@ -2016,7 +1989,6 @@ mod tests {
                     profile: "Personal".into(),
                 },
             })
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_agent_page_open);
 
@@ -2063,7 +2035,6 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .add_message::<SpawnAgentInStackRequest>()
             .insert_resource(settings)
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_agent_page_open);
         let tab = app
@@ -2104,7 +2075,6 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .add_message::<SpawnAgentInStackRequest>()
             .insert_resource(test_settings())
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_agent_page_open);
 

--- a/crates/page/vmux_agent/src/host/spawn.rs
+++ b/crates/page/vmux_agent/src/host/spawn.rs
@@ -62,7 +62,6 @@ fn respond_process_stack_spawn(
     mut reader: MessageReader<ProcessStackSpawnRequest>,
     settings: Res<AppSettings>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     for request in reader.read() {
@@ -98,12 +97,7 @@ fn respond_process_stack_spawn(
         };
         let term = commands
             .spawn((
-                new_terminal_bundle_with_cwd(
-                    &mut meshes,
-                    &mut webview_mt,
-                    &settings,
-                    Some(&request.cwd),
-                ),
+                new_terminal_bundle_with_cwd(&mut webview_mt, &settings, Some(&request.cwd)),
                 ChildOf(stack),
             ))
             .id();
@@ -169,7 +163,6 @@ pub(super) fn handle_spawn_agent_requests(
     exec_override: Option<Res<AgentExecutableOverride>>,
     children_q: Query<&Children>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     for req in reader.read() {
@@ -182,7 +175,6 @@ pub(super) fn handle_spawn_agent_requests(
                 message,
                 &children_q,
                 &mut commands,
-                &mut meshes,
                 &mut webview_mt,
             );
             continue;
@@ -193,7 +185,6 @@ pub(super) fn handle_spawn_agent_requests(
                 req.stack,
                 &children_q,
                 &mut commands,
-                &mut meshes,
                 &mut webview_mt,
             );
             continue;
@@ -214,12 +205,7 @@ pub(super) fn handle_spawn_agent_requests(
                 clear_stack_children(req.stack, &children_q, &mut commands);
                 let terminal = commands
                     .spawn((
-                        new_terminal_bundle_with_cwd(
-                            &mut meshes,
-                            &mut webview_mt,
-                            &settings,
-                            Some(&req.cwd),
-                        ),
+                        new_terminal_bundle_with_cwd(&mut webview_mt, &settings, Some(&req.cwd)),
                         ChildOf(req.stack),
                     ))
                     .id();
@@ -267,7 +253,6 @@ pub(super) fn handle_spawn_agent_requests(
                     &e,
                     &children_q,
                     &mut commands,
-                    &mut meshes,
                     &mut webview_mt,
                 );
             }
@@ -278,7 +263,6 @@ pub(super) fn handle_spawn_agent_requests(
 fn respond_page_agent_attach(
     mut reader: MessageReader<PageAgentAttachRequest>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
     idx: Option<Res<crate::client::page::strategy_index::PageStrategyIndex>>,
     kind_q: Query<&crate::client::page::strategy_components::StrategyKind>,
@@ -294,7 +278,6 @@ fn respond_page_agent_attach(
             &req.model,
             &req.sid,
             &mut commands,
-            &mut meshes,
             &mut webview_mt,
             idx,
             &kind_q,
@@ -305,7 +288,6 @@ fn respond_page_agent_attach(
 fn respond_page_agent_spawn_stack(
     mut reader: MessageReader<PageAgentSpawnStackRequest>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
     idx: Option<Res<crate::client::page::strategy_index::PageStrategyIndex>>,
     kind_q: Query<&crate::client::page::strategy_components::StrategyKind>,
@@ -328,7 +310,6 @@ fn respond_page_agent_spawn_stack(
             &req.model,
             &req.sid,
             &mut commands,
-            &mut meshes,
             &mut webview_mt,
             idx,
             &kind_q,
@@ -339,7 +320,6 @@ fn respond_page_agent_spawn_stack(
 fn respond_page_agent_spawn_default(
     mut reader: MessageReader<PageAgentSpawnDefaultRequest>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
     idx: Option<Res<crate::client::page::strategy_index::PageStrategyIndex>>,
     kind_q: Query<&crate::client::page::strategy_components::StrategyKind>,
@@ -369,7 +349,6 @@ fn respond_page_agent_spawn_default(
             p.default_model,
             &sid,
             &mut commands,
-            &mut meshes,
             &mut webview_mt,
             idx,
             &kind_q,
@@ -388,7 +367,6 @@ fn respond_page_agent_spawn_default(
 fn respond_page_agent_attach_default(
     mut reader: MessageReader<PageAgentAttachDefaultRequest>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
     idx: Option<Res<crate::client::page::strategy_index::PageStrategyIndex>>,
     kind_q: Query<&crate::client::page::strategy_components::StrategyKind>,
@@ -411,7 +389,6 @@ fn respond_page_agent_attach_default(
             p.default_model,
             &sid,
             &mut commands,
-            &mut meshes,
             &mut webview_mt,
             idx,
             &kind_q,

--- a/crates/page/vmux_editor/src/host/plugin.rs
+++ b/crates/page/vmux_editor/src/host/plugin.rs
@@ -507,7 +507,6 @@ fn path_from_files_url(url: &str) -> Option<PathBuf> {
 fn new_file_view_bundle(
     url: &str,
     path: PathBuf,
-    meshes: &mut ResMut<Assets<Mesh>>,
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) -> impl Bundle {
     let title = path
@@ -537,10 +536,6 @@ fn new_file_view_bundle(
             },
             WebviewSource::new(url),
             ResolvedWebviewUri(url.to_string()),
-            Mesh3d(meshes.add(bevy::math::primitives::Plane3d::new(
-                Vec3::Z,
-                Vec2::splat(0.5),
-            ))),
         ),
         (
             WebviewMaterialHandle(webview_mt.add(WebviewExtendStandardMaterial::default())),
@@ -563,11 +558,10 @@ fn new_file_view_bundle(
 
 pub fn restore_file_view_bundle(
     url: &str,
-    meshes: &mut ResMut<Assets<Mesh>>,
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) -> Option<impl Bundle> {
     let path = path_from_files_url(url)?;
-    Some(new_file_view_bundle(url, path, meshes, webview_mt))
+    Some(new_file_view_bundle(url, path, webview_mt))
 }
 
 fn clear_stack_children(stack: Entity, children_q: &Query<&Children>, commands: &mut Commands) {
@@ -582,7 +576,6 @@ pub fn handle_file_page_open(
     tasks: Query<(Entity, &PageOpenTask), PendingPageOpen>,
     children_q: Query<&Children>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
     mut record_writer: MessageWriter<vmux_core::event::RecordVisitRequest>,
 ) {
@@ -613,7 +606,7 @@ pub fn handle_file_page_open(
         clear_stack_children(task.stack, &children_q, &mut commands);
         let view = commands
             .spawn((
-                new_file_view_bundle(&clean_url, path, &mut meshes, &mut webview_mt),
+                new_file_view_bundle(&clean_url, path, &mut webview_mt),
                 ChildOf(task.stack),
             ))
             .id();
@@ -4617,7 +4610,6 @@ mod page_open_tests {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .add_message::<vmux_core::event::RecordVisitRequest>()
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_file_page_open);
         app

--- a/crates/page/vmux_layout/src/host/cef.rs
+++ b/crates/page/vmux_layout/src/host/cef.rs
@@ -100,7 +100,6 @@ pub(crate) fn apply_cef_state_to_meta(
 
 impl Browser {
     pub fn new(
-        meshes: &mut ResMut<Assets<Mesh>>,
         webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
         url: &str,
     ) -> impl Bundle {
@@ -117,7 +116,6 @@ impl Browser {
             },
             WebviewSource::new(url),
             ResolvedWebviewUri(url.to_string()),
-            Mesh3d(meshes.add(Plane3d::new(Vec3::Z, Vec2::splat(0.5)))),
             WebviewMaterialHandle(webview_mt.add(WebviewExtendStandardMaterial::default())),
             WebviewSize(Vec2::new(1280.0, 720.0)),
             Transform::default(),
@@ -136,7 +134,6 @@ impl Browser {
     }
 
     pub fn new_with_title(
-        meshes: &mut ResMut<Assets<Mesh>>,
         webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
         url: &str,
         title: &str,
@@ -154,7 +151,6 @@ impl Browser {
             },
             WebviewSource::new(url),
             ResolvedWebviewUri(url.to_string()),
-            Mesh3d(meshes.add(Plane3d::new(Vec3::Z, Vec2::splat(0.5)))),
             WebviewMaterialHandle(webview_mt.add(WebviewExtendStandardMaterial::default())),
             WebviewSize(Vec2::new(1280.0, 720.0)),
             Transform::default(),
@@ -173,7 +169,6 @@ impl Browser {
     }
 
     pub fn new_error(
-        meshes: &mut ResMut<Assets<Mesh>>,
         webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
         source_url: &str,
         display_url: &str,
@@ -192,7 +187,6 @@ impl Browser {
             },
             WebviewSource::new(source_url),
             ResolvedWebviewUri(source_url.to_string()),
-            Mesh3d(meshes.add(Plane3d::new(Vec3::Z, Vec2::splat(0.5)))),
             WebviewMaterialHandle(webview_mt.add(WebviewExtendStandardMaterial::default())),
             WebviewSize(Vec2::new(1280.0, 720.0)),
             Transform::default(),
@@ -213,7 +207,6 @@ impl Browser {
 
 pub fn layout_cef_bundle(
     host_window: Entity,
-    meshes: &mut ResMut<Assets<Mesh>>,
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) -> impl Bundle {
     (
@@ -235,7 +228,6 @@ pub fn layout_cef_bundle(
         },
         ZIndex(2),
         WebviewSource::new(LAYOUT_PAGE_URL),
-        Mesh3d(meshes.add(Plane3d::new(Vec3::Z, Vec2::splat(0.5)))),
         WebviewMaterialHandle(webview_mt.add(WebviewExtendStandardMaterial::default())),
         WebviewSize(Vec2::new(1280.0, 720.0)),
         Transform::default(),
@@ -376,30 +368,23 @@ mod tests {
 
     fn build_test_cef(
         mut commands: Commands,
-        mut meshes: ResMut<Assets<Mesh>>,
         mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
     ) {
         let host = commands.spawn_empty().id();
-        commands.spawn(layout_cef_bundle(host, &mut meshes, &mut webview_mt));
+        commands.spawn(layout_cef_bundle(host, &mut webview_mt));
     }
 
     fn build_test_page(
         mut commands: Commands,
-        mut meshes: ResMut<Assets<Mesh>>,
         mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
     ) {
-        commands.spawn(Browser::new(
-            &mut meshes,
-            &mut webview_mt,
-            "https://example.com",
-        ));
+        commands.spawn(Browser::new(&mut webview_mt, "https://example.com"));
     }
 
     #[test]
     fn layout_cef_uses_manual_pointer_routing() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Startup, build_test_cef);
         app.update();
@@ -417,7 +402,6 @@ mod tests {
     fn page_cef_uses_opaque_dark_initial_background() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Startup, build_test_page);
         app.update();
@@ -439,7 +423,6 @@ mod tests {
     fn page_cef_allows_native_first_responder() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Startup, build_test_page);
         app.update();

--- a/crates/page/vmux_layout/src/host/debug.rs
+++ b/crates/page/vmux_layout/src/host/debug.rs
@@ -15,10 +15,7 @@ fn is_debug_url(url: &str) -> bool {
 pub struct DebugView;
 
 impl DebugView {
-    pub fn new(
-        meshes: &mut ResMut<Assets<Mesh>>,
-        webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
-    ) -> impl Bundle {
+    pub fn new(webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>) -> impl Bundle {
         (
             (
                 Self,
@@ -31,10 +28,6 @@ impl DebugView {
                     icon: vmux_core::PageIcon::None,
                     bg_color: None,
                 },
-                Mesh3d(meshes.add(bevy::math::primitives::Plane3d::new(
-                    Vec3::Z,
-                    Vec2::splat(0.5),
-                ))),
             ),
             (
                 WebviewMaterialHandle(webview_mt.add(WebviewExtendStandardMaterial::default())),
@@ -62,7 +55,6 @@ pub fn handle_debug_page_open(
     tasks: Query<(Entity, &PageOpenTask), PendingPageOpen>,
     children_q: Query<&Children>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     for (entity, task) in &tasks {
@@ -80,10 +72,7 @@ pub fn handle_debug_page_open(
             icon: vmux_core::PageIcon::None,
             bg_color: None,
         });
-        commands.spawn((
-            DebugView::new(&mut meshes, &mut webview_mt),
-            ChildOf(task.stack),
-        ));
+        commands.spawn((DebugView::new(&mut webview_mt), ChildOf(task.stack)));
         commands.entity(entity).insert(PageOpenHandled);
     }
 }

--- a/crates/page/vmux_layout/src/host/stack.rs
+++ b/crates/page/vmux_layout/src/host/stack.rs
@@ -849,7 +849,6 @@ mod tests {
             .init_resource::<crate::tab::LastTabCloseAt>()
             .init_resource::<FocusedStack>()
             .insert_resource(test_settings())
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(
                 Update,
@@ -986,7 +985,6 @@ mod tests {
             .init_resource::<PendingCursorWarp>()
             .init_resource::<crate::tab::LastTabCloseAt>()
             .insert_resource(test_settings())
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(
                 Update,
@@ -1055,7 +1053,6 @@ mod tests {
             .init_resource::<PendingCursorWarp>()
             .init_resource::<crate::tab::LastTabCloseAt>()
             .insert_resource(test_settings())
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(
                 Update,
@@ -1112,7 +1109,6 @@ mod tests {
             .init_resource::<NewStackContext>()
             .init_resource::<PendingCursorWarp>()
             .insert_resource(test_settings())
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_stack_commands.in_set(WriteAppCommands));
 
@@ -1180,7 +1176,6 @@ mod tests {
             .insert_resource(crate::settings::EffectiveStartupUrl(
                 "vmux://agent/vibe/".to_string(),
             ))
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_stack_commands.in_set(WriteAppCommands));
 
@@ -1384,7 +1379,6 @@ mod tests {
             .init_resource::<NewStackContext>()
             .init_resource::<PendingCursorWarp>()
             .insert_resource(test_settings())
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .init_resource::<CollectedSpawns>()
             .add_systems(

--- a/crates/page/vmux_layout/src/host/warm_page.rs
+++ b/crates/page/vmux_layout/src/host/warm_page.rs
@@ -45,7 +45,6 @@ pub trait WarmPage: Component {
 
     fn spawn(
         commands: &mut Commands,
-        meshes: &mut ResMut<Assets<Mesh>>,
         webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
     ) -> Entity;
 }
@@ -122,7 +121,6 @@ fn handle_registered_page_open(
     spares: Query<(Entity, &WarmPageSpare), With<PageReady>>,
     children_q: Query<&Children>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     let pages: HashMap<&str, &PrewarmPage> = pages.iter().map(|page| (page.url, page)).collect();
@@ -151,7 +149,6 @@ fn handle_registered_page_open(
             } else {
                 let webview = commands
                     .spawn(crate::cef::Browser::new_with_title(
-                        &mut meshes,
                         &mut webview_mt,
                         page.url,
                         page.title,
@@ -173,7 +170,6 @@ fn maintain_registered_page_pools(
     layout_ready: Query<(), (With<LayoutCef>, With<PageReady>)>,
     spares: Query<&WarmPageSpare>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
     mut budget: ResMut<WarmPageSpawnBudget>,
 ) {
@@ -195,7 +191,6 @@ fn maintain_registered_page_pools(
             }
             let webview = commands
                 .spawn(crate::cef::Browser::new_with_title(
-                    &mut meshes,
                     &mut webview_mt,
                     page.url,
                     page.title,
@@ -213,7 +208,6 @@ fn handle_warm_page_open<M: WarmPage>(
     spares: Query<(Entity, &WarmPageSpare), With<PageReady>>,
     children_q: Query<&Children>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     let mut available: Vec<Entity> = spares
@@ -239,7 +233,7 @@ fn handle_warm_page_open<M: WarmPage>(
                     .insert((ChildOf(task.stack), CefKeyboardTarget))
                     .remove::<WarmPageSpare>();
             } else {
-                let page = M::spawn(&mut commands, &mut meshes, &mut webview_mt);
+                let page = M::spawn(&mut commands, &mut webview_mt);
                 commands
                     .entity(page)
                     .insert((ChildOf(task.stack), CefKeyboardTarget));
@@ -255,7 +249,6 @@ fn maintain_warm_page_pool<M: WarmPage>(
     layout_ready: Query<(), (With<LayoutCef>, With<PageReady>)>,
     spares: Query<&WarmPageSpare>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
     mut budget: ResMut<WarmPageSpawnBudget>,
 ) {
@@ -271,7 +264,7 @@ fn maintain_warm_page_pool<M: WarmPage>(
         if !budget.take() {
             return;
         }
-        let page = M::spawn(&mut commands, &mut meshes, &mut webview_mt);
+        let page = M::spawn(&mut commands, &mut webview_mt);
         commands
             .entity(page)
             .insert((WarmPageSpare { url: M::URL }, ChildOf(node)));
@@ -330,13 +323,12 @@ mod tests {
 
         fn spawn(
             commands: &mut Commands,
-            meshes: &mut ResMut<Assets<Mesh>>,
             webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
         ) -> Entity {
             commands
                 .spawn((
                     TestPage,
-                    Browser::new_with_title(meshes, webview_mt, Self::URL, Self::TITLE),
+                    Browser::new_with_title(webview_mt, Self::URL, Self::TITLE),
                 ))
                 .id()
         }
@@ -345,7 +337,6 @@ mod tests {
     fn app() -> App {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_warm_page_open::<TestPage>);
         app
@@ -408,7 +399,6 @@ mod tests {
     fn pool_waits_for_layout_then_fills() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .init_resource::<WarmPageSpawnBudget>()
             .add_systems(Update, maintain_warm_page_pool::<TestPage>);
@@ -438,7 +428,6 @@ mod tests {
     fn registered_page_claims_ready_spare() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_registered_page_open);
         app.world_mut().spawn(PrewarmPage {
@@ -483,7 +472,6 @@ mod tests {
     fn registered_page_without_pool_opens_cold() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_registered_page_open);
         app.world_mut().spawn(PrewarmPage {
@@ -519,7 +507,6 @@ mod tests {
     fn registered_pools_fill_for_every_page() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .init_resource::<WarmPageSpawnBudget>()
             .add_systems(Update, maintain_registered_page_pools);

--- a/crates/page/vmux_layout/src/host/window.rs
+++ b/crates/page/vmux_layout/src/host/window.rs
@@ -164,7 +164,6 @@ fn setup(
     main_camera: Single<Entity, With<MainCamera>>,
     mut commands: Commands,
     settings: Res<LayoutSettings>,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     let m = window.meters();
@@ -322,7 +321,6 @@ fn setup(
         },
         ZIndex(3),
         WebviewSource::new(COMMAND_BAR_PAGE_URL),
-        Mesh3d(meshes.add(Plane3d::new(Vec3::Z, Vec2::splat(0.5)))),
         WebviewMaterialHandle(webview_mt.add(WebviewExtendStandardMaterial::default())),
         WebviewSize(Vec2::new(800.0, 600.0)),
         Transform::default(),
@@ -332,10 +330,7 @@ fn setup(
         ChildOf(root),
     ));
 
-    commands.spawn((
-        layout_cef_bundle(pw, &mut meshes, &mut webview_mt),
-        ChildOf(root),
-    ));
+    commands.spawn((layout_cef_bundle(pw, &mut webview_mt), ChildOf(root)));
 }
 
 fn request_default_layout(
@@ -741,7 +736,6 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .insert_resource(test_settings(8.0))
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WindowMaterial>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>();
         app.world_mut().spawn((

--- a/crates/page/vmux_layout/src/start/plugin.rs
+++ b/crates/page/vmux_layout/src/start/plugin.rs
@@ -472,7 +472,6 @@ fn maintain_warm_start_pool(
     vmux_window: Query<Entity, With<VmuxWindow>>,
     spares: Query<(), With<WarmStartSpare>>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     let Ok(window) = vmux_window.single() else {
@@ -496,7 +495,7 @@ fn maintain_warm_start_pool(
     };
     for _ in spares.iter().count()..WARM_START_POOL_SIZE {
         commands.spawn((
-            Browser::new_with_title(&mut meshes, &mut webview_mt, START_PAGE_URL, "Start"),
+            Browser::new_with_title(&mut webview_mt, START_PAGE_URL, "Start"),
             WarmStartSpare,
             ChildOf(node),
         ));
@@ -878,7 +877,6 @@ mod tests {
     fn start_pool_fills_one_ready_slot() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, maintain_warm_start_pool);
         app.world_mut().spawn(VmuxWindow);

--- a/crates/page/vmux_setting/src/host/view.rs
+++ b/crates/page/vmux_setting/src/host/view.rs
@@ -58,10 +58,7 @@ impl Plugin for SettingsViewPlugin {
 pub struct Settings;
 
 impl Settings {
-    pub fn new(
-        meshes: &mut ResMut<Assets<Mesh>>,
-        webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
-    ) -> impl Bundle {
+    pub fn new(webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>) -> impl Bundle {
         (
             (
                 Self,
@@ -74,10 +71,6 @@ impl Settings {
                     icon: vmux_core::PageIcon::None,
                     bg_color: None,
                 },
-                Mesh3d(meshes.add(bevy::math::primitives::Plane3d::new(
-                    Vec3::Z,
-                    Vec2::splat(0.5),
-                ))),
             ),
             (
                 WebviewMaterialHandle(webview_mt.add(WebviewExtendStandardMaterial::default())),
@@ -106,10 +99,9 @@ impl WarmPage for Settings {
 
     fn spawn(
         commands: &mut Commands,
-        meshes: &mut ResMut<Assets<Mesh>>,
         webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
     ) -> Entity {
-        commands.spawn(Settings::new(meshes, webview_mt)).id()
+        commands.spawn(Settings::new(webview_mt)).id()
     }
 }
 
@@ -929,7 +921,6 @@ mod page_open_tests {
     fn settings_page_open_spawns_marker_and_handles() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_plugins(WarmPagePlugin::<Settings>::default());
         let stack = app.world_mut().spawn_empty().id();
@@ -962,7 +953,6 @@ mod page_open_tests {
     fn settings_page_open_dedupes_per_stack() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_plugins(WarmPagePlugin::<Settings>::default());
         let stack = app.world_mut().spawn_empty().id();

--- a/crates/page/vmux_space/src/host/spaces.rs
+++ b/crates/page/vmux_space/src/host/spaces.rs
@@ -27,10 +27,7 @@ pub fn space_profile_bundle(record: &SpaceRecord) -> impl Bundle {
 pub struct Spaces;
 
 impl Spaces {
-    pub fn new(
-        meshes: &mut ResMut<Assets<Mesh>>,
-        webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
-    ) -> impl Bundle {
+    pub fn new(webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>) -> impl Bundle {
         (
             (
                 Self,
@@ -43,10 +40,6 @@ impl Spaces {
                     icon: vmux_core::PageIcon::None,
                     bg_color: None,
                 },
-                Mesh3d(meshes.add(bevy::math::primitives::Plane3d::new(
-                    Vec3::Z,
-                    Vec2::splat(0.5),
-                ))),
             ),
             (
                 WebviewMaterialHandle(webview_mt.add(WebviewExtendStandardMaterial::default())),
@@ -75,10 +68,9 @@ impl WarmPage for Spaces {
 
     fn spawn(
         commands: &mut Commands,
-        meshes: &mut ResMut<Assets<Mesh>>,
         webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
     ) -> Entity {
-        commands.spawn(Spaces::new(meshes, webview_mt)).id()
+        commands.spawn(Spaces::new(webview_mt)).id()
     }
 }
 

--- a/crates/page/vmux_team/src/host.rs
+++ b/crates/page/vmux_team/src/host.rs
@@ -60,12 +60,11 @@ impl WarmPage for Team {
 
     fn spawn(
         commands: &mut Commands,
-        meshes: &mut ResMut<Assets<Mesh>>,
         webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
     ) -> Entity {
         commands
             .spawn((
-                vmux_layout::Browser::new_with_title(meshes, webview_mt, Self::URL, Self::TITLE),
+                vmux_layout::Browser::new_with_title(webview_mt, Self::URL, Self::TITLE),
                 Team,
             ))
             .id()
@@ -509,7 +508,6 @@ mod tests {
         use vmux_core::page_open::{PageOpenId, PageOpenTask};
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_plugins(WarmPagePlugin::<Team>::default());
 

--- a/crates/page/vmux_terminal/src/host/plugin.rs
+++ b/crates/page/vmux_terminal/src/host/plugin.rs
@@ -481,7 +481,6 @@ fn spawn_layout_requested_content(
     child_of: Query<&ChildOf>,
     tabs: Query<&vmux_layout::tab::Tab>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     for request in reader.read() {
@@ -497,12 +496,7 @@ fn spawn_layout_requested_content(
                 };
                 let terminal = commands
                     .spawn((
-                        new_terminal_bundle_with_cwd(
-                            &mut meshes,
-                            &mut webview_mt,
-                            &settings,
-                            cwd.as_deref(),
-                        ),
+                        new_terminal_bundle_with_cwd(&mut webview_mt, &settings, cwd.as_deref()),
                         ChildOf(*stack),
                     ))
                     .id();
@@ -523,7 +517,6 @@ fn handle_terminal_page_open(
     settings: Res<AppSettings>,
     active_space: Res<vmux_space::spaces::ActiveSpace>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     for (entity, task) in &tasks {
@@ -539,7 +532,6 @@ fn handle_terminal_page_open(
                 &settings,
                 &active_space,
                 &mut commands,
-                &mut meshes,
                 &mut webview_mt,
             ) {
                 Ok(()) => {
@@ -562,7 +554,6 @@ fn open_terminal_page(
     settings: &AppSettings,
     active_space: &vmux_space::spaces::ActiveSpace,
     commands: &mut Commands,
-    meshes: &mut ResMut<Assets<Mesh>>,
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) -> Result<(), String> {
     let parsed = url::Url::parse(&task.url)
@@ -609,7 +600,7 @@ fn open_terminal_page(
     });
     let terminal = commands
         .spawn((
-            new_terminal_bundle_with_cwd(meshes, webview_mt, settings, cwd.as_deref()),
+            new_terminal_bundle_with_cwd(webview_mt, settings, cwd.as_deref()),
             ChildOf(task.stack),
         ))
         .id();
@@ -628,7 +619,6 @@ fn clear_stack_children(stack: Entity, children_q: &Query<&Children>, commands: 
 fn respond_terminal_spawn(
     mut reader: MessageReader<TerminalSpawnRequest>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
     settings: Res<AppSettings>,
     child_of_q: Query<&ChildOf>,
@@ -636,7 +626,6 @@ fn respond_terminal_spawn(
     for req in reader.read() {
         let term_e = commands
             .spawn(new_terminal_bundle_with_cwd(
-                &mut meshes,
                 &mut webview_mt,
                 &settings,
                 req.cwd.as_deref(),
@@ -678,24 +667,21 @@ fn service_wake_callback(app: &App) -> Option<ServiceWake> {
 }
 
 pub fn new_terminal_bundle(
-    meshes: &mut ResMut<Assets<Mesh>>,
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
     settings: &AppSettings,
 ) -> impl Bundle {
-    new_terminal_bundle_with_cwd(meshes, webview_mt, settings, None)
+    new_terminal_bundle_with_cwd(webview_mt, settings, None)
 }
 
 pub fn new_terminal_bundle_with_cwd(
-    meshes: &mut ResMut<Assets<Mesh>>,
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
     settings: &AppSettings,
     cwd: Option<&std::path::Path>,
 ) -> impl Bundle {
-    new_terminal_bundle_with_cwd_and_shell(meshes, webview_mt, settings, cwd, None)
+    new_terminal_bundle_with_cwd_and_shell(webview_mt, settings, cwd, None)
 }
 
 fn new_terminal_bundle_with_cwd_and_shell(
-    meshes: &mut ResMut<Assets<Mesh>>,
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
     settings: &AppSettings,
     cwd: Option<&std::path::Path>,
@@ -740,10 +726,6 @@ fn new_terminal_bundle_with_cwd_and_shell(
             },
             WebviewSource::new(TERMINAL_PAGE_URL),
             ResolvedWebviewUri(TERMINAL_PAGE_URL.to_string()),
-            Mesh3d(meshes.add(bevy::math::primitives::Plane3d::new(
-                Vec3::Z,
-                Vec2::splat(0.5),
-            ))),
         ),
         (
             WebviewMaterialHandle(webview_mt.add(WebviewExtendStandardMaterial::default())),
@@ -769,7 +751,6 @@ pub fn respond_terminal_stack_spawn(
     mut reader: MessageReader<TerminalStackSpawnRequest>,
     settings: Res<AppSettings>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     for request in reader.read() {
@@ -799,7 +780,6 @@ pub fn respond_terminal_stack_spawn(
         let terminal = commands
             .spawn((
                 new_terminal_bundle_with_cwd_and_shell(
-                    &mut meshes,
                     &mut webview_mt,
                     &settings,
                     request.cwd.as_deref(),
@@ -824,7 +804,6 @@ pub fn respond_terminal_stack_spawn(
 }
 
 pub fn reattach_terminal_bundle(
-    meshes: &mut ResMut<Assets<Mesh>>,
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
     process_id: ProcessId,
 ) -> impl Bundle {
@@ -843,10 +822,6 @@ pub fn reattach_terminal_bundle(
             },
             WebviewSource::new(TERMINAL_PAGE_URL),
             ResolvedWebviewUri(TERMINAL_PAGE_URL.to_string()),
-            Mesh3d(meshes.add(bevy::math::primitives::Plane3d::new(
-                Vec3::Z,
-                Vec2::splat(0.5),
-            ))),
         ),
         (
             WebviewMaterialHandle(webview_mt.add(WebviewExtendStandardMaterial::default())),
@@ -3985,7 +3960,6 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .add_message::<TerminalStackSpawnRequest>()
             .insert_resource(test_settings())
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, respond_terminal_stack_spawn);
 
@@ -4021,7 +3995,6 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .insert_resource(test_settings())
             .init_resource::<vmux_space::spaces::ActiveSpace>()
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_terminal_page_open);
 
@@ -4069,7 +4042,6 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .insert_resource(settings)
             .insert_resource(vmux_space::spaces::ActiveSpace { record })
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_terminal_page_open);
 
@@ -4100,7 +4072,6 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .insert_resource(test_settings())
             .insert_resource(vmux_space::spaces::ActiveSpace { record })
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_terminal_page_open);
 
@@ -4142,7 +4113,6 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .insert_resource(settings)
             .insert_resource(vmux_space::spaces::ActiveSpace { record })
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_terminal_page_open);
 
@@ -4193,7 +4163,6 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .insert_resource(settings)
             .insert_resource(vmux_space::spaces::ActiveSpace { record })
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, handle_terminal_page_open);
 
@@ -4248,7 +4217,6 @@ mod tests {
             .add_message::<LayoutSpawnRequest>()
             .insert_resource(settings)
             .insert_resource(vmux_space::spaces::ActiveSpace { record })
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .add_systems(Update, spawn_layout_requested_content);
 

--- a/crates/page/vmux_terminal/src/host/processes_monitor.rs
+++ b/crates/page/vmux_terminal/src/host/processes_monitor.rs
@@ -58,10 +58,7 @@ impl Plugin for ProcessesMonitorPlugin {
 pub struct ProcessesMonitor;
 
 impl ProcessesMonitor {
-    pub fn new(
-        meshes: &mut ResMut<Assets<Mesh>>,
-        webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
-    ) -> impl Bundle {
+    pub fn new(webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>) -> impl Bundle {
         (
             (
                 Self,
@@ -74,10 +71,6 @@ impl ProcessesMonitor {
                     icon: vmux_core::PageIcon::None,
                     bg_color: None,
                 },
-                Mesh3d(meshes.add(bevy::math::primitives::Plane3d::new(
-                    Vec3::Z,
-                    Vec2::splat(0.5),
-                ))),
             ),
             (
                 WebviewMaterialHandle(webview_mt.add(WebviewExtendStandardMaterial::default())),
@@ -106,12 +99,9 @@ impl WarmPage for ProcessesMonitor {
 
     fn spawn(
         commands: &mut Commands,
-        meshes: &mut ResMut<Assets<Mesh>>,
         webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
     ) -> Entity {
-        commands
-            .spawn(ProcessesMonitor::new(meshes, webview_mt))
-            .id()
+        commands.spawn(ProcessesMonitor::new(webview_mt)).id()
     }
 }
 
@@ -322,7 +312,6 @@ fn on_process_navigate(
     pane_ts: Query<(Entity, &LastActivatedAt), With<Pane>>,
     pane_children: Query<&Children, With<Pane>>,
     stack_ts: Query<(Entity, &LastActivatedAt), With<Stack>>,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
     mut commands: Commands,
 ) {
@@ -361,7 +350,7 @@ fn on_process_navigate(
         .spawn((stack_bundle(), LastActivatedAt::now(), ChildOf(pane)))
         .id();
     commands.spawn((
-        reattach_terminal_bundle(&mut meshes, &mut webview_mt, process_id),
+        reattach_terminal_bundle(&mut webview_mt, process_id),
         ChildOf(tab),
     ));
 }

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -1107,7 +1107,6 @@ fn attach_cef_page_to_stack(
     bg_color: Option<String>,
     children_q: &Query<&Children>,
     commands: &mut Commands,
-    meshes: &mut ResMut<Assets<Mesh>>,
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) -> Entity {
     clear_stack_children(stack, children_q, commands);
@@ -1119,7 +1118,7 @@ fn attach_cef_page_to_stack(
     });
     let browser = commands
         .spawn((
-            Browser::new_with_title(meshes, webview_mt, url, title),
+            Browser::new_with_title(webview_mt, url, title),
             ChildOf(stack),
         ))
         .id();
@@ -1134,7 +1133,6 @@ fn attach_error_page_to_stack(
     message: &str,
     children_q: &Query<&Children>,
     commands: &mut Commands,
-    meshes: &mut ResMut<Assets<Mesh>>,
     webview_mt: &mut ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     let source = error_page_source(title, message, display_url);
@@ -1146,7 +1144,7 @@ fn attach_error_page_to_stack(
     });
     let browser = commands
         .spawn((
-            Browser::new_error(meshes, webview_mt, &source, display_url, title),
+            Browser::new_error(webview_mt, &source, display_url, title),
             ChildOf(stack),
         ))
         .id();
@@ -1985,7 +1983,6 @@ mod tests {
             app.init_resource::<AgentStrategies>()
                 .insert_resource(FocusedStack::default())
                 .insert_resource(test_settings())
-                .init_resource::<Assets<Mesh>>()
                 .init_resource::<Assets<WebviewExtendStandardMaterial>>()
                 .init_resource::<CapturedNavigateUrls>();
 
@@ -2038,7 +2035,6 @@ mod tests {
             app.init_resource::<AgentStrategies>()
                 .insert_resource(FocusedStack::default())
                 .insert_resource(test_settings())
-                .init_resource::<Assets<Mesh>>()
                 .init_resource::<Assets<WebviewExtendStandardMaterial>>();
 
             let pane = app.world_mut().spawn(Pane).id();
@@ -2093,7 +2089,6 @@ mod tests {
             app.add_plugins((MinimalPlugins, ConsumerPlugin));
             app.insert_resource(FocusedStack::default())
                 .insert_resource(test_settings())
-                .init_resource::<Assets<Mesh>>()
                 .init_resource::<Assets<WebviewExtendStandardMaterial>>();
 
             let pane = app.world_mut().spawn(Pane).id();
@@ -2151,7 +2146,6 @@ mod tests {
             app.add_plugins((MinimalPlugins, ConsumerPlugin));
             app.insert_resource(FocusedStack::default())
                 .insert_resource(test_settings())
-                .init_resource::<Assets<Mesh>>()
                 .init_resource::<Assets<WebviewExtendStandardMaterial>>();
 
             let pane = app.world_mut().spawn(Pane).id();
@@ -2204,7 +2198,6 @@ mod tests {
             app.init_resource::<AgentStrategies>()
                 .insert_resource(FocusedStack::default())
                 .insert_resource(test_settings())
-                .init_resource::<Assets<Mesh>>()
                 .init_resource::<Assets<WebviewExtendStandardMaterial>>();
 
             let pane_a = app.world_mut().spawn(Pane).id();
@@ -2252,7 +2245,6 @@ mod tests {
             app.init_resource::<AgentStrategies>()
                 .insert_resource(FocusedStack::default())
                 .insert_resource(test_settings())
-                .init_resource::<Assets<Mesh>>()
                 .init_resource::<Assets<WebviewExtendStandardMaterial>>();
 
             let pane = app.world_mut().spawn(Pane).id();
@@ -2301,7 +2293,6 @@ mod tests {
             app.init_resource::<AgentStrategies>()
                 .insert_resource(FocusedStack::default())
                 .insert_resource(test_settings())
-                .init_resource::<Assets<Mesh>>()
                 .init_resource::<Assets<WebviewExtendStandardMaterial>>();
 
             let pane_a = app.world_mut().spawn(Pane).id();
@@ -2354,7 +2345,6 @@ mod tests {
             app.init_resource::<AgentStrategies>()
                 .insert_resource(FocusedStack::default())
                 .insert_resource(test_settings())
-                .init_resource::<Assets<Mesh>>()
                 .init_resource::<Assets<WebviewExtendStandardMaterial>>();
 
             let pane = app.world_mut().spawn(Pane).id();
@@ -2403,7 +2393,6 @@ mod tests {
             app.add_plugins((MinimalPlugins, vmux_command::CommandPlugin, ConsumerPlugin));
             app.insert_resource(FocusedStack::default())
                 .insert_resource(test_settings())
-                .init_resource::<Assets<Mesh>>()
                 .init_resource::<Assets<WebviewExtendStandardMaterial>>();
 
             let pane = app.world_mut().spawn(Pane).id();
@@ -2461,7 +2450,6 @@ mod tests {
                 ))
                 .insert_resource(FocusedStack::default())
                 .insert_resource(test_settings())
-                .init_resource::<Assets<Mesh>>()
                 .init_resource::<Assets<WebviewExtendStandardMaterial>>();
 
             let pane = app.world_mut().spawn(Pane).id();
@@ -2509,7 +2497,6 @@ mod tests {
                 ))
                 .insert_resource(FocusedStack::default())
                 .insert_resource(test_settings())
-                .init_resource::<Assets<Mesh>>()
                 .init_resource::<Assets<WebviewExtendStandardMaterial>>();
 
             let pane = app.world_mut().spawn(Pane).id();
@@ -2574,7 +2561,6 @@ mod tests {
                 Update,
                 capture_page_open_requests.after(vmux_command::ReadAppCommands),
             )
-            .init_resource::<Assets<Mesh>>()
             .init_resource::<Assets<WebviewExtendStandardMaterial>>()
             .init_resource::<CapturedNavigateUrls>()
             .init_resource::<CapturedPageOpenRequests>()

--- a/crates/vmux_browser/src/page_life.rs
+++ b/crates/vmux_browser/src/page_life.rs
@@ -60,7 +60,6 @@ pub(crate) fn spawn_popup_stacks(
     stack_q: Query<(), With<Stack>>,
     leaf_panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     while let Ok(ev) = popup_rx.0.try_recv() {
@@ -85,7 +84,7 @@ pub(crate) fn spawn_popup_stacks(
             .spawn((stack_bundle(), LastActivatedAt::now(), ChildOf(pane)))
             .id();
         commands.spawn((
-            Browser::new(&mut meshes, &mut webview_mt, &ev.target_url),
+            Browser::new(&mut webview_mt, &ev.target_url),
             ChildOf(new_stack),
         ));
     }

--- a/crates/vmux_browser/src/page_open.rs
+++ b/crates/vmux_browser/src/page_open.rs
@@ -140,7 +140,6 @@ pub(crate) fn attach_cef_page_requests(
     mut reader: MessageReader<CefPageAttachRequest>,
     children_q: Query<&Children>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     for request in reader.read() {
@@ -151,7 +150,6 @@ pub(crate) fn attach_cef_page_requests(
             request.bg_color.clone(),
             &children_q,
             &mut commands,
-            &mut meshes,
             &mut webview_mt,
         );
     }
@@ -169,7 +167,6 @@ pub(crate) fn handle_unclaimed_page_open_tasks(
     >,
     children_q: Query<&Children>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
     mut webview_mt: ResMut<Assets<WebviewExtendStandardMaterial>>,
 ) {
     for (entity, task, error, deferred_once) in &mut tasks {
@@ -181,7 +178,6 @@ pub(crate) fn handle_unclaimed_page_open_tasks(
                 &error.message,
                 &children_q,
                 &mut commands,
-                &mut meshes,
                 &mut webview_mt,
             );
             commands.entity(entity).insert(PageOpenHandled);
@@ -193,7 +189,6 @@ pub(crate) fn handle_unclaimed_page_open_tasks(
                 &task.url,
                 &children_q,
                 &mut commands,
-                &mut meshes,
                 &mut webview_mt,
             );
             commands.entity(entity).insert(PageOpenHandled);
@@ -209,7 +204,6 @@ pub(crate) fn handle_unclaimed_page_open_tasks(
                 "",
                 &children_q,
                 &mut commands,
-                &mut meshes,
                 &mut webview_mt,
             );
             commands.entity(entity).insert((
@@ -226,7 +220,6 @@ pub(crate) fn handle_unclaimed_page_open_tasks(
                 None,
                 &children_q,
                 &mut commands,
-                &mut meshes,
                 &mut webview_mt,
             );
             commands.entity(entity).insert(PageOpenHandled);


### PR DESCRIPTION
Closes [VMX-166](https://linear.app/vmux/issue/VMX-166/remove-the-mesh3d-quads-nothing-renders). **Stacked on `#369`** — base is `vmx-165-collapse-interaction-mode`, because `window.rs` and `vmux_terminal/src/host/plugin.rs` are touched by both.

**273 deletions, 42 insertions across 22 files.**

## These were already dead

Every page spawned `Mesh3d(meshes.add(Plane3d::new(Vec3::Z, Vec2::splat(0.5))))` to carry its webview texture. Nothing has drawn them since `#366`.

`bevy_cef` picks its render path on the `pbr` feature (`patches/bevy_cef-0.5.2/src/webview/mesh.rs:29-50`):

- **with `pbr`** — `pub use MeshMaterial3d as WebviewMaterialHandle`; the mesh *is* the surface
- **without `pbr`** — the handle is a plain component carrying `#[require(Sprite = webview_sprite())]`, and `WebviewSpritePlugin` draws it

`#366` dropped `bevy_cef/pbr` along with the 3D scene, so the second path is what ships. Two independent confirmations that no 3D pipeline survives to consume a `Mesh3d`:

```
$ cargo tree -p vmux_desktop -i bevy_pbr
error: package ID specification `bevy_pbr` did not match any packages
```

and the only camera spawned anywhere in the workspace is `Camera2d` (`vmux_layout/src/host/scene.rs:35`). There is no `Camera3d`.

So what you see on screen is sprites drawn by `Camera2d`, plus native overlays and windowed `NSView`s on macOS. The quads were components nothing read.

## What that frees

The `meshes: &mut ResMut<Assets<Mesh>>` parameter was threaded through every bundle constructor in the codebase to feed those 12 spawns — **120 references across 19 files** — plus 69 `init_resource::<Assets<Mesh>>()` calls in test setup. All of it goes.

`Transform` and `WebviewSize` stay on the same entities. Sprite rendering and native-overlay placement both read them, so removing a `Transform` because its mesh went would break layout.

## On `bevy_mesh`

Out of the workspace feature allowlist, because nothing asks for meshes now. **It does not leave the build** — `bevy_camera` pulls it in for `bevy_core_pipeline`, which the camera needs. This is accuracy about what we request, not a dependency win. `release_invariants.rs` caught the change, which is exactly what that allowlist test is for.

## Deliberately left alone

`mesh_picking` is still enabled and now has nothing to pick. I did not remove it: picking is runtime behaviour and a clean compile proves nothing about it, so it wants verification I can't do. Same reasoning as `sprite_picking`.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --exclude bevy_cef_core --exclude bevy_cef` — 2,946 pass, identical to the base branch, so no test was lost
- [x] `grep -rn 'meshes\|Assets<Mesh>\|Mesh3d' crates/` returns nothing
- [ ] **Visual check needed.** This deletes rendering components on the argument that nothing consumes them. The argument is strong, but I don't run vmux — pages, terminal, editor, settings, spaces and the command bar all need to still draw.