### PR TITLE
Let a page follow a link to its own section

### DIFF
--- a/crates/vmux_native/src/report.rs
+++ b/crates/vmux_native/src/report.rs
@@ -24,6 +24,8 @@ enum PageReport<'a> {
         token: u64,
         measured: Option<Measured>,
     },
+    /// A link the shim held back rather than let it navigate the document away.
+    Link(&'a str),
     /// A payload a page emitted, still base64 as the shim sent it.
     Emitted(&'a str),
 }
@@ -42,6 +44,9 @@ impl<'a> PageReport<'a> {
                 token,
                 measured: Self::numbers(values),
             };
+        }
+        if let Some(href) = body.strip_prefix("link:") {
+            return Self::Link(href);
         }
 
         Self::Emitted(body)
@@ -92,8 +97,23 @@ impl PageMessage {
         match PageReport::of(body) {
             PageReport::Console { level, text } => self.log(level, text),
             PageReport::Measured { token, measured } => self.measured(token, measured),
+            PageReport::Link(href) => self.link(href),
             PageReport::Emitted(payload) => self.emit(payload),
         }
+    }
+
+    /// A link that went nowhere.
+    ///
+    /// The shim lets a fragment through to the engine and holds everything else, because a native
+    /// page's document is the one its `VirtualDom` is mounted against and navigating it away ends
+    /// the page. Nothing opens the held ones. A link that should go somewhere is a button that
+    /// emits an event the host answers — `MdInline::WikiLink` already is one — so this says which
+    /// page still renders an `<a>` expecting the engine to do it.
+    fn link(&self, href: &str) {
+        warn!(
+            "{}: no link is followed from a page hosted here, {href} went nowhere",
+            self.name
+        );
     }
 
     /// Resolve whatever asked, then wake: a task that can now run is a render nobody has scheduled.
@@ -149,6 +169,7 @@ mod tests {
                     Some([a, b, c, d]) => format!("measured {token} {a},{b},{c},{d}"),
                     None => format!("measured {token} gone"),
                 },
+                PageReport::Link(href) => format!("link {href}"),
                 PageReport::Emitted(payload) => format!("emitted {payload}"),
             }
         }
@@ -168,6 +189,7 @@ mod tests {
             "measured:7:1,2,3,4",
             "measured:9:",
             "measured:9:1,2",
+            "link:https://example.com/a:b",
             "AAAA",
         ]
         .iter()
@@ -182,6 +204,7 @@ mod tests {
                 "measured 7 1,2,3,4",
                 "measured 9 gone",
                 "measured 9 gone",
+                "link https://example.com/a:b",
                 "emitted AAAA",
             ]
         );

--- a/crates/vmux_native/src/shim.rs
+++ b/crates/vmux_native/src/shim.rs
@@ -238,6 +238,26 @@ pub(crate) const WRY_HOST_SHIM: &str = r#"
       }
     }
   };
+  // Whether this href names a place inside the document the VirtualDom is mounted against.
+  //
+  // Both halves of that matter. A url carrying no fragment is a navigation even when it resolves
+  // right back here — `href=""` resolves to this document and reloads it, which ends the page as
+  // surely as leaving would. And a fragment is the engine's to scroll only once it still lands
+  // here: `<base href="/"/>` is in every page's head, so a bare `#section` resolves against the
+  // base rather than the document, and on a page whose url carries a path — `file:///x`,
+  // `vmux://agent/<id>` — that names somewhere else entirely.
+  //
+  // Asked of the resolved url rather than of the attribute, so `#agent` and `vmux://settings/#agent`
+  // reach the same answer on `vmux://settings/`.
+  const sameDocumentFragment = (href) => {
+    const upToFragment = (url) => url.split('#')[0];
+    try {
+      const resolved = new URL(href, document.baseURI).href;
+      return resolved.includes('#') && upToFragment(resolved) === upToFragment(location.href);
+    } catch (e) {
+      return false;
+    }
+  };
   // Which links the document is allowed to follow.
   //
   // dioxus's desktop interpreter follows none of them: it prevents the default action for every
@@ -249,28 +269,17 @@ pub(crate) const WRY_HOST_SHIM: &str = r#"
   // The refusal moves here, where the two can be told apart. Bubble phase on the document, which
   // is after the interpreter's own delegated handler, so a page that claimed the click for itself
   // has already said so and this leaves it alone.
-  // Whether following this href would leave the document the VirtualDom is mounted against.
-  // `<base href="/"/>` is in every page's head, and it makes a bare fragment resolve against the
-  // base rather than against the document — so on a page whose url carries a path, `file:///x` or
-  // `vmux://agent/<id>`, `#section` names a different document and following it would end the
-  // page. A fragment is the engine's to scroll only once it still lands here.
-  const sameDocument = (href) => {
-    const upToFragment = (url) => url.split('#')[0];
-    try {
-      return upToFragment(new URL(href, document.baseURI).href) === upToFragment(location.href);
-    } catch (e) {
-      return false;
-    }
-  };
   const holdLinks = () => {
     window.interpreter.intercept_link_redirects = false;
     document.addEventListener('click', (event) => {
       if (event.defaultPrevented) return;
       const anchor = event.target instanceof Element ? event.target.closest('a') : null;
       if (!anchor) return;
+      // An `<a>` carrying no href is a placeholder rather than a link, and the engine does nothing
+      // with it either. An empty one is a link: `[text]()` in a note renders `href=""`.
       const href = anchor.getAttribute('href');
-      if (!href) return;
-      if (href.startsWith('#') && sameDocument(href)) return;
+      if (href === null) return;
+      if (sameDocumentFragment(href)) return;
       event.preventDefault();
       window.ipc.postMessage('link:' + href);
     });

--- a/crates/vmux_native/src/shim.rs
+++ b/crates/vmux_native/src/shim.rs
@@ -238,10 +238,47 @@ pub(crate) const WRY_HOST_SHIM: &str = r#"
       }
     }
   };
