### PR TITLE
chore(release): v0.0.34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10144,7 +10144,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmux_agent"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "base64 0.22.1",
  "bevy",
@@ -10193,7 +10193,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_browser"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -10244,7 +10244,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_chat"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -10264,7 +10264,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_cli"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -10279,7 +10279,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_client"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "chrono",
  "libc",
@@ -10294,7 +10294,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_clipboard"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
@@ -10304,7 +10304,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10327,7 +10327,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_command_mcp"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "serde_json",
  "vmux_command",
@@ -10336,7 +10336,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_core"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10361,7 +10361,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_desktop"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10430,7 +10430,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_editor"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -10479,7 +10479,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_flex"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "bevy",
  "taffy",
@@ -10487,7 +10487,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_git"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10507,7 +10507,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_history"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10526,7 +10526,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_knowledge"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10544,7 +10544,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_layout"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "bevy",
  "bevy_asset",
@@ -10578,7 +10578,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_macro"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "muda 0.19.2",
  "proc-macro2",
@@ -10588,7 +10588,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mcp"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -10602,7 +10602,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_mobile"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -10638,7 +10638,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_native"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "base64 0.22.1",
  "dioxus",
@@ -10661,7 +10661,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_profile"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "chrono",
  "libc",
@@ -10678,7 +10678,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_remote"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "bytes",
  "quinn",
@@ -10695,7 +10695,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_service"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "agent-client-protocol",
  "alacritty_terminal",
@@ -10738,7 +10738,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_session"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -10749,7 +10749,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_setting"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10771,7 +10771,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_space"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10798,7 +10798,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_start"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "bevy",
  "bevy_app",
@@ -10822,7 +10822,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_team"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "bevy",
  "bevy_app",
@@ -10845,7 +10845,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_terminal"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -10875,7 +10875,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_ui"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "dioxus",
  "dioxus-primitives",
@@ -10893,7 +10893,7 @@ dependencies = [
 
 [[package]]
 name = "vmux_wire"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "bevy_ecs",
  "bevy_reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/app/vmux_desktop"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.33"
+version = "0.0.34"
 edition = "2024"
 description = "AI-native workspace combining browser and terminal panes"
 license = "GPL-3.0-or-later"

--- a/Casks/vmux.rb
+++ b/Casks/vmux.rb
@@ -1,8 +1,8 @@
 cask "vmux" do
-  version "0.0.33"
-  sha256 "914edef35cbb6262ab9888879f9d317cfe3ad4a3b509bf2091f34c826c9042a9"
+  version "0.0.34"
+  sha256 "d00702c6521e515b8ffc89678296a4f19d7448b6270394d0dcf8ec781a35936e"
 
-  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.33/Vmux_0.0.33_aarch64.dmg"
+  url "https://github.com/vmux-ai/vmux/releases/download/v0.0.34/Vmux_0.0.34_aarch64.dmg"
   name "Vmux"
   desc "AI-native workspace combining browser and terminal panes"
   homepage "https://vmux.ai/"

--- a/website/public/updates.json
+++ b/website/public/updates.json
@@ -1,17 +1,17 @@
 {
-  "version": "v0.0.33",
-  "pub_date": "2026-09-02T13:13:15Z",
+  "version": "v0.0.34",
+  "pub_date": "2026-09-07T20:20:29Z",
   "platforms": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.33/Vmux-v0.0.33-aarch64-apple-darwin.app.tar.gz",
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HT3pZalZCMndJbGZ5WnQ0elFOdTZ2ekI4UWI4V0ZkbEZUZmwxdllpMjRtMzhBVUtOSWV3QmNqY0d1bHZPcy9EUGxmRDFSV3VBSzJGNjRuRzlZNlc1eVFRPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg4MzU0NzkyCWZpbGU6Vm11eC12MC4wLjMzLWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKSjhNTjJ6SmdlSUFLOUtCUkxzWWdCSmpVaHNxTUF2UmZQNkc2YmJOSU80M3gvRTBoWUJtbWlFSlV6WnVodU4rUHkzdjJtbVRFa0loQlRZVFdoQUJoQnc9PQo=",
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.34/Vmux-v0.0.34-aarch64-apple-darwin.app.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUN1lFWllXRE5HTzE4MG1CNjhNQkJmUHhvRnc0d1RVM1FQSzlYcmZMaVJaQnBKMTRyc2hTZHZrUXZtSVRZTnR2d1dlai93L0tUc0RudDNBVHE3UFZ6Q3hoV2pHcnJpa1E0PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg4ODEyNDI3CWZpbGU6Vm11eC12MC4wLjM0LWFhcmNoNjQtYXBwbGUtZGFyd2luLmFwcC50YXIuZ3oKNFJOWUZpU0hBVStFbzVTYW5VZFQ2eU8wdCtocE1TSVlrQjBKT0duR3hFK3JUY0ZTdTFFdHdEZjU5SklDK1J4Sk5HMGFTUE9tMXZncmFkMWNGdEV4RFE9PQo=",
       "format": "app"
     }
   },
   "downloads": {
     "macos-aarch64": {
-      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.33/Vmux_0.0.33_aarch64.dmg",
-      "filename": "Vmux_0.0.33_aarch64.dmg"
+      "url": "https://github.com/vmux-ai/vmux/releases/download/v0.0.34/Vmux_0.0.34_aarch64.dmg",
+      "filename": "Vmux_0.0.34_aarch64.dmg"
     }
   }
 }


### PR DESCRIPTION
Patch release. Bumps workspace version 0.0.33 -> 0.0.34. Releases on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workspace package version from 0.0.33 to 0.0.34.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->