### PR TITLE
Render the architecture diagrams at build time

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,7 @@ flowchart LR
     subgraph daemon["the daemon — launchd supervised"]
         svc["vmux_service<br/>PTYs<br/>agent + ACP sessions"]
     end
-    bevy <-->|"unix socket"| svc
+    bevy <-->|unix socket| svc
 ```
 
 Close the window and the shell keeps reading, the build keeps building, the agent keeps
@@ -48,16 +48,12 @@ a phone, or a watch.
   cannot read.
 
 ```mermaid
-flowchart TB
+flowchart LR
     subgraph host["host machine"]
-        local["local client"]
-        server["vmux_service"]
-        local <-->|"unix socket"| server
+        local["local client"] <-->|unix socket| server["vmux_service"]
     end
-    relay(["relay — vmux-cloud"])
-    remote["remote client"]
-    server <-->|"QUIC control, held open"| relay
-    remote <-->|"QUIC, the same UDP port"| relay
+    server <-->|QUIC control, held open| relay(["relay — vmux-cloud"])
+    relay <-->|QUIC, the same UDP port| remote["remote client"]
 ```
 
 Neither end of the relay listens for the other. Both dial the same UDP port and are told
@@ -70,18 +66,18 @@ Nothing is dialled until Remote is switched on.
 ### What each link carries
 
 ```mermaid
-flowchart TB
-    page["a page"]
-    localc["local client"]
-    server["vmux_service"]
-    relay(["relay"])
-    remote["remote client"]
-
-    page -->|"wry IPC + vmux:// protocol<br/>binary DOM edits, rkyv events"| localc
-    localc -->|"unix socket<br/>u32-length-prefixed rkyv, 64 MiB cap"| server
-    remote -->|"QUIC, one stream per request<br/>rkyv SharedMessage / SharedResponse"| server
-    server -->|"QUIC control connection<br/>JSON hello, then opaque DATAGRAM frames"| relay
+flowchart LR
+    page["a page"] -->|wry IPC · rkyv| localc["local client"]
+    localc -->|unix socket · rkyv| server["vmux_service"]
+    remote["remote client"] -->|QUIC · one stream per request| server
+    server -->|QUIC control · JSON hello, then DATAGRAM| relay(["relay"])
 ```
+
+A page reaches its local client over wry's IPC and the `vmux://` protocol, carrying binary
+DOM edits one way and rkyv events the other. The unix socket runs `u32`-length-prefixed
+rkyv with a 64 MiB cap. A remote client opens one bidirectional QUIC stream per request,
+carrying an rkyv `SharedMessage` and `SharedResponse`. The relay's control connection is
+the odd one: a JSON hello, then opaque DATAGRAM frames it cannot read.
 
 The hellos are JSON and everything after is rkyv, deliberately. rkyv encodes enum variants
 **positionally** — a peer one release behind does not fail to decode a reordered variant,
@@ -314,8 +310,8 @@ Two maps, and "registering" is inserting into one of them.
 
 ```mermaid
 flowchart LR
-    pm["ProcessManager"] -->|"ProcessId"| proc["Process<br/>PTY + child + cell grid"]
-    am["AgentSessionManager"] -->|"sid"| sess["SessionHandle<br/>provider stream + history"]
+    pm["ProcessManager"] -->|ProcessId| proc["Process<br/>PTY + child + cell grid"]
+    am["AgentSessionManager"] -->|sid| sess["SessionHandle<br/>provider stream + history"]
 ```
 
 Each exposes the same two surfaces: a **broadcast channel** of updates, and a point-in-time

