### PR TITLE
Install a page's host around every render so a real page can be probed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10752,6 +10752,7 @@ dependencies = [
  "vmux_flex",
  "vmux_git",
  "vmux_layout",
+ "vmux_native",
  "vmux_space",
  "vmux_ui",
  "vmux_wire",

--- a/crates/page/vmux_start/Cargo.toml
+++ b/crates/page/vmux_start/Cargo.toml
@@ -30,6 +30,12 @@ vmux_core = { path = "../../vmux_core" }
 vmux_ui = { path = "../../vmux_ui" }
 vmux_wire = { path = "../../vmux_wire", features = ["bevy"] }
 
+# Spelled out rather than as the `ui` alias, the same way `vmux_native`'s own manifest is: Cargo
+# resolves dependencies before any build script runs, so a cfg that script defines cannot gate one.
+# These are the targets on which `page` exists to be probed at all.
+[target.'cfg(any(target_os = "ios", target_os = "macos"))'.dev-dependencies]
+vmux_native = { path = "../../vmux_native" }
+
 [target.'cfg(not(target_os = "ios"))'.dependencies]
 bevy = { workspace = true }
 bevy_cef = { workspace = true }

--- a/crates/page/vmux_start/src/page.rs
+++ b/crates/page/vmux_start/src/page.rs
@@ -85,3 +85,67 @@ pub fn StartPage() -> Element {
         Page {}
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    use vmux_native::{HostBinding, Instance, PageProbe};
+    use vmux_ui::transport::event_listener::EventListenerError;
+    use vmux_ui::transport::{BytesListener, HostScope, PageHost};
+
+    use super::*;
+
+    /// A host that remembers what the page asked it for.
+    #[derive(Default)]
+    struct Recording {
+        sent: RefCell<Vec<String>>,
+    }
+
+    impl PageHost for Recording {
+        fn send(&self, id: &str, _bytes: &[u8]) -> Result<(), EventListenerError> {
+            self.sent.borrow_mut().push(id.to_string());
+            Ok(())
+        }
+
+        fn listen(&self, _id: &str, _on_bytes: BytesListener) -> Result<(), EventListenerError> {
+            Ok(())
+        }
+    }
+
+    impl Recording {
+        /// Mount the launcher against a fresh recording host, and hand both back.
+        fn probing() -> (PageProbe, Rc<Self>) {
+            let host = Rc::new(Self::default());
+            let installed = host.clone();
+            let probe = PageProbe::hosted(
+                StartPage,
+                Instance::default(),
+                HostBinding::of(move || HostScope::enter(installed.clone())),
+            );
+
+            (probe, host)
+        }
+
+        fn sent(&self) -> Vec<String> {
+            self.sent.borrow().clone()
+        }
+    }
+
+    /// The launcher renders empty and fills in when the host answers, so the request it makes on
+    /// mount is the only thing standing between a user and a permanently blank start page. Nothing
+    /// in the rendered document says whether it was made.
+    #[test]
+    fn the_launcher_asks_the_host_for_its_entries_on_mount() {
+        let (_probe, host) = Recording::probing();
+
+        assert!(
+            host.sent()
+                .iter()
+                .any(|id| id == std::any::type_name::<StartDataRequest>()),
+            "the page mounted without asking for anything, so it would stay empty; it sent {:?}",
+            host.sent()
+        );
+    }
+}

--- a/crates/vmux_native/src/host_binding.rs
+++ b/crates/vmux_native/src/host_binding.rs
@@ -1,0 +1,41 @@
+//! The host a page reaches while its components are running.
+//!
+//! A real page does not only render — it emits, listens, and reads a theme, and every one of those
+//! goes through a host the page never names. The host is installed for the thread around each
+//! entry into the `VirtualDom`, so a probe has to do the installing that
+//! [`WebView`](crate::WebView) does in production, or a real page mounts inert and a test learns
+//! nothing.
+//!
+//! Erased as a closure returning a guard, for the same reason [`Instance`](crate::Instance) is:
+//! the host's type is the caller's, and naming it here would drag the whole page runtime into a
+//! crate that deliberately knows nothing about it.
+
+use std::any::Any;
+
+/// How to put a page's host in place for as long as the page is running.
+///
+/// Built from anything that returns a guard — `HostScope::enter(host)` in practice — and entered
+/// again around every render and every event, because both can emit.
+#[derive(Default)]
+pub struct HostBinding(Option<Box<dyn Fn() -> Box<dyn Any>>>);
+
+impl HostBinding {
+    /// Bind a host, given a way to install it that yields a guard undoing the install on drop.
+    ///
+    /// ```ignore
+    /// HostBinding::of(move || HostScope::enter(host.clone()))
+    /// ```
+    pub fn of<G: 'static>(enter: impl Fn() -> G + 'static) -> Self {
+        Self(Some(Box::new(move || Box::new(enter()) as Box<dyn Any>)))
+    }
+
+    /// Install the host, for as long as the returned value is held.
+    ///
+    /// `None` is the unbound case and is not an error: a component that never reaches its host
+    /// renders the same either way.
+    pub(crate) fn entered(&self) -> Option<Box<dyn Any>> {
+        let enter = self.0.as_ref()?;
+
+        Some(enter())
+    }
+}

