### PR TITLE
Give the launcher a workspace snapshot instead of six queries

### DIFF
--- a/crates/page/vmux_command/src/host/snapshot.rs
+++ b/crates/page/vmux_command/src/host/snapshot.rs
@@ -15,6 +15,7 @@ pub struct CommandBarSnapshotPlugin;
 impl Plugin for CommandBarSnapshotPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<CommandBarAgentsSnapshot>()
+            .init_resource::<CommandBarWorkspaceSnapshot>()
             .init_resource::<CommandBarSpacesSnapshot>()
             .init_resource::<CommandBarTerminalsSnapshot>()
             .init_resource::<CommandBarPagesSnapshot>()
@@ -25,6 +26,23 @@ impl Plugin for CommandBarSnapshotPlugin {
 
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
 pub struct WriteCommandBarSnapshots;
+
+/// The workspace as the launcher needs to see it.
+///
+/// Both halves come from the same walk of panes and stacks by last-activated time — where a choice
+/// would land, and the open tabs to list. That walk is the shape of the workspace and none of the
+/// launcher's business, so whoever owns it publishes the answer and the launcher reads it.
+#[derive(Resource, Default, Clone, Debug, PartialEq)]
+pub struct CommandBarWorkspaceSnapshot {
+    /// The stack a choice lands in when the launcher did not open onto one of its own.
+    pub stack: Option<Entity>,
+    /// The pane a choice lands in when there is no stack to put it in.
+    pub pane: Option<Entity>,
+    /// The active tab's open stacks, already in wire shape.
+    pub tabs: Vec<vmux_wire::command_bar::CommandBarTab>,
+    /// How many stacks exist in total, which decides whether the launcher offers "close".
+    pub stack_count: usize,
+}
 
 #[derive(Resource, Default, Clone, Debug)]
 pub struct CommandBarAgentsSnapshot {

--- a/crates/page/vmux_layout/src/host.rs
+++ b/crates/page/vmux_layout/src/host.rs
@@ -34,6 +34,7 @@ pub mod unit;
 pub mod warm_page;
 pub mod window;
 pub mod workspace_snapshot;
+pub mod workspace_snapshot_publish;
 pub mod worktree;
 
 mod header;

--- a/crates/page/vmux_layout/src/host/pending_stack.rs
+++ b/crates/page/vmux_layout/src/host/pending_stack.rs
@@ -11,7 +11,7 @@
 use bevy::ecs::relationship::Relationship;
 use bevy::prelude::*;
 use bevy_cef::prelude::CefKeyboardTarget;
-use vmux_core::launcher::PendingStackAbandoned;
+use vmux_core::launcher::{PendingStackAbandoned, StackInPaneChosen};
 use vmux_history::LastActivatedAt;
 
 use crate::cef::Browser;
@@ -22,10 +22,13 @@ pub(crate) struct PendingStackPlugin;
 
 impl Plugin for PendingStackPlugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<PendingStackAbandoned>().add_systems(
-            Update,
-            discard_abandoned_pending_stacks.before(crate::stack::ComputeFocusSet),
-        );
+        app.add_message::<PendingStackAbandoned>()
+            .add_message::<StackInPaneChosen>()
+            .add_systems(
+                Update,
+                (discard_abandoned_pending_stacks, focus_chosen_stack_in_pane)
+                    .before(crate::stack::ComputeFocusSet),
+            );
     }
 }
 
@@ -62,6 +65,30 @@ fn discard_abandoned_pending_stacks(
                 commands.entity(child).try_insert(CefKeyboardTarget);
             }
         }
+    }
+}
+
+/// Activates the whole chain - stack, pane, tab, space - rather than just the pane, so switching
+/// to a page in another tab actually moves the active-tab marker.
+fn focus_chosen_stack_in_pane(
+    mut chosen: MessageReader<StackInPaneChosen>,
+    leaf_panes: Query<Entity, (With<crate::pane::Pane>, Without<crate::pane::PaneSplit>)>,
+    pane_children: Query<&Children, With<crate::pane::Pane>>,
+    stack_q: Query<Entity, With<Stack>>,
+    child_of_q: Query<&ChildOf>,
+    mut commands: Commands,
+) {
+    for event in chosen.read() {
+        let Some(pane) = leaf_panes.iter().find(|e| e.to_bits() == event.pane_bits) else {
+            continue;
+        };
+        let stack = pane_children.get(pane).ok().and_then(|children| {
+            children
+                .iter()
+                .filter(|&e| stack_q.contains(e))
+                .nth(event.index)
+        });
+        vmux_core::focus_pane_entity(stack.unwrap_or(pane), &mut commands, &child_of_q);
     }
 }
 

