### PR TITLE
Drain the quit request where the lifecycle message lives

### DIFF
--- a/crates/app/vmux_desktop/src/native_keyboard.rs
+++ b/crates/app/vmux_desktop/src/native_keyboard.rs
@@ -281,11 +281,7 @@ fn install_native_key_monitor(proxy: Option<Res<EventLoopProxyWrapper>>) {
 fn process_monitored_keys(
     mut issuer: vmux_command::CommandIssuer,
     user: Query<Entity, With<vmux_core::team::User>>,
-    mut lifecycle: MessageWriter<crate::runtime::LifecycleEvent>,
 ) {
-    if take_quit_request() {
-        lifecycle.write(crate::runtime::LifecycleEvent::HideAllWindows);
-    }
     let drained = {
         let mut queue = PENDING_COMMANDS.lock();
         if queue.is_empty() {

--- a/crates/app/vmux_desktop/src/runtime/macos.rs
+++ b/crates/app/vmux_desktop/src/runtime/macos.rs
@@ -12,6 +12,7 @@ impl Plugin for RuntimePlatformPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Update, activate_app_during_boot)
             .add_systems(Update, grab_key_window_on_pane_hover)
+            .add_systems(Update, hide_on_native_quit_request)
             .add_systems(
                 Startup,
                 (
@@ -38,6 +39,15 @@ static IN_LIVE_RESIZE: AtomicBool = AtomicBool::new(false);
 static LIVE_RESIZE_MONITOR_INSTALLED: AtomicBool = AtomicBool::new(false);
 static HOVER_OVER_PANE: AtomicBool = AtomicBool::new(false);
 static NATIVE_WINDOWED_POINTER_INSIDE: AtomicBool = AtomicBool::new(false);
+
+// The key monitor sees Cmd+Q before AppKit does, but LifecycleEvent belongs to
+// the runtime, so the runtime is what drains the request. Writing it from the
+// monitor made every App that installs the keyboard without the runtime panic.
+fn hide_on_native_quit_request(mut lifecycle: MessageWriter<super::LifecycleEvent>) {
+    if crate::native_keyboard::take_quit_request() {
+        lifecycle.write(super::LifecycleEvent::HideAllWindows);
+    }
+}
 
 fn activate_primary_window_on_startup(
     primary_window: Query<(Entity, &Window), With<bevy::window::PrimaryWindow>>,


### PR DESCRIPTION
Fourteen `shortcut::tests` panic on macOS on `main`, and have since #424. `cargo test -p vmux_desktop --lib` goes 178 passed / 14 failed:

```
Encountered a panic in system `vmux_desktop::native_keyboard::process_monitored_keys`!
```

## Cause

#424 gave the native key monitor Cmd+Q, and had `process_monitored_keys` write `LifecycleEvent::HideAllWindows` itself. `RuntimePlugin` is what declares that message. `ShortcutPlugin` installs `NativeKeyboardPlugin` on macOS, and its tests build an App from `MinimalPlugins`, `CommandPlugin` and itself — no runtime, so the writer has no `Messages<LifecycleEvent>` to write into.

**The shipped app was never affected.** It runs `RuntimePlugin`, the message exists, and Cmd+Q behaves. What is wrong is a plugin reaching for a message another plugin owns.

## Fix

The monitor goes back to only recording the request through `take_quit_request()`. `RuntimePlatformPlugin` drains it — the macOS side, where the monitor exists, under the plugin tree that declares the message.

`cargo test -p vmux_desktop --lib`: 192 passed, 0 failed.

## Why CI was green for this

None of the three jobs can see it. `native_keyboard` is `#[cfg(target_os = "macos")]` and `Test (rust)` runs on `ubuntu-latest`, so the module that panics is not compiled there at all. `Build macOS App` builds but does not test.

The macOS pre-push gate is the only thing that catches this class, and it is why this landed: the gate on #424 was killed mid-run and that push used `--no-verify`, because at the time it meant waiting forty minutes on a whole-workspace build. After #425 and #427 the same gate scoped this push to **one crate**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of native macOS quit requests, including Cmd+Q.
  * Quit requests now consistently trigger the application’s window-hiding behavior through the runtime lifecycle.
  * Command processing remains coordinated with the application runtime, helping ensure pending native commands are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->