### PR TITLE
Let the command bar spawn its own surface

### DIFF
--- a/crates/page/vmux_command/src/host.rs
+++ b/crates/page/vmux_command/src/host.rs
@@ -30,6 +30,7 @@ pub mod page_key;
 pub mod payload;
 pub mod shortcut;
 pub mod snapshot;
+pub mod surface;
 
 pub use bundle::{COMMAND_BAR_PAGE_URL, CommandBar};
 pub use command::*;

--- a/crates/page/vmux_command/src/host/plugin.rs
+++ b/crates/page/vmux_command/src/host/plugin.rs
@@ -4,6 +4,7 @@ use crate::command::{AppCommand, ReadAppCommands, WriteAppCommands};
 use crate::issued::CommandIssued;
 use crate::page_key::PageKeyPlugin;
 use crate::snapshot::{CommandBarSnapshotPlugin, WriteCommandBarSnapshots};
+use crate::surface::CommandBarSurfacePlugin;
 use vmux_core::team::{Profile, User};
 
 /// Wires the command protocol: the command messages, the command-bar snapshot resources,
@@ -16,19 +17,23 @@ pub struct CommandPlugin;
 
 impl Plugin for CommandPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins((PageKeyPlugin, CommandBarSnapshotPlugin))
-            .add_message::<AppCommand>()
-            .add_message::<CommandIssued>()
-            .configure_sets(
-                Update,
-                (WriteAppCommands, WriteCommandBarSnapshots, ReadAppCommands).chain(),
-            )
-            .add_systems(
-                Update,
-                log_app_commands
-                    .after(WriteAppCommands)
-                    .before(ReadAppCommands),
-            );
+        app.add_plugins((
+            PageKeyPlugin,
+            CommandBarSnapshotPlugin,
+            CommandBarSurfacePlugin,
+        ))
+        .add_message::<AppCommand>()
+        .add_message::<CommandIssued>()
+        .configure_sets(
+            Update,
+            (WriteAppCommands, WriteCommandBarSnapshots, ReadAppCommands).chain(),
+        )
+        .add_systems(
+            Update,
+            log_app_commands
+                .after(WriteAppCommands)
+                .before(ReadAppCommands),
+        );
     }
 }
 

