### PR TITLE
Drive a page with no window by rendering it into a tree

### DIFF
--- a/crates/vmux_native/src/event_request.rs
+++ b/crates/vmux_native/src/event_request.rs
@@ -52,7 +52,7 @@ impl std::fmt::Display for EventRequestError {
 impl std::error::Error for EventRequestError {}
 
 /// What the page is told once its handlers have run.
-#[derive(Serialize)]
+#[derive(Debug, PartialEq, Serialize)]
 pub struct EventOutcome {
     #[serde(rename = "preventDefault")]
     prevent_default: bool,

--- a/crates/vmux_native/src/lib.rs
+++ b/crates/vmux_native/src/lib.rs
@@ -33,12 +33,18 @@ mod event_request;
 mod instance;
 mod page;
 mod page_dom;
+mod probe;
+mod selector;
+mod shadow_tree;
 mod shell;
 
 pub use event_request::{EventOutcome, EventRequest, EventRequestError};
 pub use instance::{Instance, PageScope};
 pub use page::NativePage;
 pub use page_dom::{PageComponent, PageDom};
+pub use probe::{PageProbe, ProbeError};
+pub use selector::{Selector, SelectorError};
+pub use shadow_tree::ShadowTree;
 pub use shell::InterpreterShell;
 
 #[cfg(ui)]

--- a/crates/vmux_native/src/page_dom.rs
+++ b/crates/vmux_native/src/page_dom.rs
@@ -2,7 +2,7 @@
 
 use std::rc::Rc;
 
-use dioxus_core::{Element, Event, VirtualDom};
+use dioxus_core::{Element, Event, VirtualDom, WriteMutations};
 use dioxus_html::{EventData, HtmlEvent, MountedData, PlatformEventData, RenderedElementBacking};
 use dioxus_interpreter_js::MutationState;
 
@@ -15,18 +15,22 @@ use crate::event_request::EventOutcome;
 pub type PageComponent = fn() -> Element;
 
 /// A page whose components run here, rendering into a document owned by something else.
-pub struct PageDom {
+///
+/// `W` is where a render is written. It defaults to the interpreter's binary channel, which is
+/// what a webview applies; [`ShadowTree`](crate::ShadowTree) is the other sink in this crate, and
+/// swapping it in is what lets a test read the document the page would have been given.
+pub struct PageDom<W = MutationState> {
     dom: VirtualDom,
-    mutations: MutationState,
+    mutations: W,
     unflushed: bool,
 }
 
-impl PageDom {
-    /// Mount `app` without rendering it. Call [`PageDom::rebuild`] for the first batch.
+impl<W: WriteMutations + Default> PageDom<W> {
+    /// Mount `app` without rendering it.
     ///
     /// `instance` is provided before the first render rather than after, so a page that differs
     /// per view reads its difference on the render that produces the document.
-    pub fn mount(app: PageComponent, instance: crate::Instance) -> Self {
+    pub(crate) fn with_sink(app: PageComponent, instance: crate::Instance) -> Self {
         Self::install_event_converter();
 
         let dom = VirtualDom::new(app);
@@ -34,7 +38,7 @@ impl PageDom {
 
         Self {
             dom,
-            mutations: MutationState::default(),
+            mutations: W::default(),
             unflushed: false,
         }
     }
@@ -52,37 +56,34 @@ impl PageDom {
         });
     }
 
-    /// The first render, which always produces a batch: the document starts empty.
-    pub fn rebuild(&mut self) -> Vec<u8> {
+    /// The first render, which always describes a document that does not exist yet.
+    pub(crate) fn diff_rebuild(&mut self) {
         self.dom.rebuild(&mut self.mutations);
         self.unflushed = true;
-        self.mutations.export_memory()
     }
 
-    /// Every render after the first.
-    ///
-    /// `None` means there is nothing to send — either nothing changed, or the last batch has not
-    /// been acknowledged yet. A caller that gets `None` must ask again after [`PageDom::flushed`],
-    /// or the page stops updating.
-    ///
-    /// Rendering is withheld while a batch is in flight because an effect may read the document,
-    /// and the document does not yet reflect the render that scheduled the effect.
-    pub fn render(&mut self) -> Option<Vec<u8>> {
+    /// Every render after the first, and whether one happened.
+    pub(crate) fn diff_render(&mut self) -> bool {
         if self.unflushed || !self.has_work() {
-            return None;
+            return false;
         }
 
         self.dom.render_immediate(&mut self.mutations);
         self.unflushed = true;
 
-        Some(self.mutations.export_memory())
+        true
+    }
+
+    /// What the renders so far have been written into.
+    pub(crate) fn sink(&self) -> &W {
+        &self.mutations
     }
 
     /// Whether a render would change anything, asked without blocking.
     ///
-    /// An empty batch cannot answer this: `export_memory` always emits the channel's header, so a
-    /// render with no work still yields bytes — 36 of them, whose contents move with channel state
-    /// and so cannot be compared against a fixed baseline either.
+    /// An empty batch cannot answer this: the interpreter's `export_memory` always emits the
+    /// channel's header, so a render with no work still yields bytes — 36 of them, whose contents
+    /// move with channel state and so cannot be compared against a fixed baseline either.
     ///
     /// `wait_for_work` is `process_events` followed by a dirty-scope check, and awaits only once
     /// both say there is nothing to do. Polling it against a no-op waker runs exactly that check.
@@ -151,6 +152,36 @@ impl PageDom {
     /// Wait until the page has work to do.
     pub async fn wait_for_work(&mut self) {
         self.dom.wait_for_work().await;
+    }
+}
+
+impl PageDom<MutationState> {
+    /// Mount `app` without rendering it. Call [`PageDom::rebuild`] for the first batch.
+    pub fn mount(app: PageComponent, instance: crate::Instance) -> Self {
+        Self::with_sink(app, instance)
+    }
+
+    /// The first render, which always produces a batch: the document starts empty.
+    pub fn rebuild(&mut self) -> Vec<u8> {
+        self.diff_rebuild();
+
+        self.mutations.export_memory()
+    }
+
+    /// Every render after the first.
+    ///
+    /// `None` means there is nothing to send — either nothing changed, or the last batch has not
+    /// been acknowledged yet. A caller that gets `None` must ask again after [`PageDom::flushed`],
+    /// or the page stops updating.
+    ///
+    /// Rendering is withheld while a batch is in flight because an effect may read the document,
+    /// and the document does not yet reflect the render that scheduled the effect.
+    pub fn render(&mut self) -> Option<Vec<u8>> {
+        if !self.diff_render() {
+            return None;
+        }
+
+        Some(self.mutations.export_memory())
     }
 }
 

--- a/crates/vmux_native/src/probe.rs
+++ b/crates/vmux_native/src/probe.rs
@@ -1,0 +1,428 @@
+//! Drive a page the way a person would, with no window and no browser.
+//!
+//! A [`PageProbe`] mounts a page's components, renders them into a [`ShadowTree`], and then trades
+//! in selectors: find something, click it, read what changed. It is the same `VirtualDom` and the
+//! same mutations the webview would be given, so a behaviour that holds here holds there.
+//!
+//! What it cannot answer is anything the browser decides: layout, styling, hit-testing, input
+//! method. A probe says the page reacted; only a screenshot says it looked right.
+
+use std::fmt;
+
+use dioxus_core::ElementId;
+use dioxus_html::{EventData, HtmlEvent, SerializedMouseData};
+
+use crate::event_request::EventOutcome;
+use crate::page_dom::{PageComponent, PageDom};
+use crate::selector::{Selector, SelectorError};
+use crate::shadow_tree::ShadowTree;
+
+/// A mounted page, queried and driven by selector.
+pub struct PageProbe {
+    page: PageDom<ShadowTree>,
+}
+
+/// Why a probe could not do what it was asked.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ProbeError {
+    /// The selector was not a selector.
+    BadSelector(SelectorError),
+    /// Nothing in the document matched.
+    NoSuchElement { selector: String, outline: String },
+    /// Something matched, but dioxus never gave it an id, so no event can name it.
+    NotAddressable { selector: String },
+    /// The element is there and addressable, but nothing is listening for this event.
+    NoListener { selector: String, event: String },
+    /// Renders kept scheduling more renders.
+    DidNotSettle,
+}
+
+impl fmt::Display for ProbeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BadSelector(error) => write!(f, "{error}"),
+            Self::NoSuchElement { selector, outline } => {
+                write!(
+                    f,
+                    "nothing matched `{selector}`. The document is:\n{outline}"
+                )
+            }
+            Self::NotAddressable { selector } => write!(
+                f,
+                "`{selector}` matched an element dioxus never assigned an id, so no event can \
+                 reach it — give it a listener or a dynamic attribute"
+            ),
+            Self::NoListener { selector, event } => write!(
+                f,
+                "`{selector}` is not listening for `{event}`, so dispatching one would assert \
+                 nothing"
+            ),
+            Self::DidNotSettle => f.write_str("the page kept re-rendering and never went quiet"),
+        }
+    }
+}
+
+impl std::error::Error for ProbeError {}
+
+impl From<SelectorError> for ProbeError {
+    fn from(error: SelectorError) -> Self {
+        Self::BadSelector(error)
+    }
+}
+
+/// A render that schedules a render is normal; sixty-four in a row is a loop.
+const SETTLE_LIMIT: usize = 64;
+
+impl PageProbe {
+    /// Mount `app` and render it, leaving the document ready to query.
+    pub fn mount(app: PageComponent, instance: crate::Instance) -> Self {
+        let mut page = PageDom::with_sink(app, instance);
+        page.diff_rebuild();
+        let mut probe = Self { page };
+        let _ = probe.settle();
+
+        probe
+    }
+
+    /// Click the first element `selector` names, then let the page finish reacting.
+    pub fn click(&mut self, selector: &str) -> Result<EventOutcome, ProbeError> {
+        self.dispatch(
+            selector,
+            "click",
+            EventData::Mouse(SerializedMouseData::default()),
+        )
+    }
+
+    /// Send `event` to the first element `selector` names, then let the page finish reacting.
+    ///
+    /// The escape hatch behind [`PageProbe::click`]: anything `dioxus_html` can serialize can be
+    /// delivered here, addressed by selector rather than by a raw [`ElementId`].
+    pub fn dispatch(
+        &mut self,
+        selector: &str,
+        event: &str,
+        data: EventData,
+    ) -> Result<EventOutcome, ProbeError> {
+        let element = self.find(selector)?;
+        if !self.tree().has_listener(element, event) {
+            return Err(ProbeError::NoListener {
+                selector: selector.to_string(),
+                event: event.to_string(),
+            });
+        }
+
+        let outcome = self.page.handle(
+            HtmlEvent {
+                element,
+                name: event.to_string(),
+                bubbles: true,
+                data,
+            },
+            (),
+        );
+        self.settle()?;
+
+        Ok(outcome)
+    }
+
+    /// The id of the first element `selector` names.
+    pub fn find(&self, selector: &str) -> Result<ElementId, ProbeError> {
+        let parsed: Selector = selector.parse()?;
+        let Some(element) = self.tree().find(&parsed) else {
+            return Err(match self.tree().exists(&parsed) {
+                true => ProbeError::NotAddressable {
+                    selector: selector.to_string(),
+                },
+                false => ProbeError::NoSuchElement {
+                    selector: selector.to_string(),
+                    outline: self.outline(),
+                },
+            });
+        };
+
+        Ok(element)
+    }
+
+    /// Every character of text under the first element `selector` names.
+    pub fn text(&self, selector: &str) -> Result<String, ProbeError> {
+        let parsed: Selector = selector.parse()?;
+        let Some(text) = self.tree().text(&parsed) else {
+            return Err(ProbeError::NoSuchElement {
+                selector: selector.to_string(),
+                outline: self.outline(),
+            });
+        };
+
+        Ok(text)
+    }
+
+    /// One attribute of the first element `selector` names.
+    pub fn attribute(&self, selector: &str, name: &str) -> Result<Option<String>, ProbeError> {
+        let parsed: Selector = selector.parse()?;
+
+        Ok(self.tree().attribute(&parsed, name))
+    }
+
+    /// How many elements `selector` names, which is `0` when it names none.
+    pub fn count(&self, selector: &str) -> Result<usize, ProbeError> {
+        let parsed: Selector = selector.parse()?;
+
+        Ok(self.tree().count(&parsed))
+    }
+
+    /// The document as indented text, which is what a failing assertion should print.
+    pub fn outline(&self) -> String {
+        self.tree().outline()
+    }
+
+    /// The document itself, for a question the methods above do not cover.
+    pub fn tree(&self) -> &ShadowTree {
+        self.page.sink()
+    }
+
+    /// Render until nothing more is scheduled.
+    ///
+    /// A page acknowledges each batch before the next is produced, so a probe has to play the
+    /// document's part: flush, render, repeat. Effects run between those renders, and an effect
+    /// that sets a signal is why one render is not enough.
+    fn settle(&mut self) -> Result<(), ProbeError> {
+        for _ in 0..SETTLE_LIMIT {
+            self.page.flushed();
+            if !self.page.diff_render() {
+                return Ok(());
+            }
+        }
+
+        Err(ProbeError::DidNotSettle)
+    }
+}
+
+#[cfg(test)]
+// The fixtures below are components, and a component is PascalCase.
+#[allow(non_snake_case)]
+mod tests {
+    use dioxus::prelude::*;
+
+    use super::*;
+
+    impl PageProbe {
+        fn of(app: PageComponent) -> Self {
+            Self::mount(app, crate::Instance::default())
+        }
+    }
+
+    #[component]
+    fn Counter() -> Element {
+        let mut count = use_signal(|| 0);
+
+        rsx! {
+            button { "data-testid": "bump", onclick: move |_| count += 1, "count: {count}" }
+        }
+    }
+
+    /// The whole harness in one assertion: a click reaches a handler, the signal it sets schedules
+    /// a render, and the render reaches the document a query reads.
+    #[test]
+    fn a_click_runs_the_handler_and_the_new_text_is_readable() {
+        let mut page = PageProbe::of(Counter);
+        assert_eq!(page.text("[data-testid=bump]").unwrap(), "count: 0");
+
+        page.click("[data-testid=bump]").unwrap();
+
+        assert_eq!(page.text("[data-testid=bump]").unwrap(), "count: 1");
+    }
+
+    #[component]
+    fn Rows() -> Element {
+        let mut rows = use_signal(|| vec!["alpha", "beta", "gamma"]);
+
+        rsx! {
+            button { "data-testid": "drop", onclick: move |_| { rows.write().remove(1); }, "drop" }
+            ul {
+                for row in rows() {
+                    li { class: "row", "{row}" }
+                }
+            }
+        }
+    }
+
+    /// A list shrinking exercises the mutations a counter never reaches — the placeholder that
+    /// holds a list's position, and the removal of a node from the middle of it.
+    #[test]
+    fn removing_a_list_item_removes_it_from_the_document() {
+        let mut page = PageProbe::of(Rows);
+        assert_eq!(page.count(".row").unwrap(), 3);
+        assert_eq!(page.text("ul").unwrap(), "alphabetagamma");
+
+        page.click("[data-testid=drop]").unwrap();
+
+        assert_eq!(page.count(".row").unwrap(), 2);
+        assert_eq!(
+            page.text("ul").unwrap(),
+            "alphagamma",
+            "the middle row is the one that went, and order survived the removal"
+        );
+    }
+
+    #[component]
+    fn Growing() -> Element {
+        let mut rows = use_signal(|| vec!["only"]);
+
+        rsx! {
+            button { "data-testid": "add", onclick: move |_| rows.write().insert(0, "first"), "add" }
+            ul {
+                for row in rows() {
+                    li { class: "row", "{row}" }
+                }
+            }
+        }
+    }
+
+    /// Inserting at the head is the case that tells an append-only tree from a real one.
+    #[test]
+    fn an_item_inserted_at_the_head_lands_before_the_one_already_there() {
+        let mut page = PageProbe::of(Growing);
+
+        page.click("[data-testid=add]").unwrap();
+
+        assert_eq!(page.text("ul").unwrap(), "firstonly");
+    }
+
+    #[component]
+    fn Toggling() -> Element {
+        let mut open = use_signal(|| false);
+
+        rsx! {
+            button { "data-testid": "toggle", onclick: move |_| open.toggle(), "toggle" }
+            if open() {
+                p { "data-testid": "panel", "shown" }
+            }
+        }
+    }
+
+    #[test]
+    fn a_conditional_branch_appears_and_disappears() {
+        let mut page = PageProbe::of(Toggling);
+        assert_eq!(page.count("[data-testid=panel]").unwrap(), 0);
+
+        page.click("[data-testid=toggle]").unwrap();
+        assert_eq!(page.text("[data-testid=panel]").unwrap(), "shown");
+
+        page.click("[data-testid=toggle]").unwrap();
+        assert_eq!(
+            page.count("[data-testid=panel]").unwrap(),
+            0,
+            "the branch has to leave the document, not merely stop being rendered into"
+        );
+    }
+
+    #[component]
+    fn Inert() -> Element {
+        rsx! { div { "data-testid": "inert", "nothing happens here" } }
+    }
+
+    /// The trap this harness exists to avoid: dispatching at an element that listens for nothing
+    /// does nothing, and a test that then asserts on the unchanged document passes for the wrong
+    /// reason.
+    #[test]
+    fn clicking_something_that_listens_for_nothing_is_refused() {
+        let mut page = PageProbe::of(Inert);
+
+        assert_eq!(
+            page.click("[data-testid=inert]"),
+            Err(ProbeError::NoListener {
+                selector: "[data-testid=inert]".to_string(),
+                event: "click".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn a_selector_that_matches_nothing_reports_the_document_it_searched() {
+        let page = PageProbe::of(Counter);
+
+        let Err(ProbeError::NoSuchElement { outline, .. }) = page.text("[data-testid=absent]")
+        else {
+            panic!("a missing element must not read as an empty one");
+        };
+        assert!(
+            outline.contains("data-testid"),
+            "the failure has to show what was there instead, got:\n{outline}"
+        );
+    }
+
+    #[component]
+    fn Nested() -> Element {
+        rsx! {
+            div { "data-testid": "outer",
+                span { "data-testid": "inner", "text" }
+            }
+        }
+    }
+
+    /// A template's root is addressed when it is loaded, but a static node inside it is not —
+    /// dioxus never needs to name it again. Saying so beats reporting it as absent when it is
+    /// plainly in the outline.
+    #[test]
+    fn an_element_with_no_id_is_reported_as_unaddressable_rather_than_missing() {
+        let page = PageProbe::of(Nested);
+
+        assert_eq!(
+            page.find("[data-testid=inner]"),
+            Err(ProbeError::NotAddressable {
+                selector: "[data-testid=inner]".to_string(),
+            })
+        );
+        assert_eq!(
+            page.text("[data-testid=inner]").unwrap(),
+            "text",
+            "it is still readable — only unclickable"
+        );
+    }
+
+    #[component]
+    fn Renaming() -> Element {
+        let mut label = use_signal(|| "before".to_string());
+
+        rsx! {
+            button {
+                "data-testid": "rename",
+                "data-state": "{label}",
+                onclick: move |_| label.set("after".to_string()),
+                "go"
+            }
+        }
+    }
+
+    #[test]
+    fn a_changed_attribute_is_visible_to_a_query() {
+        let mut page = PageProbe::of(Renaming);
+        assert_eq!(
+            page.attribute("[data-testid=rename]", "data-state")
+                .unwrap(),
+            Some("before".to_string())
+        );
+
+        page.click("[data-testid=rename]").unwrap();
+
+        assert_eq!(
+            page.attribute("[data-testid=rename]", "data-state")
+                .unwrap(),
+            Some("after".to_string())
+        );
+    }
+
+    #[component]
+    fn Blocking() -> Element {
+        rsx! { a { onclick: |event: Event<MouseData>| event.prevent_default(), "link" } }
+    }
+
+    /// The answer the page blocks on. A probe returns it so a test can assert navigation was
+    /// stopped, which is not visible in the document at all.
+    #[test]
+    fn a_handler_preventing_the_default_says_so_through_the_probe() {
+        let mut page = PageProbe::of(Blocking);
+
+        assert!(page.click("a").unwrap().prevent_default());
+    }
+}

--- a/crates/vmux_native/src/selector.rs
+++ b/crates/vmux_native/src/selector.rs
@@ -1,0 +1,251 @@
+//! The subset of CSS a test needs to name an element.
+//!
+//! Deliberately not a CSS engine. A harness picks elements by test id, by tag, or by a single
+//! attribute, and every selector below is one of those three spelled the way CSS spells it. The
+//! moment a query needs a combinator it wants a different tool, not a bigger parser here.
+
+use std::fmt;
+
+/// One element, named the way a test would name it.
+///
+/// Parsed from `tag`, `#id`, `.class`, `[name=value]`, or a tag followed by one of the others.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Selector {
+    tag: Option<String>,
+    filter: Option<Filter>,
+}
+
+/// What narrows a tag down to one element.
+#[derive(Clone, Debug, PartialEq)]
+enum Filter {
+    /// An attribute equal to a value.
+    Attribute { name: String, value: String },
+    /// A token in the space-separated `class` attribute.
+    Class(String),
+}
+
+/// Why a selector string was not a selector.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SelectorError {
+    /// The string was empty, or a sigil was given nothing to name.
+    Empty,
+    /// A `[` was opened and never closed.
+    Unclosed,
+    /// A bracket held no `=`, so it named an attribute but not a value.
+    NoValue,
+}
+
+impl fmt::Display for SelectorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => f.write_str("a selector cannot be empty"),
+            Self::Unclosed => f.write_str("a `[` must be closed by a `]`"),
+            Self::NoValue => f.write_str("`[name=value]` needs the `=value`"),
+        }
+    }
+}
+
+impl std::error::Error for SelectorError {}
+
+impl std::str::FromStr for Selector {
+    type Err = SelectorError;
+
+    fn from_str(text: &str) -> Result<Self, Self::Err> {
+        let text = text.trim();
+        if text.is_empty() {
+            return Err(SelectorError::Empty);
+        }
+
+        let (tag, rest) = Self::split_tag(text);
+        if rest.is_empty() {
+            return match tag {
+                Some(tag) => Ok(Self {
+                    tag: Some(tag),
+                    filter: None,
+                }),
+                None => Err(SelectorError::Empty),
+            };
+        }
+
+        Ok(Self {
+            tag,
+            filter: Some(Filter::parse(rest)?),
+        })
+    }
+}
+
+impl Selector {
+    /// `[data-testid=<id>]`, which is how a page marks something for a test to find.
+    pub fn test_id(id: impl Into<String>) -> Self {
+        Self {
+            tag: None,
+            filter: Some(Filter::Attribute {
+                name: "data-testid".to_string(),
+                value: id.into(),
+            }),
+        }
+    }
+
+    /// Whether an element with this tag and these attributes is the one being named.
+    ///
+    /// `attribute` answers for the element under test; a missing attribute is `None`.
+    pub fn matches(&self, tag: &str, attribute: impl Fn(&str) -> Option<String>) -> bool {
+        if let Some(wanted) = &self.tag
+            && wanted != tag
+        {
+            return false;
+        }
+
+        let Some(filter) = &self.filter else {
+            return true;
+        };
+
+        filter.matches(attribute)
+    }
+
+    /// The tag, and whatever follows it, given that a sigil or a `[` ends the tag.
+    fn split_tag(text: &str) -> (Option<String>, &str) {
+        let end = text.find(['#', '.', '[']).unwrap_or(text.len());
+        let (tag, rest) = text.split_at(end);
+        let tag = match tag.is_empty() {
+            true => None,
+            false => Some(tag.to_string()),
+        };
+
+        (tag, rest)
+    }
+}
+
+impl Filter {
+    fn parse(text: &str) -> Result<Self, SelectorError> {
+        if let Some(id) = text.strip_prefix('#') {
+            return match id.is_empty() {
+                true => Err(SelectorError::Empty),
+                false => Ok(Self::Attribute {
+                    name: "id".to_string(),
+                    value: id.to_string(),
+                }),
+            };
+        }
+
+        if let Some(class) = text.strip_prefix('.') {
+            return match class.is_empty() {
+                true => Err(SelectorError::Empty),
+                false => Ok(Self::Class(class.to_string())),
+            };
+        }
+
+        let Some(inner) = text.strip_prefix('[').and_then(|t| t.strip_suffix(']')) else {
+            return Err(SelectorError::Unclosed);
+        };
+        let Some((name, value)) = inner.split_once('=') else {
+            return Err(SelectorError::NoValue);
+        };
+        let name = name.trim();
+        if name.is_empty() {
+            return Err(SelectorError::Empty);
+        }
+
+        Ok(Self::Attribute {
+            name: name.to_string(),
+            value: Self::unquote(value.trim()).to_string(),
+        })
+    }
+
+    fn matches(&self, attribute: impl Fn(&str) -> Option<String>) -> bool {
+        match self {
+            Self::Attribute { name, value } => attribute(name).as_deref() == Some(value.as_str()),
+            Self::Class(wanted) => {
+                let Some(classes) = attribute("class") else {
+                    return false;
+                };
+
+                classes.split_whitespace().any(|class| class == wanted)
+            }
+        }
+    }
+
+    fn unquote(value: &str) -> &str {
+        for quote in ['"', '\''] {
+            if let Some(inner) = value
+                .strip_prefix(quote)
+                .and_then(|v| v.strip_suffix(quote))
+            {
+                return inner;
+            }
+        }
+
+        value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    /// A class attribute holds many classes, and `.a` must not match the element whose class is
+    /// `ab` — the usual bug when a selector reaches for `contains`.
+    #[test]
+    fn a_class_matches_a_whole_token_rather_than_a_substring() {
+        let selector: Selector = ".row".parse().unwrap();
+
+        assert!(selector.matches("div", attributes(&[("class", "row tall")])));
+        assert!(!selector.matches("div", attributes(&[("class", "rowdy")])));
+    }
+
+    #[test]
+    fn a_tag_narrows_an_attribute_match() {
+        let selector: Selector = "button[data-testid=send]".parse().unwrap();
+
+        assert!(selector.matches("button", attributes(&[("data-testid", "send")])));
+        assert!(
+            !selector.matches("a", attributes(&[("data-testid", "send")])),
+            "the tag is part of the selector, not decoration"
+        );
+    }
+
+    /// The value a page writes may itself be quoted, and the quotes are the selector's, not the
+    /// value's.
+    #[test]
+    fn a_quoted_value_matches_the_unquoted_attribute() {
+        let selector: Selector = "[href=\"/spaces\"]".parse().unwrap();
+
+        assert!(selector.matches("a", attributes(&[("href", "/spaces")])));
+    }
+
+    #[test]
+    fn an_absent_attribute_does_not_match() {
+        let selector = Selector::test_id("send");
+
+        assert!(!selector.matches("button", attributes(&[])));
+    }
+
+    #[test]
+    fn a_bare_tag_matches_every_element_with_that_tag() {
+        let selector: Selector = "button".parse().unwrap();
+
+        assert!(selector.matches("button", attributes(&[])));
+        assert!(!selector.matches("div", attributes(&[])));
+    }
+
+    #[test]
+    fn a_selector_that_names_nothing_is_rejected() {
+        for text in ["", "   ", "#", ".", "[]", "[name]", "[name=value"] {
+            assert!(
+                text.parse::<Selector>().is_err(),
+                "{text:?} names no element and must not parse"
+            );
+        }
+    }
+
+    fn attributes(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let map: HashMap<String, String> = pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+
+        move |name: &str| map.get(name).cloned()
+    }
+}

--- a/crates/vmux_native/src/shadow_tree.rs
+++ b/crates/vmux_native/src/shadow_tree.rs
@@ -1,0 +1,489 @@
+//! The document a render describes, kept in Rust instead of a browser.
+//!
+//! [`MutationState`](dioxus_interpreter_js::MutationState) turns a render into the byte batch a
+//! webview applies; this turns the same render into a tree that can be asked questions. Both are
+//! [`WriteMutations`] sinks, so what a test sees is what the page would have been told to build —
+//! not a second rendering path that could agree with the components while disagreeing with the
+//! document.
+//!
+//! The mutations are a stack machine, and that is the whole of the implementation. Nodes are
+//! created onto a stack; `append_children`, `replace_*` and `insert_*` pop from it; and
+//! `assign_node_id` walks a path from whatever is on top to give a node the [`ElementId`] an event
+//! will later name it by. A node reachable here but holding no `ElementId` is one dioxus never
+//! needed to address, and it cannot be the target of an event.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use dioxus_core::{
+    AttributeValue, ElementId, Template, TemplateAttribute, TemplateNode, WriteMutations,
+};
+
+use crate::selector::Selector;
+
+/// The rendered document, addressable by [`Selector`] and by [`ElementId`].
+#[derive(Debug, Default)]
+pub struct ShadowTree {
+    nodes: Vec<Node>,
+    ids: HashMap<ElementId, Key>,
+    stack: Vec<Key>,
+}
+
+/// A node's place in [`ShadowTree::nodes`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Key(usize);
+
+/// The document root, which dioxus addresses without ever creating.
+const ROOT: Key = Key(0);
+
+#[derive(Debug)]
+struct Node {
+    parent: Option<Key>,
+    children: Vec<Key>,
+    kind: Kind,
+}
+
+#[derive(Debug)]
+enum Kind {
+    Element {
+        tag: &'static str,
+        attributes: BTreeMap<String, String>,
+        listeners: BTreeSet<&'static str>,
+    },
+    Text(String),
+    /// A slot dioxus holds open so it can put something there later.
+    Placeholder,
+}
+
+impl ShadowTree {
+    /// The `ElementId` of the first element in document order that `selector` names.
+    ///
+    /// `None` covers both "nothing matched" and "what matched was never assigned an id"; a caller
+    /// that must tell those apart asks [`ShadowTree::exists`] as well.
+    pub fn find(&self, selector: &Selector) -> Option<ElementId> {
+        let key = self.locate(selector)?;
+        self.id_of(key)
+    }
+
+    /// Whether `selector` names anything at all, addressable or not.
+    pub fn exists(&self, selector: &Selector) -> bool {
+        self.locate(selector).is_some()
+    }
+
+    /// How many elements `selector` names, which is how a test asserts a list's length.
+    pub fn count(&self, selector: &Selector) -> usize {
+        let mut found = 0;
+        self.walk(ROOT, &mut |tree, key| {
+            if tree.matches(key, selector) {
+                found += 1;
+            }
+        });
+
+        found
+    }
+
+    /// Every character of text under the first element `selector` names.
+    pub fn text(&self, selector: &Selector) -> Option<String> {
+        let key = self.locate(selector)?;
+        let mut text = String::new();
+        self.walk(key, &mut |tree, key| {
+            if let Kind::Text(value) = &tree.nodes[key.0].kind {
+                text.push_str(value);
+            }
+        });
+
+        Some(text)
+    }
+
+    /// One attribute of the first element `selector` names.
+    pub fn attribute(&self, selector: &Selector, name: &str) -> Option<String> {
+        let key = self.locate(selector)?;
+        self.attribute_of(key, name)
+    }
+
+    /// The events the first element `selector` names is listening for.
+    ///
+    /// An element with no listener for an event will not react to it, so a harness that dispatches
+    /// one blindly asserts nothing. This is what lets it refuse instead.
+    pub fn listeners(&self, selector: &Selector) -> BTreeSet<&'static str> {
+        let Some(key) = self.locate(selector) else {
+            return BTreeSet::new();
+        };
+        let Kind::Element { listeners, .. } = &self.nodes[key.0].kind else {
+            return BTreeSet::new();
+        };
+
+        listeners.clone()
+    }
+
+    /// Whether an event dispatched at `id` would reach a handler, here or on the way up.
+    ///
+    /// Dispatching at an element that listens for nothing is silently a no-op, so a harness that
+    /// does not ask this can assert on a click that never happened.
+    pub fn has_listener(&self, id: ElementId, event: &str) -> bool {
+        let Some(key) = self.ids.get(&id).copied() else {
+            return false;
+        };
+
+        let mut at = Some(key);
+        while let Some(key) = at {
+            if let Kind::Element { listeners, .. } = &self.nodes[key.0].kind
+                && listeners.contains(event)
+            {
+                return true;
+            }
+            at = self.nodes[key.0].parent;
+        }
+
+        false
+    }
+
+    /// The whole document as indented text, for when a failing test has to say what it did see.
+    pub fn outline(&self) -> String {
+        let mut out = String::new();
+        self.describe(ROOT, 0, &mut out);
+
+        out
+    }
+
+    fn locate(&self, selector: &Selector) -> Option<Key> {
+        let mut found = None;
+        self.walk(ROOT, &mut |tree, key| {
+            if found.is_none() && tree.matches(key, selector) {
+                found = Some(key);
+            }
+        });
+
+        found
+    }
+
+    fn matches(&self, key: Key, selector: &Selector) -> bool {
+        let Kind::Element { tag, .. } = &self.nodes[key.0].kind else {
+            return false;
+        };
+        if key == ROOT {
+            return false;
+        }
+
+        selector.matches(tag, |name| self.attribute_of(key, name))
+    }
+
+    fn attribute_of(&self, key: Key, name: &str) -> Option<String> {
+        let Kind::Element { attributes, .. } = &self.nodes[key.0].kind else {
+            return None;
+        };
+
+        attributes.get(name).cloned()
+    }
+
+    fn id_of(&self, key: Key) -> Option<ElementId> {
+        for (id, assigned) in &self.ids {
+            if *assigned == key {
+                return Some(*id);
+            }
+        }
+
+        None
+    }
+
+    fn walk(&self, from: Key, visit: &mut impl FnMut(&Self, Key)) {
+        visit(self, from);
+        for child in &self.nodes[from.0].children {
+            self.walk(*child, visit);
+        }
+    }
+
+    fn describe(&self, key: Key, depth: usize, out: &mut String) {
+        let pad = "  ".repeat(depth);
+        match &self.nodes[key.0].kind {
+            Kind::Element {
+                tag, attributes, ..
+            } => {
+                out.push_str(&format!("{pad}<{tag}"));
+                for (name, value) in attributes {
+                    out.push_str(&format!(" {name}={value:?}"));
+                }
+                out.push_str(">\n");
+            }
+            Kind::Text(value) => out.push_str(&format!("{pad}{value:?}\n")),
+            Kind::Placeholder => out.push_str(&format!("{pad}<!--slot-->\n")),
+        }
+
+        for child in &self.nodes[key.0].children {
+            self.describe(*child, depth + 1, out);
+        }
+    }
+
+    fn push_node(&mut self, kind: Kind) -> Key {
+        let key = Key(self.nodes.len());
+        self.nodes.push(Node {
+            parent: None,
+            children: Vec::new(),
+            kind,
+        });
+
+        key
+    }
+
+    /// The root exists before any mutation arrives, because `append_children` addresses it.
+    fn rooted(&mut self) {
+        if self.nodes.is_empty() {
+            let root = self.push_node(Kind::Element {
+                tag: "#document",
+                attributes: BTreeMap::new(),
+                listeners: BTreeSet::new(),
+            });
+            self.ids.insert(ElementId(0), root);
+        }
+    }
+
+    fn instantiate(&mut self, node: &TemplateNode) -> Key {
+        match node {
+            TemplateNode::Element {
+                tag,
+                attrs,
+                children,
+                ..
+            } => {
+                let mut attributes = BTreeMap::new();
+                for attr in *attrs {
+                    if let TemplateAttribute::Static { name, value, .. } = attr {
+                        attributes.insert((*name).to_string(), (*value).to_string());
+                    }
+                }
+
+                let key = self.push_node(Kind::Element {
+                    tag,
+                    attributes,
+                    listeners: BTreeSet::new(),
+                });
+                for child in *children {
+                    let child = self.instantiate(child);
+                    self.adopt(key, child);
+                }
+
+                key
+            }
+            TemplateNode::Text { text } => self.push_node(Kind::Text((*text).to_string())),
+            TemplateNode::Dynamic { .. } => self.push_node(Kind::Placeholder),
+        }
+    }
+
+    fn adopt(&mut self, parent: Key, child: Key) {
+        self.detach(child);
+        self.nodes[child.0].parent = Some(parent);
+        self.nodes[parent.0].children.push(child);
+    }
+
+    fn detach(&mut self, child: Key) {
+        let Some(parent) = self.nodes[child.0].parent.take() else {
+            return;
+        };
+        self.nodes[parent.0].children.retain(|key| *key != child);
+    }
+
+    /// Where a node sits among its siblings, which every insert and replace is expressed against.
+    fn position(&self, key: Key) -> Option<(Key, usize)> {
+        let parent = self.nodes[key.0].parent?;
+        let at = self.nodes[parent.0]
+            .children
+            .iter()
+            .position(|child| *child == key)?;
+
+        Some((parent, at))
+    }
+
+    fn insert(&mut self, parent: Key, at: usize, taken: Vec<Key>) {
+        for (offset, child) in taken.into_iter().enumerate() {
+            self.detach(child);
+            self.nodes[child.0].parent = Some(parent);
+            self.nodes[parent.0].children.insert(at + offset, child);
+        }
+    }
+
+    fn take(&mut self, m: usize) -> Vec<Key> {
+        let at = self.stack.len().saturating_sub(m);
+
+        self.stack.split_off(at)
+    }
+
+    /// The node `path` names, walked from whatever is on top of the stack.
+    fn child_at(&self, path: &[u8]) -> Option<Key> {
+        let mut key = *self.stack.last()?;
+        for step in path {
+            key = *self.nodes[key.0].children.get(*step as usize)?;
+        }
+
+        Some(key)
+    }
+}
+
+impl WriteMutations for ShadowTree {
+    fn append_children(&mut self, id: ElementId, m: usize) {
+        self.rooted();
+        let taken = self.take(m);
+        let Some(parent) = self.ids.get(&id).copied() else {
+            return;
+        };
+        for child in taken {
+            self.adopt(parent, child);
+        }
+    }
+
+    fn assign_node_id(&mut self, path: &'static [u8], id: ElementId) {
+        self.rooted();
+        let Some(key) = self.child_at(path) else {
+            return;
+        };
+        self.ids.insert(id, key);
+    }
+
+    fn create_placeholder(&mut self, id: ElementId) {
+        self.rooted();
+        let key = self.push_node(Kind::Placeholder);
+        self.ids.insert(id, key);
+        self.stack.push(key);
+    }
+
+    fn create_text_node(&mut self, value: &str, id: ElementId) {
+        self.rooted();
+        let key = self.push_node(Kind::Text(value.to_string()));
+        self.ids.insert(id, key);
+        self.stack.push(key);
+    }
+
+    fn load_template(&mut self, template: Template, index: usize, id: ElementId) {
+        self.rooted();
+        let Some(root) = template.roots.get(index) else {
+            return;
+        };
+        let key = self.instantiate(root);
+        self.ids.insert(id, key);
+        self.stack.push(key);
+    }
+
+    fn replace_node_with(&mut self, id: ElementId, m: usize) {
+        self.rooted();
+        let taken = self.take(m);
+        let Some(key) = self.ids.get(&id).copied() else {
+            return;
+        };
+        let Some((parent, at)) = self.position(key) else {
+            return;
+        };
+        self.detach(key);
+        self.insert(parent, at, taken);
+    }
+
+    fn replace_placeholder_with_nodes(&mut self, path: &'static [u8], m: usize) {
+        self.rooted();
+        let taken = self.take(m);
+        let Some(key) = self.child_at(path) else {
+            return;
+        };
+        let Some((parent, at)) = self.position(key) else {
+            return;
+        };
+        self.detach(key);
+        self.insert(parent, at, taken);
+    }
+
+    fn insert_nodes_after(&mut self, id: ElementId, m: usize) {
+        self.rooted();
+        let taken = self.take(m);
+        let Some(key) = self.ids.get(&id).copied() else {
+            return;
+        };
+        let Some((parent, at)) = self.position(key) else {
+            return;
+        };
+        self.insert(parent, at + 1, taken);
+    }
+
+    fn insert_nodes_before(&mut self, id: ElementId, m: usize) {
+        self.rooted();
+        let taken = self.take(m);
+        let Some(key) = self.ids.get(&id).copied() else {
+            return;
+        };
+        let Some((parent, at)) = self.position(key) else {
+            return;
+        };
+        self.insert(parent, at, taken);
+    }
+
+    fn set_attribute(
+        &mut self,
+        name: &'static str,
+        _ns: Option<&'static str>,
+        value: &AttributeValue,
+        id: ElementId,
+    ) {
+        self.rooted();
+        let Some(key) = self.ids.get(&id).copied() else {
+            return;
+        };
+        let Kind::Element { attributes, .. } = &mut self.nodes[key.0].kind else {
+            return;
+        };
+
+        match value {
+            AttributeValue::Text(text) => attributes.insert(name.to_string(), text.clone()),
+            AttributeValue::Float(number) => {
+                attributes.insert(name.to_string(), number.to_string())
+            }
+            AttributeValue::Int(number) => attributes.insert(name.to_string(), number.to_string()),
+            AttributeValue::Bool(flag) => attributes.insert(name.to_string(), flag.to_string()),
+            // A `None` value is dioxus asking for the attribute to be taken off, and the other two
+            // never reach a document: a listener arrives through `create_event_listener`, and an
+            // `Any` is a renderer-private payload with no textual form.
+            _ => attributes.remove(name),
+        };
+    }
+
+    fn set_node_text(&mut self, value: &str, id: ElementId) {
+        self.rooted();
+        let Some(key) = self.ids.get(&id).copied() else {
+            return;
+        };
+        match &mut self.nodes[key.0].kind {
+            Kind::Text(text) => *text = value.to_string(),
+            kind => *kind = Kind::Text(value.to_string()),
+        }
+    }
+
+    fn create_event_listener(&mut self, name: &'static str, id: ElementId) {
+        self.rooted();
+        let Some(key) = self.ids.get(&id).copied() else {
+            return;
+        };
+        if let Kind::Element { listeners, .. } = &mut self.nodes[key.0].kind {
+            listeners.insert(name);
+        }
+    }
+
+    fn remove_event_listener(&mut self, name: &'static str, id: ElementId) {
+        self.rooted();
+        let Some(key) = self.ids.get(&id).copied() else {
+            return;
+        };
+        if let Kind::Element { listeners, .. } = &mut self.nodes[key.0].kind {
+            listeners.remove(name);
+        }
+    }
+
+    fn remove_node(&mut self, id: ElementId) {
+        self.rooted();
+        let Some(key) = self.ids.get(&id).copied() else {
+            return;
+        };
+        self.detach(key);
+    }
+
+    fn push_root(&mut self, id: ElementId) {
+        self.rooted();
+        let Some(key) = self.ids.get(&id).copied() else {
+            return;
+        };
+        self.stack.push(key);
+    }
+}


### PR DESCRIPTION
## Summary

A page's `VirtualDom` already runs in this process; only the document lived in the webview. Rendering into a second `WriteMutations` sink puts that document in reach of a test, so a page can be clicked and read without a window, a Space, or a screenshot.

- `PageDom` grows a sink type parameter defaulting to the interpreter's channel, so every existing caller is unchanged.
- `ShadowTree` is the other sink: the same mutations a webview would apply, kept as a tree that can be queried.
- `PageProbe` trades in selectors over it — `click`, `dispatch`, `find`, `text`, `attribute`, `count`, `outline`.
- `Selector` is the subset of CSS a test needs: `tag`, `#id`, `.class`, `[name=value]`, and a tag followed by one of those. Deliberately not a CSS engine.

```rust
let mut page = PageProbe::mount(Counter, Instance::default());
assert_eq!(page.text("[data-testid=bump]")?, "count: 0");
page.click("[data-testid=bump]")?;
assert_eq!(page.text("[data-testid=bump]")?, "count: 1");
```

## Why refusals matter here

Dispatching at an element that listens for nothing is silently a no-op, and a test that then asserts on the unchanged document passes for the wrong reason. `PageProbe` refuses with `NoListener` instead.

`NotAddressable` is the same idea: a template's root is addressed when it is loaded, but a static node inside it is not, so it is readable and unclickable. Reporting that beats reporting it as absent when it is plainly in the outline.

## What this cannot answer

Anything the browser decides — layout, styling, hit-testing, input method. A probe says the page reacted; only a screenshot says it looked right.

Real pages are not yet mountable either: they reach the host through `vmux_ui::hooks` and a `HostScope` this installs none of, so one would render its empty shell. The seam for that follows next, shaped like `Instance` — erased at the call site so this crate never names `PageHost`.

## Test plan

- [x] `cargo test -p vmux_native` — 42 passed
- [x] `cargo clippy -p vmux_native --all-targets` — clean
- [x] `cargo fmt -p vmux_native`
- [x] List removal keeps sibling order; head insertion lands before the existing item; a conditional branch leaves the document rather than merely stopping being rendered into
- [x] A changed attribute is visible to a query; `prevent_default` reaches the caller
- [ ] Mount a real page once the host seam lands