### PR TITLE
Let a pane keep the wheel the layout was drawn over

### DIFF
--- a/crates/vmux_browser/src/native_page/macos.rs
+++ b/crates/vmux_browser/src/native_page/macos.rs
@@ -14,11 +14,12 @@ use bevy_cef_core::prelude::{
 use vmux_core::host::page::HostsPage;
 use vmux_core::page_metadata::PageMetadata;
 use vmux_layout::LayoutCef;
-use vmux_native::{Appearance, AssetReply, Embedding, NativePage, PageSurface};
+use vmux_native::{Appearance, AssetReply, Embedding, NativePage, PageSurface, SiblingOrder};
 use vmux_setting::{AppSettings, ColorScheme};
 use vmux_ui::hooks::EventListenerError;
 
 use super::{NativePages, Placement};
+use crate::LayoutPointerCapture;
 use crate::present::PaneFrames;
 
 pub(super) struct NativePagesMacosPlugin;
@@ -149,7 +150,7 @@ fn open_native_pages(world: &mut World) {
             Some(Ok(surface)) => {
                 surface.set_visible(false);
                 surface.set_appearance(appearance);
-                if placement.is_frontmost() {
+                if placement.paints_in_front() {
                     surface.raise_above_layers();
                 }
                 world
@@ -183,12 +184,14 @@ fn place_native_pages(
     frames: Res<PaneFrames>,
     window: Query<&Window, With<PrimaryWindow>>,
     pages: Query<(), With<HostsPage>>,
+    capturing: Query<(), (With<LayoutCef>, LayoutPointerCapture)>,
 ) {
     let Some(mut hosted) = hosted else {
         return;
     };
     hosted.0.retain(|entity, _| pages.contains(*entity));
     let window = window.single().ok();
+    let capturing = !capturing.is_empty();
     for (entity, page) in hosted.0.iter() {
         let Some(bounds) = page.placement.bounds(*entity, window, &frames) else {
             page.surface.set_visible(false);
@@ -196,8 +199,8 @@ fn place_native_pages(
         };
         page.surface.set_bounds(bounds);
         page.surface.set_visible(true);
-        if page.placement.is_frontmost() {
-            page.surface.raise_above_siblings();
+        if let Some(order) = page.placement.pointer_order(capturing) {
+            page.surface.order_among_siblings(order);
         }
     }
 }
@@ -277,12 +280,36 @@ fn appearance_of(mode: ColorScheme) -> Appearance {
 }
 
 impl Placement {
-    /// Whether the view is put back in front of its siblings every frame.
+    /// Whether the view is painted over everything else drawn into the window.
     ///
-    /// A pane opening puts its view last in the parent's subview array, which is where clicks are
-    /// resolved from — so a page drawn over the panes has to say so again after every one.
-    fn is_frontmost(self) -> bool {
+    /// Painting only, and that is the distinction this pair exists to keep: which view AppKit
+    /// hands a click to is [`Self::pointer_order`], and the two were one predicate until a layout
+    /// painted in front turned out to be swallowing every scroll aimed at the pane behind it.
+    fn paints_in_front(self) -> bool {
         matches!(self, Self::Layout | Self::Modal)
+    }
+
+    /// Which end of the subview array the view is put back at every frame, if either.
+    ///
+    /// A pane opening puts its view last, which is the end `hitTest:` resolves from — so a page
+    /// with an opinion about the pointer has to state it again after every one.
+    ///
+    /// The layout's opinion is the back. It fills the window, but `pointer-events: none` covers
+    /// all of it bar the header and the side sheet, and neither of those overlaps a pane: the
+    /// pane's rectangle starts below the header and within its span. `hitTest:` has never heard of
+    /// that CSS rule, so a layout left in front answers for the whole window and the pane under it
+    /// never sees a wheel — WebKit forwards an unclaimed click up the responder chain but keeps
+    /// the scroll, having its own machinery for it.
+    ///
+    /// `capturing` is the exception, and the reason this cannot simply be the placement. A context
+    /// menu or the command bar panel extends past every published region and dismisses on an
+    /// outside click, so while one is up the layout does have to be asked first.
+    fn pointer_order(self, capturing: bool) -> Option<SiblingOrder> {
+        match self {
+            Self::Layout if !capturing => Some(SiblingOrder::Back),
+            Self::Layout | Self::Modal => Some(SiblingOrder::Front),
+            Self::Pane => None,
+        }
     }
 
     /// The entities whose page this is, and which therefore want a view.
@@ -500,5 +527,30 @@ fn report_waiting(reason: &str) {
     static REPORTED: AtomicBool = AtomicBool::new(false);
     if !REPORTED.swap(true, Ordering::Relaxed) {
         info!("native_page: waiting, {reason}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Placement, SiblingOrder};
+
+    /// Painting in front and being asked for the pointer first are the same flag until they are
+    /// not, and collapsing them back is how a pane stops scrolling.
+    #[test]
+    fn the_layout_is_asked_for_the_pointer_only_while_a_surface_of_its_own_is_up() {
+        assert_eq!(
+            Placement::Layout.pointer_order(false),
+            Some(SiblingOrder::Back)
+        );
+        assert_eq!(
+            Placement::Layout.pointer_order(true),
+            Some(SiblingOrder::Front)
+        );
+        assert_eq!(
+            Placement::Modal.pointer_order(false),
+            Some(SiblingOrder::Front)
+        );
+        assert_eq!(Placement::Pane.pointer_order(false), None);
+        assert!(Placement::Layout.paints_in_front());
     }
 }

--- a/crates/vmux_native/src/lib.rs
+++ b/crates/vmux_native/src/lib.rs
@@ -67,7 +67,7 @@ mod surface_element;
 #[cfg(target_os = "macos")]
 pub use embed::{AssetReply, Assets, Embedding, Outbox, Wake};
 #[cfg(target_os = "macos")]
-pub use surface::{Appearance, PageSurface};
+pub use surface::{Appearance, PageSurface, SiblingOrder};
 
 // wry calls `objc2::exception::catch`, whose C shim ships as a static archive built by
 // `objc2-exception-helper`. Cargo puts that archive's directory on the link path but its `-l`

--- a/crates/vmux_native/src/surface.rs
+++ b/crates/vmux_native/src/surface.rs
@@ -17,6 +17,19 @@ pub enum Appearance {
     System,
 }
 
+/// Which end of its parent's subview array a view sits at.
+///
+/// Not where it is drawn. `hitTest:` walks the array back to front and knows nothing of
+/// `zPosition`, so a view's place in it decides who AppKit hands a click to and nothing else —
+/// [`PageSurface::raise_above_layers`] is what decides what is painted over what.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SiblingOrder {
+    /// Last, and so the first asked for any point it covers.
+    Front,
+    /// First, and so asked only for the points no sibling covers.
+    Back,
+}
+
 /// One page running in this process, painted by a webview of its own.
 pub struct PageSurface {
     webview: wry::WebView,
@@ -80,15 +93,16 @@ impl PageSurface {
         self.dom.deliver(id, payload);
     }
 
-    /// Put the view last in its parent's subview array, so clicks land on it.
+    /// Put the view at one end of its parent's subview array, so AppKit asks it first or last.
     ///
     /// `hitTest:` walks siblings back to front and knows nothing of `zPosition`, so a view
-    /// painting above another is not the same as that view receiving the pointer. Anything the
-    /// host adds to the same parent afterwards lands in front — visibly on top, and taking every
-    /// click aimed at what is drawn over it.
+    /// painting above another is not the same as that view receiving the pointer. A view at the
+    /// front takes every click aimed at what it is drawn over, whether or not its document has
+    /// anything there to receive one; a view at the back is asked only where no sibling answers.
     ///
-    /// Reasserted rather than done once, because the next sibling to arrive undoes it again.
-    pub fn raise_above_siblings(&self) {
+    /// Reasserted rather than done once, because every sibling the host adds afterwards lands in
+    /// front and undoes it.
+    pub fn order_among_siblings(&self, order: SiblingOrder) {
         use objc2_app_kit::{NSView, NSWindowOrderingMode};
         use wry::WebViewExtMacOS;
 
@@ -100,12 +114,19 @@ impl PageSurface {
             return;
         };
         let subviews = parent.subviews();
-        let frontmost = subviews.lastObject();
-        if frontmost.is_some_and(|front| std::ptr::eq(&*front, view)) {
+        let occupant = match order {
+            SiblingOrder::Front => subviews.lastObject(),
+            SiblingOrder::Back => subviews.firstObject(),
+        };
+        if occupant.is_some_and(|held| std::ptr::eq(&*held, view)) {
             return;
         }
+        let mode = match order {
+            SiblingOrder::Front => NSWindowOrderingMode::Above,
+            SiblingOrder::Back => NSWindowOrderingMode::Below,
+        };
 
-        parent.addSubview_positioned_relativeTo(view, NSWindowOrderingMode::Above, None);
+        parent.addSubview_positioned_relativeTo(view, mode, None);
     }
 
     /// Outrank the layers of whatever else is drawn in this window.
@@ -115,7 +136,8 @@ impl PageSurface {
     ///
     /// It buys painting and nothing else. A layer's `zPosition` is invisible to `hitTest:`, which
     /// walks the subview array back to front, so this does not move a single click;
-    /// [`Self::raise_above_siblings`] is what does.
+    /// [`Self::order_among_siblings`] is what does. That independence is the point: a page can
+    /// paint over every pane and still let their clicks through.
     pub fn raise_above_layers(&self) {
         use objc2_app_kit::NSView;
         use wry::WebViewExtMacOS;


### PR DESCRIPTION
Closes VMX-187.

## The bug

No pane could be scrolled. The mouse wheel did nothing over settings, the terminal, a chat — anywhere but the layout's own chrome.

## Why

The layout fills the window and is painted over every pane, and `raise_above_siblings` put it last in the parent's subview array to match. That array is what AppKit's `hitTest:` walks, back to front, so the layout answered for every point in the window:

```
[0] CefBrowserHostView  1496x991@224,84  hidden=true
[1] WryWebView          1496x991@224,84  z=0     <- the pane
[2] WryWebView          1728x1083@0,0    z=500   <- the layout, last
```

The layout's document is `pointer-events: none` everywhere but its header and side sheet, but that is a CSS rule and `hitTest:` has never heard of it. Clicks still landed because WebKit forwards one it cannot place up the responder chain. It keeps the scroll, having its own scrolling machinery, so the wheel stopped at the layout every time.

Pre-existing, from #375 — not from the native-page migration in #401.

## The fix

Painting and hit-testing were one predicate, `Placement::is_frontmost`. Split them:

- `paints_in_front` still drives `raise_above_layers`, so the layout keeps `zPosition: 500` and keeps painting over every pane. **The frosted glass is untouched.**
- `pointer_order` is new, and puts the layout at the *back* of the subview array, where AppKit asks it only for the points no pane covers.

The chrome loses nothing: its two interactive regions do not overlap a pane. `windowed_page_frame_rect` starts the pane below the header and within its span, which is exactly the geometry the probe above shows.

The exception is a surface that floats past those regions and dismisses on an outside click — a bookmark context menu, the command bar panel. While one is up the layout does need the whole window, so `pointer_order` returns `Front` for it. That condition is `LayoutPointerCapture`, which already existed for this and is what `sync_layout_cef_pointer_target` tests.

Overriding `hitTest:` was the other candidate, and the plan recorded in the issue. It needs a container view or a class swizzle around a webview wry owns, plus the chrome rectangles mirrored into a process-global in physical pixels — and it would consult the same region knowledge to reach the same answer. This is the same semantics for a fraction of the surface.

## Test plan

- [x] Scroll a settings pane. Confirmed on device.
- [ ] Scroll a terminal, a chat, an editor.
- [ ] Click the header: tabs, the address field, the window buttons.
- [ ] Open and use the side sheet.
- [ ] Open the command bar, click outside it, confirm it dismisses.
- [ ] Right-click a bookmark, click outside the menu, confirm it dismisses.
- [ ] Confirm the glass behind the layout still reads as one app.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS surface layering so layouts and modal panels display correctly in front of other content.
  - Refined pointer interaction ordering to ensure input reaches the appropriate surface.
  - Layouts now adjust their ordering automatically when pointer capture is active.
  - Preserved existing pane ordering behavior.
- **Tests**
  - Added coverage for visual layering and pointer-capture ordering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->