--- a/crates/page/vmux_command/src/host/surface.rs
+++ b/crates/page/vmux_command/src/host/surface.rs
@@ -1,0 +1,112 @@
+//! The bar's host-side surface, spawned by the crate that owns it.
+//!
+//! A page crate spawns its own webview — `vmux_terminal`, `vmux_space` and `vmux_setting` all do.
+//! The bar used to be the exception, assembled inside the layout's window `setup`, which made the
+//! shell the author of a surface it only hosts.
+//!
+//! It cannot parent itself: the window root is the layout's, and reaching for it would invert the
+//! dependency. So it spawns unparented and declares [`WindowOverlay`], and the layout adopts every
+//! unparented overlay into its root — the same handoff `maintain_warm_page_pool` already uses,
+//! and it lets the shell place the surface without being told whose it is.
+
+use bevy::prelude::*;
+use bevy_cef::prelude::{
+    CefIgnorePinchZoom, WebviewOpaqueWindowedBackground, WebviewSize, WebviewSource,
+    WebviewWindowed, WebviewWindowedNativeFocus,
+};
+use vmux_core::overlay::WindowOverlay;
+
+use crate::bundle::{COMMAND_BAR_PAGE_URL, CommandBar};
+
+pub(crate) struct CommandBarSurfacePlugin;
+
+impl Plugin for CommandBarSurfacePlugin {
+    fn build(&self, app: &mut App) {
+        app.world_mut().spawn(crate::COMMAND_BAR_PAGE_MANIFEST);
+        app.add_systems(Startup, spawn_command_bar_surface);
+    }
+}
+
+impl CommandBar {
+    /// Everything about the surface that is the bar's own. The layout adds what only it can know:
+    /// the host window, the `Browser` marker, and the parent.
+    fn surface() -> impl Bundle {
+        (
+            (
+                CommandBar,
+                WindowOverlay,
+                // An ordinary windowed surface, framed by the shared `sync_windowed_frames` and
+                // focused by the shared route. It is offscreen rendering that forced the host to
+                // inject its keystrokes; a native view is handed them by AppKit instead.
+                WebviewWindowed,
+                WebviewWindowedNativeFocus,
+                WebviewOpaqueWindowedBackground,
+                CefIgnorePinchZoom,
+            ),
+            Node {
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                position_type: PositionType::Absolute,
+                left: Val::Px(0.0),
+                top: Val::Px(0.0),
+                display: Display::None,
+                ..default()
+            },
+            ZIndex(3),
+            WebviewSource::new(COMMAND_BAR_PAGE_URL),
+            WebviewSize(Vec2::new(800.0, 600.0)),
+            Transform::default(),
+            GlobalTransform::default(),
+            Visibility::Hidden,
+            Pickable::IGNORE,
+        )
+    }
+}
+
+fn spawn_command_bar_surface(mut commands: Commands) {
+    commands.spawn(CommandBar::surface());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_cef::prelude::{WebviewNativeLiquidGlass, WebviewNativeOverlay, WebviewTransparent};
+
+    fn spawned() -> (App, Entity) {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_systems(Startup, spawn_command_bar_surface);
+        app.update();
+        let bar = app
+            .world_mut()
+            .query_filtered::<Entity, With<CommandBar>>()
+            .single(app.world())
+            .expect("command bar surface");
+        (app, bar)
+    }
+
+    /// The layout adopts overlays by looking for unparented ones, so a surface that arrives with a
+    /// parent is never placed in the window root and never appears.
+    #[test]
+    fn the_surface_spawns_unparented_and_declares_the_capability() {
+        let (app, bar) = spawned();
+        let surface = app.world().entity(bar);
+
+        assert!(surface.contains::<WindowOverlay>());
+        assert!(surface.get::<ChildOf>().is_none());
+    }
+
+    /// A windowed CEF view cannot be transparent on macOS, so the bar is composited as an opaque
+    /// native view rather than through the glass overlay. Handing it any of these back reintroduces
+    /// the black rectangle that forced the windowed path in the first place.
+    #[test]
+    fn the_surface_is_opaque_and_windowed_rather_than_composited() {
+        let (app, bar) = spawned();
+        let surface = app.world().entity(bar);
+
+        assert!(surface.contains::<WebviewOpaqueWindowedBackground>());
+        assert!(!surface.contains::<WebviewNativeOverlay>());
+        assert!(!surface.contains::<WebviewTransparent>());
+        assert!(!surface.contains::<WebviewNativeLiquidGlass>());
+    }
+}

--- a/crates/page/vmux_layout/src/event.rs
+++ b/crates/page/vmux_layout/src/event.rs
@@ -1,7 +1,6 @@
 use vmux_core::{PageIcon, PageMetadata};
 
 pub const LAYOUT_PAGE_URL: &str = "vmux://layout/";
-pub const COMMAND_BAR_PAGE_URL: &str = "vmux://command-bar/";
 pub const TERMINAL_PAGE_URL: &str = "vmux://terminal/";
 pub const SERVICES_PAGE_URL: &str = "vmux://services/";
 pub const LAYOUT_STATE_EVENT: &str = "layout-state";

--- a/crates/page/vmux_layout/src/host.rs
+++ b/crates/page/vmux_layout/src/host.rs
@@ -16,6 +16,7 @@ pub mod cef;
 pub mod contract;
 pub mod debug;
 pub mod native_pointer;
+pub mod overlay_adopt;
 pub mod pane;
 pub mod placement;
 pub mod plugin;
@@ -61,7 +62,6 @@ pub const LAYOUT_PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page:
     icon: None,
     command_bar: false,
 };
-pub use vmux_command::COMMAND_BAR_PAGE_MANIFEST;
 pub const DEBUG_PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
     host: "debug",
     title: "Debug",