--- a/website/Cargo.lock
+++ b/website/Cargo.lock
@@ -512,6 +512,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,6 +1410,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,6 +2054,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733a844dbd6fef128e98cb4487b887cb55454d92cd9994b1bafe004fabbe670c"
+dependencies = [
+ "serde",
+ "ucd-trie",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2079,6 +2121,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linked-hash-map"
@@ -2232,6 +2280,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "mermaid-rs-renderer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb5b469222ce6b9896edf0a969cf68464f5a028ef394fd6643f00bd943df117"
+dependencies = [
+ "anyhow",
+ "fontdb",
+ "json5",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -2667,10 +2732,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-automata"
-version = "0.4.14"
+name = "regex"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2679,9 +2756,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -2740,6 +2817,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rustc-hash"
@@ -3530,6 +3613,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3584,6 +3676,12 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"
@@ -3662,6 +3760,7 @@ dependencies = [
  "dioxus",
  "dioxus-primitives",
  "gloo-net",
+ "mermaid-rs-renderer",
  "pulldown-cmark",
  "serde",
  "syntect",

--- a/website/Cargo.toml
+++ b/website/Cargo.toml
@@ -15,6 +15,9 @@ path = "src/main.rs"
 name = "vmux_website"
 path = "src/lib.rs"
 
+[build-dependencies]
+mermaid-rs-renderer = { version = "0.3.1", default-features = false }
+
 [dependencies]
 dioxus = { version = "=0.7.9", features = ["fullstack", "router"] }
 dioxus-primitives = { git = "https://github.com/DioxusLabs/components", package = "dioxus-primitives", rev = "ccdb07f69383de008a0afadda0e5ab7ec14c1a9c", default-features = true }

--- a/website/build.rs
+++ b/website/build.rs
@@ -40,6 +40,29 @@ fn sources(docs: &Path) -> Vec<PathBuf> {
     found
 }
 
+struct Theme;
+
+impl Theme {
+    fn site() -> mermaid_rs_renderer::Theme {
+        let mut theme = mermaid_rs_renderer::Theme::dark();
+        theme.background = "transparent".into();
+        theme.primary_color = "#1a1a2e".into();
+        theme.primary_border_color = "#2a2a2a".into();
+        theme.primary_text_color = "#e0e0e0".into();
+        theme.text_color = "#e0e0e0".into();
+        theme.line_color = "#888".into();
+        theme.edge_label_background = "transparent".into();
+        theme.cluster_background = "#151515".into();
+        theme.cluster_border = "#2a2a2a".into();
+        theme.sequence_actor_fill = "#1a1a2e".into();
+        theme.sequence_actor_border = "#2a2a2a".into();
+        theme.sequence_actor_line = "#888".into();
+        theme.sequence_note_fill = "#151515".into();
+        theme.sequence_note_border = "#2a2a2a".into();
+        theme
+    }
+}
+
 struct Diagram;
 
 impl Diagram {
@@ -62,7 +85,11 @@ impl Diagram {
     }
 
     fn render(diagram: &str, source: &Path) -> String {
-        match mermaid_rs_renderer::render(diagram) {
+        let options = mermaid_rs_renderer::RenderOptions {
+            theme: Theme::site(),
+            ..Default::default()
+        };
+        match mermaid_rs_renderer::render_with_options(diagram, options) {
             Ok(svg) => svg,
             Err(error) => panic!(
                 "{}: mermaid diagram did not render: {error}\n---\n{diagram}\n---",

--- a/website/build.rs
+++ b/website/build.rs
@@ -1,0 +1,73 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+const FENCE: &str = "```mermaid";
+
+fn main() {
+    let manifest = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+    let docs = manifest.join("..").join("docs");
+    let out = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR")).join("mermaid.rs");
+
+    let mut rendered: BTreeMap<String, String> = BTreeMap::new();
+    for source in sources(&docs) {
+        println!("cargo::rerun-if-changed={}", source.display());
+        let markdown = std::fs::read_to_string(&source)
+            .unwrap_or_else(|error| panic!("read {}: {error}", source.display()));
+        for diagram in Diagram::all(&markdown) {
+            if rendered.contains_key(&diagram) {
+                continue;
+            }
+            rendered.insert(diagram.clone(), Diagram::render(&diagram, &source));
+        }
+    }
+
+    let mut generated = String::from("pub static DIAGRAMS: &[(&str, &str)] = &[\n");
+    for (diagram, svg) in &rendered {
+        generated.push_str(&format!("    ({:?}, {:?}),\n", diagram, svg));
+    }
+    generated.push_str("];\n");
+    std::fs::write(&out, generated).unwrap_or_else(|error| panic!("write {out:?}: {error}"));
+}
+
+fn sources(docs: &Path) -> Vec<PathBuf> {
+    let mut found: Vec<PathBuf> = std::fs::read_dir(docs)
+        .unwrap_or_else(|error| panic!("read {}: {error}", docs.display()))
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|extension| extension == "md"))
+        .collect();
+    found.sort();
+    found
+}
+
+struct Diagram;
+
+impl Diagram {
+    fn all(markdown: &str) -> Vec<String> {
+        let mut found = Vec::new();
+        let mut rest = markdown;
+        while let Some(start) = rest.find(FENCE) {
+            let after = &rest[start + FENCE.len()..];
+            let Some(body) = after.strip_prefix('\n') else {
+                rest = after;
+                continue;
+            };
+            let Some(end) = body.find("\n```") else {
+                break;
+            };
+            found.push(body[..end].to_string());
+            rest = &body[end..];
+        }
+        found
+    }
+
+    fn render(diagram: &str, source: &Path) -> String {
+        match mermaid_rs_renderer::render(diagram) {
+            Ok(svg) => svg,
+            Err(error) => panic!(
+                "{}: mermaid diagram did not render: {error}\n---\n{diagram}\n---",
+                source.display()
+            ),
+        }
+    }
+}

--- a/website/build.rs
+++ b/website/build.rs
@@ -8,9 +8,10 @@ fn main() {
     let docs = manifest.join("..").join("docs");
     let out = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR")).join("mermaid.rs");
 
+    println!("cargo::rerun-if-changed={}", docs.display());
+
     let mut rendered: BTreeMap<String, String> = BTreeMap::new();
     for source in sources(&docs) {
-        println!("cargo::rerun-if-changed={}", source.display());
         let markdown = std::fs::read_to_string(&source)
             .unwrap_or_else(|error| panic!("read {}: {error}", source.display()));
         for diagram in Diagram::all(&markdown) {
@@ -30,12 +31,17 @@ fn main() {
 }
 
 fn sources(docs: &Path) -> Vec<PathBuf> {
-    let mut found: Vec<PathBuf> = std::fs::read_dir(docs)
-        .unwrap_or_else(|error| panic!("read {}: {error}", docs.display()))
-        .flatten()
-        .map(|entry| entry.path())
-        .filter(|path| path.extension().is_some_and(|extension| extension == "md"))
-        .collect();
+    let entries =
+        std::fs::read_dir(docs).unwrap_or_else(|error| panic!("read {}: {error}", docs.display()));
+    let mut found = Vec::new();
+    for entry in entries {
+        let entry =
+            entry.unwrap_or_else(|error| panic!("read an entry in {}: {error}", docs.display()));
+        let path = entry.path();
+        if path.extension().is_some_and(|extension| extension == "md") {
+            found.push(path);
+        }
+    }
     found.sort();
     found
 }

--- a/website/src/markdown.rs
+++ b/website/src/markdown.rs
@@ -283,7 +283,10 @@ fn render_node(n: &Node) -> Element {
                 && let Some(svg) = Diagram::svg(code)
             {
                 return rsx! {
-                    figure { class: "my-6 overflow-x-auto", dangerous_inner_html: "{svg}" }
+                    figure {
+                        class: "diagram my-6 -mx-6 px-6 overflow-x-auto sm:-mx-10 sm:px-10",
+                        dangerous_inner_html: "{svg}",
+                    }
                 };
             }
             let html = highlight_code(lang, code);

--- a/website/src/markdown.rs
+++ b/website/src/markdown.rs
@@ -419,13 +419,29 @@ fn DiagramFigure(svg: String) -> Element {
     rsx! {
         figure {
             class: "my-6 -mx-6 px-6 overflow-x-auto sm:-mx-10 sm:px-10 cursor-zoom-in",
+            tabindex: "0",
+            role: "button",
+            aria_label: "Open the diagram at full size",
             onclick: move |_| zoomed.set(true),
+            onkeydown: move |event| {
+                let key = event.key();
+                if key == Key::Enter || key == Key::Character(" ".to_string()) {
+                    zoomed.set(true);
+                }
+            },
             dangerous_inner_html: "{svg}",
         }
         if zoomed() {
             div {
                 class: "fixed inset-0 z-50 overflow-auto bg-bg/95 p-6 cursor-zoom-out sm:p-10",
+                tabindex: "0",
+                autofocus: true,
                 onclick: move |_| zoomed.set(false),
+                onkeydown: move |event| {
+                    if event.key() == Key::Escape {
+                        zoomed.set(false);
+                    }
+                },
                 div { class: "grid min-h-full w-max min-w-full place-items-center",
                     div { dangerous_inner_html: "{svg}" }
                 }
@@ -453,14 +469,44 @@ mod tests {
         assert!(!html.is_empty());
     }
 
+    fn code_blocks(nodes: &[Node], found: &mut Vec<(String, String)>) {
+        for node in nodes {
+            match node {
+                Node::CodeBlock(lang, code) => found.push((lang.clone(), code.clone())),
+                Node::Heading(_, children)
+                | Node::Paragraph(children)
+                | Node::BlockQuote(children)
+                | Node::Strong(children)
+                | Node::Emphasis(children)
+                | Node::Strikethrough(children)
+                | Node::Link(_, children) => code_blocks(children, found),
+                Node::List(_, items) => {
+                    for item in items {
+                        code_blocks(item, found);
+                    }
+                }
+                Node::Table(header, rows) => {
+                    for cell in header {
+                        code_blocks(cell, found);
+                    }
+                    for row in rows {
+                        for cell in row {
+                            code_blocks(cell, found);
+                        }
+                    }
+                }
+                Node::Rule | Node::Text(_) | Node::Code(_) | Node::SoftBreak | Node::HardBreak => {}
+            }
+        }
+    }
+
     #[test]
     fn every_published_mermaid_block_resolves_to_an_svg_as_the_parser_yields_it() {
         let mut checked = 0;
         for doc in crate::docs::DOCS {
-            for node in parse(doc.content) {
-                let Node::CodeBlock(lang, code) = node else {
-                    continue;
-                };
+            let mut blocks = Vec::new();
+            code_blocks(&parse(doc.content), &mut blocks);
+            for (lang, code) in blocks {
                 if lang != "mermaid" {
                     continue;
                 }

--- a/website/src/markdown.rs
+++ b/website/src/markdown.rs
@@ -17,8 +17,9 @@ pub struct Diagram;
 
 impl Diagram {
     pub fn svg(source: &str) -> Option<&'static str> {
+        let wanted = source.trim_end();
         for (diagram, svg) in DIAGRAMS {
-            if *diagram == source {
+            if diagram.trim_end() == wanted {
                 return Some(svg);
             }
         }
@@ -432,17 +433,19 @@ mod tests {
     }
 
     #[test]
-    fn every_published_mermaid_block_was_rendered_at_build_time() {
+    fn every_published_mermaid_block_resolves_to_an_svg_as_the_parser_yields_it() {
         let mut checked = 0;
         for doc in crate::docs::DOCS {
-            for block in doc.content.split("```mermaid\n").skip(1) {
-                let Some(end) = block.find("\n```") else {
-                    panic!("{}: unterminated mermaid fence", doc.slug);
+            for node in parse(doc.content) {
+                let Node::CodeBlock(lang, code) = node else {
+                    continue;
                 };
-                let source = &block[..end];
+                if lang != "mermaid" {
+                    continue;
+                }
                 assert!(
-                    Diagram::svg(source).is_some_and(|svg| svg.contains("<svg")),
-                    "{}: a mermaid block has no build-time SVG, so the page shows its source:\n{source}",
+                    Diagram::svg(&code).is_some_and(|svg| svg.contains("<svg")),
+                    "{}: a mermaid block has no build-time SVG, so the page shows its source:\n{code}",
                     doc.slug
                 );
                 checked += 1;

--- a/website/src/markdown.rs
+++ b/website/src/markdown.rs
@@ -11,6 +11,21 @@ use syntect::util::LinesWithEndings;
 static SYNTAXES: LazyLock<SyntaxSet> = LazyLock::new(SyntaxSet::load_defaults_newlines);
 static THEMES: LazyLock<ThemeSet> = LazyLock::new(ThemeSet::load_defaults);
 
+include!(concat!(env!("OUT_DIR"), "/mermaid.rs"));
+
+pub struct Diagram;
+
+impl Diagram {
+    pub fn svg(source: &str) -> Option<&'static str> {
+        for (diagram, svg) in DIAGRAMS {
+            if *diagram == source {
+                return Some(svg);
+            }
+        }
+        None
+    }
+}
+
 fn escape_html(s: &str) -> String {
     s.replace('&', "&amp;")
         .replace('<', "&lt;")
@@ -263,6 +278,13 @@ fn render_node(n: &Node) -> Element {
             }
         },
         Node::CodeBlock(lang, code) => {
+            if lang == "mermaid"
+                && let Some(svg) = Diagram::svg(code)
+            {
+                return rsx! {
+                    figure { class: "my-6 overflow-x-auto", dangerous_inner_html: "{svg}" }
+                };
+            }
             let html = highlight_code(lang, code);
             rsx! {
                 pre { class: "bg-code-bg border border-border rounded-lg p-4 my-5 overflow-x-auto",
@@ -407,5 +429,28 @@ mod tests {
         let html = highlight_code("rust", "pub fn x() {}");
         assert!(html.contains("span"));
         assert!(!html.is_empty());
+    }
+
+    #[test]
+    fn every_published_mermaid_block_was_rendered_at_build_time() {
+        let mut checked = 0;
+        for doc in crate::docs::DOCS {
+            for block in doc.content.split("```mermaid\n").skip(1) {
+                let Some(end) = block.find("\n```") else {
+                    panic!("{}: unterminated mermaid fence", doc.slug);
+                };
+                let source = &block[..end];
+                assert!(
+                    Diagram::svg(source).is_some_and(|svg| svg.contains("<svg")),
+                    "{}: a mermaid block has no build-time SVG, so the page shows its source:\n{source}",
+                    doc.slug
+                );
+                checked += 1;
+            }
+        }
+        assert!(
+            checked > 0,
+            "no mermaid blocks found, so this proves nothing"
+        );
     }
 }

--- a/website/src/markdown.rs
+++ b/website/src/markdown.rs
@@ -283,10 +283,7 @@ fn render_node(n: &Node) -> Element {
                 && let Some(svg) = Diagram::svg(code)
             {
                 return rsx! {
-                    figure {
-                        class: "diagram my-6 -mx-6 px-6 overflow-x-auto sm:-mx-10 sm:px-10",
-                        dangerous_inner_html: "{svg}",
-                    }
+                    DiagramFigure { svg: svg.to_string() }
                 };
             }
             let html = highlight_code(lang, code);
@@ -413,6 +410,27 @@ fn resolve_link(href: &str) -> String {
             }
         }
         None => href.to_string(),
+    }
+}
+
+#[component]
+fn DiagramFigure(svg: String) -> Element {
+    let mut zoomed = use_signal(|| false);
+    rsx! {
+        figure {
+            class: "my-6 -mx-6 px-6 overflow-x-auto sm:-mx-10 sm:px-10 cursor-zoom-in",
+            onclick: move |_| zoomed.set(true),
+            dangerous_inner_html: "{svg}",
+        }
+        if zoomed() {
+            div {
+                class: "fixed inset-0 z-50 overflow-auto bg-bg/95 p-6 cursor-zoom-out sm:p-10",
+                onclick: move |_| zoomed.set(false),
+                div { class: "grid min-h-full w-max min-w-full place-items-center",
+                    div { dangerous_inner_html: "{svg}" }
+                }
+            }
+        }
     }
 }
 

--- a/website/tailwind.input.css
+++ b/website/tailwind.input.css
@@ -136,33 +136,6 @@
 }
 
 @layer components {
-    /* A diagram is wider than the prose column and scrolls rather than shrinking:
-       scaled to fit, the labels stop being readable. macOS hides overlay scrollbars
-       until they move, so this one is drawn permanently — otherwise a cut-off
-       diagram looks broken rather than scrollable. */
-    .diagram {
-        scrollbar-width: thin;
-        scrollbar-color: var(--color-border) transparent;
-    }
-    .diagram::-webkit-scrollbar {
-        height: 8px;
-    }
-    .diagram::-webkit-scrollbar-track {
-        background: transparent;
-    }
-    .diagram::-webkit-scrollbar-thumb {
-        background: var(--color-border);
-        border-radius: 4px;
-    }
-    .diagram::-webkit-scrollbar-thumb:hover {
-        background: var(--color-text-muted);
-    }
-    .diagram > svg {
-        max-width: none;
-    }
-}
-
-@layer components {
     .scene-cycle {
         position: absolute;
         inset: 0;

--- a/website/tailwind.input.css
+++ b/website/tailwind.input.css
@@ -136,6 +136,33 @@
 }
 
 @layer components {
+    /* A diagram is wider than the prose column and scrolls rather than shrinking:
+       scaled to fit, the labels stop being readable. macOS hides overlay scrollbars
+       until they move, so this one is drawn permanently — otherwise a cut-off
+       diagram looks broken rather than scrollable. */
+    .diagram {
+        scrollbar-width: thin;
+        scrollbar-color: var(--color-border) transparent;
+    }
+    .diagram::-webkit-scrollbar {
+        height: 8px;
+    }
+    .diagram::-webkit-scrollbar-track {
+        background: transparent;
+    }
+    .diagram::-webkit-scrollbar-thumb {
+        background: var(--color-border);
+        border-radius: 4px;
+    }
+    .diagram::-webkit-scrollbar-thumb:hover {
+        background: var(--color-text-muted);
+    }
+    .diagram > svg {
+        max-width: none;
+    }
+}
+
+@layer components {
     .scene-cycle {
         position: absolute;
         inset: 0;


### PR DESCRIPTION
## Context

`docs/architecture.md` is full of mermaid, and vmux.ai was serving it as a
syntax-highlighted code block — readers got the source, not the picture. The site loads no
JavaScript at all today (`index.html` has one inline line and no external `src`), and
`pulldown-cmark` is not given raw HTML, so neither mermaid.js nor an inline `<svg>` in the
markdown would have worked without changing that posture.

Adding mermaid.js would have meant 3.5 MB and the site's first third-party script, on a
page that is the only thing under `/docs`.

## Implementation

`mermaid-rs-renderer` renders mermaid to SVG natively, so `website/build.rs` does it ahead
of time as a **build-dependency** — compiled for the host, never for `wasm32`, which also
sidesteps the fact that `markdown.rs` runs in the browser. The generated table is
`include!`d, and the mermaid arm of the code-block renderer looks its SVG up.

What reaches a visitor is 76 KB of inline SVG. No CDN, no runtime fetch, no JS, and the
diagrams still render with JavaScript off. A diagram that fails to render fails the build
instead of quietly disappearing.

### Three renderer differences, worked around in the diagrams

I rendered all ten and looked at them rather than trusting the README, which was the right
call — the crate is 0.3.1 and says so.

- **Edge-label quotes are not stripped**, so `|"unix socket"|` drew *with* the quotes. The
  ten labels that did not need quotes lost them; unquoted labels containing `<br/>` and
  commas render correctly, so nothing was lost.
- **`flowchart TB` drops or overlaps edge labels.** The Three roles diagram lost both QUIC
  labels off-canvas; the link diagram overlapped its labels onto the nodes. Both are `LR`
  now and render cleanly.
- **Multi-line edge labels collide with nodes.** The detail that was crammed into `<br/>`
  labels moved into prose under the diagram, which reads better than a label did.

Node labels, subgraphs, sequence diagrams and `<br/>` inside *node* labels were all fine.

## Checks / QA

- `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — all clean.
- New test: every published mermaid block resolves to an SVG. Worth having because the
  failure is silent — an unrendered block falls back to printing its own source, which is
  exactly the bug this PR fixes.
- I also checked mechanically that every edge and node label in the source survives into
  the rendered SVG text, 10/10. Note that check passes on an *overlapping* layout, so it
  did not replace looking at them.
- **Not verified: the page in a browser.** `make website` and a look at `/docs` is worth
  someone's five minutes before merge.
- Dark mode is a non-issue today: `data-tone` is only set per-section on the landing page
  and `/docs` inherits the light default, which matches the renderer's palette. If `/docs`
  ever gains a dark tone the SVGs will need a theme pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mermaid diagrams in documentation now render as polished SVG graphics on the website.
  * Documentation pages automatically include rendered diagrams when available.
  * Wide diagrams remain readable with responsive horizontal scrolling instead of shrinking.

* **Documentation**
  * Updated architecture diagrams with clearer left-to-right layouts and simplified labels.
  * Reformatted link-carrier descriptions for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->