### PR TITLE
Ask for an overlay capability, not for the command bar

### DIFF
--- a/crates/page/vmux_layout/src/host/window.rs
+++ b/crates/page/vmux_layout/src/host/window.rs
@@ -297,6 +297,7 @@ fn setup(
     commands.spawn((
         (
             CommandBar,
+            vmux_core::overlay::WindowOverlay,
             HostWindow(pw),
             Browser,
             // An ordinary windowed surface, framed by the shared `sync_windowed_frames` and

--- a/crates/vmux_browser/src/appearance.rs
+++ b/crates/vmux_browser/src/appearance.rs
@@ -5,7 +5,7 @@
 
 use bevy::prelude::*;
 use bevy_cef::prelude::*;
-use vmux_command::CommandBar;
+use vmux_core::overlay::WindowOverlay;
 use vmux_core::page::PageReady;
 use vmux_layout::LayoutCef;
 
@@ -32,7 +32,7 @@ fn on_webview_ready_send_theme(
     browsers: NonSend<Browsers>,
     settings: Res<AppSettings>,
     cef_q: Query<(), With<LayoutCef>>,
-    modal_q: Query<(), With<CommandBar>>,
+    modal_q: Query<(), With<WindowOverlay>>,
     mut zoom_q: Query<&mut bevy_cef::prelude::ZoomLevel>,
     mut commands: Commands,
 ) {

--- a/crates/vmux_browser/src/command_bar/handler.rs
+++ b/crates/vmux_browser/src/command_bar/handler.rs
@@ -1620,13 +1620,13 @@ fn complete_path(query: &str) -> Vec<PathEntry> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::command_bar::state::CommandBarState;
     use bevy::ecs::schedule::{NodeId, Schedules, SystemSet};
     use bevy::ecs::system::RunSystemOnce;
     use vmux_command::event::CommandBarOpenEvent;
     use vmux_command::event::CommandBarSpace;
     use vmux_command::{CommandPlugin, ReadAppCommands};
     use vmux_command::{command_bar_open_payload, localized_command_name};
+    use vmux_core::overlay::OverlayState;
 
     #[test]
     fn build_payload_includes_commands_and_target() {
@@ -1747,7 +1747,7 @@ mod tests {
 
         assert_eq!(node.display, Display::Flex);
         assert_eq!(visibility, Visibility::Inherited);
-        assert!(!CommandBarState::from_modal(node.display, visibility, false).owns_input());
+        assert!(!OverlayState::of(node.display, visibility, false).owns_input());
     }
 
     #[test]
@@ -2448,7 +2448,7 @@ mod tests {
             "CefKeyboardTarget must not return after prewarm"
         );
         assert!(
-            !CommandBarState::from_modal(
+            !OverlayState::of(
                 display_after_prewarm,
                 Visibility::Hidden,
                 has_kb_after_prewarm

--- a/crates/vmux_browser/src/command_bar/state.rs
+++ b/crates/vmux_browser/src/command_bar/state.rs
@@ -1,113 +1,12 @@
 use bevy::prelude::*;
 use bevy_cef::prelude::CefKeyboardTarget;
 use vmux_command::CommandBar;
+use vmux_core::overlay::OverlayState;
 
-/// Authoritative command bar lifecycle state.
-///
-/// Two different questions get asked about the command bar, and for the two-to-ten frames the CEF
-/// page spends painting its first frame they have different answers: *does it own input?* and *is
-/// its surface on screen?* Answering the first one with a visibility test hands the user's
-/// keystrokes to whichever page was focused before, so both questions are resolved here once
-/// instead of being re-derived at each call site.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum CommandBarState {
-    /// No keyboard target, or the node is `display: none`.
-    #[default]
-    Closed,
-    /// Owns input; surface still hidden while the page paints its first frame.
-    Revealing,
-    /// Owns input and the surface is on screen.
-    Shown,
-}
-
-impl CommandBarState {
-    pub fn from_modal(display: Display, visibility: Visibility, has_keyboard_target: bool) -> Self {
-        if display == Display::None || !has_keyboard_target {
-            Self::Closed
-        } else if visibility == Visibility::Hidden {
-            Self::Revealing
-        } else {
-            Self::Shown
-        }
-    }
-
-    /// Keyboard target, first-responder handoff, toggle, and dismiss all key off this. True from
-    /// the moment the bar takes the keyboard target, before its surface is revealed.
-    pub fn owns_input(self) -> bool {
-        !matches!(self, Self::Closed)
-    }
-
-    /// Native view placement, overlay compositing, and pointer hit testing key off this.
-    pub fn is_shown(self) -> bool {
-        matches!(self, Self::Shown)
-    }
-
-    /// Owns input but is not yet on screen — the native view is parked offscreen so it can hold
-    /// first responder without being visible.
-    pub fn is_revealing(self) -> bool {
-        matches!(self, Self::Revealing)
-    }
-}
-
+/// The bar's own view of [`OverlayState`], filtered to its entity rather than to any overlay.
 pub type CommandBarStateQuery<'w, 's> =
     Query<'w, 's, (&'static Node, &'static Visibility, Has<CefKeyboardTarget>), With<CommandBar>>;
 
-pub fn command_bar_state(modal_q: &CommandBarStateQuery) -> CommandBarState {
-    modal_q
-        .iter()
-        .map(|(node, visibility, has_keyboard_target)| {
-            CommandBarState::from_modal(node.display, *visibility, has_keyboard_target)
-        })
-        .max_by_key(|state| match state {
-            CommandBarState::Closed => 0,
-            CommandBarState::Revealing => 1,
-            CommandBarState::Shown => 2,
-        })
-        .unwrap_or_default()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn missing_keyboard_target_is_closed() {
-        assert_eq!(
-            CommandBarState::from_modal(Display::Flex, Visibility::Inherited, false),
-            CommandBarState::Closed
-        );
-    }
-
-    #[test]
-    fn display_none_is_closed_even_with_keyboard_target() {
-        assert_eq!(
-            CommandBarState::from_modal(Display::None, Visibility::Inherited, true),
-            CommandBarState::Closed
-        );
-    }
-
-    #[test]
-    fn hidden_surface_with_keyboard_target_still_owns_input() {
-        let state = CommandBarState::from_modal(Display::Flex, Visibility::Hidden, true);
-
-        assert_eq!(state, CommandBarState::Revealing);
-        assert!(state.owns_input());
-        assert!(!state.is_shown());
-    }
-
-    #[test]
-    fn visible_surface_with_keyboard_target_is_shown() {
-        let state = CommandBarState::from_modal(Display::Flex, Visibility::Inherited, true);
-
-        assert_eq!(state, CommandBarState::Shown);
-        assert!(state.owns_input());
-        assert!(state.is_shown());
-    }
-
-    #[test]
-    fn closed_owns_nothing() {
-        assert!(!CommandBarState::Closed.owns_input());
-        assert!(!CommandBarState::Closed.is_shown());
-        assert!(!CommandBarState::Closed.is_revealing());
-    }
+pub fn command_bar_state(modal_q: &CommandBarStateQuery) -> OverlayState {
+    OverlayState::of_each(modal_q.iter())
 }

--- a/crates/vmux_browser/src/frame_rate.rs
+++ b/crates/vmux_browser/src/frame_rate.rs
@@ -4,7 +4,6 @@
 //! the hover state and the frame rate describe the frame that just happened rather than the one
 //! before it. The webview idles slowly and bursts back to full rate when the host emits to it.
 
-use crate::command_bar::state::CommandBarStateQuery;
 use bevy::{
     input::{
         keyboard::KeyboardInput,
@@ -17,7 +16,8 @@ use bevy::{
 };
 use bevy_cef::prelude::*;
 use std::sync::atomic::Ordering;
-use vmux_command::CommandBar;
+use vmux_core::overlay::WindowOverlay;
+use vmux_core::overlay::{OverlayState, OverlayStateQuery};
 use vmux_layout::Browser;
 use vmux_layout::{
     Header, LayoutCef,
@@ -64,7 +64,7 @@ fn refresh_layout_cef_hover(
     layout_q: Query<Entity, With<LayoutCef>>,
     pointer_capture_q: Query<(), (With<LayoutCef>, LayoutPointerCapture)>,
     cef_regions: CefPointerRegionQuery<'_, '_>,
-    modal_pointer_targets: Query<(), (With<CommandBar>, With<CefPointerTarget>)>,
+    modal_pointer_targets: Query<(), (With<WindowOverlay>, With<CefPointerTarget>)>,
     mut state: Local<LayoutHoverRefreshState>,
 ) {
     let Ok(layout) = layout_q.single() else {
@@ -167,7 +167,7 @@ fn refresh_active_windowed_hover(
     buttons: Res<ButtonInput<MouseButton>>,
     windows: Query<&Window>,
     primary_window: Query<Entity, With<PrimaryWindow>>,
-    modal_q: CommandBarStateQuery,
+    overlay_q: OverlayStateQuery,
     active_q: Query<
         (
             Entity,
@@ -181,14 +181,14 @@ fn refresh_active_windowed_hover(
             With<WebviewWindowed>,
             With<CefKeyboardTarget>,
             Without<LayoutCef>,
-            Without<CommandBar>,
+            Without<WindowOverlay>,
             Without<Header>,
             Without<SideSheet>,
         ),
     >,
     mut state: Local<WindowedHoverRefreshState>,
 ) {
-    if crate::command_bar::handler::is_command_bar_open(&modal_q) {
+    if OverlayState::of_any(&overlay_q).owns_input() {
         *state = WindowedHoverRefreshState::default();
         return;
     }

--- a/crates/vmux_browser/src/host_focus.rs
+++ b/crates/vmux_browser/src/host_focus.rs
@@ -1,8 +1,7 @@
-use crate::command_bar::state::CommandBarState;
 use bevy::ecs::relationship::Relationship;
 use bevy::prelude::*;
 use bevy_cef::prelude::{Browsers, CefKeyboardTarget, WebviewWindowed};
-use vmux_command::CommandBar;
+use vmux_core::overlay::{OverlayState, OverlayStateQuery, WindowOverlay};
 use vmux_layout::Header;
 use vmux_layout::side_sheet::SideSheet;
 use vmux_layout::stack::FocusedStack;
@@ -39,18 +38,18 @@ impl Plugin for HostFocusPlugin {
     }
 }
 
-fn page_owns_escape(terminal_focused: bool, command_bar_open: bool) -> bool {
-    terminal_focused || command_bar_open
+fn page_owns_escape(terminal_focused: bool, overlay_open: bool) -> bool {
+    terminal_focused || overlay_open
 }
 
 /// Publishes whether a page will answer Escape itself, for the native key monitor to read.
 fn publish_native_page_owns_escape(
     terminal_focus_q: Query<(), (With<Terminal>, With<CefKeyboardTarget>)>,
-    modal_q: crate::command_bar::state::CommandBarStateQuery,
+    overlay_q: OverlayStateQuery,
 ) {
     crate::set_native_page_owns_escape(page_owns_escape(
         !terminal_focus_q.is_empty(),
-        crate::command_bar::handler::is_command_bar_open(&modal_q),
+        OverlayState::of_any(&overlay_q).owns_input(),
     ));
 }
 
@@ -92,7 +91,7 @@ pub(crate) fn compute_host_focus_intent(
             Has<CefKeyboardTarget>,
             Has<WebviewWindowed>,
         ),
-        With<CommandBar>,
+        With<WindowOverlay>,
     >,
     layout_keyboard_q: Query<(), (With<Browser>, crate::present::LayoutKeyboardCapture)>,
     mut intent: ResMut<HostFocusIntent>,
@@ -101,7 +100,7 @@ pub(crate) fn compute_host_focus_intent(
         modal_q
             .iter()
             .find_map(|(entity, node, visibility, keyboard_target, windowed)| {
-                CommandBarState::from_modal(
+                OverlayState::of(
                     node.display,
                     visibility.copied().unwrap_or_default(),
                     keyboard_target,
@@ -238,7 +237,7 @@ mod tests {
         let stack = app.world_mut().spawn_empty().id();
         app.world_mut().spawn((Browser, ChildOf(stack)));
         app.world_mut().spawn((
-            CommandBar,
+            WindowOverlay,
             Node {
                 display: Display::Flex,
                 ..default()
@@ -263,7 +262,7 @@ mod tests {
         let modal = app
             .world_mut()
             .spawn((
-                CommandBar,
+                WindowOverlay,
                 Node {
                     display: Display::Flex,
                     ..default()
@@ -292,7 +291,7 @@ mod tests {
         let modal = app
             .world_mut()
             .spawn((
-                CommandBar,
+                WindowOverlay,
                 Node {
                     display: Display::Flex,
                     ..default()
@@ -318,7 +317,7 @@ mod tests {
         let stack = app.world_mut().spawn_empty().id();
         app.world_mut().spawn((Browser, ChildOf(stack)));
         app.world_mut().spawn((
-            CommandBar,
+            WindowOverlay,
             Node {
                 display: Display::Flex,
                 ..default()

--- a/crates/vmux_browser/src/input.rs
+++ b/crates/vmux_browser/src/input.rs
@@ -5,7 +5,6 @@
 //! before any click is delivered against it, and a click that lands outside the command bar has
 //! to dismiss it rather than reach the page underneath.
 
-use crate::command_bar::state::CommandBarStateQuery;
 use bevy::{
     ecs::relationship::Relationship,
     input::{
@@ -18,8 +17,9 @@ use bevy::{
 };
 use bevy_cef::prelude::*;
 use std::sync::atomic::Ordering;
-use vmux_command::CommandBar;
 use vmux_command::event::CommandBarActionEvent;
+use vmux_core::overlay::WindowOverlay;
+use vmux_core::overlay::{OverlayState, OverlayStateQuery};
 use vmux_layout::Browser;
 use vmux_layout::LayoutCef;
 
@@ -58,9 +58,9 @@ impl Plugin for InputPlugin {
 
 fn log_command_bar_keyboard_input(
     mut events: MessageReader<KeyboardInput>,
-    modal_q: CommandBarStateQuery,
+    overlay_q: OverlayStateQuery,
 ) {
-    if !crate::command_bar::handler::is_command_bar_open(&modal_q) {
+    if !OverlayState::of_any(&overlay_q).owns_input() {
         return;
     }
     for event in events.read() {
@@ -75,7 +75,7 @@ fn sync_layout_cef_pointer_target(
     layout_q: Query<(Entity, Has<CefPointerTarget>), With<LayoutCef>>,
     pointer_capture_q: Query<(), (With<LayoutCef>, LayoutPointerCapture)>,
     cef_regions: CefPointerRegionQuery<'_, '_>,
-    modal_pointer_targets: Query<(), (With<CommandBar>, With<CefPointerTarget>)>,
+    modal_pointer_targets: Query<(), (With<WindowOverlay>, With<CefPointerTarget>)>,
     mut commands: Commands,
 ) {
     let Ok((layout, has_target)) = layout_q.single() else {
@@ -129,7 +129,7 @@ fn forward_layout_cef_cursor_move(
     layout_q: Query<Entity, With<LayoutCef>>,
     pointer_capture_q: Query<(), (With<LayoutCef>, LayoutPointerCapture)>,
     cef_regions: CefPointerRegionQuery<'_, '_>,
-    modal_pointer_targets: Query<(), (With<CommandBar>, With<CefPointerTarget>)>,
+    modal_pointer_targets: Query<(), (With<WindowOverlay>, With<CefPointerTarget>)>,
     mut was_in_region: Local<bool>,
 ) {
     if suppress.0 || !modal_pointer_targets.is_empty() {
@@ -162,7 +162,7 @@ fn forward_layout_cef_mouse_button(
     layout_q: Query<Entity, With<LayoutCef>>,
     pointer_capture_q: Query<(), (With<LayoutCef>, LayoutPointerCapture)>,
     cef_regions: CefPointerRegionQuery<'_, '_>,
-    modal_pointer_targets: Query<(), (With<CommandBar>, With<CefPointerTarget>)>,
+    modal_pointer_targets: Query<(), (With<WindowOverlay>, With<CefPointerTarget>)>,
     mut captured: Local<bool>,
 ) {
     if suppress.0 || !modal_pointer_targets.is_empty() {
@@ -220,7 +220,7 @@ fn dismiss_windowed_command_bar_on_outside_click(
     mut events: MessageReader<MouseButtonInput>,
     windows: Query<&Window>,
     primary_window: Query<Entity, With<PrimaryWindow>>,
-    modal_q: Query<(Entity, Option<&HostWindow>), (With<CommandBar>, With<WebviewWindowed>)>,
+    modal_q: Query<(Entity, Option<&HostWindow>), (With<WindowOverlay>, With<WebviewWindowed>)>,
     mut commands: Commands,
 ) {
     let Ok((modal_e, host_window)) = modal_q.single() else {
@@ -265,7 +265,7 @@ fn dismiss_windowed_command_bar_on_outside_click(
 }
 
 fn dismiss_command_bar_from_native_monitor(
-    modal_q: Query<Entity, With<CommandBar>>,
+    modal_q: Query<Entity, With<WindowOverlay>>,
     mut commands: Commands,
 ) {
     if !take_native_command_bar_dismiss_requested() {

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -1128,7 +1128,7 @@ mod error_page_source_tests {
 mod tests {
     use super::*;
     use crate::appearance::sync_appearance_to_cef;
-    use vmux_command::CommandBar;
+    use vmux_core::overlay::WindowOverlay;
 
     #[test]
     fn cef_disables_bfcache_for_extension_ports() {
@@ -1414,7 +1414,7 @@ mod tests {
             .world_mut()
             .spawn((
                 Browser,
-                CommandBar,
+                WindowOverlay,
                 WebviewSource::new("vmux://command-bar/"),
             ))
             .id();

--- a/crates/vmux_browser/src/present.rs
+++ b/crates/vmux_browser/src/present.rs
@@ -6,7 +6,6 @@
 
 use crate::command_bar::handler::{CommandBarNativeSize, PendingCommandBarReveal};
 use crate::command_bar::panel::CommandBarPanelActive;
-use crate::command_bar::state::CommandBarState;
 use bevy::{
     ecs::relationship::Relationship,
     prelude::*,
@@ -16,7 +15,7 @@ use bevy::{
 };
 use bevy_cef::prelude::*;
 use std::sync::atomic::Ordering;
-use vmux_command::CommandBar;
+use vmux_core::overlay::{OverlayState, WindowOverlay};
 use vmux_core::page::PageReady;
 use vmux_history::LastActivatedAt;
 use vmux_layout::Browser;
@@ -78,7 +77,7 @@ fn sync_keyboard_target(
     child_of_q: Query<&ChildOf>,
     status_q: Query<(), With<Header>>,
     side_sheet_q: Query<(), With<SideSheet>>,
-    modal_q: Query<(Entity, &Node, Has<CefKeyboardTarget>), With<CommandBar>>,
+    modal_q: Query<(Entity, &Node, Has<CefKeyboardTarget>), With<WindowOverlay>>,
     layout_keyboard_q: Query<Entity, (With<LayoutCef>, LayoutKeyboardCapture)>,
     content_q: Query<(Entity, Has<CefKeyboardTarget>), With<Browser>>,
     terminal_q: Query<(), With<vmux_terminal::Terminal>>,
@@ -167,7 +166,7 @@ fn sync_children_to_ui(
             &mut WebviewSize,
             Option<&Header>,
             Option<&SideSheet>,
-            Option<&CommandBar>,
+            Option<&WindowOverlay>,
             Option<&Visibility>,
             Option<&HistorySwipeVisualOffset>,
             Has<PendingWebviewReveal>,
@@ -402,7 +401,7 @@ pub(crate) fn sync_windowed_frames(
             With<Browser>,
             With<WebviewWindowed>,
             Without<LayoutCef>,
-            Without<CommandBar>,
+            Without<WindowOverlay>,
         ),
     >,
     child_of_q: Query<&ChildOf>,
@@ -770,7 +769,7 @@ pub(crate) fn sync_windowed_command_bar(
             Option<&HostWindow>,
             Option<&CommandBarNativeSize>,
         ),
-        With<CommandBar>,
+        With<WindowOverlay>,
     >,
     native_size_changed: Query<(), Changed<CommandBarNativeSize>>,
     windows: Query<&Window>,
@@ -785,7 +784,7 @@ pub(crate) fn sync_windowed_command_bar(
         *was_open = false;
         return;
     };
-    let state = CommandBarState::from_modal(node.display, *visibility, has_keyboard_target);
+    let state = OverlayState::of(node.display, *visibility, has_keyboard_target);
     let open = state.is_shown();
     let owns_input = state.owns_input();
     let render_hidden = command_bar_windowed_view_should_render_hidden(node.display, *visibility);
@@ -914,7 +913,7 @@ pub(crate) fn sync_windowed_command_bar(
 #[cfg(target_os = "macos")]
 fn flush_native_command_bar_pointer_events(
     browsers: NonSend<Browsers>,
-    modal_q: Query<Entity, (With<CommandBar>, With<WebviewWindowed>)>,
+    modal_q: Query<Entity, (With<WindowOverlay>, With<WebviewWindowed>)>,
 ) {
     let Ok(entity) = modal_q.single() else {
         return;
@@ -952,7 +951,7 @@ fn apply_repaint_nudge(browsers: NonSend<Browsers>, ready: Query<Entity, Changed
 
 fn sync_cef_webview_resize_after_ui(
     browsers: NonSend<Browsers>,
-    webviews: Query<(Entity, &WebviewSize), (With<Browser>, Without<CommandBar>)>,
+    webviews: Query<(Entity, &WebviewSize), (With<Browser>, Without<WindowOverlay>)>,
     host_window: Query<&HostWindow>,
     windows: Query<&Window>,
     primary_window: Query<Entity, With<PrimaryWindow>>,
@@ -1029,7 +1028,7 @@ fn sync_osr_webview_focus(
             Option<&ComputedNode>,
             Has<PendingWebviewReveal>,
             Has<PendingCommandBarReveal>,
-            Has<CommandBar>,
+            Has<WindowOverlay>,
             Has<CefKeyboardTarget>,
             Has<WebviewWindowed>,
             Has<LayoutCef>,
@@ -1594,7 +1593,7 @@ mod tests {
             .world_mut()
             .spawn((
                 Browser,
-                CommandBar,
+                WindowOverlay,
                 Node {
                     display: Display::Flex,
                     ..default()
@@ -1891,7 +1890,7 @@ mod tests {
 
     #[test]
     fn revealing_command_bar_owns_input_while_its_view_stays_parked() {
-        let revealing = CommandBarState::from_modal(Display::Flex, Visibility::Hidden, true);
+        let revealing = OverlayState::of(Display::Flex, Visibility::Hidden, true);
 
         assert!(revealing.owns_input());
         assert!(!revealing.is_shown());

--- a/crates/vmux_core/src/host.rs
+++ b/crates/vmux_core/src/host.rs
@@ -16,6 +16,7 @@ pub mod browser;
 pub mod extension;
 pub mod host_spawn;
 pub mod notify;
+pub mod overlay;
 pub mod page;
 pub mod page_open;
 pub mod profile;
@@ -27,6 +28,7 @@ pub use archive::{
 };
 pub use host_spawn::{HostSpawnRegistry, register_host_spawn};
 pub use notify::{AgentAttention, AgentDoneUnseen, BellReceived, OsNotify};
+pub use overlay::{OverlayState, OverlayStateQuery, WindowOverlay};
 pub use page_open::{
     CefPageAttachRequest, PageOpenError, PageOpenHandled, PageOpenId, PageOpenRequest, PageOpenSet,
     PageOpenTarget, PageOpenTask, PendingPrompt, PendingPromptAttachments,

--- a/crates/vmux_core/src/host/overlay.rs
+++ b/crates/vmux_core/src/host/overlay.rs
@@ -1,0 +1,140 @@
+//! Pages that cover the window instead of sitting in a pane.
+
+use bevy::prelude::*;
+use bevy_cef::prelude::CefKeyboardTarget;
+
+/// A page that covers the window rather than sitting in a pane, and owns the keyboard while it is
+/// showing.
+///
+/// The shell lays these out against the window instead of a pane, hands them first-responder ahead
+/// of the active page, and keeps its own keybindings off them. It asks for the capability rather
+/// than for a particular page, so a page crate can declare itself an overlay without the shell
+/// being taught its name.
+#[derive(Component, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct WindowOverlay;
+
+/// Authoritative lifecycle state of an overlay surface.
+///
+/// Two different questions get asked, and for the two-to-ten frames the page spends painting its
+/// first frame they have different answers: *does it own input?* and *is its surface on screen?*
+/// Answering the first one with a visibility test hands the user's keystrokes to whichever page was
+/// focused before, so both are resolved here once instead of being re-derived at each call site.
+///
+/// Ordered least to most revealed, so the frontmost of several overlays is the `max`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub enum OverlayState {
+    /// No keyboard target, or the node is `display: none`.
+    #[default]
+    Closed,
+    /// Owns input; surface still hidden while the page paints its first frame.
+    Revealing,
+    /// Owns input and the surface is on screen.
+    Shown,
+}
+
+impl OverlayState {
+    pub fn of(display: Display, visibility: Visibility, has_keyboard_target: bool) -> Self {
+        if display == Display::None || !has_keyboard_target {
+            Self::Closed
+        } else if visibility == Visibility::Hidden {
+            Self::Revealing
+        } else {
+            Self::Shown
+        }
+    }
+
+    /// The state of the frontmost overlay, or `Closed` when none is up.
+    pub fn of_any(overlay_q: &OverlayStateQuery) -> Self {
+        let mut state = Self::Closed;
+        for (node, visibility, has_keyboard_target) in overlay_q.iter() {
+            state = state.max(Self::of(node.display, *visibility, has_keyboard_target));
+        }
+        state
+    }
+
+    /// The frontmost of the overlays matching `overlay_q`, whatever the query is filtered to.
+    pub fn of_each<'a>(surfaces: impl Iterator<Item = (&'a Node, &'a Visibility, bool)>) -> Self {
+        let mut state = Self::Closed;
+        for (node, visibility, has_keyboard_target) in surfaces {
+            state = state.max(Self::of(node.display, *visibility, has_keyboard_target));
+        }
+        state
+    }
+
+    /// Keyboard target, first-responder handoff, toggle, and dismiss all key off this. True from
+    /// the moment the overlay takes the keyboard target, before its surface is revealed.
+    pub fn owns_input(self) -> bool {
+        !matches!(self, Self::Closed)
+    }
+
+    /// Native view placement, overlay compositing, and pointer hit testing key off this.
+    pub fn is_shown(self) -> bool {
+        matches!(self, Self::Shown)
+    }
+
+    /// Owns input but is not yet on screen — the native view is parked offscreen so it can hold
+    /// first responder without being visible.
+    pub fn is_revealing(self) -> bool {
+        matches!(self, Self::Revealing)
+    }
+}
+
+pub type OverlayStateQuery<'w, 's> = Query<
+    'w,
+    's,
+    (&'static Node, &'static Visibility, Has<CefKeyboardTarget>),
+    With<WindowOverlay>,
+>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_keyboard_target_is_closed() {
+        assert_eq!(
+            OverlayState::of(Display::Flex, Visibility::Inherited, false),
+            OverlayState::Closed
+        );
+    }
+
+    #[test]
+    fn display_none_is_closed_even_with_keyboard_target() {
+        assert_eq!(
+            OverlayState::of(Display::None, Visibility::Inherited, true),
+            OverlayState::Closed
+        );
+    }
+
+    #[test]
+    fn hidden_surface_with_keyboard_target_still_owns_input() {
+        let state = OverlayState::of(Display::Flex, Visibility::Hidden, true);
+
+        assert_eq!(state, OverlayState::Revealing);
+        assert!(state.owns_input());
+        assert!(!state.is_shown());
+    }
+
+    #[test]
+    fn visible_surface_with_keyboard_target_is_shown() {
+        let state = OverlayState::of(Display::Flex, Visibility::Inherited, true);
+
+        assert_eq!(state, OverlayState::Shown);
+        assert!(state.owns_input());
+        assert!(state.is_shown());
+    }
+
+    #[test]
+    fn closed_owns_nothing() {
+        assert!(!OverlayState::Closed.owns_input());
+        assert!(!OverlayState::Closed.is_shown());
+        assert!(!OverlayState::Closed.is_revealing());
+    }
+
+    /// The frontmost overlay wins, so one still painting cannot mask another already up.
+    #[test]
+    fn the_furthest_along_overlay_is_the_greatest() {
+        assert!(OverlayState::Revealing > OverlayState::Closed);
+        assert!(OverlayState::Shown > OverlayState::Revealing);
+    }
+}


### PR DESCRIPTION
Stacked on #378.

## Summary

`vmux_browser` named `CommandBar` in six files to answer questions that were never about the command bar:

- lay this surface out against the window rather than a pane (`present.rs`)
- hand it first responder ahead of the active page (`host_focus.rs`)
- keep the shell's keybindings and pointer routing off it (`input.rs`, `frame_rate.rs`)
- exclude it from the ordinary page sweeps (`appearance.rs`, `present.rs`)

Every one of those is true of *any* page that covers the window, and none of them needs the page's name. So the shell asks for the capability instead.

```rust
/// A page that covers the window rather than sitting in a pane, and owns the keyboard while it is
/// showing.
#[derive(Component, Clone, Copy, Debug, PartialEq, Eq)]
pub struct WindowOverlay;
```

## `CommandBarState` was already the right type in the wrong crate

It answers the two questions the shell actually has — *does this own input* and *is it on screen* — which have different answers for the two-to-ten frames a page spends painting its first frame. Answering the first with a visibility test hands the user's keystrokes to whichever page was focused before.

That is overlay behaviour, not command bar behaviour. It moves to `vmux_core::overlay` as `OverlayState` with its five tests, and gains an ordering (`Closed < Revealing < Shown`) so the frontmost of several overlays is just the `max` — the hand-rolled `max_by_key` at the old call site goes away.

The bar keeps `CommandBarStateQuery`, filtered to its own entity, for its own internal use. It is the one place that legitimately means *the command bar* rather than *an overlay*.

## Why this is worth its own PR

The marker query was the last thing tying `vmux_browser` to the bar outside `src/command_bar/`:

```console
$ grep -rn "CommandBar\b" --include=*.rs crates/vmux_browser/src/ | grep -v src/command_bar
  (none)
```

That module is itself on its way to `vmux_command` — but it cannot move until the ~925 lines that read and mutate the workspace become messages, which is the next PR in the stack. This one is independent of that work and lands the capability the rest builds on.

## Test plan

- [x] `cargo fmt --check`
- [x] `clippy -D warnings` under CI's exact package selection
- [x] `cargo test --workspace` green — the five `OverlayState` tests moved verbatim
- [ ] Run the app

The behaviour is meant to be identical, so the check is that nothing regressed on the surfaces the retargeted queries drive:

- **Cmd+K** — bar takes the keyboard immediately, before its surface paints (the `Revealing` case; a regression here types into the page behind it)
- **Click outside the bar** — dismisses; **click inside** — does not (pointer routing, `input.rs`)
- **Escape / Ctrl+C** — dismisses
- **Light/dark switch with the bar open** — `appearance.rs` skips the overlay