--- a/crates/page/vmux_layout/src/host/cef.rs
+++ b/crates/page/vmux_layout/src/host/cef.rs
@@ -7,7 +7,6 @@ pub struct LayoutCefPlugin;
 impl Plugin for LayoutCefPlugin {
     fn build(&self, app: &mut App) {
         app.world_mut().spawn(crate::LAYOUT_PAGE_MANIFEST);
-        app.world_mut().spawn(crate::COMMAND_BAR_PAGE_MANIFEST);
         app.world_mut().spawn(crate::DEBUG_PAGE_MANIFEST);
         app.world_mut().spawn(crate::ERROR_PAGE_MANIFEST);
     }

--- a/crates/page/vmux_layout/src/host/overlay_adopt.rs
+++ b/crates/page/vmux_layout/src/host/overlay_adopt.rs
@@ -1,0 +1,97 @@
+//! Taking in the window-covering pages other crates spawn.
+//!
+//! A page that covers the window cannot parent itself — the root is the layout's, and a page crate
+//! reaching for it would invert the dependency. So it spawns unparented with
+//! [`WindowOverlay`](vmux_core::overlay::WindowOverlay) and the layout places it here, adding the
+//! three things only the shell knows: the host window, the `Browser` marker, and the parent.
+//!
+//! The shell never learns which page it just adopted, which is the point.
+
+use bevy::prelude::*;
+use bevy::window::PrimaryWindow;
+use bevy_cef::prelude::HostWindow;
+use vmux_core::overlay::WindowOverlay;
+
+use crate::cef::Browser;
+use crate::window::VmuxWindow;
+
+pub(crate) struct OverlayAdoptPlugin;
+
+impl Plugin for OverlayAdoptPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(PreUpdate, adopt_window_overlays);
+    }
+}
+
+fn adopt_window_overlays(
+    orphans: Query<Entity, (With<WindowOverlay>, Without<ChildOf>)>,
+    root_q: Query<Entity, With<VmuxWindow>>,
+    primary_window: Query<Entity, With<PrimaryWindow>>,
+    mut commands: Commands,
+) {
+    if orphans.is_empty() {
+        return;
+    }
+    let Ok(root) = root_q.single() else {
+        return;
+    };
+    let Ok(window) = primary_window.single() else {
+        return;
+    };
+    for overlay in orphans.iter() {
+        commands
+            .entity(overlay)
+            .insert((Browser, HostWindow(window), ChildOf(root)));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The shell has to place an overlay it knows nothing about, so adoption keys off the
+    /// capability alone — no page marker, no URL.
+    #[test]
+    fn an_unparented_overlay_is_placed_in_the_window_root() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_systems(PreUpdate, adopt_window_overlays);
+        let root = app.world_mut().spawn(VmuxWindow).id();
+        app.world_mut().spawn(PrimaryWindow);
+        let overlay = app.world_mut().spawn(WindowOverlay).id();
+
+        app.update();
+
+        let overlay_ref = app.world().entity(overlay);
+        assert_eq!(
+            overlay_ref.get::<ChildOf>().map(ChildOf::parent),
+            Some(root)
+        );
+        assert!(overlay_ref.contains::<Browser>());
+    }
+
+    /// Adoption runs every frame, so it must not re-parent a surface the layout has since moved.
+    #[test]
+    fn an_already_parented_overlay_is_left_alone() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_systems(PreUpdate, adopt_window_overlays);
+        app.world_mut().spawn(VmuxWindow);
+        app.world_mut().spawn(PrimaryWindow);
+        let elsewhere = app.world_mut().spawn_empty().id();
+        let overlay = app
+            .world_mut()
+            .spawn((WindowOverlay, ChildOf(elsewhere)))
+            .id();
+
+        app.update();
+
+        assert_eq!(
+            app.world()
+                .entity(overlay)
+                .get::<ChildOf>()
+                .map(ChildOf::parent),
+            Some(elsewhere)
+        );
+    }
+}

