### PR TITLE
chore(release): v0.0.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10095,7 +10095,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "base64 0.22.1",
  "bevy",
@@ -10144,7 +10144,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_browser"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -10195,7 +10195,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_chat"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -10215,7 +10215,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -10230,7 +10230,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_client"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "chrono",
  "libc",
@@ -10245,7 +10245,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_clipboard"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
@@ -10255,7 +10255,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10277,7 +10277,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command_mcp"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "serde_json",
  "vmux_command",
@@ -10286,7 +10286,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10311,7 +10311,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10380,7 +10380,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_editor"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -10425,7 +10425,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_flex"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "bevy",
  "taffy",
@@ -10433,7 +10433,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_git"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10453,7 +10453,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10472,7 +10472,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_knowledge"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10488,7 +10488,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -10522,7 +10522,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "muda 0.19.2",
  "proc-macro2",
@@ -10532,7 +10532,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -10546,7 +10546,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mobile"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -10582,7 +10582,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_native"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "base64 0.22.1",
  "dioxus",
@@ -10603,7 +10603,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_profile"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "chrono",
  "libc",
@@ -10620,7 +10620,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_remote"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "bytes",
  "quinn",
@@ -10637,7 +10637,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "agent-client-protocol",
  "alacritty_terminal",
@@ -10680,7 +10680,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_session"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -10691,7 +10691,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10713,7 +10713,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10738,7 +10738,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_start"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "bevy",
  "bevy_app",
@@ -10762,7 +10762,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_team"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "bevy",
  "bevy_app",
@@ -10785,7 +10785,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10815,7 +10815,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "dioxus",
  "dioxus-primitives",
@@ -10833,7 +10833,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_wire"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "bevy_ecs",
  "bevy_reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/app/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.30"
+version = "0.0.31"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "GPL-3.0-or-later"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.30"
-  sha256 "eca282cdc344b6349c7c8eb17949ab4734b7fc2dfdc491dcb3205605bcfc6626"
+  version "0.0.31"
+  sha256 "a191bc1fd233eef4e2c67ec2a57ec28c0d3f1237abbf1fe9d17d560eff5b8605"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.30/Vmux_0.0.30_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.31/Vmux_0.0.31_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai/"

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.30",
-  "pub_date": "2026-07-31T08:30:10Z",
+  "version": "v0.0.31",
+  "pub_date": "2026-08-26T09:43:00Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.30/Vmux-v0.0.30-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HT3h5eGx6bVBWeUs3b1JLSFE2Rk9OZFdhSmNoKzVYazZ5NmViNHZIMDhLWEJaZDV5ZnJyMFZmT0Z0bjhDNzZjbnZnUTFKMVUrS0d2MmcvajE3NlVkbVFBPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg1NDg2NjA3CWZpbGU6Vm11eC12MC4wLjMwLWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKRDcxMHkrc2kvMmhmQTE3aXJHWDhIbnFGOWlkaEdjdjZOMGwrRjlOVExraUYxcUlsR0g2N0dSSmMzUWVsZlVQazhFcWpYaUVRSXpsYUErMk9PaTFTQ3c9PQo=",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.31/Vmux-v0.0.31-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzR1c1Frbnczd0ZoYzArSGJ2NHpCY2l1cTFwOWI3UnFrdTZzYTNVbGtCaWE3NEtOUVBZMlVFa1EyN1ZycXhKQWlFNTRncEFVekJUTGcyOFRWU3BESGc4PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NzM3Mzc3CWZpbGU6Vm11eC12MC4wLjMxLWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKZ1d2S2N0MGR0OXJha3V2YnpObXN3T0xwcStiVUFsQno0NmMySkpBcWtNNnUwakJPbGozbzRycmJiZ1ZJOGZwMGg1Y0FqMWQ5WWRobHZnQmJlTmVqRFE9PQo=",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.30/Vmux_0.0.30_aarch64.dmg",
-      "filename": "Vmux_0.0.30_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.31/Vmux_0.0.31_aarch64.dmg",
+      "filename": "Vmux_0.0.31_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
Desktop patch release. Bumps the workspace version 0.0.30 -> 0.0.31.

## What ships

85+ commits since v0.0.30 (2026-07-31), including the Space-switch glitch fix from #418 — the glass backdrop panel no longer stands on every Space, so switching Spaces stops flashing a bare window-shaped rectangle.

## iOS

Nothing is sent to App Store Connect. #419 made the upload opt-in and only reachable from a hand-started `workflow_dispatch` run, so this push-triggered release builds, signs and layout-checks iOS without uploading it. This is the first release under that rule.

## Release steps

- [x] Version bump
- [ ] CI builds the DMG into draft release `v0.0.31`
- [ ] `./scripts/update-release-metadata.sh` for the cask and update manifest
- [ ] Merge; `release.yml` tags, publishes and deploys the website

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.0.31.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->