### PR TITLE
Move the two settings the launcher reads out of the window shell

### DIFF
--- a/crates/page/vmux_command/src/host.rs
+++ b/crates/page/vmux_command/src/host.rs
@@ -28,6 +28,7 @@ pub mod issued;
 pub mod open;
 pub mod page_key;
 pub mod payload;
+pub mod settings;
 pub mod shortcut;
 pub mod snapshot;
 pub mod surface;
@@ -41,4 +42,5 @@ pub use payload::{
     CommandBarEntry, build_command_bar_open_payload, command_bar_open_payload, command_list,
     localized_command_name,
 };
+pub use settings::ResolvedLocale;
 pub use snapshot::*;

--- a/crates/page/vmux_command/src/host/settings.rs
+++ b/crates/page/vmux_command/src/host/settings.rs
@@ -1,0 +1,19 @@
+//! Settings the command vocabulary needs to answer with.
+
+use bevy::prelude::Resource;
+use vmux_ui::i18n::Locale;
+
+/// The locale the app resolved to, once the settings file and the system preference have had their
+/// say.
+///
+/// Written by whoever owns settings and read by anything that names a command to a person. It sits
+/// here rather than with the settings page because every reader is downstream of this crate and
+/// none of them are downstream of that one.
+#[derive(Resource, Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedLocale(pub Locale);
+
+impl Default for ResolvedLocale {
+    fn default() -> Self {
+        Self(Locale::preferred())
+    }
+}

--- a/crates/page/vmux_layout/src/host/pane.rs
+++ b/crates/page/vmux_layout/src/host/pane.rs
@@ -559,7 +559,7 @@ pub fn first_stack_in_pane(
 
 #[derive(bevy::ecs::system::SystemParam)]
 struct PaneStartupContext<'w> {
-    effective: Option<Res<'w, crate::settings::EffectiveStartupUrl>>,
+    effective: Option<Res<'w, vmux_core::EffectiveStartupUrl>>,
     requests: MessageWriter<'w, PageOpenRequest>,
     new_stack_ctx: ResMut<'w, PendingLaunch>,
 }
