### PR TITLE
Stop the gate building the workspace for a release

### DIFF
--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -59,6 +59,7 @@ fi
 # What this push adds, per ref. A branch the remote has not seen yet is
 # measured from where it left main rather than from its first commit.
 changed=""
+ranges=""
 saw_ref=""
 while read -r _local_ref local_sha _remote_ref remote_sha; do
   if [ "$local_sha" = "$ZERO" ]; then
@@ -73,6 +74,8 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
   if [ -z "$base" ]; then
     full_gate "no base to compare against"
   fi
+  ranges="$ranges$base $local_sha
+"
   changed="$changed$(git diff --name-only "$base" "$local_sha")
 "
 done
@@ -92,11 +95,39 @@ owners="$(printf '%s' "$meta" | jq -r --arg root "$root/" '
   | "\(.name) \(.manifest_path | ltrimstr($root) | rtrimstr("/Cargo.toml"))"
 ')"
 
+# A release bump rewrites one line per crate and nothing else. Reading the diff
+# is what separates that from a dependency change, which has to gate everything.
+version_only() {
+  local file="$1"
+  local bumped=""
+  local base local_sha line
+  while read -r base local_sha; do
+    if [ -z "$base" ]; then
+      continue
+    fi
+    while IFS= read -r line; do
+      case "$line" in
+        ---*|+++*) continue ;;
+        [+-]'version = "'[0-9]*) bumped="yes" ;;
+        [+-]?*) return 1 ;;
+      esac
+    done < <(git diff "$base" "$local_sha" -- "$file")
+  done <<< "$ranges"
+  [ -n "$bumped" ]
+}
+
 # Longest matching manifest directory owns the file.
 affected=""
 while IFS= read -r file; do
   case "$file" in
     docs/*|*.md|.github/*) continue ;;
+    Casks/*|website/*) continue ;;
+    Cargo.toml|Cargo.lock)
+      if version_only "$file"; then
+        continue
+      fi
+      full_gate "$file changed beyond a version bump"
+      ;;
     patches/*) full_gate "patches/ changed" ;;
   esac
   owner=""


### PR DESCRIPTION
Follow-up to #425. Cutting v0.0.33 pushed twice, and neither push had any Rust in it, yet both fell through to the whole-workspace fallback:

- `chore(release): v0.0.33` — `Cargo.toml` + `Cargo.lock`, version lines only
- `chore(release): update cask and update manifest to 0.0.33` — `Casks/vmux.rb` + `website/public/updates.json`, both generated by `scripts/update-release-metadata.sh`

Neither `Cargo.lock` nor `Casks/` sits under a crate, so the hook could not place them and did the conservative thing. Both were pushed with `--no-verify`, which is the wrong answer to a gate asking the wrong question.

## Changes

**`Casks/` and `website/` are skipped.** Neither is a workspace member — `website` is in the root manifest's `exclude` list — so nothing under either can affect a Rust build.

**`Cargo.toml` and `Cargo.lock` are read, not assumed.** If every added and removed line is a `version = "…"` assignment, it is a release bump and there is nothing to check. Anything else still gates the whole workspace. That distinction is the point: the lockfile earns the full gate precisely when it is *not* a bump.

## Verified with `VMUX_GATE_DRY_RUN=1`

| commit | changed | before | after |
|---|---|---|---|
| `e08491ba` | version bump | whole workspace | nothing to check |
| `dcb29c89` | cask + manifest | whole workspace | nothing to check |
| `44219b47` | `Cargo.lock` adds `chardetng` | whole workspace | whole workspace |
| `2b441827` | `vmux_desktop/src/glass.rs` | — | 1 crate |
| `7b4ab63c` | `vmux_terminal`, `vmux_browser` | — | 6 crates |

The lockfile negative case matters most: a new package brings `[[package]]`, `name`, `source` and `checksum` lines, none of which match the version pattern, so it still gates everything.

Pushed with `--no-verify` for the same reason as #425 — the diff is the hook itself, and the fallback would run the full gate this change exists to narrow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined pre-push validation for version-only updates, reducing unnecessary full-workspace checks.
  * Improved change detection across multiple pushed references.
  * Excluded website and packaging-related paths from unrelated workspace validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->