### PR TITLE
chore(release): v0.0.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10095,7 +10095,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "base64 0.22.1",
  "bevy",
@@ -10144,7 +10144,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_browser"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -10195,7 +10195,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_chat"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -10215,7 +10215,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -10230,7 +10230,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_client"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "chrono",
  "libc",
@@ -10245,7 +10245,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_clipboard"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
@@ -10255,7 +10255,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10277,7 +10277,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command_mcp"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "serde_json",
  "vmux_command",
@@ -10286,7 +10286,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10311,7 +10311,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10380,7 +10380,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_editor"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -10425,7 +10425,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_flex"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "bevy",
  "taffy",
@@ -10433,7 +10433,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_git"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10453,7 +10453,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10472,7 +10472,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_knowledge"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10490,7 +10490,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -10524,7 +10524,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "muda 0.19.2",
  "proc-macro2",
@@ -10534,7 +10534,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -10548,7 +10548,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mobile"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -10584,7 +10584,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_native"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "base64 0.22.1",
  "dioxus",
@@ -10605,7 +10605,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_profile"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "chrono",
  "libc",
@@ -10622,7 +10622,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_remote"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "bytes",
  "quinn",
@@ -10639,7 +10639,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "agent-client-protocol",
  "alacritty_terminal",
@@ -10682,7 +10682,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_session"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -10693,7 +10693,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10715,7 +10715,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10741,7 +10741,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_start"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "bevy",
  "bevy_app",
@@ -10765,7 +10765,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_team"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "bevy",
  "bevy_app",
@@ -10788,7 +10788,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10818,7 +10818,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "dioxus",
  "dioxus-primitives",
@@ -10836,7 +10836,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_wire"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "bevy_ecs",
  "bevy_reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/app/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.31"
+version = "0.0.32"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "GPL-3.0-or-later"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.31"
-  sha256 "a191bc1fd233eef4e2c67ec2a57ec28c0d3f1237abbf1fe9d17d560eff5b8605"
+  version "0.0.32"
+  sha256 "280a18892e4f3b625869273aac071fc79fe2813128ee329181fb686cd82ff8aa"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.31/Vmux_0.0.31_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.32/Vmux_0.0.32_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai/"

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.31",
-  "pub_date": "2026-08-26T09:43:00Z",
+  "version": "v0.0.32",
+  "pub_date": "2026-08-27T17:55:18Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.31/Vmux-v0.0.31-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzR1c1Frbnczd0ZoYzArSGJ2NHpCY2l1cTFwOWI3UnFrdTZzYTNVbGtCaWE3NEtOUVBZMlVFa1EyN1ZycXhKQWlFNTRncEFVekJUTGcyOFRWU3BESGc4PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NzM3Mzc3CWZpbGU6Vm11eC12MC4wLjMxLWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKZ1d2S2N0MGR0OXJha3V2YnpObXN3T0xwcStiVUFsQno0NmMySkpBcWtNNnUwakJPbGozbzRycmJiZ1ZJOGZwMGg1Y0FqMWQ5WWRobHZnQmJlTmVqRFE9PQo=",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.32/Vmux-v0.0.32-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzdRVUpEU1ZSV3BXdUtHWEx3d2dhdzluWWo0UTlwZzh5WjYxbXlEb1JWOGVpKzA3YldydFBpS0ZQRE96OEp0Unl6T2lqQ2l4SnVSQmJyM3VvWndpc2dFPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3ODUzMzE2CWZpbGU6Vm11eC12MC4wLjMyLWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKZ0cxSlB3UGJUeUFQZ0dDUmFqZnZVYUpRMTRqZlR3NnZDa1hZbWFiNC9MdE1wa1NRZVZ4L2FtdnpNMjhDZFIrMGh6UXVPMnVTQ0xFaEpGMHhqT0xFQ1E9PQo=",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.31/Vmux_0.0.31_aarch64.dmg",
-      "filename": "Vmux_0.0.31_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.32/Vmux_0.0.32_aarch64.dmg",
+      "filename": "Vmux_0.0.32_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
Patch release. Bumps workspace version 0.0.31 -> 0.0.32. Releases on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.0.32.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->