--- a/crates/vmux_native/src/lib.rs
+++ b/crates/vmux_native/src/lib.rs
@@ -30,6 +30,7 @@
 //! two in flight cannot take each other's answer.
 
 mod event_request;
+mod host_binding;
 mod instance;
 mod page;
 mod page_dom;
@@ -39,6 +40,7 @@ mod shadow_tree;
 mod shell;
 
 pub use event_request::{EventOutcome, EventRequest, EventRequestError};
+pub use host_binding::HostBinding;
 pub use instance::{Instance, PageScope};
 pub use page::NativePage;
 pub use page_dom::{PageComponent, PageDom};

--- a/crates/vmux_native/src/probe.rs
+++ b/crates/vmux_native/src/probe.rs
@@ -13,6 +13,7 @@ use dioxus_core::ElementId;
 use dioxus_html::{EventData, HtmlEvent, SerializedMouseData};
 
 use crate::event_request::EventOutcome;
+use crate::host_binding::HostBinding;
 use crate::page_dom::{PageComponent, PageDom};
 use crate::selector::{Selector, SelectorError};
 use crate::shadow_tree::ShadowTree;
@@ -20,6 +21,7 @@ use crate::shadow_tree::ShadowTree;
 /// A mounted page, queried and driven by selector.
 pub struct PageProbe {
     page: PageDom<ShadowTree>,
+    host: HostBinding,
 }
 
 /// Why a probe could not do what it was asked.
@@ -75,10 +77,21 @@ const SETTLE_LIMIT: usize = 64;
 
 impl PageProbe {
     /// Mount `app` and render it, leaving the document ready to query.
+    ///
+    /// Nothing is installed for the page to reach, which suits a component that only renders its
+    /// props. A page that emits, listens or reads a theme wants [`PageProbe::hosted`].
     pub fn mount(app: PageComponent, instance: crate::Instance) -> Self {
+        Self::hosted(app, instance, HostBinding::default())
+    }
+
+    /// Mount `app` with `host` installed around every render and every event.
+    pub fn hosted(app: PageComponent, instance: crate::Instance, host: HostBinding) -> Self {
         let mut page = PageDom::with_sink(app, instance);
-        page.diff_rebuild();
-        let mut probe = Self { page };
+        {
+            let _entered = host.entered();
+            page.diff_rebuild();
+        }
+        let mut probe = Self { page, host };
         let _ = probe.settle();
 
         probe
@@ -111,15 +124,18 @@ impl PageProbe {
             });
         }
 
-        let outcome = self.page.handle(
-            HtmlEvent {
-                element,
-                name: event.to_string(),
-                bubbles: true,
-                data,
-            },
-            (),
-        );
+        let outcome = {
+            let _entered = self.host.entered();
+            self.page.handle(
+                HtmlEvent {
+                    element,
+                    name: event.to_string(),
+                    bubbles: true,
+                    data,
+                },
+                (),
+            )
+        };
         self.settle()?;
 
         Ok(outcome)