--- a/crates/page/vmux_layout/src/host/plugin.rs
+++ b/crates/page/vmux_layout/src/host/plugin.rs
@@ -81,6 +81,7 @@ impl Plugin for LayoutPlugin {
                 PrewarmPagesPlugin,
                 BookmarkPlugin,
                 LayoutCefPlugin,
+                crate::workspace_snapshot_publish::WorkspaceSnapshotPlugin,
                 crate::overlay_adopt::OverlayAdoptPlugin,
                 crate::pending_stack::PendingStackPlugin,
             ));

--- a/crates/page/vmux_layout/src/host/workspace_snapshot_publish.rs
+++ b/crates/page/vmux_layout/src/host/workspace_snapshot_publish.rs
@@ -1,0 +1,68 @@
+//! Telling the launcher what the workspace looks like.
+//!
+//! `focused_stack` and `gather_command_bar_tabs` both walk the active tab's panes and stacks by
+//! last-activated time. That is the shape of the workspace, so the launcher used to borrow six
+//! queries and both walks to answer two questions. It reads a snapshot now, and this fills it.
+
+use bevy::prelude::*;
+use vmux_command::snapshot::{
+    CommandBarSpacesSnapshot, CommandBarWorkspaceSnapshot, WriteCommandBarSnapshots,
+};
+use vmux_ui::i18n::Locale;
+
+use crate::settings::ResolvedLocale;
+use crate::workspace_snapshot::{TabGatherParams, gather_command_bar_tabs};
+
+pub(crate) struct WorkspaceSnapshotPlugin;
+
+impl Plugin for WorkspaceSnapshotPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            Update,
+            publish_workspace_snapshot.in_set(WriteCommandBarSnapshots),
+        );
+    }
+}
+
+fn publish_workspace_snapshot(
+    tab_gather: TabGatherParams,
+    spaces: Res<CommandBarSpacesSnapshot>,
+    locale: Option<Res<ResolvedLocale>>,
+    mut snapshot: ResMut<CommandBarWorkspaceSnapshot>,
+) {
+    let active_tab = tab_gather.active_tab.get();
+    let (_, pane, stack) = crate::stack::focused_stack(
+        active_tab,
+        &tab_gather.all_children,
+        &tab_gather.leaf_panes,
+        &tab_gather.pane_ts,
+        &tab_gather.pane_children,
+        &tab_gather.stack_ts,
+    );
+    let locale = locale
+        .as_deref()
+        .map(|resolved| resolved.0.clone())
+        .unwrap_or_else(Locale::preferred);
+    let tabs = gather_command_bar_tabs(
+        active_tab,
+        &tab_gather.all_children,
+        &tab_gather.leaf_panes,
+        &tab_gather.pane_ts,
+        &tab_gather.pane_children,
+        &tab_gather.stack_ts,
+        &tab_gather.stack_q,
+        &tab_gather.browser_meta,
+        &tab_gather.child_of_q,
+        &spaces.active_space_name,
+        &locale,
+    );
+    let next = CommandBarWorkspaceSnapshot {
+        stack,
+        pane,
+        tabs,
+        stack_count: tab_gather.stack_q.iter().count(),
+    };
+    if *snapshot != next {
+        *snapshot = next;
+    }
+}

--- a/crates/vmux_browser/src/command_bar/handler.rs
+++ b/crates/vmux_browser/src/command_bar/handler.rs
@@ -4,15 +4,15 @@ use vmux_command::build_command_bar_open_payload;
 pub(crate) use vmux_core::launcher::PendingLaunch;
 use vmux_core::launcher::{
     FocusLauncherInput, HostsLauncher, InlineTransitionRequested, PendingStackAbandoned,
+    StackInPaneChosen,
 };
