### PR TITLE
Keep the glass backdrop on its parent window's Space

### DIFF
--- a/crates/app/vmux_desktop/src/glass.rs
+++ b/crates/app/vmux_desktop/src/glass.rs
@@ -108,9 +108,7 @@ fn install_window_glass(
     backdrop_window.setFloatingPanel(false);
     backdrop_window.setBecomesKeyOnlyIfNeeded(true);
     backdrop.setCollectionBehavior(
-        NSWindowCollectionBehavior::CanJoinAllSpaces
-            | NSWindowCollectionBehavior::FullScreenAuxiliary
-            | NSWindowCollectionBehavior::IgnoresCycle,
+        NSWindowCollectionBehavior::FullScreenAuxiliary | NSWindowCollectionBehavior::IgnoresCycle,
     );
     let glass: Retained<NSGlassEffectView> = NSGlassEffectView::new(mtm);
     glass.setStyle(NSGlassEffectViewStyle::Clear);


### PR DESCRIPTION
## Problem

Switching macOS Spaces flashed a stray window: a square-cornered, shadowless black rectangle at the main window's exact frame, visible for the length of the Space transition.

## Cause

`install_window_glass` puts `NSGlassEffectView` in a borderless, shadowless `NSPanel` and attaches it as a child window of the main window, ordered below it. The panel was created with `NSWindowCollectionBehavior::CanJoinAllSpaces`, so it stood on *every* Space while the window it backs stood on one.

Switching to another Space therefore drew the backdrop alone — no chrome, no content, no rounding, no shadow — until the parent finished its own Space transition and covered it.

The panel is already a child window, and AppKit moves child windows with their parent, so the Space bit was never doing anything the parent relationship did not already do.

## Fix

Drop `CanJoinAllSpaces`. `FullScreenAuxiliary` stays (the backdrop still has to accompany the parent into native fullscreen) and so does `IgnoresCycle`.

## Verification

Confirmed by frame-stepping a screen recording of the glitch: the artifact has square corners, no shadow and no traffic lights, while the real window at the same coordinates 0.3 s later has all three — so the rectangle was the backdrop panel, not the window repainting.

Fix confirmed by hand on a local build: the rectangle no longer appears when swiping between Spaces.

`cargo test -p vmux_desktop` green; full pre-push gate (workspace fmt, clippy `-D warnings`, tests) green.

## Note

`splash.rs` also sets `CanJoinAllSpaces`, deliberately — that panel is the boot splash, centred and rounded, and is meant to show wherever the user is. Left alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backdrop window behavior when switching between spaces and full-screen apps.
  * Backdrop windows no longer appear across all desktop spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->