### PR TITLE
Declare the workspace ordering sets in vmux_core

### DIFF
--- a/crates/page/vmux_layout/src/host/stack.rs
+++ b/crates/page/vmux_layout/src/host/stack.rs
@@ -15,6 +15,7 @@ use vmux_command::{
     AppCommand, BrowserCommand, LayoutCommand, OpenCommand, ReadAppCommands, ServiceCommand,
     StackCommand,
 };
+pub use vmux_core::workspace::{ComputeFocusSet, StackCommandSet};
 use vmux_core::{PageOpenRequest, PageOpenTarget};
 use vmux_history::LastActivatedAt;
 
@@ -57,11 +58,6 @@ pub struct FocusedStack {
     pub stack: Option<Entity>,
 }
 
-/// System set for `compute_focused_stack`. Systems that read `Res<FocusedStack>`
-/// should be ordered `.after(ComputeFocusSet)` in `Update`.
-#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ComputeFocusSet;
-
 /// Marker: tab is waiting for close confirmation dialog.
 #[derive(Component)]
 pub struct PendingStackClose;
@@ -76,10 +72,6 @@ pub struct CloseConfirmed;
 pub struct CloseStackRequest {
     pub stack: Entity,
 }
-
-/// System set for `handle_stack_commands`.
-#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
-pub struct StackCommandSet;
 
 fn handle_close_stack_requests(
     mut reader: MessageReader<CloseStackRequest>,

--- a/crates/page/vmux_layout/src/host/tab.rs
+++ b/crates/page/vmux_layout/src/host/tab.rs
@@ -15,6 +15,7 @@ use std::time::Instant;
 use vmux_command::open::OpenCommand;
 use vmux_command::{AppCommand, BrowserCommand, LayoutCommand, ReadAppCommands, TabCommand};
 use vmux_core::Order;
+pub use vmux_core::workspace::TabCommandSet;
 use vmux_history::LastActivatedAt;
 
 impl Plugin for TabPlugin {
@@ -51,9 +52,6 @@ impl Plugin for TabPlugin {
 }
 
 pub struct TabPlugin;
-
-#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
-pub struct TabCommandSet;
 
 #[derive(Message, Clone, Copy)]
 pub struct CloseTabRequest {

--- a/crates/vmux_browser/src/command_bar/handler.rs
+++ b/crates/vmux_browser/src/command_bar/handler.rs
@@ -91,8 +91,8 @@ impl Plugin for CommandBarInputPlugin {
                 handle_open_command_bar
                     .in_set(ReadAppCommands)
                     .after(prewarm_command_bar_modal)
-                    .after(vmux_layout::tab::TabCommandSet)
-                    .after(vmux_layout::stack::StackCommandSet),
+                    .after(vmux_core::workspace::TabCommandSet)
+                    .after(vmux_core::workspace::StackCommandSet),
             )
             .add_systems(
                 Update,
@@ -107,7 +107,7 @@ impl Plugin for CommandBarInputPlugin {
                 Update,
                 deferred_dismiss_modal
                     .after(ReadAppCommands)
-                    .before(vmux_layout::stack::ComputeFocusSet),
+                    .before(vmux_core::workspace::ComputeFocusSet),
             )
             .add_systems(
                 PostUpdate,
@@ -2390,11 +2390,11 @@ mod tests {
         let graph = update.graph();
         let tab_command_set = graph
             .system_sets
-            .get_key(vmux_layout::stack::StackCommandSet.intern())
+            .get_key(vmux_core::workspace::StackCommandSet.intern())
             .unwrap();
         let read_command_systems = graph.systems_in_set(ReadAppCommands.intern()).unwrap();
         let tab_command_systems = graph
-            .systems_in_set(vmux_layout::stack::StackCommandSet.intern())
+            .systems_in_set(vmux_core::workspace::StackCommandSet.intern())
             .unwrap();
         let command_bar_open_system = read_command_systems
             .iter()

--- a/crates/vmux_core/src/host.rs
+++ b/crates/vmux_core/src/host.rs
@@ -23,6 +23,7 @@ pub mod page_open;
 pub mod profile;
 pub mod team;
 pub mod terminal;
+pub mod workspace;
 
 pub use archive::{
     ArchivedPage, ArchivedPagePosition, ArchivedTabPage, PageArchiveRequest, PaneStep, SplitAxis,
@@ -38,3 +39,4 @@ pub use page_open::{
     CefPageAttachRequest, PageOpenError, PageOpenHandled, PageOpenId, PageOpenRequest, PageOpenSet,
     PageOpenTarget, PageOpenTask, PendingPrompt, PendingPromptAttachments,
 };
+pub use workspace::{ComputeFocusSet, StackCommandSet, TabCommandSet};

--- a/crates/vmux_core/src/host/workspace.rs
+++ b/crates/vmux_core/src/host/workspace.rs
@@ -1,0 +1,23 @@
+//! When the workspace settles, for everything that has to run around it.
+//!
+//! The sets are declared here and populated by whichever crate owns the workspace, the same way
+//! [`PageOpenSet`](crate::page_open::PageOpenSet) is declared here and populated by the pages. Four
+//! crates already order against them, and a crate that only needs to run *after* tabs are resolved
+//! should not have to depend on the one that resolves them.
+
+use bevy::prelude::SystemSet;
+
+/// Where tab commands are answered. Anything reading the set of tabs runs after this.
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TabCommandSet;
+
+/// Where stack commands are answered. Anything reading the set of stacks runs after this.
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StackCommandSet;
+
+/// Where the focused stack is worked out.
+///
+/// Anything reading focus runs `.after` this; anything that wants its own change taken into account
+/// runs `.before` it.
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ComputeFocusSet;


### PR DESCRIPTION
Stacked on #389.

## Summary

`TabCommandSet`, `StackCommandSet` and `ComputeFocusSet` are how four crates agree on when the workspace has settled — `vmux_terminal` waits for stacks, `vmux_agent` waits for focus, the command bar waits for both, and `vmux_layout` orders its own systems around them.

They were declared in `vmux_layout`, so ordering against them meant depending on the crate that *resolves* the workspace rather than on the fact that something does.

They move to `vmux_core::workspace` — which is exactly what `PageOpenSet` already does: declared centrally, populated by whoever owns the work. `vmux_layout` re-exports them, so its own systems and the other three crates are untouched.

## Why this one matters for the stack

These are the command bar's three ordering constraints, and they are load-bearing rather than incidental:

- `handle_open_command_bar` reads the pending stack in the same frame the workspace stages it. A frame later, Cmd+T then Cmd+K opens against the stale stack.
- `deferred_dismiss_modal.before(ComputeFocusSet)` must clear the keyboard target before focus recomputes, or the bar owns the keyboard for a frame after closing.

They had to survive the eventual move of `command_bar/` into `vmux_command`, and `vmux_command` sits below `vmux_layout` — so the sets had to come down with it.

## Test plan

- [x] `cargo fmt --check`
- [x] `clippy -D warnings` under CI's exact package selection
- [x] `cargo test --workspace` green

Pure declaration move — the schedule graph is unchanged, and `vmux_browser` has a test that asserts the bar's systems land in `StackCommandSet`, which still passes. The ordering cases worth a manual look are the two above: **Cmd+T then Cmd+K** targeting the new empty stack, and **Escape** returning the keyboard to the pane behind without a frame of limbo.