-use vmux_layout::workspace_snapshot::gather_command_bar_tabs;
 
 use crate::command_bar::panel::CommandBarPanelActive;
 use crate::command_bar::state::{CommandBarStateQuery, command_bar_state};
 use crate::command_bar::work_snapshot::{update_recent_files_snapshot, update_work_dirs_snapshot};
 use bevy::{
     ecs::message::MessageReader, ecs::relationship::Relationship, ecs::system::SystemParam,
-    picking::Pickable, prelude::*, ui::UiSystems, window::PrimaryWindow,
+    picking::Pickable, prelude::*, ui::UiSystems,
 };
 use bevy_cef::prelude::*;
 use vmux_command::event::{
@@ -26,8 +26,8 @@ use vmux_command::event::{
 use vmux_command::open::OpenCommand;
 use vmux_command::open_target::OpenTarget;
 use vmux_command::snapshot::{
-    CommandBarPagesSnapshot, CommandBarSpacesSnapshot, CommandBarTerminalsSnapshot, Contributions,
-    WriteCommandBarSnapshots,
+    CommandBarPagesSnapshot, CommandBarSpacesSnapshot, CommandBarTerminalsSnapshot,
+    CommandBarWorkspaceSnapshot, Contributions, WriteCommandBarSnapshots,
 };
 use vmux_command::{
     AppCommand, BrowserBarCommand, BrowserCommand, LayoutCommand, PaneCommand, ReadAppCommands,
@@ -35,19 +35,13 @@ use vmux_command::{
 };
 use vmux_core::event::space::SpaceCommandEvent;
 use vmux_core::page::{SettingsPageSpawnRequest, SpacesPageSpawnRequest};
-use vmux_core::terminal::{Terminal, TerminalSpawnRequest, TerminalSpawnTarget};
+use vmux_core::terminal::{TerminalSpawnRequest, TerminalSpawnTarget};
 use vmux_core::{
     PageMetadata, PageOpenRequest, PageOpenTarget, PendingPrompt, PendingPromptAttachments,
 };
 use vmux_history::{LastActivatedAt, now_millis};
 use vmux_layout::cef::{Browser, LayoutCef};
-use vmux_layout::{
-    Header,
-    pane::{Pane, PaneSplit},
-    side_sheet::SideSheet,
-    stack::{ActiveTabParam, Stack, focused_stack},
-    window::Main,
-};
+use vmux_layout::{Header, side_sheet::SideSheet};
 use vmux_ui::i18n::{Locale, TranslationValue};
 
 use vmux_layout::settings::ResolvedLocale;
@@ -63,6 +57,7 @@ impl Plugin for CommandBarInputPlugin {
             .add_message::<PendingStackAbandoned>()
             .add_message::<FocusLauncherInput>()
             .add_message::<InlineTransitionRequested>()
+            .add_message::<StackInPaneChosen>()
             .add_message::<vmux_core::agent::SpawnAgentInStackRequest>()
             .add_message::<SettingsPageSpawnRequest>()
             .add_message::<SpacesPageSpawnRequest>()
@@ -532,14 +527,9 @@ fn command_bar_toggle_should_open(is_open: bool, space_switch: bool) -> bool {
 fn handle_open_command_bar(
     mut reader: MessageReader<AppCommand>,
     layout_q: Query<(Entity, Has<CommandBarPanelActive>), With<LayoutCef>>,
-    active_tab_param: ActiveTabParam,
     all_children: Query<&Children>,
-    leaf_panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
-    pane_ts: Query<(Entity, &LastActivatedAt), With<Pane>>,
-    pane_children: Query<&Children, With<Pane>>,
-    stack_ts: Query<(Entity, &LastActivatedAt), With<Stack>>,
-    stack_q: Query<Entity, With<Stack>>,
     browser_meta: Query<&PageMetadata, With<Browser>>,
+    focus: Res<CommandBarWorkspaceSnapshot>,
     mut launcher_hosts: LauncherHosts,
     child_of_q: Query<&ChildOf>,
     content_browsers: Query<
@@ -566,7 +556,7 @@ fn handle_open_command_bar(
     let Ok((layout_e, is_open)) = layout_q.single() else {
         return;
     };
-    let active_stack_count = stack_q.iter().count();
+    let active_stack_count = focus.stack_count;
     let spaces_snapshot = snapshot_params.p0().clone();
     let space_name = spaces_snapshot.active_space_name.clone();
     let startup_url = snapshot_params.p2().map(|url| url.0.clone());
@@ -621,14 +611,7 @@ fn handle_open_command_bar(
                 }
             }
         } else {
-            let (_, _, active_stack) = focused_stack(
-                active_tab_param.get(),
-                &all_children,
-                &leaf_panes,
-                &pane_ts,
-                &pane_children,
-                &stack_ts,
-            );
+            let active_stack = focus.stack;
             if let Some(tab) = active_stack {
                 for browser_e in &content_browsers {
                     let is_child = child_of_q
@@ -682,17 +665,7 @@ fn handle_open_command_bar(
     let is_new_stack = snapshot_params.p1().stack.is_some();
 
     if !is_new_stack {
-        let active_stack = active_stack_override.or_else(|| {
-            let (_, _, active_stack) = focused_stack(
-                active_tab_param.get(),
-                &all_children,
-                &leaf_panes,
-                &pane_ts,
-                &pane_children,
-                &stack_ts,
-            );
-            active_stack
-        });
+        let active_stack = active_stack_override.or(focus.stack);
         let start_browser = active_stack.and_then(|stack| {
             all_children
                 .get(stack)
@@ -717,17 +690,7 @@ fn handle_open_command_bar(
     } else if is_new_stack {
         String::new()
     } else {
-        let active_stack = active_stack_override.or_else(|| {
-            let (_, _, active_stack) = focused_stack(
-                active_tab_param.get(),
-                &all_children,
-                &leaf_panes,
-                &pane_ts,
-                &pane_children,
-                &stack_ts,
-            );
-            active_stack
-        });
+        let active_stack = active_stack_override.or(focus.stack);
         active_stack
             .and_then(|tab| {
                 let Ok(children) = all_children.get(tab) else {
@@ -739,19 +702,7 @@ fn handle_open_command_bar(
             .unwrap_or_default()
     };
 
-    let bar_tabs = gather_command_bar_tabs(
-        active_tab_param.get(),
-        &all_children,
-        &leaf_panes,
-        &pane_ts,
-        &pane_children,
-        &stack_ts,
-        &stack_q,
-        &browser_meta,
-        &child_of_q,
-        &space_name,
-        &locale,
-    );
+    let bar_tabs = focus.tabs.clone();
 
     let target = if replace_active_stack {
         Some(vmux_command::open_target::OpenTarget::InPlace)
@@ -797,12 +748,6 @@ fn close_command_bar_panel(layout: Entity, commands: &mut Commands) {
 
 #[derive(SystemParam)]
 struct CommandBarActionQueries<'w, 's> {
-    active_tab_param: ActiveTabParam<'w, 's>,
-    all_children: Query<'w, 's, &'static Children>,
-    leaf_panes: Query<'w, 's, Entity, (With<Pane>, Without<PaneSplit>)>,
-    pane_ts: Query<'w, 's, (Entity, &'static LastActivatedAt), With<Pane>>,
-    pane_children: Query<'w, 's, &'static Children, With<Pane>>,
-    stack_ts: Query<'w, 's, (Entity, &'static LastActivatedAt), With<Stack>>,
     child_of_q: Query<'w, 's, &'static ChildOf>,
     content_browsers: Query<
         'w,
@@ -816,33 +761,18 @@ struct CommandBarActionQueries<'w, 's> {
         ),
     >,
     launcher_hosts: Query<'w, 's, (), With<HostsLauncher>>,
+    focus: Res<'w, CommandBarWorkspaceSnapshot>,
 }
 
 impl CommandBarActionQueries<'_, '_> {
     /// The stack an action lands in when the command bar did not open an empty one for it.
     fn focused_stack(&self) -> Option<Entity> {
-        let (_, _, stack) = focused_stack(
-            self.active_tab_param.get(),
-            &self.all_children,
-            &self.leaf_panes,
-            &self.pane_ts,
-            &self.pane_children,
-            &self.stack_ts,
-        );
-        stack
+        self.focus.stack
     }
 
     /// The pane an action lands in when there is no stack to put it in.
     fn focused_pane(&self) -> Option<Entity> {
-        let (_, pane, _) = focused_stack(
-            self.active_tab_param.get(),
-            &self.all_children,
-            &self.leaf_panes,
-            &self.pane_ts,
-            &self.pane_children,
-            &self.stack_ts,
-        );
-        pane
+        self.focus.pane
     }
 
     /// The stack holding the start page that raised this action, which can transition in place.
@@ -899,13 +829,6 @@ fn on_command_bar_action(
         With<CommandBar>,
     >,
     queries: CommandBarActionQueries,
-    mut stack_params: ParamSet<(
-        Query<Entity, With<Stack>>,
-        Query<Entity, With<Main>>,
-        Query<Entity, With<PrimaryWindow>>,
-        Option<ResMut<vmux_layout::stack::FocusedStack>>,
-        Query<(), With<Terminal>>,
-    )>,
     mut resource_params: ParamSet<(
         Res<CommandBarSpacesSnapshot>,
         Res<CommandBarTerminalsSnapshot>,
@@ -921,6 +844,7 @@ fn on_command_bar_action(
     mut chosen_writer: MessageWriter<vmux_core::ContributedCommandChosen>,
     mut abandoned_writer: MessageWriter<PendingStackAbandoned>,
     mut inline_transition: MessageWriter<InlineTransitionRequested>,
+    mut stack_chosen: MessageWriter<StackInPaneChosen>,
     mut issued: MessageWriter<vmux_command::CommandIssued>,
     user_q: Query<Entity, With<vmux_core::team::User>>,
     mut commands: Commands,
@@ -1234,26 +1158,10 @@ fn on_command_bar_action(
                 pending_launch.stack = None;
                 pending_launch.previous_stack = None;
             }
-            if let Some(target_pane) = queries.leaf_panes.iter().find(|e| e.to_bits() == *pane) {
-                let target_stack = {
-                    let stack_q = stack_params.p0();
-                    queries
-                        .pane_children
-                        .get(target_pane)
-                        .ok()
-                        .and_then(|children| {
-                            children.iter().filter(|&e| stack_q.contains(e)).nth(*index)
-                        })
-                };
-                // Activate the whole chain (stack -> pane -> tab -> space), not just the
-                // pane/stack, so switching to a page in another tab actually moves the
-                // active-tab marker (ensure_active_tab derives Active from LastActivatedAt).
-                if let Some(target_stack) = target_stack {
-                    focus_pane_entity(target_stack, &mut commands, &queries.child_of_q);
-                } else {
-                    focus_pane_entity(target_pane, &mut commands, &queries.child_of_q);
-                }
-            }
+            stack_chosen.write(StackInPaneChosen {
+                pane_bits: *pane,
+                index: *index,
+            });
         }
         CommandBarActionEvent::Dismiss => {
             if let Some(stack_e) = empty_stack {
@@ -2057,7 +1965,9 @@ mod tests {
             .add_message::<PageOpenRequest>()
             .add_message::<FocusLauncherInput>()
             .add_message::<InlineTransitionRequested>()
+            .add_message::<StackInPaneChosen>()
             .add_message::<PendingStackAbandoned>()
+            .init_resource::<CommandBarWorkspaceSnapshot>()
             .init_resource::<CommandBarSpacesSnapshot>()
             .init_resource::<CommandBarPagesSnapshot>()
             .init_resource::<vmux_command::snapshot::CommandBarWorkSnapshot>()
@@ -2280,6 +2190,7 @@ mod tests {
             .add_message::<TerminalSpawnRequest>()
             .add_message::<FocusLauncherInput>()
             .add_message::<InlineTransitionRequested>()
+            .add_message::<StackInPaneChosen>()
             .add_message::<PendingStackAbandoned>()
             .add_message::<vmux_core::terminal::ProcessesMonitorSpawnRequest>()
             .add_message::<vmux_layout::LayoutSpawnRequest>()

--- a/crates/vmux_core/src/host.rs
+++ b/crates/vmux_core/src/host.rs
@@ -31,7 +31,7 @@ pub use archive::{
 pub use host_spawn::{HostSpawnRegistry, register_host_spawn};
 pub use launcher::{
     ContributedCommandChosen, FocusLauncherInput, HostsLauncher, InlineTransitionRequested,
-    PendingLaunch, PendingStackAbandoned,
+    PendingLaunch, PendingStackAbandoned, StackInPaneChosen,
 };
 pub use notify::{AgentAttention, AgentDoneUnseen, BellReceived, OsNotify};
 pub use overlay::{OverlayState, OverlayStateQuery, WindowOverlay};

--- a/crates/vmux_core/src/host/launcher.rs
+++ b/crates/vmux_core/src/host/launcher.rs
@@ -66,6 +66,18 @@ pub struct InlineTransitionRequested {
     pub webview: Entity,
 }
 
+/// Bring the nth stack of a pane to the front.
+///
+/// The launcher lists open stacks and reports which row was picked. Resolving that to an entity
+/// means walking the pane's children in order and activating the whole chain up to the space, so
+/// the workspace does it.
+#[derive(Message, Clone, Copy, Debug)]
+pub struct StackInPaneChosen {
+    /// The pane, as `Entity::to_bits` - what the page had to send it as.
+    pub pane_bits: u64,
+    pub index: usize,
+}
+
 /// The launcher was dismissed without ever using the empty stack it was opened on.
 ///
 /// Disposing of it is the workspace's business, and more than a despawn: opening the launcher with


### PR DESCRIPTION
Stacked on #390.

## Summary

The command bar borrowed six queries — `ActiveTabParam`, `leaf_panes`, `pane_ts`, `pane_children`, `stack_ts`, `all_children` — to run `focused_stack` three times and `gather_command_bar_tabs` once. Both walk the active tab's panes and stacks by last-activated time.

That walk *is* the shape of the workspace. The launcher was doing the workspace's job in order to find out where a choice would land.

```rust
#[derive(Resource, Default, Clone, Debug, PartialEq)]
pub struct CommandBarWorkspaceSnapshot {
    pub stack: Option<Entity>,
    pub pane: Option<Entity>,
    pub tabs: Vec<CommandBarTab>,
    pub stack_count: usize,
}
```

`vmux_layout` fills it in `WriteCommandBarSnapshots` — where `vmux_space` already fills the spaces snapshot — and that set sits between the command bus's write and read halves, so the launcher reads a snapshot taken *this* frame rather than a stale one.

## `SwitchTab` was the last write

Picking the nth stack of a pane meant finding the pane by bits, walking its children in order, and activating the whole chain up to the space so the active-tab marker actually moves. `StackInPaneChosen` reports which row was picked; the workspace resolves it.

## Dead weight that fell out

Emptying those params emptied a whole `ParamSet`, including four members that were never read and which clippy could not see because the set was still passed around: `FocusedStack`, `Main`, `PrimaryWindow` and `Terminal`.

## Where this leaves the module

Nine `vmux_layout` imports in `command_bar/`, and **six of them are the test harness** (`StackPlugin`, `LayoutSpawnRequest`, `PendingCursorWarp`). The three real ones are `Browser`/`LayoutCef`, `Header`/`SideSheet`, and the two settings resources — which need `vmux_ui`, so they are their own step.

## Test plan

- [x] `cargo fmt --check`
- [x] `clippy -D warnings` under CI's exact package selection
- [x] `cargo test --workspace` green

The snapshot is computed a system earlier than the queries were, so the things to exercise are the ones that depend on focus being current:

- **Cmd+K with several panes open** — the payload lists the right tabs, and picking a page opens it in the focused pane
- **Cmd+T then Cmd+K** — targets the new empty stack, not the previously focused one
- **Switch to another stack from the bar's tab list** — activates the whole chain, so the tab strip follows
- **Split a pane, then Cmd+K** — focus should be the new pane