### PR TITLE
Tell a frame cut short from a stream that ended

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10887,6 +10887,7 @@ dependencies = [
  "tracing",
  "url",
  "vmux_profile",
+ "vmux_remote",
  "vmux_wire",
 ]
 

--- a/crates/host/vmux_client/Cargo.toml
+++ b/crates/host/vmux_client/Cargo.toml
@@ -12,6 +12,7 @@ tokio = { workspace = true }
 tracing = "0.1"
 url = { workspace = true }
 vmux_profile = { path = "../../vmux_profile" }
+vmux_remote = { path = "../vmux_remote" }
 vmux_wire = { path = "../../vmux_wire" }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/crates/host/vmux_client/src/framing.rs
+++ b/crates/host/vmux_client/src/framing.rs
@@ -1,56 +1,34 @@
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+//! The unix socket's framing, which is [`LengthPrefixed`] with this transport's limit chosen.
+//!
+//! The codec itself lives in `vmux_remote` so the relay can link it without dragging `vmux_wire`
+//! and `vmux_profile` along. What belongs here is the policy: how large a frame this particular
+//! socket will believe.
 
-/// True for I/O errors that mean the peer is gone, so the stream has no more
-/// frames. A clean shutdown yields `UnexpectedEof`; a crashed peer that closes
-/// its socket with unread data resets the connection, so the next read fails
-/// with `ConnectionReset` (Linux) instead of EOF (macOS delivers a clean EOF).
-/// Callers must treat both as a normal end-of-stream — in the service, a read
-/// error that escaped here would skip client cleanup and orphan PTY children.
-fn is_peer_gone(e: &std::io::Error) -> bool {
-    matches!(
-        e.kind(),
-        std::io::ErrorKind::UnexpectedEof
-            | std::io::ErrorKind::ConnectionReset
-            | std::io::ErrorKind::ConnectionAborted
-            | std::io::ErrorKind::BrokenPipe
-    )
-}
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use vmux_remote::framing::LengthPrefixed;
+
+/// Generous, because both ends of this socket are already on the machine: an oversized frame here
+/// costs a memory copy, not a stranger's licence to allocate. A QUIC stream carrying the same
+/// rkyv messages picks a far smaller number for exactly that reason.
+const CODEC: LengthPrefixed = LengthPrefixed::new(64 * 1024 * 1024);
 
 /// Write a length-prefixed frame to an async writer.
 pub async fn write_raw_frame<W>(writer: &mut W, data: &[u8]) -> std::io::Result<()>
 where
     W: AsyncWriteExt + Unpin,
 {
-    let len = data.len() as u32;
-    writer.write_all(&len.to_le_bytes()).await?;
-    writer.write_all(data).await?;
-    writer.flush().await?;
-    Ok(())
+    CODEC.write(writer, data).await
 }
 
 /// Read a length-prefixed frame from an async reader.
-/// Returns `None` on clean EOF.
+///
+/// `None` means the stream ended between frames. A frame cut short is an error — see
+/// [`LengthPrefixed::read`] for why the two must not be the same answer.
 pub async fn read_raw_frame<R>(reader: &mut R) -> std::io::Result<Option<Vec<u8>>>
 where
     R: AsyncReadExt + Unpin,
 {
-    let mut len_buf = [0u8; 4];
-    match reader.read_exact(&mut len_buf).await {
-        Ok(_) => {}
-        Err(e) if is_peer_gone(&e) => return Ok(None),
-        Err(e) => return Err(e),
-    }
-    let len = u32::from_le_bytes(len_buf) as usize;
-    if len > 64 * 1024 * 1024 {
-        return Err(std::io::Error::other("frame too large"));
-    }
-    let mut buf = vec![0u8; len];
-    match reader.read_exact(&mut buf).await {
-        Ok(_) => {}
-        Err(e) if is_peer_gone(&e) => return Ok(None),
-        Err(e) => return Err(e),
-    }
-    Ok(Some(buf))
+    CODEC.read(reader).await
 }
 
 /// Write a length-prefixed frame to a blocking writer.
@@ -58,35 +36,16 @@ pub fn write_raw_frame_blocking<W: std::io::Write>(
     writer: &mut W,
     data: &[u8],
 ) -> std::io::Result<()> {
-    let len = data.len() as u32;
-    writer.write_all(&len.to_le_bytes())?;
-    writer.write_all(data)?;
-    writer.flush()?;
-    Ok(())
+    CODEC.write_blocking(writer, data)
 }
 
 /// Read a length-prefixed frame from a blocking reader.