--- a/crates/page/vmux_layout/src/host/plugin.rs
+++ b/crates/page/vmux_layout/src/host/plugin.rs
@@ -81,6 +81,7 @@ impl Plugin for LayoutPlugin {
                 PrewarmPagesPlugin,
                 BookmarkPlugin,
                 LayoutCefPlugin,
+                crate::overlay_adopt::OverlayAdoptPlugin,
             ));
     }
 }

--- a/crates/page/vmux_layout/src/host/window.rs
+++ b/crates/page/vmux_layout/src/host/window.rs
@@ -1,7 +1,6 @@
-use crate::event::COMMAND_BAR_PAGE_URL;
 use crate::{
     Header, LayoutStartupSet, SpaceFilePresent, TabLayoutSpawnContent, TabLayoutSpawnRequest,
-    cef::{Browser, layout_cef_bundle},
+    cef::layout_cef_bundle,
     pane::{Pane, PaneSplit, PaneSplitDirection, leaf_pane_bundle, pane_split_gaps},
     scene::MainCamera,
     settings::LayoutSettings,
@@ -12,7 +11,6 @@ use crate::{
 };
 use bevy::{
     asset::Asset,
-    picking::Pickable,
     prelude::*,
     ui::{FlexDirection, UiTargetCamera},
     window::PrimaryWindow,
@@ -20,7 +18,6 @@ use bevy::{
 };
 use bevy_cef::prelude::*;
 use moonshine_save::prelude::*;
-use vmux_command::CommandBar;
 use vmux_command::{AppCommand, LayoutCommand, ReadAppCommands, WindowCommand};
 use vmux_core::page::PageEmbedSet;
 use vmux_core::{PageOpenRequest, PageOpenSet, PageOpenTarget};
@@ -291,39 +288,6 @@ fn setup(
             display: Display::None,
             ..default()
         },
-        ChildOf(root),
-    ));
-
-    commands.spawn((
-        (
-            CommandBar,
-            vmux_core::overlay::WindowOverlay,
-            HostWindow(pw),
-            Browser,
-            // An ordinary windowed surface, framed by the shared `sync_windowed_frames` and
-            // focused by the shared route. It is offscreen rendering that forced the host to
-            // inject its keystrokes; a native view is handed them by AppKit instead.
-            WebviewWindowed,
-            WebviewWindowedNativeFocus,
-            WebviewOpaqueWindowedBackground,
-            bevy_cef::prelude::CefIgnorePinchZoom,
-        ),
-        Node {
-            width: Val::Percent(100.0),
-            height: Val::Percent(100.0),
-            position_type: PositionType::Absolute,
-            left: Val::Px(0.0),
-            top: Val::Px(0.0),
-            display: Display::None,
-            ..default()
-        },
-        ZIndex(3),
-        WebviewSource::new(COMMAND_BAR_PAGE_URL),
-        WebviewSize(Vec2::new(800.0, 600.0)),
-        Transform::default(),
-        GlobalTransform::default(),
-        Visibility::Hidden,
-        Pickable::IGNORE,
         ChildOf(root),
     ));
 
@@ -798,34 +762,6 @@ mod tests {
         assert_eq!(node.column_gap, Val::Px(crate::event::PANE_GAP_PX));
     }
 
-    #[test]
-    fn command_bar_spawns_as_a_windowed_surface() {
-        let mut app = setup_window_app();
-        app.update();
-
-        let modal = app
-            .world_mut()
-            .query_filtered::<Entity, With<CommandBar>>()
-            .single(app.world())
-            .expect("modal");
-
-        assert!(app.world().get::<WebviewWindowed>(modal).is_some());
-        assert!(
-            app.world()
-                .get::<bevy_cef::prelude::WebviewNativeOverlay>(modal)
-                .is_none()
-        );
-        // A windowed CEF view cannot be transparent, so the glass shell goes with the
-        // overlay it was composited through.
-        assert!(app.world().get::<WebviewTransparent>(modal).is_none());
-        assert!(app.world().get::<WebviewNativeLiquidGlass>(modal).is_none());
-        assert!(
-            app.world()
-                .get::<WebviewOpaqueWindowedBackground>(modal)
-                .is_some()
-        );
-    }
-
     /// A windowed CEF browser paints an opaque root on macOS and the layout is the one page that
     /// must be see-through, so wry serves it instead. Handing the entity a `WebviewSource` again
     /// is all it would take to undo that silently: it resolves to `ResolvedWebviewUri`, which is
