### PR TITLE
Stop a desktop release from uploading iOS to TestFlight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
         description: "Publish current Cargo.toml version even if unchanged from previous commit"
         type: boolean
         default: false
+      upload_ios:
+        description: "Send the iOS build to App Store Connect. Off by default, and unavailable to the push trigger, because an upload cannot be withdrawn"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -58,13 +62,13 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   testflight:
-    name: Upload iOS to TestFlight
+    name: Build iOS for release
     needs: detect-version
     if: needs.detect-version.outputs.should_release == 'true'
     runs-on: macos-latest
     steps:
-      # The job builds and uploads to Apple; it never pushes. The workflow token carries
-      # contents: write for the publish job, so leaving it in the checkout would hand a
+      # The job builds, signs, and may upload to Apple; it never pushes. The workflow token
+      # carries contents: write for the publish job, so leaving it in the checkout would hand a
       # write-capable credential to every build step for no reason.
       - uses: actions/checkout@v5
         with:
@@ -81,7 +85,7 @@ jobs:
       - name: Install dioxus CLI
         run: ./scripts/install-dioxus-cli.sh
 
-      - name: Build, sign and upload
+      - name: Build, sign and conditionally upload
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -94,9 +98,10 @@ jobs:
           # version alone cannot carry a resubmission. run_number is monotonic and needs no
           # committed state, which would otherwise trip update-release-metadata.sh --check.
           VMUX_IOS_BUILD_NUMBER: ${{ github.run_number }}
-          # The script builds and signs but will not send unless asked. This is the only place
-          # that asks, so an upload can only come from a release run.
-          VMUX_IOS_UPLOAD: "1"
+          # An upload cannot be withdrawn and burns its CFBundleVersion, so asking is a deliberate
+          # act: only a hand-started run can set this. The push trigger leaves the input empty,
+          # which is why a version bump still builds and signs iOS without sending it anywhere.
+          VMUX_IOS_UPLOAD: ${{ inputs.upload_ios && '1' || '' }}
         run: ./scripts/build-ios-release.sh
 
       - name: Verify bundle layout


### PR DESCRIPTION
## Problem

Every version bump merged to `main` sent an iOS build to App Store Connect. There was no way to cut a desktop-only patch.

## Why that is the wrong default

`scripts/build-ios-release.sh` already makes uploading opt-in, and says why at L163:

> App Store Connect keeps what it is given: a build cannot be withdrawn once uploaded, and its CFBundleVersion is burned even if the build is rejected.

`release.yml` was the single thing overriding that, with a hardcoded `VMUX_IOS_UPLOAD: "1"`.

## Change

Gate the upload on a `workflow_dispatch` input, default off:

```yaml
VMUX_IOS_UPLOAD: ${{ inputs.upload_ios && '1' || '' }}
```

| Trigger | build + sign + verify layout | upload to App Store Connect |
| --- | --- | --- |
| push to `main` (version bump) | yes | **no** |
| manual run, `upload_ios` unchecked | yes | no |
| manual run, `upload_ios` checked | yes | yes |

The push trigger leaves the `inputs` context empty, so the env var is empty and the script's `!= "1"` guard skips the send. A desktop release still exercises the whole iOS build and signing path, so a broken certificate or bundle layout is still caught — only the irreversible step is withheld.

Uploading becomes a deliberate, hand-started act.

## Notes

- The job keeps its id `testflight` so `needs: testflight` still resolves; only the display name changes, since it no longer always uploads. It is not renamed to `Build iOS` because `ci.yml` already has a job by that name.
- `publish` still `needs: detect-version` only, so the desktop release remains independent of the iOS job either way.
- The unmerged `submit-app-store` job on the App Store automation branch assumes an upload happened. Whoever lands that needs to reconcile it with `upload_ios`.

## Verification

`actionlint` clean. YAML parses; jobs are `detect-version`, `testflight`, `publish`; dispatch inputs are `force`, `upload_ios`.