+  // Which links the document is allowed to follow.
+  //
+  // dioxus's desktop interpreter follows none of them: it prevents the default action for every
+  // click inside an `<a>` and posts the href to the host instead, on the grounds that a document
+  // navigating away would take the VirtualDom's mounting with it. That holds for anything leaving
+  // the page. A fragment does not leave it — so refusing one turns a scroll the engine does
+  // natively, and instantly, into a link that does nothing at all.
+  //
+  // The refusal moves here, where the two can be told apart. Bubble phase on the document, which
+  // is after the interpreter's own delegated handler, so a page that claimed the click for itself
+  // has already said so and this leaves it alone.
+  // Whether following this href would leave the document the VirtualDom is mounted against.
+  // `<base href="/"/>` is in every page's head, and it makes a bare fragment resolve against the
+  // base rather than against the document — so on a page whose url carries a path, `file:///x` or
+  // `vmux://agent/<id>`, `#section` names a different document and following it would end the
+  // page. A fragment is the engine's to scroll only once it still lands here.
+  const sameDocument = (href) => {
+    const upToFragment = (url) => url.split('#')[0];
+    try {
+      return upToFragment(new URL(href, document.baseURI).href) === upToFragment(location.href);
+    } catch (e) {
+      return false;
+    }
+  };
+  const holdLinks = () => {
+    window.interpreter.intercept_link_redirects = false;
+    document.addEventListener('click', (event) => {
+      if (event.defaultPrevented) return;
+      const anchor = event.target instanceof Element ? event.target.closest('a') : null;
+      if (!anchor) return;
+      const href = anchor.getAttribute('href');
+      if (!href) return;
+      if (href.startsWith('#') && sameDocument(href)) return;
+      event.preventDefault();
+      window.ipc.postMessage('link:' + href);
+    });
+  };
   window.vmuxWry = {
     // Asking for a frame is what tells the host the page can take one, so the shell calls this
     // once the interpreter holds a root and never before.
-    start: pumpEdits,
+    start() { holdLinks(); pumpEdits(); },
     binEmit(buffer) { window.ipc.postMessage(toBase64(buffer)); },
     binListen(id, callback) {
       const existing = listeners.get(id) || [];


### PR DESCRIPTION
Closes VMX-189. Stacked on #402 — base is `vmx-187-hit-test-the-layout`.

## The bug

Clicking a section title in the settings nav does nothing, and writes an error per click:

```
ERROR vmux_native::report: vmux_native: ipc payload was not base64: Invalid symbol 123, offset 0.
```

`123` is `{`.

## Why

A natively-hosted page runs dioxus's **desktop** interpreter, `native.js`, and that one follows no link at all:

```js
handleClickNavigate(event, target) {
  if (!this.intercept_link_redirects) return;
  let a_element = target.closest("a");
  if (a_element) {
    event.preventDefault();
    let href = a_element.getAttribute("href");
    if (href !== "" && href !== null && href !== void 0)
      this.sendIpcMessage("browser_open", { href });
  }
}
```

`initialize()` sets `intercept_link_redirects = true`, and `sendIpcMessage` posts `JSON.stringify({method, params})`. No `PageReport` variant matched the JSON, so it fell through to `Emitted` and failed base64 decode.

dioxus-desktop's reasoning is that the host wants a system browser, and that a document navigating away would take the `VirtualDom`'s mounting with it. The second half is true here. The first is not — and neither is either half for a fragment, which does not leave the document.

The wasm build never hit this: `dioxus-web`'s `interpreter.js` has no such interception, and the engine followed fragments itself.

## The fix

The refusal moves into the shim, where the two cases can be told apart. A fragment that still lands on this document is left to the engine — which scrolls to it natively, and without waiting for a frame from the host. Everything else is still held, and now reaches the host as `link:<href>` rather than as unparseable JSON.

Which document a fragment lands on has to be asked rather than assumed. Every page's head carries `<base href="/"/>`, so a bare `#section` resolves against the base and not the document. On `vmux://settings/` those are the same URL. On a page whose url has a path — `file:///x`, `vmux://agent/<id>` — they are not, and letting the link through would navigate the page out of existence. `sameDocument` compares the resolved href against `location.href`, both cut at the fragment.

The listener sits in the bubble phase on `document`, which is after the interpreter's own delegated handler, so a page that claimed the click with `prevent_default()` has already said so and this leaves it alone.

## Left open

Nothing opens a held link, so `MdInline::Link` in a note is still dead — but now it says which page and which href instead of failing a base64 decode. The established pattern for a link that does something is a button that emits a typed event; `MdInline::WikiLink`, right below it, is one. Making external links open needs a decision about where they go, so it stays out of this.

## Test plan

- [ ] Click every section title in the settings nav; each scrolls to its section.
- [ ] Confirm no `ipc payload was not base64` errors in the log.
- [ ] Click a markdown link in a knowledge note: the page must not navigate away, and the log should name the href.
- [ ] Click a wiki link in a note; it still opens.
- [ ] Confirm buttons and inputs elsewhere still work — the new listener sees every click in every page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved link handling in embedded pages.
  * External and non-anchor links are now sent to the host for processing.
  * Same-page anchor links continue to scroll natively.
  * Unfollowed links are recorded as warnings without navigating away.

* **Bug Fixes**
  * Improved support for links containing colons.
  * Prevented unintended navigation from embedded content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->