### PR TITLE
Keep client-only crates out of the server tree, and drop bevy_ui_render

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,8 +277,11 @@ jobs:
           fi
           echo "control ok: vmux_desktop links bevy_cef"
 
-          # vmux_service joins this list once VMX-142 lands. It reaches bevy_cef today through
-          # vmux_core directly and through vmux_layout -> vmux_command.
+          # vmux_service still reaches bevy_cef through vmux_core and vmux_git, both of which it
+          # depends on for other reasons and both of which pull the page IPC transport
+          # (BinEventEmitterPlugin, BinReceive) the server never uses. Cutting that needs a
+          # feature split in those two crates; the client-only assertion below is the half of
+          # VMX-142 that does not.
           for pkg in vmux_session; do
             if links_cef "$pkg"; then
               echo "::error::$pkg links bevy_cef:"
@@ -286,6 +289,65 @@ jobs:
               exit 1
             fi
             echo "ok: $pkg does not link bevy_cef"
+          done
+
+      # A server has no business linking the UI component library, the tiling tree, or a page.
+      # Server versus client is a crate distinction rather than a cfg one: `cfg(host)` is true in
+      # both processes and enforces nothing, whereas a crate edge cannot come back without a
+      # manifest change this job can see.
+      - name: The server links no client-only crate
+        run: |
+          set -euo pipefail
+
+          # Pinned to the host target on purpose. vmux_service also compiles as a page for
+          # wasm and iOS, and that half depends on vmux_ui legitimately; an untargeted query
+          # sees every cfg section at once and reports it. The claim is about the server.
+          #
+          # `cargo tree --target` exits 0 whether or not it found anything and prints "nothing
+          # to print" to stderr, so unlike the untargeted query above, stdout is the only signal.
+          #
+          # Which makes discarding stderr a trap: a query that fails outright — a stale lockfile
+          # under --locked is the easy way in — also produces empty stdout, and an assertion
+          # reading "empty" as "clean" passes precisely when it has stopped working. Status and
+          # stdout are separate answers to separate questions, so keep them apart.
+          # Three outcomes, not two, and only the third is a broken query:
+          #   exit 101 + "did not match any packages"  crate is nowhere in the graph — clean
+          #   exit 0   + empty stdout                  crate resolves but nothing reaches it — clean
+          #   exit 0   + stdout                        linked
+          # Anything else — a stale lockfile under --locked is the easy way in — means the query
+          # itself failed, and that must fail the job rather than read as clean.
+          out=$(mktemp)
+          err=$(mktemp)
+
+          query() {
+            local status
+            set +e
+            cargo tree --locked --target x86_64-unknown-linux-gnu -p "$1" -i "$2" >"$out" 2>"$err"
+            status=$?
+            set -e
+            if [ "$status" -ne 0 ] && ! grep -q 'did not match any packages' "$err"; then
+              echo "::error::cargo tree failed for $1 -i $2, so this job proved nothing:"
+              cat "$err" >&2
+              exit 1
+            fi
+            [ "$status" -eq 0 ] || : >"$out"
+          }
+
+          query vmux_desktop vmux_ui
+          if [ ! -s "$out" ]; then
+            echo "::error::positive control failed: vmux_ui not found in vmux_desktop, so this job is asserting nothing"
+            exit 1
+          fi
+          echo "control ok: vmux_desktop links vmux_ui"
+
+          for pkg in vmux_ui vmux_layout vmux_editor vmux_terminal vmux_browser; do
+            query vmux_service "$pkg"
+            if [ -s "$out" ]; then
+              echo "::error::vmux_service links client-only crate $pkg:"
+              cat "$out"
+              exit 1
+            fi
+            echo "ok: vmux_service does not link $pkg"
           done
 
       # The graph is not the build. Feature unification across a workspace invocation can supply

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11562,7 +11562,7 @@ dependencies = [
  "uuid",
  "vmux_client",
  "vmux_core",
- "vmux_layout",
+ "vmux_git",
  "vmux_remote",
  "vmux_ui",
  "vmux_wire",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,7 +1395,6 @@ dependencies = [
  "bevy_time",
  "bevy_transform",
  "bevy_ui",
- "bevy_ui_render",
  "bevy_utils",
  "bevy_window",
  "bevy_winit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ bevy = { version = "0.19.0", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_sprite",
     "bevy_ui",
-    "bevy_ui_render",
     "bevy_image",
     "bevy_scene",
     "bevy_picking",

--- a/crates/app/vmux_desktop/tests/release_invariants.rs
+++ b/crates/app/vmux_desktop/tests/release_invariants.rs
@@ -532,7 +532,6 @@ fn workspace_bevy_uses_explicit_feature_allowlist() {
         "bevy_core_pipeline",
         "bevy_sprite",
         "bevy_ui",
-        "bevy_ui_render",
         "bevy_image",
         "bevy_scene",
         "bevy_picking",

--- a/crates/host/vmux_service/Cargo.toml
+++ b/crates/host/vmux_service/Cargo.toml
@@ -44,7 +44,7 @@ crossbeam-channel = "0.5"
 futures-util = "0.3"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
 vmux_core = { path = "../../vmux_core" }
-vmux_layout = { path = "../../page/vmux_layout" }
+vmux_git = { path = "../../vmux_git" }
 vmux_client = { path = "../vmux_client" }
 agent-client-protocol = "1.0.1"
 tokio-util = { version = "0.7", features = ["compat"] }

--- a/crates/host/vmux_service/src/host/acp/driver.rs
+++ b/crates/host/vmux_service/src/host/acp/driver.rs
@@ -226,7 +226,7 @@ impl AcpShared {
     }
 
     fn publish_workspace_change(&self, name: &str, branch: &str, cwd: &str, workspace_cwd: &str) {
-        let Ok(validated) = vmux_layout::worktree::validate_linked_workspace(
+        let Ok(validated) = vmux_git::worktree::validate_linked_workspace(
             Path::new(cwd),
             Path::new(workspace_cwd),
             branch,

--- a/crates/page/vmux_agent/src/host/client/acp.rs
+++ b/crates/page/vmux_agent/src/host/client/acp.rs
@@ -262,8 +262,8 @@ fn apply_acp_agent_info(
 
 fn validate_acp_workspace(
     event: &vmux_service::agent_events::PageAgentWorkspaceChanged,
-) -> Result<vmux_layout::worktree::ValidatedLinkedWorkspace, String> {
-    vmux_layout::worktree::validate_linked_workspace(
+) -> Result<vmux_git::worktree::ValidatedLinkedWorkspace, String> {
+    vmux_git::worktree::validate_linked_workspace(
         std::path::Path::new(&event.cwd),
         std::path::Path::new(&event.workspace_cwd),
         &event.branch,

--- a/crates/page/vmux_layout/src/host/worktree.rs
+++ b/crates/page/vmux_layout/src/host/worktree.rs
@@ -214,44 +214,6 @@ fn canonical_execution_dir(checkout_root: &Path, relative_dir: &Path) -> Result<
     Ok(execution_dir)
 }
 
-pub struct ValidatedLinkedWorkspace {
-    pub cwd: PathBuf,
-    pub workspace_cwd: PathBuf,
-    pub checkout: CheckoutInfo,
-}
-
-pub fn validate_linked_workspace(
-    cwd: &Path,
-    workspace_cwd: &Path,
-    branch: &str,
-) -> Result<ValidatedLinkedWorkspace, String> {
-    let cwd = cwd
-        .canonicalize()
-        .map_err(|error| format!("invalid worktree directory: {error}"))?;
-    let workspace_cwd = workspace_cwd
-        .canonicalize()
-        .map_err(|error| format!("invalid project directory: {error}"))?;
-    let checkout = worktree::checkout_info(&cwd).map_err(|error| error.0)?;
-    let workspace = worktree::checkout_info(&workspace_cwd).map_err(|error| error.0)?;
-    if checkout.common_dir != workspace.common_dir {
-        return Err("worktree belongs to a different repository".to_string());
-    }
-    if !worktree::is_linked_worktree(&cwd) {
-        return Err("worktree directory is not a linked worktree".to_string());
-    }
-    let actual_branch = worktree::head_ref(&checkout.root).map_err(|error| error.0)?;
-    if actual_branch != branch {
-        return Err(format!(
-            "worktree is on branch {actual_branch}, expected {branch}"
-        ));
-    }
-    Ok(ValidatedLinkedWorkspace {
-        cwd,
-        workspace_cwd,
-        checkout,
-    })
-}
-
 fn plan_worktree(
     checkout: &CheckoutInfo,
     managed_root: &Path,

--- a/crates/vmux_git/src/host/worktree.rs
+++ b/crates/vmux_git/src/host/worktree.rs
@@ -521,6 +521,47 @@ pub fn is_linked_worktree(dir: &Path) -> bool {
     git_dir != common_dir
 }
 
+/// A worktree that has been checked to belong to the expected repository and branch.
+pub struct ValidatedLinkedWorkspace {
+    pub cwd: PathBuf,
+    pub workspace_cwd: PathBuf,
+    pub checkout: CheckoutInfo,
+}
+
+/// Check that `cwd` is a linked worktree of the same repository as `workspace_cwd`, sitting on
+/// `branch`.
+pub fn validate_linked_workspace(
+    cwd: &Path,
+    workspace_cwd: &Path,
+    branch: &str,
+) -> Result<ValidatedLinkedWorkspace, String> {
+    let cwd = cwd
+        .canonicalize()
+        .map_err(|error| format!("invalid worktree directory: {error}"))?;
+    let workspace_cwd = workspace_cwd
+        .canonicalize()
+        .map_err(|error| format!("invalid project directory: {error}"))?;
+    let checkout = checkout_info(&cwd).map_err(|error| error.0)?;
+    let workspace = checkout_info(&workspace_cwd).map_err(|error| error.0)?;
+    if checkout.common_dir != workspace.common_dir {
+        return Err("worktree belongs to a different repository".to_string());
+    }
+    if !is_linked_worktree(&cwd) {
+        return Err("worktree directory is not a linked worktree".to_string());
+    }
+    let actual_branch = head_ref(&checkout.root).map_err(|error| error.0)?;
+    if actual_branch != branch {
+        return Err(format!(
+            "worktree is on branch {actual_branch}, expected {branch}"
+        ));
+    }
+    Ok(ValidatedLinkedWorkspace {
+        cwd,
+        workspace_cwd,
+        checkout,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/docs/specs/2026-08-08-osr-free-desktop-design.md
+++ b/docs/specs/2026-08-08-osr-free-desktop-design.md
@@ -92,6 +92,26 @@ it positions native surfaces.
 header becomes a strip at the top and the side sheet a strip at the left. Because the rectangles do
 not overlap, AppKit hit-testing resolves them with no help from us.
 
+> **Corrected 2026-08-14. The paragraph above prescribes more work than the goal needs.** Disjoint
+> rectangles are one way to let AppKit resolve hit-testing, not the only one. A *single* full-window
+> layout view placed **behind** the panes resolves it by the same rule — the topmost view under the
+> cursor gets the event, so panes win inside their rects and the layout wins in the gaps. No strips,
+> no second surface, no page split, and `page.rs` keeps the flexbox it already has.
+>
+> It sits above the panes today only because it is transparent glass, which is what forced the
+> `CALayer` overlay, the full-window canvas, and the `pointer-events-none` / `pointer-events-auto`
+> shim that re-enables the mouse on exactly two rectangles. Once glass is dropped and the view is
+> opaque it can go to the back, and that shim goes with it.
+>
+> What blocks it is popovers, not geometry. `page.rs` renders `LayoutContextMenu`,
+> `ContextMenuContent` and `SideSheetContextMenuContent`, and the side sheet carries
+> `overflow-visible` precisely so menus escape their own bounds and spill over the panes. Behind the
+> panes, every one of those renders behind them.
+>
+> So *Popovers to child windows* is not step 4 — it is the step straight after the command bar, and
+> *Header and side sheet to sibling views* disappears entirely. Corrected order in
+> [VMX-167](https://linear.app/vmux/issue/VMX-167/unify-input-on-the-key-claim-model).
+
 **Floating surfaces are child `NSWindow`s** — the command bar, context menus, dropdowns, tooltips. A
 child window may be transparent, carries a real shadow, and can extend past the parent window's
 bounds. That is what a menu needs and what an opaque sibling view cannot provide, and it is how


### PR DESCRIPTION
Closes [VMX-142](https://linear.app/vmux/issue/VMX-142/keep-client-only-crates-out-of-the-server-dependency-tree), except the `bevy_cef` half — see below.

## The cut

`vmux_service` reached `vmux_layout` for exactly one call: `validate_linked_workspace` in `acp/driver.rs:229`. That single edge pulled in `vmux_command`, `bevy_cef` and `vmux_ui`.

The function is git logic — it already builds on `vmux_git::worktree::{checkout_info, head_ref, is_linked_worktree}` — so it moves to `vmux_git` and both callers name it directly. 30 lines and a struct.

On the host target the server now links none of `vmux_ui`, `vmux_layout`, `vmux_editor`, `vmux_terminal` or `vmux_browser`.

## `bevy_cef` stays, and the note now says why

It survives through `vmux_core` and `vmux_git`, both depended on for other reasons, and in both cases the usage is the page IPC transport — `BinEventEmitterPlugin`, `BinHostEmitEvent`, `BinReceive`. The server never uses it; it talks over a unix socket and QUIC. Cutting it needs a feature split in those two crates plus a manifest change in the desktop, which is a separate piece of work.

The existing comment reserving `vmux_service`'s place on the no-CEF list said it reaches CEF "through vmux_core directly and through vmux_layout -> vmux_command". The second path is gone, so the comment now describes what is actually left.

## The assertion took three tries to make honest

Worth reading, because the first two versions were green and worthless.

**Untargeted, it fails on `vmux_ui`** — and correctly. `vmux_service` also compiles as a page for wasm and iOS, and that half depends on `vmux_ui` legitimately. An untargeted `cargo tree` sees every `cfg` section at once. The claim is about the *server*, so the query has to be pinned to the host target.

**Pinned, `cargo tree` stops using its exit code.** It returns 0 whether or not it found anything and writes "nothing to print" to stderr — the file already documents this for the iOS job. So reading empty stdout as "clean" passes *precisely when the query has stopped working*. A stale lockfile under `--locked` reproduces it in one step, and my first version did exactly that: I re-added the edge, the check stayed green, and it was only green because `cargo tree` had failed.

**There are three outcomes, not two.** Exit 101 with `did not match any packages` means the crate is nowhere in the graph — that is the clean case, not an error. Exit 0 with empty stdout is also clean. Any *other* non-zero exit means the query broke and must fail the job.

Verified against all three by extracting the step from the workflow and running it:

| case | expected | result |
| -- | -- | -- |
| clean | pass | ✅ all five reported absent |
| edge re-added, lock updated | fail, naming the crate | ✅ `vmux_service links client-only crate vmux_ui` |
| manifest changed, lock stale | fail loudly | ✅ `cargo tree failed … so this job proved nothing` |

## Also: corrects the OSR spec

`2026-08-08-osr-free-desktop-design.md` prescribes splitting the chrome into sibling strips so AppKit can hit-test disjoint rectangles. That is one way, not the only one — a single full-window layout view placed *behind* the panes resolves it by the same rule, since the topmost view under the cursor wins. No strips, no second surface, no page split.

What blocks it is popovers, not geometry: `page.rs` renders context menus and the side sheet carries `overflow-visible` so they escape their bounds over the panes. Behind the panes they render behind them. So *popovers to child windows* moves up to become the next step and *header and side sheet to sibling views* disappears. Corrected order is on VMX-167.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --exclude bevy_cef_core --exclude bevy_cef` — 2,936 pass, unchanged
- [x] The CI step run locally against all three cases above
- [x] `Cargo.lock` diff is one line: `vmux_layout` → `vmux_git`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved linked workspace validation with clearer checks for repository ownership, worktree status, and branch consistency.
  - Prevented invalid workspace configurations from being accepted.

- **Refactor**
  - Centralized workspace validation to improve consistency across workspace-related features.
  - Reduced unnecessary coupling between host services and layout functionality.

- **Documentation**
  - Updated desktop window and pane layout guidance to clarify interaction behavior and popover handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->