@@ -846,24 +782,6 @@ mod tests {
             app.world()
                 .get::<ResolvedWebviewUri>(layout_shell)
                 .is_none()
-        );
-    }
-
-    #[test]
-    fn command_bar_modal_allows_windowed_native_focus() {
-        let mut app = setup_window_app();
-        app.update();
-
-        let modal = app
-            .world_mut()
-            .query_filtered::<Entity, With<CommandBar>>()
-            .single(app.world())
-            .expect("modal");
-
-        assert!(
-            app.world()
-                .get::<WebviewWindowedNativeFocus>(modal)
-                .is_some()
         );
     }
 


### PR DESCRIPTION
Stacked on #382.

## Summary

Every other page crate spawns its own webview:

| | |
|---|---|
| `vmux_terminal/host/plugin.rs:713` | terminal |
| `vmux_space/host/spaces.rs:35` | spaces |
| `vmux_setting/host/view.rs:66` | settings |
| **`vmux_layout/host/window.rs:307`** | **command bar** |

The bar was the exception. Its 33-line bundle was assembled inside the layout's window `setup`, alongside the side sheets and the header, and its page manifest was spawned by the layout's CEF plugin — so the shell was the author of a surface it only hosts.

## It can't parent itself, so the layout adopts it

The window root is the layout's, and a page crate reaching for it would invert the dependency into a cycle. So the bar spawns **unparented** and declares `WindowOverlay` (from #382), and the layout adopts every unparented overlay:

```rust
fn adopt_window_overlays(
    orphans: Query<Entity, (With<WindowOverlay>, Without<ChildOf>)>,
    ...
) {
    for overlay in orphans.iter() {
        commands.entity(overlay).insert((Browser, HostWindow(window), ChildOf(root)));
    }
}
```

That handoff isn't new — `maintain_warm_page_pool` already places pages the layout didn't spawn. What it buys here is that **the shell never learns whose surface it just adopted**, so a second window-covering page needs no change to the layout at all.

The split falls where the knowledge is: the bar contributes what's its own (the URL, the size, the z-index, the windowed/opaque compositing choice), the layout contributes the three things only it can know (host window, `Browser`, parent).

## Test plan

- [x] `cargo fmt --check`
- [x] `clippy -D warnings` under CI's exact package selection
- [x] `cargo test --workspace` green
- [ ] Run the app

The two tests asserting the bundle's shape moved to the crate that now builds it. I kept the negative assertions, which carry a reason — a windowed CEF view cannot be transparent on macOS, so transparency or the glass overlay reappearing on this entity is a real regression — and added one for the new contract: the surface must spawn *unparented*, or adoption never finds it and the bar never appears.

Adoption is the thing to exercise manually, because a failure means the bar is simply absent:

- **Cmd+K** — the bar appears at all, full-window, above the layout
- **Cmd+K, dismiss, Cmd+K** — adoption runs every frame and must not re-parent on the second open
- **The start page launcher** — unaffected, but it shares the payload path

Also dropped: the duplicate `COMMAND_BAR_PAGE_URL` in `vmux_layout::event` and the `COMMAND_BAR_PAGE_MANIFEST` re-export in `vmux_layout::host`, both with no callers left once the spawn moved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying the command bar as a native, opaque window surface.
  * Command bar surfaces are automatically adopted into the primary application window.
  * Existing layout and page surfaces continue to load alongside the command bar.

* **Improvements**
  * Simplified layout hosting by separating command bar setup from the main layout shell.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->