### PR TITLE
feat(chat): rebrand agent conversations as sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10248,6 +10248,7 @@ version = "0.0.34"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
+ "chrono",
  "dioxus",
  "dioxus-primitives",
  "pulldown-cmark",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10248,7 +10248,6 @@ version = "0.0.34"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
- "chrono",
  "dioxus",
  "dioxus-primitives",
  "pulldown-cmark",

--- a/crates/app/vmux_desktop/src/persistence.rs
+++ b/crates/app/vmux_desktop/src/persistence.rs
@@ -359,16 +359,21 @@ fn space_is_stale(body: &str) -> bool {
 }
 
 fn space_contains_stale_agent_url(body: &str) -> bool {
-    body.split("vmux://agent/").skip(1).any(|tail| {
-        let suffix = tail.split('"').next().unwrap_or_default();
-        let url = format!("vmux://agent/{suffix}");
-        is_stale_agent_url(&url)
-    })
+    for prefix in ["vmux://sessions/", "vmux://agent/"] {
+        if body.split(prefix).skip(1).any(|tail| {
+            let suffix = tail.split('"').next().unwrap_or_default();
+            let url = format!("{prefix}{suffix}");
+            is_stale_agent_url(&url)
+        }) {
+            return true;
+        }
+    }
+    false
 }
 
 fn is_stale_agent_url(url: &str) -> bool {
     let normalized = url.trim_end_matches('/');
-    if normalized == "vmux://agent" {
+    if matches!(normalized, "vmux://sessions" | "vmux://agent") {
         return false;
     }
     if is_bare_agent_kind_url(normalized) {
@@ -1561,31 +1566,38 @@ mod tests {
     #[test]
     fn current_page_agent_url_does_not_mark_space_stale() {
         assert!(!space_contains_stale_agent_url(
-            r#"url: "vmux://agent/echo/echo/edb5335d-20cf-4c3d-9433-8619c405a0f2""#
+            r#"url: "vmux://sessions/echo/echo/edb5335d-20cf-4c3d-9433-8619c405a0f2""#
+        ));
+    }
+
+    #[test]
+    fn legacy_agent_url_does_not_mark_space_stale() {
+        assert!(!space_contains_stale_agent_url(
+            r#"url: "vmux://agent/claude/session-id""#
         ));
     }
 
     #[test]
     fn known_cli_agent_url_does_not_mark_space_stale() {
         assert!(!space_contains_stale_agent_url(
-            r#"url: "vmux://agent/codex/edb5335d-20cf-4c3d-9433-8619c405a0f2""#
+            r#"url: "vmux://sessions/codex/edb5335d-20cf-4c3d-9433-8619c405a0f2""#
         ));
     }
 
     #[test]
     fn bare_cli_agent_url_does_not_mark_space_stale() {
         assert!(!space_contains_stale_agent_url(
-            r#"url: "vmux://agent/vibe/""#
+            r#"url: "vmux://sessions/vibe/""#
         ));
     }
 
     #[test]
     fn malformed_agent_url_marks_space_stale() {
         assert!(!space_contains_stale_agent_url(
-            r#"url: "vmux://agent/bogus/edb5335d-20cf-4c3d-9433-8619c405a0f2""#
+            r#"url: "vmux://sessions/bogus/edb5335d-20cf-4c3d-9433-8619c405a0f2""#
         ));
         assert!(space_contains_stale_agent_url(
-            r#"url: "vmux://agent/a/b/c/d/e""#
+            r#"url: "vmux://sessions/a/b/c/d/e""#
         ));
     }
 
@@ -1597,7 +1609,7 @@ mod tests {
         let path = space_dir.join("space.ron");
         std::fs::write(
             &path,
-            r#"url: "vmux://agent/echo/echo/edb5335d-20cf-4c3d-9433-8619c405a0f2""#,
+            r#"url: "vmux://sessions/echo/echo/edb5335d-20cf-4c3d-9433-8619c405a0f2""#,
         )
         .expect("write space");
 

--- a/crates/page/vmux_agent/src/host/agents.rs
+++ b/crates/page/vmux_agent/src/host/agents.rs
@@ -156,7 +156,7 @@ fn catalog_snapshot(
                 icon: a.icon.clone().unwrap_or_default(),
                 description: a.description.clone().unwrap_or_default(),
                 source: "acp".to_string(),
-                launch_url: format!("vmux://agent/{}", a.id),
+                launch_url: format!("vmux://sessions/{}", a.id),
                 uninstallable: true,
                 runtime: match a.preferred_runtime() {
                     Runtime::None => "native",
@@ -419,7 +419,7 @@ mod tests {
         assert_eq!(rows.len(), 3);
         let codex = rows.iter().find(|row| row.id == "cli:codex").unwrap();
         assert_eq!(codex.source, "cli");
-        assert_eq!(codex.launch_url, "vmux://agent/codex/cli");
+        assert_eq!(codex.launch_url, "vmux://sessions/codex/cli");
         assert_eq!(codex.status, "installed");
         assert!(!codex.uninstallable);
         assert!(

--- a/crates/page/vmux_agent/src/host/attach.rs
+++ b/crates/page/vmux_agent/src/host/attach.rs
@@ -83,7 +83,7 @@ pub(crate) fn attach_page_agent_to_stack_with_webview(
             kind: Some(kind),
         },
     ));
-    let url = format!("vmux://agent/{provider}");
+    let url = format!("vmux://sessions/{provider}");
     if let Some(webview) = webview {
         commands
             .entity(webview)
@@ -142,8 +142,8 @@ pub(crate) fn attach_acp_agent_to_stack_with_webview(
 ) {
     let agent_id = crate::acp_install::agent_url_id(agent_id);
     let url = match resume {
-        Some(acp_sid) => format!("vmux://agent/{agent_id}/{acp_sid}"),
-        None => format!("vmux://agent/{agent_id}"),
+        Some(acp_sid) => format!("vmux://sessions/{agent_id}/{acp_sid}"),
+        None => format!("vmux://sessions/{agent_id}"),
     };
     commands.entity(stack).insert(PageMetadata {
         url: url.clone(),
@@ -532,7 +532,7 @@ mod tests {
             .collect();
         assert_eq!(swaps.len(), 1);
         assert_eq!(swaps[0].stack, stack);
-        assert_eq!(swaps[0].target_url, "vmux://agent/claude/session-7");
+        assert_eq!(swaps[0].target_url, "vmux://sessions/claude/session-7");
         assert_eq!(swaps[0].cwd, PathBuf::from("/workspace/project"));
         assert!(swaps[0].handoff.is_none());
     }

--- a/crates/page/vmux_agent/src/host/chat.rs
+++ b/crates/page/vmux_agent/src/host/chat.rs
@@ -28,15 +28,15 @@ impl Plugin for AgentChatPagePlugin {
             workspace::ChatWorkspacePlugin,
         ))
         .add_plugins(BinEventEmitterPlugin::<(ChatOpenPage,)>::for_hosts(&[
-            "agent", "start",
+            "sessions", "agent", "start",
         ]))
         .add_observer(on_chat_open_page);
     }
 }
 
 pub const PAGE_MANIFEST: vmux_core::page::PageManifest = vmux_core::page::PageManifest {
-    host: "agent",
-    title: "Agent",
+    host: "sessions",
+    title: "Sessions",
     title_message_id: None,
     replaces_command: None,
     keywords: &["ai", "chat", "assistant", "agent"],

--- a/crates/page/vmux_agent/src/host/chat.rs
+++ b/crates/page/vmux_agent/src/host/chat.rs
@@ -12,6 +12,8 @@ use bevy_cef::prelude::{BinEventEmitterPlugin, BinReceive};
 
 use vmux_chat::event::ChatOpenPage;
 
+const CHAT_EVENT_HOSTS: &[&str] = &["sessions", "agent", "start"];
+
 pub struct AgentChatPagePlugin;
 
 impl Plugin for AgentChatPagePlugin {
@@ -27,9 +29,9 @@ impl Plugin for AgentChatPagePlugin {
             transcript::ChatTranscriptPlugin,
             workspace::ChatWorkspacePlugin,
         ))
-        .add_plugins(BinEventEmitterPlugin::<(ChatOpenPage,)>::for_hosts(&[
-            "sessions", "agent", "start",
-        ]))
+        .add_plugins(BinEventEmitterPlugin::<(ChatOpenPage,)>::for_hosts(
+            CHAT_EVENT_HOSTS,
+        ))
         .add_observer(on_chat_open_page);
     }
 }

--- a/crates/page/vmux_agent/src/host/chat/media.rs
+++ b/crates/page/vmux_agent/src/host/chat/media.rs
@@ -19,7 +19,7 @@ impl Plugin for ChatMediaPlugin {
             ChatMediaListRequest,
             ChatAttachPaths,
             ChatAttachmentPreviewRequest,
-        )>::for_hosts(&["agent", "start"]))
+        )>::for_hosts(super::CHAT_EVENT_HOSTS))
             .add_observer(on_chat_pick_files)
             .add_observer(on_chat_paste_media)
             .add_observer(on_chat_media_list_request)

--- a/crates/page/vmux_agent/src/host/chat/model.rs
+++ b/crates/page/vmux_agent/src/host/chat/model.rs
@@ -25,9 +25,9 @@ impl Plugin for ChatModelPlugin {
             .add_message::<ModelSelectRequest>()
             .add_message::<EffortSetRequest>()
             .add_plugins(
-                BinEventEmitterPlugin::<(SelectModel, SetAgentEffort)>::for_hosts(&[
-                    "agent", "start",
-                ]),
+                BinEventEmitterPlugin::<(SelectModel, SetAgentEffort)>::for_hosts(
+                    super::CHAT_EVENT_HOSTS,
+                ),
             )
             .add_plugins(BinEventEmitterPlugin::<(StartSelectModel,)>::for_hosts(&[
                 "start",

--- a/crates/page/vmux_agent/src/host/chat/prompt.rs
+++ b/crates/page/vmux_agent/src/host/chat/prompt.rs
@@ -25,11 +25,11 @@ impl Plugin for ChatPromptPlugin {
             ChatResume,
             ChatClearQueue,
             ChatCancelQueuedPrompt,
-        )>::for_hosts(&["agent", "start"]))
+        )>::for_hosts(super::CHAT_EVENT_HOSTS))
             .add_plugins(
-                BinEventEmitterPlugin::<(ChatApproval, ChatChoiceSelected)>::for_hosts(&[
-                    "agent", "start",
-                ]),
+                BinEventEmitterPlugin::<(ChatApproval, ChatChoiceSelected)>::for_hosts(
+                    super::CHAT_EVENT_HOSTS,
+                ),
             )
             .add_observer(on_chat_submit)
             .add_observer(on_chat_cancel)

--- a/crates/page/vmux_agent/src/host/chat/resume.rs
+++ b/crates/page/vmux_agent/src/host/chat/resume.rs
@@ -552,7 +552,7 @@ mod tests {
     fn foreign_resume_keeps_active_acp_agent_fresh() {
         assert_eq!(
             foreign_handoff_target("claude", Some(AgentKind::Claude), AgentKind::Codex,),
-            Some("vmux://agent/claude".to_string())
+            Some("vmux://sessions/claude".to_string())
         );
         assert_eq!(
             foreign_handoff_target("claude", Some(AgentKind::Claude), AgentKind::Claude,),
@@ -560,7 +560,7 @@ mod tests {
         );
         assert_eq!(
             foreign_handoff_target("custom-acp", None, AgentKind::Codex),
-            Some("vmux://agent/custom-acp".to_string())
+            Some("vmux://sessions/custom-acp".to_string())
         );
     }
 
@@ -600,7 +600,7 @@ mod tests {
             assert_eq!(
                 got,
                 Some((
-                    format!("vmux://agent/{cli_segment}/cli/sid-9"),
+                    format!("vmux://sessions/{cli_segment}/cli/sid-9"),
                     std::path::PathBuf::from("/w")
                 ))
             );

--- a/crates/page/vmux_agent/src/host/chat/resume.rs
+++ b/crates/page/vmux_agent/src/host/chat/resume.rs
@@ -24,7 +24,7 @@ impl Plugin for ChatResumePlugin {
             ResumeSession,
             RuntimeSwitchRequest,
             PromptHistoryRequest,
-        )>::for_hosts(&["agent", "start"]))
+        )>::for_hosts(super::CHAT_EVENT_HOSTS))
             .init_resource::<ResumableScan>()
             .add_observer(on_resume_list_request)
             .add_observer(on_resume_session)

--- a/crates/page/vmux_agent/src/host/chat/transcript.rs
+++ b/crates/page/vmux_agent/src/host/chat/transcript.rs
@@ -22,7 +22,7 @@ pub(super) struct ChatTranscriptPlugin;
 impl Plugin for ChatTranscriptPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(BinEventEmitterPlugin::<(ChatHistoryRequest,)>::for_hosts(
-            &["agent", "start"],
+            super::CHAT_EVENT_HOSTS,
         ))
         .add_observer(on_chat_history_request)
         .add_observer(reset_chat_synced_on_page_ready)

--- a/crates/page/vmux_agent/src/host/chat/transcript.rs
+++ b/crates/page/vmux_agent/src/host/chat/transcript.rs
@@ -12,7 +12,7 @@ use vmux_chat::event::{
     CHAT_SNAPSHOT_EVENT, ChatHistoryPage, ChatHistoryRequest, ChatSnapshot, QueuedPromptSnapshot,
 };
 use vmux_core::PageMetadata;
-use vmux_core::team::Profile;
+use vmux_core::team::{Profile, User};
 use vmux_service::chat::{group_turns_before, group_turns_tail, grouped_item_count};
 use vmux_session::AcpSession;
 use vmux_session::{AgentConversationTitle, AgentMessages, PromptQueue};
@@ -73,18 +73,24 @@ fn push_chat_to_page(
     children: Query<&Children>,
     chat_views: Query<(), With<AgentChatView>>,
     choices: Query<&crate::host::PendingAgentChoice>,
+    user_profiles: Query<Ref<Profile>, With<User>>,
     browsers: NonSend<Browsers>,
     mut last_push: Local<std::collections::HashMap<Entity, std::time::Instant>>,
     mut owed: Local<std::collections::HashSet<Entity>>,
     mut removed_messages: RemovedComponents<AgentMessages>,
     mut commands: Commands,
 ) {
+    let user_profile = user_profiles.single().ok();
+    let user_moved = user_profile
+        .as_ref()
+        .is_some_and(|profile| profile.is_changed());
     for stack in removed_messages.read() {
         last_push.remove(&stack);
         owed.remove(&stack);
     }
     for (stack, messages, state, turn_meta, profile, meta, queue, imported, title) in &sessions {
-        let moved = state.is_changed()
+        let moved = user_moved
+            || state.is_changed()
             || turn_meta.as_ref().is_some_and(|meta| meta.is_changed())
             || profile.as_ref().is_some_and(|profile| profile.is_changed())
             || queue.is_changed()
@@ -126,6 +132,7 @@ fn push_chat_to_page(
             &state,
             turn_meta.as_deref(),
             profile.as_deref(),
+            user_profile.as_deref(),
             meta,
             &queue,
             imported.as_deref(),
@@ -161,6 +168,7 @@ fn snapshot_of(
     state: &AgentRunState,
     turn_meta: Option<&AgentTurnMeta>,
     profile: Option<&Profile>,
+    user_profile: Option<&Profile>,
     meta: Option<&PageMetadata>,
     queue: &PromptQueue,
     imported: Option<&ImportedConversation>,
@@ -200,6 +208,18 @@ fn snapshot_of(
     let (agent_name, accent_color) = profile
         .map(|p| (p.name.clone(), p.avatar.color.clone()))
         .unwrap_or_default();
+    let (user_name, user_initials, user_color) = user_profile
+        .map(|profile| {
+            (
+                profile.name.clone(),
+                profile.avatar.initials.clone(),
+                profile.avatar.color.clone(),
+            )
+        })
+        .unwrap_or_else(|| {
+            let profile = Profile::user();
+            (profile.name, profile.avatar.initials, profile.avatar.color)
+        });
     let agent_icon = meta
         .map(|m| m.icon.favicon_url().to_string())
         .unwrap_or_default();
@@ -218,6 +238,9 @@ fn snapshot_of(
             .unwrap_or_default(),
         agent_icon,
         accent_color,
+        user_name,
+        user_initials,
+        user_color,
         handoff_source: imported
             .map(|imported| imported.source_agent.clone())
             .unwrap_or_default(),
@@ -277,10 +300,12 @@ fn sync_chat_to_ready_views(
     )>,
     acp_sessions: Query<(&AcpSession, Option<&AcpModelState>)>,
     choices: Query<&crate::host::PendingAgentChoice>,
+    user_profiles: Query<&Profile, With<User>>,
     settings: Option<Res<vmux_setting::AppSettings>>,
     browsers: NonSend<Browsers>,
     mut commands: Commands,
 ) {
+    let user_profile = user_profiles.single().ok();
     for webview in &pending {
         let Ok(parent) = child_of.get(webview) else {
             continue;
@@ -302,6 +327,7 @@ fn sync_chat_to_ready_views(
                 state,
                 turn_meta,
                 profile,
+                user_profile,
                 meta,
                 queue,
                 imported,
@@ -461,6 +487,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             &PromptQueue::default(),
             Some(&imported),
             None,
@@ -479,6 +506,7 @@ mod tests {
                 name: "vmux.run".into(),
                 args: serde_json::json!({"command": "echo hi", "focus": true}),
             },
+            None,
             None,
             None,
             None,
@@ -504,6 +532,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             &PromptQueue::default(),
             None,
             Some(&title),
@@ -514,6 +543,27 @@ mod tests {
             snapshot.conversation_title,
             "Refine generated chat summaries"
         );
+    }
+
+    #[test]
+    fn snapshot_uses_the_active_user_profile_avatar() {
+        let profile = Profile::user_named("Personal".into());
+        let snapshot = snapshot_of(
+            &AgentMessages::default(),
+            &AgentRunState::Idle,
+            None,
+            None,
+            Some(&profile),
+            None,
+            &PromptQueue::default(),
+            None,
+            None,
+            None,
+        );
+
+        assert_eq!(snapshot.user_name, "Personal");
+        assert_eq!(snapshot.user_initials, "P");
+        assert_eq!(snapshot.user_color, "#3b82f6");
     }
 
     #[test]

--- a/crates/page/vmux_agent/src/host/chat/workspace.rs
+++ b/crates/page/vmux_agent/src/host/chat/workspace.rs
@@ -19,7 +19,7 @@ impl Plugin for ChatWorkspacePlugin {
             ChatSelectWorkspace,
             ChatBranchesRequest,
             ChatGoToBranch,
-        )>::for_hosts(&["agent", "start"]))
+        )>::for_hosts(super::CHAT_EVENT_HOSTS))
             .add_observer(on_chat_select_workspace)
             .add_observer(on_chat_branches_request)
             .add_observer(on_chat_go_to_branch)

--- a/crates/page/vmux_agent/src/host/client/acp.rs
+++ b/crates/page/vmux_agent/src/host/client/acp.rs
@@ -930,7 +930,7 @@ fn apply_acp_session_created(
             {
                 bevy::log::warn!("acp: failed to persist handoff metadata: {err}");
             }
-            let url = format!("vmux://agent/{}/{}", session.agent_id, ev.acp_session_id);
+            let url = format!("vmux://sessions/{}/{}", session.agent_id, ev.acp_session_id);
             if stack_meta.url != url {
                 stack_meta.url = url.clone();
             }
@@ -1659,7 +1659,7 @@ mod tests {
         app.world_mut()
             .entity_mut(agent)
             .insert(vmux_core::PageMetadata {
-                url: "vmux://agent/claude".into(),
+                url: "vmux://sessions/claude".into(),
                 ..default()
             });
         app.world_mut().write_message(PageAgentAcpTerminalCreated {

--- a/crates/page/vmux_agent/src/host/command_bar.rs
+++ b/crates/page/vmux_agent/src/host/command_bar.rs
@@ -22,7 +22,12 @@ impl Plugin for CommandBarPlugin {
     }
 }
 
-const DEFAULT_AGENT_URLS: [&str; 2] = ["vmux://sessions/", "vmux://sessions"];
+const DEFAULT_AGENT_URLS: [&str; 4] = [
+    "vmux://sessions/",
+    "vmux://sessions",
+    "vmux://agent/",
+    "vmux://agent",
+];
 
 #[derive(Component)]
 struct AgentContribution;
@@ -253,7 +258,7 @@ mod tests {
     }
 
     #[test]
-    fn only_the_bare_agent_url_is_claimed() {
+    fn only_bare_agent_urls_are_claimed() {
         let mut world = World::new();
         for url in DEFAULT_AGENT_URLS {
             world.spawn(ClaimedUrl(url.to_string()));
@@ -264,12 +269,19 @@ mod tests {
                 [
                     contributions.claims_url("vmux://sessions/"),
                     contributions.claims_url("vmux://sessions"),
+                    contributions.claims_url("vmux://agent/"),
+                    contributions.claims_url("vmux://agent"),
                     contributions.claims_url("vmux://sessions/codex"),
                     contributions.claims_url("vmux://sessions/codex/cli"),
+                    contributions.claims_url("vmux://agent/codex"),
+                    contributions.claims_url("vmux://agent/codex/cli"),
                 ]
             })
             .expect("claims_url system runs");
 
-        assert_eq!(claimed, [true, true, false, false]);
+        assert_eq!(
+            claimed,
+            [true, true, true, true, false, false, false, false]
+        );
     }
 }

--- a/crates/page/vmux_agent/src/host/command_bar.rs
+++ b/crates/page/vmux_agent/src/host/command_bar.rs
@@ -22,7 +22,7 @@ impl Plugin for CommandBarPlugin {
     }
 }
 
-const DEFAULT_AGENT_URLS: [&str; 2] = ["vmux://agent/", "vmux://agent"];
+const DEFAULT_AGENT_URLS: [&str; 2] = ["vmux://sessions/", "vmux://sessions"];
 
 #[derive(Component)]
 struct AgentContribution;
@@ -35,7 +35,7 @@ impl AgentContribution {
                 id: agent.id.clone(),
                 rank: 0,
                 page: CommandBarPage {
-                    host: "agent".to_string(),
+                    host: "sessions".to_string(),
                     url: agent.url.clone(),
                     title: agent.name.clone(),
                     keywords: vec![agent.id.clone(), "acp".to_string(), "agent".to_string()],
@@ -54,7 +54,7 @@ impl AgentContribution {
                 id: agent.id.clone(),
                 rank: 0,
                 page: CommandBarPage {
-                    host: "agent".to_string(),
+                    host: "sessions".to_string(),
                     url: agent.url.clone(),
                     title: format!("{} (CLI)", agent.name),
                     keywords: vec![agent.id.clone(), "cli".to_string(), "agent".to_string()],
@@ -196,13 +196,13 @@ mod tests {
             providers: vec![AgentProviderSummary {
                 id: "codex".to_string(),
                 name: "Codex".to_string(),
-                url: "vmux://agent/codex/cli".to_string(),
+                url: "vmux://sessions/codex/cli".to_string(),
                 icon: String::new(),
             }],
             acp: vec![AgentProviderSummary {
                 id: "claude-acp".to_string(),
                 name: "Claude Agent".to_string(),
-                url: "vmux://agent/claude".to_string(),
+                url: "vmux://sessions/claude".to_string(),
                 icon: "https://cdn.example/claude-acp.svg".to_string(),
             }],
             recent: vec![
@@ -219,9 +219,9 @@ mod tests {
         assert_eq!(pages.len(), 2);
         assert_eq!(pages[0].id, "codex");
         assert_eq!(pages[0].rank, 0);
-        assert_eq!(pages[0].page.url, "vmux://agent/codex/cli");
+        assert_eq!(pages[0].page.url, "vmux://sessions/codex/cli");
         assert_eq!(pages[0].page.title, "Codex (CLI)");
-        assert_eq!(pages[0].page.host, "agent");
+        assert_eq!(pages[0].page.host, "sessions");
         assert_eq!(pages[1].rank, 1);
         assert_eq!(pages[1].page.title, "Claude Agent");
         assert!(matches!(
@@ -262,10 +262,10 @@ mod tests {
         let claimed = world
             .run_system_once(|contributions: Contributions| {
                 [
-                    contributions.claims_url("vmux://agent/"),
-                    contributions.claims_url("vmux://agent"),
-                    contributions.claims_url("vmux://agent/codex"),
-                    contributions.claims_url("vmux://agent/codex/cli"),
+                    contributions.claims_url("vmux://sessions/"),
+                    contributions.claims_url("vmux://sessions"),
+                    contributions.claims_url("vmux://sessions/codex"),
+                    contributions.claims_url("vmux://sessions/codex/cli"),
                 ]
             })
             .expect("claims_url system runs");

--- a/crates/page/vmux_agent/src/host/page_open.rs
+++ b/crates/page/vmux_agent/src/host/page_open.rs
@@ -81,21 +81,21 @@ impl AgentChatTarget {
             crate::AgentUrl::Page {
                 provider, model, ..
             } => Some(Self {
-                url: format!("vmux://agent/{provider}"),
+                url: format!("vmux://sessions/{provider}"),
                 title: format!("{provider}/{model}"),
             }),
             crate::AgentUrl::PageDefault => {
                 let provider = crate::providers::resolve_default_app_provider()?;
                 Some(Self {
-                    url: format!("vmux://agent/{}", provider.provider),
+                    url: format!("vmux://sessions/{}", provider.provider),
                     title: format!("{}/{}", provider.provider, provider.default_model),
                 })
             }
             crate::AgentUrl::Acp { id, sid } => {
                 let id = crate::acp_install::agent_url_id(&id);
                 let url = match sid {
-                    Some(sid) => format!("vmux://agent/{id}/{sid}"),
-                    None => format!("vmux://agent/{id}"),
+                    Some(sid) => format!("vmux://sessions/{id}/{sid}"),
+                    None => format!("vmux://sessions/{id}"),
                 };
                 Some(Self {
                     url,
@@ -499,7 +499,7 @@ fn handle_agent_page_open(
         .map(|(entity, task)| (entity, task.clone()))
         .collect();
     for (entity, task) in tasks {
-        if !task.url.starts_with("vmux://agent/") {
+        if !task.url.starts_with("vmux://sessions/") && !task.url.starts_with("vmux://agent/") {
             continue;
         }
         let tab = ancestor_agent_tab(task.stack, &child_of_q, &workspace.tabs);
@@ -1056,7 +1056,7 @@ mod tests {
             .resource_mut::<Messages<vmux_core::agent::SwapStackSession>>()
             .write(vmux_core::agent::SwapStackSession {
                 stack,
-                target_url: "vmux://agent/not-configured/sid-1".to_string(),
+                target_url: "vmux://sessions/not-configured/sid-1".to_string(),
                 cwd: std::path::PathBuf::from("/work"),
                 handoff: None,
             });
@@ -1075,7 +1075,7 @@ mod tests {
             .resource_mut::<Messages<vmux_core::agent::SwapStackSession>>()
             .write(vmux_core::agent::SwapStackSession {
                 stack,
-                target_url: "vmux://agent/claude".to_string(),
+                target_url: "vmux://sessions/claude".to_string(),
                 cwd: std::path::PathBuf::from("/source/work"),
                 handoff: Some(vmux_core::agent::StackSessionHandoff {
                     source_agent: "Codex".into(),
@@ -1118,7 +1118,7 @@ mod tests {
             .resource_mut::<Messages<vmux_core::agent::SwapStackSession>>()
             .write(vmux_core::agent::SwapStackSession {
                 stack,
-                target_url: "vmux://agent/codex/session-2".to_string(),
+                target_url: "vmux://sessions/codex/session-2".to_string(),
                 cwd: std::path::PathBuf::from("/work"),
                 handoff: None,
             });
@@ -1187,7 +1187,7 @@ mod tests {
         app.world_mut().spawn(PageOpenTask {
             id: vmux_core::PageOpenId::new(),
             stack,
-            url: "vmux://agent/vibe/".to_string(),
+            url: "vmux://sessions/vibe/".to_string(),
             request_id: None,
         });
 
@@ -1196,7 +1196,7 @@ mod tests {
 
         assert!(app.world().get_entity(child).is_err());
         let stack_meta = app.world().get::<PageMetadata>(stack).unwrap();
-        assert_eq!(stack_meta.url, "vmux://agent/vibe/setup");
+        assert_eq!(stack_meta.url, "vmux://sessions/vibe/setup");
         assert_eq!(stack_meta.title, "Set up Vibe CLI");
         let mut browsers = app
             .world_mut()
@@ -1208,7 +1208,7 @@ mod tests {
             .collect();
         assert_eq!(metas.len(), 1);
         assert_eq!(metas[0].title, "Set up Vibe CLI");
-        assert_eq!(metas[0].url, "vmux://agent/vibe/setup");
+        assert_eq!(metas[0].url, "vmux://sessions/vibe/setup");
     }
 
     #[test]
@@ -1236,7 +1236,7 @@ mod tests {
             app.world_mut().spawn(PageOpenTask {
                 id: vmux_core::PageOpenId::new(),
                 stack,
-                url: format!("vmux://agent/{segment}/"),
+                url: format!("vmux://sessions/{segment}/"),
                 request_id: None,
             });
 
@@ -1244,7 +1244,7 @@ mod tests {
             app.update();
 
             let stack_meta = app.world().get::<PageMetadata>(stack).unwrap();
-            assert_eq!(stack_meta.url, format!("vmux://agent/{segment}/setup"));
+            assert_eq!(stack_meta.url, format!("vmux://sessions/{segment}/setup"));
             assert_eq!(
                 stack_meta.title,
                 format!("Set up {} CLI", kind.display_name())
@@ -1253,7 +1253,7 @@ mod tests {
     }
 
     #[test]
-    pub(crate) fn registry_acp_opens_without_settings_entry() {
+    pub(crate) fn legacy_registry_acp_url_opens_as_session() {
         use crate::acp_registry::{Distribution, RegistryAgent};
 
         let mut settings = test_settings();
@@ -1295,7 +1295,7 @@ mod tests {
         let session = app.world().get::<vmux_session::AcpSession>(stack).unwrap();
         assert_eq!(session.agent_id, "custom");
         let meta = app.world().get::<PageMetadata>(stack).unwrap();
-        assert_eq!(meta.url, "vmux://agent/custom");
+        assert_eq!(meta.url, "vmux://sessions/custom");
         assert_eq!(meta.title, "Custom ACP");
         assert_eq!(meta.icon.favicon_url(), "https://cdn.example/custom.svg");
     }
@@ -1316,7 +1316,7 @@ mod tests {
         app.world_mut().spawn(PageOpenTask {
             id: vmux_core::PageOpenId::new(),
             stack,
-            url: "vmux://agent/codex/setup".to_string(),
+            url: "vmux://sessions/codex/setup".to_string(),
             request_id: None,
         });
 
@@ -1324,7 +1324,7 @@ mod tests {
         app.update();
 
         let stack_meta = app.world().get::<PageMetadata>(stack).unwrap();
-        assert_eq!(stack_meta.url, "vmux://agent/codex/setup");
+        assert_eq!(stack_meta.url, "vmux://sessions/codex/setup");
         assert_eq!(stack_meta.title, "Set up Codex CLI");
     }
 
@@ -1361,7 +1361,7 @@ mod tests {
             .spawn(PageOpenTask {
                 id: vmux_core::PageOpenId::new(),
                 stack: first_stack,
-                url: "vmux://agent/claude/cli".to_string(),
+                url: "vmux://sessions/claude/cli".to_string(),
                 request_id: None,
             })
             .id();
@@ -1405,7 +1405,7 @@ mod tests {
         app.world_mut().spawn(PageOpenTask {
             id: vmux_core::PageOpenId::new(),
             stack: second_stack,
-            url: "vmux://agent/codex/cli".to_string(),
+            url: "vmux://sessions/codex/cli".to_string(),
             request_id: None,
         });
         app.update();
@@ -1467,7 +1467,7 @@ mod tests {
             .spawn(PageOpenTask {
                 id: vmux_core::PageOpenId::new(),
                 stack,
-                url: "vmux://agent/claude".to_string(),
+                url: "vmux://sessions/claude".to_string(),
                 request_id: None,
             })
             .id();
@@ -1476,7 +1476,7 @@ mod tests {
             .spawn(PageOpenTask {
                 id: vmux_core::PageOpenId::new(),
                 stack,
-                url: "vmux://agent/claude".to_string(),
+                url: "vmux://sessions/claude".to_string(),
                 request_id: None,
             })
             .id();
@@ -1603,7 +1603,7 @@ mod tests {
             .spawn(PageOpenTask {
                 id: vmux_core::PageOpenId::new(),
                 stack,
-                url: "vmux://agent/claude".to_string(),
+                url: "vmux://sessions/claude".to_string(),
                 request_id: None,
             })
             .id();
@@ -1664,7 +1664,7 @@ mod tests {
         app.world_mut().spawn(PageOpenTask {
             id: vmux_core::PageOpenId::new(),
             stack,
-            url: "vmux://agent/claude/cli".to_string(),
+            url: "vmux://sessions/claude/cli".to_string(),
             request_id: None,
         });
 
@@ -1731,7 +1731,7 @@ mod tests {
         app.world_mut().spawn(PageOpenTask {
             id: vmux_core::PageOpenId::new(),
             stack,
-            url: "vmux://agent/claude/cli".to_string(),
+            url: "vmux://sessions/claude/cli".to_string(),
             request_id: None,
         });
 
@@ -1831,7 +1831,7 @@ mod tests {
             .spawn(PageOpenTask {
                 id: vmux_core::PageOpenId::new(),
                 stack,
-                url: "vmux://agent/codex/cli".to_string(),
+                url: "vmux://sessions/codex/cli".to_string(),
                 request_id: None,
             })
             .id();
@@ -1882,7 +1882,7 @@ mod tests {
         app.world_mut().spawn(PageOpenTask {
             id: vmux_core::PageOpenId::new(),
             stack,
-            url: "vmux://agent/claude".to_string(),
+            url: "vmux://sessions/claude".to_string(),
             request_id: None,
         });
 
@@ -1954,7 +1954,7 @@ mod tests {
         app.world_mut().spawn(PageOpenTask {
             id: vmux_core::PageOpenId::new(),
             stack,
-            url: "vmux://agent/claude".to_string(),
+            url: "vmux://sessions/claude".to_string(),
             request_id: None,
         });
 
@@ -1973,7 +1973,7 @@ mod tests {
             panic!("expected exactly one chat view, got {}", opened.len());
         };
         assert_eq!(*entity, webview);
-        assert_eq!(meta.url, "vmux://agent/claude");
+        assert_eq!(meta.url, "vmux://sessions/claude");
         assert_eq!(parent.parent(), stack);
         let queue = app.world().get::<vmux_session::PromptQueue>(stack).unwrap();
         assert_eq!(
@@ -2040,7 +2040,7 @@ mod tests {
             .spawn(PageOpenTask {
                 id: vmux_core::PageOpenId::new(),
                 stack,
-                url: "vmux://agent/codex".to_string(),
+                url: "vmux://sessions/codex".to_string(),
                 request_id: None,
             })
             .id();
@@ -2106,7 +2106,7 @@ mod tests {
         app.world_mut().spawn(PageOpenTask {
             id: vmux_core::PageOpenId::new(),
             stack,
-            url: "vmux://agent/claude/".to_string(),
+            url: "vmux://sessions/claude/".to_string(),
             request_id: None,
         });
 
@@ -2184,7 +2184,7 @@ mod tests {
         app.world_mut().spawn(PageOpenTask {
             id: vmux_core::PageOpenId::new(),
             stack,
-            url: "vmux://agent/claude/cli".to_string(),
+            url: "vmux://sessions/claude/cli".to_string(),
             request_id: None,
         });
 
@@ -2218,7 +2218,7 @@ mod tests {
         app.world_mut().spawn(PageOpenTask {
             id: vmux_core::PageOpenId::new(),
             stack,
-            url: "vmux://agent/codex/cli".to_string(),
+            url: "vmux://sessions/codex/cli".to_string(),
             request_id: None,
         });
 
@@ -2311,7 +2311,7 @@ mod tests {
         app.world_mut().spawn(PageOpenTask {
             id: vmux_core::PageOpenId::new(),
             stack,
-            url: "vmux://agent/claude".to_string(),
+            url: "vmux://sessions/claude".to_string(),
             request_id: None,
         });
 
@@ -2375,7 +2375,7 @@ mod tests {
         app.world_mut().spawn(PageOpenTask {
             id: vmux_core::PageOpenId::new(),
             stack,
-            url: "vmux://agent/claude/".to_string(),
+            url: "vmux://sessions/claude/".to_string(),
             request_id: None,
         });
 
@@ -2421,7 +2421,7 @@ mod tests {
             .spawn(PageOpenTask {
                 id: vmux_core::PageOpenId::new(),
                 stack,
-                url: "vmux://agent/claude/".to_string(),
+                url: "vmux://sessions/claude/".to_string(),
                 request_id: None,
             })
             .id();
@@ -2458,7 +2458,7 @@ mod tests {
         app.world_mut().spawn(PageOpenTask {
             id: vmux_core::PageOpenId::new(),
             stack,
-            url: "vmux://agent/vibe/".to_string(),
+            url: "vmux://sessions/vibe/".to_string(),
             request_id: None,
         });
 

--- a/crates/page/vmux_agent/src/host/page_open.rs
+++ b/crates/page/vmux_agent/src/host/page_open.rs
@@ -165,7 +165,7 @@ impl RestoredAgentWorktree {
 fn agent_url_uses_local_workspace(url: &str) -> bool {
     if AgentKind::all()
         .into_iter()
-        .any(|kind| url == kind.setup_url())
+        .any(|kind| kind.is_setup_url(url))
     {
         return false;
     }
@@ -708,7 +708,7 @@ fn handle_agent_page_open_task(
 ) -> Result<(), String> {
     if let Some(kind) = AgentKind::all()
         .into_iter()
-        .find(|k| task.url == k.setup_url())
+        .find(|kind| kind.is_setup_url(&task.url))
     {
         attach_cli_setup_to_stack(kind, task.stack, children_q, commands);
         return Ok(());
@@ -1301,31 +1301,33 @@ mod tests {
     }
 
     #[test]
-    pub(crate) fn explicit_setup_url_attaches_setup_page() {
-        let mut app = App::new();
-        app.add_plugins(MinimalPlugins)
-            .add_message::<SpawnAgentInStackRequest>()
-            .insert_resource(AgentStrategies::default())
-            .insert_resource(test_settings())
-            .add_systems(Update, handle_agent_page_open);
+    pub(crate) fn canonical_and_legacy_setup_urls_attach_setup_page() {
+        for url in ["vmux://sessions/codex/setup", "vmux://agent/codex/setup"] {
+            let mut app = App::new();
+            app.add_plugins(MinimalPlugins)
+                .add_message::<SpawnAgentInStackRequest>()
+                .insert_resource(AgentStrategies::default())
+                .insert_resource(test_settings())
+                .add_systems(Update, handle_agent_page_open);
 
-        let stack = app
-            .world_mut()
-            .spawn(vmux_layout::stack::stack_bundle())
-            .id();
-        app.world_mut().spawn(PageOpenTask {
-            id: vmux_core::PageOpenId::new(),
-            stack,
-            url: "vmux://sessions/codex/setup".to_string(),
-            request_id: None,
-        });
+            let stack = app
+                .world_mut()
+                .spawn(vmux_layout::stack::stack_bundle())
+                .id();
+            app.world_mut().spawn(PageOpenTask {
+                id: vmux_core::PageOpenId::new(),
+                stack,
+                url: url.to_string(),
+                request_id: None,
+            });
 
-        app.update();
-        app.update();
+            app.update();
+            app.update();
 
-        let stack_meta = app.world().get::<PageMetadata>(stack).unwrap();
-        assert_eq!(stack_meta.url, "vmux://sessions/codex/setup");
-        assert_eq!(stack_meta.title, "Set up Codex CLI");
+            let stack_meta = app.world().get::<PageMetadata>(stack).unwrap();
+            assert_eq!(stack_meta.url, "vmux://sessions/codex/setup", "{url}");
+            assert_eq!(stack_meta.title, "Set up Codex CLI", "{url}");
+        }
     }
 
     #[test]

--- a/crates/page/vmux_agent/src/host/session.rs
+++ b/crates/page/vmux_agent/src/host/session.rs
@@ -132,7 +132,7 @@ mod url_tests {
             .id();
         app.update();
         let url = &app.world().get::<PageMetadata>(entity).unwrap().url;
-        assert_eq!(url, "vmux://agent/vibe/cli/abc");
+        assert_eq!(url, "vmux://sessions/vibe/cli/abc");
     }
 
     #[test]
@@ -154,7 +154,7 @@ mod url_tests {
             .id();
         app.update();
         let url = &app.world().get::<PageMetadata>(entity).unwrap().url;
-        assert_eq!(url, "vmux://agent/vibe/cli");
+        assert_eq!(url, "vmux://sessions/vibe/cli");
     }
 
     #[test]

--- a/crates/page/vmux_agent/src/host/snapshot_updater.rs
+++ b/crates/page/vmux_agent/src/host/snapshot_updater.rs
@@ -91,7 +91,7 @@ fn acp_agent_summaries(
             id: agent.id.clone(),
             name: agent.name.clone(),
             url: format!(
-                "vmux://agent/{}",
+                "vmux://sessions/{}",
                 crate::acp_install::agent_url_id(&agent.id)
             ),
             icon: agent.icon.clone().unwrap_or_default(),
@@ -257,7 +257,7 @@ mod tests {
 
         assert_eq!(agents.len(), 1);
         assert_eq!(agents[0].id, "new-agent-acp");
-        assert_eq!(agents[0].url, "vmux://agent/new-agent");
+        assert_eq!(agents[0].url, "vmux://sessions/new-agent");
     }
 
     #[test]
@@ -351,7 +351,7 @@ mod tests {
             ChildOf(cli_stack),
         ));
         app.world_mut().spawn(ArchivedPage {
-            url: "vmux://agent/codex-acp/session-1".to_string(),
+            url: "vmux://sessions/codex-acp/session-1".to_string(),
             closed_at: 30,
             ..default()
         });

--- a/crates/page/vmux_agent/src/host/tree.rs
+++ b/crates/page/vmux_agent/src/host/tree.rs
@@ -53,6 +53,7 @@ pub struct AgentSessionPlugin;
 
 impl Plugin for AgentSessionPlugin {
     fn build(&self, app: &mut App) {
+        vmux_core::register_host_spawn(app, "sessions");
         vmux_core::register_host_spawn(app, "agent");
         let mut strategies = AgentStrategies::default();
         strategies.register_cli(Box::new(VibeStrategy));

--- a/crates/page/vmux_agent/src/host/url.rs
+++ b/crates/page/vmux_agent/src/host/url.rs
@@ -5,7 +5,7 @@ use crate::AgentVariant;
 pub const CLI_FRESH_SID: &str = "cli";
 
 pub fn page_url_prefix(provider: &str, model: &str) -> String {
-    format!("vmux://agent/{provider}/{model}/")
+    format!("vmux://sessions/{provider}/{model}/")
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -28,7 +28,9 @@ pub enum AgentUrl {
 
 impl AgentUrl {
     pub fn parse(url: &str) -> Option<Self> {
-        let body = url.strip_prefix("vmux://agent/")?;
+        let body = url
+            .strip_prefix("vmux://sessions/")
+            .or_else(|| url.strip_prefix("vmux://agent/"))?;
         let segs: Vec<&str> = body.split('/').filter(|s| !s.is_empty()).collect();
         match segs.as_slice() {
             [] => Some(AgentUrl::PageDefault),
@@ -99,15 +101,15 @@ impl AgentUrl {
                 }
             }
             AgentUrl::Acp { id, sid } => match sid {
-                Some(sid) => format!("vmux://agent/{id}/{sid}"),
-                None => format!("vmux://agent/{id}"),
+                Some(sid) => format!("vmux://sessions/{id}/{sid}"),
+                None => format!("vmux://sessions/{id}"),
             },
             AgentUrl::Page {
                 provider,
                 model,
                 sid,
             } => format!("{}{sid}", page_url_prefix(provider, model)),
-            AgentUrl::PageDefault => "vmux://agent/".to_string(),
+            AgentUrl::PageDefault => "vmux://sessions/".to_string(),
         }
     }
 
@@ -134,7 +136,7 @@ mod tests {
     #[test]
     fn bare_agent_url_parses_to_page_default() {
         assert_eq!(
-            AgentUrl::parse("vmux://agent/"),
+            AgentUrl::parse("vmux://sessions/"),
             Some(AgentUrl::PageDefault)
         );
     }
@@ -142,14 +144,14 @@ mod tests {
     #[test]
     fn single_segment_is_acp_fresh() {
         assert_eq!(
-            AgentUrl::parse("vmux://agent/claude"),
+            AgentUrl::parse("vmux://sessions/claude"),
             Some(AgentUrl::Acp {
                 id: "claude".into(),
                 sid: None,
             })
         );
         assert_eq!(
-            AgentUrl::parse("vmux://agent/mistral-vibe"),
+            AgentUrl::parse("vmux://sessions/mistral-vibe"),
             Some(AgentUrl::Acp {
                 id: "mistral-vibe".into(),
                 sid: None,
@@ -160,7 +162,7 @@ mod tests {
     #[test]
     fn two_segment_plain_is_acp_session() {
         assert_eq!(
-            AgentUrl::parse("vmux://agent/claude/abc-123"),
+            AgentUrl::parse("vmux://sessions/claude/abc-123"),
             Some(AgentUrl::Acp {
                 id: "claude".into(),
                 sid: Some("abc-123".into()),
@@ -171,7 +173,7 @@ mod tests {
     #[test]
     fn two_segment_cli_marker_is_fresh_cli() {
         assert_eq!(
-            AgentUrl::parse("vmux://agent/claude/cli"),
+            AgentUrl::parse("vmux://sessions/claude/cli"),
             Some(AgentUrl::Cli {
                 kind: AgentKind::Claude,
                 sid: CLI_FRESH_SID.into(),
@@ -182,7 +184,7 @@ mod tests {
     #[test]
     fn three_segment_cli_marker_is_cli_resume() {
         assert_eq!(
-            AgentUrl::parse("vmux://agent/vibe/cli/abc-123"),
+            AgentUrl::parse("vmux://sessions/vibe/cli/abc-123"),
             Some(AgentUrl::Cli {
                 kind: AgentKind::Vibe,
                 sid: "abc-123".into(),
@@ -193,7 +195,7 @@ mod tests {
     #[test]
     fn three_segment_plain_is_page() {
         assert_eq!(
-            AgentUrl::parse("vmux://agent/openai/gpt-5.5/xHigh"),
+            AgentUrl::parse("vmux://sessions/openai/gpt-5.5/xHigh"),
             Some(AgentUrl::Page {
                 provider: "openai".into(),
                 model: "gpt-5.5".into(),
@@ -205,7 +207,7 @@ mod tests {
     #[test]
     fn cli_marker_with_non_kind_falls_through_to_acp() {
         assert_eq!(
-            AgentUrl::parse("vmux://agent/fast-agent/cli"),
+            AgentUrl::parse("vmux://sessions/fast-agent/cli"),
             Some(AgentUrl::Acp {
                 id: "fast-agent".into(),
                 sid: Some("cli".into()),
@@ -215,8 +217,8 @@ mod tests {
 
     #[test]
     fn too_many_segments_rejected() {
-        assert_eq!(AgentUrl::parse("vmux://agent/vibe/cli/abc/extra"), None);
-        assert_eq!(AgentUrl::parse("vmux://agent/o/m/sid/extra"), None);
+        assert_eq!(AgentUrl::parse("vmux://sessions/vibe/cli/abc/extra"), None);
+        assert_eq!(AgentUrl::parse("vmux://sessions/o/m/sid/extra"), None);
     }
 
     #[test]
@@ -241,14 +243,14 @@ mod tests {
             kind: AgentKind::Codex,
             sid: CLI_FRESH_SID.into(),
         };
-        assert_eq!(fresh.format(), "vmux://agent/codex/cli");
+        assert_eq!(fresh.format(), "vmux://sessions/codex/cli");
         assert_eq!(AgentUrl::parse(&fresh.format()), Some(fresh));
 
         let resume = AgentUrl::Cli {
             kind: AgentKind::Codex,
             sid: "xyz".into(),
         };
-        assert_eq!(resume.format(), "vmux://agent/codex/cli/xyz");
+        assert_eq!(resume.format(), "vmux://sessions/codex/cli/xyz");
         assert_eq!(AgentUrl::parse(&resume.format()), Some(resume));
     }
 
@@ -259,17 +261,23 @@ mod tests {
             model: "claude-opus-4.7".into(),
             sid: "xyz".into(),
         };
-        assert_eq!(u.format(), "vmux://agent/anthropic/claude-opus-4.7/xyz");
+        assert_eq!(u.format(), "vmux://sessions/anthropic/claude-opus-4.7/xyz");
         assert_eq!(AgentUrl::parse(&u.format()), Some(u));
     }
 
     #[test]
     fn page_default_round_trips() {
-        assert_eq!(AgentUrl::PageDefault.format(), "vmux://agent/");
+        assert_eq!(AgentUrl::PageDefault.format(), "vmux://sessions/");
         assert_eq!(
             AgentUrl::parse(&AgentUrl::PageDefault.format()),
             Some(AgentUrl::PageDefault)
         );
+    }
+
+    #[test]
+    fn legacy_agent_url_parses_but_formats_as_session() {
+        let parsed = AgentUrl::parse("vmux://agent/codex/cli/xyz").unwrap();
+        assert_eq!(parsed.format(), "vmux://sessions/codex/cli/xyz");
     }
 
     #[test]

--- a/crates/page/vmux_agent/src/vibe/setup/plugin.rs
+++ b/crates/page/vmux_agent/src/vibe/setup/plugin.rs
@@ -272,7 +272,7 @@ mod tests {
         assert!(close_install_pane_after_success("vmux://agents"));
         assert!(close_install_pane_after_success("vmux://agents/"));
         assert!(!close_install_pane_after_success(
-            "vmux://agent/codex/setup"
+            "vmux://sessions/codex/setup"
         ));
     }
 }

--- a/crates/page/vmux_chat/Cargo.toml
+++ b/crates/page/vmux_chat/Cargo.toml
@@ -12,7 +12,6 @@ path = "src/lib.rs"
 [dependencies]
 bevy_app = { workspace = true }
 bevy_ecs = { workspace = true }
-chrono = { workspace = true }
 dioxus = { version = "=0.7.9", default-features = false, features = [
     "minimal",
     "document",

--- a/crates/page/vmux_chat/Cargo.toml
+++ b/crates/page/vmux_chat/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 [dependencies]
 bevy_app = { workspace = true }
 bevy_ecs = { workspace = true }
+chrono = { workspace = true }
 dioxus = { version = "=0.7.9", default-features = false, features = [
     "minimal",
     "document",

--- a/crates/page/vmux_chat/src/event.rs
+++ b/crates/page/vmux_chat/src/event.rs
@@ -708,7 +708,7 @@ mod tests {
                 project: "w".into(),
                 branch: "main".into(),
                 cross_runtime: true,
-                url: "vmux://agent/claude/sid-9".into(),
+                url: "vmux://sessions/claude/sid-9".into(),
             }],
             offset: 0,
             total: 1,

--- a/crates/page/vmux_chat/src/event.rs
+++ b/crates/page/vmux_chat/src/event.rs
@@ -73,6 +73,12 @@ pub struct ChatSnapshot {
     pub conversation_title: String,
     pub agent_icon: String,
     pub accent_color: String,
+    #[serde(default)]
+    pub user_name: String,
+    #[serde(default)]
+    pub user_initials: String,
+    #[serde(default)]
+    pub user_color: String,
     pub handoff_source: String,
     pub handoff_truncated: bool,
     pub handoff_message_count: u32,

--- a/crates/page/vmux_chat/src/page.rs
+++ b/crates/page/vmux_chat/src/page.rs
@@ -8,7 +8,7 @@ use self::state::use_chat;
 use self::transcript::ChatTranscript;
 use crate::transcript::MD_CSS;
 use dioxus::prelude::*;
-use vmux_ui::matrix_rain::MatrixRain;
+
 #[component]
 pub fn Page() -> Element {
     let chat = use_chat();
@@ -18,27 +18,15 @@ pub fn Page() -> Element {
 
     rsx! {
         main {
-            class: "agent-chat-page relative isolate flex h-dvh flex-col overflow-hidden bg-background text-foreground outline-none",
+            class: "session-chat-page relative isolate flex h-dvh flex-col overflow-hidden bg-zinc-100 text-foreground outline-none dark:bg-zinc-900",
             style: "--agent-accent:{accent.css};",
             tabindex: "-1",
             onkeydown: move |event| keys.on_root_keydown(event),
             style { dangerous_inner_html: MD_CSS }
-            if chat.installing_splash() {
-                InstallBackdrop { accent_rgb: accent.rgb, title: chat.header_name().to_uppercase() }
-            }
             ChatHeader { chat }
             ChatTranscript { chat }
             ChatApprovalDock { chat }
             ChatDock { chat }
-        }
-    }
-}
-
-#[component]
-fn InstallBackdrop(accent_rgb: String, title: String) -> Element {
-    rsx! {
-        div { class: "pointer-events-none absolute inset-0 overflow-hidden",
-            MatrixRain { accent_rgb, words: vec![title] }
         }
     }
 }

--- a/crates/page/vmux_chat/src/page/agent.rs
+++ b/crates/page/vmux_chat/src/page/agent.rs
@@ -4,13 +4,16 @@ use vmux_ui::back::BackButton;
 use vmux_ui::components::avatar::Avatar;
 use vmux_ui::components::composer_bar::StatusDot;
 use vmux_ui::favicon::favicon_src_for_url;
-use vmux_ui::i18n::translate;
+use vmux_ui::i18n::{TranslationValue, translate_with};
 
 #[component]
 pub(super) fn ChatHeader(chat: Chat) -> Element {
     let name = chat.header_name();
     let title = chat.title();
-    let you = translate("team-you");
+    let subtitle = translate_with(
+        "agent-chat-subtitle",
+        &[("agent", TranslationValue::String(&name))],
+    );
     let user_name = (chat.user.name)();
     let user_initials = (chat.user.initials)();
     let user_color = (chat.user.color)();
@@ -36,7 +39,7 @@ pub(super) fn ChatHeader(chat: Chat) -> Element {
                 }
                 div { class: "flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground",
                     StatusDot { status: chat.status(), size_class: "h-2 w-2" }
-                    span { class: "truncate", {format!("{you} · {name}")} }
+                    span { class: "truncate", "{subtitle}" }
                 }
             }
         }

--- a/crates/page/vmux_chat/src/page/agent.rs
+++ b/crates/page/vmux_chat/src/page/agent.rs
@@ -11,21 +11,20 @@ pub(super) fn ChatHeader(chat: Chat) -> Element {
     let name = chat.header_name();
     let title = chat.title();
     let you = translate("team-you");
-    let you_initial = you
-        .chars()
-        .next()
-        .map(|character| character.to_uppercase().to_string())
-        .unwrap_or_default();
+    let user_name = (chat.user.name)();
+    let user_initials = (chat.user.initials)();
+    let user_color = (chat.user.color)();
     rsx! {
         header { class: "session-chat-header relative z-10 flex min-w-0 items-center gap-3 bg-transparent px-3 pb-2 pt-[calc(0.75rem+env(safe-area-inset-top))] sm:px-5",
             BackButton {}
             div { class: "relative h-8 w-12 shrink-0",
                 Avatar {
                     src: None,
-                    fallback: you_initial,
-                    background: "#71717a".to_string(),
-                    alt: you.clone(),
+                    fallback: user_initials,
+                    background: user_color,
+                    alt: user_name.clone(),
                     class: "absolute left-0 top-0 h-8 w-8 border-2 border-zinc-100 text-[10px] dark:border-zinc-900".to_string(),
+                    seed: Some(user_name),
                 }
                 AgentAvatar { chat, size_class: "absolute left-5 top-0 h-8 w-8 border-2 border-zinc-100 text-[10px] dark:border-zinc-900" }
             }
@@ -77,20 +76,18 @@ pub(super) fn AgentAvatar(chat: Chat, size_class: String) -> Element {
 #[component]
 pub(super) fn AgentBanner(chat: Chat) -> Element {
     let name = chat.header_name();
-    let you = translate("team-you");
-    let you_initial = you
-        .chars()
-        .next()
-        .map(|character| character.to_uppercase().to_string())
-        .unwrap_or_default();
+    let user_name = (chat.user.name)();
+    let user_initials = (chat.user.initials)();
+    let user_color = (chat.user.color)();
     rsx! {
         div { class: "flex items-center -space-x-2",
             Avatar {
                 src: None,
-                fallback: you_initial,
-                background: "#71717a".to_string(),
-                alt: you,
+                fallback: user_initials,
+                background: user_color,
+                alt: user_name.clone(),
                 class: "h-10 w-10 border-2 border-zinc-100 text-xs dark:border-zinc-900".to_string(),
+                seed: Some(user_name),
             }
             AgentAvatar { chat, size_class: "h-10 w-10 border-2 border-zinc-100 text-xs dark:border-zinc-900" }
         }

--- a/crates/page/vmux_chat/src/page/agent.rs
+++ b/crates/page/vmux_chat/src/page/agent.rs
@@ -4,35 +4,53 @@ use vmux_ui::back::BackButton;
 use vmux_ui::components::avatar::Avatar;
 use vmux_ui::components::composer_bar::StatusDot;
 use vmux_ui::favicon::favicon_src_for_url;
+use vmux_ui::i18n::translate;
 
 #[component]
 pub(super) fn ChatHeader(chat: Chat) -> Element {
     let name = chat.header_name();
     let title = chat.title();
+    let you = translate("team-you");
+    let you_initial = you
+        .chars()
+        .next()
+        .map(|character| character.to_uppercase().to_string())
+        .unwrap_or_default();
     rsx! {
-        header { class: "agent-chat-header relative z-10 flex min-w-0 animate-agent-surface items-center gap-2.5 border-b bg-background/95 px-3 pb-3 pt-[calc(0.75rem+env(safe-area-inset-top))] shadow-[0_1px_0_rgba(255,255,255,0.02)] motion-reduce:animate-none sm:px-5",
+        header { class: "session-chat-header relative z-10 flex min-w-0 items-center gap-3 bg-transparent px-3 pb-2 pt-[calc(0.75rem+env(safe-area-inset-top))] sm:px-5",
             BackButton {}
-            AgentAvatar { chat, size_class: "h-6 w-6 text-[11px]" }
-            StatusDot { status: chat.status(), size_class: "h-2.5 w-2.5" }
+            div { class: "relative h-8 w-12 shrink-0",
+                Avatar {
+                    src: None,
+                    fallback: you_initial,
+                    background: "#71717a".to_string(),
+                    alt: you.clone(),
+                    class: "absolute left-0 top-0 h-8 w-8 border-2 border-zinc-100 text-[10px] dark:border-zinc-900".to_string(),
+                }
+                AgentAvatar { chat, size_class: "absolute left-5 top-0 h-8 w-8 border-2 border-zinc-100 text-[10px] dark:border-zinc-900" }
+            }
             div { class: "min-w-0 flex-1",
                 div {
-                    class: "truncate bg-gradient-to-b from-foreground to-foreground/60 bg-clip-text text-sm font-semibold text-transparent",
+                    class: "truncate text-sm font-semibold text-foreground",
                     title: "{title}",
                     "{title}"
                 }
-                div { class: "truncate text-[10px] text-muted-foreground/60", "{name}" }
+                div { class: "flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground",
+                    StatusDot { status: chat.status(), size_class: "h-2 w-2" }
+                    span { class: "truncate", {format!("{you} · {name}")} }
+                }
             }
         }
     }
 }
 
 #[component]
-fn AgentAvatar(chat: Chat, size_class: String) -> Element {
+pub(super) fn AgentAvatar(chat: Chat, size_class: String) -> Element {
     let agent = chat.agent();
     let accent = (chat.identity.accent)();
     let src = favicon_src_for_url(
         &(chat.identity.agent_icon)(),
-        &format!("vmux://agent/{agent}"),
+        &format!("vmux://sessions/{agent}"),
     );
     let initial: String = chat
         .header_name()
@@ -59,9 +77,24 @@ fn AgentAvatar(chat: Chat, size_class: String) -> Element {
 #[component]
 pub(super) fn AgentBanner(chat: Chat) -> Element {
     let name = chat.header_name();
+    let you = translate("team-you");
+    let you_initial = you
+        .chars()
+        .next()
+        .map(|character| character.to_uppercase().to_string())
+        .unwrap_or_default();
     rsx! {
-        AgentAvatar { chat, size_class: "h-14 w-14 text-xl" }
-        h2 { class: "bg-gradient-to-b from-foreground to-foreground/50 bg-clip-text text-3xl font-semibold capitalize tracking-tight text-transparent",
+        div { class: "flex items-center -space-x-2",
+            Avatar {
+                src: None,
+                fallback: you_initial,
+                background: "#71717a".to_string(),
+                alt: you,
+                class: "h-10 w-10 border-2 border-zinc-100 text-xs dark:border-zinc-900".to_string(),
+            }
+            AgentAvatar { chat, size_class: "h-10 w-10 border-2 border-zinc-100 text-xs dark:border-zinc-900" }
+        }
+        h2 { class: "text-xl font-semibold capitalize tracking-tight text-foreground",
             "{name}"
         }
     }

--- a/crates/page/vmux_chat/src/page/approval.rs
+++ b/crates/page/vmux_chat/src/page/approval.rs
@@ -41,7 +41,7 @@ pub fn ApprovalPanel(
                         )}
                     }
                     if !details.is_empty() {
-                        div { class: "mt-2 max-h-40 overflow-auto rounded-lg bg-foreground/[0.05] ring-1 ring-inset ring-foreground/10",
+                        div { class: "mt-2 max-h-40 overflow-auto border-y border-foreground/10",
                             for (i , detail) in details.iter().enumerate() {
                                 div {
                                     key: "approval-detail-{i}",
@@ -99,7 +99,7 @@ pub(super) fn ChoiceList(chat: Chat) -> Element {
     let mut menu_sel = chat.slash.menu_sel;
     let question = (chat.run.choice_question)();
     rsx! {
-        div { class: "rounded-2xl border border-foreground/10 bg-foreground/[0.045] p-3.5 shadow-sm",
+        div { class: "border-l-2 border-foreground/15 py-2 pl-3.5",
             div { class: "mb-3 text-sm font-medium text-foreground", "{question}" }
             div { class: "flex flex-col gap-1.5",
                 for (index , option) in options.into_iter().enumerate() {

--- a/crates/page/vmux_chat/src/page/composer.rs
+++ b/crates/page/vmux_chat/src/page/composer.rs
@@ -46,6 +46,7 @@ fn ChatComposer(chat: Chat) -> Element {
     rsx! {
         PromptComposer {
             shared_transition: true,
+            show_send_button: false,
             value: drafted,
             preview: (chat.composer.transition_preview)(),
             attachments: chat.composer_attachments(),

--- a/crates/page/vmux_chat/src/page/composer.rs
+++ b/crates/page/vmux_chat/src/page/composer.rs
@@ -15,8 +15,8 @@ use vmux_ui::i18n::translate;
 #[component]
 pub(super) fn ChatDock(chat: Chat) -> Element {
     rsx! {
-        div { class: "relative z-10 bg-gradient-to-t from-background via-background/95 to-transparent px-4 pb-[calc(1rem+env(safe-area-inset-bottom))] pt-8",
-            div { class: "agent-chat-prompt-shell relative mx-auto flex max-w-3xl animate-agent-prompt-dock flex-col gap-2 motion-reduce:animate-none",
+        div { class: "relative z-20 px-4 pb-[calc(0.75rem+env(safe-area-inset-bottom))] pt-2",
+            div { class: "session-chat-prompt-shell relative mx-auto flex max-w-3xl flex-col gap-2 drop-shadow-[0_20px_32px_rgba(0,0,0,0.28)]",
                 if chat.media_menu_open() {
                     MediaMenu { chat }
                 }

--- a/crates/page/vmux_chat/src/page/error.rs
+++ b/crates/page/vmux_chat/src/page/error.rs
@@ -15,7 +15,7 @@ pub(super) fn ChatErrorCard(message: String) -> Element {
     let copy_label = translate("common-copy");
     let copy_text = message.clone();
     rsx! {
-        div { class: "flex flex-col gap-2 rounded-xl bg-red-500/[0.07] px-4 py-3 ring-1 ring-inset ring-red-500/20",
+        div { class: "flex flex-col gap-2 border-l-2 border-red-500/40 px-4 py-2",
             div { class: "flex items-center gap-2",
                 svg {
                     class: "h-4 w-4 shrink-0 text-red-500",
@@ -48,12 +48,12 @@ pub(super) fn ChatErrorCard(message: String) -> Element {
                     }
                 }
             }
-            div { class: "max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-red-500/[0.06] px-3 py-2 font-mono text-[11px] leading-relaxed text-red-700/90 dark:text-red-200/80",
+            div { class: "max-h-40 overflow-auto whitespace-pre-wrap break-words border-l border-red-500/20 px-3 py-2 font-mono text-[11px] leading-relaxed text-red-700/90 dark:text-red-200/80",
                 "{message}"
             }
         }
         if is_version_error(&message) {
-            div { class: "flex items-start gap-3 rounded-xl bg-foreground/[0.04] px-4 py-3 ring-1 ring-inset ring-foreground/10",
+            div { class: "flex items-start gap-3 border-t border-foreground/10 px-4 py-3",
                 div { class: "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-amber-500/15 text-amber-500",
                     svg {
                         class: "h-4 w-4",

--- a/crates/page/vmux_chat/src/page/keys.rs
+++ b/crates/page/vmux_chat/src/page/keys.rs
@@ -39,6 +39,9 @@ impl ChatKeys {
         if self.answered_by_number(&event) {
             return;
         }
+        if self.submits_prompt(&event) {
+            return;
+        }
         self.hand_over(&event);
     }
 
@@ -186,6 +189,22 @@ impl ChatKeys {
         };
         event.prevent_default();
         list.choose(self.chat, index);
+        true
+    }
+
+    fn submits_prompt(&self, event: &KeyboardEvent) -> bool {
+        let modifiers = event.modifiers();
+        if event.key() != Key::Enter
+            || modifiers.shift()
+            || modifiers.meta()
+            || modifiers.ctrl()
+            || modifiers.alt()
+            || ChatList::of(self.chat).is_some()
+        {
+            return false;
+        }
+        event.prevent_default();
+        self.chat.submit();
         true
     }
 

--- a/crates/page/vmux_chat/src/page/keys.rs
+++ b/crates/page/vmux_chat/src/page/keys.rs
@@ -39,9 +39,6 @@ impl ChatKeys {
         if self.answered_by_number(&event) {
             return;
         }
-        if self.submits_prompt(&event) {
-            return;
-        }
         self.hand_over(&event);
     }
 
@@ -189,22 +186,6 @@ impl ChatKeys {
         };
         event.prevent_default();
         list.choose(self.chat, index);
-        true
-    }
-
-    fn submits_prompt(&self, event: &KeyboardEvent) -> bool {
-        let modifiers = event.modifiers();
-        if event.key() != Key::Enter
-            || modifiers.shift()
-            || modifiers.meta()
-            || modifiers.ctrl()
-            || modifiers.alt()
-            || ChatList::of(self.chat).is_some()
-        {
-            return false;
-        }
-        event.prevent_default();
-        self.chat.submit();
         true
     }
 

--- a/crates/page/vmux_chat/src/page/state.rs
+++ b/crates/page/vmux_chat/src/page/state.rs
@@ -41,6 +41,7 @@ pub struct Chat {
     pub transcript: Transcript,
     pub run: RunState,
     pub identity: AgentIdentity,
+    pub user: UserIdentity,
     pub handoff: Handoff,
     pub composer: ComposerDraft,
     pub queue: PromptQueue,
@@ -64,6 +65,7 @@ pub fn use_chat() -> Chat {
         transcript,
         run: use_run_state(),
         identity: use_agent_identity(),
+        user: use_user_identity(),
         handoff: use_handoff(),
         composer: use_composer_draft(),
         queue: use_prompt_queue(),
@@ -238,6 +240,15 @@ impl Chat {
         );
         set_if_changed(self.identity.agent_icon, snapshot.agent_icon.clone());
         set_if_changed(self.identity.accent, snapshot.accent_color.clone());
+        if !snapshot.user_name.is_empty() {
+            set_if_changed(self.user.name, snapshot.user_name.clone());
+        }
+        if !snapshot.user_initials.is_empty() {
+            set_if_changed(self.user.initials, snapshot.user_initials.clone());
+        }
+        if !snapshot.user_color.is_empty() {
+            set_if_changed(self.user.color, snapshot.user_color.clone());
+        }
         set_if_changed(self.handoff.source, snapshot.handoff_source.clone());
         set_if_changed(self.handoff.truncated, snapshot.handoff_truncated);
         set_if_changed(self.handoff.message_count, snapshot.handoff_message_count);
@@ -946,6 +957,21 @@ pub fn use_agent_identity() -> AgentIdentity {
         conversation_title: use_signal(String::new),
         agent_icon: use_signal(String::new),
         accent: use_signal(String::new),
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+pub struct UserIdentity {
+    pub name: Signal<String>,
+    pub initials: Signal<String>,
+    pub color: Signal<String>,
+}
+
+pub fn use_user_identity() -> UserIdentity {
+    UserIdentity {
+        name: use_signal(|| "You".to_string()),
+        initials: use_signal(|| "Y".to_string()),
+        color: use_signal(|| "#3b82f6".to_string()),
     }
 }
 

--- a/crates/page/vmux_chat/src/page/state.rs
+++ b/crates/page/vmux_chat/src/page/state.rs
@@ -968,9 +968,15 @@ pub struct UserIdentity {
 }
 
 pub fn use_user_identity() -> UserIdentity {
+    let name = translate("team-you");
+    let initials = name
+        .chars()
+        .next()
+        .map(|character| character.to_uppercase().collect())
+        .unwrap_or_default();
     UserIdentity {
-        name: use_signal(|| "You".to_string()),
-        initials: use_signal(|| "Y".to_string()),
+        name: use_signal(move || name),
+        initials: use_signal(move || initials),
         color: use_signal(|| "#3b82f6".to_string()),
     }
 }

--- a/crates/page/vmux_chat/src/page/state.rs
+++ b/crates/page/vmux_chat/src/page/state.rs
@@ -1139,7 +1139,10 @@ fn current_agent() -> String {
     }
 
     if let Some(meta) = try_consume_context::<vmux_core::PageMetadata>()
-        && let Some(rest) = meta.url.strip_prefix("vmux://agent/")
+        && let Some(rest) = meta
+            .url
+            .strip_prefix("vmux://sessions/")
+            .or_else(|| meta.url.strip_prefix("vmux://agent/"))
         && let Some(agent) = provider(rest)
     {
         return agent;

--- a/crates/page/vmux_chat/src/page/transcript.rs
+++ b/crates/page/vmux_chat/src/page/transcript.rs
@@ -7,6 +7,7 @@ use crate::transcript::ChatItemRow;
 use dioxus::prelude::*;
 use std::collections::HashMap;
 use vmux_ui::agent_accent::agent_accent;
+use vmux_ui::favicon::favicon_src_for_url;
 use vmux_ui::hooks::send;
 use vmux_ui::i18n::{TranslationValue, translate, translate_with};
 use vmux_wire::prompt_media::ChatAttachment;
@@ -67,11 +68,23 @@ pub(super) fn ChatTranscript(chat: Chat) -> Element {
     let handoff_source = (chat.handoff.source)();
     let handoff_truncated = (chat.handoff.truncated)();
     let handoff_count = (chat.handoff.message_count)();
+    let agent = chat.agent();
+    let agent_name = chat.header_name();
+    let agent_avatar = favicon_src_for_url(
+        &(chat.identity.agent_icon)(),
+        &format!("vmux://sessions/{agent}"),
+    );
+    let agent_initial = agent_name
+        .chars()
+        .next()
+        .map(|character| character.to_ascii_uppercase().to_string())
+        .unwrap_or_default();
+    let agent_color = chat.accent().css;
     rsx! {
         div {
             id: "chat-scroll",
             onmounted: move |e| scroll_container.set(Some(e.data())),
-            class: "relative z-10 flex-1 animate-agent-surface overflow-y-auto overscroll-contain px-3 py-6 [animation-delay:40ms] motion-reduce:animate-none sm:px-4 md:px-6",
+            class: "relative z-10 flex-1 overflow-y-auto overscroll-contain px-3 pb-8 pt-3 sm:px-4 md:px-6",
             onscroll: move |e: Event<ScrollData>| {
                 let top = e.scroll_top() as i32;
                 let dist = e.scroll_height() - top - e.client_height();
@@ -85,11 +98,11 @@ pub(super) fn ChatTranscript(chat: Chat) -> Element {
                     chat.request_history();
                 }
             },
-            div { class: "mx-auto flex min-h-full max-w-none flex-col gap-5 md:max-w-3xl",
+            div { class: "mx-auto flex min-h-full w-full max-w-3xl flex-col gap-5",
                 if loaded_start() > 0 {
                     button {
                         id: "chat-load-older",
-                        class: "mx-auto rounded-full border border-foreground/10 bg-background/90 px-3 py-1.5 text-xs text-muted-foreground shadow-sm transition-colors hover:bg-foreground/[0.06] hover:text-foreground disabled:opacity-50",
+                        class: "mx-auto mb-3 px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50",
                         disabled: history_loading(),
                         onclick: move |_| chat.request_history(),
                         {if history_loading() { translate("agent-loading-older") } else { translate("agent-load-older") }}
@@ -106,6 +119,10 @@ pub(super) fn ChatTranscript(chat: Chat) -> Element {
                         absolute_index: loaded_start() as usize + i,
                         item,
                         attachment_previews: chat.composer.attachment_previews,
+                        agent_name: agent_name.clone(),
+                        agent_avatar: agent_avatar.clone(),
+                        agent_initial: agent_initial.clone(),
+                        agent_color: agent_color.clone(),
                         latest_tool_block: latest_tool
                             .filter(|(item_index, _)| *item_index == i)
                             .map(|(_, block_index)| block_index),
@@ -135,9 +152,9 @@ pub(super) fn ChatTranscript(chat: Chat) -> Element {
 fn InstallIntro(chat: Chat, detail: String) -> Element {
     let accent = agent_accent(&chat.agent());
     rsx! {
-        div { class: "my-auto flex flex-col items-center gap-3 py-16 text-center",
+        div { class: "my-auto flex flex-col items-center gap-3 py-12 text-center",
             AgentBanner { chat }
-            div { class: "flex max-w-sm items-center gap-2 rounded-full bg-background/90 px-3 py-1.5 text-xs text-muted-foreground ring-1 ring-inset ring-foreground/10",
+            div { class: "flex max-w-sm items-center gap-2 text-xs text-muted-foreground",
                 span { class: "h-1.5 w-1.5 shrink-0 rounded-full {accent.accent_bg}" }
                 span { class: "truncate", "{detail}" }
             }
@@ -148,7 +165,7 @@ fn InstallIntro(chat: Chat, detail: String) -> Element {
 #[component]
 fn ReadyIntro(chat: Chat) -> Element {
     rsx! {
-        div { class: "flex animate-agent-ready flex-col items-center gap-3 py-24 text-center motion-reduce:animate-none",
+        div { class: "flex flex-col items-center gap-3 py-16 text-center",
             AgentBanner { chat }
             p { class: "text-sm text-muted-foreground", {translate("agent-ready")} }
         }
@@ -187,7 +204,7 @@ pub(super) fn QueuedPrompts(chat: Chat) -> Element {
             for queued_prompt in queued.into_iter() {
                 div {
                     key: "q{queued_prompt.id}",
-                    class: "group flex max-w-[80%] items-center gap-2 rounded-2xl border border-dashed border-foreground/20 bg-foreground/[0.03] py-2 pl-3.5 pr-2 text-sm text-muted-foreground",
+                    class: "group flex max-w-[80%] items-center gap-2 border-l-2 border-dashed border-foreground/20 py-2 pl-3 pr-2 text-sm text-muted-foreground",
                     span { class: "shrink-0 text-[10px] uppercase tracking-wide text-foreground/40", {translate("agent-queued")} }
                     span { class: "min-w-0 flex-1 whitespace-pre-wrap break-words",
                         if !queued_prompt.text.is_empty() {

--- a/crates/page/vmux_chat/src/page/transcript.rs
+++ b/crates/page/vmux_chat/src/page/transcript.rs
@@ -80,6 +80,9 @@ pub(super) fn ChatTranscript(chat: Chat) -> Element {
         .map(|character| character.to_ascii_uppercase().to_string())
         .unwrap_or_default();
     let agent_color = chat.accent().css;
+    let user_name = (chat.user.name)();
+    let user_initials = (chat.user.initials)();
+    let user_color = (chat.user.color)();
     rsx! {
         div {
             id: "chat-scroll",
@@ -123,6 +126,9 @@ pub(super) fn ChatTranscript(chat: Chat) -> Element {
                         agent_avatar: agent_avatar.clone(),
                         agent_initial: agent_initial.clone(),
                         agent_color: agent_color.clone(),
+                        user_name: user_name.clone(),
+                        user_initials: user_initials.clone(),
+                        user_color: user_color.clone(),
                         latest_tool_block: latest_tool
                             .filter(|(item_index, _)| *item_index == i)
                             .map(|(_, block_index)| block_index),

--- a/crates/page/vmux_chat/src/transcript.rs
+++ b/crates/page/vmux_chat/src/transcript.rs
@@ -1,5 +1,6 @@
 use dioxus::prelude::*;
 use std::collections::HashMap;
+use vmux_ui::components::avatar::Avatar;
 use vmux_ui::file_icon::{FilePath, TypeIcon};
 use vmux_ui::i18n::{TranslationValue, translate, translate_with};
 use vmux_ui::icon::{LineIcon, LineIconView};
@@ -17,27 +18,51 @@ pub fn UserBubble(
     #[props(extends = GlobalAttributes)] attributes: Vec<Attribute>,
     children: Element,
 ) -> Element {
+    let you = translate("team-you");
+    let initial = you
+        .chars()
+        .next()
+        .map(|character| character.to_uppercase().to_string())
+        .unwrap_or_default();
     rsx! {
-        div { class: "chat-user-bubble flex max-w-[80%] self-end flex-col gap-2 rounded-[1.35rem] rounded-tr-md border p-2.5 text-sm [contain-intrinsic-size:auto_160px] [contain:layout_paint_style] [content-visibility:auto]", ..attributes,
-            {children}
+        div { class: "chat-user-bubble group flex w-full gap-3 px-1 py-1 text-sm [contain-intrinsic-size:auto_160px] [contain:layout_paint_style] [content-visibility:auto]", ..attributes,
+            Avatar {
+                src: None,
+                fallback: initial,
+                background: "#71717a".to_string(),
+                alt: you.clone(),
+                class: "mt-0.5 h-8 w-8 text-[10px]".to_string(),
+            }
+            div { class: "relative min-w-0 flex-1 pr-8",
+                div { class: "mb-1 text-xs font-semibold text-foreground", "{you}" }
+                div { class: "flex min-w-0 flex-col gap-2", {children} }
+            }
         }
     }
 }
 
 #[component]
 pub fn AssistantTurn(
-    #[props(default = true)] standalone: bool,
+    name: String,
+    avatar_src: Option<String>,
+    avatar_fallback: String,
+    avatar_background: String,
     #[props(extends = GlobalAttributes)] attributes: Vec<Attribute>,
     children: Element,
 ) -> Element {
-    let placement = if standalone {
-        "max-w-[94%] self-start"
-    } else {
-        "w-full"
-    };
     rsx! {
-        div { class: "chat-assistant-turn relative flex flex-col gap-2.5 overflow-hidden rounded-2xl border px-3.5 py-3 [contain-intrinsic-size:auto_160px] [contain:layout_paint_style] [content-visibility:auto] {placement}", ..attributes,
-            {children}
+        div { class: "chat-assistant-turn group flex w-full gap-3 px-1 py-1 [contain-intrinsic-size:auto_160px] [contain:layout_paint_style] [content-visibility:auto]", ..attributes,
+            Avatar {
+                src: avatar_src,
+                fallback: avatar_fallback,
+                background: avatar_background,
+                alt: name.clone(),
+                class: "mt-0.5 h-8 w-8 text-[10px]".to_string(),
+            }
+            div { class: "relative min-w-0 flex-1 pr-8",
+                div { class: "mb-1 text-xs font-semibold text-foreground", "{name}" }
+                div { class: "flex min-w-0 flex-col gap-2.5", {children} }
+            }
         }
     }
 }
@@ -47,7 +72,7 @@ pub fn MessageCopyButton(text: String) -> Element {
     let label = translate("agent-copy");
     rsx! {
         button {
-            class: "pointer-events-none flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground/60 opacity-0 transition group-hover/message:pointer-events-auto group-hover/message:opacity-100 hover:bg-foreground/[0.08] hover:text-foreground focus-visible:pointer-events-auto focus-visible:opacity-100",
+            class: "absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground/60 transition hover:bg-foreground/[0.08] hover:text-foreground",
             title: "{label}",
             aria_label: "{label}",
             onclick: move |event| {
@@ -65,6 +90,10 @@ pub fn ChatItemRow(
     item: ChatItem,
     attachment_previews: Signal<HashMap<String, ChatAttachment>>,
     latest_tool_block: Option<usize>,
+    agent_name: String,
+    agent_avatar: Option<String>,
+    agent_initial: String,
+    agent_color: String,
 ) -> Element {
     let key = absolute_index;
     let item = &item;
@@ -74,46 +103,42 @@ pub fn ChatItemRow(
             context,
             attachments,
         } => rsx! {
-            div {
+            UserBubble {
                 key: "{key}",
-                class: "group/message flex max-w-[80%] self-end flex-col items-end gap-0.5",
-                UserBubble {
-                    class: "chat-user-bubble flex max-w-full self-end flex-col gap-2 rounded-[1.35rem] rounded-tr-md border p-2.5 text-sm [contain-intrinsic-size:auto_96px] [content-visibility:auto]",
-                    if let Some(context) = context {
-                        details { class: "disclosure user-context-panel rounded-xl border",
-                            summary { class: "flex cursor-pointer select-none items-center gap-2 px-2.5 py-2 text-xs list-none [&::-webkit-details-marker]:hidden",
-                                span { class: "agent-themed-activity flex h-5 w-5 shrink-0 items-center justify-center rounded-md",
-                                    LineIconView { icon: LineIcon::Shield, class: "h-3 w-3" }
-                                }
-                                span { class: "font-medium", {translate("agent-prompt-context")} }
-                                span {
-                                    class: "text-[10px] text-muted-foreground",
-                                    {translate_with(
-                                        "agent-bytes",
-                                        &[("count", TranslationValue::Number(context.len() as i64))],
-                                    )}
-                                }
-                                DisclosureIcon {}
+                if !text.is_empty() {
+                    MessageCopyButton { text: text.clone() }
+                }
+                if let Some(context) = context {
+                    details { class: "disclosure user-context-panel rounded-xl border",
+                        summary { class: "flex cursor-pointer select-none items-center gap-2 px-2.5 py-2 text-xs list-none [&::-webkit-details-marker]:hidden",
+                            span { class: "agent-themed-activity flex h-5 w-5 shrink-0 items-center justify-center rounded-md",
+                                LineIconView { icon: LineIcon::Shield, class: "h-3 w-3" }
                             }
-                            pre { class: "user-context-content max-h-72 overflow-auto whitespace-pre-wrap rounded-lg px-3 py-2.5 font-mono text-[11px] leading-relaxed text-muted-foreground", "{context}" }
-                        }
-                    }
-                    if !text.is_empty() {
-                        div { class: "whitespace-pre-wrap px-1.5", "{text}" }
-                    }
-                    if !attachments.is_empty() {
-                        div { class: "flex w-full flex-col gap-2",
-                            for attachment in attachments {
-                                UserAttachment {
-                                    attachment: attachment.clone(),
-                                    previews: attachment_previews,
-                                }
+                            span { class: "font-medium", {translate("agent-prompt-context")} }
+                            span {
+                                class: "text-[10px] text-muted-foreground",
+                                {translate_with(
+                                    "agent-bytes",
+                                    &[("count", TranslationValue::Number(context.len() as i64))],
+                                )}
                             }
+                            DisclosureIcon {}
                         }
+                        pre { class: "user-context-content max-h-72 overflow-auto whitespace-pre-wrap rounded-lg px-3 py-2.5 font-mono text-[11px] leading-relaxed text-muted-foreground", "{context}" }
                     }
                 }
                 if !text.is_empty() {
-                    MessageCopyButton { text: text.clone() }
+                    div { class: "whitespace-pre-wrap px-1.5", "{text}" }
+                }
+                if !attachments.is_empty() {
+                    div { class: "flex w-full flex-col gap-2",
+                        for attachment in attachments {
+                            UserAttachment {
+                                attachment: attachment.clone(),
+                                previews: attachment_previews,
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -122,6 +147,10 @@ pub fn ChatItemRow(
                 turn_index: key,
                 turn: turn.clone(),
                 latest_tool_index: latest_tool_block,
+                agent_name,
+                agent_avatar,
+                agent_initial,
+                agent_color,
             }
         },
     }
@@ -164,7 +193,15 @@ fn UserAttachment(
 }
 
 #[component]
-pub fn TurnView(turn_index: usize, turn: ChatTurn, latest_tool_index: Option<usize>) -> Element {
+pub fn TurnView(
+    turn_index: usize,
+    turn: ChatTurn,
+    latest_tool_index: Option<usize>,
+    agent_name: String,
+    agent_avatar: Option<String>,
+    agent_initial: String,
+    agent_color: String,
+) -> Element {
     let key = turn_index;
     let turn = &turn;
     let reconnecting = matches!(turn.blocks.last(), Some(ChatBlock::Reconnect { .. }));
@@ -228,11 +265,16 @@ pub fn TurnView(turn_index: usize, turn: ChatTurn, latest_tool_index: Option<usi
     rsx! {
         div {
             key: "{key}",
-            class: "group/message flex max-w-[92%] flex-col gap-0.5 self-start [contain-intrinsic-size:auto_180px] [content-visibility:auto]",
-            if !blocks.is_empty() {
+            class: "flex w-full flex-col gap-2 [contain-intrinsic-size:auto_180px] [content-visibility:auto]",
+            if !blocks.is_empty() || turn.running || duration_label.is_some() {
                 AssistantTurn {
-                    standalone: false,
-                    class: "chat-assistant-turn flex flex-col gap-2.5 overflow-hidden rounded-2xl border px-3.5 py-3",
+                    name: agent_name,
+                    avatar_src: agent_avatar,
+                    avatar_fallback: agent_initial,
+                    avatar_background: agent_color,
+                    if !copy_text.is_empty() {
+                        MessageCopyButton { text: copy_text.clone() }
+                    }
                     for item in items {
                         match item {
                             TurnItem::Block((j, block, children)) => rsx! {
@@ -250,19 +292,14 @@ pub fn TurnView(turn_index: usize, turn: ChatTurn, latest_tool_index: Option<usi
                             },
                         }
                     }
-                }
-                if !copy_text.is_empty() {
-                    div { class: "flex justify-end px-1",
-                        MessageCopyButton { text: copy_text.clone() }
+                    if turn.running && !reconnecting {
+                        WorkingIndicator {}
+                    } else if let Some(label) = duration_label {
+                        div { class: "flex items-center gap-2 text-sm text-muted-foreground/70",
+                            span { class: "h-1.5 w-1.5 rounded-full bg-[color:var(--agent-accent)]" }
+                            span { class: "tabular-nums", "{label}" }
+                        }
                     }
-                }
-            }
-            if turn.running && !reconnecting {
-                WorkingIndicator {}
-            } else if let Some(label) = duration_label {
-                div { class: "flex items-center gap-2 px-1 pt-1.5 text-sm text-muted-foreground/70",
-                    span { class: "h-1.5 w-1.5 rounded-full bg-[color:var(--agent-accent)]" }
-                    span { class: "tabular-nums", "{label}" }
                 }
             }
         }
@@ -968,26 +1005,18 @@ fn md_to_html(src: &str) -> String {
 }
 
 pub const MD_CSS: &str = r#"
-.agent-chat-prompt-shell::before{content:"";position:absolute;inset:-28px -42px;z-index:-1;border-radius:2.5rem;background:radial-gradient(60% 90% at 50% 75%,rgba(255,255,255,0.1),transparent 72%);pointer-events:none}
-.agent-chat-page{background-image:radial-gradient(80% 55% at 15% 0%,color-mix(in srgb,var(--agent-accent) 9%,transparent),transparent 65%),radial-gradient(75% 55% at 90% 10%,color-mix(in srgb,var(--agent-accent) 7%,transparent),transparent 62%),radial-gradient(65% 45% at 55% 100%,color-mix(in srgb,var(--agent-accent) 5%,transparent),transparent 70%)}
-.agent-chat-header{border-color:color-mix(in srgb,var(--agent-accent) 12%,transparent)}
-.chat-user-bubble,.chat-assistant-turn{transition:border-color 180ms ease,box-shadow 180ms ease,transform 180ms ease}
-.chat-user-bubble{border-color:color-mix(in srgb,var(--agent-accent) 18%,transparent);background:linear-gradient(135deg,color-mix(in srgb,var(--agent-accent) 19%,transparent),color-mix(in srgb,var(--agent-accent) 9%,transparent) 58%,color-mix(in srgb,var(--agent-accent) 4%,transparent));box-shadow:0 10px 32px color-mix(in srgb,var(--agent-accent) 9%,transparent)}
-.chat-user-bubble:hover{border-color:color-mix(in srgb,var(--agent-accent) 30%,transparent);box-shadow:0 14px 38px color-mix(in srgb,var(--agent-accent) 14%,transparent);transform:translateY(-1px)}
-.chat-assistant-turn{border-color:color-mix(in srgb,var(--agent-accent) 9%,rgba(127,127,127,0.08));background:linear-gradient(135deg,color-mix(in srgb,var(--agent-accent) 5%,transparent),rgba(127,127,127,0.025) 55%,transparent);box-shadow:0 10px 35px rgba(0,0,0,0.035)}
-.chat-assistant-turn::before{content:"";position:absolute;inset:0 auto 0 0;width:2px;background:linear-gradient(180deg,color-mix(in srgb,var(--agent-accent) 82%,transparent),color-mix(in srgb,var(--agent-accent) 52%,transparent),color-mix(in srgb,var(--agent-accent) 28%,transparent));opacity:0.75}
-.chat-assistant-turn:hover{border-color:color-mix(in srgb,var(--agent-accent) 17%,transparent);box-shadow:0 14px 40px color-mix(in srgb,var(--agent-accent) 5%,rgba(0,0,0,0.055))}
+.session-chat-page{background-image:none}
 .chat-assistant-turn .disclosure>summary{transition:color 160ms ease}
 .chat-assistant-turn .disclosure>summary:hover{color:color-mix(in srgb,currentColor 68%,var(--agent-accent))}
 .agent-themed-activity{color:var(--agent-accent);background:color-mix(in srgb,var(--agent-accent) 11%,transparent);box-shadow:inset 0 0 0 1px color-mix(in srgb,var(--agent-accent) 18%,transparent)}
 .python-activity-icon{background:linear-gradient(145deg,rgba(55,118,171,0.15),rgba(255,212,59,0.11));color:#3776ab;box-shadow:inset 0 0 0 1px rgba(55,118,171,0.3)}
 .agent-working-label{color:color-mix(in srgb,var(--agent-accent) 82%,currentColor)}
 .agent-row-hover:hover{background:color-mix(in srgb,var(--agent-accent) 4%,transparent)}
-.agent-code-panel,.user-context-content{background:color-mix(in srgb,var(--agent-accent) 4%,transparent);box-shadow:inset 0 0 0 1px color-mix(in srgb,var(--agent-accent) 11%,transparent)}
+.agent-code-panel,.user-context-content{background:rgba(127,127,127,0.07);box-shadow:inset 0 0 0 1px rgba(127,127,127,0.14)}
 .agent-context-tree{border-color:color-mix(in srgb,var(--agent-accent) 22%,transparent)}
 .agent-turn-meta{color:color-mix(in srgb,var(--agent-accent) 72%,currentColor);border-color:color-mix(in srgb,var(--agent-accent) 13%,transparent);background:color-mix(in srgb,var(--agent-accent) 7%,transparent)}
 .agent-turn-meta-dot{background:var(--agent-accent)}
 .user-context-panel{border-color:color-mix(in srgb,var(--agent-accent) 14%,transparent);background:color-mix(in srgb,var(--agent-accent) 5%,rgba(127,127,127,0.025))}
 .user-context-panel>summary:hover{color:color-mix(in srgb,currentColor 65%,var(--agent-accent))}
-@media (prefers-reduced-motion:reduce){.agent-chat-caret{animation:none}.chat-user-bubble,.chat-assistant-turn{transition:none}.chat-user-bubble:hover{transform:none}}
+@media (prefers-reduced-motion:reduce){.agent-chat-caret{animation:none}}
 "#;

--- a/crates/page/vmux_chat/src/transcript.rs
+++ b/crates/page/vmux_chat/src/transcript.rs
@@ -15,23 +15,22 @@ use vmux_ui::platform::{random_index, sleep_ms};
 
 #[component]
 pub fn UserBubble(
+    avatar_name: String,
+    avatar_initials: String,
+    avatar_color: String,
     #[props(extends = GlobalAttributes)] attributes: Vec<Attribute>,
     children: Element,
 ) -> Element {
     let you = translate("team-you");
-    let initial = you
-        .chars()
-        .next()
-        .map(|character| character.to_uppercase().to_string())
-        .unwrap_or_default();
     rsx! {
         div { class: "chat-user-bubble group flex w-full gap-3 px-1 py-1 text-sm [contain-intrinsic-size:auto_160px] [contain:layout_paint_style] [content-visibility:auto]", ..attributes,
             Avatar {
                 src: None,
-                fallback: initial,
-                background: "#71717a".to_string(),
-                alt: you.clone(),
+                fallback: avatar_initials,
+                background: avatar_color,
+                alt: avatar_name.clone(),
                 class: "mt-0.5 h-8 w-8 text-[10px]".to_string(),
+                seed: Some(avatar_name),
             }
             div { class: "relative min-w-0 flex-1 pr-8",
                 div { class: "mb-1 text-xs font-semibold text-foreground", "{you}" }
@@ -94,6 +93,9 @@ pub fn ChatItemRow(
     agent_avatar: Option<String>,
     agent_initial: String,
     agent_color: String,
+    user_name: String,
+    user_initials: String,
+    user_color: String,
 ) -> Element {
     let key = absolute_index;
     let item = &item;
@@ -105,6 +107,9 @@ pub fn ChatItemRow(
         } => rsx! {
             UserBubble {
                 key: "{key}",
+                avatar_name: user_name,
+                avatar_initials: user_initials,
+                avatar_color: user_color,
                 if !text.is_empty() {
                     MessageCopyButton { text: text.clone() }
                 }

--- a/crates/page/vmux_chat/src/transcript.rs
+++ b/crates/page/vmux_chat/src/transcript.rs
@@ -72,7 +72,6 @@ pub fn AssistantTurn(
 
 #[component]
 fn MessageMeta(text: String, #[props(default)] right: bool) -> Element {
-    let timestamp = use_hook(|| chrono::Local::now().format("%-I:%M%P").to_string());
     let alignment = if right {
         "justify-end"
     } else {
@@ -83,7 +82,6 @@ fn MessageMeta(text: String, #[props(default)] right: bool) -> Element {
             if !text.is_empty() {
                 MessageCopyButton { text }
             }
-            time { class: "tabular-nums", "{timestamp}" }
         }
     }
 }

--- a/crates/page/vmux_chat/src/transcript.rs
+++ b/crates/page/vmux_chat/src/transcript.rs
@@ -23,7 +23,7 @@ pub fn UserBubble(
 ) -> Element {
     let you = translate("team-you");
     rsx! {
-        div { class: "chat-user-bubble group flex w-full gap-3 px-1 py-1 text-sm [contain-intrinsic-size:auto_160px] [contain:layout_paint_style] [content-visibility:auto]", ..attributes,
+        div { class: "chat-user-bubble group flex w-full flex-row-reverse items-start justify-start gap-3 px-1 py-1 text-sm [contain-intrinsic-size:auto_160px] [contain:layout_paint_style] [content-visibility:auto]", ..attributes,
             Avatar {
                 src: None,
                 fallback: avatar_initials,
@@ -32,9 +32,9 @@ pub fn UserBubble(
                 class: "mt-0.5 h-8 w-8 text-[10px]".to_string(),
                 seed: Some(avatar_name),
             }
-            div { class: "relative min-w-0 flex-1 pr-8",
-                div { class: "mb-1 text-xs font-semibold text-foreground", "{you}" }
-                div { class: "flex min-w-0 flex-col gap-2", {children} }
+            div { class: "relative min-w-0 max-w-[80%] flex-none pl-8",
+                div { class: "mb-1 text-right text-xs font-semibold text-foreground", "{you}" }
+                div { class: "flex min-w-0 flex-col items-end gap-2 text-left", {children} }
             }
         }
     }
@@ -67,11 +67,12 @@ pub fn AssistantTurn(
 }
 
 #[component]
-pub fn MessageCopyButton(text: String) -> Element {
+pub fn MessageCopyButton(text: String, #[props(default)] left: bool) -> Element {
     let label = translate("agent-copy");
+    let position = if left { "left-0" } else { "right-2" };
     rsx! {
         button {
-            class: "absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground/60 transition hover:bg-foreground/[0.08] hover:text-foreground",
+            class: "absolute {position} top-2 z-10 flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground/60 transition hover:bg-foreground/[0.08] hover:text-foreground",
             title: "{label}",
             aria_label: "{label}",
             onclick: move |event| {
@@ -111,7 +112,7 @@ pub fn ChatItemRow(
                 avatar_initials: user_initials,
                 avatar_color: user_color,
                 if !text.is_empty() {
-                    MessageCopyButton { text: text.clone() }
+                    MessageCopyButton { text: text.clone(), left: true }
                 }
                 if let Some(context) = context {
                     details { class: "disclosure user-context-panel rounded-xl border",

--- a/crates/page/vmux_chat/src/transcript.rs
+++ b/crates/page/vmux_chat/src/transcript.rs
@@ -18,6 +18,7 @@ pub fn UserBubble(
     avatar_name: String,
     avatar_initials: String,
     avatar_color: String,
+    #[props(default)] copy_text: String,
     #[props(extends = GlobalAttributes)] attributes: Vec<Attribute>,
     children: Element,
 ) -> Element {
@@ -35,6 +36,7 @@ pub fn UserBubble(
             div { class: "relative min-w-0 max-w-[80%] flex-none pl-8",
                 div { class: "mb-1 text-right text-xs font-semibold text-foreground", "{you}" }
                 div { class: "flex min-w-0 flex-col items-end gap-2 text-left", {children} }
+                MessageMeta { text: copy_text, right: true }
             }
         }
     }
@@ -46,6 +48,7 @@ pub fn AssistantTurn(
     avatar_src: Option<String>,
     avatar_fallback: String,
     avatar_background: String,
+    #[props(default)] copy_text: String,
     #[props(extends = GlobalAttributes)] attributes: Vec<Attribute>,
     children: Element,
 ) -> Element {
@@ -61,18 +64,36 @@ pub fn AssistantTurn(
             div { class: "relative min-w-0 flex-1 pr-8",
                 div { class: "mb-1 text-xs font-semibold text-foreground", "{name}" }
                 div { class: "flex min-w-0 flex-col gap-2.5", {children} }
+                MessageMeta { text: copy_text }
             }
         }
     }
 }
 
 #[component]
-pub fn MessageCopyButton(text: String, #[props(default)] left: bool) -> Element {
+fn MessageMeta(text: String, #[props(default)] right: bool) -> Element {
+    let timestamp = use_hook(|| chrono::Local::now().format("%-I:%M%P").to_string());
+    let alignment = if right {
+        "justify-end"
+    } else {
+        "justify-start"
+    };
+    rsx! {
+        div { class: "mt-1 flex h-6 items-center gap-1 {alignment} text-[11px] text-muted-foreground/45",
+            if !text.is_empty() {
+                MessageCopyButton { text }
+            }
+            time { class: "tabular-nums", "{timestamp}" }
+        }
+    }
+}
+
+#[component]
+pub fn MessageCopyButton(text: String) -> Element {
     let label = translate("agent-copy");
-    let position = if left { "left-0" } else { "right-2" };
     rsx! {
         button {
-            class: "absolute {position} top-2 z-10 flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground/60 transition hover:bg-foreground/[0.08] hover:text-foreground",
+            class: "pointer-events-none flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground/60 opacity-0 transition group-hover:pointer-events-auto group-hover:opacity-100 hover:bg-foreground/[0.08] hover:text-foreground focus-visible:pointer-events-auto focus-visible:opacity-100",
             title: "{label}",
             aria_label: "{label}",
             onclick: move |event| {
@@ -111,9 +132,7 @@ pub fn ChatItemRow(
                 avatar_name: user_name,
                 avatar_initials: user_initials,
                 avatar_color: user_color,
-                if !text.is_empty() {
-                    MessageCopyButton { text: text.clone(), left: true }
-                }
+                copy_text: text.clone(),
                 if let Some(context) = context {
                     details { class: "disclosure user-context-panel rounded-xl border",
                         summary { class: "flex cursor-pointer select-none items-center gap-2 px-2.5 py-2 text-xs list-none [&::-webkit-details-marker]:hidden",
@@ -278,9 +297,7 @@ pub fn TurnView(
                     avatar_src: agent_avatar,
                     avatar_fallback: agent_initial,
                     avatar_background: agent_color,
-                    if !copy_text.is_empty() {
-                        MessageCopyButton { text: copy_text.clone() }
-                    }
+                    copy_text,
                     for item in items {
                         match item {
                             TurnItem::Block((j, block, children)) => rsx! {

--- a/crates/page/vmux_command/src/host/snapshot.rs
+++ b/crates/page/vmux_command/src/host/snapshot.rs
@@ -150,7 +150,7 @@ impl AgentPromptTarget {
     pub fn url(&self) -> String {
         match self {
             Self::Cli(kind) => format!("{}cli", kind.cli_url_prefix()),
-            Self::Acp { id } => format!("vmux://agent/{id}"),
+            Self::Acp { id } => format!("vmux://sessions/{id}"),
         }
     }
 }
@@ -289,13 +289,13 @@ mod tests {
     #[test]
     fn prompt_goes_to_the_lowest_ranked_page() {
         let pages = vec![
-            ContributedPage::ranked("vmux://agent/claude", 1),
-            ContributedPage::ranked("vmux://agent/codex/cli", 0),
+            ContributedPage::ranked("vmux://sessions/claude", 1),
+            ContributedPage::ranked("vmux://sessions/codex/cli", 0),
         ];
 
         assert_eq!(
             ContributedPage::prompt_url_among(pages, None).as_deref(),
-            Some("vmux://agent/codex/cli")
+            Some("vmux://sessions/codex/cli")
         );
     }
 
@@ -303,18 +303,19 @@ mod tests {
     fn prompt_honours_a_listed_request_and_ignores_a_stale_one() {
         let pages = || {
             vec![
-                ContributedPage::ranked("vmux://agent/codex/cli", 0),
-                ContributedPage::ranked("vmux://agent/claude", 1),
+                ContributedPage::ranked("vmux://sessions/codex/cli", 0),
+                ContributedPage::ranked("vmux://sessions/claude", 1),
             ]
         };
 
         assert_eq!(
-            ContributedPage::prompt_url_among(pages(), Some("vmux://agent/claude")).as_deref(),
-            Some("vmux://agent/claude")
+            ContributedPage::prompt_url_among(pages(), Some("vmux://sessions/claude")).as_deref(),
+            Some("vmux://sessions/claude")
         );
         assert_eq!(
-            ContributedPage::prompt_url_among(pages(), Some("vmux://agent/uninstalled")).as_deref(),
-            Some("vmux://agent/codex/cli")
+            ContributedPage::prompt_url_among(pages(), Some("vmux://sessions/uninstalled"))
+                .as_deref(),
+            Some("vmux://sessions/codex/cli")
         );
     }
 

--- a/crates/page/vmux_layout/src/host/cef.rs
+++ b/crates/page/vmux_layout/src/host/cef.rs
@@ -238,26 +238,29 @@ mod apply_cef_state_tests {
 
     #[test]
     fn vmux_agent_url_accepts_dynamic_title_only() {
-        let mut meta = PageMetadata {
-            url: "vmux://sessions/codex".into(),
-            title: "Codex".into(),
-            icon: vmux_core::PageIcon::Builtin(vmux_core::BuiltinIcon::Sparkles),
-            bg_color: None,
-        };
-        apply_cef_state_to_meta(
-            &mut meta,
-            ev(
-                Some("● Codex"),
-                Some("https://example.com/favicon.ico"),
-                None,
-            ),
-        );
-        assert_eq!(meta.title, "● Codex");
-        assert_eq!(meta.url, "vmux://sessions/codex");
-        assert_eq!(
-            meta.icon,
-            vmux_core::PageIcon::Builtin(vmux_core::BuiltinIcon::Sparkles)
-        );
+        for url in ["vmux://sessions/codex", "vmux://agent/codex"] {
+            let mut meta = PageMetadata {
+                url: url.into(),
+                title: "Codex".into(),
+                icon: vmux_core::PageIcon::Builtin(vmux_core::BuiltinIcon::Sparkles),
+                bg_color: None,
+            };
+            apply_cef_state_to_meta(
+                &mut meta,
+                ev(
+                    Some("● Codex"),
+                    Some("https://example.com/favicon.ico"),
+                    None,
+                ),
+            );
+            assert_eq!(meta.title, "● Codex", "{url}");
+            assert_eq!(meta.url, url);
+            assert_eq!(
+                meta.icon,
+                vmux_core::PageIcon::Builtin(vmux_core::BuiltinIcon::Sparkles),
+                "{url}"
+            );
+        }
     }
 
     #[test]

--- a/crates/page/vmux_layout/src/host/cef.rs
+++ b/crates/page/vmux_layout/src/host/cef.rs
@@ -73,7 +73,8 @@ pub(crate) fn apply_cef_state_to_meta(
     ev: bevy_cef_core::prelude::WebviewCefStateEvent,
 ) {
     let on_native_view = meta.url.starts_with("vmux://");
-    let accepts_dynamic_title = meta.url.starts_with("vmux://agent/");
+    let accepts_dynamic_title =
+        meta.url.starts_with("vmux://sessions/") || meta.url.starts_with("vmux://agent/");
     let navigating_away = ev.url.as_deref().is_some_and(|u| !u.starts_with("vmux://"));
     if on_native_view && !navigating_away {
         if accepts_dynamic_title && let Some(title) = ev.title {
@@ -238,7 +239,7 @@ mod apply_cef_state_tests {
     #[test]
     fn vmux_agent_url_accepts_dynamic_title_only() {
         let mut meta = PageMetadata {
-            url: "vmux://agent/codex".into(),
+            url: "vmux://sessions/codex".into(),
             title: "Codex".into(),
             icon: vmux_core::PageIcon::Builtin(vmux_core::BuiltinIcon::Sparkles),
             bg_color: None,
@@ -252,7 +253,7 @@ mod apply_cef_state_tests {
             ),
         );
         assert_eq!(meta.title, "● Codex");
-        assert_eq!(meta.url, "vmux://agent/codex");
+        assert_eq!(meta.url, "vmux://sessions/codex");
         assert_eq!(
             meta.icon,
             vmux_core::PageIcon::Builtin(vmux_core::BuiltinIcon::Sparkles)

--- a/crates/page/vmux_layout/src/host/pane.rs
+++ b/crates/page/vmux_layout/src/host/pane.rs
@@ -2802,7 +2802,7 @@ mod tests {
             tab,
             1,
             Vec2::new(800.0, 900.0),
-            "vmux://agent/claude/session",
+            "vmux://sessions/claude/session",
         );
         place_pane_with_url(
             &mut app,
@@ -2865,7 +2865,7 @@ mod tests {
             tab,
             1,
             Vec2::new(1600.0, 900.0),
-            "vmux://agent/claude/session",
+            "vmux://sessions/claude/session",
         );
 
         for (i, url) in [
@@ -2960,7 +2960,7 @@ mod tests {
             tab,
             1,
             Vec2::new(1600.0, 900.0),
-            "vmux://agent/claude/session",
+            "vmux://sessions/claude/session",
         );
 
         for (i, url) in [
@@ -3030,7 +3030,7 @@ mod tests {
             tab,
             1,
             Vec2::new(1600.0, 900.0),
-            "vmux://agent/claude/session",
+            "vmux://sessions/claude/session",
         );
 
         for (i, url) in [
@@ -3099,7 +3099,7 @@ mod tests {
             tab,
             1,
             Vec2::new(1600.0, 900.0),
-            "vmux://agent/claude/session",
+            "vmux://sessions/claude/session",
         );
 
         for (i, url) in [
@@ -3176,7 +3176,7 @@ mod tests {
             tab,
             1,
             Vec2::new(1600.0, 900.0),
-            "vmux://agent/claude/session",
+            "vmux://sessions/claude/session",
         );
 
         for (i, url) in [
@@ -3260,7 +3260,7 @@ mod tests {
             tab,
             1,
             Vec2::new(1600.0, 900.0),
-            "vmux://agent/claude/session",
+            "vmux://sessions/claude/session",
         );
         let browser_pane = place_pane_with_url(
             &mut app,
@@ -3332,7 +3332,7 @@ mod tests {
             tab,
             1,
             Vec2::new(1600.0, 900.0),
-            "vmux://agent/claude/session",
+            "vmux://sessions/claude/session",
         );
 
         for (i, url) in [
@@ -3408,7 +3408,7 @@ mod tests {
             tab,
             1,
             Vec2::new(1600.0, 900.0),
-            "vmux://agent/claude/session",
+            "vmux://sessions/claude/session",
         );
 
         for (i, url) in [
@@ -3482,7 +3482,7 @@ mod tests {
             tab,
             1,
             Vec2::new(1600.0, 900.0),
-            "vmux://agent/claude/session",
+            "vmux://sessions/claude/session",
         );
 
         for i in 0..2 {
@@ -3529,7 +3529,7 @@ mod tests {
             tab,
             1,
             Vec2::new(1600.0, 900.0),
-            "vmux://agent/claude/session",
+            "vmux://sessions/claude/session",
         );
 
         app.world_mut()
@@ -3603,7 +3603,7 @@ mod tests {
             tab,
             1,
             Vec2::new(1600.0, 900.0),
-            "vmux://agent/claude/session",
+            "vmux://sessions/claude/session",
         );
 
         app.world_mut()
@@ -4287,7 +4287,7 @@ mod tests {
     #[test]
     fn run_terminal_spirals_off_newest_nonagent_leaf() {
         let (mut app, agent) = spiral_app(
-            "vmux://agent/vibe/x",
+            "vmux://sessions/vibe/x",
             Some(("https://a.com", 9, Vec2::new(1600.0, 900.0))),
         );
         let browser = app
@@ -4322,7 +4322,7 @@ mod tests {
     #[test]
     fn run_terminal_adds_tab_to_existing_terminal_stack() {
         let (mut app, agent) = spiral_app(
-            "vmux://agent/vibe/x",
+            "vmux://sessions/vibe/x",
             Some(("vmux://terminal/7", 9, Vec2::new(1600.0, 900.0))),
         );
         let term_pane = app

--- a/crates/page/vmux_layout/src/host/placement.rs
+++ b/crates/page/vmux_layout/src/host/placement.rs
@@ -11,7 +11,7 @@ pub enum PageKind {
 }
 
 pub fn page_kind_for_url(url: &str) -> PageKind {
-    if url.starts_with("vmux://agent/") {
+    if url.starts_with("vmux://sessions/") || url.starts_with("vmux://agent/") {
         PageKind::Agent
     } else if url.starts_with("vmux://terminal/") {
         PageKind::Terminal
@@ -168,7 +168,10 @@ mod tests {
 
     #[test]
     fn classifies_core_four_kinds() {
-        assert_eq!(page_kind_for_url("vmux://agent/vibe/abc"), PageKind::Agent);
+        assert_eq!(
+            page_kind_for_url("vmux://sessions/vibe/abc"),
+            PageKind::Agent
+        );
         assert_eq!(page_kind_for_url("vmux://terminal/123"), PageKind::Terminal);
         assert_eq!(page_kind_for_url("file:///x.rs"), PageKind::File);
         assert_eq!(page_kind_for_url("https://example.com"), PageKind::Browser);
@@ -365,7 +368,7 @@ mod tests {
             leaf(1, &[PageKind::Agent], 1, (800.0, 900.0)),
             leaf(2, &[PageKind::Browser], 9, (900.0, 400.0)),
         ];
-        let got = resolve_placement("vmux://agent/vibe/x", None, &leaves, e(2));
+        let got = resolve_placement("vmux://sessions/vibe/x", None, &leaves, e(2));
         assert_eq!(got, Placement::AddTab { pane: e(1) });
     }
 
@@ -385,7 +388,7 @@ mod tests {
     #[test]
     fn agent_page_bootstraps_by_splitting_newest_nonagent_when_no_agent_pane() {
         let leaves = [leaf(2, &[PageKind::Browser], 9, (400.0, 900.0))];
-        let got = resolve_placement("vmux://agent/vibe/x", None, &leaves, e(2));
+        let got = resolve_placement("vmux://sessions/vibe/x", None, &leaves, e(2));
         assert_eq!(
             got,
             Placement::Spiral {

--- a/crates/page/vmux_layout/src/host/placement.rs
+++ b/crates/page/vmux_layout/src/host/placement.rs
@@ -77,12 +77,19 @@ fn file_reuse_key(url: &str) -> &str {
     url.split('#').next().unwrap_or(url)
 }
 
+fn agent_reuse_key(url: &str) -> &str {
+    url.strip_prefix("vmux://sessions/")
+        .or_else(|| url.strip_prefix("vmux://agent/"))
+        .unwrap_or(url)
+}
+
 pub fn reusable_page_match(request_url: &str, existing_url: &str) -> bool {
     let kind = page_kind_for_url(request_url);
     if page_kind_for_url(existing_url) != kind {
         return false;
     }
     match kind {
+        PageKind::Agent => agent_reuse_key(request_url) == agent_reuse_key(existing_url),
         PageKind::File => file_reuse_key(request_url) == file_reuse_key(existing_url),
         _ => request_url == existing_url,
     }
@@ -211,6 +218,22 @@ mod tests {
                 stack: e(2)
             }
         );
+    }
+
+    #[test]
+    fn canonical_and_legacy_agent_urls_reuse_the_same_session() {
+        assert!(reusable_page_match(
+            "vmux://sessions/codex/session-1",
+            "vmux://agent/codex/session-1"
+        ));
+        assert!(reusable_page_match(
+            "vmux://agent/codex/session-1",
+            "vmux://sessions/codex/session-1"
+        ));
+        assert!(!reusable_page_match(
+            "vmux://sessions/codex/session-1",
+            "vmux://agent/codex/session-2"
+        ));
     }
 
     #[test]

--- a/crates/page/vmux_layout/src/host/stack.rs
+++ b/crates/page/vmux_layout/src/host/stack.rs
@@ -1186,7 +1186,7 @@ mod tests {
             .init_resource::<PendingCursorWarp>()
             .insert_resource(test_settings())
             .insert_resource(vmux_core::EffectiveStartupUrl(
-                "vmux://agent/vibe/".to_string(),
+                "vmux://sessions/vibe/".to_string(),
             ))
             .add_systems(
                 Update,

--- a/crates/page/vmux_layout/src/host/tab.rs
+++ b/crates/page/vmux_layout/src/host/tab.rs
@@ -770,7 +770,7 @@ mod tests {
         app.world_mut()
             .resource_mut::<Messages<crate::NewTabRequest>>()
             .write(crate::NewTabRequest {
-                url: "vmux://agent/codex/cli".to_string(),
+                url: "vmux://sessions/codex/cli".to_string(),
                 pending_prompt: Some("continue from my phone".to_string()),
             });
 
@@ -778,7 +778,7 @@ mod tests {
 
         let collected = app.world().resource::<CollectedSpawns>();
         assert_eq!(collected.0.len(), 1);
-        assert_eq!(collected.0[0].url, "vmux://agent/codex/cli");
+        assert_eq!(collected.0[0].url, "vmux://sessions/codex/cli");
         let prompts = app
             .world_mut()
             .query::<&vmux_core::PendingPrompt>()

--- a/crates/page/vmux_layout/src/host/window.rs
+++ b/crates/page/vmux_layout/src/host/window.rs
@@ -946,7 +946,7 @@ mod tests {
                 focus_ring: crate::settings::FocusRingSettings::default(),
             })
             .insert_resource(vmux_core::EffectiveStartupUrl(
-                "vmux://agent/vibe/".to_string(),
+                "vmux://sessions/vibe/".to_string(),
             ))
             .add_systems(
                 Startup,
@@ -999,7 +999,7 @@ mod tests {
                 focus_ring: crate::settings::FocusRingSettings::default(),
             })
             .insert_resource(vmux_core::EffectiveStartupUrl(
-                "vmux://agent/vibe/".to_string(),
+                "vmux://sessions/vibe/".to_string(),
             ))
             .add_systems(
                 Startup,

--- a/crates/page/vmux_layout/src/page.rs
+++ b/crates/page/vmux_layout/src/page.rs
@@ -1628,6 +1628,7 @@ fn TeamFacepile(members: Vec<TeamMemberRow>) -> Element {
                         background: user.color.clone(),
                         alt: user.name.clone(),
                         class: "size-5 text-[9px]",
+                        seed: Some(user.name.clone()),
                     }
                     span { class: "whitespace-nowrap text-xs font-medium text-foreground", "{user.name}" }
                 }
@@ -1655,6 +1656,7 @@ fn TeamFacepile(members: Vec<TeamMemberRow>) -> Element {
                                         background: m.color.clone(),
                                         alt: m.name.clone(),
                                         class: "size-5 text-[9px] ring-2 ring-background",
+                                        seed: None,
                                     }
                                     if m.is_running {
                                         span { class: "absolute -bottom-0.5 -right-0.5 size-1.5 rounded-full bg-success ring-2 ring-background" }

--- a/crates/page/vmux_setting/src/host/runtime.rs
+++ b/crates/page/vmux_setting/src/host/runtime.rs
@@ -88,7 +88,15 @@ impl AppSettings {
             .map(str::trim)
             .filter(|s| !s.is_empty());
         let chosen = per_space.unwrap_or_else(|| self.browser.startup_url.trim());
-        if chosen.is_empty() || chosen == "vmux://sessions/" || chosen == "vmux://sessions" {
+        if chosen.is_empty()
+            || [
+                "vmux://sessions/",
+                "vmux://sessions",
+                "vmux://agent/",
+                "vmux://agent",
+            ]
+            .contains(&chosen)
+        {
             default_browser_startup_url()
         } else {
             chosen.to_string()
@@ -1825,10 +1833,17 @@ mod tests {
     }
 
     #[test]
-    fn resolve_startup_url_treats_legacy_agent_default_as_start() {
-        let mut s = base_settings();
-        s.browser.startup_url = "vmux://sessions/".into();
-        assert_eq!(s.startup_url("space-1"), "vmux://start/");
+    fn resolve_startup_url_treats_agent_roots_as_start() {
+        for url in [
+            "vmux://sessions/",
+            "vmux://sessions",
+            "vmux://agent/",
+            "vmux://agent",
+        ] {
+            let mut s = base_settings();
+            s.browser.startup_url = url.into();
+            assert_eq!(s.startup_url("space-1"), "vmux://start/", "{url}");
+        }
     }
 
     #[test]

--- a/crates/page/vmux_setting/src/host/runtime.rs
+++ b/crates/page/vmux_setting/src/host/runtime.rs
@@ -88,7 +88,7 @@ impl AppSettings {
             .map(str::trim)
             .filter(|s| !s.is_empty());
         let chosen = per_space.unwrap_or_else(|| self.browser.startup_url.trim());
-        if chosen.is_empty() || chosen == "vmux://agent/" || chosen == "vmux://agent" {
+        if chosen.is_empty() || chosen == "vmux://sessions/" || chosen == "vmux://sessions" {
             default_browser_startup_url()
         } else {
             chosen.to_string()
@@ -1827,7 +1827,7 @@ mod tests {
     #[test]
     fn resolve_startup_url_treats_legacy_agent_default_as_start() {
         let mut s = base_settings();
-        s.browser.startup_url = "vmux://agent/".into();
+        s.browser.startup_url = "vmux://sessions/".into();
         assert_eq!(s.startup_url("space-1"), "vmux://start/");
     }
 

--- a/crates/page/vmux_start/src/host.rs
+++ b/crates/page/vmux_start/src/host.rs
@@ -743,22 +743,22 @@ mod tests {
     #[test]
     fn inline_transition_only_supports_page_agents() {
         assert!(crate::supports_inline_agent_transition(
-            "vmux://agent/codex"
+            "vmux://sessions/codex"
         ));
         assert!(crate::supports_inline_agent_transition(
-            "vmux://agent/openai/gpt-5/session"
+            "vmux://sessions/openai/gpt-5/session"
         ));
         assert!(!crate::supports_inline_agent_transition(
-            "vmux://agent/codex/cli"
+            "vmux://sessions/codex/cli"
         ));
         assert!(!crate::supports_inline_agent_transition(
-            "vmux://agent/vibe/setup"
+            "vmux://sessions/vibe/setup"
         ));
         assert!(crate::supports_inline_agent_transition(
-            "vmux://agent/cliff"
+            "vmux://sessions/cliff"
         ));
         assert!(crate::supports_inline_agent_transition(
-            "vmux://agent/setupwizard"
+            "vmux://sessions/setupwizard"
         ));
     }
 

--- a/crates/page/vmux_start/src/roster.rs
+++ b/crates/page/vmux_start/src/roster.rs
@@ -58,7 +58,7 @@ impl Launcher {
             let cwd = vmux_ui::file_icon::FilePath(&session.cwd).name();
             tabs.push(CommandBarTab {
                 title: session.name.clone(),
-                url: format!("vmux://agent/{sid}", sid = session.sid),
+                url: format!("vmux://sessions/{sid}", sid = session.sid),
                 pane_id: 0,
                 tab_index: index as u32,
                 is_active: false,
@@ -107,7 +107,7 @@ mod tests {
                 agents: vec![RemoteAgent {
                     id: "claude".into(),
                     name: "Claude".into(),
-                    url: "vmux://agent/claude".into(),
+                    url: "vmux://sessions/claude".into(),
                     icon: String::new(),
                 }],
             }
@@ -179,7 +179,7 @@ mod tests {
         let started = Started::with(Roster::of_one());
         let tab = &started.launcher().tabs[0];
 
-        assert_eq!(tab.url, "vmux://agent/sid-api");
+        assert_eq!(tab.url, "vmux://sessions/sid-api");
         assert!(
             tab.location.contains("api") && tab.location.contains("claude"),
             "the row names the runtime and the directory: {}",
@@ -194,7 +194,7 @@ mod tests {
 
         assert_eq!(pages.len(), 1);
         assert!(pages[0].prompt_target);
-        assert_eq!(pages[0].url, "vmux://agent/claude");
+        assert_eq!(pages[0].url, "vmux://sessions/claude");
     }
 
     #[test]

--- a/crates/page/vmux_team/src/host.rs
+++ b/crates/page/vmux_team/src/host.rs
@@ -567,7 +567,7 @@ mod tests {
                 kind: None,
             },
             PageMetadata {
-                url: "vmux://agent/mistral-vibe".to_string(),
+                url: "vmux://sessions/mistral-vibe".to_string(),
                 icon: vmux_core::PageIcon::favicon("https://cdn.example/vibe.svg"),
                 ..default()
             },
@@ -610,6 +610,6 @@ mod tests {
             .expect("acp agent in roster");
         assert_eq!(agent.name, "Mistral Vibe");
         assert_eq!(agent.icon, "https://cdn.example/vibe.svg");
-        assert_eq!(agent.url, "vmux://agent/mistral-vibe");
+        assert_eq!(agent.url, "vmux://sessions/mistral-vibe");
     }
 }

--- a/crates/page/vmux_team/src/page.rs
+++ b/crates/page/vmux_team/src/page.rs
@@ -141,6 +141,7 @@ fn TeamAvatar(member: TeamMemberRow) -> Element {
                 background: member.color.clone(),
                 alt: member.name.clone(),
                 class: "size-8 text-sm",
+                seed: member.is_user.then(|| member.name.clone()),
             }
             if member.is_running {
                 span { class: "absolute -bottom-0.5 -right-0.5 size-3 rounded-full bg-success ring-2 ring-background animate-pulse" }

--- a/crates/page/vmux_terminal/src/host/plugin.rs
+++ b/crates/page/vmux_terminal/src/host/plugin.rs
@@ -5194,7 +5194,7 @@ mod tests {
                 pid,
                 PageMetadata {
                     title: "Vibe (abc12345)".to_string(),
-                    url: "vmux://agent/vibe/abc12345".to_string(),
+                    url: "vmux://sessions/vibe/abc12345".to_string(),
                     icon: vmux_core::PageIcon::None,
                     bg_color: None,
                 },

--- a/crates/page/vmux_terminal/src/page.rs
+++ b/crates/page/vmux_terminal/src/page.rs
@@ -519,7 +519,7 @@ pub fn Page() -> Element {
                     } else {
                         label.clone()
                     };
-                    let favicon_url = format!("vmux://agent/{segment}/cli/");
+                    let favicon_url = format!("vmux://sessions/{segment}/cli/");
                     let words = vec![display_label.to_uppercase()];
                     let (draft_text, draft_skipped) = prompt_draft.read().clone();
                     let composing = !draft_skipped && !draft_text.is_empty();

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -685,6 +685,11 @@ fn should_emit_update(
 
 fn normalize_vmux_url(url: &str) -> String {
     let url = url.trim();
+    if let Some(rest) = url.strip_prefix("vmux://agent")
+        && (rest.is_empty() || rest.starts_with('/'))
+    {
+        return normalize_vmux_url(&format!("vmux://sessions{rest}"));
+    }
     if let Some(rest) = url.strip_prefix("vmux://")
         && !rest.is_empty()
         && !rest.contains('/')
@@ -806,8 +811,8 @@ mod tests {
         assert_eq!(normalize_vmux_url("vmux://terminal"), "vmux://terminal/");
         assert_eq!(normalize_vmux_url("vmux://lsp/"), "vmux://lsp/");
         assert_eq!(
-            normalize_vmux_url("vmux://agent/vibe/"),
-            "vmux://agent/vibe/"
+            normalize_vmux_url("vmux://sessions/vibe/"),
+            "vmux://sessions/vibe/"
         );
         assert_eq!(
             normalize_vmux_url("vmux://error/?title=x"),
@@ -818,8 +823,12 @@ mod tests {
             "file:///tmp/main.rs"
         );
         assert_eq!(
-            normalize_vmux_url("  vmux://agent/codex/session-id  "),
-            "vmux://agent/codex/session-id"
+            normalize_vmux_url("  vmux://sessions/codex/session-id  "),
+            "vmux://sessions/codex/session-id"
+        );
+        assert_eq!(
+            normalize_vmux_url("vmux://agent/codex/session-id"),
+            "vmux://sessions/codex/session-id"
         );
     }
 
@@ -857,7 +866,7 @@ mod tests {
             .spawn((
                 Stack::default(),
                 PageMetadata {
-                    url: "vmux://agent/vibe/".to_string(),
+                    url: "vmux://sessions/vibe/".to_string(),
                     ..default()
                 },
             ))
@@ -867,7 +876,7 @@ mod tests {
             .spawn((
                 Browser,
                 PageMetadata {
-                    url: "vmux://agent/vibe/".to_string(),
+                    url: "vmux://sessions/vibe/".to_string(),
                     ..default()
                 },
                 ChildOf(stack),
@@ -877,12 +886,12 @@ mod tests {
         app.update();
 
         app.world_mut().get_mut::<PageMetadata>(child).unwrap().url =
-            "vmux://agent/vibe/abc-123".to_string();
+            "vmux://sessions/vibe/abc-123".to_string();
 
         app.update();
 
         let stack_url = app.world().get::<PageMetadata>(stack).unwrap().url.clone();
-        assert_eq!(stack_url, "vmux://agent/vibe/abc-123");
+        assert_eq!(stack_url, "vmux://sessions/vibe/abc-123");
     }
 
     #[test]
@@ -1132,7 +1141,7 @@ mod tests {
                     crate::clear_stack_children(task.stack, &children_q, &mut commands);
                     commands.spawn((Browser, Terminal, ChildOf(task.stack)));
                     commands.entity(entity).insert(PageOpenHandled);
-                } else if task.url.starts_with("vmux://agent/") {
+                } else if task.url.starts_with("vmux://sessions/") {
                     crate::clear_stack_children(task.stack, &children_q, &mut commands);
                     commands.entity(entity).insert(PageOpenHandled);
                 }
@@ -1561,7 +1570,7 @@ mod tests {
                     PageOpenTask {
                         id: PageOpenId::new(),
                         stack,
-                        url: "vmux://agent/claude".to_string(),
+                        url: "vmux://sessions/claude".to_string(),
                         request_id: None,
                     },
                     PageOpenDeferred,
@@ -1649,7 +1658,7 @@ mod tests {
                     request_id: AgentRequestId::new(),
                     origin: vmux_service::agent_events::CommandOrigin::User,
                     command: ServiceAgentCommand::BrowserNavigate {
-                        url: "vmux://agent/claude/cli/".into(),
+                        url: "vmux://sessions/claude/cli/".into(),
                         pane: None,
                     },
                 });
@@ -1695,7 +1704,7 @@ mod tests {
                     request_id: AgentRequestId::new(),
                     origin: vmux_service::agent_events::CommandOrigin::User,
                     command: ServiceAgentCommand::BrowserNavigate {
-                        url: "vmux://agent/codex/cli/".into(),
+                        url: "vmux://sessions/codex/cli/".into(),
                         pane: None,
                     },
                 });
@@ -1757,7 +1766,7 @@ mod tests {
                 },
             );
             for host in [
-                "terminal", "agent", "services", "settings", "team", "spaces",
+                "terminal", "sessions", "services", "settings", "team", "spaces",
             ] {
                 vmux_core::register_host_spawn(&mut app, host);
             }
@@ -1862,7 +1871,7 @@ mod tests {
                 .resource_mut::<Messages<AppCommand>>()
                 .write(AppCommand::Browser(BrowserCommand::Open(
                     OpenCommand::InPlace {
-                        url: Some("vmux://agent/vibe".into()),
+                        url: Some("vmux://sessions/vibe".into()),
                     },
                 )));
 
@@ -1872,7 +1881,7 @@ mod tests {
             assert!(navigates.0.is_empty());
             let page_opens = app.world().resource::<CapturedPageOpenRequests>();
             assert_eq!(page_opens.0.len(), 1);
-            assert_eq!(page_opens.0[0].url, "vmux://agent/vibe");
+            assert_eq!(page_opens.0[0].url, "vmux://sessions/vibe");
             assert!(matches!(page_opens.0[0].target, PageOpenTarget::Stack(_)));
         }
 

--- a/crates/vmux_browser/src/native_page.rs
+++ b/crates/vmux_browser/src/native_page.rs
@@ -129,8 +129,8 @@ pub static AGENTS_PAGE: NativePage =
     NativePage::pane("vmux://agents/", vmux_agent::page::Page).titled("Agents");
 
 #[cfg(target_os = "macos")]
-pub static CHAT_PAGE: NativePage = NativePage::pane("vmux://agent/", vmux_chat::page::Page)
-    .titled("Agent")
+pub static CHAT_PAGE: NativePage = NativePage::pane("vmux://sessions/", vmux_chat::page::Page)
+    .titled("Sessions")
     .preserving_host_title()
     .without_favicon()
     .owning_subtree();
@@ -257,6 +257,18 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn chat_document_uses_the_host_that_serves_its_assets() {
+        let host = CHAT_PAGE
+            .document_url()
+            .strip_prefix("vmux://")
+            .and_then(|url| url.split('/').next())
+            .unwrap();
+
+        assert_eq!(host, vmux_agent::host::chat::PAGE_MANIFEST.host);
+    }
+
     #[test]
     fn the_editor_still_answers_for_file_urls() {
         assert_eq!(FILES_PAGE.url, "file://");

--- a/crates/vmux_browser/src/native_page/macos.rs
+++ b/crates/vmux_browser/src/native_page/macos.rs
@@ -623,11 +623,11 @@ mod tests {
             waker: super::PageWaker(None),
         };
 
-        vmux_native::Outbox::set_page(&outbox, "vmux://agent/claude");
+        vmux_native::Outbox::set_page(&outbox, "vmux://sessions/claude");
         vmux_native::Outbox::send(&outbox, "event", &[1, 2, 3]).unwrap();
 
         let emitted = rx.recv_blocking().unwrap();
-        assert_eq!(emitted.host, "agent");
+        assert_eq!(emitted.host, "sessions");
     }
 
     #[test]

--- a/crates/vmux_browser/src/navigation.rs
+++ b/crates/vmux_browser/src/navigation.rs
@@ -99,11 +99,11 @@ pub(crate) fn sync_page_metadata_to_tab(
             continue;
         }
         let content_is_web = meta.url.starts_with("http://") || meta.url.starts_with("https://");
-        let content_is_agent = meta.url.starts_with("vmux://agent/");
-        if parent_meta
-            .as_ref()
-            .is_some_and(|m| m.url.starts_with("vmux://agent/"))
-            && !content_is_web
+        let content_is_agent =
+            meta.url.starts_with("vmux://sessions/") || meta.url.starts_with("vmux://agent/");
+        if parent_meta.as_ref().is_some_and(|m| {
+            m.url.starts_with("vmux://sessions/") || m.url.starts_with("vmux://agent/")
+        }) && !content_is_web
             && !content_is_agent
         {
             continue;

--- a/crates/vmux_core/src/host/agent.rs
+++ b/crates/vmux_core/src/host/agent.rs
@@ -116,7 +116,9 @@ pub struct RestartAgentPty {
 }
 
 pub fn parse_page_agent_url(url: &str) -> Option<(String, String, Option<String>)> {
-    let body = url.strip_prefix("vmux://agent/")?;
+    let body = url
+        .strip_prefix("vmux://sessions/")
+        .or_else(|| url.strip_prefix("vmux://agent/"))?;
     let segs: Vec<&str> = body.split('/').filter(|s| !s.is_empty()).collect();
     match segs.as_slice() {
         [provider, model] => Some(((*provider).to_string(), (*model).to_string(), None)),
@@ -130,7 +132,9 @@ pub fn parse_page_agent_url(url: &str) -> Option<(String, String, Option<String>
 }
 
 pub fn parse_acp_agent_url(url: &str) -> Option<String> {
-    let body = url.strip_prefix("vmux://agent/")?;
+    let body = url
+        .strip_prefix("vmux://sessions/")
+        .or_else(|| url.strip_prefix("vmux://agent/"))?;
     let segs: Vec<&str> = body.split('/').filter(|s| !s.is_empty()).collect();
     match segs.as_slice() {
         [id] => Some((*id).to_string()),
@@ -151,7 +155,8 @@ mod tests {
 
     #[test]
     fn parse_page_agent_url_provider_model_only() {
-        let (provider, model, sid) = parse_page_agent_url("vmux://agent/openai/gpt-5.5").unwrap();
+        let (provider, model, sid) =
+            parse_page_agent_url("vmux://sessions/openai/gpt-5.5").unwrap();
         assert_eq!(provider, "openai");
         assert_eq!(model, "gpt-5.5");
         assert!(sid.is_none());
@@ -160,7 +165,7 @@ mod tests {
     #[test]
     fn parse_page_agent_url_with_sid() {
         let (provider, model, sid) =
-            parse_page_agent_url("vmux://agent/anthropic/claude-opus-4.7/xHigh").unwrap();
+            parse_page_agent_url("vmux://sessions/anthropic/claude-opus-4.7/xHigh").unwrap();
         assert_eq!(provider, "anthropic");
         assert_eq!(model, "claude-opus-4.7");
         assert_eq!(sid.as_deref(), Some("xHigh"));
@@ -168,27 +173,39 @@ mod tests {
 
     #[test]
     fn parse_page_agent_url_rejects_single_segment() {
-        assert!(parse_page_agent_url("vmux://agent/vibe").is_none());
+        assert!(parse_page_agent_url("vmux://sessions/vibe").is_none());
     }
 
     #[test]
     fn parse_acp_agent_url_single_segment() {
         assert_eq!(
-            parse_acp_agent_url("vmux://agent/vibe-acp"),
+            parse_acp_agent_url("vmux://sessions/vibe-acp"),
             Some("vibe-acp".to_string())
         );
-        assert!(parse_acp_agent_url("vmux://agent/openai/gpt-5.5").is_none());
+        assert!(parse_acp_agent_url("vmux://sessions/openai/gpt-5.5").is_none());
         assert!(parse_acp_agent_url("https://google.com").is_none());
     }
 
     #[test]
     fn parse_page_agent_url_rejects_too_many_segments() {
-        assert!(parse_page_agent_url("vmux://agent/openai/gpt/sid/extra").is_none());
+        assert!(parse_page_agent_url("vmux://sessions/openai/gpt/sid/extra").is_none());
     }
 
     #[test]
     fn parse_page_agent_url_rejects_non_agent_host() {
         assert!(parse_page_agent_url("https://google.com").is_none());
+    }
+
+    #[test]
+    fn legacy_agent_urls_still_parse() {
+        assert_eq!(
+            parse_acp_agent_url("vmux://agent/claude"),
+            Some("claude".to_string())
+        );
+        assert_eq!(
+            parse_page_agent_url("vmux://agent/openai/gpt-5.5"),
+            Some(("openai".to_string(), "gpt-5.5".to_string(), None))
+        );
     }
 
     #[test]

--- a/crates/vmux_native/src/page.rs
+++ b/crates/vmux_native/src/page.rs
@@ -149,12 +149,12 @@ mod tests {
             dioxus_core::VNode::empty()
         }
         let list = NativePage::pane("vmux://agents/", nowhere).titled("Agents");
-        let chat = NativePage::pane("vmux://agent/", nowhere)
-            .titled("Agent")
+        let chat = NativePage::pane("vmux://sessions/", nowhere)
+            .titled("Sessions")
             .owning_subtree();
 
-        assert!(chat.answers_for("vmux://agent/"));
-        assert!(chat.answers_for("vmux://agent/claude/sess-7"));
+        assert!(chat.answers_for("vmux://sessions/"));
+        assert!(chat.answers_for("vmux://sessions/claude/sess-7"));
         assert!(!chat.answers_for("vmux://agents/"));
         assert!(list.answers_for("vmux://agents/"));
         assert!(!list.answers_for("vmux://agents/anything"));

--- a/crates/vmux_native/src/webview/route.rs
+++ b/crates/vmux_native/src/webview/route.rs
@@ -157,7 +157,13 @@ mod tests {
 
     #[test]
     fn navigation_rejects_requests_from_the_previous_document() {
-        assert!(Route::belongs_to("vmux://agent/__edits", "vmux://agent/"));
-        assert!(!Route::belongs_to("vmux://start/__edits", "vmux://agent/"));
+        assert!(Route::belongs_to(
+            "vmux://sessions/__edits",
+            "vmux://sessions/"
+        ));
+        assert!(!Route::belongs_to(
+            "vmux://start/__edits",
+            "vmux://sessions/"
+        ));
     }
 }

--- a/crates/vmux_ui/locales/ar.ftl
+++ b/crates/vmux_ui/locales/ar.ftl
@@ -172,6 +172,7 @@ team-agents = { $count ->
 }
 team-empty = لا أحد هنا بعد
 team-you = أنت
+agent-chat-subtitle = { team-you } · { $agent }
 team-agent = وكيل
 
 services-title = خدمات الخلفية

--- a/crates/vmux_ui/locales/de.ftl
+++ b/crates/vmux_ui/locales/de.ftl
@@ -172,6 +172,7 @@ team-agents = { $count ->
 }
 team-empty = Noch niemand hier
 team-you = Sie
+agent-chat-subtitle = { team-you } · { $agent }
 team-agent = Agent
 
 services-title = Hintergrunddienste

--- a/crates/vmux_ui/locales/en-US.ftl
+++ b/crates/vmux_ui/locales/en-US.ftl
@@ -185,6 +185,7 @@ team-agents = { $count ->
 }
 team-empty = No one here yet
 team-you = You
+agent-chat-subtitle = { team-you } · { $agent }
 team-agent = Agent
 
 services-title = Background Services

--- a/crates/vmux_ui/locales/es.ftl
+++ b/crates/vmux_ui/locales/es.ftl
@@ -172,6 +172,7 @@ team-agents = { $count ->
 }
 team-empty = Aún no hay nadie aquí
 team-you = Tú
+agent-chat-subtitle = { team-you } · { $agent }
 team-agent = Agente
 
 services-title = Servicios en segundo plano

--- a/crates/vmux_ui/locales/fr.ftl
+++ b/crates/vmux_ui/locales/fr.ftl
@@ -172,6 +172,7 @@ team-agents = { $count ->
 }
 team-empty = Personne ici pour l’instant
 team-you = Vous
+agent-chat-subtitle = { team-you } · { $agent }
 team-agent = Agent
 
 services-title = Services en arrière-plan

--- a/crates/vmux_ui/locales/it.ftl
+++ b/crates/vmux_ui/locales/it.ftl
@@ -172,6 +172,7 @@ team-agents = { $count ->
 }
 team-empty = Non c’è ancora nessuno
 team-you = Tu
+agent-chat-subtitle = { team-you } · { $agent }
 team-agent = Agente
 
 services-title = Servizi in background

--- a/crates/vmux_ui/locales/ja.ftl
+++ b/crates/vmux_ui/locales/ja.ftl
@@ -163,6 +163,7 @@ team-just-you = このスペースにはあなたのみ参加中です
 team-agents = あなたと { $count } エージェント
 team-empty = まだ誰もいません
 team-you = あなた
+agent-chat-subtitle = { team-you }・{ $agent }
 team-agent = エージェント
 
 services-title = バックグラウンドサービス

--- a/crates/vmux_ui/locales/ko.ftl
+++ b/crates/vmux_ui/locales/ko.ftl
@@ -172,6 +172,7 @@ team-agents = { $count ->
 }
 team-empty = 아직 아무도 없습니다
 team-you = 나
+agent-chat-subtitle = { team-you } · { $agent }
 team-agent = 에이전트
 
 services-title = 백그라운드 서비스

--- a/crates/vmux_ui/locales/nl.ftl
+++ b/crates/vmux_ui/locales/nl.ftl
@@ -172,6 +172,7 @@ team-agents = { $count ->
 }
 team-empty = Nog niemand hier
 team-you = Jij
+agent-chat-subtitle = { team-you } · { $agent }
 team-agent = Agent
 
 services-title = Achtergrondservices

--- a/crates/vmux_ui/locales/pl.ftl
+++ b/crates/vmux_ui/locales/pl.ftl
@@ -172,6 +172,7 @@ team-agents = { $count ->
 }
 team-empty = Nikogo tu jeszcze nie ma
 team-you = Ty
+agent-chat-subtitle = { team-you } · { $agent }
 team-agent = Agent
 
 services-title = Usługi w tle

--- a/crates/vmux_ui/locales/pt-BR.ftl
+++ b/crates/vmux_ui/locales/pt-BR.ftl
@@ -172,6 +172,7 @@ team-agents = { $count ->
 }
 team-empty = Ainda não há ninguém aqui
 team-you = Você
+agent-chat-subtitle = { team-you } · { $agent }
 team-agent = Agente
 
 services-title = Serviços em segundo plano

--- a/crates/vmux_ui/locales/ru.ftl
+++ b/crates/vmux_ui/locales/ru.ftl
@@ -172,6 +172,7 @@ team-agents = { $count ->
 }
 team-empty = Здесь пока никого нет
 team-you = Вы
+agent-chat-subtitle = { team-you } · { $agent }
 team-agent = Агент
 
 services-title = Фоновые службы

--- a/crates/vmux_ui/locales/uk.ftl
+++ b/crates/vmux_ui/locales/uk.ftl
@@ -172,6 +172,7 @@ team-agents = { $count ->
 }
 team-empty = Тут поки нікого немає
 team-you = Ви
+agent-chat-subtitle = { team-you } · { $agent }
 team-agent = Агент
 
 services-title = Фонові служби

--- a/crates/vmux_ui/locales/zh-Hans.ftl
+++ b/crates/vmux_ui/locales/zh-Hans.ftl
@@ -172,6 +172,7 @@ team-agents = { $count ->
 }
 team-empty = 暂无成员
 team-you = 你
+agent-chat-subtitle = { team-you } · { $agent }
 team-agent = Agent
 
 services-title = 后台服务

--- a/crates/vmux_ui/locales/zh-Hant.ftl
+++ b/crates/vmux_ui/locales/zh-Hant.ftl
@@ -172,6 +172,7 @@ team-agents = { $count ->
 }
 team-empty = 這裡還沒有人
 team-you = 你
+agent-chat-subtitle = { team-you } · { $agent }
 team-agent = Agent
 
 services-title = 背景服務

--- a/crates/vmux_ui/src/components/avatar.rs
+++ b/crates/vmux_ui/src/components/avatar.rs
@@ -10,17 +10,88 @@ pub fn Avatar(
     background: String,
     #[props(default)] alt: String,
     #[props(default)] class: String,
+    #[props(default)] seed: Option<String>,
 ) -> Element {
     let class = cn([AVATAR, class.as_str()]);
+    let identicon = seed
+        .as_deref()
+        .filter(|seed| !seed.is_empty())
+        .map(Identicon::of);
     rsx! {
         div {
             class,
             style: "--avatar-background:{background}",
             if let Some(src) = src {
                 img { class: "size-full object-cover", src, alt }
+            } else if let Some(identicon) = identicon {
+                svg {
+                    class: "size-full",
+                    view_box: "0 0 5 5",
+                    role: "img",
+                    shape_rendering: "crispEdges",
+                    title { "{alt}" }
+                    rect { width: "5", height: "5", fill: "var(--avatar-background)" }
+                    for (x, y) in identicon.cells {
+                        rect {
+                            x: "{x}",
+                            y: "{y}",
+                            width: "1",
+                            height: "1",
+                            fill: "rgba(255,255,255,0.82)",
+                        }
+                    }
+                }
             } else {
                 "{fallback}"
             }
         }
+    }
+}
+
+struct Identicon {
+    cells: Vec<(u8, u8)>,
+}
+
+impl Identicon {
+    fn of(seed: &str) -> Self {
+        let mut hash = 0xcbf29ce484222325u64;
+        for byte in seed.as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        let mut cells = Vec::new();
+        for y in 0..5u8 {
+            for x in 0..3u8 {
+                hash ^= u64::from(x + y * 3);
+                hash = hash.wrapping_mul(0x100000001b3);
+                if hash & 1 == 0 {
+                    continue;
+                }
+                cells.push((x, y));
+                if x != 2 {
+                    cells.push((4 - x, y));
+                }
+            }
+        }
+        Self { cells }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Identicon;
+
+    #[test]
+    fn generated_avatar_is_horizontally_symmetric() {
+        let identicon = Identicon::of("Personal");
+
+        for (x, y) in &identicon.cells {
+            assert!(identicon.cells.contains(&(4 - x, *y)));
+        }
+    }
+
+    #[test]
+    fn different_profiles_get_different_patterns() {
+        assert_ne!(Identicon::of("Personal").cells, Identicon::of("Work").cells);
     }
 }

--- a/crates/vmux_ui/src/components/avatar.rs
+++ b/crates/vmux_ui/src/components/avatar.rs
@@ -2,6 +2,9 @@ use crate::util::cn;
 use dioxus::prelude::*;
 
 const AVATAR: &str = "inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full bg-[var(--avatar-background)] font-semibold text-white";
+const GENERATED_AVATAR_COLORS: [&str; 6] = [
+    "#fda4af", "#fdba74", "#fde68a", "#86efac", "#67e8f9", "#c4b5fd",
+];
 
 #[component]
 pub fn Avatar(
@@ -13,31 +16,57 @@ pub fn Avatar(
     #[props(default)] seed: Option<String>,
 ) -> Element {
     let class = cn([AVATAR, class.as_str()]);
-    let identicon = seed
+    let generated = seed
         .as_deref()
         .filter(|seed| !seed.is_empty())
-        .map(Identicon::of);
+        .map(|seed| GeneratedAvatar::of(seed, &background));
     rsx! {
         div {
             class,
             style: "--avatar-background:{background}",
             if let Some(src) = src {
                 img { class: "size-full object-cover", src, alt }
-            } else if let Some(identicon) = identicon {
+            } else if let Some(generated) = generated {
                 svg {
                     class: "size-full",
-                    view_box: "0 0 5 5",
+                    view_box: "0 0 36 36",
                     role: "img",
-                    shape_rendering: "crispEdges",
                     title { "{alt}" }
-                    rect { width: "5", height: "5", fill: "var(--avatar-background)" }
-                    for (x, y) in identicon.cells {
+                    rect { width: "36", height: "36", fill: generated.background_color }
+                    rect {
+                        width: "36",
+                        height: "36",
+                        rx: generated.shape_radius,
+                        fill: generated.shape_color,
+                        transform: generated.shape_transform,
+                    }
+                    g { transform: generated.face_transform,
+                        if generated.smiles {
+                            path {
+                                d: generated.mouth_path,
+                                fill: "none",
+                                stroke: generated.face_color,
+                                stroke_width: "1.5",
+                                stroke_linecap: "round",
+                            }
+                        } else {
+                            path { d: generated.mouth_path, fill: generated.face_color }
+                        }
                         rect {
-                            x: "{x}",
-                            y: "{y}",
-                            width: "1",
-                            height: "1",
-                            fill: "rgba(255,255,255,0.82)",
+                            x: generated.left_eye_x,
+                            y: "14",
+                            width: "1.75",
+                            height: "2.25",
+                            rx: "1",
+                            fill: generated.face_color,
+                        }
+                        rect {
+                            x: generated.right_eye_x,
+                            y: "14",
+                            width: "1.75",
+                            height: "2.25",
+                            rx: "1",
+                            fill: generated.face_color,
                         }
                     }
                 }
@@ -48,50 +77,144 @@ pub fn Avatar(
     }
 }
 
-struct Identicon {
-    cells: Vec<(u8, u8)>,
+#[derive(Debug, PartialEq)]
+struct GeneratedAvatar {
+    background_color: &'static str,
+    shape_color: String,
+    face_color: &'static str,
+    shape_radius: usize,
+    shape_transform: String,
+    face_transform: String,
+    smiles: bool,
+    mouth_path: String,
+    left_eye_x: usize,
+    right_eye_x: usize,
 }
 
-impl Identicon {
+impl GeneratedAvatar {
+    fn of(seed: &str, shape_color: &str) -> Self {
+        let mut random = AvatarRandom::of(seed);
+        let background_color = GENERATED_AVATAR_COLORS[random.below(GENERATED_AVATAR_COLORS.len())];
+        let translate_x = 3 + random.below(8);
+        let translate_y = 3 + random.below(8);
+        let rotate = random.below(360);
+        let scale = 100 + random.below(21);
+        let shape_radius = if random.yes() { 18 } else { 6 };
+        let smiles = random.yes();
+        let eye_spread = random.below(5);
+        let mouth_spread = random.below(4);
+        let face_rotate = random.below(11) as isize - 5;
+        let face_translate_x = if translate_x > 6 {
+            translate_x / 2
+        } else {
+            random.below(8)
+        };
+        let face_translate_y = if translate_y > 6 {
+            translate_y / 2
+        } else {
+            random.below(7)
+        };
+        let mouth_y = 19 + mouth_spread;
+        let mouth_path = if smiles {
+            format!("M14 {mouth_y} Q18 {} 22 {mouth_y}", mouth_y + 3)
+        } else {
+            format!("M13 {mouth_y} a1 0.75 0 0 0 10 0")
+        };
+
+        Self {
+            background_color,
+            shape_color: shape_color.to_string(),
+            face_color: Self::contrast_color(shape_color),
+            shape_radius,
+            shape_transform: format!(
+                "translate({translate_x} {translate_y}) rotate({rotate} 18 18) scale({}.{:02})",
+                scale / 100,
+                scale % 100
+            ),
+            face_transform: format!(
+                "translate({face_translate_x} {face_translate_y}) rotate({face_rotate} 18 18)"
+            ),
+            smiles,
+            mouth_path,
+            left_eye_x: 14 - eye_spread,
+            right_eye_x: 20 + eye_spread,
+        }
+    }
+
+    fn contrast_color(color: &str) -> &'static str {
+        let value = color.strip_prefix('#').unwrap_or(color);
+        if value.len() != 6 || !value.is_ascii() {
+            return "#fafafa";
+        }
+        let Ok(red) = u8::from_str_radix(&value[0..2], 16) else {
+            return "#fafafa";
+        };
+        let Ok(green) = u8::from_str_radix(&value[2..4], 16) else {
+            return "#fafafa";
+        };
+        let Ok(blue) = u8::from_str_radix(&value[4..6], 16) else {
+            return "#fafafa";
+        };
+        let luminance = u32::from(red) * 299 + u32::from(green) * 587 + u32::from(blue) * 114;
+        if luminance > 150_000 {
+            "#18181b"
+        } else {
+            "#fafafa"
+        }
+    }
+}
+
+struct AvatarRandom(u64);
+
+impl AvatarRandom {
     fn of(seed: &str) -> Self {
         let mut hash = 0xcbf29ce484222325u64;
         for byte in seed.as_bytes() {
             hash ^= u64::from(*byte);
             hash = hash.wrapping_mul(0x100000001b3);
         }
-        let mut cells = Vec::new();
-        for y in 0..5u8 {
-            for x in 0..3u8 {
-                hash ^= u64::from(x + y * 3);
-                hash = hash.wrapping_mul(0x100000001b3);
-                if hash & 1 == 0 {
-                    continue;
-                }
-                cells.push((x, y));
-                if x != 2 {
-                    cells.push((4 - x, y));
-                }
-            }
-        }
-        Self { cells }
+        Self(hash)
+    }
+
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+
+    fn below(&mut self, ceiling: usize) -> usize {
+        self.next() as usize % ceiling
+    }
+
+    fn yes(&mut self) -> bool {
+        self.below(2) == 0
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Identicon;
+    use super::GeneratedAvatar;
 
     #[test]
-    fn generated_avatar_is_horizontally_symmetric() {
-        let identicon = Identicon::of("Personal");
-
-        for (x, y) in &identicon.cells {
-            assert!(identicon.cells.contains(&(4 - x, *y)));
-        }
+    fn generated_avatar_is_stable_for_a_profile() {
+        assert_eq!(
+            GeneratedAvatar::of("Personal", "#3b82f6"),
+            GeneratedAvatar::of("Personal", "#3b82f6")
+        );
     }
 
     #[test]
-    fn different_profiles_get_different_patterns() {
-        assert_ne!(Identicon::of("Personal").cells, Identicon::of("Work").cells);
+    fn different_profiles_get_different_faces() {
+        assert_ne!(
+            GeneratedAvatar::of("Personal", "#3b82f6"),
+            GeneratedAvatar::of("Work", "#3b82f6")
+        );
+    }
+
+    #[test]
+    fn face_color_contrasts_with_the_profile_color() {
+        assert_eq!(GeneratedAvatar::contrast_color("#ffffff"), "#18181b");
+        assert_eq!(GeneratedAvatar::contrast_color("#000000"), "#fafafa");
     }
 }

--- a/crates/vmux_ui/src/components/composer.rs
+++ b/crates/vmux_ui/src/components/composer.rs
@@ -87,6 +87,7 @@ pub fn PromptComposer(
     accent_gradient: String,
     #[props(default)] footer: Option<Element>,
     #[props(default)] shared_transition: bool,
+    #[props(default = true)] show_send_button: bool,
     #[props(default = PROMPT_INPUT_ID.to_string())] input_id: String,
     #[props(default = translate("composer-attach-files"))] attach_title: String,
     #[props(default = translate("composer-remove-attachment"))] remove_attachment_title: String,
@@ -245,35 +246,37 @@ pub fn PromptComposer(
                     }
                 }
             }
-            button {
-                class: "{action_class}",
-                r#type: "button",
-                disabled: !action_enabled,
-                title: "{action_title}",
-                onmousedown: move |event| event.prevent_default(),
-                onclick: move |_| {
-                    if action_enabled {
-                        on_action.call(());
-                    }
-                },
-                if action == PromptComposerAction::Stop {
-                    svg {
-                        class: "h-4 w-4",
-                        view_box: "0 0 24 24",
-                        fill: "currentColor",
-                        rect { x: "6", y: "6", width: "12", height: "12", rx: "2.5" }
-                    }
-                } else {
-                    svg {
-                        class: "h-4 w-4",
-                        view_box: "0 0 24 24",
-                        fill: "none",
-                        stroke: "currentColor",
-                        stroke_width: "2",
-                        stroke_linecap: "round",
-                        stroke_linejoin: "round",
-                        path { d: "M12 19V5" }
-                        path { d: "M5 12l7-7 7 7" }
+            if action == PromptComposerAction::Stop || show_send_button {
+                button {
+                    class: "{action_class}",
+                    r#type: "button",
+                    disabled: !action_enabled,
+                    title: "{action_title}",
+                    onmousedown: move |event| event.prevent_default(),
+                    onclick: move |_| {
+                        if action_enabled {
+                            on_action.call(());
+                        }
+                    },
+                    if action == PromptComposerAction::Stop {
+                        svg {
+                            class: "h-4 w-4",
+                            view_box: "0 0 24 24",
+                            fill: "currentColor",
+                            rect { x: "6", y: "6", width: "12", height: "12", rx: "2.5" }
+                        }
+                    } else {
+                        svg {
+                            class: "h-4 w-4",
+                            view_box: "0 0 24 24",
+                            fill: "none",
+                            stroke: "currentColor",
+                            stroke_width: "2",
+                            stroke_linecap: "round",
+                            stroke_linejoin: "round",
+                            path { d: "M12 19V5" }
+                            path { d: "M5 12l7-7 7 7" }
+                        }
                     }
                 }
             }

--- a/crates/vmux_ui/src/favicon.rs
+++ b/crates/vmux_ui/src/favicon.rs
@@ -19,9 +19,11 @@ pub fn agent_host(url: &str) -> Option<&'static str> {
         ("gemini", "gemini.google.com"),
     ];
     for &(kind, host) in AGENTS {
-        let base = format!("vmux://agent/{kind}");
-        if url == base || url.starts_with(&format!("{base}/")) {
-            return Some(host);
+        for prefix in ["vmux://sessions/", "vmux://agent/"] {
+            let base = format!("{prefix}{kind}");
+            if url == base || url.starts_with(&format!("{base}/")) {
+                return Some(host);
+            }
         }
     }
     None
@@ -199,30 +201,36 @@ mod tests {
     #[test]
     fn agent_host_maps_vibe() {
         assert_eq!(
-            agent_host("vmux://agent/vibe/chat/abc"),
+            agent_host("vmux://sessions/vibe/chat/abc"),
             Some("chat.mistral.ai")
         );
         assert_eq!(
-            agent_host("vmux://agent/vibe/cli/abc"),
+            agent_host("vmux://sessions/vibe/cli/abc"),
             Some("chat.mistral.ai")
         );
         assert_eq!(
-            agent_host("vmux://agent/mistral-vibe/session-1"),
+            agent_host("vmux://sessions/mistral-vibe/session-1"),
             Some("chat.mistral.ai")
         );
     }
 
     #[test]
     fn agent_host_maps_claude_and_codex() {
-        assert_eq!(agent_host("vmux://agent/claude/x"), Some("claude.ai"));
-        assert_eq!(agent_host("vmux://agent/claude-acp/x"), Some("claude.ai"));
-        assert_eq!(agent_host("vmux://agent/codex/x"), Some("chatgpt.com"));
-        assert_eq!(agent_host("vmux://agent/codex-acp/x"), Some("chatgpt.com"));
+        assert_eq!(agent_host("vmux://sessions/claude/x"), Some("claude.ai"));
+        assert_eq!(
+            agent_host("vmux://sessions/claude-acp/x"),
+            Some("claude.ai")
+        );
+        assert_eq!(agent_host("vmux://sessions/codex/x"), Some("chatgpt.com"));
+        assert_eq!(
+            agent_host("vmux://sessions/codex-acp/x"),
+            Some("chatgpt.com")
+        );
     }
 
     #[test]
     fn agent_host_unknown_returns_none() {
-        assert_eq!(agent_host("vmux://agent/unknown/x"), None);
+        assert_eq!(agent_host("vmux://sessions/unknown/x"), None);
         assert_eq!(agent_host("https://example.com"), None);
     }
 
@@ -237,7 +245,10 @@ mod tests {
     #[test]
     fn favicon_src_prefers_agent_host_over_passed_icon() {
         assert_eq!(
-            favicon_src_for_url("https://cdn.example/claude-acp.svg", "vmux://agent/claude"),
+            favicon_src_for_url(
+                "https://cdn.example/claude-acp.svg",
+                "vmux://sessions/claude"
+            ),
             Some("https://www.google.com/s2/favicons?domain=claude.ai&sz=64".to_string())
         );
     }
@@ -261,7 +272,7 @@ mod tests {
     #[test]
     fn favicon_src_falls_back_to_agent_host() {
         assert_eq!(
-            favicon_src_for_url("", "vmux://agent/vibe/chat/abc"),
+            favicon_src_for_url("", "vmux://sessions/vibe/chat/abc"),
             Some("https://www.google.com/s2/favicons?domain=chat.mistral.ai&sz=64".to_string())
         );
     }
@@ -281,18 +292,21 @@ mod tests {
 
     #[test]
     fn agent_host_matches_single_segment_acp_url() {
-        assert_eq!(agent_host("vmux://agent/claude"), Some("claude.ai"));
-        assert_eq!(agent_host("vmux://agent/codex"), Some("chatgpt.com"));
-        assert_eq!(agent_host("vmux://agent/claude/cli"), Some("claude.ai"));
+        assert_eq!(agent_host("vmux://sessions/claude"), Some("claude.ai"));
+        assert_eq!(agent_host("vmux://sessions/codex"), Some("chatgpt.com"));
+        assert_eq!(agent_host("vmux://sessions/claude/cli"), Some("claude.ai"));
     }
 
     #[test]
     fn agent_host_maps_gemini() {
-        assert_eq!(agent_host("vmux://agent/gemini"), Some("gemini.google.com"));
+        assert_eq!(
+            agent_host("vmux://sessions/gemini"),
+            Some("gemini.google.com")
+        );
     }
 
     #[test]
     fn agent_host_does_not_over_match_similar_ids() {
-        assert_eq!(agent_host("vmux://agent/claudex"), None);
+        assert_eq!(agent_host("vmux://sessions/claudex"), None);
     }
 }

--- a/crates/vmux_ui/src/launcher/palette.rs
+++ b/crates/vmux_ui/src/launcher/palette.rs
@@ -1031,7 +1031,9 @@ impl AgentSegment {
     }
 
     pub fn in_url(url: &str) -> Option<String> {
-        let path = url.strip_prefix("vmux://agent/")?;
+        let path = url
+            .strip_prefix("vmux://sessions/")
+            .or_else(|| url.strip_prefix("vmux://agent/"))?;
         let segment = path.split('/').next()?;
         (!segment.is_empty()).then(|| segment.to_string())
     }
@@ -1336,7 +1338,7 @@ mod tests {
                     },
                     CommandBarPage {
                         host: "agent".into(),
-                        url: "vmux://agent/vibe/".into(),
+                        url: "vmux://sessions/vibe/".into(),
                         title: "Vibe".into(),
                         keywords: vec!["vibe".into()],
                         icon: vmux_wire::PageIcon::None,
@@ -1345,7 +1347,7 @@ mod tests {
                     },
                     CommandBarPage {
                         host: "agent".into(),
-                        url: "vmux://agent/codex/cli".into(),
+                        url: "vmux://sessions/codex/cli".into(),
                         title: "Codex".into(),
                         keywords: vec!["codex".into()],
                         icon: vmux_wire::PageIcon::None,
@@ -1420,7 +1422,7 @@ mod tests {
             CommandBarOpenEvent {
                 tabs: vec![CommandBarTab {
                     title: "Docs".into(),
-                    url: "vmux://agent/codex/def".into(),
+                    url: "vmux://sessions/codex/def".into(),
                     pane_id: 8,
                     tab_index: 1,
                     is_active: false,
@@ -1659,16 +1661,16 @@ mod tests {
         let defaulted = PaletteState::start(&state, PaletteDraft::typed("fix the failing test"));
         assert_eq!(
             prompt_target_url(&defaulted.rows[0]),
-            Some("vmux://agent/vibe/")
+            Some("vmux://sessions/vibe/")
         );
 
         let chosen = PaletteState::start(
             &state,
-            PaletteDraft::typed("fix the failing test").targeting("vmux://agent/codex/cli"),
+            PaletteDraft::typed("fix the failing test").targeting("vmux://sessions/codex/cli"),
         );
         assert_eq!(
             prompt_target_url(&chosen.rows[0]),
-            Some("vmux://agent/codex/cli")
+            Some("vmux://sessions/codex/cli")
         );
         assert_eq!(chosen.composer.agent_title, "Codex");
         assert_eq!(chosen.accent_agent.as_deref(), Some("codex"));
@@ -2035,13 +2037,13 @@ mod tests {
             submitted.action,
             Some(CommandBarActionEvent::prompt(
                 "fix the failing test",
-                "vmux://agent/vibe/",
+                "vmux://sessions/vibe/",
                 &[]
             ))
         );
         assert_eq!(
             submitted.inline_target.as_deref(),
-            Some("vmux://agent/vibe/")
+            Some("vmux://sessions/vibe/")
         );
     }
 
@@ -2050,7 +2052,7 @@ mod tests {
         let state = Launcher::state();
         let palette = PaletteState::start(
             &state,
-            PaletteDraft::typed("fix the failing test").targeting("vmux://agent/codex/cli"),
+            PaletteDraft::typed("fix the failing test").targeting("vmux://sessions/codex/cli"),
         );
 
         let submitted = palette.submit_start(&[]);
@@ -2059,7 +2061,7 @@ mod tests {
             submitted.action,
             Some(CommandBarActionEvent::prompt(
                 "fix the failing test",
-                "vmux://agent/codex/cli",
+                "vmux://sessions/codex/cli",
                 &[]
             ))
         );
@@ -2076,7 +2078,7 @@ mod tests {
         assert_eq!(
             submitted.action,
             Some(CommandBarActionEvent::open(
-                "vmux://agent/vibe/",
+                "vmux://sessions/vibe/",
                 palette.open_target
             ))
         );
@@ -2100,7 +2102,7 @@ mod tests {
             submitted.action,
             Some(CommandBarActionEvent::prompt(
                 "",
-                "vmux://agent/vibe/",
+                "vmux://sessions/vibe/",
                 &attached
             ))
         );
@@ -2220,14 +2222,14 @@ mod tests {
         let state = Launcher::state();
         let palette = PaletteState::start(
             &state,
-            PaletteDraft::typed("fix the failing test").targeting("vmux://agent/codex/cli"),
+            PaletteDraft::typed("fix the failing test").targeting("vmux://sessions/codex/cli"),
         );
 
         assert_eq!(
             palette.submit_action(&[]).action,
             Some(CommandBarActionEvent::prompt(
                 "fix the failing test",
-                "vmux://agent/codex/cli",
+                "vmux://sessions/codex/cli",
                 &[]
             ))
         );
@@ -2250,7 +2252,7 @@ mod tests {
         let mut state = Launcher::state();
         state.agent_models = vec![AgentModels {
             agent_key: "vibe".into(),
-            url: "vmux://agent/vibe/".into(),
+            url: "vmux://sessions/vibe/".into(),
             selected: "big".into(),
             models: vec![
                 ModelOptionEntry {
@@ -2273,7 +2275,7 @@ mod tests {
 
         let codex = PaletteState::start(
             &state,
-            PaletteDraft::typed("fix it").targeting("vmux://agent/codex/cli"),
+            PaletteDraft::typed("fix it").targeting("vmux://sessions/codex/cli"),
         );
         assert!(codex.composer.model_name.is_empty());
         assert!(codex.composer.model_options.is_empty());
@@ -2317,6 +2319,9 @@ mod tests {
             .map(|agent| agent.url.as_str())
             .collect();
 
-        assert_eq!(urls, vec!["vmux://agent/vibe/", "vmux://agent/codex/cli"]);
+        assert_eq!(
+            urls,
+            vec!["vmux://sessions/vibe/", "vmux://sessions/codex/cli"]
+        );
     }
 }

--- a/crates/vmux_ui/src/launcher/results.rs
+++ b/crates/vmux_ui/src/launcher/results.rs
@@ -841,7 +841,7 @@ mod tests {
             },
             CommandBarPage {
                 host: "agent".into(),
-                url: "vmux://agent/vibe/".into(),
+                url: "vmux://sessions/vibe/".into(),
                 title: "Vibe".into(),
                 keywords: vec!["vibe".into(), "agent".into()],
                 icon: vmux_wire::PageIcon::None,
@@ -1060,7 +1060,7 @@ mod tests {
         assert!(results.iter().any(|r| matches!(
             r,
             CommandBarResultItem::Page { url, icon, .. }
-                if url == "vmux://agent/vibe/" && matches!(icon, vmux_wire::PageIcon::None)
+                if url == "vmux://sessions/vibe/" && matches!(icon, vmux_wire::PageIcon::None)
         )));
     }
 
@@ -1079,7 +1079,7 @@ mod tests {
         let mut pages = sample_pages();
         pages.push(CommandBarPage {
             host: "agent".into(),
-            url: "vmux://agent/codex/cli".into(),
+            url: "vmux://sessions/codex/cli".into(),
             title: "Codex (CLI)".into(),
             keywords: vec!["codex".into(), "agent".into()],
             icon: vmux_wire::PageIcon::None,
@@ -1096,7 +1096,10 @@ mod tests {
             })
             .collect();
 
-        assert_eq!(urls, vec!["vmux://agent/vibe/", "vmux://agent/codex/cli"]);
+        assert_eq!(
+            urls,
+            vec!["vmux://sessions/vibe/", "vmux://sessions/codex/cli"]
+        );
     }
 
     #[test]
@@ -1104,7 +1107,7 @@ mod tests {
         let mut pages = sample_pages();
         pages.push(CommandBarPage {
             host: "agent".into(),
-            url: "vmux://agent/codex/cli".into(),
+            url: "vmux://sessions/codex/cli".into(),
             title: "Codex (CLI)".into(),
             keywords: vec!["codex".into(), "agent".into()],
             icon: vmux_wire::PageIcon::None,
@@ -1117,7 +1120,7 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert!(matches!(
             &results[0],
-            CommandBarResultItem::Page { url, .. } if url == "vmux://agent/vibe/"
+            CommandBarResultItem::Page { url, .. } if url == "vmux://sessions/vibe/"
         ));
     }
 
@@ -1126,7 +1129,7 @@ mod tests {
         let mut pages = sample_pages();
         pages.push(CommandBarPage {
             host: "agent".into(),
-            url: "vmux://agent/codex-acp".into(),
+            url: "vmux://sessions/codex-acp".into(),
             title: "Codex".into(),
             keywords: vec!["codex-acp".into(), "acp".into(), "agent".into()],
             icon: vmux_wire::PageIcon::None,
@@ -1146,7 +1149,7 @@ mod tests {
         let mut pages = sample_pages();
         pages.push(CommandBarPage {
             host: "agent".into(),
-            url: "vmux://agent/codex/cli".into(),
+            url: "vmux://sessions/codex/cli".into(),
             title: "Codex (CLI)".into(),
             keywords: vec!["codex".into(), "agent".into()],
             icon: vmux_wire::PageIcon::None,
@@ -1157,7 +1160,10 @@ mod tests {
         let results = prompt_target_results(&pages, "show me something fun in terminal");
         let urls: Vec<_> = results.iter().filter_map(prompt_target_url).collect();
 
-        assert_eq!(urls, vec!["vmux://agent/vibe/", "vmux://agent/codex/cli"]);
+        assert_eq!(
+            urls,
+            vec!["vmux://sessions/vibe/", "vmux://sessions/codex/cli"]
+        );
     }
 
     #[test]
@@ -1201,7 +1207,7 @@ mod tests {
         pages.extend([
             CommandBarPage {
                 host: "agent".into(),
-                url: "vmux://agent/codex/cli".into(),
+                url: "vmux://sessions/codex/cli".into(),
                 title: "Codex".into(),
                 keywords: vec!["codex".into(), "agent".into()],
                 icon: vmux_wire::PageIcon::None,
@@ -1210,7 +1216,7 @@ mod tests {
             },
             CommandBarPage {
                 host: "agent".into(),
-                url: "vmux://agent/claude".into(),
+                url: "vmux://sessions/claude".into(),
                 title: "Claude".into(),
                 keywords: vec!["claude".into(), "agent".into()],
                 icon: vmux_wire::PageIcon::None,
@@ -1237,10 +1243,16 @@ mod tests {
 
         assert_eq!(
             prompt_target_url(&results[0]),
-            Some("vmux://agent/codex/cli")
+            Some("vmux://sessions/codex/cli")
         );
-        assert_eq!(prompt_target_url(&results[1]), Some("vmux://agent/vibe/"));
-        assert_eq!(prompt_target_url(&results[2]), Some("vmux://agent/claude"));
+        assert_eq!(
+            prompt_target_url(&results[1]),
+            Some("vmux://sessions/vibe/")
+        );
+        assert_eq!(
+            prompt_target_url(&results[2]),
+            Some("vmux://sessions/claude")
+        );
         assert!(matches!(results[3], CommandBarResultItem::Search { .. }));
     }
 
@@ -1359,7 +1371,7 @@ mod tests {
             prompt_target: false,
         };
 
-        assert_eq!(prompt_target_url(&agent), Some("vmux://agent/vibe/"));
+        assert_eq!(prompt_target_url(&agent), Some("vmux://sessions/vibe/"));
         assert_eq!(prompt_target_url(&settings), None);
     }
 
@@ -1432,8 +1444,8 @@ mod tests {
         assert_eq!(
             urls,
             vec![
-                "vmux://agent/vibe/",
                 "vmux://history/",
+                "vmux://sessions/vibe/",
                 "vmux://settings/",
                 "vmux://spaces/",
             ]
@@ -1597,7 +1609,7 @@ mod tests {
         let tabs = vec![
             CommandBarTab {
                 title: "Fun terminal demo".into(),
-                url: "vmux://agent/claude/abc".into(),
+                url: "vmux://sessions/claude/abc".into(),
                 pane_id: 7,
                 tab_index: 0,
                 is_active: true,
@@ -1605,7 +1617,7 @@ mod tests {
             },
             CommandBarTab {
                 title: "Docs".into(),
-                url: "vmux://agent/codex/def".into(),
+                url: "vmux://sessions/codex/def".into(),
                 pane_id: 8,
                 tab_index: 1,
                 is_active: false,

--- a/crates/vmux_wire/src/agent.rs
+++ b/crates/vmux_wire/src/agent.rs
@@ -44,11 +44,11 @@ impl AgentKind {
     }
 
     pub fn cli_url_prefix(self) -> String {
-        format!("vmux://agent/{}/", self.as_url_segment())
+        format!("vmux://sessions/{}/", self.as_url_segment())
     }
 
     pub fn setup_url(self) -> String {
-        format!("vmux://agent/{}/setup", self.as_url_segment())
+        format!("vmux://sessions/{}/setup", self.as_url_segment())
     }
 
     pub fn all() -> [AgentKind; 3] {
@@ -69,7 +69,10 @@ impl AgentKind {
 }
 
 pub fn supports_inline_agent_transition(url: &str) -> bool {
-    let Some(path) = url.strip_prefix("vmux://agent/") else {
+    let Some(path) = url
+        .strip_prefix("vmux://sessions/")
+        .or_else(|| url.strip_prefix("vmux://agent/"))
+    else {
         return false;
     };
     !path
@@ -101,8 +104,17 @@ mod tests {
 
     #[test]
     fn cli_url_prefix_returns_three_segment_form() {
-        assert_eq!(AgentKind::Vibe.cli_url_prefix(), "vmux://agent/vibe/");
-        assert_eq!(AgentKind::Claude.cli_url_prefix(), "vmux://agent/claude/");
+        assert_eq!(AgentKind::Vibe.cli_url_prefix(), "vmux://sessions/vibe/");
+        assert_eq!(
+            AgentKind::Claude.cli_url_prefix(),
+            "vmux://sessions/claude/"
+        );
+    }
+
+    #[test]
+    fn legacy_agent_urls_still_support_inline_transition() {
+        assert!(supports_inline_agent_transition("vmux://agent/claude"));
+        assert!(!supports_inline_agent_transition("vmux://agent/claude/cli"));
     }
 
     #[test]

--- a/crates/vmux_wire/src/agent.rs
+++ b/crates/vmux_wire/src/agent.rs
@@ -51,6 +51,10 @@ impl AgentKind {
         format!("vmux://sessions/{}/setup", self.as_url_segment())
     }
 
+    pub fn is_setup_url(self, url: &str) -> bool {
+        url == self.setup_url() || url == format!("vmux://agent/{}/setup", self.as_url_segment())
+    }
+
     pub fn all() -> [AgentKind; 3] {
         [AgentKind::Vibe, AgentKind::Claude, AgentKind::Codex]
     }
@@ -109,6 +113,18 @@ mod tests {
             AgentKind::Claude.cli_url_prefix(),
             "vmux://sessions/claude/"
         );
+    }
+
+    #[test]
+    fn setup_urls_accept_canonical_and_legacy_forms() {
+        for kind in AgentKind::all() {
+            assert!(kind.is_setup_url(&kind.setup_url()));
+            assert!(kind.is_setup_url(&format!("vmux://agent/{}/setup", kind.as_url_segment())));
+            assert!(!kind.is_setup_url(&format!(
+                "vmux://sessions/{}/session-1",
+                kind.as_url_segment()
+            )));
+        }
     }
 
     #[test]

--- a/crates/vmux_wire/src/protocol.rs
+++ b/crates/vmux_wire/src/protocol.rs
@@ -1085,7 +1085,7 @@ mod tests {
         let command = AgentCommand::Shared(SharedAgentCommand::NewAgentChat {
             client_op_id: ClientOpId::new("op"),
             prompt: "continue from my phone".to_string(),
-            agent_url: Some("vmux://agent/claude".to_string()),
+            agent_url: Some("vmux://sessions/claude".to_string()),
         });
         let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&command).unwrap();
         let back: AgentCommand =

--- a/crates/vmux_wire/src/room.rs
+++ b/crates/vmux_wire/src/room.rs
@@ -610,7 +610,7 @@ mod tests {
         let request = NewChatRequest {
             client_op_id: ClientOpId::new("op-1"),
             text: "start here".to_string(),
-            agent_url: Some("vmux://agent/claude".to_string()),
+            agent_url: Some("vmux://sessions/claude".to_string()),
         };
         let json = serde_json::to_string(&request).unwrap();
         let back: NewChatRequest = serde_json::from_str(&json).unwrap();

--- a/crates/vmux_wire/src/team.rs
+++ b/crates/vmux_wire/src/team.rs
@@ -97,7 +97,7 @@ mod tests {
                 initials: "You".to_string(),
                 color: "#3b82f6".to_string(),
                 icon: "https://x/favicon.png".to_string(),
-                url: "vmux://agent/vibe/".to_string(),
+                url: "vmux://sessions/vibe/".to_string(),
                 title: "Vibe session".to_string(),
                 sid: "021fb65c".to_string(),
                 is_user: true,


### PR DESCRIPTION
## Context

Agent conversations still use an agent-specific URL and cinematic card UI. Sessions provide the room-oriented foundation needed for future group chat and invitations.

## Implementation

Makes `vmux://sessions/` canonical while preserving legacy agent URLs. Reworks chat into a flat, neutral group conversation with participant identity, while retaining the shared liquid-glass composer.

## Checks / QA

Open a new and resumed session, confirm message rows and participant identity remain readable, and verify an old `vmux://agent/...` URL opens as its corresponding session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Session links now use the `vmux://sessions/` format across agent, CLI, and chat experiences.
  - Existing `vmux://agent/` links remain supported and continue to open correctly.
  - Chat messages now display user and agent avatars, names, initials, colors, and timestamps.
  - Avatars can use consistent generated visuals when no image is available.
  - Pressing Enter submits a chat prompt when no selection menu is open.

- **Style**
  - Refreshed chat headers, transcripts, composer, approval panels, and error states with a cleaner visual design.
  - Removed the installing-chat Matrix animation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->