### PR TITLE
Stop pages naming themselves through a document that is not there

### DIFF
--- a/crates/host/vmux_service/src/page.rs
+++ b/crates/host/vmux_service/src/page.rs
@@ -34,7 +34,6 @@ pub fn Page() -> Element {
     let process_count = data.processes.len();
 
     rsx! {
-        document::Title { {translate("services-title")} }
         div { class: "flex h-full flex-col bg-background p-4 overflow-auto",
             // Header
             div { class: "mb-3 flex items-center justify-between",

--- a/crates/page/vmux_agent/src/page.rs
+++ b/crates/page/vmux_agent/src/page.rs
@@ -19,7 +19,6 @@ pub fn Page() -> Element {
     let filtered = catalog.matching();
 
     rsx! {
-        document::Title { {translate("agents-title")} }
         ManagerPage {
             ManagerHeader {
                 title: translate("agents-title"),

--- a/crates/page/vmux_agent/src/vibe/setup/page.rs
+++ b/crates/page/vmux_agent/src/vibe/setup/page.rs
@@ -70,9 +70,6 @@ pub fn Page() -> Element {
 
     let emit_segment = segment.clone();
     rsx! {
-        document::Title {
-            {translate_with("setup-install-title", &[("name", TranslationValue::String(name))])}
-        }
         main { class: "relative flex min-h-screen items-center justify-center overflow-hidden bg-background p-10 text-foreground",
             div { class: "{accent.glow_top}" }
             div { class: "{accent.glow_bottom}" }

--- a/crates/page/vmux_editor/src/lsp_page.rs
+++ b/crates/page/vmux_editor/src/lsp_page.rs
@@ -63,7 +63,6 @@ pub fn Page() -> Element {
 
     let visible = packages();
     rsx! {
-        document::Title { {translate("lsp-title")} }
         ManagerPage {
             ManagerHeader {
                 title: translate("lsp-title"),

--- a/crates/page/vmux_editor/src/page.rs
+++ b/crates/page/vmux_editor/src/page.rs
@@ -620,7 +620,6 @@ pub fn Page() -> Element {
 
     rsx! {
         if !doc_title().is_empty() {
-            document::Title { "{doc_title}" }
         }
         div {
             id: PAGE_ID,

--- a/crates/page/vmux_history/src/page.rs
+++ b/crates/page/vmux_history/src/page.rs
@@ -96,7 +96,6 @@ pub fn Page() -> Element {
     let groups = group_by_day(&entries.read(), now_millis());
 
     rsx! {
-        document::Title { {translate("history-title")} }
         div { class: "flex flex-col h-screen bg-background text-foreground",
             header { class: "p-3 border-b border-border flex gap-2 items-center",
                 input {

--- a/crates/page/vmux_layout/src/error_page.rs
+++ b/crates/page/vmux_layout/src/error_page.rs
@@ -22,7 +22,6 @@ pub fn Page() -> Element {
     };
 
     rsx! {
-        document::Title { "{title}" }
         div { class: "flex h-full min-h-0 items-center justify-center bg-background p-10 text-foreground",
             section { class: "max-w-[640px]",
                 h1 { class: "mb-3 text-[28px] font-semibold leading-tight", "{title}" }

--- a/crates/page/vmux_layout/src/extensions_page.rs
+++ b/crates/page/vmux_layout/src/extensions_page.rs
@@ -86,7 +86,6 @@ pub fn Page() -> Element {
     let installing: Vec<ExtInstallProgress> = progress().values().cloned().collect();
 
     rsx! {
-        document::Title { {translate("extensions-title")} }
         ManagerPage {
             ManagerHeader {
                 title: translate("extensions-title"),

--- a/crates/page/vmux_layout/src/tools_page.rs
+++ b/crates/page/vmux_layout/src/tools_page.rs
@@ -51,7 +51,6 @@ pub fn Page() -> Element {
         .filter(|item| item_matches(item, &search))
         .count();
     rsx! {
-        document::Title { {translate("tools-title")} }
         ManagerPage {
             ManagerHeader {
                 title: translate("tools-title"),

--- a/crates/page/vmux_layout/src/vault_page.rs
+++ b/crates/page/vmux_layout/src/vault_page.rs
@@ -178,7 +178,6 @@ pub fn Page() -> Element {
 
     let current = snapshot();
     rsx! {
-        document::Title { {translate("vault-title")} }
         ManagerPage {
             header { class: "shrink-0 border-b border-foreground/[0.07] px-5 py-3",
                 div { class: "flex items-center gap-3",

--- a/crates/page/vmux_setting/src/page.rs
+++ b/crates/page/vmux_setting/src/page.rs
@@ -40,7 +40,6 @@ pub fn Page() -> Element {
     let s = snapshot.read().clone();
     if s.is_null() {
         return rsx! {
-            document::Title { {translate("settings-title")} }
             div { class: "flex h-full items-center justify-center text-sm text-muted-foreground",
                 {translate("settings-loading")}
             }
@@ -56,7 +55,6 @@ pub fn Page() -> Element {
     let search_placeholder = format!("{}…", translate("command-search"));
 
     rsx! {
-        document::Title { {translate("settings-title")} }
         div { class: "flex h-full min-h-0 flex-row bg-background text-foreground",
             aside { class: "hidden w-56 shrink-0 border-r border-border px-4 py-6 lg:block",
                 div { class: "mb-4 px-2",

--- a/crates/page/vmux_space/src/page.rs
+++ b/crates/page/vmux_space/src/page.rs
@@ -41,7 +41,6 @@ pub fn Page() -> Element {
         });
 
     rsx! {
-        document::Title { {translate("spaces-title")} }
         div {
             id: "spaces-root",
             tabindex: "0",

--- a/crates/page/vmux_start/src/page.rs
+++ b/crates/page/vmux_start/src/page.rs
@@ -4,7 +4,6 @@ use dioxus::prelude::*;
 use vmux_command::event::CommandBarOpenEvent;
 use vmux_ui::components::start_hero::{START_BACKDROP_STYLE, StartBackdrop, StartHero};
 use vmux_ui::hooks::{send, use_event, use_listener, use_theme};
-use vmux_ui::i18n::translate;
 
 use crate::event::{
     START_COMMAND_BAR_OPEN_EVENT, START_FOCUS_INPUT_EVENT, StartDataRequest, StartFocusInput,
@@ -39,7 +38,6 @@ pub fn Page(
     use_effect(StartFocus::install);
 
     rsx! {
-        document::Title { {translate("start-title")} }
         main {
             class: "relative isolate flex h-screen items-center justify-center overflow-hidden bg-background px-4 text-foreground sm:px-6",
             style: START_BACKDROP_STYLE,

--- a/crates/page/vmux_team/src/page.rs
+++ b/crates/page/vmux_team/src/page.rs
@@ -25,7 +25,6 @@ pub fn Page() -> Element {
     };
 
     rsx! {
-        document::Title { {translate("team-title")} }
         div {
             class: "flex h-full min-h-0 flex-col bg-background text-foreground",
             header { class: "flex items-center justify-between border-b border-border px-5 py-4",

--- a/crates/page/vmux_terminal/src/page.rs
+++ b/crates/page/vmux_terminal/src/page.rs
@@ -388,7 +388,6 @@ pub fn Page() -> Element {
 
     rsx! {
         if !title.is_empty() {
-            document::Title { "{title}" }
         }
         div {
             id: CONTAINER_ID,


### PR DESCRIPTION
Closes VMX-190. Stacked on #403 — base is `vmx-189-fragment-links`.

## The bug

Six of these per boot, and one more on every render of the offending node:

```
ERROR dioxus_document: Unable to find a document in the renderer. Using the default no-op document.
```

## Why

`dioxus_document::document()` looks for a renderer-provided `Document` in the root scope and shouts when there is none:

```rust
match dioxus_core::try_consume_context::<Rc<dyn Document>>() {
    Some(document) => document,
    None => {
        tracing::error!("Unable to find a document in the renderer. Using the default no-op document.");
        Rc::new(NoOpDocument)
    }
}
```

dioxus-web and dioxus-desktop each install one. `vmux_native` mounts a bare `VirtualDom` and never has, so the caller — `document::Title`, in sixteen pages — gets the no-op and an error line.

Nothing was broken by it, which is why the tab labels have been right all along. The wasm build turned `document::Title` into the DOM's own `<title>`, CEF read it back, and the host stored it as `OscTitle`. #401 replaced that path: a tab's label is `PageMetadata` resolved through `PageIdentity` (`PageMetadata::title_with`), and `vmux_start` already declares its name the way that survives — `title_message_id: Some("start-title")` in `lib.rs:48`, with the `document::Title` sitting redundantly beside it.

## The change

Delete all sixteen. Deletions only, 18 lines across 15 files.

`crates/app/vmux_mobile/src/main.rs:1693` keeps its own `document::Title { "Vmux" }`: dioxus-mobile provides a `Document`, and that title names the app rather than a page.

No Fluent key is orphaned — I checked all twelve `*-title` ids and every one is still used by a heading or by the url-to-title map in `vmux_layout/src/page.rs`. One import in `vmux_start` became unused and went with it.

## The road not taken

Install a `Document` in `vmux_native` whose `set_title` feeds `PageIdentity`. That keeps the declarative colocated title and gives iOS and desktop the same behaviour. Rejected: it gives `PageIdentity` a second writer, and the terminal already had both — the host sets it from the OSC title sequence while the page rendered `document::Title { "{title}" }`. One mechanism beats the colocation.

## Test plan

- [ ] No `dioxus_document` errors in the log at boot or while using the app.
- [ ] Tab labels are still right: settings, terminal, chat, editor, start, history, spaces, team, tools, vault, extensions, services, lsp, agents.
- [ ] A terminal's tab still follows its OSC title.
- [ ] A chat tab still follows its activity.
