### PR TITLE
Give every frame a type, and one framing for all of them

### DIFF
--- a/crates/app/vmux_mobile/src/quic_api.rs
+++ b/crates/app/vmux_mobile/src/quic_api.rs
@@ -16,17 +16,23 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use vmux_remote::DeviceId;
 use vmux_remote::PeerRole;
+use vmux_remote::framing::{Frame, FrameStream};
 use vmux_remote::quic::endpoint::Trust;
 use vmux_remote::quic::tunnel::{DESKTOP_TAG, TunnelSocket, relayed_peer};
-use vmux_remote::quic::{
-    ClientHello, CloseCode, RelayAccepted, RelayHello, ServerHello, StreamKind, decode_hello,
-    encode_hello,
-};
+use vmux_remote::quic::{Accepted, ClientSetup, CloseCode, MessageType, RelaySetup};
 use vmux_ui::i18n::{TranslationValue, translate, translate_with};
 use vmux_wire::protocol::{AgentAction, SharedEvent, SharedFailure, SharedMessage, SharedResponse};
 
 /// Matches the daemon's cap on a control response.
 const MAX_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
+/// Frames on a setup exchange, either leg. The same bound both ways: the desktop caps what it
+/// reads from this phone identically, and two directions of one exchange disagreeing on how much
+/// they will accept is a difference nobody would notice until a message grew.
+const SETUP: FrameStream = FrameStream::new(16 * 1024);
+
+/// Frames on a control or subscription stream.
+const CONTROL: FrameStream = FrameStream::new(MAX_RESPONSE_BYTES);
 
 /// What went wrong, in the terms a page needs to decide whether to retry.
 #[derive(Debug)]
