### PR TITLE
Refuse a bad control stream with a reason, not silence

### DIFF
--- a/crates/host/vmux_service/src/remote/quic.rs
+++ b/crates/host/vmux_service/src/remote/quic.rs
@@ -261,15 +261,22 @@ const MAX_REQUEST_BYTES: usize = (RECEIVE_WINDOW / 8) as usize;
 
 /// One request in, one response out, then the stream closes.
 ///
-/// The stream kind leads so the peer can route without decoding, and so a client that opens the
-/// wrong kind is told rather than left waiting.
+/// Every way this can fail resets the stream with a reason rather than dropping it. A dropped
+/// stream finishes clean and empty, which is exactly what a subscription to a session that does
+/// not exist looks like — so a peer could not tell "no such session" from "I could not read what
+/// you sent". Resetting is also per-stream: one bad request must not take the connection, which
+/// is what `connection.close` would do.
 async fn dispatch_control(
     state: super::server::RemoteState,
     mut send: quinn::SendStream,
     mut recv: quinn::RecvStream,
 ) {
-    let Ok(frame) = CONTROL.accept(&mut recv).await else {
-        return;
+    let frame = match CONTROL.accept(&mut recv).await {
+        Ok(frame) => frame,
+        Err(error) => {
+            refuse(&mut send, &mut recv, Rejection::from(error));
+            return;
+        }
     };
     // Must stay ahead of the decode below: rejecting a foreign type afterwards would mean the
     // decoder had already run on bytes this handler was never addressed by.
@@ -280,11 +287,13 @@ async fn dispatch_control(
                 ?unserved,
                 "remote quic: stream refused, unserved message type"
             );
+            refuse(&mut send, &mut recv, Rejection::Malformed);
             return;
         }
     }
 
     let Ok(request) = rkyv::from_bytes::<SharedMessage, rkyv::rancor::Error>(&frame.body) else {
+        refuse(&mut send, &mut recv, Rejection::Malformed);
         return;
     };
 
@@ -295,12 +304,23 @@ async fn dispatch_control(
 
     let response = dispatch::dispatch(&state, request).await;
     let Ok(encoded) = rkyv::to_bytes::<rkyv::rancor::Error>(&response) else {
+        refuse(&mut send, &mut recv, Rejection::Malformed);
         return;
     };
     let frame = Frame::new(MessageType::CONTROL_RESPONSE, encoded.to_vec());
     if CONTROL.open(&mut send, &frame).await.is_ok() {
         let _ = send.finish();
     }
+}
+
+/// Turn one stream away with a reason, leaving the connection alone.
+///
+/// `stop` as well as `reset` so the peer stops writing a request nothing will read, rather than
+/// filling its send window against a stream that has already been answered.
+fn refuse(send: &mut quinn::SendStream, recv: &mut quinn::RecvStream, rejection: Rejection) {
+    let code = quinn::VarInt::from(rejection.close_code().as_u32());
+    let _ = send.reset(code);
+    let _ = recv.stop(code);
 }
 
 /// Push a session's events until the client goes away.
@@ -702,12 +722,16 @@ mod live {
         )
         .await;
 
-        let served = matches!(&answered, Ok(Ok(bytes)) if !bytes.is_empty());
+        assert!(answered.is_ok(), "it must not hang, got {answered:?}");
+        let Ok(read) = answered else {
+            unreachable!("checked above")
+        };
         assert!(
-            !served,
-            "a foreign message type must not be served as a control request, got {answered:?}"
+            read.is_err(),
+            "a refused stream must reset, not finish clean — a clean empty finish is what a \
+             subscription to a session that does not exist looks like, so the peer could not \
+             tell the two apart. Got {read:?}"
         );
-        assert!(answered.is_ok(), "and it must not hang, got {answered:?}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fourth slice of [VMX-184](https://linear.app/vmux/issue/VMX-184). No wire change beyond close codes. Stacked on #385 → #383 → #381.

## The bug

`dispatch_control` had four bare `return`s — a read failure, an empty frame, an unknown stream kind, and an rkyv decode failure. Each dropped the stream, which finishes **clean and empty**.

That is byte for byte what a legitimate answer looks like:

```rust
let Some(mut events) = subscribe(state, &sid).await else {
    // No such session. Closing empty says so without inventing an error frame.
    let _ = send.finish();
    return;
};
```

So a peer could not tell *"no such session"* from *"I could not read what you sent"*. Meanwhile the function's own rustdoc claimed a client opening the wrong kind "is told rather than left waiting" — it was not told anything at all.

The old test asserted the silent behaviour:

```rust
assert!(matches!(answered, Ok(Ok(bytes)) if bytes.is_empty()), ...)
```

## The fix

Each failure resets the stream with a close code. `recv.stop` too, so the peer stops writing a request nothing will read rather than filling its send window against a stream already answered.

**Per-stream, not `connection.close`** — one bad request must not take the other sixty-three streams with it. Neither primitive appeared anywhere in the tree before this.

The payoff beyond the diagnostics: the clean empty finish is unambiguous again. It now means "no such session" and nothing else.

`Rejection` also gains `UnsupportedFraming`, distinct from `Malformed`, so a peer that is merely an old build is not filed alongside one sending rubbish — only one of those is worth chasing.

## Test plan

- [x] `cargo test -p vmux_service` — 226 green
- [x] `cargo clippy -p vmux_service --all-targets` clean
- [x] `a_frame_of_a_foreign_type_is_not_answered_as_a_control_request` inverted: it now asserts the read **errors** rather than returning empty, and says why in the failure message
- [x] `subscribing_to_an_unknown_session_closes_rather_than_hangs` still passes — the legitimate empty finish is untouched, which is the half that had to keep working