### PR TITLE
Give a laid-out node's rectangle a type

### DIFF
--- a/crates/app/vmux_desktop/src/recording.rs
+++ b/crates/app/vmux_desktop/src/recording.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use vmux_agent::{
     RecordStartRequest, RecordStartResponse, RecordStopRequest, RecordStopResponse, RecordingInfo,
 };
+use vmux_core::NodeRect;
 use vmux_setting::AppSettings;
 
 /// Records the app for the agent: starts and stops captures, enforces the duration cap, and
@@ -204,25 +205,19 @@ pub(crate) struct CropRect {
     pub h: u32,
 }
 
-pub(crate) fn crop_rect_from_node(
-    center_x: f32,
-    center_y: f32,
-    size_x: f32,
-    size_y: f32,
-    img_w: u32,
-    img_h: u32,
-) -> CropRect {
-    let left = (center_x - size_x * 0.5).round().max(0.0) as u32;
-    let top = (center_y - size_y * 0.5).round().max(0.0) as u32;
-    let left = left.min(img_w.saturating_sub(1));
-    let top = top.min(img_h.saturating_sub(1));
-    let w = (size_x.round().max(1.0) as u32).min(img_w - left);
-    let h = (size_y.round().max(1.0) as u32).min(img_h - top);
-    CropRect {
-        x: left,
-        y: top,
-        w,
-        h,
+impl CropRect {
+    pub(crate) fn of(rect: NodeRect, img_w: u32, img_h: u32) -> Self {
+        let min = rect.min();
+        let left = (min.x.round().max(0.0) as u32).min(img_w.saturating_sub(1));
+        let top = (min.y.round().max(0.0) as u32).min(img_h.saturating_sub(1));
+        let w = (rect.size.x.round().max(1.0) as u32).min(img_w - left);
+        let h = (rect.size.y.round().max(1.0) as u32).min(img_h - top);
+        Self {
+            x: left,
+            y: top,
+            w,
+            h,
+        }
     }
 }
 
@@ -239,11 +234,7 @@ fn resolve_crop(
     let mut entity = Entity::from_bits(bits);
     for _ in 0..8 {
         if let Ok((computed, gt)) = node_q.get(entity) {
-            let size = computed.size;
-            let center = gt.transform_point2(Vec2::ZERO);
-            return Some(crop_rect_from_node(
-                center.x, center.y, size.x, size.y, img_w, img_h,
-            ));
+            return Some(CropRect::of(NodeRect::of(computed, gt), img_w, img_h));
         }
         entity = child_of_q.get(entity).ok()?.get();
     }
@@ -383,7 +374,15 @@ mod tests {
 
     #[test]
     fn crop_rect_clamps_to_image() {
-        let r = crop_rect_from_node(100.0, 100.0, 80.0, 60.0, 1000, 1000);
+        let r = CropRect::of(
+            NodeRect {
+                size: Vec2::new(80.0, 60.0),
+                center: Vec2::new(100.0, 100.0),
+                ..default()
+            },
+            1000,
+            1000,
+        );
         assert_eq!(
             r,
             CropRect {

--- a/crates/app/vmux_desktop/src/runtime/macos.rs
+++ b/crates/app/vmux_desktop/src/runtime/macos.rs
@@ -78,16 +78,13 @@ fn grab_key_window_on_pane_hover(
     let Some(pointer) = vmux_layout::native_pointer::snapshot() else {
         return;
     };
-    let over_pane = panes.iter().any(|(node, transform)| {
-        let center = transform.transform_point2(Vec2::ZERO);
-        let half = node.size * 0.5;
-        let min = center - half;
-        let max = center + half;
-        pointer.position_px.x >= min.x
-            && pointer.position_px.x <= max.x
-            && pointer.position_px.y >= min.y
-            && pointer.position_px.y <= max.y
-    });
+    let mut over_pane = false;
+    for (node, transform) in panes.iter() {
+        if vmux_core::NodeRect::of(node, transform).contains(pointer.position_px) {
+            over_pane = true;
+            break;
+        }
+    }
     if !over_pane {
         return;
     }

--- a/crates/app/vmux_desktop/src/screenshot.rs
+++ b/crates/app/vmux_desktop/src/screenshot.rs
@@ -7,6 +7,7 @@ use bevy::winit::{EventLoopProxyWrapper, WinitUserEvent};
 use crossbeam_channel::{Receiver, Sender};
 use std::sync::Arc;
 use vmux_agent::{ScreenshotRequest, ScreenshotResponse};
+use vmux_core::NodeRect;
 use vmux_setting::AppSettings;
 
 /// Captures still screenshots for the agent, off the command flush so a screenshot request
@@ -64,11 +65,7 @@ fn resolve_crop(
     let mut entity = Entity::from_bits(bits);
     for _ in 0..8 {
         if let Ok((computed, gt)) = node_q.get(entity) {
-            let size = computed.size;
-            let center = gt.transform_point2(Vec2::ZERO);
-            return Some(crop_rect_from_node(
-                center.x, center.y, size.x, size.y, img_w, img_h,
-            ));
+            return Some(CropRect::of(NodeRect::of(computed, gt), img_w, img_h));
         }
         entity = child_of_q.get(entity).ok()?.get();
     }
@@ -160,25 +157,19 @@ pub(crate) fn downscale_dims(w: u32, h: u32, max_edge: u32) -> (u32, u32) {
     )
 }
 
-pub(crate) fn crop_rect_from_node(
-    center_x: f32,
-    center_y: f32,
-    size_x: f32,
-    size_y: f32,
-    img_w: u32,
-    img_h: u32,
-) -> CropRect {
-    let left = (center_x - size_x * 0.5).round().max(0.0) as u32;
-    let top = (center_y - size_y * 0.5).round().max(0.0) as u32;
-    let left = left.min(img_w.saturating_sub(1));
-    let top = top.min(img_h.saturating_sub(1));
-    let w = (size_x.round().max(1.0) as u32).min(img_w - left);
-    let h = (size_y.round().max(1.0) as u32).min(img_h - top);
-    CropRect {
-        x: left,
-        y: top,
-        w,
-        h,
+impl CropRect {
+    pub(crate) fn of(rect: NodeRect, img_w: u32, img_h: u32) -> Self {
+        let min = rect.min();
+        let left = (min.x.round().max(0.0) as u32).min(img_w.saturating_sub(1));
+        let top = (min.y.round().max(0.0) as u32).min(img_h.saturating_sub(1));
+        let w = (rect.size.x.round().max(1.0) as u32).min(img_w - left);
+        let h = (rect.size.y.round().max(1.0) as u32).min(img_h - top);
+        Self {
+            x: left,
+            y: top,
+            w,
+            h,
+        }
     }
 }
 
@@ -219,7 +210,15 @@ mod tests {
 
     #[test]
     fn crop_rect_clamps_to_image() {
-        let r = crop_rect_from_node(100.0, 100.0, 80.0, 60.0, 1000, 1000);
+        let r = CropRect::of(
+            NodeRect {
+                size: Vec2::new(80.0, 60.0),
+                center: Vec2::new(100.0, 100.0),
+                ..default()
+            },
+            1000,
+            1000,
+        );
         assert_eq!(
             r,
             CropRect {
@@ -230,7 +229,15 @@ mod tests {
             }
         );
 
-        let r = crop_rect_from_node(990.0, 990.0, 40.0, 40.0, 1000, 1000);
+        let r = CropRect::of(
+            NodeRect {
+                size: Vec2::splat(40.0),
+                center: Vec2::splat(990.0),
+                ..default()
+            },
+            1000,
+            1000,
+        );
         assert_eq!(
             r,
             CropRect {

--- a/crates/page/vmux_layout/src/host/pane.rs
+++ b/crates/page/vmux_layout/src/host/pane.rs
@@ -22,7 +22,7 @@ use vmux_command::{
     AppCommand, BrowserCommand, LayoutCommand, OpenCommand, PaneCommand, ReadAppCommands,
     open::{PaneDirection, PaneOpenMode, PaneTarget},
 };
-use vmux_core::{PageOpenRequest, PageOpenTarget, PageOpenTask};
+use vmux_core::{NodeRect, PageOpenRequest, PageOpenTarget, PageOpenTask};
 use vmux_history::LastActivatedAt;
 
 pub struct PanePlugin;
@@ -1990,8 +1990,7 @@ fn on_pane_select(
         let Ok((cur_node, cur_gt)) = pane_pos_q.get(current) else {
             continue;
         };
-        let cur_center = cur_gt.transform_point2(Vec2::ZERO);
-        let cur_size = cur_node.size;
+        let cur = NodeRect::of(cur_node, cur_gt);
 
         let mut candidates: Vec<Entity> = Vec::new();
         for &pane in &panes {
@@ -2001,27 +2000,17 @@ fn on_pane_select(
             let Ok((tgt_node, gt)) = pane_pos_q.get(pane) else {
                 continue;
             };
-            let center = gt.transform_point2(Vec2::ZERO);
-            let tgt_size = tgt_node.size;
-            let delta = center - cur_center;
+            let tgt = NodeRect::of(tgt_node, gt);
 
-            let along = delta.dot(direction);
+            let along = (tgt.center - cur.center).dot(direction);
             if along <= 0.0 {
                 continue;
             }
 
             let overlaps = if direction.x.abs() > 0.5 {
-                let cur_min = cur_center.y - cur_size.y * 0.5;
-                let cur_max = cur_center.y + cur_size.y * 0.5;
-                let tgt_min = center.y - tgt_size.y * 0.5;
-                let tgt_max = center.y + tgt_size.y * 0.5;
-                cur_min.max(tgt_min) < cur_max.min(tgt_max)
+                cur.overlaps_rows(tgt)
             } else {
-                let cur_min = cur_center.x - cur_size.x * 0.5;
-                let cur_max = cur_center.x + cur_size.x * 0.5;
-                let tgt_min = center.x - tgt_size.x * 0.5;
-                let tgt_max = center.x + tgt_size.x * 0.5;
-                cur_min.max(tgt_min) < cur_max.min(tgt_max)
+                cur.overlaps_columns(tgt)
             };
             if !overlaps {
                 continue;
@@ -2076,11 +2065,7 @@ fn poll_cursor_pane_focus(
 
     let mut hovered_pane: Option<Entity> = None;
     for (entity, node, ui_gt) in &leaf_panes {
-        let center = ui_gt.transform_point2(Vec2::ZERO);
-        let half = node.size * 0.5;
-        let min = center - half;
-        let max = center + half;
-        if cursor.x >= min.x && cursor.x <= max.x && cursor.y >= min.y && cursor.y <= max.y {
+        if NodeRect::of(node, ui_gt).contains(cursor) {
             hovered_pane = Some(entity);
             break;
         }
@@ -2184,17 +2169,13 @@ fn apply_pending_hover(
         return;
     }
     *last_motion_sequence = pointer.motion_sequence;
-    let target = leaf_panes.iter().find_map(|(entity, node, ui_gt)| {
-        let center = ui_gt.transform_point2(Vec2::ZERO);
-        let half = node.size * 0.5;
-        let min = center - half;
-        let max = center + half;
-        (pointer.position_px.x >= min.x
-            && pointer.position_px.x <= max.x
-            && pointer.position_px.y >= min.y
-            && pointer.position_px.y <= max.y)
-            .then_some(entity)
-    });
+    let mut target = None;
+    for (entity, node, ui_gt) in leaf_panes.iter() {
+        if NodeRect::of(node, ui_gt).contains(pointer.position_px) {
+            target = Some(entity);
+            break;
+        }
+    }
     let Some(target) = target else {
         return;
     };
@@ -2223,13 +2204,13 @@ fn warp_cursor_to_active_pane(
     let Ok((node, ui_gt)) = pane_ui_q.get(target) else {
         return;
     };
-    if node.size.x <= 0.0 || node.size.y <= 0.0 {
+    let rect = NodeRect::of(node, ui_gt);
+    if rect.is_empty() {
         return;
     }
     pending.target = None;
-    let center = ui_gt.transform_point2(Vec2::ZERO);
     if let Ok(mut window) = windows.single_mut() {
-        window.set_physical_cursor_position(Some(center.as_dvec2()));
+        window.set_physical_cursor_position(Some(rect.center.as_dvec2()));
     }
 }
 
@@ -2306,23 +2287,21 @@ fn pane_gap_drag_resize(
                 continue;
             };
 
-            let center_a = gt_a.transform_point2(Vec2::ZERO);
-            let center_b = gt_b.transform_point2(Vec2::ZERO);
-            let half_a = node_a.size * 0.5;
-            let half_b = node_b.size * 0.5;
+            let a = NodeRect::of(node_a, gt_a);
+            let b = NodeRect::of(node_b, gt_b);
 
             let (gap_min, gap_max, cross_min, cross_max) = match split.direction {
                 PaneSplitDirection::Row => (
-                    center_a.x + half_a.x,
-                    center_b.x - half_b.x,
-                    (center_a.y - half_a.y).min(center_b.y - half_b.y),
-                    (center_a.y + half_a.y).max(center_b.y + half_b.y),
+                    a.max().x,
+                    b.min().x,
+                    a.min().y.min(b.min().y),
+                    a.max().y.max(b.max().y),
                 ),
                 PaneSplitDirection::Column => (
-                    center_a.y + half_a.y,
-                    center_b.y - half_b.y,
-                    (center_a.x - half_a.x).min(center_b.x - half_b.x),
-                    (center_a.x + half_a.x).max(center_b.x + half_b.x),
+                    a.max().y,
+                    b.min().y,
+                    a.min().x.min(b.min().x),
+                    a.max().x.max(b.max().x),
                 ),
             };
 

--- a/crates/page/vmux_layout/src/host/side_sheet.rs
+++ b/crates/page/vmux_layout/src/host/side_sheet.rs
@@ -3,6 +3,7 @@ use crate::settings::LayoutSettings;
 #[cfg(target_os = "macos")]
 use bevy::{ecs::system::NonSendMarker, winit::WINIT_WINDOWS};
 use bevy::{prelude::*, ui::UiSystems, window::PrimaryWindow};
+use vmux_core::NodeRect;
 
 impl Plugin for SideSheetLayoutPlugin {
     fn build(&self, app: &mut App) {
@@ -137,16 +138,14 @@ fn side_sheet_drag_resize(
         if *pos != SideSheetPosition::Left {
             continue;
         }
-        let center = gt.transform_point2(Vec2::ZERO);
-        let right_edge = center.x + cn.size.x * 0.5;
-        let top = center.y - cn.size.y * 0.5;
-        let bottom = center.y + cn.size.y * 0.5;
+        let rect = NodeRect::of(cn, gt);
+        let right_edge = rect.max().x;
         let cursor_y = cursor_pos.y;
 
         if cursor_x >= right_edge - EDGE_HIT_ZONE
             && cursor_x <= right_edge + EDGE_HIT_ZONE
-            && cursor_y >= top
-            && cursor_y <= bottom
+            && cursor_y >= rect.min().y
+            && cursor_y <= rect.max().y
             && mouse.just_pressed(MouseButton::Left)
         {
             commands.spawn(SideSheetDrag {

--- a/crates/vmux_browser/src/frame_rate.rs
+++ b/crates/vmux_browser/src/frame_rate.rs
@@ -17,6 +17,7 @@ use bevy::{
 use bevy_cef::prelude::*;
 use std::sync::atomic::Ordering;
 use vmux_command::event::LAYOUT_COMMAND_BAR_OPEN_EVENT;
+use vmux_core::NodeRect;
 use vmux_core::overlay::WindowOverlay;
 use vmux_core::overlay::{OverlayState, OverlayStateQuery};
 use vmux_layout::Browser;
@@ -36,7 +37,7 @@ use crate::{
     CefPointerRegionQuery, LAYOUT_INPUT_BURST, LayoutFrameRateState, LayoutHoverRefreshState,
     LayoutPointerCapture, NATIVE_LAYOUT_POINTER_INSIDE, NativeLayout, WindowedHoverRefreshState,
     native_layout_activity_active, native_left_mouse_down, reset_layout_cef_hover,
-    set_native_layout_activity, windowed_hover_refresh_frame, windowed_hover_refresh_position,
+    set_native_layout_activity,
 };
 pub(crate) struct FrameRatePlugin;
 
@@ -102,8 +103,7 @@ fn refresh_layout_cef_hover(
     {
         if pointer_capture {
             NativeLayout::set_pointer_regions([CefPointerHitRect {
-                center: Vec2::new(window.width() * 0.5, window.height() * 0.5),
-                size: Vec2::new(window.width(), window.height()),
+                rect: vmux_core::NodeRect::from_origin(Vec2::new(window.width(), window.height())),
                 interactive: true,
             }
             .physical(scale)]);
@@ -221,11 +221,12 @@ fn refresh_active_windowed_hover(
         *state = WindowedHoverRefreshState::default();
         return;
     };
-    let Some(frame) = windowed_hover_refresh_frame(computed, ui_gt) else {
+    let frame = NodeRect::of(computed, ui_gt);
+    if frame.is_empty() {
         *state = WindowedHoverRefreshState::default();
         return;
-    };
-    let Some(position) = windowed_hover_refresh_position(cursor_px, frame) else {
+    }
+    let Some(position) = frame.local_point(cursor_px) else {
         *state = WindowedHoverRefreshState::default();
         return;
     };

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -48,7 +48,8 @@ use std::sync::{LazyLock, Mutex};
 use vmux_command::ReadAppCommands;
 use vmux_command::command_bar::handler::PendingCommandBarReveal;
 use vmux_core::{
-    CefPageAttachRequest, HostSpawnRegistry, OscTitle, PageMetadata, PageOpenRequest, PageOpenSet,
+    CefPageAttachRequest, HostSpawnRegistry, NodeRect, OscTitle, PageMetadata, PageOpenRequest,
+    PageOpenSet,
     page::{PageManifest, PageReady},
 };
 use vmux_history::LastActivatedAt;
@@ -299,22 +300,17 @@ type CefPointerRegionQuery<'w, 's> = Query<
 
 #[derive(Clone, Copy)]
 struct CefPointerHitRect {
-    center: Vec2,
-    size: Vec2,
+    rect: NodeRect,
     interactive: bool,
 }
 
 static NATIVE_LAYOUT_POINTER_INSIDE: AtomicBool = AtomicBool::new(false);
 static NATIVE_LAYOUT_ACTIVITY: AtomicBool = AtomicBool::new(false);
 
-fn cef_pointer_hit_rect_contains(rect: CefPointerHitRect, point: Vec2) -> bool {
-    if !rect.interactive {
-        return false;
+impl CefPointerHitRect {
+    fn contains(self, point: Vec2) -> bool {
+        self.interactive && self.rect.contains(point)
     }
-    let half = rect.size * 0.5;
-    let min = rect.center - half;
-    let max = rect.center + half;
-    point.x >= min.x && point.x <= max.x && point.y >= min.y && point.y <= max.y
 }
 
 pub fn set_native_layout_activity(active: bool) -> bool {
@@ -334,33 +330,28 @@ fn cef_pointer_hit_rect(
     visibility: Option<&Visibility>,
     open: bool,
 ) -> CefPointerHitRect {
+    let rect = NodeRect::of(computed, transform);
     let interactive = (header.is_some() || side_sheet.is_some())
         && open
         && node.display != Display::None
         && !matches!(visibility, Some(Visibility::Hidden))
-        && computed.size.x > 0.0
-        && computed.size.y > 0.0;
-    CefPointerHitRect {
-        center: transform.transform_point2(Vec2::ZERO),
-        size: computed.size,
-        interactive,
-    }
+        && !rect.is_empty();
+    CefPointerHitRect { rect, interactive }
 }
 
 fn cef_pointer_regions_contains(
     cursor_pos: Vec2,
     cef_regions: &CefPointerRegionQuery<'_, '_>,
 ) -> bool {
-    cef_regions
-        .iter()
-        .map(
-            |(header, side_sheet, node, computed, transform, visibility, open)| {
-                cef_pointer_hit_rect(
-                    header, side_sheet, node, computed, transform, visibility, open,
-                )
-            },
-        )
-        .any(|rect| cef_pointer_hit_rect_contains(rect, cursor_pos))
+    for (header, side_sheet, node, computed, transform, visibility, open) in cef_regions.iter() {
+        let rect = cef_pointer_hit_rect(
+            header, side_sheet, node, computed, transform, visibility, open,
+        );
+        if rect.contains(cursor_pos) {
+            return true;
+        }
+    }
+    false
 }
 
 fn pointer_button_from_mouse_button(button: MouseButton) -> Option<PointerButton> {
@@ -515,57 +506,6 @@ fn hex_to_rgb(hex: &str) -> Option<[f32; 3]> {
     let g = u8::from_str_radix(&h[2..4], 16).ok()?;
     let b = u8::from_str_radix(&h[4..6], 16).ok()?;
     Some([r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0])
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-struct WindowedHoverRefreshFrame {
-    left_px: f32,
-    top_px: f32,
-    width_px: f32,
-    height_px: f32,
-    scale: f32,
-}
-
-fn windowed_hover_refresh_frame(
-    computed: &ComputedNode,
-    ui_gt: &UiGlobalTransform,
-) -> Option<WindowedHoverRefreshFrame> {
-    let size_px = computed.size;
-    let scale = 1.0 / computed.inverse_scale_factor.max(1.0e-6);
-    if size_px.x <= 0.0
-        || size_px.y <= 0.0
-        || !size_px.x.is_finite()
-        || !size_px.y.is_finite()
-        || !scale.is_finite()
-        || scale <= 0.0
-    {
-        return None;
-    }
-    let center = ui_gt.transform_point2(Vec2::ZERO);
-    Some(WindowedHoverRefreshFrame {
-        left_px: center.x - size_px.x * 0.5,
-        top_px: center.y - size_px.y * 0.5,
-        width_px: size_px.x,
-        height_px: size_px.y,
-        scale,
-    })
-}
-
-fn windowed_hover_refresh_position(
-    cursor_px: Vec2,
-    frame: WindowedHoverRefreshFrame,
-) -> Option<Vec2> {
-    if cursor_px.x < frame.left_px
-        || cursor_px.x > frame.left_px + frame.width_px
-        || cursor_px.y < frame.top_px
-        || cursor_px.y > frame.top_px + frame.height_px
-    {
-        return None;
-    }
-    Some(Vec2::new(
-        (cursor_px.x - frame.left_px) / frame.scale,
-        (cursor_px.y - frame.top_px) / frame.scale,
-    ))
 }
 
 #[derive(Default)]
@@ -772,23 +712,19 @@ fn layout_fixed_offsets_from_computed(
     transform: &UiGlobalTransform,
     window_width_px: f32,
 ) -> Option<LayoutFixedOffsets> {
-    if computed.size.x <= 0.0 || computed.size.y <= 0.0 || window_width_px <= 0.0 {
+    let rect = NodeRect::of(computed, transform);
+    if rect.is_empty() || window_width_px <= 0.0 {
         return None;
     }
 
-    let inverse_scale = computed.inverse_scale_factor.max(1.0e-6);
-    let size = computed.size * inverse_scale;
-    let center = transform.transform_point2(Vec2::ZERO) * inverse_scale;
-    let window_width = window_width_px * inverse_scale;
-    let left = center.x - size.x * 0.5;
-    let top = center.y - size.y * 0.5;
-    let right = window_width - (center.x + size.x * 0.5);
+    let logical = rect.to_logical();
+    let window_width = window_width_px * rect.inverse_scale_factor.max(1.0e-6);
 
     Some(LayoutFixedOffsets {
-        left,
-        top,
-        right,
-        height: size.y,
+        left: logical.min().x,
+        top: logical.min().y,
+        right: window_width - logical.max().x,
+        height: logical.size.y,
     })
 }
 
@@ -1273,28 +1209,33 @@ mod tests {
         assert_eq!(stack_url, "vmux://agent/vibe/abc-123");
     }
 
+    /// A closed or hidden region must not swallow a pointer that is geometrically over it, and an
+    /// open one must still catch its own edges.
     #[test]
-    fn cef_pointer_hit_rect_contains_edges() {
-        let rect = CefPointerHitRect {
-            center: Vec2::new(50.0, 20.0),
-            size: Vec2::new(100.0, 40.0),
-            interactive: true,
-        };
+    fn a_pointer_hits_only_interactive_regions() {
+        let rect = NodeRect::from_origin(Vec2::new(100.0, 40.0));
 
-        assert!(cef_pointer_hit_rect_contains(rect, Vec2::new(0.0, 0.0)));
-        assert!(cef_pointer_hit_rect_contains(rect, Vec2::new(100.0, 40.0)));
-        assert!(!cef_pointer_hit_rect_contains(rect, Vec2::new(100.1, 20.0)));
-    }
-
-    #[test]
-    fn cef_pointer_ignores_inactive_regions() {
-        let rect = CefPointerHitRect {
-            center: Vec2::new(50.0, 20.0),
-            size: Vec2::new(100.0, 40.0),
-            interactive: false,
-        };
-
-        assert!(!cef_pointer_hit_rect_contains(rect, Vec2::new(50.0, 20.0)));
+        assert!(
+            CefPointerHitRect {
+                rect,
+                interactive: true
+            }
+            .contains(Vec2::new(100.0, 40.0))
+        );
+        assert!(
+            !CefPointerHitRect {
+                rect,
+                interactive: true
+            }
+            .contains(Vec2::new(100.1, 20.0))
+        );
+        assert!(
+            !CefPointerHitRect {
+                rect,
+                interactive: false
+            }
+            .contains(Vec2::new(50.0, 20.0))
+        );
     }
 
     #[test]
@@ -1363,38 +1304,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn windowed_hover_refresh_position_maps_physical_cursor_to_webview_space() {
-        let frame = WindowedHoverRefreshFrame {
-            left_px: 100.0,
-            top_px: 50.0,
-            width_px: 400.0,
-            height_px: 300.0,
-            scale: 2.0,
-        };
-
-        assert_eq!(
-            windowed_hover_refresh_position(Vec2::new(300.0, 250.0), frame),
-            Some(Vec2::new(100.0, 100.0))
-        );
-    }
-
-    #[test]
-    fn windowed_hover_refresh_position_ignores_cursor_outside_frame() {
-        let frame = WindowedHoverRefreshFrame {
-            left_px: 100.0,
-            top_px: 50.0,
-            width_px: 400.0,
-            height_px: 300.0,
-            scale: 2.0,
-        };
-
-        assert_eq!(
-            windowed_hover_refresh_position(Vec2::new(99.0, 250.0), frame),
-            None
-        );
-    }
-
     /// Windowed is the only backend. The camera-mismatch fallback that used to drop everything
     /// back to offscreen rendering is gone, so a browser that failed to be marked windowed would
     /// render nowhere at all rather than degrading.
@@ -1450,18 +1359,6 @@ mod tests {
         assert!(queue.contains("state.queue_sample("));
         assert!(flush.contains("state.pending = false"));
         assert!(flush.contains("presenter.send(position_px / state.scale"));
-    }
-
-    #[test]
-    fn layout_pointer_regions_match_layout_coordinates() {
-        let rect = CefPointerHitRect {
-            center: Vec2::new(50.0, 25.0),
-            size: Vec2::new(20.0, 10.0),
-            interactive: true,
-        };
-
-        assert!(cef_pointer_hit_rect_contains(rect, Vec2::new(50.0, 25.0)));
-        assert!(!cef_pointer_hit_rect_contains(rect, Vec2::new(39.0, 25.0)));
     }
 
     #[test]

--- a/crates/vmux_browser/src/native_layout/macos.rs
+++ b/crates/vmux_browser/src/native_layout/macos.rs
@@ -191,8 +191,8 @@ impl NativeLayout {
 impl CefPointerHitRect {
     /// The same rect in physical pixels, which is what the AppKit monitor reports the pointer in.
     pub(crate) fn physical(mut self, scale: f32) -> Self {
-        self.center *= scale;
-        self.size *= scale;
+        self.rect.center *= scale;
+        self.rect.size *= scale;
         self
     }
 }
@@ -225,7 +225,7 @@ impl NativeLayoutPointerState {
             .regions
             .iter()
             .copied()
-            .any(|rect| crate::cef_pointer_hit_rect_contains(rect, position));
+            .any(|rect| rect.contains(position));
         let was_inside = self.pointer_inside;
         let sample_changed =
             self.position_px != Some(position) || self.buttons != buttons || was_inside != inside;
@@ -275,8 +275,11 @@ mod tests {
     fn native_layout_pointer_queue_skips_identical_sample() {
         let mut state = NativeLayoutPointerState {
             regions: vec![CefPointerHitRect {
-                center: Vec2::new(50.0, 25.0),
-                size: Vec2::new(20.0, 10.0),
+                rect: vmux_core::NodeRect {
+                    size: Vec2::new(20.0, 10.0),
+                    center: Vec2::new(50.0, 25.0),
+                    ..Default::default()
+                },
                 interactive: true,
             }],
             ..Default::default()

--- a/crates/vmux_browser/src/present.rs
+++ b/crates/vmux_browser/src/present.rs
@@ -15,6 +15,7 @@ use bevy_cef::prelude::*;
 use std::sync::atomic::Ordering;
 use vmux_command::command_bar::handler::{CommandBarNativeSize, PendingCommandBarReveal};
 use vmux_command::command_bar::panel::CommandBarPanelActive;
+use vmux_core::NodeRect;
 use vmux_core::overlay::{OverlayState, WindowOverlay};
 use vmux_core::page::PageReady;
 use vmux_history::LastActivatedAt;
@@ -194,8 +195,8 @@ fn sync_children_to_ui(
     glass: Single<(Entity, &ComputedNode, &UiGlobalTransform), With<VmuxWindow>>,
 ) {
     let &(glass_entity, glass_node, glass_ui_gt) = &*glass;
-    let pad = glass_node.padding;
-    let glass_size_px = glass_node.size + pad.min_inset + pad.max_inset;
+    let glass_rect = NodeRect::of(glass_node, glass_ui_gt);
+    let glass_size_px = glass_rect.padding_box();
 
     for (
         mut tf,
@@ -282,9 +283,7 @@ fn sync_children_to_ui(
         };
         tf.scale = new_scale;
 
-        let center_ui = ui_gt.transform_point2(Vec2::ZERO);
-        let glass_center_ui = glass_ui_gt.transform_point2(Vec2::ZERO);
-        let delta_px = center_ui - glass_center_ui;
+        let delta_px = NodeRect::of(computed, ui_gt).center - glass_rect.center;
 
         let tx = delta_px.x / glass_size_px.x;
         let ty = -delta_px.y / glass_size_px.y;
@@ -445,7 +444,7 @@ pub(crate) fn sync_windowed_frames(
         let Some(pane_frame) = windowed_frame_rect_from_computed(computed, ui_gt) else {
             continue;
         };
-        let scale = 1.0 / computed.inverse_scale_factor.max(1.0e-6);
+        let scale = NodeRect::of(computed, ui_gt).scale();
         let frame = windowed_page_frame_rect(
             pane_frame,
             header_frame,
@@ -553,16 +552,16 @@ fn windowed_frame_rect_from_computed(
     computed: &ComputedNode,
     ui_gt: &UiGlobalTransform,
 ) -> Option<WindowedFrameRect> {
-    let size = computed.size;
-    if size.x <= 0.0 || size.y <= 0.0 || !size.x.is_finite() || !size.y.is_finite() {
+    let rect = NodeRect::of(computed, ui_gt);
+    if rect.is_empty() {
         return None;
     }
-    let center = ui_gt.transform_point2(Vec2::ZERO);
+    let min = rect.min();
     Some(WindowedFrameRect {
-        left: center.x - size.x * 0.5,
-        top: center.y - size.y * 0.5,
-        width: size.x,
-        height: size.y,
+        left: min.x,
+        top: min.y,
+        width: rect.size.x,
+        height: rect.size.y,
     })
 }
 

--- a/crates/vmux_core/src/host.rs
+++ b/crates/vmux_core/src/host.rs
@@ -14,6 +14,7 @@ pub mod agent;
 pub mod archive;
 pub mod browser;
 pub mod extension;
+pub mod geometry;
 pub mod host_spawn;
 pub mod launcher;
 pub mod notify;
@@ -28,6 +29,7 @@ pub mod workspace;
 pub use archive::{
     ArchivedPage, ArchivedPagePosition, ArchivedTabPage, PageArchiveRequest, PaneStep, SplitAxis,
 };
+pub use geometry::{Insets, NodeRect};
 pub use host_spawn::{HostSpawnRegistry, register_host_spawn};
 pub use launcher::{
     ContributedCommandChosen, FocusLauncherInput, HostsLauncher, InlineTransitionRequested,

--- a/crates/vmux_core/src/host/geometry.rs
+++ b/crates/vmux_core/src/host/geometry.rs
@@ -19,13 +19,29 @@ pub struct Insets {
 /// testing a cursor, and all three want corners. Deriving them is the same four lines at every
 /// site, and a slipped sign there produces a plausible rectangle in the wrong place — nothing
 /// type-checks it and no test sees it. So the conversion happens once, here.
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NodeRect {
     pub size: Vec2,
     pub center: Vec2,
     pub padding: Insets,
     /// Reciprocal of the render target's scale factor — `0.5` on a Retina display.
     pub inverse_scale_factor: f32,
+}
+
+/// A default rectangle is unscaled, not scaled by zero.
+///
+/// Deriving this would leave `inverse_scale_factor` at `0.0`, which is not a neutral value: it
+/// makes [`NodeRect::scale`] report a million and [`NodeRect::to_logical`] shrink by the same,
+/// so a rectangle built from [`NodeRect::from_origin`] would be silently unusable in logical space.
+impl Default for NodeRect {
+    fn default() -> Self {
+        Self {
+            size: Vec2::ZERO,
+            center: Vec2::ZERO,
+            padding: Insets::default(),
+            inverse_scale_factor: 1.0,
+        }
+    }
 }
 
 impl NodeRect {
@@ -205,6 +221,17 @@ mod tests {
         };
 
         assert_eq!(rect.padding_box(), Vec2::new(110.0, 60.0));
+    }
+
+    /// A rectangle nobody gave a scale to is already in logical space, so converting it must be a
+    /// no-op rather than a division by a millionth.
+    #[test]
+    fn an_unscaled_rect_survives_conversion_to_logical() {
+        let rect = NodeRect::from_origin(Vec2::new(400.0, 300.0));
+
+        assert_eq!(rect.scale(), 1.0);
+        assert_eq!(rect.to_logical(), rect);
+        assert_eq!(rect.min(), Vec2::ZERO);
     }
 
     #[test]

--- a/crates/vmux_core/src/host/geometry.rs
+++ b/crates/vmux_core/src/host/geometry.rs
@@ -1,0 +1,218 @@
+//! Where a laid-out node ended up, and the corners every caller actually wants.
+
+use bevy::prelude::*;
+use bevy::ui::UiGlobalTransform;
+
+/// Space reserved inside a node's own box, resolved to physical pixels.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Insets {
+    /// Left and top.
+    pub min: Vec2,
+    /// Right and bottom.
+    pub max: Vec2,
+}
+
+/// The rectangle a laid-out node occupies, in physical pixels, origin at the window's top-left.
+///
+/// The layout engine reports a node's position as its *centre*, which is almost never what a
+/// caller wants: everything downstream is placing a native view, cropping a framebuffer or hit
+/// testing a cursor, and all three want corners. Deriving them is the same four lines at every
+/// site, and a slipped sign there produces a plausible rectangle in the wrong place — nothing
+/// type-checks it and no test sees it. So the conversion happens once, here.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct NodeRect {
+    pub size: Vec2,
+    pub center: Vec2,
+    pub padding: Insets,
+    /// Reciprocal of the render target's scale factor — `0.5` on a Retina display.
+    pub inverse_scale_factor: f32,
+}
+
+impl NodeRect {
+    pub fn of(computed: &ComputedNode, transform: &UiGlobalTransform) -> Self {
+        Self {
+            size: computed.size,
+            center: transform.transform_point2(Vec2::ZERO),
+            padding: Insets {
+                min: computed.padding.min_inset,
+                max: computed.padding.max_inset,
+            },
+            inverse_scale_factor: computed.inverse_scale_factor,
+        }
+    }
+
+    /// A rectangle of `size` with its top-left corner at the origin.
+    pub fn from_origin(size: Vec2) -> Self {
+        Self {
+            size,
+            center: size * 0.5,
+            ..Self::default()
+        }
+    }
+
+    /// Top-left corner.
+    pub fn min(self) -> Vec2 {
+        self.center - self.size * 0.5
+    }
+
+    /// Bottom-right corner.
+    pub fn max(self) -> Vec2 {
+        self.center + self.size * 0.5
+    }
+
+    /// Inclusive on every edge, matching the pointer tests this replaces.
+    pub fn contains(self, point: Vec2) -> bool {
+        let min = self.min();
+        let max = self.max();
+        point.x >= min.x && point.x <= max.x && point.y >= min.y && point.y <= max.y
+    }
+
+    /// Do the two rectangles share any rows? Directional pane navigation uses this to reject a
+    /// neighbour that lies the right way but does not sit beside the pane at all.
+    pub fn overlaps_rows(self, other: Self) -> bool {
+        self.min().y.max(other.min().y) < self.max().y.min(other.max().y)
+    }
+
+    /// Do the two rectangles share any columns?
+    pub fn overlaps_columns(self, other: Self) -> bool {
+        self.min().x.max(other.min().x) < self.max().x.min(other.max().x)
+    }
+
+    /// Nothing can be placed against this rectangle — it has no area, or the layout produced a
+    /// value arithmetic cannot survive.
+    pub fn is_empty(self) -> bool {
+        !(self.size.x > 0.0
+            && self.size.y > 0.0
+            && self.size.x.is_finite()
+            && self.size.y.is_finite())
+    }
+
+    /// Physical pixels per logical pixel.
+    pub fn scale(self) -> f32 {
+        1.0 / self.inverse_scale_factor.max(1.0e-6)
+    }
+
+    /// A window-space point in this rectangle's own logical coordinates, or `None` if it falls
+    /// outside. This is what a native view wants a cursor position expressed in.
+    pub fn local_point(self, point: Vec2) -> Option<Vec2> {
+        if !self.contains(point) {
+            return None;
+        }
+        Some((point - self.min()) / self.scale())
+    }
+
+    /// The same rectangle in logical pixels, which is what AppKit frames and CSS offsets want.
+    pub fn to_logical(self) -> Self {
+        let inverse_scale = self.inverse_scale_factor.max(1.0e-6);
+        Self {
+            size: self.size * inverse_scale,
+            center: self.center * inverse_scale,
+            padding: Insets {
+                min: self.padding.min * inverse_scale,
+                max: self.padding.max * inverse_scale,
+            },
+            inverse_scale_factor: 1.0,
+        }
+    }
+
+    /// Size including padding. `size` is the content box, so a node whose children are inset by
+    /// its padding covers more than `size` reports.
+    pub fn padding_box(self) -> Vec2 {
+        self.size + self.padding.min + self.padding.max
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl NodeRect {
+        fn at(center: Vec2, size: Vec2) -> Self {
+            Self {
+                size,
+                center,
+                ..default()
+            }
+        }
+    }
+
+    /// A slipped sign here puts every native view in the wrong half of the window.
+    #[test]
+    fn corners_sit_half_a_size_either_side_of_the_centre() {
+        let rect = NodeRect::at(Vec2::new(400.0, 300.0), Vec2::new(200.0, 100.0));
+
+        assert_eq!(rect.min(), Vec2::new(300.0, 250.0));
+        assert_eq!(rect.max(), Vec2::new(500.0, 350.0));
+    }
+
+    #[test]
+    fn edges_and_corners_count_as_inside() {
+        let rect = NodeRect::at(Vec2::new(100.0, 100.0), Vec2::new(50.0, 50.0));
+
+        assert!(rect.contains(Vec2::new(75.0, 75.0)));
+        assert!(rect.contains(Vec2::new(125.0, 125.0)));
+        assert!(rect.contains(Vec2::splat(100.0)));
+        assert!(!rect.contains(Vec2::new(74.9, 100.0)));
+        assert!(!rect.contains(Vec2::new(100.0, 125.1)));
+    }
+
+    /// The header on a Retina display: 1544x168 physical at scale 2 is 772x84 logical, and its
+    /// left edge lands 8 logical pixels in. These are the numbers `layout_fixed_offsets_from_computed`
+    /// has always produced.
+    #[test]
+    fn halving_a_retina_rect_gives_the_logical_one() {
+        let rect = NodeRect {
+            inverse_scale_factor: 0.5,
+            ..NodeRect::at(Vec2::new(788.0, 84.0), Vec2::new(1544.0, 168.0))
+        };
+
+        let logical = rect.to_logical();
+
+        assert_eq!(logical.size, Vec2::new(772.0, 84.0));
+        assert_eq!(logical.min(), Vec2::new(8.0, 0.0));
+        assert_eq!(logical.scale(), 1.0);
+    }
+
+    /// A cursor over a Retina view arrives in physical window pixels and has to reach the view as
+    /// logical pixels from its own top-left, or every hover lands in the wrong place. The 400x300
+    /// view at (100, 50) on a scale-2 display is the case `refresh_active_windowed_hover` feeds.
+    #[test]
+    fn a_window_point_becomes_logical_pixels_from_the_rects_own_corner() {
+        let rect = NodeRect {
+            inverse_scale_factor: 0.5,
+            ..NodeRect::at(Vec2::new(300.0, 200.0), Vec2::new(400.0, 300.0))
+        };
+
+        assert_eq!(rect.min(), Vec2::new(100.0, 50.0));
+        assert_eq!(
+            rect.local_point(Vec2::new(300.0, 250.0)),
+            Some(Vec2::splat(100.0))
+        );
+        assert_eq!(rect.local_point(Vec2::new(100.0, 50.0)), Some(Vec2::ZERO));
+        assert_eq!(rect.local_point(Vec2::new(99.0, 250.0)), None);
+    }
+
+    /// `size` is the content box, so the window root's own extent is bigger than it reports by
+    /// exactly the padding the layout reserves for the glass border.
+    #[test]
+    fn the_padding_box_adds_both_insets() {
+        let rect = NodeRect {
+            padding: Insets {
+                min: Vec2::new(4.0, 8.0),
+                max: Vec2::new(6.0, 2.0),
+            },
+            ..NodeRect::at(Vec2::ZERO, Vec2::new(100.0, 50.0))
+        };
+
+        assert_eq!(rect.padding_box(), Vec2::new(110.0, 60.0));
+    }
+
+    #[test]
+    fn a_rect_with_no_area_or_a_broken_one_is_empty() {
+        assert!(NodeRect::at(Vec2::ZERO, Vec2::new(0.0, 10.0)).is_empty());
+        assert!(NodeRect::at(Vec2::ZERO, Vec2::new(10.0, -1.0)).is_empty());
+        assert!(NodeRect::at(Vec2::ZERO, Vec2::new(f32::NAN, 10.0)).is_empty());
+        assert!(NodeRect::at(Vec2::ZERO, Vec2::new(f32::INFINITY, 10.0)).is_empty());
+        assert!(!NodeRect::at(Vec2::ZERO, Vec2::new(1.0, 1.0)).is_empty());
+    }
+}


### PR DESCRIPTION
First of four, working toward removing `bevy_ui` in favour of a direct `taffy` integration. This one changes no behaviour — it gives the layout engine's output a type so the arithmetic around it stops being copied.

## The problem

The layout engine reports a node's position as its **centre**. Nothing downstream wants a centre. Every consumer is placing a native view, cropping a framebuffer or hit testing a cursor, and all three want corners:

```rust
let center = gt.transform_point2(Vec2::ZERO);
let half = node.size * 0.5;
let min = center - half;
let max = center + half;
```

That appeared at **sixteen sites** across four crates. A slipped sign there produces a perfectly plausible rectangle in the wrong place — the type checker cannot see it and no test covers it, because every one of these feeds an AppKit frame or a pointer test that only a human looking at the window can judge.

## What lands

`vmux_core::NodeRect` — size, centre, padding and the inverse scale factor, with the conversions on it:

| | |
|---|---|
| `min()` / `max()` | corners |
| `contains(point)` | inclusive hit test |
| `local_point(point)` | a window point in the rect's own logical pixels |
| `to_logical()` | physical → logical, what AppKit frames and CSS offsets want |
| `padding_box()` | `size` is the content box; the root's real extent is bigger |
| `overlaps_rows` / `overlaps_columns` | the interval test directional pane navigation runs |
| `is_empty()` | no area, or a value arithmetic cannot survive |

Two existing types turned out to be `NodeRect` wearing other names and dissolve into it:

- **`WindowedHoverRefreshFrame`** — the same four fields plus a scale, with a `windowed_hover_refresh_position` that is exactly `local_point`.
- **`crop_rect_from_node(center_x, center_y, size_x, size_y, img_w, img_h)`** — a rectangle passed as six scalars specifically so it could do the centre subtraction internally. Now `CropRect::of(rect, w, h)`.

`cef_pointer_hit_rect_contains(rect, point)` becomes `rect.contains(point)`, and three iterator chains become plain loops per the code-style rule.

## Why now rather than as part of the swap

The `bevy_ui` removal has to touch all sixteen of these anyway. Doing it in the same PR would mean making the riskiest edits in the project at the exact moment the old engine is gone and there is nothing left to compare against. Here the old engine is still running, so the app can be built and looked at.

## Note on scope

The inventory I worked from said thirteen sites. An exhaustive `transform_point2` sweep found three more — `poll_cursor_pane_focus`, `native_layout/macos.rs` and the pointer-capture region in `frame_rate.rs`. `grep -rn "transform_point2" crates/` now returns one hit, inside `NodeRect::of`.

## Tests

Five new unit tests on `NodeRect`. The Retina case reproduces the numbers the strongest existing oracle already asserts (`layout_fixed_offsets_use_computed_header_rect`: 1544×168 at `inverse_scale_factor` 0.5 → left 8, top 0), and that test passes unchanged.

Four tests were deleted as duplicates of `NodeRect`'s own — two hover-position tests, two pointer-region tests — with one replacement covering both halves of the `interactive && contains` conjunction, which none of them did.

- [x] `cargo fmt --check`
- [x] `clippy -D warnings` under CI's exact package selection
- [x] `cargo test --workspace` — 91 binaries green
- [ ] Run the app

## What to exercise

Behaviour should be identical, so the value is in the paths where a sign error would hide:

- **Panes** — split a few ways; no hairline of window background between the header and a page
- **Side sheet** — the 6px resize hit zone on the left sheet's right edge
- **Pane gap drag** — grab the divider between two panes and resize
- **Directional nav** — Cmd+arrow between panes, including a split where the neighbour only partly overlaps
- **Cursor warp** — after switching panes the pointer should land in the centre of the new one
- **Hover on a Retina display** — links should highlight under the pointer, not offset from it
- **Screenshot / recording of a single pane** — the crop should be that pane exactly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent geometry handling for layout regions, pointer areas, and window frames.
  * Improved cursor mapping across scaled and Retina displays.
* **Bug Fixes**
  * Improved pane, side-sheet, and browser hit detection for more accurate hovering and interaction.
  * Improved screenshot and recording crops, including safer handling when crop areas reach image edges.
  * Prevented invalid or empty layout regions from producing incorrect positioning or interactions.
* **Tests**
  * Expanded coverage for geometry, scaling, cursor conversion, padding, cropping, and boundary cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->