### PR TITLE
Let the workspace answer what the launcher asks

### DIFF
--- a/crates/page/vmux_layout/src/host.rs
+++ b/crates/page/vmux_layout/src/host.rs
@@ -52,6 +52,7 @@ pub use pane::{OpenBesideRequest, handle_open_beside_requests};
 pub use plugin::LayoutPlugin;
 pub use stack::CloseStackRequest;
 pub use vmux_core::ContributedCommandChosen;
+pub use vmux_core::launcher::PendingLaunch;
 pub use webview_reveal::PendingWebviewReveal;
 pub use window::fit_window_to_screen;
 
@@ -95,14 +96,6 @@ pub enum LayoutStartupSet {
 #[reflect(Component)]
 #[type_path = "vmux_desktop::layout"]
 pub struct Open;
-
-#[derive(Resource, Default)]
-pub struct NewStackContext {
-    pub stack: Option<Entity>,
-    pub previous_stack: Option<Entity>,
-    pub needs_open: bool,
-    pub dismiss_modal: bool,
-}
 
 #[derive(Component)]
 pub struct CloseRequiresConfirmation;

--- a/crates/page/vmux_layout/src/host.rs
+++ b/crates/page/vmux_layout/src/host.rs
@@ -18,6 +18,7 @@ pub mod debug;
 pub mod native_pointer;
 pub mod overlay_adopt;
 pub mod pane;
+pub mod pending_stack;
 pub mod placement;
 pub mod plugin;
 pub mod profile;
@@ -50,6 +51,7 @@ pub use header::Header;
 pub use pane::{OpenBesideRequest, handle_open_beside_requests};
 pub use plugin::LayoutPlugin;
 pub use stack::CloseStackRequest;
+pub use vmux_core::ContributedCommandChosen;
 pub use webview_reveal::PendingWebviewReveal;
 pub use window::fit_window_to_screen;
 
@@ -149,18 +151,6 @@ pub struct TabLayoutSpawnRequest {
     pub content: TabLayoutSpawnContent,
     pub clear_pending_stack: bool,
     pub focus: bool,
-}
-
-/// A command-bar row contributed through `CommandBarContributions` was chosen.
-///
-/// The command bar does not know what the row means — whoever published the id answers this.
-/// `stack` is the empty stack the bar was opened on; when there is none, `pane` is the focused
-/// pane to spawn into. Exactly one of the two is set.
-#[derive(Message, Clone, Debug)]
-pub struct ContributedCommandChosen {
-    pub id: String,
-    pub stack: Option<Entity>,
-    pub pane: Option<Entity>,
 }
 
 /// Open `url` in a new focused tab in the active space.

--- a/crates/page/vmux_layout/src/host/archive.rs
+++ b/crates/page/vmux_layout/src/host/archive.rs
@@ -9,7 +9,7 @@ use bevy::window::PrimaryWindow;
 use bevy_cef::prelude::HostWindow;
 use vmux_command::{AppCommand, LayoutCommand, ReadAppCommands, StackCommand};
 use vmux_core::agent::{AgentKind, SpawnAgentInStackRequest};
-use vmux_core::terminal::{TerminalLaunch, TerminalSpawnRequest};
+use vmux_core::terminal::{TerminalLaunch, TerminalSpawnRequest, TerminalSpawnTarget};
 use vmux_core::{
     ArchivedPage, ArchivedPagePosition, ArchivedTabPage, CreatedAt, PageArchiveRequest,
     PageMetadata, PageOpenRequest, PageOpenTarget, PaneStep, SplitAxis, now_millis,
@@ -625,7 +625,8 @@ fn reopen_page_content(page: &ArchivedPage, stack: Entity, commands: &mut Comman
             .map(PathBuf::from);
         let request = TerminalSpawnRequest {
             cwd,
-            target_stack: Some(stack),
+            target: TerminalSpawnTarget::Stack(stack),
+            metadata: None,
         };
         commands.queue(move |world: &mut World| {
             world.write_message(request);
@@ -1688,11 +1689,11 @@ mod tests {
         mut captured: ResMut<CapturedTerminalSpawnTargets>,
     ) {
         for request in reader.read() {
-            captured.0.push(
-                request
-                    .target_stack
-                    .is_some_and(|stack| stacks.contains(stack)),
-            );
+            let restored_into_a_real_stack = match request.target {
+                TerminalSpawnTarget::Stack(stack) => stacks.contains(stack),
+                _ => false,
+            };
+            captured.0.push(restored_into_a_real_stack);
         }
     }
 
@@ -1990,7 +1991,7 @@ mod tests {
             .collect();
         assert_eq!(spawns.len(), 1);
         assert_eq!(spawns[0].cwd, Some(PathBuf::from("/work")));
-        assert!(spawns[0].target_stack.is_some());
+        assert!(matches!(spawns[0].target, TerminalSpawnTarget::Stack(_)));
     }
 
     fn drain_agent_spawns(app: &mut App) -> Vec<SpawnAgentInStackRequest> {

--- a/crates/page/vmux_layout/src/host/contract.rs
+++ b/crates/page/vmux_layout/src/host/contract.rs
@@ -20,8 +20,8 @@ use crate::stack::{CloseStackRequest, FocusedStack};
 use crate::worktree::TabDirectoryObserved;
 use crate::{
     BrowserGoBackRequest, BrowserGoForwardRequest, BrowserNavigateRequest,
-    ContributedCommandChosen, ExtensionInstallRequest, NewStackContext, NewTabRequest,
-    OpenInNewStackRequest,
+    ContributedCommandChosen, ExtensionInstallRequest, NewTabRequest, OpenInNewStackRequest,
+    PendingLaunch,
 };
 
 /// Registers every layout message and resource that crates outside `vmux_layout` send, read or
@@ -44,7 +44,7 @@ impl Plugin for LayoutContractPlugin {
             .init_resource::<EffectiveStartupDir>()
             .init_resource::<EffectiveStartupUrl>()
             .init_resource::<FocusedStack>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<SpawnCounter>()
             .add_message::<ActivatePane>()
             .add_message::<BookmarkOp>()

--- a/crates/page/vmux_layout/src/host/pane.rs
+++ b/crates/page/vmux_layout/src/host/pane.rs
@@ -1,5 +1,5 @@
 use crate::{
-    CloseRequiresConfirmation, NewStackContext,
+    CloseRequiresConfirmation, PendingLaunch,
     host::swap::{find_kind_index, resolve_next, resolve_prev, swap_siblings},
     settings::{ConfirmCloseSettings, LayoutSettings},
     stack::{
@@ -561,7 +561,7 @@ pub fn first_stack_in_pane(
 struct PaneStartupContext<'w> {
     effective: Option<Res<'w, crate::settings::EffectiveStartupUrl>>,
     requests: MessageWriter<'w, PageOpenRequest>,
-    new_stack_ctx: ResMut<'w, NewStackContext>,
+    new_stack_ctx: ResMut<'w, PendingLaunch>,
 }
 
 impl PaneStartupContext<'_> {
@@ -1005,7 +1005,7 @@ pub fn handle_open_beside_requests(
     rc: ResolverCtx,
     mut commands: Commands,
     mut page_open_requests: MessageWriter<PageOpenRequest>,
-    mut new_stack_ctx: ResMut<NewStackContext>,
+    mut new_stack_ctx: ResMut<PendingLaunch>,
     mut spawn_counter: ResMut<SpawnCounter>,
 ) {
     let mut split_this_batch: std::collections::HashSet<Entity> = std::collections::HashSet::new();
@@ -1394,7 +1394,7 @@ fn spawn_beside_stack(
     target_pane: Entity,
     req: &OpenBesideRequest,
     commands: &mut Commands,
-    new_stack_ctx: &mut NewStackContext,
+    new_stack_ctx: &mut PendingLaunch,
     page_open_requests: &mut MessageWriter<PageOpenRequest>,
     spawn_counter: &mut SpawnCounter,
     seq_q: &Query<&SpawnSeq>,
@@ -1806,7 +1806,7 @@ fn handle_open_in_pane(
     effective_startup_url: Option<Res<crate::settings::EffectiveStartupUrl>>,
     mut commands: Commands,
     mut page_open_requests: MessageWriter<PageOpenRequest>,
-    mut new_stack_ctx: ResMut<NewStackContext>,
+    mut new_stack_ctx: ResMut<PendingLaunch>,
     mut pending_warp: ResMut<PendingCursorWarp>,
 ) {
     for cmd in reader.read() {
@@ -1926,7 +1926,7 @@ fn open_or_prompt_stack(
     stack: Entity,
     url: Option<String>,
     request_id: Option<[u8; 16]>,
-    new_stack_ctx: &mut NewStackContext,
+    new_stack_ctx: &mut PendingLaunch,
     page_open_requests: &mut MessageWriter<PageOpenRequest>,
 ) {
     if let Some(url) = url {
@@ -1954,7 +1954,7 @@ fn on_pane_select(
     pane_pos_q: Query<(&ComputedNode, &UiGlobalTransform), With<Pane>>,
     mut hover_intent: ResMut<PaneHoverIntent>,
     mut pending_warp: ResMut<PendingCursorWarp>,
-    mut new_stack_ctx: ResMut<NewStackContext>,
+    mut new_stack_ctx: ResMut<PendingLaunch>,
     mut commands: Commands,
 ) {
     for cmd in reader.read() {
@@ -2686,7 +2686,7 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .add_message::<OpenBesideRequest>()
             .add_message::<PageOpenRequest>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<SpawnCounter>()
             .add_systems(Update, handle_open_beside_requests);
 
@@ -2749,7 +2749,7 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .add_message::<OpenBesideRequest>()
             .add_message::<PageOpenRequest>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<SpawnCounter>()
             .add_systems(Update, handle_open_beside_requests);
 
@@ -2845,7 +2845,7 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .add_message::<OpenBesideRequest>()
             .add_message::<PageOpenRequest>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<SpawnCounter>()
             .add_systems(Update, handle_open_beside_requests);
         app
@@ -4515,7 +4515,7 @@ mod tests {
         app.add_plugins((MinimalPlugins, CommandPlugin))
             .init_resource::<PaneHoverIntent>()
             .init_resource::<PendingCursorWarp>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .add_systems(Update, on_pane_select.in_set(WriteAppCommands));
 
         let _window = app.world_mut().spawn(PrimaryWindow).id();
@@ -4603,7 +4603,7 @@ mod tests {
         app.add_plugins((MinimalPlugins, CommandPlugin))
             .init_resource::<PaneHoverIntent>()
             .init_resource::<PendingCursorWarp>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .add_systems(Update, on_pane_select.in_set(WriteAppCommands));
 
         let _window = app.world_mut().spawn(PrimaryWindow).id();
@@ -4685,7 +4685,7 @@ mod tests {
         app.add_plugins((MinimalPlugins, CommandPlugin))
             .init_resource::<PaneHoverIntent>()
             .init_resource::<PendingCursorWarp>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .add_systems(Update, on_pane_select.in_set(WriteAppCommands));
 
         let _window = app.world_mut().spawn(PrimaryWindow).id();
@@ -4764,7 +4764,7 @@ mod tests {
         app.add_plugins((MinimalPlugins, CommandPlugin))
             .init_resource::<PaneHoverIntent>()
             .init_resource::<PendingCursorWarp>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<ConfirmCloseSettings>()
             .add_message::<PageOpenRequest>()
             .insert_resource(test_settings())
@@ -4813,7 +4813,7 @@ mod tests {
         app.add_plugins((MinimalPlugins, CommandPlugin))
             .init_resource::<PaneHoverIntent>()
             .init_resource::<PendingCursorWarp>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<ConfirmCloseSettings>()
             .add_message::<PageOpenRequest>()
             .insert_resource(test_settings())
@@ -4914,7 +4914,7 @@ mod tests {
         app.add_plugins((MinimalPlugins, CommandPlugin))
             .init_resource::<PaneHoverIntent>()
             .init_resource::<PendingCursorWarp>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<ConfirmCloseSettings>()
             .add_message::<PageOpenRequest>()
             .insert_resource(test_settings())
@@ -5046,7 +5046,7 @@ mod tests {
         app.add_plugins((MinimalPlugins, CommandPlugin))
             .init_resource::<PaneHoverIntent>()
             .init_resource::<PendingCursorWarp>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<ConfirmCloseSettings>()
             .insert_resource(test_settings())
             .add_systems(Update, handle_zoom_command.in_set(WriteAppCommands));
@@ -5113,7 +5113,7 @@ mod tests {
         app.add_plugins((MinimalPlugins, CommandPlugin))
             .init_resource::<PaneHoverIntent>()
             .init_resource::<PendingCursorWarp>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<ConfirmCloseSettings>()
             .insert_resource(test_settings())
             .add_systems(Update, handle_zoom_command.in_set(WriteAppCommands));
@@ -5179,7 +5179,7 @@ mod tests {
         app.add_plugins((MinimalPlugins, CommandPlugin))
             .init_resource::<PaneHoverIntent>()
             .init_resource::<PendingCursorWarp>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<ConfirmCloseSettings>()
             .insert_resource(test_settings())
             .add_systems(Update, handle_zoom_command.in_set(WriteAppCommands));
@@ -5368,7 +5368,7 @@ mod tests {
         app.add_plugins((MinimalPlugins, CommandPlugin))
             .init_resource::<PaneHoverIntent>()
             .init_resource::<PendingCursorWarp>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<ConfirmCloseSettings>()
             .insert_resource(test_settings())
             .add_systems(Update, handle_zoom_command.in_set(WriteAppCommands));
@@ -5445,7 +5445,7 @@ mod tests {
         app.add_plugins((MinimalPlugins, CommandPlugin))
             .init_resource::<PaneHoverIntent>()
             .init_resource::<PendingCursorWarp>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<ConfirmCloseSettings>()
             .insert_resource(test_settings())
             .add_systems(Update, handle_zoom_command.in_set(WriteAppCommands));
@@ -5676,7 +5676,7 @@ mod tests {
         app.add_plugins((MinimalPlugins, CommandPlugin))
             .add_message::<crate::LayoutSpawnRequest>()
             .add_message::<PageOpenRequest>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<PendingCursorWarp>()
             .init_resource::<InPaneCollectedSpawns>()
             .insert_resource(test_settings())
@@ -5986,7 +5986,7 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .add_message::<OpenBesideRequest>()
             .add_message::<PageOpenRequest>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<SpawnCounter>()
             .add_systems(Update, handle_open_beside_requests);
         let tab = app.world_mut().spawn(crate::tab::tab_bundle()).id();
@@ -6020,7 +6020,7 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .add_message::<OpenBesideRequest>()
             .add_message::<PageOpenRequest>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<SpawnCounter>()
             .add_systems(Update, handle_open_beside_requests);
         let tab = app.world_mut().spawn(crate::tab::tab_bundle()).id();
@@ -6057,7 +6057,7 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .add_message::<OpenBesideRequest>()
             .add_message::<PageOpenRequest>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<SpawnCounter>()
             .add_systems(Update, handle_open_beside_requests);
         let tab = app.world_mut().spawn(crate::tab::tab_bundle()).id();
@@ -6221,7 +6221,7 @@ mod tests {
         assert!(app.world().get::<PaneSplit>(pane).is_some());
         let collected = app.world().resource::<InPaneCollectedSpawns>();
         assert!(collected.0.is_empty());
-        let ctx = app.world().resource::<NewStackContext>();
+        let ctx = app.world().resource::<PendingLaunch>();
         assert!(ctx.stack.is_some());
         assert!(ctx.needs_open);
     }

--- a/crates/page/vmux_layout/src/host/pending_stack.rs
+++ b/crates/page/vmux_layout/src/host/pending_stack.rs
@@ -1,0 +1,232 @@
+//! Disposing of an empty stack a launcher never used.
+//!
+//! Opening the launcher on an empty pane hands it a fresh stack to fill. Dismissing without picking
+//! anything has to undo that, and it is more than a despawn: Cmd+T creates a whole tab to hold the
+//! one stack, so abandoning it should take the tab too, and which of the two happened decides where
+//! the keyboard goes back to.
+//!
+//! All of that is workspace shape, so the launcher only reports
+//! [`PendingStackAbandoned`](vmux_core::launcher::PendingStackAbandoned) and this answers it.
+
+use bevy::ecs::relationship::Relationship;
+use bevy::prelude::*;
+use bevy_cef::prelude::CefKeyboardTarget;
+use vmux_core::launcher::PendingStackAbandoned;
+use vmux_history::LastActivatedAt;
+
+use crate::cef::Browser;
+use crate::stack::Stack;
+use crate::tab::{Tab, pick_after_close};
+
+pub(crate) struct PendingStackPlugin;
+
+impl Plugin for PendingStackPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_message::<PendingStackAbandoned>().add_systems(
+            Update,
+            discard_abandoned_pending_stacks.before(crate::stack::ComputeFocusSet),
+        );
+    }
+}
+
+fn discard_abandoned_pending_stacks(
+    mut abandoned: MessageReader<PendingStackAbandoned>,
+    tab_q: Query<(Entity, &LastActivatedAt), With<Tab>>,
+    child_of_q: Query<&ChildOf>,
+    all_children: Query<&Children>,
+    stack_q: Query<Entity, With<Stack>>,
+    content_browsers: Query<Entity, With<Browser>>,
+    mut commands: Commands,
+) {
+    for event in abandoned.read() {
+        let closed_tab = Tab::close_if_only_holds(
+            event.stack,
+            &tab_q,
+            &child_of_q,
+            &all_children,
+            &stack_q,
+            &mut commands,
+        );
+        if closed_tab {
+            continue;
+        }
+        commands.entity(event.stack).despawn();
+        let Some(previous) = event.previous_stack else {
+            continue;
+        };
+        let Ok(children) = all_children.get(previous) else {
+            continue;
+        };
+        for child in children.iter() {
+            if content_browsers.contains(child) {
+                commands.entity(child).try_insert(CefKeyboardTarget);
+            }
+        }
+    }
+}
+
+impl Tab {
+    /// Despawns the tab holding `stack` when that stack is the only thing in it, and hands the
+    /// active marker to a sibling. Reports whether it did.
+    ///
+    /// Refuses when the tab is the last one: a workspace with no tabs has nothing to show.
+    fn close_if_only_holds(
+        stack: Entity,
+        tab_q: &Query<(Entity, &LastActivatedAt), With<Tab>>,
+        child_of_q: &Query<&ChildOf>,
+        all_children: &Query<&Children>,
+        stack_q: &Query<Entity, With<Stack>>,
+        commands: &mut Commands,
+    ) -> bool {
+        let Some(tab) = Self::ancestor_of(stack, tab_q, child_of_q) else {
+            return false;
+        };
+        if subtree_holds_another_stack(tab, stack, all_children, stack_q) {
+            return false;
+        }
+        let siblings = Self::siblings_of(tab, tab_q, child_of_q, all_children);
+        if siblings.len() <= 1 {
+            return false;
+        }
+        if let Some(next) = pick_after_close(tab, &siblings) {
+            commands.entity(next).insert(LastActivatedAt::now());
+        }
+        commands.entity(tab).despawn();
+        true
+    }
+
+    fn ancestor_of(
+        entity: Entity,
+        tab_q: &Query<(Entity, &LastActivatedAt), With<Tab>>,
+        child_of_q: &Query<&ChildOf>,
+    ) -> Option<Entity> {
+        let mut current = entity;
+        while let Ok(parent) = child_of_q.get(current).map(Relationship::get) {
+            if tab_q.get(parent).is_ok() {
+                return Some(parent);
+            }
+            current = parent;
+        }
+        None
+    }
+
+    fn siblings_of(
+        tab: Entity,
+        tab_q: &Query<(Entity, &LastActivatedAt), With<Tab>>,
+        child_of_q: &Query<&ChildOf>,
+        all_children: &Query<&Children>,
+    ) -> Vec<Entity> {
+        let Ok(parent) = child_of_q.get(tab).map(Relationship::get) else {
+            return vec![tab];
+        };
+        let Ok(children) = all_children.get(parent) else {
+            return vec![tab];
+        };
+        children.iter().filter(|e| tab_q.get(*e).is_ok()).collect()
+    }
+}
+
+fn subtree_holds_another_stack(
+    entity: Entity,
+    ignored_stack: Entity,
+    all_children: &Query<&Children>,
+    stack_q: &Query<Entity, With<Stack>>,
+) -> bool {
+    (stack_q.contains(entity) && entity != ignored_stack)
+        || all_children.get(entity).is_ok_and(|children| {
+            children.iter().any(|child| {
+                subtree_holds_another_stack(child, ignored_stack, all_children, stack_q)
+            })
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Workspace {
+        app: App,
+        root: Entity,
+    }
+
+    impl Workspace {
+        fn new() -> Self {
+            let mut app = App::new();
+            app.add_plugins(MinimalPlugins)
+                .add_message::<PendingStackAbandoned>()
+                .add_systems(Update, discard_abandoned_pending_stacks);
+            let root = app.world_mut().spawn_empty().id();
+            Self { app, root }
+        }
+
+        fn tab(&mut self) -> Entity {
+            self.app
+                .world_mut()
+                .spawn((Tab::default(), LastActivatedAt::now(), ChildOf(self.root)))
+                .id()
+        }
+
+        fn stack_in(&mut self, tab: Entity) -> Entity {
+            self.app
+                .world_mut()
+                .spawn((Stack::default(), ChildOf(tab)))
+                .id()
+        }
+
+        fn abandon(&mut self, stack: Entity) {
+            self.app.world_mut().write_message(PendingStackAbandoned {
+                stack,
+                previous_stack: None,
+            });
+            self.app.update();
+        }
+
+        fn exists(&self, entity: Entity) -> bool {
+            self.app.world().get_entity(entity).is_ok()
+        }
+    }
+
+    /// Cmd+T makes a tab just to hold the stack the launcher opens on, so walking away from the
+    /// launcher has to take the tab with it — otherwise every dismissed Cmd+T leaves an empty tab.
+    #[test]
+    fn abandoning_the_only_stack_in_a_tab_closes_the_tab() {
+        let mut workspace = Workspace::new();
+        let keeper = workspace.tab();
+        workspace.stack_in(keeper);
+        let throwaway = workspace.tab();
+        let stack = workspace.stack_in(throwaway);
+
+        workspace.abandon(stack);
+
+        assert!(!workspace.exists(throwaway));
+        assert!(workspace.exists(keeper));
+    }
+
+    #[test]
+    fn abandoning_a_stack_beside_others_closes_only_that_stack() {
+        let mut workspace = Workspace::new();
+        let tab = workspace.tab();
+        let sibling = workspace.stack_in(tab);
+        let stack = workspace.stack_in(tab);
+
+        workspace.abandon(stack);
+
+        assert!(!workspace.exists(stack));
+        assert!(workspace.exists(sibling));
+        assert!(workspace.exists(tab));
+    }
+
+    /// Closing the last tab would leave a workspace with nothing to show, so the stack goes and
+    /// the tab stays.
+    #[test]
+    fn abandoning_the_only_stack_in_the_only_tab_keeps_the_tab() {
+        let mut workspace = Workspace::new();
+        let tab = workspace.tab();
+        let stack = workspace.stack_in(tab);
+
+        workspace.abandon(stack);
+
+        assert!(!workspace.exists(stack));
+        assert!(workspace.exists(tab));
+    }
+}

--- a/crates/page/vmux_layout/src/host/plugin.rs
+++ b/crates/page/vmux_layout/src/host/plugin.rs
@@ -82,6 +82,7 @@ impl Plugin for LayoutPlugin {
                 BookmarkPlugin,
                 LayoutCefPlugin,
                 crate::overlay_adopt::OverlayAdoptPlugin,
+                crate::pending_stack::PendingStackPlugin,
             ));
     }
 }

--- a/crates/page/vmux_layout/src/host/stack.rs
+++ b/crates/page/vmux_layout/src/host/stack.rs
@@ -1,6 +1,6 @@
 use crate::event::SERVICES_PAGE_URL;
 use crate::{
-    NewStackContext,
+    PendingLaunch,
     host::swap::{find_kind_index, resolve_next, resolve_prev, swap_siblings},
     pane::{Pane, PaneSplit, PendingCursorWarp, first_leaf_descendant, first_stack_in_pane},
     tab::{CloseTabRequest, Tab},
@@ -86,7 +86,7 @@ fn handle_close_stack_requests(
     child_of_q: Query<&ChildOf>,
     pane_children: Query<&Children, With<Pane>>,
     stack_q: Query<Entity, With<Stack>>,
-    mut new_stack_ctx: ResMut<NewStackContext>,
+    mut new_stack_ctx: ResMut<PendingLaunch>,
     mut commands: Commands,
 ) {
     for req in reader.read() {
@@ -262,7 +262,7 @@ fn handle_stack_commands(
     split_dir_q: Query<&PaneSplit>,
     effective_startup_url: Option<Res<crate::settings::EffectiveStartupUrl>>,
 
-    mut new_stack_ctx: ResMut<NewStackContext>,
+    mut new_stack_ctx: ResMut<PendingLaunch>,
     mut close_tab_requests: MessageWriter<CloseTabRequest>,
     mut page_open_requests: MessageWriter<PageOpenRequest>,
     mut commands: Commands,
@@ -652,7 +652,7 @@ pub fn open_startup_url_if_no_stacks(
     stack_q: Query<Entity, With<Stack>>,
     closing_primary: Query<(), (With<PrimaryWindow>, With<ClosingWindow>)>,
     effective_startup_url: Option<Res<crate::settings::EffectiveStartupUrl>>,
-    mut new_stack_ctx: ResMut<NewStackContext>,
+    mut new_stack_ctx: ResMut<PendingLaunch>,
     mut page_open_requests: MessageWriter<PageOpenRequest>,
     mut commands: Commands,
 ) {
@@ -730,7 +730,7 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .add_message::<CloseStackRequest>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .add_systems(Update, handle_close_stack_requests);
 
         let tab = app
@@ -764,7 +764,7 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .add_message::<CloseStackRequest>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .add_systems(Update, handle_close_stack_requests);
 
         let tab = app
@@ -843,7 +843,7 @@ mod tests {
             .add_message::<CloseTabRequest>()
             .add_message::<crate::TabLayoutSpawnRequest>()
             .add_message::<PageOpenRequest>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<PendingCursorWarp>()
             .init_resource::<crate::tab::LastTabCloseAt>()
             .init_resource::<FocusedStack>()
@@ -950,7 +950,7 @@ mod tests {
             app.world().get::<Tab>(replacement_tab).unwrap().startup_dir,
             None
         );
-        let ctx = app.world().resource::<NewStackContext>();
+        let ctx = app.world().resource::<PendingLaunch>();
         assert!(ctx.needs_open);
         assert!(ctx.stack.is_some());
         assert_eq!(ctx.previous_stack, None);
@@ -979,7 +979,7 @@ mod tests {
             .add_message::<CloseTabRequest>()
             .add_message::<crate::TabLayoutSpawnRequest>()
             .add_message::<PageOpenRequest>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<PendingCursorWarp>()
             .init_resource::<crate::tab::LastTabCloseAt>()
             .insert_resource(test_settings())
@@ -1034,7 +1034,7 @@ mod tests {
         assert!(app.world().get_entity(remaining_tab).is_ok());
         assert!(app.world().get::<LastActivatedAt>(remaining_tab).unwrap().0 > 1);
 
-        let ctx = app.world().resource::<NewStackContext>();
+        let ctx = app.world().resource::<PendingLaunch>();
         assert_eq!(ctx.stack, None);
         assert!(!ctx.needs_open);
     }
@@ -1046,7 +1046,7 @@ mod tests {
             .add_message::<CloseTabRequest>()
             .add_message::<crate::TabLayoutSpawnRequest>()
             .add_message::<PageOpenRequest>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<PendingCursorWarp>()
             .init_resource::<crate::tab::LastTabCloseAt>()
             .insert_resource(test_settings())
@@ -1102,7 +1102,7 @@ mod tests {
         app.add_plugins((MinimalPlugins, CommandPlugin))
             .add_message::<CloseTabRequest>()
             .add_message::<PageOpenRequest>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<PendingCursorWarp>()
             .insert_resource(test_settings())
             .add_systems(Update, handle_stack_commands.in_set(WriteAppCommands));
@@ -1155,8 +1155,8 @@ mod tests {
             Some(split)
         );
         assert!(!app.world().entity(split).contains::<PaneSplit>());
-        assert_eq!(app.world().resource::<NewStackContext>().stack, None);
-        assert!(!app.world().resource::<NewStackContext>().needs_open);
+        assert_eq!(app.world().resource::<PendingLaunch>().stack, None);
+        assert!(!app.world().resource::<PendingLaunch>().needs_open);
     }
 
     #[test]
@@ -1165,7 +1165,7 @@ mod tests {
         app.add_plugins((MinimalPlugins, CommandPlugin))
             .add_message::<CloseTabRequest>()
             .add_message::<PageOpenRequest>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<PendingCursorWarp>()
             .insert_resource(test_settings())
             .insert_resource(crate::settings::EffectiveStartupUrl(
@@ -1257,7 +1257,7 @@ mod tests {
     fn empty_active_pane_opens_command_bar_even_when_other_tabs_have_stacks() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .add_message::<PageOpenRequest>()
             .add_systems(Update, open_startup_url_if_no_stacks);
 
@@ -1283,7 +1283,7 @@ mod tests {
 
         app.update();
 
-        let ctx = app.world().resource::<NewStackContext>();
+        let ctx = app.world().resource::<PendingLaunch>();
         let Some(new_stack) = ctx.stack else {
             panic!("expected empty active pane to get pending stack");
         };
@@ -1298,7 +1298,7 @@ mod tests {
     fn empty_active_pane_does_not_open_command_bar_when_tab_has_stacks() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .add_message::<PageOpenRequest>()
             .add_systems(Update, open_startup_url_if_no_stacks);
 
@@ -1320,7 +1320,7 @@ mod tests {
 
         app.update();
 
-        let ctx = app.world().resource::<NewStackContext>();
+        let ctx = app.world().resource::<PendingLaunch>();
         assert_eq!(ctx.stack, None);
         assert!(!ctx.needs_open);
     }
@@ -1329,7 +1329,7 @@ mod tests {
     fn active_empty_stack_does_not_reopen_command_bar() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .add_message::<PageOpenRequest>()
             .add_systems(Update, open_startup_url_if_no_stacks);
 
@@ -1348,7 +1348,7 @@ mod tests {
 
         app.update();
 
-        let ctx = app.world().resource::<NewStackContext>();
+        let ctx = app.world().resource::<PendingLaunch>();
         assert_ne!(ctx.stack, Some(stack));
         assert!(!ctx.needs_open);
     }
@@ -1370,7 +1370,7 @@ mod tests {
         app.add_plugins((MinimalPlugins, CommandPlugin))
             .add_message::<CloseTabRequest>()
             .add_message::<PageOpenRequest>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<PendingCursorWarp>()
             .insert_resource(test_settings())
             .init_resource::<CollectedSpawns>()
@@ -1417,7 +1417,7 @@ mod tests {
 
         assert!(app.world().get_entity(original_stack).is_ok());
         assert!(app.world().get_entity(tab).is_ok());
-        let ctx = app.world().resource::<NewStackContext>();
+        let ctx = app.world().resource::<PendingLaunch>();
         assert_eq!(ctx.stack, None);
         assert!(!ctx.needs_open);
 
@@ -1489,7 +1489,7 @@ mod tests {
             collected.0.is_empty(),
             "no spawn request until URL is provided"
         );
-        let ctx = app.world().resource::<NewStackContext>();
+        let ctx = app.world().resource::<PendingLaunch>();
         let queued = ctx.stack.expect("an empty stack should be queued");
         assert_eq!(
             app.world().get::<ChildOf>(queued).map(Relationship::get),

--- a/crates/page/vmux_layout/src/host/tab.rs
+++ b/crates/page/vmux_layout/src/host/tab.rs
@@ -463,7 +463,7 @@ fn tab_target(id: Option<&str>, tabs: impl IntoIterator<Item = Entity>) -> Optio
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::NewStackContext;
+    use crate::PendingLaunch;
     use crate::settings::{
         FocusRingSettings, LayoutSettings, PaneSettings, SideSheetSettings, WindowSettings,
     };
@@ -704,7 +704,7 @@ mod tests {
             .add_message::<CloseTabRequest>()
             .add_message::<PageOpenRequest>()
             .add_message::<vmux_core::agent::SpawnAgentInStackRequest>()
-            .init_resource::<crate::NewStackContext>()
+            .init_resource::<crate::PendingLaunch>()
             .insert_resource(test_settings())
             .init_resource::<CollectedSpawns>()
             .add_systems(
@@ -830,7 +830,7 @@ mod tests {
 
         let collected = app.world().resource::<CollectedSpawns>();
         assert!(collected.0.is_empty(), "expected no spawn request");
-        let ctx = app.world().resource::<NewStackContext>();
+        let ctx = app.world().resource::<PendingLaunch>();
         assert!(ctx.stack.is_some());
         assert!(ctx.needs_open);
     }

--- a/crates/page/vmux_layout/src/host/window.rs
+++ b/crates/page/vmux_layout/src/host/window.rs
@@ -393,7 +393,7 @@ pub fn spawn_requested_tab_layouts(
     mut reader: MessageReader<TabLayoutSpawnRequest>,
     settings: Res<LayoutSettings>,
     effective_startup_url: Option<Res<crate::settings::EffectiveStartupUrl>>,
-    mut new_stack_ctx: ResMut<crate::NewStackContext>,
+    mut new_stack_ctx: ResMut<crate::PendingLaunch>,
     mut page_open_requests: MessageWriter<PageOpenRequest>,
     mut focus: Option<ResMut<crate::stack::FocusedStack>>,
     spaces: Query<(), With<crate::space::Space>>,
@@ -791,7 +791,7 @@ mod tests {
         let startup_dir = tempfile::tempdir().unwrap();
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<crate::NewStackContext>()
+            .init_resource::<crate::PendingLaunch>()
             .add_message::<crate::TabLayoutSpawnRequest>()
             .add_message::<PageOpenRequest>()
             .add_message::<vmux_core::agent::SpawnAgentInStackRequest>()
@@ -820,7 +820,7 @@ mod tests {
 
         app.update();
 
-        let ctx = app.world().resource::<crate::NewStackContext>();
+        let ctx = app.world().resource::<crate::PendingLaunch>();
         assert!(ctx.stack.is_some());
         assert!(ctx.needs_open);
     }
@@ -831,7 +831,7 @@ mod tests {
         let startup_dir = tempfile::tempdir().unwrap();
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<crate::NewStackContext>()
+            .init_resource::<crate::PendingLaunch>()
             .add_message::<crate::TabLayoutSpawnRequest>()
             .add_message::<PageOpenRequest>()
             .add_message::<vmux_core::agent::SpawnAgentInStackRequest>()
@@ -866,7 +866,7 @@ mod tests {
         let _home = HomeEnvGuard::use_temp_home("default-tab-no-workspace");
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<crate::NewStackContext>()
+            .init_resource::<crate::PendingLaunch>()
             .add_message::<crate::TabLayoutSpawnRequest>()
             .add_message::<PageOpenRequest>()
             .add_message::<vmux_core::agent::SpawnAgentInStackRequest>()
@@ -895,7 +895,7 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<crate::NewStackContext>()
+            .init_resource::<crate::PendingLaunch>()
             .add_message::<crate::TabLayoutSpawnRequest>()
             .add_message::<PageOpenRequest>()
             .add_message::<vmux_core::agent::SpawnAgentInStackRequest>()
@@ -930,7 +930,7 @@ mod tests {
         let startup_dir = tempfile::tempdir().unwrap();
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<crate::NewStackContext>()
+            .init_resource::<crate::PendingLaunch>()
             .add_message::<crate::TabLayoutSpawnRequest>()
             .add_message::<PageOpenRequest>()
             .add_message::<vmux_core::agent::SpawnAgentInStackRequest>()
@@ -985,7 +985,7 @@ mod tests {
         let startup_dir = tempfile::tempdir().unwrap();
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<crate::NewStackContext>()
+            .init_resource::<crate::PendingLaunch>()
             .add_message::<crate::TabLayoutSpawnRequest>()
             .add_message::<PageOpenRequest>()
             .add_message::<vmux_core::agent::SpawnAgentInStackRequest>()
@@ -1038,7 +1038,7 @@ mod tests {
         let startup_dir = tempfile::tempdir().unwrap();
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .init_resource::<crate::NewStackContext>()
+            .init_resource::<crate::PendingLaunch>()
             .add_message::<crate::TabLayoutSpawnRequest>()
             .add_message::<PageOpenRequest>()
             .add_message::<vmux_core::agent::SpawnAgentInStackRequest>()

--- a/crates/page/vmux_layout/src/start/plugin.rs
+++ b/crates/page/vmux_layout/src/start/plugin.rs
@@ -26,6 +26,7 @@ use crate::tab::{Tab, TabWorkspace, TabWorktree};
 use crate::window::VmuxWindow;
 use crate::workspace_snapshot::{TabGatherParams, gather_command_bar_tabs};
 use vmux_command::build_command_bar_open_payload;
+use vmux_core::launcher::{FocusLauncherInput, HostsLauncher, InlineTransitionRequested};
 
 /// Bevy plugin for `vmux://start/`: spawns the page manifest, claims start page-open tasks,
 /// and answers [`StartDataRequest`] with the shared command-bar payload.
@@ -34,6 +35,16 @@ pub struct StartPlugin;
 impl Plugin for StartPlugin {
     fn build(&self, app: &mut App) {
         app.world_mut().spawn(crate::start::PAGE_MANIFEST);
+        app.add_message::<FocusLauncherInput>()
+            .add_message::<InlineTransitionRequested>()
+            .add_systems(
+                Update,
+                (
+                    mark_start_pages_as_launcher_hosts,
+                    focus_start_input_on_request,
+                    begin_requested_inline_transition,
+                ),
+            );
         app.add_plugins(BinEventEmitterPlugin::<(
             StartDataRequest,
             StartSelectWorkspace,
@@ -640,6 +651,55 @@ fn clear_stack_children(stack: Entity, children_q: &Query<&Children>, commands: 
         for child in children.iter() {
             commands.entity(child).try_despawn();
         }
+    }
+}
+
+/// Claims [`HostsLauncher`] for every start webview, so the command bar can ask what a page can do
+/// instead of comparing its URL.
+fn mark_start_pages_as_launcher_hosts(
+    starts: Query<(Entity, &WebviewSource), Without<HostsLauncher>>,
+    mut commands: Commands,
+) {
+    for (entity, source) in starts.iter() {
+        let WebviewSource::Url(url) = source else {
+            continue;
+        };
+        if url.starts_with(START_PAGE_URL) {
+            commands.entity(entity).insert(HostsLauncher);
+        }
+    }
+}
+
+fn focus_start_input_on_request(
+    mut requests: MessageReader<FocusLauncherInput>,
+    starts: Query<(), With<HostsLauncher>>,
+    mut commands: Commands,
+) {
+    for request in requests.read() {
+        if !starts.contains(request.webview) {
+            continue;
+        }
+        commands.trigger(BinHostEmitEvent::from_rkyv(
+            request.webview,
+            crate::start::event::START_FOCUS_INPUT_EVENT,
+            &crate::start::event::StartFocusInput,
+        ));
+    }
+}
+
+fn begin_requested_inline_transition(
+    mut requests: MessageReader<InlineTransitionRequested>,
+    mut commands: Commands,
+) {
+    for request in requests.read() {
+        commands
+            .entity(request.stack)
+            .insert(crate::start::StartInlineTransition {
+                webview: request.webview,
+            });
+        commands
+            .entity(request.webview)
+            .insert(crate::start::StartInlineTransitionView);
     }
 }
 

--- a/crates/page/vmux_terminal/src/host/plugin.rs
+++ b/crates/page/vmux_terminal/src/host/plugin.rs
@@ -18,7 +18,9 @@ use vmux_command::{
 };
 use vmux_core::input::KeyStroke;
 use vmux_core::page::PageReady;
-use vmux_core::terminal::{ProcessesMonitorSpawnRequest, TerminalSpawnRequest};
+use vmux_core::terminal::{
+    ProcessesMonitorSpawnRequest, TerminalSpawnRequest, TerminalSpawnTarget,
+};
 use vmux_core::{
     OscTitle, PageMetadata, PageOpenError, PageOpenHandled, PageOpenRequest, PageOpenSet,
     PageOpenTarget, PageOpenTask,
@@ -623,12 +625,24 @@ fn respond_terminal_spawn(
             .spawn(new_terminal_bundle_with_cwd(&settings, req.cwd.as_deref()))
             .id();
         commands.entity(term_e).insert(CefKeyboardTarget);
-        if let Some(stack_e) = req.target_stack {
-            commands.entity(term_e).insert(ChildOf(stack_e));
-            commands.entity(stack_e).insert(LastActivatedAt::now());
-            if let Ok(parent) = child_of_q.get(stack_e) {
-                commands.entity(parent.0).insert(LastActivatedAt::now());
-            }
+        let stack_e = match req.target {
+            TerminalSpawnTarget::Detached => continue,
+            TerminalSpawnTarget::Stack(stack) => stack,
+            TerminalSpawnTarget::NewStackInPane(pane) => commands
+                .spawn((
+                    vmux_layout::stack::stack_bundle(),
+                    LastActivatedAt::now(),
+                    ChildOf(pane),
+                ))
+                .id(),
+        };
+        if let Some(metadata) = req.metadata.clone() {
+            commands.entity(stack_e).insert(metadata);
+        }
+        commands.entity(term_e).insert(ChildOf(stack_e));
+        commands.entity(stack_e).insert(LastActivatedAt::now());
+        if let Ok(parent) = child_of_q.get(stack_e) {
+            commands.entity(parent.0).insert(LastActivatedAt::now());
         }
     }
 }

--- a/crates/vmux_browser/src/command_bar/handler.rs
+++ b/crates/vmux_browser/src/command_bar/handler.rs
@@ -1,7 +1,9 @@
 use std::time::{Duration, Instant};
 use vmux_command::CommandBar;
 use vmux_command::build_command_bar_open_payload;
-use vmux_core::launcher::PendingStackAbandoned;
+use vmux_core::launcher::{
+    FocusLauncherInput, HostsLauncher, InlineTransitionRequested, PendingStackAbandoned,
+};
 pub(crate) use vmux_layout::NewStackContext;
 use vmux_layout::workspace_snapshot::gather_command_bar_tabs;
 
@@ -39,7 +41,6 @@ use vmux_layout::cef::{Browser, LayoutCef};
 use vmux_layout::event::{
     CommandBarPanelCloseEvent, LAYOUT_COMMAND_BAR_CLOSE_EVENT, LAYOUT_COMMAND_BAR_OPEN_EVENT,
 };
-use vmux_layout::start::event::{START_FOCUS_INPUT_EVENT, StartFocusInput};
 use vmux_layout::{
     Header,
     pane::{Pane, PaneSplit},
@@ -60,6 +61,8 @@ impl Plugin for CommandBarInputPlugin {
         app.init_resource::<NewStackContext>()
             .add_message::<vmux_core::ContributedCommandChosen>()
             .add_message::<PendingStackAbandoned>()
+            .add_message::<FocusLauncherInput>()
+            .add_message::<InlineTransitionRequested>()
             .add_message::<vmux_core::agent::SpawnAgentInStackRequest>()
             .add_message::<SettingsPageSpawnRequest>()
             .add_message::<SpacesPageSpawnRequest>()
@@ -496,6 +499,23 @@ fn command_bar_cancel_pending_stack_for_active_open(
     Some((stack, previous_stack))
 }
 
+/// The pages that host a launcher of their own, and the way to hand one the caret.
+#[derive(SystemParam)]
+struct LauncherHosts<'w, 's> {
+    pages: Query<'w, 's, (), With<HostsLauncher>>,
+    focus: MessageWriter<'w, FocusLauncherInput>,
+}
+
+impl LauncherHosts<'_, '_> {
+    fn hosts_one(&self, webview: Entity) -> bool {
+        self.pages.contains(webview)
+    }
+
+    fn focus(&mut self, webview: Entity) {
+        self.focus.write(FocusLauncherInput { webview });
+    }
+}
+
 fn command_bar_should_focus_start(
     is_new_stack: bool,
     space_switch: bool,
@@ -520,6 +540,7 @@ fn handle_open_command_bar(
     stack_ts: Query<(Entity, &LastActivatedAt), With<Stack>>,
     stack_q: Query<Entity, With<Stack>>,
     browser_meta: Query<&PageMetadata, With<Browser>>,
+    mut launcher_hosts: LauncherHosts,
     child_of_q: Query<&ChildOf>,
     content_browsers: Query<
         Entity,
@@ -673,15 +694,10 @@ fn handle_open_command_bar(
             active_stack
         });
         let start_browser = active_stack.and_then(|stack| {
-            all_children.get(stack).ok().and_then(|children| {
-                children.iter().find_map(|e| {
-                    browser_meta
-                        .get(e)
-                        .ok()
-                        .filter(|meta| meta.url == vmux_layout::start::START_PAGE_URL)
-                        .map(|_| e)
-                })
-            })
+            all_children
+                .get(stack)
+                .ok()
+                .and_then(|children| children.iter().find(|e| launcher_hosts.hosts_one(*e)))
         });
         if command_bar_should_focus_start(
             is_new_stack,
@@ -690,11 +706,7 @@ fn handle_open_command_bar(
             replace_active_stack,
         ) && let Some(browser_e) = start_browser
         {
-            commands.trigger(BinHostEmitEvent::from_rkyv(
-                browser_e,
-                START_FOCUS_INPUT_EVENT,
-                &StartFocusInput,
-            ));
+            launcher_hosts.focus(browser_e);
             return;
         }
     }
@@ -803,7 +815,7 @@ struct CommandBarActionQueries<'w, 's> {
             Without<CommandBar>,
         ),
     >,
-    webview_sources: Query<'w, 's, &'static WebviewSource>,
+    launcher_hosts: Query<'w, 's, (), With<HostsLauncher>>,
 }
 
 impl CommandBarActionQueries<'_, '_> {
@@ -835,23 +847,11 @@ impl CommandBarActionQueries<'_, '_> {
 
     /// The stack holding the start page that raised this action, which can transition in place.
     fn inline_transition_stack(&self, webview: Entity) -> Option<Entity> {
-        let WebviewSource::Url(url) = self.webview_sources.get(webview).ok()? else {
-            return None;
-        };
-        if !url.starts_with(vmux_layout::start::START_PAGE_URL) {
+        if !self.launcher_hosts.contains(webview) {
             return None;
         }
         self.child_of_q.get(webview).ok().map(|parent| parent.0)
     }
-}
-
-fn mark_inline_transition(stack: Entity, webview: Entity, commands: &mut Commands) {
-    commands
-        .entity(stack)
-        .insert(vmux_layout::start::StartInlineTransition { webview });
-    commands
-        .entity(webview)
-        .insert(vmux_layout::start::StartInlineTransitionView);
 }
 
 fn build_open_command(target: Option<OpenTarget>, url: String) -> OpenCommand {
@@ -920,6 +920,7 @@ fn on_command_bar_action(
     )>,
     mut chosen_writer: MessageWriter<vmux_core::ContributedCommandChosen>,
     mut abandoned_writer: MessageWriter<PendingStackAbandoned>,
+    mut inline_transition: MessageWriter<InlineTransitionRequested>,
     mut issued: MessageWriter<vmux_command::CommandIssued>,
     user_q: Query<Entity, With<vmux_core::team::User>>,
     mut commands: Commands,
@@ -962,9 +963,9 @@ fn on_command_bar_action(
                     && let Some(url) = resource_params.p2().prompt_url(target_url.as_deref())
                 {
                     if inline_transition_stack == Some(stack)
-                        && vmux_layout::start::supports_inline_agent_transition(&url)
+                        && vmux_wire::agent::supports_inline_agent_transition(&url)
                     {
-                        mark_inline_transition(stack, webview, &mut commands);
+                        inline_transition.write(InlineTransitionRequested { stack, webview });
                     }
                     commands
                         .entity(stack)
@@ -1032,10 +1033,10 @@ fn on_command_bar_action(
                     search_engine.map(|setting| setting.0).unwrap_or_default(),
                 );
                 let inline_transition = if matches!(open, None | Some(OpenTarget::InPlace))
-                    && vmux_layout::start::supports_inline_agent_transition(&url)
+                    && vmux_wire::agent::supports_inline_agent_transition(&url)
                     && let Some(stack) = inline_transition_stack
                 {
-                    mark_inline_transition(stack, webview, &mut commands);
+                    inline_transition.write(InlineTransitionRequested { stack, webview });
                     true
                 } else {
                     false
@@ -2054,6 +2055,9 @@ mod tests {
         let mut app = App::new();
         app.add_message::<AppCommand>()
             .add_message::<PageOpenRequest>()
+            .add_message::<FocusLauncherInput>()
+            .add_message::<InlineTransitionRequested>()
+            .add_message::<PendingStackAbandoned>()
             .init_resource::<CommandBarSpacesSnapshot>()
             .init_resource::<CommandBarPagesSnapshot>()
             .init_resource::<vmux_command::snapshot::CommandBarWorkSnapshot>()
@@ -2274,6 +2278,9 @@ mod tests {
             .add_plugins(vmux_layout::stack::StackPlugin)
             .add_plugins(CommandBarInputPlugin)
             .add_message::<TerminalSpawnRequest>()
+            .add_message::<FocusLauncherInput>()
+            .add_message::<InlineTransitionRequested>()
+            .add_message::<PendingStackAbandoned>()
             .add_message::<vmux_core::terminal::ProcessesMonitorSpawnRequest>()
             .add_message::<vmux_layout::LayoutSpawnRequest>()
             .add_message::<PageOpenRequest>()

--- a/crates/vmux_browser/src/command_bar/handler.rs
+++ b/crates/vmux_browser/src/command_bar/handler.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 use vmux_command::CommandBar;
 use vmux_command::build_command_bar_open_payload;
+use vmux_core::launcher::PendingStackAbandoned;
 pub(crate) use vmux_layout::NewStackContext;
 use vmux_layout::workspace_snapshot::gather_command_bar_tabs;
 
@@ -44,7 +45,6 @@ use vmux_layout::{
     pane::{Pane, PaneSplit},
     side_sheet::SideSheet,
     stack::{ActiveTabParam, Stack, focused_stack},
-    tab::Tab,
     window::Main,
 };
 use vmux_ui::i18n::{Locale, TranslationValue};
@@ -58,7 +58,8 @@ pub(crate) struct CommandBarInputPlugin;
 impl Plugin for CommandBarInputPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<NewStackContext>()
-            .add_message::<vmux_layout::ContributedCommandChosen>()
+            .add_message::<vmux_core::ContributedCommandChosen>()
+            .add_message::<PendingStackAbandoned>()
             .add_message::<vmux_core::agent::SpawnAgentInStackRequest>()
             .add_message::<SettingsPageSpawnRequest>()
             .add_message::<SpacesPageSpawnRequest>()
@@ -784,7 +785,6 @@ fn close_command_bar_panel(layout: Entity, commands: &mut Commands) {
 
 #[derive(SystemParam)]
 struct CommandBarActionQueries<'w, 's> {
-    tab_q: Query<'w, 's, (Entity, &'static LastActivatedAt), With<Tab>>,
     active_tab_param: ActiveTabParam<'w, 's>,
     all_children: Query<'w, 's, &'static Children>,
     leaf_panes: Query<'w, 's, Entity, (With<Pane>, Without<PaneSplit>)>,
@@ -918,7 +918,8 @@ fn on_command_bar_action(
         MessageWriter<PageOpenRequest>,
         MessageWriter<TerminalSpawnRequest>,
     )>,
-    mut chosen_writer: MessageWriter<vmux_layout::ContributedCommandChosen>,
+    mut chosen_writer: MessageWriter<vmux_core::ContributedCommandChosen>,
+    mut abandoned_writer: MessageWriter<PendingStackAbandoned>,
     mut issued: MessageWriter<vmux_command::CommandIssued>,
     user_q: Query<Entity, With<vmux_core::team::User>>,
     mut commands: Commands,
@@ -1041,7 +1042,7 @@ fn on_command_bar_action(
                 };
                 if !inline_transition && resource_params.p2().claims_url(&url) {
                     if let Some(stack_e) = empty_stack {
-                        chosen_writer.write(vmux_layout::ContributedCommandChosen {
+                        chosen_writer.write(vmux_core::ContributedCommandChosen {
                             id: url.clone(),
                             stack: Some(stack_e),
                             pane: None,
@@ -1052,7 +1053,7 @@ fn on_command_bar_action(
                     } else {
                         let active_pane_opt = queries.focused_pane();
                         if let Some(pane_e) = active_pane_opt {
-                            chosen_writer.write(vmux_layout::ContributedCommandChosen {
+                            chosen_writer.write(vmux_core::ContributedCommandChosen {
                                 id: url.clone(),
                                 stack: None,
                                 pane: Some(pane_e),
@@ -1173,7 +1174,7 @@ fn on_command_bar_action(
                     new_stack_ctx.previous_stack = None;
                 }
                 if empty_stack.is_some() || pane.is_some() {
-                    chosen_writer.write(vmux_layout::ContributedCommandChosen {
+                    chosen_writer.write(vmux_core::ContributedCommandChosen {
                         id: id.clone(),
                         stack: empty_stack,
                         pane,
@@ -1262,31 +1263,11 @@ fn on_command_bar_action(
         }
         CommandBarActionEvent::Dismiss => {
             if let Some(stack_e) = empty_stack {
-                let stack_q = stack_params.p0();
-                let closed_tab = close_tab_if_only_pending_stack(
-                    stack_e,
-                    &queries.tab_q,
-                    &queries.child_of_q,
-                    &queries.all_children,
-                    &stack_q,
-                    &mut commands,
-                );
-                if !closed_tab {
-                    commands.entity(stack_e).despawn();
-                }
+                abandoned_writer.write(PendingStackAbandoned {
+                    stack: stack_e,
+                    previous_stack,
+                });
                 new_stack_ctx.stack = None;
-                if !closed_tab {
-                    // Restore keyboard to previous tab's browser
-                    if let Some(prev) = previous_stack
-                        && let Ok(children) = queries.all_children.get(prev)
-                    {
-                        for child in children.iter() {
-                            if queries.content_browsers.contains(child) {
-                                commands.entity(child).try_insert(CefKeyboardTarget);
-                            }
-                        }
-                    }
-                }
                 new_stack_ctx.previous_stack = None;
                 custom_keyboard_restore = true;
             }
@@ -1321,75 +1302,6 @@ fn on_command_bar_action(
             }
         }
     }
-}
-
-fn close_tab_if_only_pending_stack(
-    stack: Entity,
-    tab_q: &Query<(Entity, &LastActivatedAt), With<Tab>>,
-    child_of_q: &Query<&ChildOf>,
-    all_children: &Query<&Children>,
-    stack_q: &Query<Entity, With<Stack>>,
-    commands: &mut Commands,
-) -> bool {
-    let Some(tab) = ancestor_tab(stack, tab_q, child_of_q) else {
-        return false;
-    };
-    if entity_tree_contains_stack_other_than(tab, stack, all_children, stack_q) {
-        return false;
-    }
-    let siblings = sibling_tabs(tab, tab_q, child_of_q, all_children);
-    if siblings.len() <= 1 {
-        return false;
-    }
-    if let Some(next) = vmux_layout::tab::pick_after_close(tab, &siblings) {
-        commands.entity(next).insert(LastActivatedAt::now());
-    }
-    commands.entity(tab).despawn();
-    true
-}
-
-fn ancestor_tab(
-    entity: Entity,
-    tab_q: &Query<(Entity, &LastActivatedAt), With<Tab>>,
-    child_of_q: &Query<&ChildOf>,
-) -> Option<Entity> {
-    let mut current = entity;
-    while let Ok(parent) = child_of_q.get(current).map(Relationship::get) {
-        if tab_q.get(parent).is_ok() {
-            return Some(parent);
-        }
-        current = parent;
-    }
-    None
-}
-
-fn entity_tree_contains_stack_other_than(
-    entity: Entity,
-    ignored_stack: Entity,
-    all_children: &Query<&Children>,
-    stack_q: &Query<Entity, With<Stack>>,
-) -> bool {
-    (stack_q.contains(entity) && entity != ignored_stack)
-        || all_children.get(entity).is_ok_and(|children| {
-            children.iter().any(|child| {
-                entity_tree_contains_stack_other_than(child, ignored_stack, all_children, stack_q)
-            })
-        })
-}
-
-fn sibling_tabs(
-    tab: Entity,
-    tab_q: &Query<(Entity, &LastActivatedAt), With<Tab>>,
-    child_of_q: &Query<&ChildOf>,
-    all_children: &Query<&Children>,
-) -> Vec<Entity> {
-    let Ok(parent) = child_of_q.get(tab).map(Relationship::get) else {
-        return vec![tab];
-    };
-    let Ok(children) = all_children.get(parent) else {
-        return vec![tab];
-    };
-    children.iter().filter(|e| tab_q.get(*e).is_ok()).collect()
 }
 
 fn deferred_dismiss_modal(

--- a/crates/vmux_browser/src/command_bar/handler.rs
+++ b/crates/vmux_browser/src/command_bar/handler.rs
@@ -1,10 +1,10 @@
 use std::time::{Duration, Instant};
 use vmux_command::CommandBar;
 use vmux_command::build_command_bar_open_payload;
+pub(crate) use vmux_core::launcher::PendingLaunch;
 use vmux_core::launcher::{
     FocusLauncherInput, HostsLauncher, InlineTransitionRequested, PendingStackAbandoned,
 };
-pub(crate) use vmux_layout::NewStackContext;
 use vmux_layout::workspace_snapshot::gather_command_bar_tabs;
 
 use crate::command_bar::panel::CommandBarPanelActive;
@@ -58,7 +58,7 @@ pub(crate) struct CommandBarInputPlugin;
 
 impl Plugin for CommandBarInputPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<NewStackContext>()
+        app.init_resource::<PendingLaunch>()
             .add_message::<vmux_core::ContributedCommandChosen>()
             .add_message::<PendingStackAbandoned>()
             .add_message::<FocusLauncherInput>()
@@ -452,17 +452,17 @@ fn command_bar_open_request(
 }
 
 fn pending_stack_startup_url_request(
-    new_stack_ctx: &mut NewStackContext,
+    pending_launch: &mut PendingLaunch,
     startup_url: Option<&str>,
 ) -> Option<PageOpenRequest> {
-    if !new_stack_ctx.needs_open {
+    if !pending_launch.needs_open {
         return None;
     }
-    let stack = new_stack_ctx.stack?;
+    let stack = pending_launch.stack?;
     let url = startup_url.filter(|url| !url.is_empty())?;
-    new_stack_ctx.stack = None;
-    new_stack_ctx.previous_stack = None;
-    new_stack_ctx.needs_open = false;
+    pending_launch.stack = None;
+    pending_launch.previous_stack = None;
+    pending_launch.needs_open = false;
     Some(PageOpenRequest {
         target: PageOpenTarget::Stack(stack),
         url: url.to_string(),
@@ -471,15 +471,15 @@ fn pending_stack_startup_url_request(
 }
 
 fn command_bar_should_open_pending_stack(
-    new_stack_ctx: &mut NewStackContext,
+    pending_launch: &mut PendingLaunch,
     explicit_toggle: bool,
 ) -> bool {
     if explicit_toggle {
-        new_stack_ctx.needs_open = false;
+        pending_launch.needs_open = false;
         return false;
     }
-    if new_stack_ctx.needs_open {
-        new_stack_ctx.needs_open = false;
+    if pending_launch.needs_open {
+        pending_launch.needs_open = false;
         true
     } else {
         false
@@ -487,15 +487,15 @@ fn command_bar_should_open_pending_stack(
 }
 
 fn command_bar_cancel_pending_stack_for_active_open(
-    new_stack_ctx: &mut NewStackContext,
+    pending_launch: &mut PendingLaunch,
     replace_active_stack: bool,
 ) -> Option<(Entity, Option<Entity>)> {
     if !replace_active_stack {
         return None;
     }
-    new_stack_ctx.needs_open = false;
-    let previous_stack = new_stack_ctx.previous_stack.take();
-    let stack = new_stack_ctx.stack.take()?;
+    pending_launch.needs_open = false;
+    let previous_stack = pending_launch.previous_stack.take();
+    let stack = pending_launch.stack.take()?;
     Some((stack, previous_stack))
 }
 
@@ -554,7 +554,7 @@ fn handle_open_command_bar(
     contributions: Contributions,
     mut snapshot_params: ParamSet<(
         Res<CommandBarSpacesSnapshot>,
-        ResMut<NewStackContext>,
+        ResMut<PendingLaunch>,
         Option<Res<vmux_layout::settings::EffectiveStartupUrl>>,
         MessageWriter<PageOpenRequest>,
         Res<CommandBarPagesSnapshot>,
@@ -594,8 +594,8 @@ fn handle_open_command_bar(
 
     let mut active_stack_override = None;
     let canceled_pending_stack = {
-        let mut new_stack_ctx = snapshot_params.p1();
-        command_bar_cancel_pending_stack_for_active_open(&mut new_stack_ctx, replace_active_stack)
+        let mut pending_launch = snapshot_params.p1();
+        command_bar_cancel_pending_stack_for_active_open(&mut pending_launch, replace_active_stack)
     };
     if let Some((stack, previous_stack)) = canceled_pending_stack {
         commands.entity(stack).despawn();
@@ -607,11 +607,11 @@ fn handle_open_command_bar(
 
     if (should_dismiss || toggle_closes) && is_open {
         close_command_bar_panel(layout_e, &mut commands);
-        let mut new_stack_ctx = snapshot_params.p1();
+        let mut pending_launch = snapshot_params.p1();
         // Discard empty tab created by a previous Cmd+T
-        if let Some(stack_e) = new_stack_ctx.stack.take() {
+        if let Some(stack_e) = pending_launch.stack.take() {
             commands.entity(stack_e).despawn();
-            if let Some(prev) = new_stack_ctx.previous_stack.take()
+            if let Some(prev) = pending_launch.previous_stack.take()
                 && let Ok(children) = all_children.get(prev)
             {
                 for child in children.iter() {
@@ -642,7 +642,7 @@ fn handle_open_command_bar(
                 }
             }
         }
-        new_stack_ctx.needs_open = false;
+        pending_launch.needs_open = false;
         return;
     }
 
@@ -655,8 +655,8 @@ fn handle_open_command_bar(
     }
 
     let startup_request = {
-        let mut new_stack_ctx = snapshot_params.p1();
-        pending_stack_startup_url_request(&mut new_stack_ctx, startup_url.as_deref())
+        let mut pending_launch = snapshot_params.p1();
+        pending_stack_startup_url_request(&mut pending_launch, startup_url.as_deref())
     };
     if let Some(request) = startup_request {
         snapshot_params.p3().write(request);
@@ -664,8 +664,8 @@ fn handle_open_command_bar(
     }
 
     let should_open_pending_stack = {
-        let mut new_stack_ctx = snapshot_params.p1();
-        command_bar_should_open_pending_stack(&mut new_stack_ctx, should_toggle)
+        let mut pending_launch = snapshot_params.p1();
+        command_bar_should_open_pending_stack(&mut pending_launch, should_toggle)
     };
     if should_open_pending_stack {
         should_open = true;
@@ -912,7 +912,7 @@ fn on_command_bar_action(
         Contributions,
         Option<Res<ResolvedLocale>>,
     )>,
-    mut new_stack_ctx: ResMut<NewStackContext>,
+    mut pending_launch: ResMut<PendingLaunch>,
     mut writer_params: ParamSet<(
         MessageWriter<AppCommand>,
         MessageWriter<PageOpenRequest>,
@@ -931,8 +931,8 @@ fn on_command_bar_action(
     let terminals_snapshot = resource_params.p1().clone();
     let terminal_page_url = terminals_snapshot.terminal_page_url.clone();
     let running_terminals = terminals_snapshot.running.clone();
-    let mut empty_stack = new_stack_ctx.stack;
-    let previous_stack = new_stack_ctx.previous_stack;
+    let mut empty_stack = pending_launch.stack;
+    let previous_stack = pending_launch.previous_stack;
     let mut custom_keyboard_restore = false;
     let inline_transition_stack = queries.inline_transition_stack(webview);
     let locale = resource_params
@@ -982,8 +982,8 @@ fn on_command_bar_action(
                         url,
                         request_id: None,
                     });
-                    new_stack_ctx.stack = None;
-                    new_stack_ctx.previous_stack = None;
+                    pending_launch.stack = None;
+                    pending_launch.previous_stack = None;
                     custom_keyboard_restore = true;
                 }
             }
@@ -1023,8 +1023,8 @@ fn on_command_bar_action(
                             ..default()
                         }),
                     });
-                    new_stack_ctx.stack = None;
-                    new_stack_ctx.previous_stack = None;
+                    pending_launch.stack = None;
+                    pending_launch.previous_stack = None;
                     custom_keyboard_restore = true;
                 }
             } else {
@@ -1048,8 +1048,8 @@ fn on_command_bar_action(
                             stack: Some(stack_e),
                             pane: None,
                         });
-                        new_stack_ctx.stack = None;
-                        new_stack_ctx.previous_stack = None;
+                        pending_launch.stack = None;
+                        pending_launch.previous_stack = None;
                         custom_keyboard_restore = true;
                     } else {
                         let active_pane_opt = queries.focused_pane();
@@ -1068,8 +1068,8 @@ fn on_command_bar_action(
                         url,
                         request_id: None,
                     });
-                    new_stack_ctx.stack = None;
-                    new_stack_ctx.previous_stack = None;
+                    pending_launch.stack = None;
+                    pending_launch.previous_stack = None;
                     custom_keyboard_restore = true;
                 } else {
                     let target = *open;
@@ -1087,8 +1087,8 @@ fn on_command_bar_action(
             let known_terminal = running_terminals.get(value).copied();
             if let Some(entity) = known_terminal {
                 focus_pane_entity(entity, &mut commands, &queries.child_of_q);
-                new_stack_ctx.stack = None;
-                new_stack_ctx.previous_stack = None;
+                pending_launch.stack = None;
+                pending_launch.previous_stack = None;
                 custom_keyboard_restore = true;
             } else {
                 if value.starts_with(&terminal_page_url) {
@@ -1120,8 +1120,8 @@ fn on_command_bar_action(
                             ..default()
                         }),
                     });
-                    new_stack_ctx.stack = None;
-                    new_stack_ctx.previous_stack = None;
+                    pending_launch.stack = None;
+                    pending_launch.previous_stack = None;
                     custom_keyboard_restore = true;
                 } else {
                     let active_pane_opt = queries.focused_pane();
@@ -1164,8 +1164,8 @@ fn on_command_bar_action(
                     if let Ok(parent) = queries.child_of_q.get(stack_e) {
                         commands.entity(parent.0).insert(LastActivatedAt::now());
                     }
-                    new_stack_ctx.stack = None;
-                    new_stack_ctx.previous_stack = None;
+                    pending_launch.stack = None;
+                    pending_launch.previous_stack = None;
                 }
                 if empty_stack.is_some() || pane.is_some() {
                     chosen_writer.write(vmux_core::ContributedCommandChosen {
@@ -1182,8 +1182,8 @@ fn on_command_bar_action(
                         url,
                         request_id: None,
                     });
-                    new_stack_ctx.stack = None;
-                    new_stack_ctx.previous_stack = None;
+                    pending_launch.stack = None;
+                    pending_launch.previous_stack = None;
                     empty_stack = None;
                 } else {
                     let target = *open;
@@ -1206,8 +1206,8 @@ fn on_command_bar_action(
             // If in new-tab mode and a command was executed, clean up the empty tab
             if let Some(stack_e) = empty_stack {
                 commands.entity(stack_e).despawn();
-                new_stack_ctx.stack = None;
-                new_stack_ctx.previous_stack = None;
+                pending_launch.stack = None;
+                pending_launch.previous_stack = None;
             }
         }
         CommandBarActionEvent::Space { id } => {
@@ -1224,15 +1224,15 @@ fn on_command_bar_action(
             }
             if let Some(stack_e) = empty_stack {
                 commands.entity(stack_e).despawn();
-                new_stack_ctx.stack = None;
-                new_stack_ctx.previous_stack = None;
+                pending_launch.stack = None;
+                pending_launch.previous_stack = None;
             }
         }
         CommandBarActionEvent::SwitchTab { pane, index } => {
             if let Some(stack_e) = empty_stack {
                 commands.entity(stack_e).despawn();
-                new_stack_ctx.stack = None;
-                new_stack_ctx.previous_stack = None;
+                pending_launch.stack = None;
+                pending_launch.previous_stack = None;
             }
             if let Some(target_pane) = queries.leaf_panes.iter().find(|e| e.to_bits() == *pane) {
                 let target_stack = {
@@ -1261,8 +1261,8 @@ fn on_command_bar_action(
                     stack: stack_e,
                     previous_stack,
                 });
-                new_stack_ctx.stack = None;
-                new_stack_ctx.previous_stack = None;
+                pending_launch.stack = None;
+                pending_launch.previous_stack = None;
                 custom_keyboard_restore = true;
             }
         }
@@ -1299,7 +1299,7 @@ fn on_command_bar_action(
 }
 
 fn deferred_dismiss_modal(
-    mut new_stack_ctx: ResMut<NewStackContext>,
+    mut pending_launch: ResMut<PendingLaunch>,
     mut modal_q: Query<
         (
             Entity,
@@ -1311,10 +1311,10 @@ fn deferred_dismiss_modal(
     >,
     mut commands: Commands,
 ) {
-    if !new_stack_ctx.dismiss_modal {
+    if !pending_launch.dismiss_modal {
         return;
     }
-    new_stack_ctx.dismiss_modal = false;
+    pending_launch.dismiss_modal = false;
     if let Ok((modal_e, mut modal_node, mut modal_vis, native_overlay)) = modal_q.single_mut()
         && modal_node.display != Display::None
     {
@@ -2061,7 +2061,7 @@ mod tests {
             .init_resource::<CommandBarSpacesSnapshot>()
             .init_resource::<CommandBarPagesSnapshot>()
             .init_resource::<vmux_command::snapshot::CommandBarWorkSnapshot>()
-            .init_resource::<NewStackContext>()
+            .init_resource::<PendingLaunch>()
             .init_resource::<EmittedToPage>()
             .add_observer(capture_page_emit)
             .add_systems(Update, handle_open_command_bar);
@@ -2144,7 +2144,7 @@ mod tests {
             .spawn((LayoutCef, CommandBarPanelActive))
             .id();
         let pending = app.world_mut().spawn_empty().id();
-        app.insert_resource(NewStackContext {
+        app.insert_resource(PendingLaunch {
             stack: Some(pending),
             previous_stack: None,
             needs_open: true,
@@ -2161,7 +2161,7 @@ mod tests {
             vec![(layout, LAYOUT_COMMAND_BAR_CLOSE_EVENT.to_string())]
         );
         assert!(app.world().get_entity(pending).is_err());
-        let ctx = app.world().resource::<NewStackContext>();
+        let ctx = app.world().resource::<PendingLaunch>();
         assert!(ctx.stack.is_none());
         assert!(!ctx.needs_open);
     }
@@ -2208,7 +2208,7 @@ mod tests {
         let request = command_bar_open_request([AppCommand::Browser(BrowserCommand::Bar(
             BrowserBarCommand::OpenPageInCommandBar,
         ))]);
-        let mut ctx = NewStackContext {
+        let mut ctx = PendingLaunch {
             stack: Some(pending_stack),
             previous_stack: Some(previous_stack),
             needs_open: true,
@@ -2232,7 +2232,7 @@ mod tests {
     fn pending_stack_with_startup_url_dispatches_url_request() {
         let stack = Entity::from_bits(7);
         let previous_stack = Entity::from_bits(6);
-        let mut ctx = NewStackContext {
+        let mut ctx = PendingLaunch {
             stack: Some(stack),
             previous_stack: Some(previous_stack),
             needs_open: true,
@@ -2255,7 +2255,7 @@ mod tests {
     #[test]
     fn pending_stack_without_startup_url_keeps_prompt_pending() {
         let stack = Entity::from_bits(7);
-        let mut ctx = NewStackContext {
+        let mut ctx = PendingLaunch {
             stack: Some(stack),
             previous_stack: None,
             needs_open: true,

--- a/crates/vmux_browser/src/command_bar/handler.rs
+++ b/crates/vmux_browser/src/command_bar/handler.rs
@@ -30,7 +30,7 @@ use vmux_command::{
 };
 use vmux_core::event::space::SpaceCommandEvent;
 use vmux_core::page::{SettingsPageSpawnRequest, SpacesPageSpawnRequest};
-use vmux_core::terminal::{Terminal, TerminalSpawnRequest};
+use vmux_core::terminal::{Terminal, TerminalSpawnRequest, TerminalSpawnTarget};
 use vmux_core::{
     PageMetadata, PageOpenRequest, PageOpenTarget, PendingPrompt, PendingPromptAttachments,
 };
@@ -1010,17 +1010,17 @@ fn on_command_bar_action(
                     expanded.parent().unwrap_or(&expanded)
                 };
                 if let Some(stack_e) = empty_stack {
-                    commands.entity(stack_e).insert(PageMetadata {
-                        url: terminal_page_url.clone(),
-                        title: locale.translate_with(
-                            "command-terminal-path",
-                            &[("path", TranslationValue::String(&dir.display().to_string()))],
-                        ),
-                        ..default()
-                    });
                     writer_params.p2().write(TerminalSpawnRequest {
                         cwd: Some(dir.to_path_buf()),
-                        target_stack: Some(stack_e),
+                        target: TerminalSpawnTarget::Stack(stack_e),
+                        metadata: Some(PageMetadata {
+                            url: terminal_page_url.clone(),
+                            title: locale.translate_with(
+                                "command-terminal-path",
+                                &[("path", TranslationValue::String(&dir.display().to_string()))],
+                            ),
+                            ..default()
+                        }),
                     });
                     new_stack_ctx.stack = None;
                     new_stack_ctx.previous_stack = None;
@@ -1110,14 +1110,14 @@ fn on_command_bar_action(
                     Some(expanded)
                 };
                 if let Some(stack_e) = empty_stack {
-                    commands.entity(stack_e).insert(PageMetadata {
-                        url: terminal_page_url.clone(),
-                        title: locale.translate("command-terminal"),
-                        ..default()
-                    });
                     writer_params.p2().write(TerminalSpawnRequest {
                         cwd: cwd.clone(),
-                        target_stack: Some(stack_e),
+                        target: TerminalSpawnTarget::Stack(stack_e),
+                        metadata: Some(PageMetadata {
+                            url: terminal_page_url.clone(),
+                            title: locale.translate("command-terminal"),
+                            ..default()
+                        }),
                     });
                     new_stack_ctx.stack = None;
                     new_stack_ctx.previous_stack = None;
@@ -1125,21 +1125,14 @@ fn on_command_bar_action(
                 } else {
                     let active_pane_opt = queries.focused_pane();
                     if let Some(pane_e) = active_pane_opt {
-                        let stack_e = commands
-                            .spawn((
-                                vmux_layout::stack::stack_bundle(),
-                                LastActivatedAt::now(),
-                                ChildOf(pane_e),
-                            ))
-                            .id();
-                        commands.entity(stack_e).insert(PageMetadata {
-                            url: terminal_page_url.clone(),
-                            title: locale.translate("command-terminal"),
-                            ..default()
-                        });
                         writer_params.p2().write(TerminalSpawnRequest {
                             cwd: cwd.clone(),
-                            target_stack: Some(stack_e),
+                            target: TerminalSpawnTarget::NewStackInPane(pane_e),
+                            metadata: Some(PageMetadata {
+                                url: terminal_page_url.clone(),
+                                title: locale.translate("command-terminal"),
+                                ..default()
+                            }),
                         });
                     } else {
                         let cmd =

--- a/crates/vmux_browser/src/command_bar/wake.rs
+++ b/crates/vmux_browser/src/command_bar/wake.rs
@@ -26,7 +26,7 @@ fn command_bar_should_wake(needs_open: bool, has_active_reveal: bool) -> bool {
 }
 
 /// The bar opens across several reactive frames: the first shortcut may defer
-/// (`NewStackContext::needs_open`) until the webview is ready, then a reveal
+/// (`PendingLaunch::needs_open`) until the webview is ready, then a reveal
 /// (`PendingCommandBarReveal`) waits for the rendered/sized ack. Without an explicit wake the loop
 /// idles after the keystroke and the open stalls until the next input — the user has to press
 /// Cmd+K/Cmd+L twice. Runs after `ReadAppCommands` so a `needs_open` set this frame is observed.
@@ -34,10 +34,10 @@ fn command_bar_should_wake(needs_open: bool, has_active_reveal: bool) -> bool {
 /// `open_id == 0` (inactive), so we stop waking.
 fn keep_awake_while_command_bar_opening(
     proxy: Option<Res<EventLoopProxyWrapper>>,
-    new_stack_ctx: Option<Res<vmux_layout::NewStackContext>>,
+    pending_launch: Option<Res<vmux_core::launcher::PendingLaunch>>,
     pending: Query<&PendingCommandBarReveal>,
 ) {
-    let needs_open = new_stack_ctx.map(|ctx| ctx.needs_open).unwrap_or(false);
+    let needs_open = pending_launch.map(|ctx| ctx.needs_open).unwrap_or(false);
     let has_active_reveal = pending.iter().any(PendingCommandBarReveal::is_active);
     if !command_bar_should_wake(needs_open, has_active_reveal) {
         return;

--- a/crates/vmux_browser/src/page_state.rs
+++ b/crates/vmux_browser/src/page_state.rs
@@ -138,7 +138,7 @@ fn push_stacks_host_emit(
     >,
     stack_q: Query<(), With<Stack>>,
     zoomed_q: Query<(), With<vmux_layout::pane::Zoomed>>,
-    new_stack_ctx: Res<vmux_layout::NewStackContext>,
+    pending_launch: Res<vmux_core::launcher::PendingLaunch>,
     focus: Res<vmux_layout::stack::FocusedStack>,
     child_of_q: Query<&ChildOf>,
     mut last: Local<String>,
@@ -181,7 +181,7 @@ fn push_stacks_host_emit(
             });
         }
     }
-    if should_emit_new_stack_placeholder(new_stack_ctx.stack, active_stack_opt, &rows) {
+    if should_emit_new_stack_placeholder(pending_launch.stack, active_stack_opt, &rows) {
         rows.retain(|r| !r.is_active);
         rows.push(StackRow {
             title: "New Stack".to_string(),
@@ -213,7 +213,7 @@ fn push_pane_tree_emit(
     mut commands: Commands,
     browsers: NonSend<Browsers>,
     cef_q: Query<(Entity, Ref<PageReady>), With<LayoutCef>>,
-    new_stack_ctx: Res<vmux_layout::NewStackContext>,
+    pending_launch: Res<vmux_core::launcher::PendingLaunch>,
     focus: Res<vmux_layout::stack::FocusedStack>,
     tab_q: Query<(), With<Tab>>,
     tab_sections: Query<&SideSheetSectionsExpanded, With<Tab>>,
@@ -262,7 +262,7 @@ fn push_pane_tree_emit(
                 if let Ok(stack_kids) = stack_children.get(child) {
                     for browser_e in stack_kids.iter() {
                         if let Ok((meta, loading, osc)) = browser_meta.get(browser_e) {
-                            let is_new_stack = new_stack_ctx.stack == Some(child)
+                            let is_new_stack = pending_launch.stack == Some(child)
                                 && (meta.url.is_empty() || meta.url == "about:blank");
                             stacks.push(StackNode {
                                 title: if is_new_stack {

--- a/crates/vmux_browser/src/present.rs
+++ b/crates/vmux_browser/src/present.rs
@@ -182,7 +182,7 @@ fn sync_children_to_ui(
     tab_ts: Query<(Entity, &LastActivatedAt), With<Stack>>,
     tabs_q: Query<(Entity, &LastActivatedAt), With<Tab>>,
     active_tab_q: Query<(), (With<Tab>, With<vmux_core::Active>)>,
-    new_stack_ctx: Res<vmux_layout::NewStackContext>,
+    pending_launch: Res<vmux_core::launcher::PendingLaunch>,
     glass: Single<(Entity, &ComputedNode, &UiGlobalTransform), With<VmuxWindow>>,
 ) {
     let &(glass_entity, glass_node, glass_ui_gt) = &*glass;
@@ -258,7 +258,7 @@ fn sync_children_to_ui(
         // Keep rendering the previous tab behind while a new empty tab
         // (without CEF content) is pending in the command bar flow.
         let is_previous_stack =
-            new_stack_ctx.stack.is_some() && new_stack_ctx.previous_stack == Some(parent);
+            pending_launch.stack.is_some() && pending_launch.previous_stack == Some(parent);
 
         let is_inactive_stack =
             parent != glass_entity && !is_cef_ui && !is_active_stack && !is_previous_stack;
@@ -1040,7 +1040,7 @@ fn sync_osr_webview_focus(
     >,
     primary_window: Single<&Window, With<PrimaryWindow>>,
     focus: Res<vmux_layout::stack::FocusedStack>,
-    new_stack_ctx: Res<vmux_layout::NewStackContext>,
+    pending_launch: Res<vmux_core::launcher::PendingLaunch>,
     leaf_panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
     pane_children_q: Query<&Children, With<Pane>>,
     tab_ts: Query<(Entity, &LastActivatedAt), With<Stack>>,
@@ -1149,8 +1149,8 @@ fn sync_osr_webview_focus(
                         active_stack_in_pane(pane, &pane_children_q, &tab_ts) == Some(parent);
                     // Keep previous tab's webview visible while an empty new tab is
                     // pending (user is picking content in the command bar).
-                    is_prev = new_stack_ctx.stack.is_some()
-                        && new_stack_ctx.previous_stack == Some(parent);
+                    is_prev = pending_launch.stack.is_some()
+                        && pending_launch.previous_stack == Some(parent);
                 }
             }
         }

--- a/crates/vmux_core/src/host.rs
+++ b/crates/vmux_core/src/host.rs
@@ -30,7 +30,7 @@ pub use archive::{
 pub use host_spawn::{HostSpawnRegistry, register_host_spawn};
 pub use launcher::{
     ContributedCommandChosen, FocusLauncherInput, HostsLauncher, InlineTransitionRequested,
-    PendingStackAbandoned,
+    PendingLaunch, PendingStackAbandoned,
 };
 pub use notify::{AgentAttention, AgentDoneUnseen, BellReceived, OsNotify};
 pub use overlay::{OverlayState, OverlayStateQuery, WindowOverlay};

--- a/crates/vmux_core/src/host.rs
+++ b/crates/vmux_core/src/host.rs
@@ -28,7 +28,10 @@ pub use archive::{
     ArchivedPage, ArchivedPagePosition, ArchivedTabPage, PageArchiveRequest, PaneStep, SplitAxis,
 };
 pub use host_spawn::{HostSpawnRegistry, register_host_spawn};
-pub use launcher::{ContributedCommandChosen, PendingStackAbandoned};
+pub use launcher::{
+    ContributedCommandChosen, FocusLauncherInput, HostsLauncher, InlineTransitionRequested,
+    PendingStackAbandoned,
+};
 pub use notify::{AgentAttention, AgentDoneUnseen, BellReceived, OsNotify};
 pub use overlay::{OverlayState, OverlayStateQuery, WindowOverlay};
 pub use page_open::{

--- a/crates/vmux_core/src/host.rs
+++ b/crates/vmux_core/src/host.rs
@@ -15,6 +15,7 @@ pub mod archive;
 pub mod browser;
 pub mod extension;
 pub mod host_spawn;
+pub mod launcher;
 pub mod notify;
 pub mod overlay;
 pub mod page;
@@ -27,6 +28,7 @@ pub use archive::{
     ArchivedPage, ArchivedPagePosition, ArchivedTabPage, PageArchiveRequest, PaneStep, SplitAxis,
 };
 pub use host_spawn::{HostSpawnRegistry, register_host_spawn};
+pub use launcher::{ContributedCommandChosen, PendingStackAbandoned};
 pub use notify::{AgentAttention, AgentDoneUnseen, BellReceived, OsNotify};
 pub use overlay::{OverlayState, OverlayStateQuery, WindowOverlay};
 pub use page_open::{

--- a/crates/vmux_core/src/host/launcher.rs
+++ b/crates/vmux_core/src/host/launcher.rs
@@ -22,6 +22,22 @@ pub struct ContributedCommandChosen {
     pub pane: Option<Entity>,
 }
 
+/// An empty stack waiting for a launcher to fill it, and what to undo if it never does.
+///
+/// The workspace stages this when a launcher is about to open onto fresh space - Cmd+T, or Cmd+K
+/// on an empty pane - and the launcher consumes it. Both sides need it, so it belongs to neither:
+/// the workspace cannot depend on the launcher, and the launcher must not depend on the workspace.
+#[derive(Resource, Default, Debug)]
+pub struct PendingLaunch {
+    /// The empty stack staged for whatever the user picks.
+    pub stack: Option<Entity>,
+    /// Where focus was beforehand, to go back to on dismiss.
+    pub previous_stack: Option<Entity>,
+    /// The launcher has been asked to open and has not managed it yet.
+    pub needs_open: bool,
+    pub dismiss_modal: bool,
+}
+
 /// A page that hosts a launcher of its own.
 ///
 /// The start page carries this. Two things follow from it, and both used to be decided by

--- a/crates/vmux_core/src/host/launcher.rs
+++ b/crates/vmux_core/src/host/launcher.rs
@@ -1,0 +1,36 @@
+//! What a launcher surface tells the workspace.
+//!
+//! A launcher — the command bar, the start page — opens *onto* the workspace without owning it. It
+//! knows what the user picked; it does not know what a stack, a tab or a pane is. These are the
+//! things it has to say, so that the crate that does own the workspace can answer them.
+//!
+//! They live here rather than with either side because neither is the author: the launcher cannot
+//! depend on the workspace without inverting the layering, and the workspace must not be taught
+//! which launcher is asking.
+
+use bevy::prelude::*;
+
+/// A launcher row contributed through `CommandBarContributions` was chosen.
+///
+/// The launcher does not know what the row means — whoever published the id answers this. `stack`
+/// is the empty stack the launcher was opened on; when there is none, `pane` is the focused pane to
+/// spawn into. Exactly one of the two is set.
+#[derive(Message, Clone, Debug)]
+pub struct ContributedCommandChosen {
+    pub id: String,
+    pub stack: Option<Entity>,
+    pub pane: Option<Entity>,
+}
+
+/// The launcher was dismissed without ever using the empty stack it was opened on.
+///
+/// Disposing of it is the workspace's business, and more than a despawn: opening the launcher with
+/// Cmd+T creates a whole tab to hold that one stack, and abandoning it should take the tab too.
+/// Which of the two happened also decides where the keyboard goes back to, so the workspace
+/// restores it rather than reporting back.
+#[derive(Message, Clone, Debug)]
+pub struct PendingStackAbandoned {
+    pub stack: Entity,
+    /// Where focus was before the launcher opened.
+    pub previous_stack: Option<Entity>,
+}

--- a/crates/vmux_core/src/host/launcher.rs
+++ b/crates/vmux_core/src/host/launcher.rs
@@ -22,6 +22,34 @@ pub struct ContributedCommandChosen {
     pub pane: Option<Entity>,
 }
 
+/// A page that hosts a launcher of its own.
+///
+/// The start page carries this. Two things follow from it, and both used to be decided by
+/// comparing the page's URL against `vmux://start/` from outside: the launcher shortcut focuses
+/// this page's input rather than opening a second launcher over it, and picking something the page
+/// can become morphs it in place rather than opening a page beside it.
+///
+/// Asking for the capability means the command bar never learns which page this is, and a second
+/// page that wants the same behaviour needs no change to the bar.
+#[derive(Component, Clone, Copy, Debug)]
+pub struct HostsLauncher;
+
+/// Put the caret in the launcher this page hosts, rather than opening one over it.
+#[derive(Message, Clone, Copy, Debug)]
+pub struct FocusLauncherInput {
+    pub webview: Entity,
+}
+
+/// The page in `stack` can become what was just picked, so it should morph rather than be replaced.
+///
+/// What "morph" means belongs to the page — the launcher only reports that the opportunity is
+/// there, having checked the target is something the page can turn into.
+#[derive(Message, Clone, Copy, Debug)]
+pub struct InlineTransitionRequested {
+    pub stack: Entity,
+    pub webview: Entity,
+}
+
 /// The launcher was dismissed without ever using the empty stack it was opened on.
 ///
 /// Disposing of it is the workspace's business, and more than a despawn: opening the launcher with

--- a/crates/vmux_core/src/host/terminal.rs
+++ b/crates/vmux_core/src/host/terminal.rs
@@ -28,10 +28,25 @@ pub enum TerminalKind {
     Codex,
 }
 
+/// Where a spawning terminal should land.
+///
+/// `NewStackInPane` exists so a caller that has a pane but no stack does not have to build one:
+/// making a stack is workspace shape, and a launcher asking for a terminal has no business
+/// knowing how one is assembled.
+#[derive(Debug, Clone, Copy)]
+pub enum TerminalSpawnTarget {
+    Stack(Entity),
+    NewStackInPane(Entity),
+    /// Left unparented for the caller to place.
+    Detached,
+}
+
 #[derive(Message, Debug, Clone)]
 pub struct TerminalSpawnRequest {
     pub cwd: Option<std::path::PathBuf>,
-    pub target_stack: Option<Entity>,
+    pub target: TerminalSpawnTarget,
+    /// Shown in the tab strip until the terminal reports a title of its own.
+    pub metadata: Option<crate::PageMetadata>,
 }
 
 #[derive(Message, Debug, Clone)]


### PR DESCRIPTION
Stacked on #384. Part of stage 3 of giving the command bar to `vmux_command` — see #378 for the full picture.

## Summary

The bar can't move to its own crate while it reaches into `vmux_layout`, because `vmux_layout -> vmux_command` already exists and the reverse is a cycle. So each reach becomes a message the workspace answers, the same way `vmux_terminal` and `vmux_space` already work. This PR does two of them.

## Dismissing the bar was doing workspace surgery

Walking away from the launcher without picking anything ran 55 lines *inside the bar*: climb to the ancestor tab, recurse the subtree looking for another stack, gather sibling tabs, pick which one gets the active marker, despawn the tab or the stack, then put the keyboard back. Four private helpers, plus `Tab`, `Stack` and `pick_after_close`.

None of it is the launcher's. It knows one thing — the user walked away without using the empty stack it was handed — and `PendingStackAbandoned` says exactly that. The workspace answers it, **including where the keyboard goes back to**, because which of the two disposals happened is what decides that, and only the workspace knows which it did.

The helpers land in `vmux_layout::pending_stack` hanging off `Tab`, which is what they were always about. Three tests now cover branches that had none:

- the throwaway tab from Cmd+T is closed with its stack
- a stack beside siblings takes only itself
- the last tab in the workspace survives either way

## A terminal request couldn't say where it wanted to go

`TerminalSpawnRequest.target_stack: Option<Entity>` could only name a stack that already existed, so a caller holding a *pane* had to build one first — and the bar did: `stack_bundle()`, `LastActivatedAt::now()`, `ChildOf(pane)`, then a `PageMetadata` insert. Assembling workspace shape in order to ask for a terminal.

```rust
pub enum TerminalSpawnTarget {
    Stack(Entity),
    NewStackInPane(Entity),
    Detached,
}
```

`vmux_terminal` builds the stack now, which costs nothing — it already depends on the layout. The tab-strip title rides along as `metadata` for the same reason: it describes the terminal about to exist, rather than editing the workspace on the way past. `Detached` gives the old `None` a name.

## Also here

`ContributedCommandChosen` moves to the new `vmux_core::launcher`. Its own doc already said the launcher doesn't know what the row means and whoever published the id answers it — so it belonged to neither side. `vmux_layout` re-exports it; `vmux_agent` and the layout contract are untouched.

## What's left in stage 3

`NewStackContext` (the shared mutable handshake, ~25 write sites in the bar), the start-page inline transition, and the workspace *reads* — those come next, and the module can only move to `vmux_command` once they're done.

## Test plan

- [x] `cargo fmt --check`
- [x] `clippy -D warnings` under CI's exact package selection
- [x] `cargo test --workspace` green
- [ ] Run the app

Both changed paths are user-visible and the suite can't see the wiring end-to-end:

- **Cmd+T then Escape** — the throwaway tab must disappear, not linger empty
- **Cmd+K on a pane with content, then Escape** — only the pending stack goes; the tab and its other stacks stay, and the keyboard returns to the page behind
- **Type a path in the bar** — terminal opens there, tab strip shows the path
- **Pick "Terminal" with no empty stack** — this is the `NewStackInPane` branch; a stack should be created in the focused pane
- **Restore a saved session containing a terminal** — `archive.rs` writes the same message

---

## Added: the start page answers for itself

The bar decided three things about the start page by comparing URLs against `vmux://start/` — whether Cmd+K should focus that page's input instead of opening a bar over it, whether the page could morph into what was picked, and then it reached in and inserted the two marker components that make the morph happen.

None of that needed the page's *identity*, only its capabilities. `HostsLauncher` is a marker the start page puts on itself; the bar tests for the capability, so a second page wanting the same behaviour needs no change to the bar. Focusing and morphing become `FocusLauncherInput` and `InlineTransitionRequested`, which the start plugin answers by emitting its own IPC and inserting its own components.

`supports_inline_agent_transition` turned out to be a re-export of `vmux_wire::agent`, so the bar calls the wire crate directly.

That's every start-page reference gone: `START_PAGE_URL`, `StartInlineTransition`, `StartInlineTransitionView`, `StartFocusInput`, `START_FOCUS_INPUT_EVENT`.

`handle_open_command_bar` hit Bevy's 16-parameter ceiling on the way, so the two new params are bundled into a `LauncherHosts` system param owning both halves of the question — which pages host a launcher, and how to hand one the caret.

**Layout references in the bar: 20 → 15.** What remains is `NewStackContext`, the ordering sets, and the workspace reads.

Add to the manual pass:

- **Cmd+K on the start page** — focuses the start page's own input rather than opening the bar over it
- **Pick an agent from the start page** — morphs in place, does not open a second page beside it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added launcher support for start pages, including focused input and inline transitions.
  * Added flexible terminal placement options for existing stacks, new stacks, or detached launches.
  * Improved handling of dismissed or abandoned pending launches.
* **Bug Fixes**
  * Automatically cleans up unused pending stacks while preserving the last remaining tab.
  * Restores appropriate activation and keyboard focus after stack or tab removal.
* **Refactor**
  * Standardized launcher and terminal launch state across the application for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->