@@ -266,27 +272,27 @@ impl QuicApi {
             .map_err(|error| QuicError::Transport(error.to_string()))?;
         // The desktop does not read this — it admits on the token alone — so it names the pairing
         // rather than the phone, which is the only identity either end shares.
-        let hello = AuthenticatedHello {
-            hello: ClientHello {
-                device_id: self.endpoint.desktop.clone(),
-            },
+        let setup = ClientSetup {
+            device_id: self.endpoint.desktop.clone(),
             token: self.endpoint.token.clone(),
         };
-        let bytes =
-            encode_hello(&hello).map_err(|error| QuicError::Transport(error.to_string()))?;
-        send.write_all(&bytes)
+        let frame = Frame::json(MessageType::CLIENT_SETUP, &setup)
+            .map_err(|error| QuicError::Transport(error.to_string()))?;
+        SETUP
+            .open(&mut send, &frame)
             .await
             .map_err(|error| QuicError::Transport(error.to_string()))?;
         send.finish()
             .map_err(|error| QuicError::Transport(error.to_string()))?;
 
-        let answer = recv
-            .read_to_end(64 * 1024)
+        // The answer carries nothing; reading a well-formed one of the right type is the accept
+        // signal. A refusal arrives as a close code, which is what `from_close` turns into advice.
+        SETUP
+            .accept(&mut recv)
             .await
+            .map_err(|_| QuicError::from_close(&connection))?
+            .read_json::<Accepted>(MessageType::SESSION_ACCEPTED)
             .map_err(|_| QuicError::from_close(&connection))?;
-        // The answer carries nothing; reading a well-formed one is the accept signal. A refusal
-        // arrives as a close code instead, which is what `from_close` turns into advice.
-        decode_hello::<ServerHello>(&answer).map_err(|_| QuicError::from_close(&connection))?;
         Ok(Dialled {
             connection,
             _relay: relay_endpoint,
@@ -303,24 +309,26 @@ impl QuicApi {
             .open_bi()
             .await
             .map_err(|error| QuicError::Transport(error.to_string()))?;
-        let hello = RelayHello {
+        let setup = RelaySetup {
             device_id: self.endpoint.desktop.clone(),
             role: PeerRole::Client,
             token: self.endpoint.token.clone(),
         };
-        let bytes =
-            encode_hello(&hello).map_err(|error| QuicError::Transport(error.to_string()))?;
-        send.write_all(&bytes)
+        let frame = Frame::json(MessageType::RELAY_SETUP, &setup)
+            .map_err(|error| QuicError::Transport(error.to_string()))?;
+        SETUP
+            .open(&mut send, &frame)
             .await
             .map_err(|error| QuicError::Transport(error.to_string()))?;
         send.finish()
             .map_err(|error| QuicError::Transport(error.to_string()))?;
 
-        let answer = recv
-            .read_to_end(16 * 1024)
+        SETUP
+            .accept(&mut recv)
             .await
+            .map_err(|_| QuicError::from_close(control))?
+            .read_json::<Accepted>(MessageType::RELAY_ACCEPTED)
             .map_err(|_| QuicError::from_close(control))?;
-        decode_hello::<RelayAccepted>(&answer).map_err(|_| QuicError::from_close(control))?;
         Ok(())
     }
 
@@ -337,18 +345,20 @@ impl QuicApi {
             .map_err(|error| QuicError::Transport(error.to_string()))?;
 
         let request = SharedMessage::agent(sid, AgentAction::Attach);
-        let mut frame = vec![StreamKind::SessionEvents.as_byte()];
-        frame.extend_from_slice(
-            &rkyv::to_bytes::<rkyv::rancor::Error>(&request)
-                .map_err(|error| QuicError::Transport(error.to_string()))?,
-        );
-        send.write_all(&frame)
+        let body = rkyv::to_bytes::<rkyv::rancor::Error>(&request)
+            .map_err(|error| QuicError::Transport(error.to_string()))?;
+        let frame = Frame::new(MessageType::SESSION_EVENTS, body.to_vec());
+        CONTROL
+            .open(&mut send, &frame)
             .await
             .map_err(|error| QuicError::Transport(error.to_string()))?;
         send.finish()
             .map_err(|error| QuicError::Transport(error.to_string()))?;
 
-        Ok(Subscription { recv })
+        Ok(Subscription {
+            recv,
+            opened: false,
+        })
     }
 
     /// One request, one response, on its own stream.
@@ -359,24 +369,24 @@ impl QuicApi {
             .await
             .map_err(|error| QuicError::Transport(error.to_string()))?;
 
-        let mut frame = vec![StreamKind::Control.as_byte()];
-        frame.extend_from_slice(
-            &rkyv::to_bytes::<rkyv::rancor::Error>(&message)
-                .map_err(|error| QuicError::Transport(error.to_string()))?,
-        );
-        send.write_all(&frame)
+        let body = rkyv::to_bytes::<rkyv::rancor::Error>(&message)
+            .map_err(|error| QuicError::Transport(error.to_string()))?;
+        let frame = Frame::new(MessageType::CONTROL_REQUEST, body.to_vec());
+        CONTROL
+            .open(&mut send, &frame)
             .await
             .map_err(|error| QuicError::Transport(error.to_string()))?;
         send.finish()
             .map_err(|error| QuicError::Transport(error.to_string()))?;
 
-        let bytes = recv
-            .read_to_end(MAX_RESPONSE_BYTES)
+        let answer = CONTROL
+            .accept(&mut recv)
             .await
             .map_err(|_| QuicError::from_close(&connection))?;
-        // Copied so rkyv sees an aligned buffer.
-        let bytes = bytes.to_vec();
-        let response = rkyv::from_bytes::<SharedResponse, rkyv::rancor::Error>(&bytes)
+        let body = answer
+            .body_of(MessageType::CONTROL_RESPONSE)
+            .map_err(|_| QuicError::from_close(&connection))?;
+        let response = rkyv::from_bytes::<SharedResponse, rkyv::rancor::Error>(body)
             .map_err(|error| QuicError::Transport(error.to_string()))?;
         match response {
             SharedResponse::Failed(failure) => Err(QuicError::Refused(failure)),
@@ -388,32 +398,25 @@ impl QuicApi {
 /// A live session subscription. Yields events until the desktop closes the stream.
 pub struct Subscription {
     recv: quinn::RecvStream,
+    /// Whether the desktop's half of this stream has announced its version yet.
+    opened: bool,
 }
 
 impl Subscription {
     /// The next event, or `None` once the desktop is done sending.
     ///
-    /// Events are length-prefixed because many share one stream; a control response is not,
-    /// because it is the only thing on its own.
+    /// The desktop announces its half of the stream on the first event, so the version is read
+    /// once and every event after it is just another frame.
     pub async fn next(&mut self) -> Option<SharedEvent> {
-        let mut length = [0u8; 4];
-        self.recv.read_exact(&mut length).await.ok()?;
-        let length = u32::from_le_bytes(length) as usize;
-        if length > MAX_RESPONSE_BYTES {
-            return None;
-        }
-        let mut body = vec![0u8; length];
-        self.recv.read_exact(&mut body).await.ok()?;
-        rkyv::from_bytes::<SharedEvent, rkyv::rancor::Error>(&body).ok()
+        let frame = if self.opened {
+            CONTROL.next(&mut self.recv).await.ok()??
+        } else {
+            self.opened = true;
+            CONTROL.accept(&mut self.recv).await.ok()?
+        };
+        let body = frame.body_of(MessageType::SESSION_EVENT).ok()?;
+        rkyv::from_bytes::<SharedEvent, rkyv::rancor::Error>(body).ok()
     }
-}
-
-/// The hello carries the bearer token, since QUIC has no headers.
-#[derive(serde::Deserialize, serde::Serialize)]
-struct AuthenticatedHello {
-    #[serde(flatten)]
-    hello: ClientHello,
-    token: String,
 }
 
 #[cfg(test)]

--- a/crates/host/vmux_remote/src/framing.rs
+++ b/crates/host/vmux_remote/src/framing.rs
@@ -51,14 +51,47 @@ impl LengthPrefixed {
         R: AsyncReadExt + Unpin,
     {
         let mut length = [0u8; 4];
-        match reader.read_exact(&mut length).await {
-            Ok(_) => {}
-            Err(error) if Self::peer_gone(&error) => return Ok(None),
-            Err(error) => return Err(error),
+        if !Self::fill_or_end(reader, &mut length).await? {
+            return Ok(None);
         }
         let mut body = vec![0u8; self.length_of(length)?];
         reader.read_exact(&mut body).await?;
         Ok(Some(body))
+    }
+
+    /// Fill `buffer`, saying whether the stream ended instead.
+    ///
+    /// `false` means nothing at all was there, which is how a stream ordinarily ends. Anything
+    /// short of a full buffer is an error, and telling those apart is the entire job: `read_exact`
+    /// reports an empty prefix and a half-written one identically, so using it directly here is
+    /// how a peer that vanished mid-prefix comes back as a clean end of stream.
+    async fn fill_or_end<R>(reader: &mut R, buffer: &mut [u8]) -> std::io::Result<bool>
+    where
+        R: AsyncReadExt + Unpin,
+    {
+        match reader.read(&mut buffer[..1]).await {
+            Ok(0) => return Ok(false),
+            Ok(_) => {}
+            Err(error) if Self::peer_gone(&error) => return Ok(false),
+            Err(error) => return Err(error),
+        }
+        reader.read_exact(&mut buffer[1..]).await?;
+        Ok(true)
+    }
+
+    /// The blocking twin of [`LengthPrefixed::fill_or_end`].
+    fn fill_or_end_blocking<R: std::io::Read>(
+        reader: &mut R,
+        buffer: &mut [u8],
+    ) -> std::io::Result<bool> {
+        match reader.read(&mut buffer[..1]) {
+            Ok(0) => return Ok(false),
+            Ok(_) => {}
+            Err(error) if Self::peer_gone(&error) => return Ok(false),
+            Err(error) => return Err(error),
+        }
+        reader.read_exact(&mut buffer[1..])?;
+        Ok(true)
     }
 
     pub fn write_blocking<W: std::io::Write>(
@@ -78,10 +111,8 @@ impl LengthPrefixed {
         reader: &mut R,
     ) -> std::io::Result<Option<Vec<u8>>> {
         let mut length = [0u8; 4];
-        match reader.read_exact(&mut length) {
-            Ok(_) => {}
-            Err(error) if Self::peer_gone(&error) => return Ok(None),
-            Err(error) => return Err(error),
+        if !Self::fill_or_end_blocking(reader, &mut length)? {
+            return Ok(None);
         }
         let mut body = vec![0u8; self.length_of(length)?];
         reader.read_exact(&mut body)?;
@@ -253,10 +284,8 @@ impl FrameStream {
         R: AsyncReadExt + Unpin,
     {
         let mut message_type = [0u8; 2];
-        match reader.read_exact(&mut message_type).await {
-            Ok(_) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
-            Err(error) => return Err(error.into()),
+        if !LengthPrefixed::fill_or_end(reader, &mut message_type).await? {
+            return Ok(None);
         }
         let Some(body) = self.codec.read(reader).await? else {
             return Err(FrameError::Truncated);
@@ -337,9 +366,36 @@ mod tests {
              got {body_cut:?} and {body_absent:?}"
         );
         assert!(
-            matches!(prefix_cut, Ok(None)),
-            "a prefix cut mid-way is a peer that stopped before promising anything, got \
-             {prefix_cut:?}"
+            prefix_cut.is_err(),
+            "a length prefix cut mid-way lost bytes too — `read_exact` reports an empty prefix \
+             and a half-written one alike, and folding them together is how a peer that vanished \
+             comes back as a clean end. Got {prefix_cut:?}"
+        );
+    }
+
+    /// The same distinction one layer up. A subscription that dies after one byte of a message
+    /// type has lost data; reading that as the desktop finishing is what stops the client
+    /// reconnecting.
+    #[tokio::test]
+    async fn a_message_type_cut_in_half_is_not_a_stream_that_ended() {
+        let stream = FrameStream::new(64 * 1024);
+        let mut wire = Vec::new();
+        stream
+            .open(
+                &mut wire,
+                &Frame::new(MessageType::SESSION_EVENT, b"first".to_vec()),
+            )
+            .await
+            .expect("open");
+        wire.push(0x05);
+
+        let mut reader = wire.as_slice();
+        stream.accept(&mut reader).await.expect("first frame");
+        let after = stream.next(&mut reader).await;
+
+        assert!(
+            matches!(after, Err(FrameError::Truncated)),
+            "half a message type is a truncated frame, not the end of the stream, got {after:?}"
         );
     }
 

--- a/crates/host/vmux_remote/src/framing.rs
+++ b/crates/host/vmux_remote/src/framing.rs
@@ -8,11 +8,12 @@
 //! `vmux_remote` precisely for being free of domain types. A codec in `vmux_client` would drag
 //! `vmux_wire` and `vmux_profile` behind it, and the relay must stay unable to decode a payload.
 //!
-//! Contrast the *control* frame in [`crate::quic`], which is one message per stream delimited by
-//! the stream's own finish. This is the other shape: many messages, one long-lived stream, so a
-//! boundary has to be written down.
+//! [`Frame`] builds on it: a message type, then a length-prefixed body. One scheme serves every
+//! stream in the transport — a control exchange is one frame and a subscription is many.
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::quic::{FRAME_VERSION, MessageType};
 
 /// A stream of length-prefixed frames, bounded by what one frame may claim.
 ///
@@ -119,6 +120,151 @@ impl LengthPrefixed {
                 | std::io::ErrorKind::ConnectionAborted
                 | std::io::ErrorKind::BrokenPipe
         )
+    }
+}
+
+/// Why a frame could not be read.
+#[derive(Debug)]
+pub enum FrameError {
+    /// The peer frames its streams in a layout this build cannot read.
+    UnsupportedVersion(u8),
+    /// A frame arrived, and it was not the one this reader is waiting for.
+    ///
+    /// The refusal the type field exists to make possible. Without it a reader parses whatever it
+    /// expects, and serde's tolerance for unknown fields means another leg's message decodes
+    /// cleanly instead of being turned away.
+    UnexpectedType(MessageType),
+    /// The stream ended part-way through a frame, so bytes were lost.
+    Truncated,
+    /// Read, but the body was not what its type promised.
+    Malformed,
+    Io(std::io::Error),
+}
+
+impl From<std::io::Error> for FrameError {
+    fn from(error: std::io::Error) -> Self {
+        if error.kind() == std::io::ErrorKind::UnexpectedEof {
+            return Self::Truncated;
+        }
+        Self::Io(error)
+    }
+}
+
+/// One typed message, as it travels.
+///
+/// A stream announces [`FRAME_VERSION`] once and then carries these. That is the whole framing:
+/// a control exchange writes one and finishes, a subscription writes many, and the same reader
+/// serves both.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Frame {
+    pub message_type: MessageType,
+    pub body: Vec<u8>,
+}
+
+impl Frame {
+    pub fn new(message_type: MessageType, body: Vec<u8>) -> Self {
+        Self { message_type, body }
+    }
+
+    /// A frame carrying `value` as JSON, for the messages parsed before either peer has agreed on
+    /// anything.
+    pub fn json<T: serde::Serialize>(
+        message_type: MessageType,
+        value: &T,
+    ) -> Result<Self, serde_json::Error> {
+        Ok(Self::new(message_type, serde_json::to_vec(value)?))
+    }
+
+    /// The body, once the type has been checked against what the caller is waiting for.
+    ///
+    /// Checked *before* the body is looked at, which is the point: a relay setup satisfies a
+    /// session setup byte for byte, so deciding on the payload is deciding too late.
+    pub fn body_of(&self, want: MessageType) -> Result<&[u8], FrameError> {
+        if self.message_type != want {
+            return Err(FrameError::UnexpectedType(self.message_type));
+        }
+        Ok(&self.body)
+    }
+
+    /// Read this frame's body as JSON, if it is the type expected.
+    pub fn read_json<T: serde::de::DeserializeOwned>(
+        &self,
+        want: MessageType,
+    ) -> Result<T, FrameError> {
+        serde_json::from_slice(self.body_of(want)?).map_err(|_| FrameError::Malformed)
+    }
+}
+
+/// Frames on one stream: a version byte, then any number of [`Frame`]s.
+#[derive(Clone, Copy, Debug)]
+pub struct FrameStream {
+    codec: LengthPrefixed,
+}
+
+impl FrameStream {
+    pub const fn new(max_body_bytes: usize) -> Self {
+        Self {
+            codec: LengthPrefixed::new(max_body_bytes),
+        }
+    }
+
+    /// Announce this build's framing, then write the first frame.
+    pub async fn open<W>(self, writer: &mut W, frame: &Frame) -> std::io::Result<()>
+    where
+        W: AsyncWriteExt + Unpin,
+    {
+        writer.write_all(&[FRAME_VERSION]).await?;
+        self.send(writer, frame).await
+    }
+
+    /// Write a further frame on a stream already opened.
+    pub async fn send<W>(self, writer: &mut W, frame: &Frame) -> std::io::Result<()>
+    where
+        W: AsyncWriteExt + Unpin,
+    {
+        writer
+            .write_all(&frame.message_type.0.to_le_bytes())
+            .await?;
+        self.codec.write(writer, &frame.body).await
+    }
+
+    /// Check the peer's framing, then read its first frame.
+    ///
+    /// A version this build cannot read is refused here rather than being carried into a decode
+    /// that would fail somewhere less obvious.
+    pub async fn accept<R>(self, reader: &mut R) -> Result<Frame, FrameError>
+    where
+        R: AsyncReadExt + Unpin,
+    {
+        let mut version = [0u8; 1];
+        reader.read_exact(&mut version).await?;
+        if version[0] != FRAME_VERSION {
+            return Err(FrameError::UnsupportedVersion(version[0]));
+        }
+        match self.next(reader).await? {
+            Some(frame) => Ok(frame),
+            None => Err(FrameError::Truncated),
+        }
+    }
+
+    /// Read a further frame, or `None` once the peer has finished sending.
+    pub async fn next<R>(self, reader: &mut R) -> Result<Option<Frame>, FrameError>
+    where
+        R: AsyncReadExt + Unpin,
+    {
+        let mut message_type = [0u8; 2];
+        match reader.read_exact(&mut message_type).await {
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+            Err(error) => return Err(error.into()),
+        }
+        let Some(body) = self.codec.read(reader).await? else {
+            return Err(FrameError::Truncated);
+        };
+        Ok(Some(Frame::new(
+            MessageType(u16::from_le_bytes(message_type)),
+            body,
+        )))
     }
 }
 
@@ -230,6 +376,133 @@ mod tests {
             tiny.read(&mut &wire[..4]).await.is_err(),
             "the prefix alone is enough to refuse; the body need never arrive"
         );
+    }
+
+    /// The defect the type field exists to close. A relay setup carries `device_id`, `role` and
+    /// `token`; a client setup carries `device_id` and `token`. Serde ignores the extra field, so
+    /// before there was a type on the wire the first decoded cleanly as the second — and a shared
+    /// ALPN meant nothing at the connection layer separated them either.
+    #[tokio::test]
+    async fn one_legs_setup_is_refused_by_the_other_legs_reader() {
+        use crate::quic::{PeerRole, RelaySetup};
+
+        let stream = FrameStream::new(64 * 1024);
+        let relay_setup = RelaySetup {
+            device_id: crate::DeviceId::new("alpha"),
+            role: PeerRole::Client,
+            token: "a-relay-credential".into(),
+        };
+        let mut wire = Vec::new();
+        stream
+            .open(
+                &mut wire,
+                &Frame::json(MessageType::RELAY_SETUP, &relay_setup).expect("encode"),
+            )
+            .await
+            .expect("write");
+
+        let frame = stream.accept(&mut wire.as_slice()).await.expect("read");
+        let as_session = frame.read_json::<crate::quic::ClientSetup>(MessageType::CLIENT_SETUP);
+
+        assert!(
+            matches!(
+                as_session,
+                Err(FrameError::UnexpectedType(MessageType::RELAY_SETUP))
+            ),
+            "a relay setup must not satisfy a session reader, got {as_session:?}"
+        );
+        assert!(
+            frame
+                .read_json::<RelaySetup>(MessageType::RELAY_SETUP)
+                .is_ok(),
+            "and the reader it was addressed to must still accept it"
+        );
+    }
+
+    /// A stale peer must be told its framing is old, not handed a decode failure that looks like
+    /// corruption. `read_hello` used to collapse both into one answer.
+    #[tokio::test]
+    async fn a_stale_framing_is_refused_as_a_version_rather_than_as_rubbish() {
+        let stream = FrameStream::new(64 * 1024);
+        let mut wire = Vec::new();
+        stream
+            .open(&mut wire, &Frame::new(MessageType::CLIENT_SETUP, vec![]))
+            .await
+            .expect("write");
+        wire[0] = FRAME_VERSION - 1;
+
+        let accepted = stream.accept(&mut wire.as_slice()).await;
+
+        assert!(
+            matches!(accepted, Err(FrameError::UnsupportedVersion(v)) if v == FRAME_VERSION - 1),
+            "got {accepted:?}"
+        );
+    }
+
+    /// One version byte for the stream, one length for each message. This is what lets a
+    /// subscription and a one-shot request share a format.
+    #[tokio::test]
+    async fn a_stream_announces_itself_once_and_then_carries_many_frames() {
+        let stream = FrameStream::new(64 * 1024);
+        let mut wire = Vec::new();
+        stream
+            .open(
+                &mut wire,
+                &Frame::new(MessageType::SESSION_EVENTS, b"attach".to_vec()),
+            )
+            .await
+            .expect("open");
+        for event in [b"first".as_slice(), b"second".as_slice()] {
+            stream
+                .send(
+                    &mut wire,
+                    &Frame::new(MessageType::SESSION_EVENT, event.to_vec()),
+                )
+                .await
+                .expect("send");
+        }
+
+        let mut reader = wire.as_slice();
+        let opened = stream.accept(&mut reader).await.expect("accept");
+        let mut bodies = Vec::new();
+        while let Some(frame) = stream.next(&mut reader).await.expect("next") {
+            bodies.push(
+                frame
+                    .body_of(MessageType::SESSION_EVENT)
+                    .expect("typed")
+                    .to_vec(),
+            );
+        }
+
+        assert_eq!(opened.message_type, MessageType::SESSION_EVENTS);
+        assert_eq!(bodies, vec![b"first".to_vec(), b"second".to_vec()]);
+    }
+
+    /// The reason the setups are JSON: a peer one release ahead can send a field this build has
+    /// never heard of and still be understood, so a message can grow without a version bump.
+    #[tokio::test]
+    async fn an_unknown_field_degrades_instead_of_failing() {
+        let stream = FrameStream::new(64 * 1024);
+        let mut wire = Vec::new();
+        stream
+            .open(
+                &mut wire,
+                &Frame::new(
+                    MessageType::CLIENT_SETUP,
+                    br#"{"device_id":"d","token":"t","teleportation":true}"#.to_vec(),
+                ),
+            )
+            .await
+            .expect("write");
+
+        let setup = stream
+            .accept(&mut wire.as_slice())
+            .await
+            .expect("read")
+            .read_json::<crate::quic::ClientSetup>(MessageType::CLIENT_SETUP)
+            .expect("an unknown field must not stop it parsing");
+
+        assert_eq!(setup.device_id, crate::DeviceId::new("d"));
     }
 
     #[test]

--- a/crates/host/vmux_remote/src/lib.rs
+++ b/crates/host/vmux_remote/src/lib.rs
@@ -13,4 +13,4 @@ pub mod framing;
 pub mod quic;
 
 pub use device::DeviceId;
-pub use quic::{ClientHello, CloseCode, Envelope, PeerRole, RelayHello, StreamKind};
+pub use quic::{Accepted, ClientSetup, CloseCode, MessageType, PeerRole, Protocol, RelaySetup};

--- a/crates/host/vmux_remote/src/quic.rs
+++ b/crates/host/vmux_remote/src/quic.rs
@@ -1,12 +1,12 @@
-//! Connection setup for the QUIC link.
+//! What the messages on a QUIC link are, and which number names each one.
 //!
-//! Everything here is parsed *before* the two peers have agreed on a protocol version, which is
-//! why none of it is rkyv: rkyv encodes enum variants positionally, so a peer several releases
-//! behind would misread a reordered variant rather than notice the mismatch. The hello is a fixed
-//! byte layout that any version can read far enough to decide whether to keep talking.
+//! How they are framed is [`crate::framing`]. What they mean is here.
 //!
-//! Application frames after the hello are rkyv, length-prefixed by the same codec the local unix
-//! socket uses.
+//! The setup messages are JSON rather than rkyv because they are parsed *before* the two peers
+//! have agreed on anything: rkyv encodes enum variants positionally, so a peer several releases
+//! behind would misread a reordered variant rather than notice the mismatch, where serde skips a
+//! field it does not know. Session traffic after the setup is rkyv, which is faster and by then
+//! safe.
 
 /// Endpoint construction and certificate pinning. Absent on wasm, which has no UDP socket.
 #[cfg(not(web))]
@@ -28,8 +28,8 @@ use crate::DeviceId;
 /// peer several releases behind must be refused outright rather than talked down to some common
 /// version. No application message carries a capability list or a version of its own.
 ///
-/// It is not the only gate, and the doc here used to claim it was. [`HELLO_VERSION`] answers the
-/// narrower question of how to *read* a hello, which is a different question from what the hello
+/// It is not the only gate, and the doc here used to claim it was. [`FRAME_VERSION`] answers the
+/// narrower question of how to *read* a frame, which is a different question from what the frame
 /// then means — see its own note.
 pub const ALPN: &[u8] = b"vmux/2";
 
@@ -41,63 +41,98 @@ pub const ALPN: &[u8] = b"vmux/2";
 /// probe that spoke [`ALPN`] would have to invent a device id and leave a registration behind.
 pub const PROBE_ALPN: &[u8] = b"vmux-probe/1";
 
-/// Leading bytes of every connection, so a mis-dialled port fails loudly rather than as a decode
-/// error hundreds of bytes later.
-pub const HELLO_MAGIC: [u8; 5] = *b"VMUXQ";
-
-/// Layout version of the hello envelope. Bumping it changes how to *read* a hello, where bumping
-/// [`ALPN`] says the conversation after it means something different.
-pub const HELLO_VERSION: u8 = 1;
-
-/// First application frame a client sends.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct ClientHello {
-    pub device_id: DeviceId,
-}
-
-/// The desktop's answer to a [`ClientHello`].
+/// Layout version, sent once at the head of every stream.
 ///
-/// The accept signal, and nothing else: a client that reads a well-formed answer was admitted,
-/// where a refusal arrives as a connection close carrying a [`CloseCode`]. Empty on purpose —
-/// a capability list and a version were both carried here for a while and neither was ever read.
-/// Serde ignores unknown fields, so a field can be added the day something needs one.
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
-pub struct ServerHello {}
+/// Bumping it changes how to *read* a frame, where bumping [`ALPN`] says the conversation means
+/// something different. Two gates rather than one because they answer different questions and a
+/// layout can change without the vocabulary doing so — which is exactly what version 2 was: the
+/// magic and the untyped envelope went, and a message type arrived.
+///
+/// Per stream rather than per connection. One byte is cheap, and the alternative is a reader that
+/// cannot make sense of a stream without first consulting connection state it may not hold.
+pub const FRAME_VERSION: u8 = 2;
 
-/// What a QUIC stream carries, written as its first byte so the peer can dispatch without
-/// decoding the payload — and so the relay can route without decoding it at all.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "snake_case")]
-#[repr(u8)]
-pub enum StreamKind {
-    /// Bidirectional request/response. One frame each way, then closed.
-    Control = 0,
-    /// Server to client, one per subscribed session.
-    SessionEvents = 1,
+/// Which conversation a message belongs to, read off the high byte of a [`MessageType`].
+///
+/// Ranges rather than one flat list, because this crate is public and the relay's repo consumes it
+/// through a pin that only advances to `main`. A flat registry would make every new account-service
+/// message need a change here first, just to be allocated a number.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Protocol {
+    /// Framing itself, shared by every leg.
+    Transport,
+    /// A client talking to the desktop that holds its sessions.
+    Session,
+    /// Either peer talking to the relay.
+    Relay,
+    /// A device talking to the account service. Codes are defined in that service, not here.
+    Account,
+    /// A range this build has never heard of.
+    Unknown(u8),
 }
 
-impl StreamKind {
-    pub fn from_byte(byte: u8) -> Option<Self> {
-        match byte {
-            0 => Some(Self::Control),
-            1 => Some(Self::SessionEvents),
-            _ => None,
+/// What a frame carries, as a number on the wire.
+///
+/// The discriminator that makes a frame self-describing. Without one a reader parses whatever it
+/// happens to expect, and serde's tolerance for unknown fields means a message from another leg
+/// decodes cleanly rather than being refused — a relay setup satisfied a session setup exactly
+/// that way, because a shared ALPN meant nothing else separated them either.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct MessageType(pub u16);
+
+impl MessageType {
+    /// A client naming itself to the desktop that holds its sessions.
+    pub const CLIENT_SETUP: Self = Self(0x0100);
+    /// The desktop admitting it.
+    pub const SESSION_ACCEPTED: Self = Self(0x0101);
+    /// One request on a control stream.
+    pub const CONTROL_REQUEST: Self = Self(0x0102);
+    /// Its answer.
+    pub const CONTROL_RESPONSE: Self = Self(0x0103);
+    /// A client asking to be sent a session's events.
+    pub const SESSION_EVENTS: Self = Self(0x0104);
+    /// One of them. Many ride a single stream, which is why frames carry a length.
+    pub const SESSION_EVENT: Self = Self(0x0105);
+
+    /// A peer naming the pair it belongs to, to the relay.
+    pub const RELAY_SETUP: Self = Self(0x0200);
+    /// The relay admitting it.
+    pub const RELAY_ACCEPTED: Self = Self(0x0201);
+
+    pub const fn protocol(self) -> Protocol {
+        match (self.0 >> 8) as u8 {
+            0x00 => Protocol::Transport,
+            0x01 => Protocol::Session,
+            0x02 => Protocol::Relay,
+            0x03 => Protocol::Account,
+            other => Protocol::Unknown(other),
         }
     }
-
-    pub fn as_byte(self) -> u8 {
-        self as u8
-    }
 }
 
-/// One routed unit as the relay sees it: who it is for, which stream it belongs to, and bytes it
-/// does not interpret.
+/// First frame a client sends to a desktop: who it is, and the token that says it may.
+///
+/// The token rides here rather than in a header because QUIC has none. It used to be a second
+/// struct wrapping this one with `#[serde(flatten)]`, declared twice in two crates with nothing
+/// keeping them in step.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct Envelope {
+pub struct ClientSetup {
     pub device_id: DeviceId,
-    pub stream_kind: StreamKind,
-    pub payload: Vec<u8>,
+    pub token: String,
 }
+
+/// An admission, carrying nothing.
+///
+/// Both legs answer with this, under their own [`MessageType`] — [`MessageType::SESSION_ACCEPTED`]
+/// and [`MessageType::RELAY_ACCEPTED`] — so the two stay distinguishable on the wire even though
+/// the payload is identical. Reading a well-formed one is the accept signal; a refusal arrives as
+/// a close carrying a [`CloseCode`].
+///
+/// Empty on purpose: a capability list and a version were both carried here for a while and
+/// neither was ever read. Serde ignores unknown fields, so a field can be added the day something
+/// needs one.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct Accepted {}
 
 /// Application close codes, so a disconnect says why.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -110,6 +145,17 @@ pub enum CloseCode {
     RemoteDisabled = 3,
     /// Frame was malformed, oversized, or arrived out of order.
     ProtocolError = 4,
+    /// A phone named a desktop the relay is not holding.
+    ///
+    /// Its own code rather than a normal close, so a phone can tell "not registered yet, retry"
+    /// from "the desktop went away deliberately". A desktop reconnects on a backoff, so this is
+    /// the ordinary answer during a redeploy.
+    NoSuchDesktop = 5,
+    /// The relay, or the desktop, is already carrying as many peers as it will.
+    ///
+    /// Distinct from [`CloseCode::NoSuchDesktop`] because retrying helps with one and not the
+    /// other, and both used to arrive as a clean shutdown.
+    AtCapacity = 6,
 }
 
 impl CloseCode {
@@ -127,124 +173,10 @@ impl CloseCode {
             2 => Some(Self::Unauthorized),
             3 => Some(Self::RemoteDisabled),
             4 => Some(Self::ProtocolError),
+            5 => Some(Self::NoSuchDesktop),
+            6 => Some(Self::AtCapacity),
             _ => None,
         }
-    }
-}
-
-/// Encode a hello frame: magic, layout version, then a length-prefixed JSON body.
-///
-/// JSON rather than rkyv precisely because this frame outlives version agreement — an unknown
-/// field is skipped instead of shifting every byte after it.
-pub fn encode_hello<T: Serialize>(value: &T) -> Result<Vec<u8>, serde_json::Error> {
-    let body = serde_json::to_vec(value)?;
-    let mut out = Vec::with_capacity(HELLO_MAGIC.len() + 1 + 4 + body.len());
-    out.extend_from_slice(&HELLO_MAGIC);
-    out.push(HELLO_VERSION);
-    out.extend_from_slice(&(body.len() as u32).to_le_bytes());
-    out.extend_from_slice(&body);
-    Ok(out)
-}
-
-/// Why a hello frame could not be read.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum HelloError {
-    /// Not a vmux endpoint, or not speaking this transport.
-    BadMagic,
-    /// Hello envelope itself is a layout this build cannot read.
-    UnsupportedHelloVersion(u8),
-    /// Fewer bytes than the declared length.
-    Truncated,
-    /// Envelope read, body did not parse.
-    Malformed,
-}
-
-/// Decode a hello frame, returning the value and how many bytes it consumed.
-pub fn decode_hello<T: for<'de> Deserialize<'de>>(bytes: &[u8]) -> Result<(T, usize), HelloError> {
-    let header = HELLO_MAGIC.len() + 1 + 4;
-    if bytes.len() < header {
-        return Err(HelloError::Truncated);
-    }
-    if bytes[..HELLO_MAGIC.len()] != HELLO_MAGIC {
-        return Err(HelloError::BadMagic);
-    }
-    let hello_version = bytes[HELLO_MAGIC.len()];
-    if hello_version != HELLO_VERSION {
-        return Err(HelloError::UnsupportedHelloVersion(hello_version));
-    }
-    let mut length = [0u8; 4];
-    length.copy_from_slice(&bytes[HELLO_MAGIC.len() + 1..header]);
-    let length = u32::from_le_bytes(length) as usize;
-    let end = header + length;
-    if bytes.len() < end {
-        return Err(HelloError::Truncated);
-    }
-    let value = serde_json::from_slice(&bytes[header..end]).map_err(|_| HelloError::Malformed)?;
-    Ok((value, end))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn hello_roundtrips_and_reports_its_length() {
-        let hello = ClientHello {
-            device_id: DeviceId::new("device-1"),
-        };
-        let mut bytes = encode_hello(&hello).unwrap();
-        bytes.extend_from_slice(b"frames follow");
-
-        let (decoded, consumed) = decode_hello::<ClientHello>(&bytes).unwrap();
-
-        assert_eq!(decoded, hello);
-        assert_eq!(&bytes[consumed..], b"frames follow");
-    }
-
-    /// The whole reason the hello is JSON: a client several releases ahead can send a field
-    /// this build has never heard of and still be understood. That tolerance is what lets the
-    /// hello grow later without a version bump, so it is worth a test of its own.
-    #[test]
-    fn an_unknown_field_degrades_instead_of_failing() {
-        let wire = br#"{"device_id":"d","teleportation":true}"#;
-        let mut bytes = Vec::new();
-        bytes.extend_from_slice(&HELLO_MAGIC);
-        bytes.push(HELLO_VERSION);
-        bytes.extend_from_slice(&(wire.len() as u32).to_le_bytes());
-        bytes.extend_from_slice(wire);
-
-        let (decoded, _) = decode_hello::<ClientHello>(&bytes).unwrap();
-
-        assert_eq!(decoded.device_id, DeviceId::new("d"));
-    }
-
-    #[test]
-    fn a_non_vmux_endpoint_is_rejected_before_parsing() {
-        assert_eq!(
-            decode_hello::<ClientHello>(b"HTTP/1.1 200 OK\r\n\r\n").unwrap_err(),
-            HelloError::BadMagic
-        );
-    }
-
-    #[test]
-    fn a_partial_frame_is_not_mistaken_for_a_complete_one() {
-        let hello = ClientHello {
-            device_id: DeviceId::new("d"),
-        };
-        let bytes = encode_hello(&hello).unwrap();
-
-        assert_eq!(
-            decode_hello::<ClientHello>(&bytes[..bytes.len() - 1]).unwrap_err(),
-            HelloError::Truncated
-        );
-    }
-
-    #[test]
-    fn stream_kind_byte_roundtrips_and_rejects_unknown() {
-        for kind in [StreamKind::Control, StreamKind::SessionEvents] {
-            assert_eq!(StreamKind::from_byte(kind.as_byte()), Some(kind));
-        }
-        assert_eq!(StreamKind::from_byte(200), None);
     }
 }
 
@@ -261,12 +193,12 @@ pub enum PeerRole {
     Client,
 }
 
-/// First frame on a connection to the relay.
+/// First frame a peer sends to the relay.
 ///
 /// Deliberately the only thing the relay parses. Everything after it is opaque bytes copied
 /// between two peers — the relay routes on `device_id` and never learns what it moved.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct RelayHello {
+pub struct RelaySetup {
     /// The desktop being named, whichever end is speaking: its own id from a
     /// [`PeerRole::Desktop`], the id of the desktop it wants from a [`PeerRole::Client`].
     ///
@@ -276,11 +208,3 @@ pub struct RelayHello {
     /// Proves both ends belong to the same pairing. The relay compares, it does not mint.
     pub token: String,
 }
-
-/// The relay's answer to a hello it admitted.
-///
-/// Carries nothing, and exists for the ordering alone: a desktop must not offer a pairing link
-/// for a registration the relay has not taken, and a phone must not tunnel into a pairing it has
-/// not matched. Both only need to know the hello was accepted.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct RelayAccepted {}

--- a/crates/host/vmux_service/src/remote/quic.rs
+++ b/crates/host/vmux_service/src/remote/quic.rs
@@ -26,9 +26,8 @@ use vmux_remote::quic::endpoint::{RECEIVE_WINDOW, SelfSignedIdentity};
 
 use vmux_wire::protocol::{ServiceMessage, SharedMessage};
 
-use vmux_remote::quic::{
-    ClientHello, CloseCode, ServerHello, StreamKind, decode_hello, encode_hello,
-};
+use vmux_remote::framing::{Frame, FrameError, FrameStream};
+use vmux_remote::quic::{Accepted, ClientSetup, CloseCode, MessageType};
 
 /// How often the kill switch is re-read. Matches the HTTP path's in-stream recheck.
 const REMOTE_STATE_POLL: Duration = Duration::from_secs(1);
@@ -102,6 +101,11 @@ pub enum Rejection {
     Unauthorized,
     RemoteDisabled,
     Malformed,
+    /// The peer frames its streams in a layout this build cannot read.
+    ///
+    /// Distinct from [`Rejection::Malformed`] because it names a build that is merely old rather
+    /// than one sending rubbish, and only one of those is worth a bug report.
+    UnsupportedFraming,
 }
 
 impl Rejection {
@@ -109,7 +113,16 @@ impl Rejection {
         match self {
             Self::Unauthorized => CloseCode::Unauthorized,
             Self::RemoteDisabled => CloseCode::RemoteDisabled,
-            Self::Malformed => CloseCode::ProtocolError,
+            Self::Malformed | Self::UnsupportedFraming => CloseCode::ProtocolError,
+        }
+    }
+}
+
+impl From<FrameError> for Rejection {
+    fn from(error: FrameError) -> Self {
+        match error {
+            FrameError::UnsupportedVersion(_) => Self::UnsupportedFraming,
+            _ => Self::Malformed,
         }
     }
 }
@@ -123,22 +136,14 @@ pub fn admit(
     presented_token: &str,
     expected_token: &str,
     remote_enabled: bool,
-) -> Result<ServerHello, Rejection> {
+) -> Result<Accepted, Rejection> {
     if !remote_enabled {
         return Err(Rejection::RemoteDisabled);
     }
     if !super::server::secure_eq(presented_token, expected_token) {
         return Err(Rejection::Unauthorized);
     }
-    Ok(ServerHello {})
-}
-
-/// The bearer token is carried in the hello rather than a header, since QUIC has none.
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
-pub struct AuthenticatedHello {
-    #[serde(flatten)]
-    pub hello: ClientHello,
-    pub token: String,
+    Ok(Accepted {})
 }
 
 /// Watches the Remote kill switch, for everything whose lifetime it decides.
@@ -168,15 +173,23 @@ pub fn spawn_liveness_watch() -> watch::Receiver<bool> {
     rx
 }
 
-/// Read one hello frame, bounded so an unauthenticated peer cannot buffer without limit.
-pub async fn read_hello(stream: &mut quinn::RecvStream) -> Result<AuthenticatedHello, Rejection> {
-    let bytes = stream
-        .read_to_end(MAX_HELLO_BYTES)
-        .await
-        .map_err(|_| Rejection::Malformed)?;
-    decode_hello::<AuthenticatedHello>(&bytes)
-        .map(|(hello, _)| hello)
-        .map_err(|_| Rejection::Malformed)
+/// Frames on the setup exchange, bounded so an unauthenticated peer cannot buffer without limit.
+const SETUP: FrameStream = FrameStream::new(MAX_HELLO_BYTES);
+
+/// Frames on a control or subscription stream, once the peer has authenticated.
+const CONTROL: FrameStream = FrameStream::new(MAX_REQUEST_BYTES);
+
+/// Read one setup frame, refusing anything that is not one.
+///
+/// A frame addressed to another leg is turned away here rather than decoded: a relay setup
+/// satisfies this message field for field, so the type has to be what decides.
+pub async fn read_setup(stream: &mut quinn::RecvStream) -> Result<ClientSetup, Rejection> {
+    match SETUP.accept(stream).await {
+        Ok(frame) => frame
+            .read_json::<ClientSetup>(MessageType::CLIENT_SETUP)
+            .map_err(Rejection::from),
+        Err(error) => Err(Rejection::from(error)),
+    }
 }
 
 /// Serve one accepted connection: exchange hellos, then dispatch its streams.
@@ -190,13 +203,13 @@ async fn serve(
     let Ok((mut send, mut recv)) = connection.accept_bi().await else {
         return;
     };
-    let admitted = match read_hello(&mut recv).await {
-        Ok(authenticated) => admit(&authenticated.token, &token, *liveness.borrow()),
+    let admitted = match read_setup(&mut recv).await {
+        Ok(setup) => admit(&setup.token, &token, *liveness.borrow()),
         Err(rejection) => Err(rejection),
     };
 
-    let server_hello = match admitted {
-        Ok(server_hello) => server_hello,
+    let accepted = match admitted {
+        Ok(accepted) => accepted,
         Err(rejection) => {
             tracing::info!(?rejection, "remote quic: connection refused");
             connection.close(rejection.close_code().as_u32().into(), b"refused");
@@ -204,11 +217,11 @@ async fn serve(
         }
     };
 
-    let Ok(bytes) = encode_hello(&server_hello) else {
-        connection.close(CloseCode::ProtocolError.as_u32().into(), b"hello");
+    let Ok(frame) = Frame::json(MessageType::SESSION_ACCEPTED, &accepted) else {
+        connection.close(CloseCode::ProtocolError.as_u32().into(), b"setup");
         return;
     };
-    if send.write_all(&bytes).await.is_err() || send.finish().is_err() {
+    if SETUP.open(&mut send, &frame).await.is_err() || send.finish().is_err() {
         return;
     }
     super::server::mark_paired(&paired);
@@ -255,32 +268,28 @@ async fn dispatch_control(
     mut send: quinn::SendStream,
     mut recv: quinn::RecvStream,
 ) {
-    let Ok(bytes) = recv.read_to_end(MAX_REQUEST_BYTES).await else {
+    let Ok(frame) = CONTROL.accept(&mut recv).await else {
         return;
     };
-    let Some((kind, body)) = bytes.split_first() else {
-        return;
-    };
-    let Some(kind) = StreamKind::from_byte(*kind) else {
-        return;
-    };
-    // Copied so rkyv sees an aligned buffer; a slice at a one-byte offset is not.
-    let body = body.to_vec();
-    let Ok(request) = rkyv::from_bytes::<SharedMessage, rkyv::rancor::Error>(&body) else {
+    // Owned by the frame, so rkyv sees an aligned buffer; the old shape sliced past a leading
+    // byte, which is not aligned.
+    let Ok(request) = rkyv::from_bytes::<SharedMessage, rkyv::rancor::Error>(&frame.body) else {
         return;
     };
 
-    match kind {
-        StreamKind::Control => {
+    match frame.message_type {
+        MessageType::CONTROL_REQUEST => {
             let response = dispatch::dispatch(&state, request).await;
             let Ok(encoded) = rkyv::to_bytes::<rkyv::rancor::Error>(&response) else {
                 return;
             };
-            if send.write_all(&encoded).await.is_ok() {
+            let frame = Frame::new(MessageType::CONTROL_RESPONSE, encoded.to_vec());
+            if CONTROL.open(&mut send, &frame).await.is_ok() {
                 let _ = send.finish();
             }
         }
-        StreamKind::SessionEvents => stream_session_events(&state, send, request).await,
+        MessageType::SESSION_EVENTS => stream_session_events(&state, send, request).await,
+        _ => {}
     }
 }
 
@@ -307,11 +316,15 @@ async fn stream_session_events(
         let _ = send.finish();
         return;
     };
+    // The stream announces its version once, on whichever event goes out first.
+    let mut opened = false;
 
     // Snapshot first, so a client that attaches mid-conversation renders the transcript it
     // missed rather than only what happens next.
     if let Some(snapshot) = session_snapshot(state, &sid).await
-        && write_event(&mut send, &snapshot).await.is_err()
+        && write_event(&mut send, &snapshot, &mut opened)
+            .await
+            .is_err()
     {
         return;
     }
@@ -328,7 +341,7 @@ async fn stream_session_events(
                     Some(event) => event,
                     None => continue,
                 };
-                if write_event(&mut send, &event).await.is_err() {
+                if write_event(&mut send, &event, &mut opened).await.is_err() {
                     return;
                 }
             }
@@ -338,7 +351,10 @@ async fn stream_session_events(
                 let Some(snapshot) = session_snapshot(state, &sid).await else {
                     return;
                 };
-                if write_event(&mut send, &snapshot).await.is_err() {
+                if write_event(&mut send, &snapshot, &mut opened)
+                    .await
+                    .is_err()
+                {
                     return;
                 }
             }
@@ -372,18 +388,24 @@ async fn resolve(
     }
 }
 
-/// Length-prefixed, because unlike a control response there are many of these on one stream and
-/// the reader needs to know where each ends.
+/// One event, framed like everything else.
+///
+/// `opened` says whether this half of the stream has announced its version yet: a subscription
+/// sends many of these, and the version belongs to the stream rather than to each message.
 async fn write_event(
     send: &mut quinn::SendStream,
     event: &vmux_wire::protocol::SharedEvent,
+    opened: &mut bool,
 ) -> Result<(), ()> {
     let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(event).map_err(|_| ())?;
-    let length = u32::try_from(bytes.len()).map_err(|_| ())?;
-    send.write_all(&length.to_le_bytes())
-        .await
-        .map_err(|_| ())?;
-    send.write_all(&bytes).await.map_err(|_| ())
+    let frame = Frame::new(MessageType::SESSION_EVENT, bytes.to_vec());
+    let written = if *opened {
+        CONTROL.send(send, &frame).await
+    } else {
+        *opened = true;
+        CONTROL.open(send, &frame).await
+    };
+    written.map_err(|_| ())
 }
 
 async fn subscribe(
@@ -563,21 +585,20 @@ mod live {
             .expect("dial")
             .await?;
 
-        let (mut send, mut recv) = connection.open_bi().await.expect("hello stream");
-        let hello = AuthenticatedHello {
-            hello: ClientHello {
-                device_id: DeviceId::new("test-device"),
-            },
+        let (mut send, mut recv) = connection.open_bi().await.expect("setup stream");
+        let setup = ClientSetup {
+            device_id: DeviceId::new("test-device"),
             token: token.to_string(),
         };
-        send.write_all(&encode_hello(&hello).expect("encode"))
-            .await
-            .expect("write hello");
-        send.finish().expect("finish hello");
+        let frame = Frame::json(MessageType::CLIENT_SETUP, &setup).expect("encode");
+        SETUP.open(&mut send, &frame).await.expect("write setup");
+        send.finish().expect("finish setup");
 
-        match recv.read_to_end(64 * 1024).await {
-            Ok(bytes) => {
-                decode_hello::<vmux_remote::quic::ServerHello>(&bytes).expect("server hello");
+        match SETUP.accept(&mut recv).await {
+            Ok(frame) => {
+                frame
+                    .read_json::<Accepted>(MessageType::SESSION_ACCEPTED)
+                    .expect("accepted");
                 Ok(connection)
             }
             Err(_) => Err(connection
@@ -588,24 +609,26 @@ mod live {
 
     async fn request(connection: &quinn::Connection, message: SharedMessage) -> SharedResponse {
         let (mut send, mut recv) = connection.open_bi().await.expect("control stream");
-        let mut frame = vec![StreamKind::Control.as_byte()];
-        frame.extend_from_slice(&rkyv::to_bytes::<rkyv::rancor::Error>(&message).expect("encode"));
-        send.write_all(&frame).await.expect("write request");
+        let body = rkyv::to_bytes::<rkyv::rancor::Error>(&message).expect("encode");
+        let frame = Frame::new(MessageType::CONTROL_REQUEST, body.to_vec());
+        CONTROL
+            .open(&mut send, &frame)
+            .await
+            .expect("write request");
         send.finish().expect("finish request");
 
-        let bytes = recv.read_to_end(8 * 1024 * 1024).await.expect("response");
-        // Copied so rkyv sees an aligned buffer, for the same reason the production readers do.
-        let bytes = bytes.to_vec();
-        rkyv::from_bytes::<SharedResponse, rkyv::rancor::Error>(&bytes).expect("decode")
+        let answer = CONTROL.accept(&mut recv).await.expect("response");
+        let body = answer
+            .body_of(MessageType::CONTROL_RESPONSE)
+            .expect("a control stream answers with a control response");
+        rkyv::from_bytes::<SharedResponse, rkyv::rancor::Error>(body).expect("decode")
     }
 
-    /// Read one length-prefixed event off a subscription stream.
+    /// Read the first event off a subscription stream, version byte and all.
     async fn read_event(recv: &mut quinn::RecvStream) -> Option<vmux_wire::protocol::SharedEvent> {
-        let mut length = [0u8; 4];
-        recv.read_exact(&mut length).await.ok()?;
-        let mut body = vec![0u8; u32::from_le_bytes(length) as usize];
-        recv.read_exact(&mut body).await.ok()?;
-        rkyv::from_bytes::<vmux_wire::protocol::SharedEvent, rkyv::rancor::Error>(&body).ok()
+        let frame = CONTROL.accept(recv).await.ok()?;
+        let body = frame.body_of(MessageType::SESSION_EVENT).ok()?;
+        rkyv::from_bytes::<vmux_wire::protocol::SharedEvent, rkyv::rancor::Error>(body).ok()
     }
 
     /// Subscribing to a session that does not exist must close the stream rather than hang.
@@ -618,15 +641,18 @@ mod live {
         let connection = connect(&harness, "correct-token").await.expect("handshake");
 
         let (mut send, mut recv) = connection.open_bi().await.expect("stream");
-        let mut frame = vec![StreamKind::SessionEvents.as_byte()];
-        frame.extend_from_slice(
-            &rkyv::to_bytes::<rkyv::rancor::Error>(&SharedMessage::agent(
-                "ghost",
-                vmux_wire::protocol::AgentAction::Attach,
-            ))
-            .expect("encode"),
-        );
-        send.write_all(&frame).await.expect("write");
+        let body = rkyv::to_bytes::<rkyv::rancor::Error>(&SharedMessage::agent(
+            "ghost",
+            vmux_wire::protocol::AgentAction::Attach,
+        ))
+        .expect("encode");
+        CONTROL
+            .open(
+                &mut send,
+                &Frame::new(MessageType::SESSION_EVENTS, body.to_vec()),
+            )
+            .await
+            .expect("write");
         send.finish().expect("finish");
 
         let closed = tokio::time::timeout(std::time::Duration::from_secs(5), async {
@@ -640,19 +666,24 @@ mod live {
         );
     }
 
-    /// A control request on a subscription stream, or the reverse, must not be silently treated
-    /// as the other. The kind byte is the only thing distinguishing them.
+    /// A well-formed frame carrying a type this handler does not serve must not be answered as if
+    /// it were a control request. The message type is the only thing separating a request from a
+    /// subscription, or from another leg's traffic entirely — which is why it is on the wire.
+    ///
+    /// The body is a perfectly good `ListSessions`, so nothing but the type can refuse it.
     #[tokio::test]
-    async fn an_unknown_stream_kind_is_dropped() {
+    async fn a_frame_of_a_foreign_type_is_not_answered_as_a_control_request() {
         let harness = start("correct-token");
         let connection = connect(&harness, "correct-token").await.expect("handshake");
 
         let (mut send, mut recv) = connection.open_bi().await.expect("stream");
-        let mut frame = vec![200u8];
-        frame.extend_from_slice(
-            &rkyv::to_bytes::<rkyv::rancor::Error>(&SharedMessage::ListSessions).expect("encode"),
-        );
-        send.write_all(&frame).await.expect("write");
+        let body = rkyv::to_bytes::<rkyv::rancor::Error>(&SharedMessage::ListSessions)
+            .expect("encode")
+            .to_vec();
+        CONTROL
+            .open(&mut send, &Frame::new(MessageType(0x0999), body))
+            .await
+            .expect("write");
         send.finish().expect("finish");
 
         let answered = tokio::time::timeout(
@@ -661,10 +692,12 @@ mod live {
         )
         .await;
 
+        let served = matches!(&answered, Ok(Ok(bytes)) if !bytes.is_empty());
         assert!(
-            matches!(answered, Ok(Ok(bytes)) if bytes.is_empty()),
-            "an unrecognised stream kind must not be answered as if it were a control request"
+            !served,
+            "a foreign message type must not be served as a control request, got {answered:?}"
         );
+        assert!(answered.is_ok(), "and it must not hang, got {answered:?}");
     }
 
     #[tokio::test]
@@ -721,7 +754,7 @@ mod tests {
 
     #[test]
     fn a_matching_token_is_admitted() {
-        assert_eq!(admit("secret", "secret", true), Ok(ServerHello {}));
+        assert_eq!(admit("secret", "secret", true), Ok(Accepted {}));
     }
 
     #[test]

--- a/crates/host/vmux_service/src/remote/quic.rs
+++ b/crates/host/vmux_service/src/remote/quic.rs
@@ -271,9 +271,8 @@ async fn dispatch_control(
     let Ok(frame) = CONTROL.accept(&mut recv).await else {
         return;
     };
-    // The type decides before the body is touched. Handing another leg's payload to a decoder and
-    // rejecting it afterwards would leave the type field decorative — the decoder would already
-    // have run on bytes this handler was never addressed by.
+    // Must stay ahead of the decode below: rejecting a foreign type afterwards would mean the
+    // decoder had already run on bytes this handler was never addressed by.
     match frame.message_type {
         MessageType::CONTROL_REQUEST | MessageType::SESSION_EVENTS => {}
         unserved => {
@@ -285,8 +284,6 @@ async fn dispatch_control(
         }
     }
 
-    // Owned by the frame, so rkyv sees an aligned buffer; the old shape sliced past a leading
-    // byte, which is not aligned.
     let Ok(request) = rkyv::from_bytes::<SharedMessage, rkyv::rancor::Error>(&frame.body) else {
         return;
     };

--- a/crates/host/vmux_service/src/remote/quic.rs
+++ b/crates/host/vmux_service/src/remote/quic.rs
@@ -271,25 +271,38 @@ async fn dispatch_control(
     let Ok(frame) = CONTROL.accept(&mut recv).await else {
         return;
     };
+    // The type decides before the body is touched. Handing another leg's payload to a decoder and
+    // rejecting it afterwards would leave the type field decorative — the decoder would already
+    // have run on bytes this handler was never addressed by.
+    match frame.message_type {
+        MessageType::CONTROL_REQUEST | MessageType::SESSION_EVENTS => {}
+        unserved => {
+            tracing::debug!(
+                ?unserved,
+                "remote quic: stream refused, unserved message type"
+            );
+            return;
+        }
+    }
+
     // Owned by the frame, so rkyv sees an aligned buffer; the old shape sliced past a leading
     // byte, which is not aligned.
     let Ok(request) = rkyv::from_bytes::<SharedMessage, rkyv::rancor::Error>(&frame.body) else {
         return;
     };
 
-    match frame.message_type {
-        MessageType::CONTROL_REQUEST => {
-            let response = dispatch::dispatch(&state, request).await;
-            let Ok(encoded) = rkyv::to_bytes::<rkyv::rancor::Error>(&response) else {
-                return;
-            };
-            let frame = Frame::new(MessageType::CONTROL_RESPONSE, encoded.to_vec());
-            if CONTROL.open(&mut send, &frame).await.is_ok() {
-                let _ = send.finish();
-            }
-        }
-        MessageType::SESSION_EVENTS => stream_session_events(&state, send, request).await,
-        _ => {}
+    if frame.message_type == MessageType::SESSION_EVENTS {
+        stream_session_events(&state, send, request).await;
+        return;
+    }
+
+    let response = dispatch::dispatch(&state, request).await;
+    let Ok(encoded) = rkyv::to_bytes::<rkyv::rancor::Error>(&response) else {
+        return;
+    };
+    let frame = Frame::new(MessageType::CONTROL_RESPONSE, encoded.to_vec());
+    if CONTROL.open(&mut send, &frame).await.is_ok() {
+        let _ = send.finish();
     }
 }
 

--- a/crates/host/vmux_service/src/remote/quic/dialer.rs
+++ b/crates/host/vmux_service/src/remote/quic/dialer.rs
@@ -12,9 +12,10 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use tokio::sync::watch;
+use vmux_remote::framing::{Frame, FrameStream};
 use vmux_remote::quic::endpoint::SelfSignedIdentity;
 use vmux_remote::quic::tunnel::TunnelSocket;
-use vmux_remote::quic::{RelayAccepted, RelayHello, decode_hello, encode_hello};
+use vmux_remote::quic::{Accepted, MessageType, RelaySetup};
 use vmux_remote::{DeviceId, PeerRole};
 
 use super::super::server::RemoteState;
@@ -268,7 +269,10 @@ impl Drop for RegisteredDevice {
     }
 }
 
-/// Send the hello and wait for the relay to admit it.
+/// Frames on the relay setup exchange. Bounded well under anything a setup could need.
+const SETUP: FrameStream = FrameStream::new(16 * 1024);
+
+/// Send the setup and wait for the relay to admit it.
 async fn register(
     control: &quinn::Connection,
     device_id: &DeviceId,
@@ -278,22 +282,24 @@ async fn register(
         .open_bi()
         .await
         .map_err(|error| format!("relay stream: {error}"))?;
-    let hello = RelayHello {
+    let setup = RelaySetup {
         device_id: device_id.clone(),
         role: PeerRole::Desktop,
         token: token.to_string(),
     };
-    let bytes = encode_hello(&hello).map_err(|error| format!("encode hello: {error}"))?;
-    send.write_all(&bytes)
+    let frame = Frame::json(MessageType::RELAY_SETUP, &setup)
+        .map_err(|error| format!("encode setup: {error}"))?;
+    SETUP
+        .open(&mut send, &frame)
         .await
-        .map_err(|error| format!("write hello: {error}"))?;
+        .map_err(|error| format!("write setup: {error}"))?;
     send.finish().map_err(|error| format!("finish: {error}"))?;
 
-    let answer = recv
-        .read_to_end(16 * 1024)
+    SETUP
+        .accept(&mut recv)
         .await
-        .map_err(|error| format!("read acceptance: {error}"))?;
-    decode_hello::<RelayAccepted>(&answer)
+        .map_err(|error| format!("read acceptance: {error:?}"))?
+        .read_json::<Accepted>(MessageType::RELAY_ACCEPTED)
         .map_err(|error| format!("decode acceptance: {error:?}"))?;
     Ok(())
 }


### PR DESCRIPTION
Third slice of [VMX-184](https://linear.app/vmux/issue/VMX-184). **Breaks the wire.** Stacked on #383 → #381.

## The defect

There is no message type on the wire, so `decode_hello::<T>` parses into whatever the *caller* expects. Serde ignores unknown fields, so a frame from one leg decodes cleanly as a frame from another. Proven before the change:

```
CONFUSED: a RelayHello decoded as ClientHello, device_id=DeviceId("alpha")
```

A `RelayHello` satisfied `AuthenticatedHello` too (`device_id` + `token`, `role` dropped). And all three services share ALPN `vmux/2`, so nothing at the connection layer separated them either.

Nothing exploited it only because both legs currently carry the **same shared token** — and VMX-176 and VMX-177 are in the middle of giving them different credentials, which is exactly when that stops being true.

There is now a test for it, which fails without this change:

```
one_legs_setup_is_refused_by_the_other_legs_reader ... ok
```

## The framing is MoQ Transport's

```
stream = version:u8, then frames
frame  = type:u16 | length:u32 | payload
```

A control exchange is one frame then a finish; a subscription is many. **One scheme now serves both**, which collapses the five that existed: the JSON hello codec, the bare `StreamKind` byte, bare rkyv delimited by stream finish, and the `u32+rkyv` event framing. `Frame` is a `u16` followed by #381's `LengthPrefixed`, so one length codec exists in the tree rather than three written to look alike.

Not borrowed from MoQ: symmetric `SETUP` (vmux's exchange is asymmetric — a peer asks, the other admits), its pair of unidirectional streams (#383 set `max_concurrent_uni_streams` to 0, since the relay only routes streams a *client* opened), and version negotiation inside SETUP (vmux refuses to negotiate at all).

## `MessageType` uses ranges, not a flat list

```
0x00xx transport   0x01xx session   0x02xx relay   0x03xx account
```

`vmux_remote` is public and the relay's repo consumes it through a pin that only advances to `main`. A flat registry would make every new **account-service** message need a change in this repo first, just to be allocated a number — inverting the rule that the relay deploys before the app. Each service enumerates its own codes; this crate owns the newtype and the ranges.

## Deleted

- `HELLO_MAGIC` — all three services used the same five bytes behind the same ALPN, so it distinguished nothing. Its stated job, catching a mis-dialled port, is ALPN's.
- The old envelope's length prefix, which no production reader ever consumed.
- `Envelope` — defined and re-exported, never constructed.
- The second `AuthenticatedHello`, declared in two crates with `#[serde(flatten)]` and nothing keeping them in step. Its token folded into `ClientSetup`.

## Compatibility

`FRAME_VERSION` 1 → 2. ALPN unchanged, deliberately: a layout version is exactly the right gate for a layout change, and a stale peer now fails as `UnsupportedVersion` rather than misparsing. No compatibility window, because nothing is deployed to users.

`CloseCode` gains `NoSuchDesktop` and `AtCapacity` so the relay can stop reporting both as a clean shutdown. Nothing sends them yet — that is the cloud-side slice, and putting them here means it needs no second pin bump.

## Test plan

- [x] `cargo test -p vmux_remote -p vmux_client -p vmux_service` — 276 green
- [x] `cargo clippy` on all three, `--all-targets`, clean
- [x] `cargo check -p vmux_mobile --features mobile --target aarch64-apple-ios --bin vmux_mobile` clean
- [x] New: cross-leg type confusion refused; stale version distinct from malformed; two frames on one stream after one version byte; serde field tolerance preserved
- [x] `an_unknown_stream_kind_is_dropped` replaced — it wrote a raw `200` byte, which the new framing reads as a *version*, so it passed for the wrong reason. Now `a_frame_of_a_foreign_type_is_not_answered_as_a_control_request`, with a well-formed body so only the type can refuse it.

## Follows

The relay and account service adapt in the cloud repo, written against this branch and merged as soon as this lands. Stream-level refusals (`send.reset` instead of the four bare returns in `dispatch_control`) are a separate slice — this one keeps the existing silent-drop behaviour so the diff stays about framing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - QUIC connections now use structured, versioned messages for setup, authentication, requests, subscriptions, and session events.
  - Improved validation and routing across relay, desktop, and client connections.
  - Session streams now announce their framing version and reliably process multiple messages.
  - Added clearer handling for unsupported protocol versions, malformed or incomplete messages, unavailable desktops, and capacity limits.
  - Added tolerant JSON handling and safeguards against oversized setup messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->