### PR TITLE
Fix the editing chords, the caret, and what a scroll costs

### DIFF
--- a/crates/app/vmux_desktop/src/os_menu.rs
+++ b/crates/app/vmux_desktop/src/os_menu.rs
@@ -259,17 +259,19 @@ fn collect_edit_menu_items() -> Vec<Retained<NSMenuItem>> {
 }
 
 #[cfg(target_os = "macos")]
-fn edit_menu_items_enabled(intent: HostFocusIntent) -> bool {
-    !matches!(
-        intent,
-        HostFocusIntent::WinitHost | HostFocusIntent::NativePane(_)
-    )
+fn edit_menu_items_enabled(intent: HostFocusIntent, binds_chords: bool) -> bool {
+    match intent {
+        HostFocusIntent::WinitHost => false,
+        HostFocusIntent::NativePane(_) => !binds_chords,
+        HostFocusIntent::Windowed(_) | HostFocusIntent::LayoutView => true,
+    }
 }
 
 #[cfg(target_os = "macos")]
 fn sync_edit_menu_items(
     menu: Option<NonSend<OsMenuResource>>,
     intent: Option<Res<HostFocusIntent>>,
+    chord_panes: Query<(), With<vmux_core::host::page::BindsEditingChords>>,
 ) {
     let Some(intent) = intent else {
         return;
@@ -280,7 +282,11 @@ fn sync_edit_menu_items(
     let Some(menu) = menu else {
         return;
     };
-    let enabled = edit_menu_items_enabled(*intent);
+    let binds_chords = match *intent {
+        HostFocusIntent::NativePane(pane) => chord_panes.contains(pane),
+        _ => false,
+    };
+    let enabled = edit_menu_items_enabled(*intent, binds_chords);
     for item in &menu.edit_items {
         item.setEnabled(enabled);
     }
@@ -441,20 +447,23 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn edit_items_are_released_to_whatever_answers_the_chords_itself() {
-        assert!(
-            !edit_menu_items_enabled(HostFocusIntent::WinitHost),
-            "terminal focus must release ⌘C/⌘V to the terminal's own handler"
-        );
-        assert!(
-            !edit_menu_items_enabled(HostFocusIntent::NativePane(Entity::PLACEHOLDER)),
-            "a page hosted in this process binds ⌘Z itself, and the menu's undo would rewind the \
-             wrong buffer"
-        );
-        assert!(edit_menu_items_enabled(HostFocusIntent::Windowed(
-            Entity::PLACEHOLDER
-        )));
-        assert!(edit_menu_items_enabled(HostFocusIntent::LayoutView));
+    fn only_a_pane_that_binds_the_chords_takes_the_menu_away_from_the_platform() {
+        let pane = HostFocusIntent::NativePane(Entity::PLACEHOLDER);
+        let cases = [
+            (pane, true, false),
+            (pane, false, true),
+            (HostFocusIntent::Windowed(Entity::PLACEHOLDER), false, true),
+            (HostFocusIntent::LayoutView, false, true),
+            (HostFocusIntent::WinitHost, false, false),
+        ];
+
+        for (intent, binds_chords, want) in cases {
+            assert_eq!(
+                edit_menu_items_enabled(intent, binds_chords),
+                want,
+                "{intent:?} with binds_chords={binds_chords}"
+            );
+        }
     }
 
     fn test_settings() -> AppSettings {

--- a/crates/page/vmux_editor/src/host/edit/command.rs
+++ b/crates/page/vmux_editor/src/host/edit/command.rs
@@ -185,6 +185,7 @@ pub enum EditCommand {
         count: usize,
         register: Option<char>,
     },
+    Paste,
     ReplaceChar {
         ch: char,
         count: usize,

--- a/crates/page/vmux_editor/src/host/edit/core.rs
+++ b/crates/page/vmux_editor/src/host/edit/core.rs
@@ -1439,7 +1439,12 @@ impl EditCore {
                 self.checkpoint(Group::Other);
                 self.buf_insert(at, &text);
                 let end = at + text.chars().count();
-                self.set_caret(end.saturating_sub(1).max(at));
+                let caret = if self.mode == EditMode::Insert {
+                    end
+                } else {
+                    end.saturating_sub(1).max(at)
+                };
+                self.set_caret(caret);
             }
             RegisterKind::Blockwise => {
                 let head = self.primary().head;
@@ -2036,6 +2041,62 @@ mod tests {
 
     fn text_of(c: &EditCore) -> String {
         c.buffer.text()
+    }
+
+    fn typed_after_vim_keys(text: &str, caret: usize, keys: &[&str], typed: &str) -> String {
+        use crate::host::keymap::vim::VimKeymap;
+        use crate::keymap::{KeyInput, Keymap, Mods};
+
+        let mut c = core(text);
+        c.mode = EditMode::Normal;
+        c.set_caret(caret);
+        let mut keymap = VimKeymap::default();
+        for key in keys {
+            let stroke = KeyInput {
+                key: (*key).into(),
+                mods: Mods::default(),
+                repeat: false,
+            };
+            for cmd in keymap.handle(&stroke) {
+                c.apply(cmd);
+            }
+        }
+        c.apply(EditCommand::InsertText(typed.into()));
+        text_of(&c)
+    }
+
+    #[test]
+    fn append_at_line_end_types_past_the_last_character() {
+        assert_eq!(typed_after_vim_keys("ab\n", 0, &["A"], "X"), "abX\n");
+    }
+
+    #[test]
+    fn append_on_the_last_character_types_past_it() {
+        assert_eq!(typed_after_vim_keys("ab\n", 1, &["a"], "X"), "abX\n");
+    }
+
+    #[test]
+    fn pasting_while_inserting_types_after_the_pasted_text() {
+        let mut c = core("ab\n");
+        c.mode = EditMode::Insert;
+        c.registers.set_unnamed(RegisterValue::charwise("XY"));
+        c.set_caret(2);
+        c.apply(put(true));
+        c.apply(EditCommand::InsertText("Z".into()));
+
+        assert_eq!(text_of(&c), "abXYZ\n");
+    }
+
+    #[test]
+    fn putting_in_normal_mode_lands_on_the_last_pasted_character() {
+        let mut c = core("ab\n");
+        c.mode = EditMode::Normal;
+        c.registers.set_unnamed(RegisterValue::charwise("XY"));
+        c.set_caret(0);
+        c.apply(put(false));
+
+        assert_eq!(text_of(&c), "aXYb\n");
+        assert_eq!(c.primary().head, 2);
     }
 
     #[test]

--- a/crates/page/vmux_editor/src/host/edit/core.rs
+++ b/crates/page/vmux_editor/src/host/edit/core.rs
@@ -967,6 +967,13 @@ impl EditCore {
         i
     }
 
+    pub fn paste(&mut self, text: &str) -> bool {
+        self.break_group();
+        let changed = self.insert_text(text);
+        self.break_group();
+        changed
+    }
+
     fn insert_text(&mut self, text: &str) -> bool {
         self.checkpoint(Group::Insert);
         if !self.primary().is_empty() {
@@ -1439,12 +1446,7 @@ impl EditCore {
                 self.checkpoint(Group::Other);
                 self.buf_insert(at, &text);
                 let end = at + text.chars().count();
-                let caret = if self.mode == EditMode::Insert {
-                    end
-                } else {
-                    end.saturating_sub(1).max(at)
-                };
-                self.set_caret(caret);
+                self.set_caret(end.saturating_sub(1).max(at));
             }
             RegisterKind::Blockwise => {
                 let head = self.primary().head;
@@ -1961,6 +1963,7 @@ impl EditCore {
                 }
             }
             EditCommand::Save
+            | EditCommand::Paste
             | EditCommand::ScrollViewport(_)
             | EditCommand::ScrollCursorTo(_)
             | EditCommand::GotoDefinition
@@ -2076,15 +2079,38 @@ mod tests {
     }
 
     #[test]
-    fn pasting_while_inserting_types_after_the_pasted_text() {
+    fn pasting_types_after_the_pasted_text() {
         let mut c = core("ab\n");
         c.mode = EditMode::Insert;
-        c.registers.set_unnamed(RegisterValue::charwise("XY"));
         c.set_caret(2);
-        c.apply(put(true));
+        c.paste("XY");
         c.apply(EditCommand::InsertText("Z".into()));
 
         assert_eq!(text_of(&c), "abXYZ\n");
+    }
+
+    #[test]
+    fn pasting_replaces_the_selection() {
+        let mut c = core("abcd\n");
+        c.mode = EditMode::Insert;
+        c.selections = vec![Selection { anchor: 1, head: 3 }];
+        c.paste("X");
+
+        assert_eq!(text_of(&c), "aXd\n");
+    }
+
+    #[test]
+    fn undo_takes_a_paste_back_on_its_own() {
+        let mut c = core("");
+        c.mode = EditMode::Insert;
+        c.apply(EditCommand::InsertText("a".into()));
+        c.paste("XY");
+        c.apply(EditCommand::InsertText("b".into()));
+
+        c.apply(EditCommand::Undo);
+        assert_eq!(text_of(&c), "aXY");
+        c.apply(EditCommand::Undo);
+        assert_eq!(text_of(&c), "a");
     }
 
     #[test]

--- a/crates/page/vmux_editor/src/host/edit/core.rs
+++ b/crates/page/vmux_editor/src/host/edit/core.rs
@@ -96,6 +96,7 @@ pub struct EditCore {
     memory: Vec<CaretMemory>,
     pub fold_view: crate::fold::FoldView,
     pub search: Option<crate::edit::search::Search>,
+    search_cache: Option<(u64, String, Vec<std::ops::Range<usize>>)>,
     block_insert: Option<(Vec<usize>, usize)>,
     pub search_highlight: bool,
     marks: std::collections::HashMap<char, usize>,
@@ -129,6 +130,7 @@ impl EditCore {
             memory: vec![CaretMemory::default()],
             fold_view,
             search: None,
+            search_cache: None,
             block_insert: None,
             search_highlight: false,
             marks: std::collections::HashMap::new(),
@@ -584,6 +586,31 @@ impl EditCore {
             out.push(chars..chars + len);
         }
         out
+    }
+
+    pub fn refresh_search_matches(&mut self) {
+        let Some(search) = self.search.as_ref() else {
+            self.search_cache = None;
+            return;
+        };
+        if self
+            .search_cache
+            .as_ref()
+            .is_some_and(|(rev, pattern, _)| *rev == self.rev && *pattern == search.pattern)
+        {
+            return;
+        }
+        let rev = self.rev;
+        let pattern = search.pattern.clone();
+        let matches = self.search_matches();
+        self.search_cache = Some((rev, pattern, matches));
+    }
+
+    pub fn cached_search_matches(&self) -> &[std::ops::Range<usize>] {
+        match self.search_cache.as_ref() {
+            Some((_, _, matches)) => matches,
+            None => &[],
+        }
     }
 
     fn search_step(&self, from: usize, reverse: bool) -> Option<usize> {
@@ -2126,6 +2153,37 @@ mod tests {
     #[test]
     fn append_on_the_last_character_types_past_it() {
         assert_eq!(typed_after_vim_keys("ab\n", 1, &["a"], "X"), "abX\n");
+    }
+
+    #[test]
+    fn cached_search_matches_follow_an_edit_and_a_new_pattern() {
+        let mut c = core("foo bar foo\n");
+        c.mode = EditMode::Normal;
+        let count = |c: &mut EditCore| {
+            c.refresh_search_matches();
+            c.cached_search_matches().len()
+        };
+
+        c.apply(EditCommand::SetSearch {
+            pattern: "foo".into(),
+            forward: true,
+        });
+        assert_eq!(count(&mut c), 2);
+
+        c.mode = EditMode::Insert;
+        c.set_caret(0);
+        c.apply(EditCommand::InsertText("foo ".into()));
+        assert_eq!(count(&mut c), 3, "an edit must not serve a stale match set");
+
+        c.apply(EditCommand::SetSearch {
+            pattern: "bar".into(),
+            forward: true,
+        });
+        assert_eq!(
+            count(&mut c),
+            1,
+            "a new pattern must not serve the old one's matches"
+        );
     }
 
     #[test]

--- a/crates/page/vmux_editor/src/host/edit/core.rs
+++ b/crates/page/vmux_editor/src/host/edit/core.rs
@@ -493,6 +493,7 @@ impl EditCore {
         self.selections = state.selections;
         self.active = 0;
         self.rev = state.rev;
+        self.search_cache = None;
         self.dirty = self.saved_rev != Some(self.rev);
         self.break_group();
         let len = self.buffer.len_chars();
@@ -679,8 +680,8 @@ impl EditCore {
                 out.push(SelSpan {
                     line: line as u32,
                     row: line as u32,
-                    start: column as u32,
-                    end: (absolute + needle.len() - line_start) as u32,
+                    start: self.vis_col(line_start, column),
+                    end: self.vis_col(line_start, absolute + needle.len() - line_start),
                 });
                 at += needle.len();
                 continue;
@@ -2183,6 +2184,31 @@ mod tests {
             count(&mut c),
             1,
             "a new pattern must not serve the old one's matches"
+        );
+    }
+
+    #[test]
+    fn cached_search_matches_survive_an_undo_onto_a_different_edit() {
+        let mut c = core("foo\n");
+        c.mode = EditMode::Insert;
+        c.apply(EditCommand::SetSearch {
+            pattern: "foo".into(),
+            forward: true,
+        });
+        c.set_caret(3);
+        c.apply(EditCommand::InsertText(" foo".into()));
+        c.refresh_search_matches();
+        assert_eq!(c.cached_search_matches().len(), 2);
+
+        c.apply(EditCommand::Undo);
+        c.set_caret(3);
+        c.apply(EditCommand::InsertText(" foo foo".into()));
+        c.refresh_search_matches();
+
+        assert_eq!(
+            c.cached_search_matches().len(),
+            3,
+            "a revision number is reused across undo branches, so it cannot key the cache alone"
         );
     }
 

--- a/crates/page/vmux_editor/src/host/edit/core.rs
+++ b/crates/page/vmux_editor/src/host/edit/core.rs
@@ -593,37 +593,87 @@ impl EditCore {
         crate::edit::search::step(&matches, from, forward)
     }
 
+    fn is_word_char(&self, at: usize) -> bool {
+        at < self.buffer.len_chars() && {
+            let c = self.buffer.rope.char(at);
+            c.is_alphanumeric() || c == '_'
+        }
+    }
+
+    fn word_at(&self, caret: usize) -> Option<std::ops::Range<usize>> {
+        let caret = caret.min(self.buffer.len_chars());
+        let mut start = caret;
+        while start > 0 && self.is_word_char(start - 1) {
+            start -= 1;
+        }
+        let mut end = caret;
+        while self.is_word_char(end) {
+            end += 1;
+        }
+        (start != end).then_some(start..end)
+    }
+
     pub fn word_highlight_spans(&self, first: u32, rows: u16) -> Vec<SelSpan> {
         if rows == 0 || !self.primary().is_empty() {
             return Vec::new();
         }
-        let Some((_, found)) = self.word_occurrences() else {
+        let Some(word) = self.word_at(self.primary().head) else {
             return Vec::new();
         };
-        let last_line = first as usize + rows as usize;
+        let first_line = first as usize;
+        let last_line = (first_line + rows as usize).min(self.buffer.len_lines());
+        if first_line >= last_line {
+            return Vec::new();
+        }
+        let band_start = self.buffer.line_to_char(first_line);
+        let band_end = if last_line >= self.buffer.len_lines() {
+            self.buffer.len_chars()
+        } else {
+            self.buffer.line_to_char(last_line)
+        };
+        let needle: Vec<char> = self.buffer.rope.slice(word).chars().collect();
+        let band: Vec<char> = self
+            .buffer
+            .rope
+            .slice(band_start..band_end)
+            .chars()
+            .collect();
+
         let mut out = Vec::new();
-        for range in found {
-            let (line, start) = self.buffer.char_to_coords(range.start);
-            if line < first as usize || line >= last_line {
+        let mut at = 0;
+        while at + needle.len() <= band.len() {
+            let found = band[at..at + needle.len()] == needle[..];
+            let absolute = band_start + at;
+            let bounded = (absolute == 0 || !self.is_word_char(absolute - 1))
+                && !self.is_word_char(absolute + needle.len());
+            if found && bounded {
+                let (line, column) = self.buffer.char_to_coords(absolute);
+                let line_start = self.buffer.line_to_char(line);
+                out.push(SelSpan {
+                    line: line as u32,
+                    row: line as u32,
+                    start: column as u32,
+                    end: (absolute + needle.len() - line_start) as u32,
+                });
+                at += needle.len();
                 continue;
             }
-            let ls = self.buffer.line_to_char(line);
-            out.push(SelSpan {
-                line: line as u32,
-                row: line as u32,
-                start: start as u32,
-                end: (range.end - ls) as u32,
-            });
+            at += 1;
         }
         out
     }
-    pub fn search_spans(&self, first: u32, rows: u16) -> Vec<SelSpan> {
+    pub fn search_spans(
+        &self,
+        matches: &[std::ops::Range<usize>],
+        first: u32,
+        rows: u16,
+    ) -> Vec<SelSpan> {
         if !self.search_highlight || rows == 0 {
             return Vec::new();
         }
         let last_line = first as usize + rows as usize;
         let mut out = Vec::new();
-        for m in self.search_matches() {
+        for m in matches.iter().cloned() {
             let (l0, _) = self.buffer.char_to_coords(m.start);
             let (l1, _) = self.buffer.char_to_coords(m.end);
             if l1 < first as usize || l0 >= last_line {
@@ -2079,6 +2129,24 @@ mod tests {
     }
 
     #[test]
+    fn word_highlight_scans_the_band_and_skips_longer_words() {
+        let mut c = core("id\nid_x\nother\nid\nid\n");
+        c.mode = EditMode::Normal;
+        c.set_caret(0);
+
+        let in_band = |first, rows| {
+            c.word_highlight_spans(first, rows)
+                .iter()
+                .map(|s| (s.line, s.start, s.end))
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(in_band(0, 3), vec![(0, 0, 2)]);
+        assert_eq!(in_band(0, 5), vec![(0, 0, 2), (3, 0, 2), (4, 0, 2)]);
+        assert_eq!(in_band(3, 2), vec![(3, 0, 2), (4, 0, 2)]);
+    }
+
+    #[test]
     fn pasting_types_after_the_pasted_text() {
         let mut c = core("ab\n");
         c.mode = EditMode::Insert;
@@ -2887,9 +2955,9 @@ mod tests {
             pattern: "foo".into(),
             forward: true,
         });
-        assert_eq!(c.search_spans(0, 4).len(), 2);
+        assert_eq!(c.search_spans(&c.search_matches(), 0, 4).len(), 2);
         c.apply(EditCommand::ClearSearchHighlight);
-        assert!(c.search_spans(0, 4).is_empty());
+        assert!(c.search_spans(&c.search_matches(), 0, 4).is_empty());
     }
 
     #[test]

--- a/crates/page/vmux_editor/src/host/keymap/vim.rs
+++ b/crates/page/vmux_editor/src/host/keymap/vim.rs
@@ -615,15 +615,15 @@ impl VimKeymap {
             }
             "a" => {
                 self.enter_insert();
-                vec![Move(Motion::Right), SetMode(EditMode::Insert)]
+                vec![SetMode(EditMode::Insert), Move(Motion::Right)]
             }
             "I" => {
                 self.enter_insert();
-                vec![Move(Motion::FirstNonBlank), SetMode(EditMode::Insert)]
+                vec![SetMode(EditMode::Insert), Move(Motion::FirstNonBlank)]
             }
             "A" => {
                 self.enter_insert();
-                vec![Move(Motion::LineEnd), SetMode(EditMode::Insert)]
+                vec![SetMode(EditMode::Insert), Move(Motion::LineEnd)]
             }
             "o" => {
                 self.enter_insert();

--- a/crates/page/vmux_editor/src/host/keymap/vim.rs
+++ b/crates/page/vmux_editor/src/host/keymap/vim.rs
@@ -1163,11 +1163,7 @@ impl VimKeymap {
                     target: Target::Selection,
                     register: None,
                 }),
-                "v" => Some(EditCommand::Put {
-                    before: true,
-                    count: 1,
-                    register: None,
-                }),
+                "v" => Some(EditCommand::Paste),
                 "a" => Some(EditCommand::Move(Motion::DocStart)),
                 "s" => Some(EditCommand::Save),
                 "z" if k.mods.shift => Some(EditCommand::Redo),

--- a/crates/page/vmux_editor/src/host/keymap/vscode.rs
+++ b/crates/page/vmux_editor/src/host/keymap/vscode.rs
@@ -74,11 +74,7 @@ impl Keymap for VscodeKeymap {
             let cmd = match k.key.to_ascii_lowercase().as_str() {
                 "c" => Some(vec![selection_op(Operator::Yank)]),
                 "x" => Some(vec![selection_op(Operator::Delete)]),
-                "v" => Some(vec![Put {
-                    before: true,
-                    count: 1,
-                    register: None,
-                }]),
+                "v" => Some(vec![EditCommand::Paste]),
                 "a" => Some(vec![Move(Motion::DocStart), Select(Motion::DocEnd)]),
                 "s" => Some(vec![Save]),
                 "z" if m.shift => Some(vec![Redo]),

--- a/crates/page/vmux_editor/src/host/plugin.rs
+++ b/crates/page/vmux_editor/src/host/plugin.rs
@@ -163,7 +163,7 @@ impl Plugin for EditorPlugin {
                 Update,
                 (
                     init_explorer_state,
-                    emit_explorer_tree,
+                    emit_explorer_tree.after(drain_explorer_dir_loads),
                     sync_explorer_chrome,
                     emit_explorer_chrome,
                     sync_open_editors,
@@ -1247,14 +1247,27 @@ fn emit_window(
     let layouts = wrapped_view(edit, vp).window(first_row, end_row);
     let first_row = layouts.first().map_or(first_row, |line| line.row);
     let mut lines = Vec::with_capacity(layouts.len());
-    for layout in &layouts {
-        let ln = layout.line_no;
-        let mut fl = edit
+    if let (Some(first_line), Some(last_line)) = (
+        layouts.first().map(|layout| layout.line_no),
+        layouts.last().map(|layout| layout.line_no),
+    ) {
+        let mut window: Vec<Option<vmux_core::event::FileLine>> = edit
             .hl
-            .line_window(&edit.core.buffer.rope, ln as usize, ln as usize + 1);
-        if let Some(mut l) = fl.pop() {
-            l.fold = edit.folds.gutter(ln);
-            lines.push(l);
+            .line_window(
+                &edit.core.buffer.rope,
+                first_line as usize,
+                last_line as usize + 1,
+            )
+            .into_iter()
+            .map(Some)
+            .collect();
+        for layout in &layouts {
+            let index = (layout.line_no - first_line) as usize;
+            let Some(mut line) = window.get_mut(index).and_then(Option::take) else {
+                continue;
+            };
+            line.fold = edit.folds.gutter(layout.line_no);
+            lines.push(line);
         }
     }
     commands.trigger(BinHostEmitEvent::from_rkyv(
@@ -1327,9 +1340,10 @@ fn emit_cursor(
         .into_iter()
         .filter(|span| !view.is_hidden(span.line))
         .collect::<Vec<_>>();
+    let matches = edit.core.search_matches();
     let raw_search = edit
         .core
-        .search_spans(span_first, span_rows)
+        .search_spans(&matches, span_first, span_rows)
         .into_iter()
         .filter(|span| !view.is_hidden(span.line))
         .collect::<Vec<_>>();
@@ -1348,7 +1362,6 @@ fn emit_cursor(
     let selections = wrap.selections(raw_selections.iter().copied());
     let search = wrap.selections(raw_search.iter().copied());
     let word_highlights = wrap.selections(raw_word_highlights.iter().copied());
-    let matches = edit.core.search_matches();
     let caret = edit.core.primary().head;
     let search_index = matches
         .iter()
@@ -3602,6 +3615,8 @@ fn explorer_root_name(root: &Path) -> String {
         .unwrap_or_else(|| root.to_string_lossy().to_uppercase())
 }
 
+const EXPLORER_WARM_AHEAD: usize = 64;
+
 fn start_explorer_dir_load(
     entity: Entity,
     path: PathBuf,
@@ -3717,8 +3732,24 @@ fn drain_explorer_dir_loads(
         if !st.loading.remove(&path) {
             continue;
         }
-        st.children.insert(path, entries);
+        let warm_ahead = st.expanded.contains(&path);
+        st.children.insert(path.clone(), entries);
         commands.entity(webview).insert(ExplorerTreeDirty);
+        if !warm_ahead {
+            continue;
+        }
+        let ahead = st
+            .children
+            .get(&path)
+            .into_iter()
+            .flatten()
+            .filter(|entry| entry.is_dir)
+            .take(EXPLORER_WARM_AHEAD)
+            .map(|entry| PathBuf::from(&entry.path))
+            .collect::<Vec<_>>();
+        for dir in ahead {
+            start_explorer_dir_load(webview, dir, &mut st, &mut commands, false);
+        }
     }
 }
 
@@ -4835,6 +4866,42 @@ mod explorer_tests {
                 .any(|x| x.name == "src")
         );
         assert!(app.world().get::<ExplorerTreeDirty>(e).is_some());
+    }
+
+    #[test]
+    fn expanding_warms_the_next_level_and_stops_there() {
+        let tmp = git_repo();
+        let deep = tmp.path().join("src").join("deep");
+        fs::create_dir_all(&deep).unwrap();
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_systems(Update, (init_explorer_state, drain_explorer_dir_loads));
+        let e = app
+            .world_mut()
+            .spawn((
+                FileView {
+                    path: tmp.path().join("README.md"),
+                },
+                ExplorerState::default(),
+            ))
+            .id();
+
+        wait_for_children(&mut app, e, tmp.path());
+        wait_for_children(&mut app, e, &tmp.path().join("src"));
+
+        for _ in 0..200 {
+            app.update();
+            std::thread::yield_now();
+        }
+        let st = app.world().get::<ExplorerState>(e).unwrap();
+        assert!(
+            !st.expanded.contains(&tmp.path().join("src")),
+            "warming must not expand anything on the user's behalf"
+        );
+        assert!(
+            !st.children.contains_key(&deep),
+            "a warmed directory must not warm its own children, or a deep tree loads itself"
+        );
     }
 
     #[test]

--- a/crates/page/vmux_editor/src/host/plugin.rs
+++ b/crates/page/vmux_editor/src/host/plugin.rs
@@ -2715,31 +2715,36 @@ fn accelerate_repeated_navigation(cmds: Vec<EditCommand>, repeat: bool) -> Vec<E
     if !repeat {
         return cmds;
     }
-    cmds.into_iter()
-        .flat_map(|cmd| {
-            let accelerate = matches!(
-                &cmd,
-                EditCommand::Move(
-                    Motion::Left
-                        | Motion::Right
-                        | Motion::LeftBounded
-                        | Motion::RightBounded
-                        | Motion::Up
-                        | Motion::Down,
-                ) | EditCommand::Select(
-                    Motion::Left
-                        | Motion::Right
-                        | Motion::LeftBounded
-                        | Motion::RightBounded
-                        | Motion::Up
-                        | Motion::Down,
-                )
-            );
-            [Some(cmd.clone()), accelerate.then_some(cmd)]
-                .into_iter()
-                .flatten()
-        })
-        .collect()
+    let mut out = Vec::with_capacity(cmds.len() * 2);
+    for cmd in cmds {
+        if let EditCommand::ScrollViewport(lines) = cmd {
+            out.push(EditCommand::ScrollViewport(lines.saturating_mul(2)));
+            continue;
+        }
+        let accelerate = matches!(
+            &cmd,
+            EditCommand::Move(
+                Motion::Left
+                    | Motion::Right
+                    | Motion::LeftBounded
+                    | Motion::RightBounded
+                    | Motion::Up
+                    | Motion::Down,
+            ) | EditCommand::Select(
+                Motion::Left
+                    | Motion::Right
+                    | Motion::LeftBounded
+                    | Motion::RightBounded
+                    | Motion::Up
+                    | Motion::Down,
+            )
+        );
+        if accelerate {
+            out.push(cmd.clone());
+        }
+        out.push(cmd);
+    }
+    out
 }
 
 fn remap_note_vertical_commands(
@@ -4783,6 +4788,30 @@ mod edit_flow_tests {
         assert_eq!(
             accelerate_repeated_navigation(vec![EditCommand::DeleteBack], true),
             [EditCommand::DeleteBack]
+        );
+    }
+
+    #[test]
+    fn a_held_scroll_key_covers_the_same_ground_as_a_held_motion_key() {
+        let held = |cmd| accelerate_repeated_navigation(vec![cmd], true);
+        let rows = |cmds: Vec<EditCommand>| {
+            cmds.iter()
+                .map(|cmd| match cmd {
+                    EditCommand::ScrollViewport(lines) => *lines,
+                    EditCommand::Move(Motion::Down) => 1,
+                    EditCommand::Move(Motion::Up) => -1,
+                    other => panic!("unexpected {other:?}"),
+                })
+                .sum::<i32>()
+        };
+
+        assert_eq!(
+            rows(held(EditCommand::ScrollViewport(1))),
+            rows(held(EditCommand::Move(Motion::Down)))
+        );
+        assert_eq!(
+            rows(held(EditCommand::ScrollViewport(-1))),
+            rows(held(EditCommand::Move(Motion::Up)))
         );
     }
 

--- a/crates/page/vmux_editor/src/host/plugin.rs
+++ b/crates/page/vmux_editor/src/host/plugin.rs
@@ -2545,6 +2545,22 @@ fn run_commands(
             }
             continue;
         }
+        if matches!(cmd, EditCommand::Paste) {
+            let Some(cb) = clipboard.0.as_mut() else {
+                continue;
+            };
+            let Ok(s) = cb.get_text() else {
+                continue;
+            };
+            if edit.core.paste(&s) {
+                text_changed = true;
+                let (l, _) = edit.core.buffer.char_to_coords(edit.core.primary().head);
+                edit.hl.invalidate_from(l.saturating_sub(1));
+            }
+            sel_or_mode = true;
+            dirty_changed = true;
+            continue;
+        }
         if matches!(cmd, EditCommand::Put { .. })
             && let Some(cb) = clipboard.0.as_mut()
             && let Ok(s) = cb.get_text()
@@ -3237,11 +3253,7 @@ fn on_file_editor_action(
             target: crate::edit::command::Target::Selection,
             register: None,
         }],
-        EditorAction::Paste => vec![EditCommand::Put {
-            before: false,
-            count: 1,
-            register: None,
-        }],
+        EditorAction::Paste => vec![EditCommand::Paste],
         EditorAction::ChangeAllOccurrences => vec![EditCommand::SelectAllOccurrences],
     };
     run_commands(

--- a/crates/page/vmux_editor/src/host/plugin.rs
+++ b/crates/page/vmux_editor/src/host/plugin.rs
@@ -590,6 +590,7 @@ fn new_file_view_bundle(url: &str, path: PathBuf) -> impl Bundle {
                 bg_color: None,
             },
             vmux_core::host::page::HostsPage,
+            vmux_core::host::page::BindsEditingChords,
         ),
         (
             WebviewSize(Vec2::new(1280.0, 720.0)),

--- a/crates/page/vmux_editor/src/host/plugin.rs
+++ b/crates/page/vmux_editor/src/host/plugin.rs
@@ -1340,13 +1340,21 @@ fn emit_cursor(
         .into_iter()
         .filter(|span| !view.is_hidden(span.line))
         .collect::<Vec<_>>();
-    let matches = edit.core.search_matches();
+    edit.core.refresh_search_matches();
+    let matches = edit.core.cached_search_matches();
     let raw_search = edit
         .core
-        .search_spans(&matches, span_first, span_rows)
+        .search_spans(matches, span_first, span_rows)
         .into_iter()
         .filter(|span| !view.is_hidden(span.line))
         .collect::<Vec<_>>();
+    let caret = edit.core.primary().head;
+    let search_index = matches
+        .iter()
+        .position(|found| found.contains(&caret) || found.start == caret)
+        .map(|at| at as u32 + 1)
+        .unwrap_or_default();
+    let search_total = matches.len() as u32;
     let raw_carets: Vec<_> = edit
         .core
         .cursor_positions()
@@ -1362,13 +1370,6 @@ fn emit_cursor(
     let selections = wrap.selections(raw_selections.iter().copied());
     let search = wrap.selections(raw_search.iter().copied());
     let word_highlights = wrap.selections(raw_word_highlights.iter().copied());
-    let caret = edit.core.primary().head;
-    let search_index = matches
-        .iter()
-        .position(|found| found.contains(&caret) || found.start == caret)
-        .map(|at| at as u32 + 1)
-        .unwrap_or_default();
-    let search_total = matches.len() as u32;
     commands.trigger(BinHostEmitEvent::from_rkyv(
         entity,
         FILE_CURSOR_EVENT,

--- a/crates/page/vmux_editor/src/page.rs
+++ b/crates/page/vmux_editor/src/page.rs
@@ -127,7 +127,7 @@ pub fn Page() -> Element {
     let mut explorer_resizing = use_signal(|| false);
     let explorer_client_id = use_signal(explorer_client_id);
     let explorer_request_id = use_signal(|| 0u64);
-    let explorer_reflowed_at = use_signal(|| 0u32);
+    let explorer_reflowed_at = use_signal(|| Option::<ExplorerReflowKey>::None);
     let explorer = ExplorerPane {
         visible: explorer_visible,
         preferred_visible: explorer_preferred_visible,
@@ -3798,6 +3798,13 @@ fn explorer_has_room(page_width: u32, explorer_width: u32) -> bool {
     page_width > 0 && NOTE_MAX_CONTENT_WIDTH_PX.saturating_add(explorer_width) <= page_width
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ExplorerReflowKey {
+    page_width: u32,
+    width: u32,
+    preferred_visible: bool,
+}
+
 #[derive(Clone, Copy, PartialEq)]
 pub struct ExplorerPane {
     pub visible: Signal<bool>,
@@ -3806,7 +3813,7 @@ pub struct ExplorerPane {
     pub page_width: Signal<u32>,
     pub client_id: Signal<u64>,
     pub request_id: Signal<u64>,
-    pub reflowed_at: Signal<u32>,
+    pub reflowed_at: Signal<Option<ExplorerReflowKey>>,
 }
 
 impl ExplorerPane {
@@ -3814,13 +3821,21 @@ impl ExplorerPane {
         explorer_has_room((self.page_width)(), (self.width)())
     }
 
+    fn reflow_key(self) -> ExplorerReflowKey {
+        ExplorerReflowKey {
+            page_width: (self.page_width)(),
+            width: (self.width)(),
+            preferred_visible: (self.preferred_visible)(),
+        }
+    }
+
     fn sync(mut self) {
-        let page_width = (self.page_width)();
-        if page_width == 0 || (self.reflowed_at)() == page_width {
+        let key = self.reflow_key();
+        if key.page_width == 0 || (self.reflowed_at)() == Some(key) {
             return;
         }
-        self.reflowed_at.set(page_width);
-        let next = (self.preferred_visible)() && self.has_room();
+        self.reflowed_at.set(Some(key));
+        let next = key.preferred_visible && self.has_room();
         if (self.visible)() != next {
             self.visible.set(next);
         }
@@ -3831,7 +3846,7 @@ impl ExplorerPane {
         self.request_id.set(request_id);
         self.preferred_visible.set(next);
         self.visible.set(next);
-        self.reflowed_at.set((self.page_width)());
+        self.reflowed_at.set(Some(self.reflow_key()));
         let _ = send(&ExplorerPanelSetVisible {
             visible: next,
             client_id: (self.client_id)(),

--- a/crates/page/vmux_editor/src/page.rs
+++ b/crates/page/vmux_editor/src/page.rs
@@ -127,6 +127,7 @@ pub fn Page() -> Element {
     let mut explorer_resizing = use_signal(|| false);
     let explorer_client_id = use_signal(explorer_client_id);
     let explorer_request_id = use_signal(|| 0u64);
+    let explorer_reflowed_at = use_signal(|| 0u32);
     let explorer = ExplorerPane {
         visible: explorer_visible,
         preferred_visible: explorer_preferred_visible,
@@ -134,6 +135,7 @@ pub fn Page() -> Element {
         page_width,
         client_id: explorer_client_id,
         request_id: explorer_request_id,
+        reflowed_at: explorer_reflowed_at,
     };
     let mut tidy_prompt = use_signal(|| Option::<u32>::None);
     let mut doc_title = use_signal(String::new);
@@ -3804,6 +3806,7 @@ pub struct ExplorerPane {
     pub page_width: Signal<u32>,
     pub client_id: Signal<u64>,
     pub request_id: Signal<u64>,
+    pub reflowed_at: Signal<u32>,
 }
 
 impl ExplorerPane {
@@ -3812,9 +3815,11 @@ impl ExplorerPane {
     }
 
     fn sync(mut self) {
-        if (self.page_width)() == 0 {
+        let page_width = (self.page_width)();
+        if page_width == 0 || (self.reflowed_at)() == page_width {
             return;
         }
+        self.reflowed_at.set(page_width);
         let next = (self.preferred_visible)() && self.has_room();
         if (self.visible)() != next {
             self.visible.set(next);
@@ -3825,7 +3830,8 @@ impl ExplorerPane {
         let request_id = (self.request_id)().wrapping_add(1);
         self.request_id.set(request_id);
         self.preferred_visible.set(next);
-        self.visible.set(next && self.has_room());
+        self.visible.set(next);
+        self.reflowed_at.set((self.page_width)());
         let _ = send(&ExplorerPanelSetVisible {
             visible: next,
             client_id: (self.client_id)(),

--- a/crates/page/vmux_terminal/src/host/plugin.rs
+++ b/crates/page/vmux_terminal/src/host/plugin.rs
@@ -749,6 +749,7 @@ fn new_terminal_bundle_with_cwd_and_shell(
             },
             WebviewWindowed,
             vmux_core::host::page::HostsPage,
+            vmux_core::host::page::BindsEditingChords,
         ),
         (
             WebviewSize(Vec2::new(1280.0, 720.0)),
@@ -837,6 +838,7 @@ pub fn reattach_terminal_bundle(process_id: ProcessId) -> impl Bundle {
             },
             WebviewWindowed,
             vmux_core::host::page::HostsPage,
+            vmux_core::host::page::BindsEditingChords,
         ),
         (
             WebviewSize(Vec2::new(1280.0, 720.0)),

--- a/crates/vmux_core/src/host/page.rs
+++ b/crates/vmux_core/src/host/page.rs
@@ -36,6 +36,9 @@ pub struct PageManifest {
 pub struct HostsPage;
 
 #[derive(Component, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BindsEditingChords;
+
+#[derive(Component, Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PrewarmPage {
     pub host: &'static str,
     pub url: &'static str,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -263,6 +263,25 @@ the app's bus. Nothing about a native page's messages touches CEF — wry carrie
 end — but the channel they land in is registered by a CEF plugin, so a wry page will not
 build until that plugin has. The transport moved and the channel types did not.
 
+### Who owns ⌘V
+
+macOS hands a menu key equivalent to the menu **before** the key window's responder chain
+sees a keyDown. So while the Edit menu's Paste item is enabled, no page can observe ⌘V as a
+keystroke — the menu has already eaten it and dispatched `paste:` down the responder chain,
+where the WKWebView answers with its own text editing.
+
+That is what most pages want. Two do not: the terminal forwards the chord to a pty, and the
+editor binds all five of ⌘C/⌘X/⌘V/⌘Z/⌘A to its own keymap, where the menu's undo would
+rewind the wrong buffer. They can only see the raw keyDown if the menu item is disabled
+while they hold focus.
+
+A pane says which it is by carrying `BindsEditingChords`, and `sync_edit_menu_items` greys
+the Edit menu for exactly those panes. The declaration is on the pane, not in the desktop
+crate, because the hosting mechanism cannot answer the question: the composer and the editor
+are both native panes, so anything keyed on `HostFocusIntent::NativePane` alone gives one
+answer to two pages that want opposite things. Absence of the marker means platform text
+editing, which is the default a new page wants.
+
 ---
 
 ## Pages, and the trust boundary


### PR DESCRIPTION
Seven fixes found by using the app. All verified by hand in a local build.

## The regression v0.0.31 shipped

⌘V/⌘C/⌘X/⌘Z/⌘A did nothing in the agent chat composer — the whole Edit menu greyed out while it had focus.

macOS hands a menu key equivalent to the menu *before* the key window's responder chain sees a keyDown, so the item has to be disabled for a pane that answers the chord itself. #412 keyed that on `HostFocusIntent::NativePane` — the hosting mechanism. The composer and the editor are both native panes and want opposite things, so one of them was always going to be wrong.

A pane now carries `BindsEditingChords` when it binds the chords, and the gate reads that. Absence means the platform's text editing, which is what a new page wants and what the composer needed. The terminal and the editor are the only two that opt in. The *why* is in `docs/architecture.md` under "Who owns ⌘V", since the code may not carry comments.

## The caret

Three vim commands left the caret one short of the end of a line: `a`, `A` and `I` emitted their motion before `SetMode(Insert)`, so `place_caret` clamped the target under normal-mode rules — where the caret may not sit past the last character.

Pasting had the same symptom from a different cause. ⌘V and `p` both produced `EditCommand::Put`, so `apply_put` had to infer which one it was serving from the register's kind, and got it wrong whenever they disagreed: after a `yy` it pasted a whole line and parked the caret at its first non-blank. There is no second paste to write — `insert_text` already replaces the selection, inserts at the caret and leaves the caret after the text — so ⌘V is now a host-fulfilled `Paste` that calls it. `Put` keeps pure vim semantics.

## What a scroll costs

Scrolling stuttered in an 830-line file, which is far too small for that.

`emit_cursor` runs on every caret move and called `word_occurrences`, which materialises the whole rope as a `String`, expands it to a `Vec<char>` and runs a naive O(n·m) scan — then discards every hit outside the visible band. The output was windowed; the scan never was. It now scans only the band, and the search match set is cached against the buffer revision and the pattern, so a scroll reuses it. `emit_window` also asked the highlight cache one line at a time, rebuilding a syntect `Highlighter` per line when scrolling into fresh territory.

Holding Ctrl-E or Ctrl-Y moved half as far as holding j or k — `accelerate_repeated_navigation` doubles a motion while a key repeats, and `ScrollViewport` was not in the list.

## Two more

A cold expand in the file tree paid a full round trip. The next level now starts loading as soon as a directory's own listing arrives, bounded to one level — a warmed directory does not warm its children, or opening a repo would walk the whole tree.

The file tree would not open at all below 1008px: `has_room` measured the pane against `NOTE_MAX_CONTENT_WIDTH_PX`, the width a markdown column is allowed to *grow* to, and applied it to the user's own press. An explicit press now opens the panel whatever the width.

## Verification

`cargo test` green across the workspace; the pre-push gate (workspace fmt, clippy `-D warnings`, tests) green. Each fix confirmed in a local build: composer paste works and terminal/editor keep their own chords; `A` and `a` append at end of line; ⌘V after `yy` behaves like a paste and `p` still behaves like `p`; `{`/`}`/Ctrl-E/Y scroll without stutter and at j/k speed; a first folder expand is instant; the tree opens in a narrow pane.

New tests fail under the bug and pass after — checked by reverting each fix in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable paste support across editor keymaps, including macOS Command+V.
  * Improved search performance with cached matches and more efficient visible-line highlighting.
  * Added accelerated repeated scrolling and faster, bounded explorer loading.
  * Improved editor insert-mode commands and paste undo behavior.

* **Bug Fixes**
  * macOS Edit menu actions now correctly reflect whether the focused pane handles editing shortcuts.
  * Explorer reflow and visibility behavior is more consistent.

* **Documentation**
  * Documented macOS editing shortcut ownership between native panes and platform text editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->