### PR TITLE
Take the last layout types out of the command bar

### DIFF
--- a/crates/page/vmux_layout/src/host/cef.rs
+++ b/crates/page/vmux_layout/src/host/cef.rs
@@ -199,6 +199,7 @@ impl Browser {
 pub fn layout_cef_bundle(host_window: Entity) -> impl Bundle {
     (
         LayoutCef,
+        vmux_core::launcher::RendersLauncherPanel,
         HostWindow(host_window),
         Node {
             width: Val::Percent(100.0),

--- a/crates/page/vmux_layout/src/host/pending_stack.rs
+++ b/crates/page/vmux_layout/src/host/pending_stack.rs
@@ -11,7 +11,7 @@
 use bevy::ecs::relationship::Relationship;
 use bevy::prelude::*;
 use bevy_cef::prelude::CefKeyboardTarget;
-use vmux_core::launcher::{PendingStackAbandoned, StackInPaneChosen};
+use vmux_core::launcher::{PendingStackAbandoned, RestoreKeyboardToStack, StackInPaneChosen};
 use vmux_history::LastActivatedAt;
 
 use crate::cef::Browser;
@@ -24,9 +24,14 @@ impl Plugin for PendingStackPlugin {
     fn build(&self, app: &mut App) {
         app.add_message::<PendingStackAbandoned>()
             .add_message::<StackInPaneChosen>()
+            .add_message::<RestoreKeyboardToStack>()
             .add_systems(
                 Update,
-                (discard_abandoned_pending_stacks, focus_chosen_stack_in_pane)
+                (
+                    discard_abandoned_pending_stacks,
+                    focus_chosen_stack_in_pane,
+                    restore_keyboard_to_stack,
+                )
                     .before(crate::stack::ComputeFocusSet),
             );
     }
@@ -62,6 +67,32 @@ fn discard_abandoned_pending_stacks(
         };
         for child in children.iter() {
             if content_browsers.contains(child) {
+                commands.entity(child).try_insert(CefKeyboardTarget);
+            }
+        }
+    }
+}
+
+/// Hands the keyboard to the content page in a stack, skipping the header and side sheet.
+fn restore_keyboard_to_stack(
+    mut requests: MessageReader<RestoreKeyboardToStack>,
+    all_children: Query<&Children>,
+    content_pages: Query<
+        Entity,
+        (
+            With<Browser>,
+            Without<crate::Header>,
+            Without<crate::side_sheet::SideSheet>,
+        ),
+    >,
+    mut commands: Commands,
+) {
+    for request in requests.read() {
+        let Ok(children) = all_children.get(request.stack) else {
+            continue;
+        };
+        for child in children.iter() {
+            if content_pages.contains(child) {
                 commands.entity(child).try_insert(CefKeyboardTarget);
             }
         }

--- a/crates/vmux_browser/src/command_bar/handler.rs
+++ b/crates/vmux_browser/src/command_bar/handler.rs
@@ -4,15 +4,15 @@ use vmux_command::build_command_bar_open_payload;
 pub(crate) use vmux_core::launcher::PendingLaunch;
 use vmux_core::launcher::{
     FocusLauncherInput, HostsLauncher, InlineTransitionRequested, PendingStackAbandoned,
-    StackInPaneChosen,
+    RendersLauncherPanel, RestoreKeyboardToStack, StackInPaneChosen,
 };
 
 use crate::command_bar::panel::CommandBarPanelActive;
 use crate::command_bar::state::{CommandBarStateQuery, command_bar_state};
 use crate::command_bar::work_snapshot::{update_recent_files_snapshot, update_work_dirs_snapshot};
 use bevy::{
-    ecs::message::MessageReader, ecs::relationship::Relationship, ecs::system::SystemParam,
-    picking::Pickable, prelude::*, ui::UiSystems,
+    ecs::message::MessageReader, ecs::system::SystemParam, picking::Pickable, prelude::*,
+    ui::UiSystems,
 };
 use bevy_cef::prelude::*;
 use vmux_command::event::{
@@ -40,8 +40,6 @@ use vmux_core::{
     PageMetadata, PageOpenRequest, PageOpenTarget, PendingPrompt, PendingPromptAttachments,
 };
 use vmux_history::{LastActivatedAt, now_millis};
-use vmux_layout::cef::{Browser, LayoutCef};
-use vmux_layout::{Header, side_sheet::SideSheet};
 use vmux_ui::i18n::{Locale, TranslationValue};
 
 use vmux_command::ResolvedLocale;
@@ -58,6 +56,7 @@ impl Plugin for CommandBarInputPlugin {
             .add_message::<FocusLauncherInput>()
             .add_message::<InlineTransitionRequested>()
             .add_message::<StackInPaneChosen>()
+            .add_message::<RestoreKeyboardToStack>()
             .add_message::<vmux_core::agent::SpawnAgentInStackRequest>()
             .add_message::<SettingsPageSpawnRequest>()
             .add_message::<SpacesPageSpawnRequest>()
@@ -526,21 +525,15 @@ fn command_bar_toggle_should_open(is_open: bool, space_switch: bool) -> bool {
 
 fn handle_open_command_bar(
     mut reader: MessageReader<AppCommand>,
-    layout_q: Query<(Entity, Has<CommandBarPanelActive>), With<LayoutCef>>,
+    layout_q: Query<(Entity, Has<CommandBarPanelActive>), With<RendersLauncherPanel>>,
     all_children: Query<&Children>,
-    browser_meta: Query<&PageMetadata, With<Browser>>,
+    // Filtered to webviews because a stack carries `PageMetadata` of its own; only the page
+    // showing inside it answers "what is open here".
+    browser_meta: Query<&PageMetadata, With<WebviewSource>>,
     focus: Res<CommandBarWorkspaceSnapshot>,
+    mut restore_keyboard: MessageWriter<RestoreKeyboardToStack>,
     mut launcher_hosts: LauncherHosts,
     child_of_q: Query<&ChildOf>,
-    content_browsers: Query<
-        Entity,
-        (
-            With<Browser>,
-            Without<Header>,
-            Without<SideSheet>,
-            Without<CommandBar>,
-        ),
-    >,
     contributions: Contributions,
     mut snapshot_params: ParamSet<(
         Res<CommandBarSpacesSnapshot>,
@@ -601,28 +594,12 @@ fn handle_open_command_bar(
         // Discard empty tab created by a previous Cmd+T
         if let Some(stack_e) = pending_launch.stack.take() {
             commands.entity(stack_e).despawn();
-            if let Some(prev) = pending_launch.previous_stack.take()
-                && let Ok(children) = all_children.get(prev)
-            {
-                for child in children.iter() {
-                    if content_browsers.contains(child) {
-                        commands.entity(child).try_insert(CefKeyboardTarget);
-                    }
-                }
+            if let Some(prev) = pending_launch.previous_stack.take() {
+                restore_keyboard.write(RestoreKeyboardToStack { stack: prev });
             }
         } else {
-            let active_stack = focus.stack;
-            if let Some(tab) = active_stack {
-                for browser_e in &content_browsers {
-                    let is_child = child_of_q
-                        .get(browser_e)
-                        .ok()
-                        .map(|co| co.get() == tab)
-                        .unwrap_or(false);
-                    if is_child {
-                        commands.entity(browser_e).try_insert(CefKeyboardTarget);
-                    }
-                }
+            if let Some(stack) = focus.stack {
+                restore_keyboard.write(RestoreKeyboardToStack { stack });
             }
         }
         pending_launch.needs_open = false;
@@ -749,17 +726,6 @@ fn close_command_bar_panel(layout: Entity, commands: &mut Commands) {
 #[derive(SystemParam)]
 struct CommandBarActionQueries<'w, 's> {
     child_of_q: Query<'w, 's, &'static ChildOf>,
-    content_browsers: Query<
-        'w,
-        's,
-        Entity,
-        (
-            With<Browser>,
-            Without<Header>,
-            Without<SideSheet>,
-            Without<CommandBar>,
-        ),
-    >,
     launcher_hosts: Query<'w, 's, (), With<HostsLauncher>>,
     focus: Res<'w, CommandBarWorkspaceSnapshot>,
 }
@@ -845,6 +811,7 @@ fn on_command_bar_action(
     mut abandoned_writer: MessageWriter<PendingStackAbandoned>,
     mut inline_transition: MessageWriter<InlineTransitionRequested>,
     mut stack_chosen: MessageWriter<StackInPaneChosen>,
+    mut restore_keyboard: MessageWriter<RestoreKeyboardToStack>,
     mut issued: MessageWriter<vmux_command::CommandIssued>,
     user_q: Query<Entity, With<vmux_core::team::User>>,
     mut commands: Commands,
@@ -1188,21 +1155,8 @@ fn on_command_bar_action(
             .remove::<PendingCommandBarReveal>()
             .remove::<CommandBarRecreating>();
     }
-    if !custom_keyboard_restore {
-        let active_stack = queries.focused_stack();
-        if let Some(tab) = active_stack {
-            for browser_e in &queries.content_browsers {
-                let is_child = queries
-                    .child_of_q
-                    .get(browser_e)
-                    .ok()
-                    .map(|co| co.get() == tab)
-                    .unwrap_or(false);
-                if is_child {
-                    commands.entity(browser_e).try_insert(CefKeyboardTarget);
-                }
-            }
-        }
+    if !custom_keyboard_restore && let Some(stack) = queries.focused_stack() {
+        restore_keyboard.write(RestoreKeyboardToStack { stack });
     }
 }
 
@@ -1966,6 +1920,7 @@ mod tests {
             .add_message::<FocusLauncherInput>()
             .add_message::<InlineTransitionRequested>()
             .add_message::<StackInPaneChosen>()
+            .add_message::<RestoreKeyboardToStack>()
             .add_message::<PendingStackAbandoned>()
             .init_resource::<CommandBarWorkspaceSnapshot>()
             .init_resource::<CommandBarSpacesSnapshot>()
@@ -2009,7 +1964,7 @@ mod tests {
     #[test]
     fn opening_the_command_bar_pushes_the_payload_to_the_layout_page() {
         let mut app = panel_app();
-        let layout = app.world_mut().spawn(LayoutCef).id();
+        let layout = app.world_mut().spawn(RendersLauncherPanel).id();
 
         send(
             &mut app,
@@ -2029,7 +1984,7 @@ mod tests {
         let mut app = panel_app();
         let layout = app
             .world_mut()
-            .spawn((LayoutCef, CommandBarPanelActive))
+            .spawn((RendersLauncherPanel, CommandBarPanelActive))
             .id();
 
         send(
@@ -2051,7 +2006,7 @@ mod tests {
         let mut app = panel_app();
         let layout = app
             .world_mut()
-            .spawn((LayoutCef, CommandBarPanelActive))
+            .spawn((RendersLauncherPanel, CommandBarPanelActive))
             .id();
         let pending = app.world_mut().spawn_empty().id();
         app.insert_resource(PendingLaunch {
@@ -2083,7 +2038,7 @@ mod tests {
         let mut app = panel_app();
         let layout = app
             .world_mut()
-            .spawn((LayoutCef, CommandBarPanelActive))
+            .spawn((RendersLauncherPanel, CommandBarPanelActive))
             .id();
 
         send(
@@ -2101,7 +2056,7 @@ mod tests {
     #[test]
     fn open_page_in_command_bar_marks_payload_as_in_place_target() {
         let mut app = panel_app();
-        app.world_mut().spawn(LayoutCef);
+        app.world_mut().spawn(RendersLauncherPanel);
 
         send(
             &mut app,
@@ -2191,6 +2146,7 @@ mod tests {
             .add_message::<FocusLauncherInput>()
             .add_message::<InlineTransitionRequested>()
             .add_message::<StackInPaneChosen>()
+            .add_message::<RestoreKeyboardToStack>()
             .add_message::<PendingStackAbandoned>()
             .add_message::<vmux_core::terminal::ProcessesMonitorSpawnRequest>()
             .add_message::<vmux_layout::LayoutSpawnRequest>()

--- a/crates/vmux_browser/src/command_bar/panel.rs
+++ b/crates/vmux_browser/src/command_bar/panel.rs
@@ -16,7 +16,7 @@ impl Plugin for CommandBarPanelPlugin {
 
 /// The command bar panel in the layout page holds a focused DOM field.
 ///
-/// Sits on the `LayoutCef` webview entity, exactly like [`vmux_layout::bookmark::BookmarkTextInputActive`],
+/// Sits on the webview that renders the panel, exactly like the bookmark field's own active marker,
 /// and feeds the same "the layout page owns the keyboard" rule: `CefKeyboardTarget` moves to the
 /// layout shell, OSR focus follows it, and AppKit first responder stays with winit so keys route
 /// winit -> Bevy -> `send_key_event` -> the focused element.

--- a/crates/vmux_browser/src/layout_view.rs
+++ b/crates/vmux_browser/src/layout_view.rs
@@ -54,6 +54,7 @@ impl Plugin for LayoutViewPlugin {
             Update,
             (
                 resize_layout_view,
+                keep_layout_view_hit_testable,
                 sync_layout_view_color_scheme.run_if(resource_changed::<AppSettings>),
             )
                 .after(spawn_layout_view),
@@ -179,6 +180,7 @@ fn spawn_layout_view(world: &mut World) {
         None => report_waiting("primary window has no winit window yet"),
         Some(Ok(webview)) => {
             raise_above_window_layers(&webview);
+            raise_above_window_views(&webview);
             world
                 .non_send_mut::<Browsers>()
                 .set_externally_hosted(layout);
@@ -192,6 +194,15 @@ fn spawn_layout_view(world: &mut World) {
 }
 
 #[cfg(target_os = "macos")]
+/// Re-asserts the chrome's place in the subview order, which new panes keep taking.
+#[cfg(target_os = "macos")]
+fn keep_layout_view_hit_testable(view: Option<NonSend<LayoutView>>) {
+    let Some(view) = view else {
+        return;
+    };
+    raise_above_window_views(&view.webview);
+}
+
 fn resize_layout_view(
     view: Option<NonSend<LayoutView>>,
     window: Query<&Window, (With<PrimaryWindow>, Changed<Window>)>,
@@ -447,6 +458,34 @@ const WRY_HOST_SHIM: &str = r#"
 /// `sync_layout_overlay` still parents a `CALayer` at `zPosition` 100 and subview order cannot
 /// outrank a `zPosition` — only another one can.
 #[cfg(target_os = "macos")]
+/// Keep the chrome frontmost for hit-testing, not only for compositing.
+///
+/// [`raise_above_window_layers`] orders the *layer*, which is what makes the chrome paint over the
+/// panes. AppKit hit-tests the *subview array* and ignores layer z entirely, so on its own that
+/// leaves the chrome drawn on top with every click landing on the pane behind it. Panes are created
+/// after this view and each one appends a subview, so the order has to be re-asserted rather than
+/// set once.
+fn raise_above_window_views(webview: &wry::WebView) {
+    use objc2_app_kit::{NSView, NSWindowOrderingMode};
+    use wry::WebViewExtMacOS;
+
+    let wk = webview.webview();
+    let view: &NSView = &wk;
+    // SAFETY: the view is alive for as long as the `LayoutView` holding it, and this runs on the
+    // main thread with the window's hierarchy quiescent.
+    let Some(parent) = (unsafe { view.superview() }) else {
+        return;
+    };
+    let subviews = parent.subviews();
+    let already_front = subviews
+        .lastObject()
+        .is_some_and(|last| std::ptr::eq(&*last, view));
+    if already_front {
+        return;
+    }
+    parent.addSubview_positioned_relativeTo(view, NSWindowOrderingMode::Above, None);
+}
+
 fn raise_above_window_layers(webview: &wry::WebView) {
     use objc2_app_kit::NSView;
     use wry::WebViewExtMacOS;

--- a/crates/vmux_browser/src/layout_view.rs
+++ b/crates/vmux_browser/src/layout_view.rs
@@ -54,7 +54,6 @@ impl Plugin for LayoutViewPlugin {
             Update,
             (
                 resize_layout_view,
-                keep_layout_view_hit_testable,
                 sync_layout_view_color_scheme.run_if(resource_changed::<AppSettings>),
             )
                 .after(spawn_layout_view),
@@ -180,7 +179,6 @@ fn spawn_layout_view(world: &mut World) {
         None => report_waiting("primary window has no winit window yet"),
         Some(Ok(webview)) => {
             raise_above_window_layers(&webview);
-            raise_above_window_views(&webview);
             world
                 .non_send_mut::<Browsers>()
                 .set_externally_hosted(layout);
@@ -194,15 +192,6 @@ fn spawn_layout_view(world: &mut World) {
 }
 
 #[cfg(target_os = "macos")]
-/// Re-asserts the chrome's place in the subview order, which new panes keep taking.
-#[cfg(target_os = "macos")]
-fn keep_layout_view_hit_testable(view: Option<NonSend<LayoutView>>) {
-    let Some(view) = view else {
-        return;
-    };
-    raise_above_window_views(&view.webview);
-}
-
 fn resize_layout_view(
     view: Option<NonSend<LayoutView>>,
     window: Query<&Window, (With<PrimaryWindow>, Changed<Window>)>,
@@ -458,34 +447,6 @@ const WRY_HOST_SHIM: &str = r#"
 /// `sync_layout_overlay` still parents a `CALayer` at `zPosition` 100 and subview order cannot
 /// outrank a `zPosition` — only another one can.
 #[cfg(target_os = "macos")]
-/// Keep the chrome frontmost for hit-testing, not only for compositing.
-///
-/// [`raise_above_window_layers`] orders the *layer*, which is what makes the chrome paint over the
-/// panes. AppKit hit-tests the *subview array* and ignores layer z entirely, so on its own that
-/// leaves the chrome drawn on top with every click landing on the pane behind it. Panes are created
-/// after this view and each one appends a subview, so the order has to be re-asserted rather than
-/// set once.
-fn raise_above_window_views(webview: &wry::WebView) {
-    use objc2_app_kit::{NSView, NSWindowOrderingMode};
-    use wry::WebViewExtMacOS;
-
-    let wk = webview.webview();
-    let view: &NSView = &wk;
-    // SAFETY: the view is alive for as long as the `LayoutView` holding it, and this runs on the
-    // main thread with the window's hierarchy quiescent.
-    let Some(parent) = (unsafe { view.superview() }) else {
-        return;
-    };
-    let subviews = parent.subviews();
-    let already_front = subviews
-        .lastObject()
-        .is_some_and(|last| std::ptr::eq(&*last, view));
-    if already_front {
-        return;
-    }
-    parent.addSubview_positioned_relativeTo(view, NSWindowOrderingMode::Above, None);
-}
-
 fn raise_above_window_layers(webview: &wry::WebView) {
     use objc2_app_kit::NSView;
     use wry::WebViewExtMacOS;

--- a/crates/vmux_core/src/host.rs
+++ b/crates/vmux_core/src/host.rs
@@ -31,7 +31,8 @@ pub use archive::{
 pub use host_spawn::{HostSpawnRegistry, register_host_spawn};
 pub use launcher::{
     ContributedCommandChosen, FocusLauncherInput, HostsLauncher, InlineTransitionRequested,
-    PendingLaunch, PendingStackAbandoned, StackInPaneChosen,
+    PendingLaunch, PendingStackAbandoned, RendersLauncherPanel, RestoreKeyboardToStack,
+    StackInPaneChosen,
 };
 pub use notify::{AgentAttention, AgentDoneUnseen, BellReceived, OsNotify};
 pub use overlay::{OverlayState, OverlayStateQuery, WindowOverlay};

--- a/crates/vmux_core/src/host/launcher.rs
+++ b/crates/vmux_core/src/host/launcher.rs
@@ -66,6 +66,23 @@ pub struct InlineTransitionRequested {
     pub webview: Entity,
 }
 
+/// The webview that renders the launcher panel.
+///
+/// The bar is not always a page of its own: a host page can render the palette inline, and the
+/// payload has to be delivered to that page rather than to a webview of the bar's. Which page it is
+/// is the host's business, so it says so with this and the launcher looks for the capability.
+#[derive(Component, Clone, Copy, Debug)]
+pub struct RendersLauncherPanel;
+
+/// Give the keyboard back to whatever content page is showing in `stack`.
+///
+/// Finding it means knowing which webviews are pages and which are chrome, which is workspace
+/// shape. The launcher only knows that it is done with the keyboard.
+#[derive(Message, Clone, Copy, Debug)]
+pub struct RestoreKeyboardToStack {
+    pub stack: Entity,
+}
+
 /// Bring the nth stack of a pane to the front.
 ///
 /// The launcher lists open stacks and reports which row was picked. Resolving that to an entity

--- a/crates/vmux_page/assets/index.css
+++ b/crates/vmux_page/assets/index.css
@@ -3,6 +3,7 @@
 @source "../src";
 @source "../../page/vmux_agent/src";
 @source "../../page/vmux_chat/src";
+@source "../../page/vmux_command/src";
 @source "../../page/vmux_editor/src";
 @source "../../page/vmux_history/src";
 @source "../../page/vmux_layout/src";


### PR DESCRIPTION
Stacked on #392.

## Summary

Two imports were left, and neither was about the window shell. Both were the bar reaching for a concrete page when what it wanted was a capability or an action.

**`LayoutCef`** was the webview to deliver the panel payload to. Since the panel moved to `vmux_command` in #389 that is no longer "the layout" but "whichever page renders the panel" — so the layout declares `RendersLauncherPanel` and the bar looks for the capability.

**`Browser` + `Header` + `SideSheet`** filtered *"content webviews, not chrome"*, three times over, for one purpose: handing the keyboard back after the bar closes. Knowing which webviews are pages and which are chrome is workspace shape. The bar only knows it is done with the keyboard, so `RestoreKeyboardToStack` says that and the workspace answers it — collapsing three near-identical loops into three one-line writes.

## One filter kept, for a reason

A stack carries `PageMetadata` of its own — `vmux_terminal` and `vmux_agent` both set it on the stack, not the webview. So "what is open here" has to skip the stack and look at the page inside it, which is what `With<Browser>` was quietly doing. It filters on `WebviewSource` now, which is what it always meant and does not need the layout.

## Where this leaves it

```console
$ grep -rn "vmux_layout" crates/vmux_browser/src/command_bar/
handler.rs:2143:  .add_plugins(vmux_layout::stack::StackPlugin)
handler.rs:2152:  .add_message::<vmux_layout::LayoutSpawnRequest>()
handler.rs:2155:  .init_resource::<vmux_layout::pane::PendingCursorWarp>()
handler.rs:2251:  .add_plugins(vmux_layout::stack::StackPlugin)
```

**No production code in the command bar names `vmux_layout`.** What is left is the test harness, which builds a layout app on purpose — and that goes when the module itself moves to `vmux_command`, which is now unblocked.

For the record, the count across this stack: **24 layout references → 0**.

## Test plan

- [x] `cargo fmt --check`
- [x] `clippy -D warnings` under CI's exact package selection
- [x] `cargo test --workspace` green

Keyboard handling is the risk here — it changed from an inline loop to a message answered a system later, and a lost keyboard is invisible to the suite:

- **Cmd+K then Escape** — the keyboard returns to the page behind, and typing goes there
- **Cmd+T then Escape** — same, back to the tab you came from
- **Cmd+K, pick a page** — the opened page takes the keyboard
- **Cmd+K on a pane split** — the keyboard lands in the focused pane, not a sibling
- **Cmd+K with the bar already open, then Escape** — the panel closes and nothing is left holding the keyboard