### PR TITLE
Treat the panel as the command bar, not the webview behind it

### DIFF
--- a/crates/page/vmux_command/src/host/command_bar/handler.rs
+++ b/crates/page/vmux_command/src/host/command_bar/handler.rs
@@ -1528,7 +1528,7 @@ mod tests {
 
         assert_eq!(node.display, Display::Flex);
         assert_eq!(visibility, Visibility::Inherited);
-        assert!(!OverlayState::of(node.display, visibility, false).owns_input());
+        assert!(!OverlayState::of(node.display, visibility, false, false).owns_input());
     }
 
     #[test]
@@ -2248,7 +2248,8 @@ mod tests {
             !OverlayState::of(
                 display_after_prewarm,
                 Visibility::Hidden,
-                has_kb_after_prewarm
+                has_kb_after_prewarm,
+                false
             )
             .owns_input(),
             "is_command_bar_open must report false after dismiss + prewarm"

--- a/crates/page/vmux_command/src/host/command_bar/panel.rs
+++ b/crates/page/vmux_command/src/host/command_bar/panel.rs
@@ -1,7 +1,9 @@
 use bevy::prelude::*;
 use bevy_cef::prelude::{BinEventEmitterPlugin, BinReceive};
 
+use crate::CommandBar;
 use crate::event::CommandBarPanelActiveEvent;
+use vmux_core::overlay::OverlayShownInline;
 
 pub struct CommandBarPanelPlugin;
 
@@ -10,7 +12,8 @@ impl Plugin for CommandBarPanelPlugin {
         app.add_plugins(
             BinEventEmitterPlugin::<(CommandBarPanelActiveEvent,)>::for_hosts(&["layout"]),
         )
-        .add_observer(on_command_bar_panel_active);
+        .add_observer(on_command_bar_panel_active)
+        .add_systems(Update, mark_command_bar_shown_inline);
     }
 }
 
