### PR TITLE
Name the relay hello for the peer that sends it

### DIFF
--- a/crates/app/vmux_mobile/src/quic_api.rs
+++ b/crates/app/vmux_mobile/src/quic_api.rs
@@ -19,7 +19,7 @@ use vmux_remote::PeerRole;
 use vmux_remote::quic::endpoint::Trust;
 use vmux_remote::quic::tunnel::{DESKTOP_TAG, TunnelSocket, relayed_peer};
 use vmux_remote::quic::{
-    ClientHello, CloseCode, RelayAccepted, RelayHello, ServerHello, StreamKind, decode_hello,
+    ClientHello, CloseCode, PeerHello, RelayAccepted, ServerHello, StreamKind, decode_hello,
     encode_hello,
 };
 use vmux_ui::i18n::{TranslationValue, translate, translate_with};
@@ -303,7 +303,7 @@ impl QuicApi {
             .open_bi()
             .await
             .map_err(|error| QuicError::Transport(error.to_string()))?;
-        let hello = RelayHello {
+        let hello = PeerHello {
             device_id: self.endpoint.desktop.clone(),
             role: PeerRole::Client,
             token: self.endpoint.token.clone(),

--- a/crates/host/vmux_remote/src/lib.rs
+++ b/crates/host/vmux_remote/src/lib.rs
@@ -9,4 +9,4 @@ pub mod device;
 pub mod quic;
 
 pub use device::DeviceId;
-pub use quic::{ClientHello, CloseCode, Envelope, PeerRole, RelayHello, StreamKind};
+pub use quic::{ClientHello, CloseCode, Envelope, PeerHello, PeerRole, StreamKind};

--- a/crates/host/vmux_remote/src/quic.rs
+++ b/crates/host/vmux_remote/src/quic.rs
@@ -256,12 +256,16 @@ pub enum PeerRole {
     Client,
 }
 
-/// First frame on a connection to the relay.
+/// What a peer says first on a connection to the relay, whichever end it is.
+///
+/// Named for the speaker, like [`ClientHello`] and [`ServerHello`] beside it and like the TLS
+/// messages those borrow from. The relay's own word is [`RelayAccepted`]; nothing the relay sends
+/// is a hello.
 ///
 /// Deliberately the only thing the relay parses. Everything after it is opaque bytes copied
 /// between two peers — the relay routes on `device_id` and never learns what it moved.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct RelayHello {
+pub struct PeerHello {
     /// The desktop being named, whichever end is speaking: its own id from a
     /// [`PeerRole::Desktop`], the id of the desktop it wants from a [`PeerRole::Client`].
     ///
@@ -272,7 +276,7 @@ pub struct RelayHello {
     pub token: String,
 }
 
-/// The relay's answer to a hello it admitted.
+/// The relay's answer to a [`PeerHello`] it admitted.
 ///
 /// Carries nothing, and exists for the ordering alone: a desktop must not offer a pairing link
 /// for a registration the relay has not taken, and a phone must not tunnel into a pairing it has

--- a/crates/host/vmux_service/src/remote/quic/dialer.rs
+++ b/crates/host/vmux_service/src/remote/quic/dialer.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::watch;
 use vmux_remote::quic::endpoint::SelfSignedIdentity;
 use vmux_remote::quic::tunnel::TunnelSocket;
-use vmux_remote::quic::{RelayAccepted, RelayHello, decode_hello, encode_hello};
+use vmux_remote::quic::{PeerHello, RelayAccepted, decode_hello, encode_hello};
 use vmux_remote::{DeviceId, PeerRole};
 
 use super::super::server::RemoteState;
@@ -278,7 +278,7 @@ async fn register(
         .open_bi()
         .await
         .map_err(|error| format!("relay stream: {error}"))?;
-    let hello = RelayHello {
+    let hello = PeerHello {
         device_id: device_id.clone(),
         role: PeerRole::Desktop,
         token: token.to_string(),

--- a/docs/architecture/topology.md
+++ b/docs/architecture/topology.md
@@ -109,7 +109,7 @@ named that way precisely because it resolves on its own, unlike `NotFound`.
 | page ↔ local client | `window.cef` binEmit/binListen | rkyv; page→host adds a `vmux-bin-ipc-v1` envelope, host→page bare |
 | local client ↔ server | unix socket | `u32`-length-prefixed rkyv frames, 64 MiB cap |
 | remote client ↔ server | QUIC, one bidirectional stream per request | rkyv `SharedMessage` / `SharedResponse`, after a JSON hello |
-| server ↔ relay | QUIC control connection | JSON `RelayHello` / `RelayAccepted`, then opaque DATAGRAM frames |
+| server ↔ relay | QUIC control connection | JSON `PeerHello` / `RelayAccepted`, then opaque DATAGRAM frames |
 
 The last row is the one worth reading twice. Only the hello is the relay's business; everything
 after it is a remote client's own QUIC session in transit.


### PR DESCRIPTION
Pure rename: `RelayHello` → `PeerHello`.

## Why

`RelayHello` is the only type in `crates/host/vmux_remote/src/quic.rs` named for the end that *receives* it.

| Type | Sent by | Named for |
|---|---|---|
| `ClientHello` | client | sender |
| `ServerHello` | desktop | sender |
| `RelayHello` | **desktop or phone** | **recipient** |
| `RelayAccepted` | relay | sender |

`ClientHello` and `ServerHello` aren't just a local convention — they're TLS 1.3's own handshake message names, where the prefix is unambiguously the speaker. And `RelayAccepted` shares the `Relay` prefix while running the other way, so the same prefix means "to" in one type and "from" in the next.

Read next to its neighbours, `RelayHello` says the relay sends it. It never does; a desktop sends one to register, a phone sends one to attach.

`PeerHello` is what the code already calls it in prose — `relay/src/session.rs` "One peer's time on the relay", `relay/src/server.rs` "Every peer — desktop and phone — dials the same port" — and it pairs with the `PeerRole` field the struct already carries. `PeerHello` → `RelayAccepted` then reads in one direction: peer says hello, relay accepts.

## Nothing reaches the wire

The struct has no serde container attributes, and `encode_hello` does `serde_json::to_vec(value)` — only field names are serialized. So this is source-only: no protocol version bump, no compatibility window, no deploy ordering against the relay.

## Test plan

- [x] `cargo clippy -p vmux_remote -p vmux_service --all-targets` clean
- [x] `cargo test -p vmux_remote -p vmux_service` — all green
- [x] `cargo check -p vmux_mobile --features mobile --target aarch64-apple-ios --bin vmux_mobile` clean (after generating the tailwind bundle CI generates)
- [x] `cargo fmt` on the three touched crates
- [x] `docs/architecture/topology.md` updated

## Why now

The relay side needs a field on this struct for per-pair phone credentials (VMX-177), so renaming here rides along with work that has to touch it anyway rather than spending a pin bump on a rename alone. The vmux-cloud pin advances to this once it lands, and the two doc references there get corrected in the same step.