@@ -1803,7 +1803,7 @@ fn handle_open_in_pane(
     child_of_q: Query<&ChildOf>,
     split_dir_q: Query<&PaneSplit>,
     tab_filter: Query<Entity, With<Stack>>,
-    effective_startup_url: Option<Res<crate::settings::EffectiveStartupUrl>>,
+    effective_startup_url: Option<Res<vmux_core::EffectiveStartupUrl>>,
     mut commands: Commands,
     mut page_open_requests: MessageWriter<PageOpenRequest>,
     mut new_stack_ctx: ResMut<PendingLaunch>,

--- a/crates/page/vmux_layout/src/host/settings.rs
+++ b/crates/page/vmux_layout/src/host/settings.rs
@@ -1,5 +1,7 @@
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
+pub use vmux_command::settings::ResolvedLocale;
+pub use vmux_core::EffectiveStartupUrl;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Resource)]
 pub struct LayoutSettings {
@@ -23,19 +25,7 @@ pub struct ConfirmCloseSettings {
 }
 
 #[derive(Resource, Clone, Debug, Default)]
-pub struct EffectiveStartupUrl(pub String);
-
-#[derive(Resource, Clone, Debug, Default)]
 pub struct EffectiveStartupDir(pub Option<(Entity, Option<std::path::PathBuf>)>);
-
-#[derive(Resource, Clone, Debug, PartialEq, Eq)]
-pub struct ResolvedLocale(pub vmux_ui::i18n::Locale);
-
-impl Default for ResolvedLocale {
-    fn default() -> Self {
-        Self(vmux_ui::i18n::Locale::preferred())
-    }
-}
 
 #[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct EffectiveStartupDirSet;

--- a/crates/page/vmux_layout/src/host/stack.rs
+++ b/crates/page/vmux_layout/src/host/stack.rs
@@ -252,7 +252,7 @@ fn handle_stack_commands(
     stack_q: Query<Entity, With<Stack>>,
     child_of_q: Query<&ChildOf>,
     split_dir_q: Query<&PaneSplit>,
-    effective_startup_url: Option<Res<crate::settings::EffectiveStartupUrl>>,
+    effective_startup_url: Option<Res<vmux_core::EffectiveStartupUrl>>,
 
     mut new_stack_ctx: ResMut<PendingLaunch>,
     mut close_tab_requests: MessageWriter<CloseTabRequest>,
@@ -643,7 +643,7 @@ pub fn open_startup_url_if_no_stacks(
     stack_ts: Query<(Entity, &LastActivatedAt), With<Stack>>,
     stack_q: Query<Entity, With<Stack>>,
     closing_primary: Query<(), (With<PrimaryWindow>, With<ClosingWindow>)>,
-    effective_startup_url: Option<Res<crate::settings::EffectiveStartupUrl>>,
+    effective_startup_url: Option<Res<vmux_core::EffectiveStartupUrl>>,
     mut new_stack_ctx: ResMut<PendingLaunch>,
     mut page_open_requests: MessageWriter<PageOpenRequest>,
     mut commands: Commands,
@@ -1160,7 +1160,7 @@ mod tests {
             .init_resource::<PendingLaunch>()
             .init_resource::<PendingCursorWarp>()
             .insert_resource(test_settings())
-            .insert_resource(crate::settings::EffectiveStartupUrl(
+            .insert_resource(vmux_core::EffectiveStartupUrl(
                 "vmux://agent/vibe/".to_string(),
             ))
             .add_systems(Update, handle_stack_commands.in_set(WriteAppCommands));
@@ -1394,7 +1394,7 @@ mod tests {
     #[test]
     fn closing_last_stack_requests_tab_replacement() {
         let mut app = build_app_with_collector();
-        app.insert_resource(crate::settings::EffectiveStartupUrl(
+        app.insert_resource(vmux_core::EffectiveStartupUrl(
             "https://startup.test".into(),
         ));
         let (tab, pane, original_stack) = build_hierarchy(&mut app);
@@ -1493,7 +1493,7 @@ mod tests {
     #[test]
     fn in_new_stack_with_no_url_uses_startup_url() {
         let mut app = build_app_with_collector();
-        app.insert_resource(crate::settings::EffectiveStartupUrl(
+        app.insert_resource(vmux_core::EffectiveStartupUrl(
             "https://startup.test".into(),
         ));
         let (_tab, _pane, _stack) = build_hierarchy(&mut app);

--- a/crates/page/vmux_layout/src/host/tab.rs
+++ b/crates/page/vmux_layout/src/host/tab.rs
@@ -154,7 +154,7 @@ fn handle_tab_commands(
     primary_window: Single<Entity, With<PrimaryWindow>>,
     child_of_q: Query<&ChildOf>,
     all_children: Query<&Children>,
-    effective_startup_url: Option<Res<crate::settings::EffectiveStartupUrl>>,
+    effective_startup_url: Option<Res<vmux_core::EffectiveStartupUrl>>,
     effective_startup_dir: Option<Res<crate::settings::EffectiveStartupDir>>,
     mut layout_requests: MessageWriter<TabLayoutSpawnRequest>,
     mut close_requests: MessageWriter<CloseTabRequest>,
@@ -795,7 +795,7 @@ mod tests {
     #[test]
     fn open_in_new_tab_none_url_falls_back_to_startup() {
         let mut app = build_app();
-        app.insert_resource(crate::settings::EffectiveStartupUrl(
+        app.insert_resource(vmux_core::EffectiveStartupUrl(
             "https://startup.test".into(),
         ));
         build_main_and_tab(&mut app);

--- a/crates/page/vmux_layout/src/host/window.rs
+++ b/crates/page/vmux_layout/src/host/window.rs
@@ -392,7 +392,7 @@ pub fn spawn_tab_scaffold_in_space(
 pub fn spawn_requested_tab_layouts(
     mut reader: MessageReader<TabLayoutSpawnRequest>,
     settings: Res<LayoutSettings>,
-    effective_startup_url: Option<Res<crate::settings::EffectiveStartupUrl>>,
+    effective_startup_url: Option<Res<vmux_core::EffectiveStartupUrl>>,
     mut new_stack_ctx: ResMut<crate::PendingLaunch>,
     mut page_open_requests: MessageWriter<PageOpenRequest>,
     mut focus: Option<ResMut<crate::stack::FocusedStack>>,
@@ -996,7 +996,7 @@ mod tests {
                 side_sheet: crate::settings::SideSheetSettings::default(),
                 focus_ring: crate::settings::FocusRingSettings::default(),
             })
-            .insert_resource(crate::settings::EffectiveStartupUrl(
+            .insert_resource(vmux_core::EffectiveStartupUrl(
                 "vmux://agent/vibe/".to_string(),
             ))
             .add_systems(
@@ -1049,7 +1049,7 @@ mod tests {
                 side_sheet: crate::settings::SideSheetSettings::default(),
                 focus_ring: crate::settings::FocusRingSettings::default(),
             })
-            .insert_resource(crate::settings::EffectiveStartupUrl(
+            .insert_resource(vmux_core::EffectiveStartupUrl(
                 "vmux://agent/vibe/".to_string(),
             ))
             .add_systems(

--- a/crates/page/vmux_space/src/host/plugin.rs
+++ b/crates/page/vmux_space/src/host/plugin.rs
@@ -88,7 +88,7 @@ pub struct SpaceCommandRequest {
 fn update_effective_startup_url(
     settings: Option<Res<vmux_setting::AppSettings>>,
     active: Option<Res<ActiveSpace>>,
-    mut effective: ResMut<vmux_layout::settings::EffectiveStartupUrl>,
+    mut effective: ResMut<vmux_core::EffectiveStartupUrl>,
 ) {
     let (Some(settings), Some(active)) = (settings, active) else {
         return;
@@ -560,7 +560,7 @@ fn handle_open_in_new_space(
     spaces: SpaceQuery,
     main_q: Query<Entity, With<vmux_layout::window::Main>>,
     primary_window: Single<Entity, With<PrimaryWindow>>,
-    effective_startup_url: Option<Res<vmux_layout::settings::EffectiveStartupUrl>>,
+    effective_startup_url: Option<Res<vmux_core::EffectiveStartupUrl>>,
     settings: Option<Res<vmux_setting::AppSettings>>,
     mut active_id: ResMut<vmux_layout::space::ActiveSpaceId>,
     mut layout_requests: MessageWriter<TabLayoutSpawnRequest>,
@@ -726,9 +726,7 @@ mod tests {
         app.update();
 
         assert_eq!(
-            app.world()
-                .resource::<vmux_layout::settings::EffectiveStartupUrl>()
-                .0,
+            app.world().resource::<vmux_core::EffectiveStartupUrl>().0,
             "https://work.example"
         );
     }

--- a/crates/vmux_browser/src/command.rs
+++ b/crates/vmux_browser/src/command.rs
@@ -57,7 +57,7 @@ fn handle_browser_commands(
     mut zoom_q: Query<&mut ZoomLevel, With<Browser>>,
     mut meta_q: Query<&mut PageMetadata, With<Browser>>,
     terminal_q: Query<(), With<Terminal>>,
-    effective_startup_url: Option<Res<vmux_layout::settings::EffectiveStartupUrl>>,
+    effective_startup_url: Option<Res<vmux_core::EffectiveStartupUrl>>,
     host_spawn: Res<HostSpawnRegistry>,
     mut page_open_requests: MessageWriter<PageOpenRequest>,
     mut font_size_writer: MessageWriter<vmux_terminal::TerminalFontSizeCommand>,

--- a/crates/vmux_browser/src/command_bar/handler.rs
+++ b/crates/vmux_browser/src/command_bar/handler.rs
@@ -44,7 +44,7 @@ use vmux_layout::cef::{Browser, LayoutCef};
 use vmux_layout::{Header, side_sheet::SideSheet};
 use vmux_ui::i18n::{Locale, TranslationValue};
 
-use vmux_layout::settings::ResolvedLocale;
+use vmux_command::ResolvedLocale;
 
 pub(crate) use vmux_core::focus_pane_entity;
 
@@ -545,7 +545,7 @@ fn handle_open_command_bar(
     mut snapshot_params: ParamSet<(
         Res<CommandBarSpacesSnapshot>,
         ResMut<PendingLaunch>,
-        Option<Res<vmux_layout::settings::EffectiveStartupUrl>>,
+        Option<Res<vmux_core::EffectiveStartupUrl>>,
         MessageWriter<PageOpenRequest>,
         Res<CommandBarPagesSnapshot>,
         Res<vmux_command::snapshot::CommandBarWorkSnapshot>,

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -2519,7 +2519,7 @@ mod tests {
         #[test]
         fn in_place_with_none_url_uses_startup_setting() {
             let mut app = build_app();
-            app.insert_resource(vmux_layout::settings::EffectiveStartupUrl(
+            app.insert_resource(vmux_core::EffectiveStartupUrl(
                 "https://startup.example".into(),
             ));
             build_focused_stack(&mut app);

--- a/crates/vmux_core/src/host/component.rs
+++ b/crates/vmux_core/src/host/component.rs
@@ -151,3 +151,10 @@ pub enum TransitionType {
     Redirect,
     Other,
 }
+
+/// The URL a fresh stack opens when nothing else has been asked for.
+///
+/// Resolved once from settings and the active space, then read by everything that has to open
+/// something without being told what.
+#[derive(bevy::prelude::Resource, Clone, Debug, Default)]
+pub struct EffectiveStartupUrl(pub String);


### PR DESCRIPTION
Stacked on #391.

## Summary

`ResolvedLocale` and `EffectiveStartupUrl` lived in `vmux_layout::settings`, and neither is about the window:

| | written by | read by |
|---|---|---|
| `ResolvedLocale` | `vmux_setting` | the command bar, the start page, anything naming a command to a person |
| `EffectiveStartupUrl` | `vmux_space`, `vmux_layout` | everything that opens something without being told what |

The layout was just where they happened to be declared, and that made it a dependency for reasons that had nothing to do with windows, tabs or panes.

`ResolvedLocale` moves to `vmux_command` — downstream of every reader, and `vmux_setting` already depends on it. `EffectiveStartupUrl` is a bare `String` and moves to `vmux_core`. `vmux_layout` re-exports both, so its own eight uses and `vmux_space`'s three don't move.

`vmux_ui` would have been the natural home for `ResolvedLocale` since it owns `Locale` — but it has no Bevy dependency at all, so it cannot hold a `Resource`.

## Where the module stands

Two real `vmux_layout` imports left in `command_bar/`:

```
handler.rs:43: use vmux_layout::cef::{Browser, LayoutCef};
handler.rs:44: use vmux_layout::{Header, side_sheet::SideSheet};
```

plus four in the test harness (`StackPlugin`, `LayoutSpawnRequest`, `PendingCursorWarp`). `Browser`/`Header`/`SideSheet` are the "page webviews, excluding chrome" filter; `LayoutCef` is the shell the panel payload is emitted at. Those are the last step before the module can move to `vmux_command`.

## Test plan

- [x] `cargo fmt --check`
- [x] `clippy -D warnings` under CI's exact package selection
- [x] `cargo test --workspace` green

Pure type relocation with re-exports, so behaviour should be identical. Worth confirming the two readers still see values rather than defaults:

- **Switch the app language in settings** — command names in the bar follow (that's `ResolvedLocale` reaching the payload builder)
- **Cmd+T with a startup URL configured** — the new stack opens it rather than a blank page