@@ -22,6 +25,29 @@ impl Plugin for CommandBarPanelPlugin {
 /// winit -> Bevy -> `send_key_event` -> the focused element.
 #[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct CommandBarPanelActive;
+
+/// Tells the bar's overlay entity that the panel is its surface right now.
+///
+/// Every question the host asks about the bar is asked of the overlay entity: is it open, does it
+/// own input, should Escape dismiss it. The overlay's own node stays hidden while the panel is up,
+/// so without this each of those answers is wrong about a bar the user is looking at.
+fn mark_command_bar_shown_inline(
+    panel_active: Query<(), With<CommandBarPanelActive>>,
+    bar_q: Query<(Entity, Has<OverlayShownInline>), With<CommandBar>>,
+    mut commands: Commands,
+) {
+    let inline = !panel_active.is_empty();
+    for (bar, marked) in bar_q.iter() {
+        if inline == marked {
+            continue;
+        }
+        if inline {
+            commands.entity(bar).insert(OverlayShownInline);
+        } else {
+            commands.entity(bar).remove::<OverlayShownInline>();
+        }
+    }
+}
 
 fn on_command_bar_panel_active(
     trigger: On<BinReceive<CommandBarPanelActiveEvent>>,
@@ -44,7 +70,8 @@ mod tests {
     fn app() -> App {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .add_observer(on_command_bar_panel_active);
+            .add_observer(on_command_bar_panel_active)
+            .add_systems(Update, mark_command_bar_shown_inline);
         app
     }
 

--- a/crates/page/vmux_command/src/host/command_bar/state.rs
+++ b/crates/page/vmux_command/src/host/command_bar/state.rs
@@ -4,8 +4,17 @@ use bevy_cef::prelude::CefKeyboardTarget;
 use vmux_core::overlay::OverlayState;
 
 /// The bar's own view of [`OverlayState`], filtered to its entity rather than to any overlay.
-pub type CommandBarStateQuery<'w, 's> =
-    Query<'w, 's, (&'static Node, &'static Visibility, Has<CefKeyboardTarget>), With<CommandBar>>;
+pub type CommandBarStateQuery<'w, 's> = Query<
+    'w,
+    's,
+    (
+        &'static Node,
+        &'static Visibility,
+        Has<CefKeyboardTarget>,
+        Has<vmux_core::overlay::OverlayShownInline>,
+    ),
+    With<CommandBar>,
+>;
 
 pub fn command_bar_state(modal_q: &CommandBarStateQuery) -> OverlayState {
     OverlayState::of_each(modal_q.iter())

--- a/crates/vmux_browser/src/host_focus.rs
+++ b/crates/vmux_browser/src/host_focus.rs
@@ -63,6 +63,12 @@ fn publish_native_page_owns_escape(
 pub enum HostFocusIntent {
     /// Active page is a windowed web page; give this webview native first-responder.
     Windowed(Entity),
+    /// The layout's own chrome holds the keyboard, and a `WKWebView` of its own draws it.
+    ///
+    /// Distinct from [`Self::WinitHost`] because the two want opposite things. `WinitHost` exists
+    /// so keys reach a terminal by way of winit and Bevy; the chrome is a DOM that must receive
+    /// them natively, and routing them through winit sends them to a CEF browser that is not there.
+    LayoutView,
     /// Active page is a terminal, or there is none — the winit host window must own first-responder.
     #[default]
     WinitHost,
@@ -90,24 +96,25 @@ pub(crate) fn compute_host_focus_intent(
             Option<&Visibility>,
             Has<CefKeyboardTarget>,
             Has<WebviewWindowed>,
+            Has<vmux_core::overlay::OverlayShownInline>,
         ),
         With<WindowOverlay>,
     >,
-    layout_keyboard_q: Query<(), (With<Browser>, crate::present::LayoutKeyboardCapture)>,
+    layout_keyboard_q: Query<(), crate::present::LayoutKeyboardHost>,
     mut intent: ResMut<HostFocusIntent>,
 ) {
-    let next = if let Some((modal, windowed)) =
-        modal_q
-            .iter()
-            .find_map(|(entity, node, visibility, keyboard_target, windowed)| {
-                OverlayState::of(
-                    node.display,
-                    visibility.copied().unwrap_or_default(),
-                    keyboard_target,
-                )
-                .owns_input()
-                .then_some((entity, windowed))
-            }) {
+    let next = if let Some((modal, windowed)) = modal_q.iter().find_map(
+        |(entity, node, visibility, keyboard_target, windowed, shown_inline)| {
+            OverlayState::of(
+                node.display,
+                visibility.copied().unwrap_or_default(),
+                keyboard_target,
+                shown_inline,
+            )
+            .owns_input()
+            .then_some((entity, windowed))
+        },
+    ) {
         // A windowed command bar hosts a real DOM text field, so Chromium must receive the
         // keystrokes itself — `send_key_event` forwarding is a windowless API and produces no DOM
         // key events here. Escape and Ctrl-C are intercepted by the `NSEvent` monitor before the
@@ -118,7 +125,7 @@ pub(crate) fn compute_host_focus_intent(
             HostFocusIntent::WinitHost
         }
     } else if !layout_keyboard_q.is_empty() {
-        HostFocusIntent::WinitHost
+        HostFocusIntent::LayoutView
     } else {
         let active = focus.stack.and_then(|stack| {
             content_q.iter().find(|&webview| {
@@ -145,12 +152,17 @@ fn windowed_focus_action(
     has_browser: bool,
     has_native_focus: Option<bool>,
     focused: &mut Option<Entity>,
+    reclaiming: bool,
 ) -> Option<Entity> {
     match intent {
         HostFocusIntent::Windowed(webview) if has_browser => {
-            let should_focus = has_native_focus
-                .map(|has_focus| !has_focus)
-                .unwrap_or(*focused != Some(webview));
+            // `has_native_focus` is CEF's belief about its own view. AppKit does not tell it when
+            // the chrome takes first responder, so after that it still answers "yes" and the pane
+            // is never re-focused — leaving the keyboard with nobody.
+            let should_focus = reclaiming
+                || has_native_focus
+                    .map(|has_focus| !has_focus)
+                    .unwrap_or(*focused != Some(webview));
             *focused = Some(webview);
             should_focus.then_some(webview)
         }
@@ -165,7 +177,10 @@ pub(crate) fn apply_windowed_host_focus(
     intent: Res<HostFocusIntent>,
     browsers: NonSend<Browsers>,
     mut focused: Local<Option<Entity>>,
+    mut was_layout_view: Local<bool>,
 ) {
+    let reclaiming = *was_layout_view && *intent != HostFocusIntent::LayoutView;
+    *was_layout_view = *intent == HostFocusIntent::LayoutView;
     let (has_browser, has_native_focus) = match *intent {
         HostFocusIntent::Windowed(webview) => (
             browsers.has_browser(webview),
@@ -173,9 +188,13 @@ pub(crate) fn apply_windowed_host_focus(
         ),
         _ => (false, None),
     };
-    if let Some(webview) =
-        windowed_focus_action(*intent, has_browser, has_native_focus, &mut focused)
-    {
+    if let Some(webview) = windowed_focus_action(
+        *intent,
+        has_browser,
+        has_native_focus,
+        &mut focused,
+        reclaiming,
+    ) {
         browsers.set_windowed_focus(&webview, true);
     }
 }
@@ -184,6 +203,7 @@ pub(crate) fn apply_windowed_host_focus(
 mod tests {
     use super::*;
     use vmux_layout::bookmark::{BookmarkContextMenuActive, BookmarkTextInputActive};
+    use vmux_layout::cef::LayoutCef;
 
     fn app() -> App {
         let mut app = App::new();
@@ -336,31 +356,32 @@ mod tests {
     }
 
     #[test]
-    fn bookmark_text_input_reclaims_winit_host_focus() {
+    fn bookmark_text_input_gives_the_caret_to_the_layout_view() {
         let mut app = app();
         let stack = app.world_mut().spawn_empty().id();
         app.world_mut().spawn((Browser, ChildOf(stack)));
-        app.world_mut().spawn((Browser, BookmarkTextInputActive));
+        app.world_mut().spawn((LayoutCef, BookmarkTextInputActive));
         app.insert_resource(FocusedStack {
             stack: Some(stack),
             ..default()
         });
         app.update();
-        assert_eq!(intent(&app), HostFocusIntent::WinitHost);
+        assert_eq!(intent(&app), HostFocusIntent::LayoutView);
     }
 
     #[test]
-    fn bookmark_context_menu_reclaims_winit_host_focus() {
+    fn bookmark_context_menu_gives_the_caret_to_the_layout_view() {
         let mut app = app();
         let stack = app.world_mut().spawn_empty().id();
         app.world_mut().spawn((Browser, ChildOf(stack)));
-        app.world_mut().spawn((Browser, BookmarkContextMenuActive));
+        app.world_mut()
+            .spawn((LayoutCef, BookmarkContextMenuActive));
         app.insert_resource(FocusedStack {
             stack: Some(stack),
             ..default()
         });
         app.update();
-        assert_eq!(intent(&app), HostFocusIntent::WinitHost);
+        assert_eq!(intent(&app), HostFocusIntent::LayoutView);
     }
 
     #[test]
@@ -369,12 +390,24 @@ mod tests {
         let mut focused = None;
 
         assert_eq!(
-            windowed_focus_action(HostFocusIntent::Windowed(webview), true, None, &mut focused,),
+            windowed_focus_action(
+                HostFocusIntent::Windowed(webview),
+                true,
+                None,
+                &mut focused,
+                false
+            ),
             Some(webview)
         );
         assert_eq!(focused, Some(webview));
         assert_eq!(
-            windowed_focus_action(HostFocusIntent::Windowed(webview), true, None, &mut focused,),
+            windowed_focus_action(
+                HostFocusIntent::Windowed(webview),
+                true,
+                None,
+                &mut focused,
+                false
+            ),
             None
         );
         assert_eq!(focused, Some(webview));
@@ -386,7 +419,13 @@ mod tests {
         let mut focused = None;
 
         assert_eq!(
-            windowed_focus_action(HostFocusIntent::Windowed(webview), true, None, &mut focused,),
+            windowed_focus_action(
+                HostFocusIntent::Windowed(webview),
+                true,
+                None,
+                &mut focused,
+                false
+            ),
             Some(webview)
         );
         assert_eq!(
@@ -395,12 +434,19 @@ mod tests {
                 false,
                 None,
                 &mut focused,
+                false,
             ),
             None
         );
         assert_eq!(focused, None);
         assert_eq!(
-            windowed_focus_action(HostFocusIntent::Windowed(webview), true, None, &mut focused,),
+            windowed_focus_action(
+                HostFocusIntent::Windowed(webview),
+                true,
+                None,
+                &mut focused,
+                false
+            ),
             Some(webview)
         );
     }
@@ -416,6 +462,7 @@ mod tests {
                 true,
                 Some(false),
                 &mut focused,
+                false,
             ),
             Some(webview)
         );
@@ -432,6 +479,7 @@ mod tests {
                 true,
                 Some(true),
                 &mut focused,
+                false,
             ),
             None
         );
@@ -449,10 +497,30 @@ mod tests {
                 true,
                 Some(false),
                 &mut focused,
+                false,
             ),
             Some(next)
         );
         assert_eq!(focused, Some(next));
+    }
+
+    /// CEF keeps answering "I have focus" after the chrome took first responder out from under it,
+    /// so coming back from the chrome has to focus the pane regardless of what CEF believes.
+    #[test]
+    fn leaving_the_layout_view_refocuses_the_pane_despite_cef_claiming_focus() {
+        let webview = Entity::from_bits(1);
+        let mut focused = Some(webview);
+
+        assert_eq!(
+            windowed_focus_action(
+                HostFocusIntent::Windowed(webview),
+                true,
+                Some(true),
+                &mut focused,
+                true,
+            ),
+            Some(webview)
+        );
     }
 
     #[test]
@@ -460,7 +528,7 @@ mod tests {
         let mut focused = Some(Entity::from_bits(1));
 
         assert_eq!(
-            windowed_focus_action(HostFocusIntent::WinitHost, false, None, &mut focused),
+            windowed_focus_action(HostFocusIntent::WinitHost, false, None, &mut focused, false),
             None
         );
         assert_eq!(focused, None);
@@ -471,7 +539,7 @@ mod tests {
         let mut focused = Some(Entity::from_bits(1));
 
         assert_eq!(
-            windowed_focus_action(HostFocusIntent::WinitHost, false, None, &mut focused),
+            windowed_focus_action(HostFocusIntent::WinitHost, false, None, &mut focused, false),
             None
         );
         assert_eq!(focused, None);

--- a/crates/vmux_browser/src/layout_view.rs
+++ b/crates/vmux_browser/src/layout_view.rs
@@ -58,6 +58,12 @@ impl Plugin for LayoutViewPlugin {
             )
                 .after(spawn_layout_view),
         );
+        // After the CEF route has had its say, or it re-focuses the pane in the same frame.
+        #[cfg(target_os = "macos")]
+        app.add_systems(
+            PostUpdate,
+            sync_layout_view_focus.after(crate::host_focus::apply_windowed_host_focus),
+        );
         #[cfg(target_os = "macos")]
         app.add_observer(forward_host_emit);
     }
@@ -101,6 +107,31 @@ impl LayoutView {
     /// `sync_appearance_to_cef` drives, so a CEF page's media queries already agreed with the
     /// setting; a `WKWebView` has no such thing and inherits its `NSAppearance` from the window.
     /// Left alone it renders the chrome dark on a dark desktop no matter what the setting says.
+    /// Hand the view AppKit first responder, so its DOM receives keys.
+    ///
+    /// A CEF page is focused through `Browsers::set_windowed_focus` and a terminal wants the
+    /// keyboard on the winit window; neither route can reach a `WKWebView`, so nothing else in the
+    /// app can give this view the responder.
+    fn take_first_responder(&self) {
+        use objc2_app_kit::NSView;
+        use wry::WebViewExtMacOS;
+
+        let wk = self.webview.webview();
+        let view: &NSView = &wk;
+        let Some(window) = view.window() else {
+            return;
+        };
+        let already_holds_it = window
+            .firstResponder()
+            .is_some_and(|current| std::ptr::eq(&*current as *const _ as *const NSView, view));
+        if already_holds_it {
+            return;
+        }
+        if !window.makeFirstResponder(Some(view)) {
+            warn!("layout_view: the window refused first responder, chrome input will not work");
+        }
+    }
+
     fn set_color_scheme(&self, mode: vmux_setting::ColorScheme) {
         use objc2_app_kit::{
             NSAppearance, NSAppearanceCustomization, NSAppearanceNameAqua,
@@ -219,6 +250,28 @@ fn sync_layout_view_color_scheme(view: Option<NonSend<LayoutView>>, settings: Re
 ///
 /// `bevy_cef`'s own observer still runs and finds no browser for this entity, so it is this that
 /// carries the payload the rest of the way.
+/// Holds first responder for the layout view while its chrome owns the keyboard.
+///
+/// Runs every frame rather than on the edge, because `apply_winit_host_focus` reclaims for winit on
+/// its own schedule and losing the responder silently looks exactly like never having had it.
+///
+/// Nothing resigns it here: leaving it to nobody is a state the app is never otherwise in, and CEF
+/// then declines to reclaim. The pane takes it back through `set_windowed_focus` instead, which
+/// `apply_windowed_host_focus` forces on the way out of this intent.
+#[cfg(target_os = "macos")]
+fn sync_layout_view_focus(
+    view: Option<NonSend<LayoutView>>,
+    intent: Res<crate::host_focus::HostFocusIntent>,
+) {
+    if *intent != crate::host_focus::HostFocusIntent::LayoutView {
+        return;
+    }
+    let Some(view) = view else {
+        return;
+    };
+    view.take_first_responder();
+}
+
 #[cfg(target_os = "macos")]
 fn forward_host_emit(host_emit: On<BinHostEmitEvent>, view: Option<NonSend<LayoutView>>) {
     use base64::Engine;

--- a/crates/vmux_browser/src/present.rs
+++ b/crates/vmux_browser/src/present.rs
@@ -72,13 +72,21 @@ pub(crate) type LayoutKeyboardCapture = Or<(
     With<BookmarkContextMenuActive>,
     With<CommandBarPanelActive>,
 )>;
+
+/// The layout shell, when one of its DOM surfaces holds the keyboard.
+///
+/// Both readers have to name the same entity or the keyboard goes one way and first responder the
+/// other, so they share the filter rather than each spelling it out. `LayoutCef` is the shell
+/// whether or not CEF is behind it — `Browser` left it in the wry migration, which is how these two
+/// last drifted apart.
+pub(crate) type LayoutKeyboardHost = (With<LayoutCef>, LayoutKeyboardCapture);
 fn sync_keyboard_target(
     focus: Res<vmux_layout::stack::FocusedStack>,
     child_of_q: Query<&ChildOf>,
     status_q: Query<(), With<Header>>,
     side_sheet_q: Query<(), With<SideSheet>>,
     modal_q: Query<(Entity, &Node, Has<CefKeyboardTarget>), With<WindowOverlay>>,
-    layout_keyboard_q: Query<Entity, (With<LayoutCef>, LayoutKeyboardCapture)>,
+    layout_keyboard_q: Query<Entity, LayoutKeyboardHost>,
     content_q: Query<(Entity, Has<CefKeyboardTarget>), With<Browser>>,
     terminal_q: Query<(), With<vmux_terminal::Terminal>>,
     mut suppress: ResMut<bevy_cef::prelude::CefSuppressKeyboardInput>,
@@ -766,6 +774,7 @@ pub(crate) fn sync_windowed_command_bar(
             &Visibility,
             Has<CefKeyboardTarget>,
             Has<WebviewWindowed>,
+            Has<vmux_core::overlay::OverlayShownInline>,
             Option<&HostWindow>,
             Option<&CommandBarNativeSize>,
         ),
@@ -777,14 +786,22 @@ pub(crate) fn sync_windowed_command_bar(
     mut was_open: Local<bool>,
 ) {
     let matched = modal_q.single();
-    let Ok((entity, node, visibility, has_keyboard_target, is_windowed, host_window, native_size)) =
-        matched
+    let Ok((
+        entity,
+        node,
+        visibility,
+        has_keyboard_target,
+        is_windowed,
+        shown_inline,
+        host_window,
+        native_size,
+    )) = matched
     else {
         publish_native_command_bar_route(false, None, 1.0);
         *was_open = false;
         return;
     };
-    let state = OverlayState::of(node.display, *visibility, has_keyboard_target);
+    let state = OverlayState::of(node.display, *visibility, has_keyboard_target, shown_inline);
     let open = state.is_shown();
     let owns_input = state.owns_input();
     let render_hidden = command_bar_windowed_view_should_render_hidden(node.display, *visibility);
@@ -1890,7 +1907,7 @@ mod tests {
 
     #[test]
     fn revealing_command_bar_owns_input_while_its_view_stays_parked() {
-        let revealing = OverlayState::of(Display::Flex, Visibility::Hidden, true);
+        let revealing = OverlayState::of(Display::Flex, Visibility::Hidden, true, false);
 
         assert!(revealing.owns_input());
         assert!(!revealing.is_shown());

--- a/crates/vmux_core/src/host.rs
+++ b/crates/vmux_core/src/host.rs
@@ -35,7 +35,7 @@ pub use launcher::{
     StackInPaneChosen,
 };
 pub use notify::{AgentAttention, AgentDoneUnseen, BellReceived, OsNotify};
-pub use overlay::{OverlayState, OverlayStateQuery, WindowOverlay};
+pub use overlay::{OverlayShownInline, OverlayState, OverlayStateQuery, WindowOverlay};
 pub use page_open::{
     CefPageAttachRequest, PageOpenError, PageOpenHandled, PageOpenId, PageOpenRequest, PageOpenSet,
     PageOpenTarget, PageOpenTask, PendingPrompt, PendingPromptAttachments,

--- a/crates/vmux_core/src/host/overlay.rs
+++ b/crates/vmux_core/src/host/overlay.rs
@@ -13,6 +13,18 @@ use bevy_cef::prelude::CefKeyboardTarget;
 #[derive(Component, Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WindowOverlay;
 
+/// The overlay's surface is being drawn inline by a host page, not by its own webview.
+///
+/// The command bar has two implementations of one feature: a webview at `vmux://command-bar/`, and
+/// a panel drawn inside the layout page. While the panel is the one on screen the overlay's own
+/// node stays hidden, so every question asked of it - is it open, does it own input, should Escape
+/// dismiss it - answers "no" about a bar the user is looking at.
+///
+/// This is how the overlay says its surface lives elsewhere, so all of those answers come out right
+/// without each caller having to know which implementation is in play.
+#[derive(Component, Clone, Copy, Debug)]
+pub struct OverlayShownInline;
+
 /// Authoritative lifecycle state of an overlay surface.
 ///
 /// Two different questions get asked, and for the two-to-ten frames the page spends painting its
@@ -33,7 +45,17 @@ pub enum OverlayState {
 }
 
 impl OverlayState {
-    pub fn of(display: Display, visibility: Visibility, has_keyboard_target: bool) -> Self {
+    pub fn of(
+        display: Display,
+        visibility: Visibility,
+        has_keyboard_target: bool,
+        shown_inline: bool,
+    ) -> Self {
+        // An inline surface is on screen and taking keys by the time the host page says so. The
+        // overlay's own node stays hidden throughout and says nothing useful about it.
+        if shown_inline {
+            return Self::Shown;
+        }
         if display == Display::None || !has_keyboard_target {
             Self::Closed
         } else if visibility == Visibility::Hidden {
@@ -46,17 +68,29 @@ impl OverlayState {
     /// The state of the frontmost overlay, or `Closed` when none is up.
     pub fn of_any(overlay_q: &OverlayStateQuery) -> Self {
         let mut state = Self::Closed;
-        for (node, visibility, has_keyboard_target) in overlay_q.iter() {
-            state = state.max(Self::of(node.display, *visibility, has_keyboard_target));
+        for (node, visibility, has_keyboard_target, shown_inline) in overlay_q.iter() {
+            state = state.max(Self::of(
+                node.display,
+                *visibility,
+                has_keyboard_target,
+                shown_inline,
+            ));
         }
         state
     }
 
     /// The frontmost of the overlays matching `overlay_q`, whatever the query is filtered to.
-    pub fn of_each<'a>(surfaces: impl Iterator<Item = (&'a Node, &'a Visibility, bool)>) -> Self {
+    pub fn of_each<'a>(
+        surfaces: impl Iterator<Item = (&'a Node, &'a Visibility, bool, bool)>,
+    ) -> Self {
         let mut state = Self::Closed;
-        for (node, visibility, has_keyboard_target) in surfaces {
-            state = state.max(Self::of(node.display, *visibility, has_keyboard_target));
+        for (node, visibility, has_keyboard_target, shown_inline) in surfaces {
+            state = state.max(Self::of(
+                node.display,
+                *visibility,
+                has_keyboard_target,
+                shown_inline,
+            ));
         }
         state
     }
@@ -82,7 +116,12 @@ impl OverlayState {
 pub type OverlayStateQuery<'w, 's> = Query<
     'w,
     's,
-    (&'static Node, &'static Visibility, Has<CefKeyboardTarget>),
+    (
+        &'static Node,
+        &'static Visibility,
+        Has<CefKeyboardTarget>,
+        Has<OverlayShownInline>,
+    ),
     With<WindowOverlay>,
 >;
 
@@ -93,7 +132,7 @@ mod tests {
     #[test]
     fn missing_keyboard_target_is_closed() {
         assert_eq!(
-            OverlayState::of(Display::Flex, Visibility::Inherited, false),
+            OverlayState::of(Display::Flex, Visibility::Inherited, false, false),
             OverlayState::Closed
         );
     }
@@ -101,14 +140,14 @@ mod tests {
     #[test]
     fn display_none_is_closed_even_with_keyboard_target() {
         assert_eq!(
-            OverlayState::of(Display::None, Visibility::Inherited, true),
+            OverlayState::of(Display::None, Visibility::Inherited, true, false),
             OverlayState::Closed
         );
     }
 
     #[test]
     fn hidden_surface_with_keyboard_target_still_owns_input() {
-        let state = OverlayState::of(Display::Flex, Visibility::Hidden, true);
+        let state = OverlayState::of(Display::Flex, Visibility::Hidden, true, false);
 
         assert_eq!(state, OverlayState::Revealing);
         assert!(state.owns_input());
@@ -117,7 +156,7 @@ mod tests {
 
     #[test]
     fn visible_surface_with_keyboard_target_is_shown() {
-        let state = OverlayState::of(Display::Flex, Visibility::Inherited, true);
+        let state = OverlayState::of(Display::Flex, Visibility::Inherited, true, false);
 
         assert_eq!(state, OverlayState::Shown);
         assert!(state.owns_input());
@@ -129,6 +168,16 @@ mod tests {
         assert!(!OverlayState::Closed.owns_input());
         assert!(!OverlayState::Closed.is_shown());
         assert!(!OverlayState::Closed.is_revealing());
+    }
+
+    /// A surface the host page draws is on screen whatever the overlay's own node says, which is
+    /// the whole point: the node stays hidden for as long as the panel is up.
+    #[test]
+    fn an_inline_surface_is_shown_however_the_overlay_node_looks() {
+        assert_eq!(
+            OverlayState::of(Display::None, Visibility::Hidden, false, true),
+            OverlayState::Shown
+        );
     }
 
     /// The frontmost overlay wins, so one still painting cannot mask another already up.


### PR DESCRIPTION
Stacked on #394.

## Summary

The command bar has **two implementations of one feature**: a webview at `vmux://command-bar/`, and a panel drawn inside the layout page. The panel is what opens. The host talks to the webview.

Every question asked about the bar since the wry migration has been answered by the wrong one — which is why Escape doesn't dismiss it, why the toggle gets stuck, and why it can't take the keyboard.

## One point of truth, not thirty patches

Roughly thirty host sites read the bar's state, through two choke points: `OverlayState` and the `WindowOverlay` query. So the fix is to let the overlay entity say its surface is drawn elsewhere:

```rust
/// The overlay's surface is being drawn inline by a host page, not by its own webview.
pub struct OverlayShownInline;
```

Set while the panel is up; `OverlayState::of` reports `Shown` for it. Every reader — `is_command_bar_open`, the native `owns_input` route that gates Escape, the keyboard target, the focus intent, the frame-rate and input paths — comes out right with no change at the call site.

## Two things had to move with it

**`host_focus` matched the layout shell with `With<Browser>`** — which the shell lost when it stopped being a CEF browser, so the query silently never matched. It shares one `LayoutKeyboardHost` filter with `sync_keyboard_target` now, keyed on `LayoutCef`, so the two can't drift apart again. That drift is why the bookmark field has also been dead.

**`WinitHost` is wrong for a chrome served by wry.** It exists so keys reach a terminal by way of winit and Bevy; routing them there sends them to a CEF browser that is no longer behind the layout. `HostFocusIntent::LayoutView` is the third answer, and the view takes first responder while it holds.

## The part that bit twice

Coming back out. Two earlier attempts resigned first responder and left it with **nobody** — a state the app is never otherwise in — and CEF then declined to reclaim, so typing died everywhere.

The reason is that `windowed_has_native_focus` is *CEF's belief about its own view*, and AppKit never told it the chrome had taken the responder. So nothing resigns here; `apply_windowed_host_focus` forces the re-focus on the way out of `LayoutView`, past that stale belief. There's a unit test pinning exactly that case.

## Test plan

- [x] `cargo fmt --check`
- [x] `clippy -D warnings` under CI's exact package selection
- [x] `cargo test --workspace` green
- [ ] **Run the app — this one needs it**

This is the only branch touching AppKit first responder, and two previous attempts at it left the app unusable in ways the suite cannot see. Worth testing in isolation, and cheap to abandon if it misbehaves.

- **Type in the bar** — the thing that has never worked since the wry migration
- **Escape** — dismisses it (the `owns_input` gate is what has been returning false)
- **Then type in Codex** — the reclaim path; this is what broke twice
- **Cmd+K, Cmd+K** — toggles closed rather than sticking open
- **Click a pane, type** — panes must keep the keyboard when the bar is closed
- **The bookmark field** — dead by the same mechanism, should come back