@@ -188,6 +204,7 @@ impl PageProbe {
     fn settle(&mut self) -> Result<(), ProbeError> {
         for _ in 0..SETTLE_LIMIT {
             self.page.flushed();
+            let _entered = self.host.entered();
             if !self.page.diff_render() {
                 return Ok(());
             }
@@ -209,6 +226,90 @@ mod tests {
         fn of(app: PageComponent) -> Self {
             Self::mount(app, crate::Instance::default())
         }
+    }
+
+    /// Records whether the page ran with its host installed, from inside the page.
+    ///
+    /// A component cannot see a [`HostBinding`], only the thread state one leaves behind, which is
+    /// exactly what a real page's transport reads.
+    struct Witness;
+
+    thread_local! {
+        static DEPTH: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+        static RAN_UNHOSTED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    }
+
+    /// Undoes its install on drop, the way `HostScope` does.
+    struct Installed;
+
+    impl Drop for Installed {
+        fn drop(&mut self) {
+            DEPTH.with(|depth| depth.set(depth.get() - 1));
+        }
+    }
+
+    impl Witness {
+        fn binding() -> HostBinding {
+            HostBinding::of(|| {
+                DEPTH.with(|depth| depth.set(depth.get() + 1));
+                Installed
+            })
+        }
+
+        /// Called from wherever a real page would reach its host.
+        fn note() {
+            if DEPTH.with(|depth| depth.get()) == 0 {
+                RAN_UNHOSTED.with(|seen| seen.set(true));
+            }
+        }
+
+        fn ran_unhosted() -> bool {
+            RAN_UNHOSTED.with(|seen| seen.get())
+        }
+    }
+
+    #[component]
+    fn Reaching() -> Element {
+        let mut count = use_signal(|| 0);
+        Witness::note();
+
+        rsx! {
+            button {
+                "data-testid": "go",
+                onclick: move |_| {
+                    Witness::note();
+                    count += 1;
+                },
+                "{count}"
+            }
+        }
+    }
+
+    /// A page emits from its render *and* from its handlers, and the render a handler schedules is
+    /// a third entry again. Installing the host for only one of them leaves a real page reaching
+    /// into an empty slot on the others.
+    #[test]
+    fn a_hosted_page_never_runs_without_its_host() {
+        let mut page = PageProbe::hosted(Reaching, crate::Instance::default(), Witness::binding());
+
+        page.click("[data-testid=go]").unwrap();
+
+        assert_eq!(page.text("[data-testid=go]").unwrap(), "1");
+        assert!(
+            !Witness::ran_unhosted(),
+            "the mount render, the handler, or the render it scheduled ran with no host installed"
+        );
+    }
+
+    /// The counterpart, so the test above cannot pass by never looking: unbound, the same page runs
+    /// with nothing installed.
+    #[test]
+    fn an_unhosted_page_runs_with_nothing_installed() {
+        let mut page = PageProbe::of(Reaching);
+
+        page.click("[data-testid=go]").unwrap();
+
+        assert!(Witness::ran_unhosted());
     }
 
     #[component]


### PR DESCRIPTION
Stacked on #414 — review that one first.

## Summary

#414 could mount a component that only renders its props. A real page emits, listens and reads a theme, all through a host held in a thread-local, so it mounted inert: `StartPage` rendered its whole shell and never asked the host for its entries.

- `HostBinding` is that host, erased as a closure returning a guard — the same shape `Instance` already uses, and for the same reason: the type is the caller's, and naming it here would drag the page runtime into a crate that deliberately knows nothing about it.
- `PageProbe::hosted` enters it around the mount render, around every event, and around the renders an event schedules. All three can emit, and installing for only one leaves a real page reaching into an empty slot on the others.
- `PageProbe::mount` is unchanged and stays host-free.

```rust
let probe = PageProbe::hosted(
    StartPage,
    Instance::default(),
    HostBinding::of(move || HostScope::enter(host.clone())),
);
```

## What this makes testable

The launcher renders empty and fills in when the host answers, so the request it makes on mount is the only thing between a user and a permanently blank start page — and nothing in the rendered document says whether it was made.

`vmux_start` gains that test. It mounts the real `StartPage` — hero, composer, `CommandPalette`, `dioxus-primitives` and all — against a recording host, in about 30ms and with no window.

Verified the oracle by deleting the `send(&StartDataRequest)` from the page's effect: the test fails, and says the page sent only `vmux-page-ready`.

## Notes

`vmux_native` is a dev-dependency of `vmux_start` gated to macOS and iOS, spelled out rather than as the `ui` alias because Cargo resolves dependencies before any build script runs. Those are the targets on which `page` exists at all, so the test does not run on the Linux CI leg.

## Test plan

- [x] `cargo test -p vmux_native -p vmux_start` — 44 + 9 passed
- [x] `cargo clippy -p vmux_native -p vmux_start --all-targets` — clean
- [x] `cargo fmt`
- [x] Mutation-checked the new page test: removing the mount-time request fails it
- [x] A page bound to a host never runs a render or a handler with nothing installed, and the unbound counterpart proves that test is looking