-/// Returns `None` on clean EOF.
+///
+/// `None` means the stream ended between frames.
 pub fn read_raw_frame_blocking<R: std::io::Read>(
     reader: &mut R,
 ) -> std::io::Result<Option<Vec<u8>>> {
-    let mut len_buf = [0u8; 4];
-    match reader.read_exact(&mut len_buf) {
-        Ok(_) => {}
-        Err(e) if is_peer_gone(&e) => return Ok(None),
-        Err(e) => return Err(e),
-    }
-    let len = u32::from_le_bytes(len_buf) as usize;
-    if len > 64 * 1024 * 1024 {
-        return Err(std::io::Error::other("frame too large"));
-    }
-    let mut buf = vec![0u8; len];
-    match reader.read_exact(&mut buf) {
-        Ok(_) => {}
-        Err(e) if is_peer_gone(&e) => return Ok(None),
-        Err(e) => return Err(e),
-    }
-    Ok(Some(buf))
+    CODEC.read_blocking(reader)
 }
 
 /// Serialize a message to rkyv bytes, write as a length-prefixed frame (blocking).
@@ -111,93 +70,35 @@ macro_rules! write_message {
 }
 
 /// Read a length-prefixed frame, deserialize from rkyv bytes.
-/// Use: `let msg: Option<MyMsg> = read_message!(reader)?;`
+///
+/// Yields `Ok(None)` at a clean end of stream and `Err` for everything else, including a frame cut
+/// short. Every failure is *returned*, never propagated out of the caller behind its back — a
+/// caller with cleanup after its read loop has to be able to see the error and still run it.
 #[macro_export]
 macro_rules! read_message {
     ($reader:expr, $ty:ty) => {{
-        match $crate::framing::read_raw_frame($reader).await? {
-            Some(bytes) => {
-                let msg = rkyv::from_bytes::<$ty, rkyv::rancor::Error>(&bytes)
-                    .map_err(|e| std::io::Error::other(e.to_string()))?;
-                Ok::<Option<$ty>, std::io::Error>(Some(msg))
-            }
-            None => Ok(None),
+        match $crate::framing::read_raw_frame($reader).await {
+            Ok(Some(bytes)) => rkyv::from_bytes::<$ty, rkyv::rancor::Error>(&bytes)
+                .map(Some)
+                .map_err(|e| std::io::Error::other(e.to_string())),
+            Ok(None) => Ok(None),
+            Err(error) => Err(error),
         }
     }};
 }
 
 /// Read a length-prefixed frame (blocking), deserialize from rkyv bytes.
-/// Use: `let msg: Option<MyMsg> = read_message_blocking!(reader, MyMsg)?;`
+///
+/// Returns rather than propagates, for the reason in [`read_message`].
 #[macro_export]
 macro_rules! read_message_blocking {
     ($reader:expr, $ty:ty) => {{
-        match $crate::framing::read_raw_frame_blocking($reader)? {
-            Some(bytes) => {
-                let msg = rkyv::from_bytes::<$ty, rkyv::rancor::Error>(&bytes)
-                    .map_err(|e| std::io::Error::other(e.to_string()))?;
-                Ok::<Option<$ty>, std::io::Error>(Some(msg))
-            }
-            None => Ok(None),
+        match $crate::framing::read_raw_frame_blocking($reader) {
+            Ok(Some(bytes)) => rkyv::from_bytes::<$ty, rkyv::rancor::Error>(&bytes)
+                .map(Some)
+                .map_err(|e| std::io::Error::other(e.to_string())),
+            Ok(None) => Ok::<Option<$ty>, std::io::Error>(None),
+            Err(error) => Err(error),
         }
     }};
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::io::ErrorKind;
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
-    use tokio::io::{AsyncRead, ReadBuf};
-
-    struct AsyncErrReader(Option<ErrorKind>);
-
-    impl AsyncRead for AsyncErrReader {
-        fn poll_read(
-            mut self: Pin<&mut Self>,
-            _cx: &mut Context<'_>,
-            _buf: &mut ReadBuf<'_>,
-        ) -> Poll<std::io::Result<()>> {
-            let kind = self.0.take().expect("reader polled again after error");
-            Poll::Ready(Err(std::io::Error::from(kind)))
-        }
-    }
-
-    struct BlockingErrReader(Option<ErrorKind>);
-
-    impl std::io::Read for BlockingErrReader {
-        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
-            let kind = self.0.take().expect("reader read again after error");
-            Err(std::io::Error::from(kind))
-        }
-    }
-
-    #[tokio::test]
-    async fn read_raw_frame_maps_connection_reset_to_clean_eof() {
-        let mut reader = AsyncErrReader(Some(ErrorKind::ConnectionReset));
-        let got = read_raw_frame(&mut reader)
-            .await
-            .expect("a reset peer must not surface as an error");
-        assert!(
-            got.is_none(),
-            "a reset connection must read as end-of-stream, like a clean EOF"
-        );
-    }
-
-    #[tokio::test]
-    async fn read_raw_frame_propagates_non_disconnect_errors() {
-        let mut reader = AsyncErrReader(Some(ErrorKind::InvalidData));
-        let err = read_raw_frame(&mut reader)
-            .await
-            .expect_err("genuine I/O errors must still surface");
-        assert_eq!(err.kind(), ErrorKind::InvalidData);
-    }
-
-    #[test]
-    fn read_raw_frame_blocking_maps_connection_reset_to_clean_eof() {
-        let mut reader = BlockingErrReader(Some(ErrorKind::ConnectionReset));
-        let got = read_raw_frame_blocking(&mut reader)
-            .expect("a reset peer must not surface as an error");
-        assert!(got.is_none());
-    }
 }

--- a/crates/host/vmux_remote/src/framing.rs
+++ b/crates/host/vmux_remote/src/framing.rs
@@ -1,0 +1,258 @@
+//! Length-prefixed frames, for a stream that carries more than one message.
+//!
+//! `u32` little-endian length, then that many bytes. Nothing here interprets the body — the same
+//! framing carries rkyv over a local unix socket and over a QUIC stream, and neither transport is
+//! named in this module.
+//!
+//! It lives in this crate rather than beside its first caller because the relay links
+//! `vmux_remote` precisely for being free of domain types. A codec in `vmux_client` would drag
+//! `vmux_wire` and `vmux_profile` behind it, and the relay must stay unable to decode a payload.
+//!
+//! Contrast the *control* frame in [`crate::quic`], which is one message per stream delimited by
+//! the stream's own finish. This is the other shape: many messages, one long-lived stream, so a
+//! boundary has to be written down.
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+/// A stream of length-prefixed frames, bounded by what one frame may claim.
+///
+/// The bound is a field rather than a constant because one framing runs over two transports with
+/// very different threat models: a local unix socket, where an oversized frame is a memory copy,
+/// and a remote QUIC stream, where it is a peer's licence to make this process allocate. A single
+/// constant would have to be the looser of the two.
+#[derive(Clone, Copy, Debug)]
+pub struct LengthPrefixed {
+    max_frame_bytes: usize,
+}
+
+impl LengthPrefixed {
+    pub const fn new(max_frame_bytes: usize) -> Self {
+        Self { max_frame_bytes }
+    }
+
+    pub async fn write<W>(self, writer: &mut W, body: &[u8]) -> std::io::Result<()>
+    where
+        W: AsyncWriteExt + Unpin,
+    {
+        writer.write_all(&(body.len() as u32).to_le_bytes()).await?;
+        writer.write_all(body).await?;
+        writer.flush().await
+    }
+
+    /// Read one frame, or `None` once the peer has stopped sending.
+    ///
+    /// `None` means the stream ended *between* frames, which is how a stream ordinarily ends. A
+    /// peer that stopped part-way through one is an error and must not be folded into the same
+    /// answer: a subscription that was reset mid-frame would otherwise read as one the desktop
+    /// finished, and the caller would stop listening instead of reconnecting.
+    pub async fn read<R>(self, reader: &mut R) -> std::io::Result<Option<Vec<u8>>>
+    where
+        R: AsyncReadExt + Unpin,
+    {
+        let mut length = [0u8; 4];
+        match reader.read_exact(&mut length).await {
+            Ok(_) => {}
+            Err(error) if Self::peer_gone(&error) => return Ok(None),
+            Err(error) => return Err(error),
+        }
+        let mut body = vec![0u8; self.length_of(length)?];
+        reader.read_exact(&mut body).await?;
+        Ok(Some(body))
+    }
+
+    pub fn write_blocking<W: std::io::Write>(
+        self,
+        writer: &mut W,
+        body: &[u8],
+    ) -> std::io::Result<()> {
+        writer.write_all(&(body.len() as u32).to_le_bytes())?;
+        writer.write_all(body)?;
+        writer.flush()
+    }
+
+    /// The blocking twin of [`LengthPrefixed::read`], with the same distinction between a stream
+    /// that ended and a frame that was cut short.
+    pub fn read_blocking<R: std::io::Read>(
+        self,
+        reader: &mut R,
+    ) -> std::io::Result<Option<Vec<u8>>> {
+        let mut length = [0u8; 4];
+        match reader.read_exact(&mut length) {
+            Ok(_) => {}
+            Err(error) if Self::peer_gone(&error) => return Ok(None),
+            Err(error) => return Err(error),
+        }
+        let mut body = vec![0u8; self.length_of(length)?];
+        reader.read_exact(&mut body)?;
+        Ok(Some(body))
+    }
+
+    /// What the prefix claims, once it is small enough to believe.
+    ///
+    /// Checked before the allocation it sizes, so a peer cannot spend this process's memory with
+    /// four bytes and then hang up.
+    fn length_of(self, prefix: [u8; 4]) -> std::io::Result<usize> {
+        let length = u32::from_le_bytes(prefix) as usize;
+        if length > self.max_frame_bytes {
+            return Err(std::io::Error::other(format!(
+                "frame of {length} bytes over the {} byte limit",
+                self.max_frame_bytes
+            )));
+        }
+        Ok(length)
+    }
+
+    /// Whether an error means the peer is gone rather than that something went wrong.
+    ///
+    /// A clean shutdown yields `UnexpectedEof`; a crashed peer that closes its socket with unread
+    /// data resets the connection, so the next read fails with `ConnectionReset` on Linux where
+    /// macOS delivers a clean EOF. Both are a normal end of stream — in the service, a read error
+    /// that escaped here would skip client cleanup and orphan PTY children.
+    ///
+    /// Only ever consulted at a frame boundary. Part-way through a frame the same error kinds mean
+    /// data was lost, which is the opposite conclusion.
+    fn peer_gone(error: &std::io::Error) -> bool {
+        matches!(
+            error.kind(),
+            std::io::ErrorKind::UnexpectedEof
+                | std::io::ErrorKind::ConnectionReset
+                | std::io::ErrorKind::ConnectionAborted
+                | std::io::ErrorKind::BrokenPipe
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::ErrorKind;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use tokio::io::{AsyncRead, ReadBuf};
+
+    const CODEC: LengthPrefixed = LengthPrefixed::new(64 * 1024);
+
+    struct FailsWith(Option<ErrorKind>);
+
+    impl AsyncRead for FailsWith {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            let kind = self.0.take().expect("reader polled again after error");
+            Poll::Ready(Err(std::io::Error::from(kind)))
+        }
+    }
+
+    impl std::io::Read for FailsWith {
+        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+            let kind = self.0.take().expect("reader read again after error");
+            Err(std::io::Error::from(kind))
+        }
+    }
+
+    #[tokio::test]
+    async fn a_frame_survives_the_round_trip() {
+        let mut wire = Vec::new();
+        CODEC
+            .write(&mut wire, b"\x00opaque\xff")
+            .await
+            .expect("write");
+
+        let read = CODEC.read(&mut wire.as_slice()).await.expect("read");
+
+        assert_eq!(read.as_deref(), Some(&b"\x00opaque\xff"[..]));
+    }
+
+    /// The distinction the whole type exists for. A peer that stopped part-way through a frame
+    /// lost data; reporting that as "no more frames" is how a reset subscription reads as one the
+    /// desktop finished, and the caller stops listening instead of reconnecting.
+    #[tokio::test]
+    async fn a_frame_cut_short_is_not_a_stream_that_ended() {
+        let mut whole = Vec::new();
+        CODEC
+            .write(&mut whole, b"twelve bytes")
+            .await
+            .expect("write");
+
+        let ended = CODEC.read(&mut &b""[..]).await;
+        let body_cut = CODEC.read(&mut &whole[..whole.len() - 1]).await;
+        let body_absent = CODEC.read(&mut &whole[..4]).await;
+        let prefix_cut = CODEC.read(&mut &whole[..3]).await;
+
+        assert!(
+            matches!(ended, Ok(None)),
+            "nothing at all is a stream that ended, got {ended:?}"
+        );
+        assert!(
+            body_cut.is_err() && body_absent.is_err(),
+            "a promised body that did not arrive must not read as a stream that ended, \
+             got {body_cut:?} and {body_absent:?}"
+        );
+        assert!(
+            matches!(prefix_cut, Ok(None)),
+            "a prefix cut mid-way is a peer that stopped before promising anything, got \
+             {prefix_cut:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_peer_that_went_away_between_frames_ends_the_stream() {
+        for kind in [
+            ErrorKind::UnexpectedEof,
+            ErrorKind::ConnectionReset,
+            ErrorKind::ConnectionAborted,
+            ErrorKind::BrokenPipe,
+        ] {
+            let read = CODEC.read(&mut FailsWith(Some(kind))).await;
+            assert!(matches!(read, Ok(None)), "{kind:?} should end the stream");
+        }
+
+        let genuine = CODEC
+            .read(&mut FailsWith(Some(ErrorKind::InvalidData)))
+            .await;
+        assert_eq!(
+            genuine.expect_err("a real I/O error must surface").kind(),
+            ErrorKind::InvalidData
+        );
+    }
+
+    /// Refused from the prefix alone, so four bytes cannot make this process allocate.
+    #[tokio::test]
+    async fn a_frame_over_the_limit_is_refused_before_it_is_allocated() {
+        let tiny = LengthPrefixed::new(16);
+        let mut wire = Vec::new();
+        CODEC.write(&mut wire, &[0u8; 17]).await.expect("write");
+
+        assert!(tiny.read(&mut wire.as_slice()).await.is_err());
+        assert!(
+            tiny.read(&mut &wire[..4]).await.is_err(),
+            "the prefix alone is enough to refuse; the body need never arrive"
+        );
+    }
+
+    #[test]
+    fn the_blocking_twin_draws_the_same_line() {
+        let mut whole = Vec::new();
+        CODEC
+            .write_blocking(&mut whole, b"twelve bytes")
+            .expect("write");
+
+        assert_eq!(
+            CODEC
+                .read_blocking(&mut whole.as_slice())
+                .expect("read")
+                .as_deref(),
+            Some(&b"twelve bytes"[..])
+        );
+        assert!(matches!(
+            CODEC.read_blocking(&mut FailsWith(Some(ErrorKind::ConnectionReset))),
+            Ok(None)
+        ));
+        assert!(
+            CODEC.read_blocking(&mut &whole[..whole.len() - 1]).is_err(),
+            "a frame cut short must not read as a stream that ended"
+        );
+    }
+}

--- a/crates/host/vmux_remote/src/lib.rs
+++ b/crates/host/vmux_remote/src/lib.rs
@@ -6,6 +6,10 @@
 //! [`vmux_wire::room`].
 
 pub mod device;
+/// Length-prefixed frames, for a stream carrying many messages. Absent on wasm, which has no
+/// socket to carry them over.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod framing;
 pub mod quic;
 
 pub use device::DeviceId;

--- a/crates/host/vmux_service/src/host/server.rs
+++ b/crates/host/vmux_service/src/host/server.rs
@@ -350,7 +350,16 @@ async fn handle_client(
     let mut created_processes: Vec<ProcessId> = Vec::new();
 
     loop {
-        let msg: Option<ClientMessage> = read_message!(&mut reader, ClientMessage)?;
+        // Broken out of rather than propagated: the reap below is what stops a crashed desktop
+        // orphaning PTY children, and `?` here would step over it. A frame cut short is a
+        // disconnect that lost data, so it is reported and then treated as one.
+        let msg: Option<ClientMessage> = match read_message!(&mut reader, ClientMessage) {
+            Ok(msg) => msg,
+            Err(error) => {
+                tracing::warn!(%error, "client stream ended mid-frame");
+                break;
+            }
+        };
         let Some(msg) = msg else {
             break; // client disconnected
         };
@@ -1358,6 +1367,79 @@ mod tests {
         assert!(
             reaped.is_ok(),
             "child pid {pid} still alive after client disconnect — service did not reap it (state: {})",
+            proc_state_label(pid)
+        );
+    }
+
+    /// A desktop that dies mid-write leaves a length prefix promising bytes that never arrive.
+    /// The framing now calls that an error rather than a clean end, so the read loop has to break
+    /// on it instead of propagating — `?` would step over the reap and orphan the PTY child.
+    #[tokio::test]
+    async fn a_client_that_dies_mid_frame_still_has_its_processes_reaped() {
+        use crate::protocol::ClientMessage;
+
+        let dir = std::env::temp_dir().join(format!("vmux-torn-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let sock = dir.join("torn.sock");
+        let pidfile = dir.join("child.pid");
+        let _ = std::fs::remove_file(&sock);
+        let _ = std::fs::remove_file(&pidfile);
+        let listener = tokio::net::UnixListener::bind(&sock).unwrap();
+
+        let (wake_tx, _wake_rx) = mpsc::unbounded_channel();
+        let server = tokio::spawn(super::run_server(listener, wake_tx));
+
+        let stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        let (r, mut w) = stream.into_split();
+
+        let create = ClientMessage::CreateProcess {
+            process_id: ProcessId::new(),
+            command: "/bin/sh".into(),
+            args: vec![
+                "-c".into(),
+                format!("echo $$ > {}; exec sleep 30", pidfile.display()),
+            ],
+            cwd: dir.display().to_string(),
+            env: vec![],
+            cols: 80,
+            rows: 24,
+        };
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&create).expect("serialize");
+        crate::framing::write_raw_frame(&mut w, &bytes)
+            .await
+            .expect("write create");
+
+        let pid = await_child_pid(&pidfile)
+            .await
+            .expect("child process should report its pid");
+        let identity = proc_identity(pid);
+
+        // A second frame that promises far more than it delivers, then the connection dies.
+        tokio::io::AsyncWriteExt::write_all(&mut w, &1024u32.to_le_bytes())
+            .await
+            .expect("write prefix");
+        tokio::io::AsyncWriteExt::write_all(&mut w, b"only a few bytes")
+            .await
+            .expect("write partial body");
+        drop(w);
+        drop(r);
+
+        let reaped = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while process_alive(pid, &identity) {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+        })
+        .await;
+
+        unsafe {
+            libc::kill(pid as i32, libc::SIGKILL);
+        }
+        server.abort();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert!(
+            reaped.is_ok(),
+            "child pid {pid} survived a torn frame — the read loop propagated instead of reaping (state: {})",
             proc_state_label(pid)
         );
     }


### PR DESCRIPTION
First slice of [VMX-184](https://linear.app/vmux/issue/VMX-184). No wire change.

## The bug

`read_raw_frame` applied its peer-gone check to the **body** read as well as the length read:

```rust
let mut buf = vec![0u8; len];
match reader.read_exact(&mut buf).await {
    Ok(_) => {}
    Err(e) if is_peer_gone(&e) => return Ok(None),   // <-- a truncated frame
    Err(e) => return Err(e),
}
```

So a frame whose length prefix arrived but whose body did not returned `Ok(None)` — byte-identical to a clean close. On a session-events subscription that turns a reset into "the desktop is done", and the caller stops listening instead of reconnecting.

EOF is clean only at a frame boundary. Part-way through a frame the same error kinds mean data was lost, which is the opposite conclusion.

## Two things it dragged out

**`read_message!` had a `?` inside the macro.** A read error propagated out of the enclosing function before the caller could match on it. That matters because `vmux_service`'s client loop reaps the PTY children a desktop created *after* the loop:

```rust
// Reap the processes this client created so a disconnected/crashed desktop
// never orphans PTY children (which would exhaust the system PTY pool).
```

Fixing the framing without fixing the macro would have made a torn frame skip that reap — the leak the old doc comment warned about. The macro now returns every failure instead of propagating it, and the loop breaks on one. New test: `a_client_that_dies_mid_frame_still_has_its_processes_reaped`, which fails without the loop change.

**The cap was a constant shared by two transports.** 64 MiB is right for a local unix socket, where an oversized frame is a memory copy, and wrong for a remote QUIC stream, where it is a stranger's licence to make this process allocate. It is now a field, so each transport picks its own.

## Where the codec lives

`vmux_remote`, not `vmux_client`. The relay links `vmux_remote` precisely because it has no vmux dependency — a codec in `vmux_client` would drag `vmux_wire` and `vmux_profile` behind it, and the relay must stay unable to decode a payload. `vmux_client::framing` keeps its rkyv macros and supplies the unix socket's limit.

This also sets up the second half of VMX-184: the control frame is one message per stream delimited by the stream's own finish, and this is the other shape — many messages, one long-lived stream, so a boundary has to be written down. Naming them apart makes that distinction visible.

## Test plan

- [x] `cargo test -p vmux_remote -p vmux_client -p vmux_service` — all green
- [x] `cargo clippy -p vmux_remote -p vmux_client -p vmux_service --all-targets` clean
- [x] `a_frame_cut_short_is_not_a_stream_that_ended` covers the four cases: nothing at all, body cut, body absent, prefix cut mid-way
- [x] `a_client_that_dies_mid_frame_still_has_its_processes_reaped` fails without the loop change and passes with it
- [x] Existing `client_disconnect_reaps_created_processes` still passes — the clean path is unchanged
