### PR TITLE
Stop granting streams nothing drains, and a window one request can take

### DIFF
--- a/crates/host/vmux_remote/src/quic.rs
+++ b/crates/host/vmux_remote/src/quic.rs
@@ -20,12 +20,17 @@ use serde::{Deserialize, Serialize};
 
 use crate::DeviceId;
 
-/// ALPN identifier offered during the TLS handshake, and the only compatibility gate there is.
+/// ALPN identifier offered during the TLS handshake, and the gate on what the conversation
+/// *means*.
 ///
 /// Bumping it rejects an incompatible peer during the QUIC handshake, before a single application
-/// byte is exchanged. There is deliberately no second version field in the hellos: one gate that
-/// always runs beats two that can disagree, and rkyv's positional variants mean a mismatched peer
-/// has to be refused outright rather than negotiated with.
+/// byte is exchanged. Nothing after it negotiates: rkyv encodes enum variants positionally, so a
+/// peer several releases behind must be refused outright rather than talked down to some common
+/// version. No application message carries a capability list or a version of its own.
+///
+/// It is not the only gate, and the doc here used to claim it was. [`HELLO_VERSION`] answers the
+/// narrower question of how to *read* a hello, which is a different question from what the hello
+/// then means — see its own note.
 pub const ALPN: &[u8] = b"vmux/2";
 
 /// ALPN a liveness probe negotiates instead of [`ALPN`].

--- a/crates/host/vmux_remote/src/quic/endpoint.rs
+++ b/crates/host/vmux_remote/src/quic/endpoint.rs
@@ -36,10 +36,29 @@ pub const KEEP_ALIVE_MS: u64 = 10_000;
 ///
 /// The prompt-size check still runs in the dispatcher; this stops a hostile peer from making the
 /// daemon hold the bytes before that check is reached.
+///
+/// This is the *connection's* budget, shared by every stream on it. Per-stream backpressure is
+/// quinn's own `stream_receive_window`, deliberately left at its default: that is well under this
+/// number, so one stream cannot drain the whole connection's allowance before the others get a
+/// turn. An application frame cap sized at or above this constant would undo that, which is why
+/// [`MAX_REQUEST_BYTES`] is a fraction of it rather than its equal.
+///
+/// [`MAX_REQUEST_BYTES`]: https://docs.rs/vmux_service
 pub const RECEIVE_WINDOW: u32 = 8 * 1024 * 1024;
 
 /// Concurrent request streams one peer may open.
 pub const MAX_CONCURRENT_BIDI_STREAMS: u32 = 64;
+
+/// Concurrent unidirectional streams one peer may open, and there are none by design.
+///
+/// Nothing here calls `open_uni`. The session-events stream looks unidirectional but is a bidi
+/// stream the *client* opens, because the relay only routes streams a client opened — a
+/// desktop-initiated one would work on a direct connection and vanish through the relay, a
+/// difference that would not show up until someone tested off their own network.
+///
+/// So a uni stream is something no vmux build sends. Granting a budget for one only buys a stream
+/// nothing will ever drain, holding connection window while it waits.
+pub const MAX_CONCURRENT_UNI_STREAMS: u32 = 0;
 
 /// A self-signed identity for a desktop that no CA will vouch for.
 #[derive(Clone, Debug)]
@@ -312,7 +331,7 @@ fn transport_config() -> Arc<TransportConfig> {
     transport.keep_alive_interval(Some(std::time::Duration::from_millis(KEEP_ALIVE_MS)));
     transport.receive_window(RECEIVE_WINDOW.into());
     transport.max_concurrent_bidi_streams(MAX_CONCURRENT_BIDI_STREAMS.into());
-    transport.max_concurrent_uni_streams(MAX_CONCURRENT_BIDI_STREAMS.into());
+    transport.max_concurrent_uni_streams(MAX_CONCURRENT_UNI_STREAMS.into());
     Arc::new(transport)
 }
 

--- a/crates/host/vmux_service/src/remote/quic.rs
+++ b/crates/host/vmux_service/src/remote/quic.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 
 use tokio::sync::watch;
 
-use vmux_remote::quic::endpoint::SelfSignedIdentity;
+use vmux_remote::quic::endpoint::{RECEIVE_WINDOW, SelfSignedIdentity};
 
 use vmux_wire::protocol::{ServiceMessage, SharedMessage};
 
@@ -235,9 +235,16 @@ async fn serve(
 
 /// Largest request frame accepted on a control stream.
 ///
-/// Above the prompt cap so an oversized prompt is refused by the dispatcher with a reason, rather
-/// than looking to the client like a broken connection.
-const MAX_REQUEST_BYTES: usize = 8 * 1024 * 1024;
+/// Above the prompt cap so an oversized prompt is refused by the dispatcher with a reason rather
+/// than looking to the client like a broken connection — and well below the connection's window,
+/// because nothing a request carries is large. Attachments travel as paths validated against
+/// `$HOME`, never as bytes, so the biggest legitimate request is one full prompt and a handful of
+/// file names.
+///
+/// Derived rather than written out, because the invariant is the *relationship*: this used to be
+/// exactly [`RECEIVE_WINDOW`], so one max-size request could take the whole connection's
+/// allowance and stall the other sixty-three streams behind it.
+const MAX_REQUEST_BYTES: usize = (RECEIVE_WINDOW / 8) as usize;
 
 /// One request in, one response out, then the stream closes.
 ///


### PR DESCRIPTION
Second slice of [VMX-184](https://linear.app/vmux/issue/VMX-184). No wire change. Stacked on #381 — retarget to `main` once that merges.

## Three findings

**64 unidirectional streams nothing will ever read.** `transport.max_concurrent_uni_streams` was handed `MAX_CONCURRENT_BIDI_STREAMS`. But `open_uni` and `accept_uni` appear nowhere in the tree — the session-events stream *looks* unidirectional and is actually a bidi stream the client opens, because the relay only routes streams a client opened. So the budget bought 64 streams no accept loop drains, each able to hold connection window while it waits. Now `MAX_CONCURRENT_UNI_STREAMS = 0`, with the reason written down.

**One request could take the whole connection's window.** `MAX_REQUEST_BYTES` and `RECEIVE_WINDOW` were both exactly 8 MiB, so a single max-size request could consume a connection's entire allowance and stall the other 63 streams. It is now derived from the window, because the invariant is the relationship and not the number.

Sizing it down is safe: nothing a request carries is large. `MAX_PROMPT_BYTES` is 64 KiB, and attachments travel as **paths** validated against `$HOME` (`validate_remote_attachments`), never as bytes. The biggest legitimate request is one full prompt plus a handful of file names.

**The ALPN doc contradicted the code.** It claimed to be *"the only compatibility gate there is"* and that *"there is deliberately no second version field in the hellos"* — twenty lines above `HELLO_VERSION`, which `decode_hello` checks. The design is sound (one gates what the conversation *means*, the other how to *read* a hello, as `HELLO_VERSION`'s own note explains); only the prose was false.

## Test plan

- [x] `cargo test -p vmux_remote -p vmux_service` — all green
- [x] `cargo clippy -p vmux_remote -p vmux_service --all-targets` clean
- [ ] No test added. The uni-stream change is one line and a behavioural test for it belongs with the refusal work in the next slice, where there is a reader to observe the refusal; asserting the constant here would only restate it.