### PR TITLE
feat(desktop): add complete multi-window workspace support

### DIFF
--- a/crates/app/vmux_desktop/src/bookmark_menu.rs
+++ b/crates/app/vmux_desktop/src/bookmark_menu.rs
@@ -2,7 +2,8 @@ use bevy::prelude::*;
 
 impl Plugin for BookmarkMenuPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(vmux_layout::LayoutContractPlugin);
+        app.add_plugins(vmux_layout::LayoutContractPlugin)
+            .init_resource::<vmux_layout::window::FocusedWindow>();
         #[cfg(target_os = "macos")]
         app.add_message::<macos::BookmarkMenuSelection>()
             .init_resource::<macos::BookmarkMenuActionSequence>()
@@ -37,7 +38,6 @@ mod macos {
     use bevy::ecs::relationship::Relationship;
     use bevy::ecs::system::NonSendMarker;
     use bevy::prelude::*;
-    use bevy::window::PrimaryWindow;
     use bevy_cef::prelude::{BinHostEmitEvent, Browsers};
     use muda::ContextMenu;
     use parking_lot::Mutex;
@@ -139,7 +139,7 @@ mod macos {
     pub(super) fn show_bookmark_menu(
         _non_send: NonSendMarker,
         mut reader: MessageReader<ShowBookmarkMenuRequest>,
-        primary: Query<Entity, With<PrimaryWindow>>,
+        focused: Res<vmux_layout::window::FocusedWindow>,
         entries: Query<(
             Entity,
             &Uuid,
@@ -159,7 +159,8 @@ mod macos {
         let Some(request) = reader.read().last().cloned() else {
             return;
         };
-        let Ok(window_entity) = primary.single() else {
+
+        let Some(window_entity) = focused.0 else {
             return;
         };
         let view_ptr = WINIT_WINDOWS.with_borrow(|windows| {

--- a/crates/app/vmux_desktop/src/display.rs
+++ b/crates/app/vmux_desktop/src/display.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy::window::{Monitor, MonitorSelection, PrimaryWindow, Window, WindowPosition};
+use bevy::window::{Monitor, MonitorSelection, Window, WindowPosition};
 
 impl Plugin for DisplayPlugin {
     fn build(&self, app: &mut App) {
@@ -26,7 +26,7 @@ fn relocate_window_to_live_display(
     monitors_added: Query<(), Added<Monitor>>,
     monitors_removed: RemovedComponents<Monitor>,
     monitors: Query<&Monitor>,
-    mut window: Query<&mut Window, With<PrimaryWindow>>,
+    mut windows: Query<&mut Window>,
 ) {
     if monitors_added.is_empty() && monitors_removed.is_empty() {
         return;
@@ -34,24 +34,23 @@ fn relocate_window_to_live_display(
     if monitors.is_empty() {
         return;
     }
-    let Ok(mut window) = window.single_mut() else {
-        return;
-    };
-    let WindowPosition::At(pos) = window.position else {
-        return;
-    };
-    let size = window.resolution.physical_size().as_ivec2();
-    let window_rect = IRect::from_corners(pos, pos + size);
     let monitor_rects: Vec<IRect> = monitors.iter().map(monitor_rect).collect();
-    if window_off_all_monitors(window_rect, &monitor_rects) {
-        window.position = WindowPosition::Centered(MonitorSelection::Primary);
+    for mut window in &mut windows {
+        let WindowPosition::At(pos) = window.position else {
+            continue;
+        };
+        let size = window.resolution.physical_size().as_ivec2();
+        let window_rect = IRect::from_corners(pos, pos + size);
+        if window_off_all_monitors(window_rect, &monitor_rects) {
+            window.position = WindowPosition::Centered(MonitorSelection::Primary);
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bevy::window::OnMonitor;
+    use bevy::window::{OnMonitor, PrimaryWindow};
 
     fn test_monitor(x: i32, y: i32, w: u32, h: u32) -> Monitor {
         Monitor {

--- a/crates/app/vmux_desktop/src/glass.rs
+++ b/crates/app/vmux_desktop/src/glass.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use bevy::prelude::*;
@@ -34,9 +35,12 @@ impl Plugin for GlassPlugin {
 const ACTIVATION_RETRY_BUDGET: Duration = Duration::from_secs(3);
 
 #[derive(Default)]
-struct GlassState {
-    installed: bool,
+struct GlassState(HashMap<Entity, WindowGlass>);
+
+#[derive(Default)]
+struct WindowGlass {
     visible: bool,
+    shadowed: bool,
     revealed: bool,
     revealed_at: Option<Instant>,
     active_confirmed: bool,
@@ -45,7 +49,7 @@ struct GlassState {
     _parent_window: Option<objc2::rc::Retained<objc2_app_kit::NSWindow>>,
 }
 
-impl GlassState {
+impl WindowGlass {
     fn track_parent_frame(&self) {
         use objc2::ClassType;
         use objc2_app_kit::{NSWindowDidMoveNotification, NSWindowDidResizeNotification};
@@ -77,10 +81,7 @@ impl GlassState {
     }
 }
 
-fn install_window_glass(
-    mut state: NonSendMut<GlassState>,
-    window: Query<Entity, With<bevy::window::PrimaryWindow>>,
-) {
+fn install_window_glass(mut state: NonSendMut<GlassState>, windows: Query<(Entity, &Window)>) {
     use bevy::winit::WINIT_WINDOWS;
     use objc2::{ClassType, MainThreadMarker, MainThreadOnly, rc::Retained, runtime::AnyClass};
     use objc2_app_kit::{
@@ -91,99 +92,121 @@ fn install_window_glass(
     use objc2_foundation::{NSPoint, NSRect, NSSize};
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
-    if state.installed {
-        return;
-    }
     let Some(mtm) = MainThreadMarker::new() else {
         return;
     };
-    let Ok(entity) = window.single() else {
-        return;
-    };
-    let ns_view = WINIT_WINDOWS.with_borrow(|windows| {
-        let id = windows.entity_to_winit.get(&entity)?;
-        let wrapper = windows.windows.get(id)?;
-        let handle = wrapper.window_handle().ok()?;
-        match handle.as_raw() {
-            RawWindowHandle::AppKit(h) => Some(h.ns_view),
-            _ => None,
+    for (entity, window) in &windows {
+        if state.0.contains_key(&entity) {
+            continue;
         }
-    });
-    let Some(ns_view) = ns_view else {
-        return;
-    };
-    let content: &NSView = unsafe { &*ns_view.as_ptr().cast::<NSView>() };
-    let Some(parent_window) = content.window() else {
-        return;
-    };
-    if AnyClass::get(c"NSGlassEffectView").is_none() {
-        warn!("glass: NSGlassEffectView unavailable (needs macOS 26+)");
-        state.installed = true;
-        return;
+        let ns_view = WINIT_WINDOWS.with_borrow(|windows| {
+            let id = windows.entity_to_winit.get(&entity)?;
+            let wrapper = windows.windows.get(id)?;
+            let handle = wrapper.window_handle().ok()?;
+            match handle.as_raw() {
+                RawWindowHandle::AppKit(h) => Some(h.ns_view),
+                _ => None,
+            }
+        });
+        let Some(ns_view) = ns_view else {
+            continue;
+        };
+        let content: &NSView = unsafe { &*ns_view.as_ptr().cast::<NSView>() };
+        let Some(parent_window) = content.window() else {
+            continue;
+        };
+        if AnyClass::get(c"NSGlassEffectView").is_none() {
+            warn!("glass: NSGlassEffectView unavailable (needs macOS 26+)");
+            state.0.insert(
+                entity,
+                WindowGlass {
+                    revealed: window.visible,
+                    ..default()
+                },
+            );
+            continue;
+        }
+        let frame = parent_window.frame();
+        let backdrop_window = NSPanel::initWithContentRect_styleMask_backing_defer(
+            NSPanel::alloc(mtm),
+            frame,
+            NSWindowStyleMask::Borderless | NSWindowStyleMask::NonactivatingPanel,
+            NSBackingStoreType::Buffered,
+            false,
+        );
+        let clear_color = NSColor::clearColor();
+        let backdrop: &objc2_app_kit::NSWindow = backdrop_window.as_super();
+        backdrop.setOpaque(false);
+        backdrop.setBackgroundColor(Some(&clear_color));
+        backdrop.setHasShadow(false);
+        backdrop.setIgnoresMouseEvents(true);
+        backdrop.setCanHide(false);
+        backdrop.setHidesOnDeactivate(false);
+        backdrop_window.setFloatingPanel(false);
+        backdrop_window.setBecomesKeyOnlyIfNeeded(true);
+        backdrop.setCollectionBehavior(
+            NSWindowCollectionBehavior::FullScreenAuxiliary
+                | NSWindowCollectionBehavior::IgnoresCycle,
+        );
+        let glass: Retained<NSGlassEffectView> = NSGlassEffectView::new(mtm);
+        glass.setStyle(NSGlassEffectViewStyle::Clear);
+        glass.setTintColor(Some(&NSColor::clearColor()));
+        let glass_view: &NSView = &glass;
+        glass_view.setFrame(NSRect::new(
+            NSPoint::new(0.0, 0.0),
+            NSSize::new(frame.size.width, frame.size.height),
+        ));
+        glass_view.setAutoresizingMask(
+            NSAutoresizingMaskOptions::ViewWidthSizable
+                | NSAutoresizingMaskOptions::ViewHeightSizable,
+        );
+        backdrop.setContentView(Some(glass_view));
+        unsafe {
+            parent_window.addChildWindow_ordered(backdrop, NSWindowOrderingMode::Below);
+        }
+        let installed = WindowGlass {
+            visible: true,
+            shadowed: false,
+            revealed: window.visible,
+            revealed_at: window.visible.then(Instant::now),
+            active_confirmed: window.visible,
+            _glass: Some(glass),
+            _backdrop_window: Some(backdrop_window),
+            _parent_window: Some(parent_window),
+        };
+        installed.track_parent_frame();
+        state.0.insert(entity, installed);
+        info!(
+            ?entity,
+            "glass: NSGlassEffectView installed in nonactivating child-window backdrop"
+        );
     }
-    let frame = parent_window.frame();
-    let backdrop_window = NSPanel::initWithContentRect_styleMask_backing_defer(
-        NSPanel::alloc(mtm),
-        frame,
-        NSWindowStyleMask::Borderless | NSWindowStyleMask::NonactivatingPanel,
-        NSBackingStoreType::Buffered,
-        false,
-    );
-    let clear_color = NSColor::clearColor();
-    let backdrop: &objc2_app_kit::NSWindow = backdrop_window.as_super();
-    backdrop.setOpaque(false);
-    backdrop.setBackgroundColor(Some(&clear_color));
-    backdrop.setHasShadow(false);
-    backdrop.setIgnoresMouseEvents(true);
-    backdrop.setCanHide(false);
-    backdrop.setHidesOnDeactivate(false);
-    backdrop_window.setFloatingPanel(false);
-    backdrop_window.setBecomesKeyOnlyIfNeeded(true);
-    backdrop.setCollectionBehavior(
-        NSWindowCollectionBehavior::FullScreenAuxiliary | NSWindowCollectionBehavior::IgnoresCycle,
-    );
-    let glass: Retained<NSGlassEffectView> = NSGlassEffectView::new(mtm);
-    glass.setStyle(NSGlassEffectViewStyle::Clear);
-    glass.setTintColor(Some(&NSColor::clearColor()));
-    let glass_view: &NSView = &glass;
-    glass_view.setFrame(NSRect::new(
-        NSPoint::new(0.0, 0.0),
-        NSSize::new(frame.size.width, frame.size.height),
-    ));
-    glass_view.setAutoresizingMask(
-        NSAutoresizingMaskOptions::ViewWidthSizable | NSAutoresizingMaskOptions::ViewHeightSizable,
-    );
-    backdrop.setContentView(Some(glass_view));
-    unsafe {
-        parent_window.addChildWindow_ordered(backdrop, NSWindowOrderingMode::Below);
-    }
-    state.visible = true;
-    state._glass = Some(glass);
-    state._backdrop_window = Some(backdrop_window);
-    state._parent_window = Some(parent_window);
-    state.installed = true;
-    state.track_parent_frame();
-    info!("glass: NSGlassEffectView installed in nonactivating child-window backdrop");
 }
 
 fn reveal_window_after_layout_ready(
     mut state: NonSendMut<GlassState>,
-    mut window: Query<(Entity, &mut Window), With<bevy::window::PrimaryWindow>>,
+    mut windows: Query<(Entity, &mut Window)>,
     status: Res<crate::boot_status::SplashStatus>,
 ) {
-    if state.revealed || !state.installed || !status.reveal_ready {
+    if !status.reveal_ready {
         return;
     }
-    let Ok((_, mut window)) = window.single_mut() else {
-        return;
-    };
-    window.visible = true;
-    state.revealed = true;
-    state.revealed_at = Some(Instant::now());
+    for (entity, mut window) in &mut windows {
+        let Some(glass) = state.0.get_mut(&entity) else {
+            continue;
+        };
+        if glass.revealed {
+            continue;
+        }
+        window.visible = true;
+        glass.revealed = true;
+        glass.revealed_at = Some(Instant::now());
+    }
 }
 
 fn restore_fullscreen_after_reveal(
     state: NonSend<GlassState>,
+    primary_window: Query<Entity, With<bevy::window::PrimaryWindow>>,
     pending: Option<Res<crate::window_state::PendingFullscreenRestore>>,
     mut commands: Commands,
 ) {
@@ -192,11 +215,18 @@ fn restore_fullscreen_after_reveal(
     let Some(pending) = pending else {
         return;
     };
-    if !state.revealed {
+    let Some(glass) = primary_window
+        .single()
+        .ok()
+        .and_then(|window| state.0.get(&window))
+    else {
+        return;
+    };
+    if !glass.revealed {
         return;
     }
     if pending.0
-        && let Some(parent_window) = &state._parent_window
+        && let Some(parent_window) = &glass._parent_window
         && !parent_window
             .styleMask()
             .contains(NSWindowStyleMask::FullScreen)
@@ -223,25 +253,28 @@ fn should_attempt_activation(
 
 fn ensure_window_active_after_reveal(
     mut state: NonSendMut<GlassState>,
-    window: Query<Entity, With<bevy::window::PrimaryWindow>>,
+    windows: Query<Entity, With<Window>>,
     proxy: Option<Res<bevy::winit::EventLoopProxyWrapper>>,
 ) {
-    let elapsed = state.revealed_at.map(|at| at.elapsed());
-    if !should_attempt_activation(state.revealed, state.active_confirmed, elapsed) {
-        return;
-    }
-    let Ok(entity) = window.single() else {
-        return;
-    };
-    if crate::runtime::ensure_native_window_active(entity) {
-        state.active_confirmed = true;
-    } else if let Some(proxy) = proxy {
-        let _ = proxy.send_event(bevy::winit::WinitUserEvent::WakeUp);
+    for entity in &windows {
+        let Some(glass) = state.0.get_mut(&entity) else {
+            continue;
+        };
+        let elapsed = glass.revealed_at.map(|at| at.elapsed());
+        if !should_attempt_activation(glass.revealed, glass.active_confirmed, elapsed) {
+            continue;
+        }
+        if crate::runtime::ensure_native_window_active(entity) {
+            glass.active_confirmed = true;
+        } else if let Some(proxy) = proxy.as_ref() {
+            let _ = proxy.send_event(bevy::winit::WinitUserEvent::WakeUp);
+        }
     }
 }
 
 fn handle_toggle_fullscreen_command(
     state: NonSend<GlassState>,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
     mut reader: MessageReader<vmux_command::AppCommand>,
 ) {
     use vmux_command::{AppCommand, LayoutCommand, WindowCommand};
@@ -252,7 +285,12 @@ fn handle_toggle_fullscreen_command(
             AppCommand::Layout(LayoutCommand::Window(WindowCommand::ToggleFullscreen))
         )
     });
-    if toggle && let Some(parent_window) = &state._parent_window {
+    if toggle
+        && let Some(parent_window) = focused_window
+            .0
+            .and_then(|window| state.0.get(&window))
+            .and_then(|glass| glass._parent_window.as_ref())
+    {
         parent_window.toggleFullScreen(None);
     }
 }
@@ -260,34 +298,73 @@ fn handle_toggle_fullscreen_command(
 fn sync_window_glass_visibility(
     mut state: NonSendMut<GlassState>,
     mut clear_color: ResMut<vmux_layout::window::WindowBackground>,
-    mut window_q: Query<&mut bevy::window::Window, With<bevy::window::PrimaryWindow>>,
+    mut window_q: Query<(Entity, &mut bevy::window::Window)>,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
     mut window_fullscreen: ResMut<crate::window_state::WindowFullscreen>,
 ) {
     use objc2::ClassType;
     use objc2_app_kit::NSWindowStyleMask;
 
-    let bevy_fullscreen = window_q
-        .single()
-        .map(|w| {
-            matches!(
-                w.mode,
-                bevy::window::WindowMode::BorderlessFullscreen(_)
-                    | bevy::window::WindowMode::Fullscreen(..)
-            )
-        })
-        .unwrap_or(false);
-    let native_fullscreen = state
-        ._parent_window
-        .as_ref()
-        .is_some_and(|w| w.styleMask().contains(NSWindowStyleMask::FullScreen));
-    let fullscreen = bevy_fullscreen || native_fullscreen;
+    let mut focused_fullscreen = false;
+    let exit_fullscreen = crate::native_keyboard::take_exit_fullscreen_request();
+    state.0.retain(|entity, _| window_q.contains(*entity));
+    for (entity, mut window) in &mut window_q {
+        let Some(glass) = state.0.get_mut(&entity) else {
+            continue;
+        };
+        let bevy_fullscreen = matches!(
+            window.mode,
+            bevy::window::WindowMode::BorderlessFullscreen(_)
+                | bevy::window::WindowMode::Fullscreen(..)
+        );
+        let native_fullscreen = glass
+            ._parent_window
+            .as_ref()
+            .is_some_and(|window| window.styleMask().contains(NSWindowStyleMask::FullScreen));
+        let fullscreen = bevy_fullscreen || native_fullscreen;
+        if focused_window.0 == Some(entity) {
+            focused_fullscreen = fullscreen;
+            if exit_fullscreen {
+                if native_fullscreen {
+                    if let Some(parent_window) = &glass._parent_window {
+                        parent_window.toggleFullScreen(None);
+                    }
+                } else {
+                    window.mode = bevy::window::WindowMode::Windowed;
+                }
+            }
+        }
 
-    if window_fullscreen.0 != fullscreen {
-        window_fullscreen.0 = fullscreen;
+        let visible = !fullscreen;
+        if let (Some(backdrop_window), Some(parent_window)) =
+            (&glass._backdrop_window, &glass._parent_window)
+        {
+            let backdrop_window: &objc2_app_kit::NSWindow = backdrop_window.as_super();
+            backdrop_window.setFrame_display(parent_window.frame(), false);
+            let shadowed =
+                focus_shadow_visible(focused_window.0 == Some(entity), window.visible, fullscreen);
+            if glass.shadowed != shadowed {
+                backdrop_window.setHasShadow(shadowed);
+                backdrop_window.invalidateShadow();
+                glass.shadowed = shadowed;
+            }
+        }
+        if glass.visible == visible {
+            continue;
+        }
+        if let Some(effect) = &glass._glass {
+            let glass_view: &objc2_app_kit::NSView = effect;
+            glass_view.setHidden(!visible);
+        }
+        glass.visible = visible;
+    }
+
+    if window_fullscreen.0 != focused_fullscreen {
+        window_fullscreen.0 = focused_fullscreen;
     }
 
     let [r, g, b] = vmux_layout::window::WINDOW_BACKGROUND_SRGB;
-    let want_clear = if fullscreen {
+    let want_clear = if focused_fullscreen {
         Color::srgb(r, g, b)
     } else {
         Color::NONE
@@ -296,37 +373,14 @@ fn sync_window_glass_visibility(
         clear_color.0 = want_clear;
     }
 
-    crate::native_keyboard::set_window_fullscreen(fullscreen);
-
-    if crate::native_keyboard::take_exit_fullscreen_request() {
-        if native_fullscreen {
-            if let Some(parent_window) = &state._parent_window {
-                parent_window.toggleFullScreen(None);
-            }
-        } else if let Ok(mut window) = window_q.single_mut() {
-            window.mode = bevy::window::WindowMode::Windowed;
-        }
-        return;
-    }
-
-    let visible = !fullscreen;
-    if let (Some(backdrop_window), Some(parent_window)) =
-        (&state._backdrop_window, &state._parent_window)
-    {
-        let backdrop_window: &objc2_app_kit::NSWindow = backdrop_window.as_super();
-        backdrop_window.setFrame_display(parent_window.frame(), false);
-    }
-    if state.visible == visible {
-        return;
-    }
-    if let Some(glass) = &state._glass {
-        let glass_view: &objc2_app_kit::NSView = glass;
-        glass_view.setHidden(!visible);
-    }
-    state.visible = visible;
+    crate::native_keyboard::set_window_fullscreen(focused_fullscreen);
 }
 
-fn primary_content_view_ptr(entity: Entity) -> Option<*mut core::ffi::c_void> {
+fn focus_shadow_visible(focused: bool, visible: bool, fullscreen: bool) -> bool {
+    focused && visible && !fullscreen
+}
+
+fn content_view_ptr(entity: Entity) -> Option<*mut core::ffi::c_void> {
     use bevy::winit::WINIT_WINDOWS;
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
     WINIT_WINDOWS.with_borrow(|windows| {
@@ -340,27 +394,26 @@ fn primary_content_view_ptr(entity: Entity) -> Option<*mut core::ffi::c_void> {
     })
 }
 
-fn keep_window_surface_layer_transparent(window: Query<Entity, With<bevy::window::PrimaryWindow>>) {
+fn keep_window_surface_layer_transparent(windows: Query<Entity, With<Window>>) {
     use objc2::MainThreadMarker;
     use objc2_app_kit::{NSColor, NSView};
 
     if MainThreadMarker::new().is_none() {
         return;
     }
-    let Ok(entity) = window.single() else {
-        return;
-    };
-    let Some(ns_view) = primary_content_view_ptr(entity) else {
-        return;
-    };
-    let content: &NSView = unsafe { &*ns_view.cast::<NSView>() };
-    content.setWantsLayer(true);
-    let Some(layer) = content.layer() else {
-        return;
-    };
-    let clear_color = NSColor::clearColor();
-    layer.setOpaque(false);
-    layer.setBackgroundColor(Some(&clear_color.CGColor()));
+    for entity in &windows {
+        let Some(ns_view) = content_view_ptr(entity) else {
+            continue;
+        };
+        let content: &NSView = unsafe { &*ns_view.cast::<NSView>() };
+        content.setWantsLayer(true);
+        let Some(layer) = content.layer() else {
+            continue;
+        };
+        let clear_color = NSColor::clearColor();
+        layer.setOpaque(false);
+        layer.setBackgroundColor(Some(&clear_color.CGColor()));
+    }
 }
 
 #[cfg(test)]
@@ -427,7 +480,7 @@ mod tests {
         let sync = source
             .split("fn sync_window_glass_visibility")
             .nth(1)
-            .and_then(|tail| tail.split("fn primary_content_view_ptr").next())
+            .and_then(|tail| tail.split("fn content_view_ptr").next())
             .unwrap_or_default();
 
         assert!(sync.contains("backdrop_window.setFrame_display(parent_window.frame(), false)"));
@@ -443,17 +496,19 @@ mod tests {
     fn reveal_test_app(reveal_ready: bool) -> App {
         let mut app = App::new();
         app.add_systems(Update, reveal_window_after_layout_ready);
-        app.world_mut().insert_non_send(GlassState {
-            installed: true,
-            ..default()
-        });
-        app.world_mut().spawn((
-            Window {
-                visible: false,
-                ..default()
-            },
-            bevy::window::PrimaryWindow,
-        ));
+        let window = app
+            .world_mut()
+            .spawn((
+                Window {
+                    visible: false,
+                    ..default()
+                },
+                bevy::window::PrimaryWindow,
+            ))
+            .id();
+        let mut state = GlassState::default();
+        state.0.insert(window, WindowGlass::default());
+        app.world_mut().insert_non_send(state);
         app.insert_resource(crate::boot_status::SplashStatus {
             phase: crate::boot_status::BootPhase::Starting,
             reveal_ready,
@@ -524,6 +579,14 @@ mod tests {
     }
 
     #[test]
+    fn only_the_focused_visible_window_gets_the_emphasis_shadow() {
+        assert!(focus_shadow_visible(true, true, false));
+        assert!(!focus_shadow_visible(false, true, false));
+        assert!(!focus_shadow_visible(true, false, false));
+        assert!(!focus_shadow_visible(true, true, true));
+    }
+
+    #[test]
     fn reveal_does_not_activate_inline() {
         let source = include_str!("glass.rs");
         let reveal = source
@@ -533,7 +596,7 @@ mod tests {
             .unwrap_or_default();
 
         assert!(!reveal.contains("activate_native_window"));
-        assert!(reveal.contains("state.revealed_at = Some(Instant::now())"));
+        assert!(reveal.contains("glass.revealed_at = Some(Instant::now())"));
     }
 
     #[test]

--- a/crates/app/vmux_desktop/src/lib.rs
+++ b/crates/app/vmux_desktop/src/lib.rs
@@ -48,6 +48,7 @@ pub(crate) mod shortcut;
 mod tray;
 #[cfg(feature = "updater")]
 pub mod updater;
+mod window_manager;
 mod window_state;
 use bevy::prelude::*;
 use bevy::window::{
@@ -62,14 +63,7 @@ pub struct VmuxPlugin;
 
 impl Plugin for VmuxPlugin {
     fn build(&self, app: &mut App) {
-        let title = match env!("VMUX_BUILD_PROFILE") {
-            "release" => "Vmux".to_string(),
-            "local" => format!("Vmux ({})", env!("VMUX_GIT_HASH")),
-            "dev" => format!("Vmux Dev ({})", env!("VMUX_GIT_HASH")),
-            other => format!("Vmux ({})", other),
-        };
-
-        let primary_window = primary_window_config(title);
+        let primary_window = window_config(false);
         let window_plugin = WindowPlugin {
             primary_window: Some(primary_window),
             close_when_requested: false,
@@ -96,9 +90,9 @@ impl Plugin for VmuxPlugin {
 const DEFAULT_WINDOW_WIDTH: u32 = 1280;
 const DEFAULT_WINDOW_HEIGHT: u32 = 800;
 
-fn primary_window_config(title: String) -> NativeWindow {
+pub(crate) fn window_config(secondary: bool) -> NativeWindow {
     NativeWindow {
-        title,
+        title: window_title(),
         transparent: true,
         composite_alpha_mode: CompositeAlphaMode::PostMultiplied,
         decorations: true,
@@ -111,9 +105,22 @@ fn primary_window_config(title: String) -> NativeWindow {
         resizable: true,
         ime_enabled: true,
         visible: !cfg!(all(target_os = "macos", feature = "native-glass")),
-        position: WindowPosition::Centered(MonitorSelection::Primary),
+        position: if secondary {
+            WindowPosition::Automatic
+        } else {
+            WindowPosition::Centered(MonitorSelection::Primary)
+        },
         resolution: WindowResolution::new(DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT),
         ..default()
+    }
+}
+
+fn window_title() -> String {
+    match env!("VMUX_BUILD_PROFILE") {
+        "release" => "Vmux".to_string(),
+        "local" => format!("Vmux ({})", env!("VMUX_GIT_HASH")),
+        "dev" => format!("Vmux Dev ({})", env!("VMUX_GIT_HASH")),
+        other => format!("Vmux ({})", other),
     }
 }
 
@@ -123,14 +130,14 @@ mod tests {
 
     #[test]
     fn primary_window_enables_ime_input() {
-        let window = primary_window_config("Vmux".to_string());
+        let window = window_config(false);
 
         assert!(window.ime_enabled);
     }
 
     #[test]
     fn primary_window_starts_hidden_when_native_glass_needs_backdrop_setup() {
-        let window = primary_window_config("Vmux".to_string());
+        let window = window_config(false);
 
         assert_eq!(
             window.visible,
@@ -140,7 +147,7 @@ mod tests {
 
     #[test]
     fn primary_window_defaults_to_centered_default_size() {
-        let window = primary_window_config("Vmux".to_string());
+        let window = window_config(false);
 
         assert!(matches!(
             window.position,
@@ -148,6 +155,11 @@ mod tests {
         ));
         assert_eq!(window.resolution.physical_width(), DEFAULT_WINDOW_WIDTH);
         assert_eq!(window.resolution.physical_height(), DEFAULT_WINDOW_HEIGHT);
+    }
+
+    #[test]
+    fn secondary_window_uses_system_positioning() {
+        assert_eq!(window_config(true).position, WindowPosition::Automatic);
     }
 
     #[test]

--- a/crates/app/vmux_desktop/src/os_menu.rs
+++ b/crates/app/vmux_desktop/src/os_menu.rs
@@ -27,6 +27,7 @@ pub struct OsMenuPlugin;
 impl Plugin for OsMenuPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(crate::bookmark_menu::BookmarkMenuPlugin)
+            .add_message::<crate::window_manager::CloseVmuxWindow>()
             .init_resource::<LastMenuCommandAt>()
             .init_resource::<LastStackCloseAt>()
             .init_resource::<LastNativePageOpenAt>()
@@ -401,6 +402,7 @@ fn remember_native_page_open_commands(
 fn hide_window_on_close_request(
     mut closed: MessageReader<WindowCloseRequested>,
     mut windows: Query<&mut Window>,
+    mut close_windows: MessageWriter<crate::window_manager::CloseVmuxWindow>,
     last_menu_command: Res<LastMenuCommandAt>,
     last_stack_close: Res<LastStackCloseAt>,
     last_native_page_open: Res<LastNativePageOpenAt>,
@@ -419,6 +421,7 @@ fn hide_window_on_close_request(
     let from_native_page_open = last_native_page_open
         .0
         .is_some_and(|t| t.elapsed() < NATIVE_PAGE_OPEN_CLOSE_SUPPRESSION_WINDOW);
+    let window_count = windows.iter().count();
     for event in closed.read() {
         if from_menu_key_equivalent || from_stack_close || from_tab_close || from_native_page_open {
             info!(
@@ -430,6 +433,10 @@ fn hide_window_on_close_request(
                 from_native_page_open,
                 "suppressed WindowCloseRequested"
             );
+            continue;
+        }
+        if window_count > 1 {
+            close_windows.write(crate::window_manager::CloseVmuxWindow(event.window));
             continue;
         }
         if let Ok(mut window) = windows.get_mut(event.window) {

--- a/crates/app/vmux_desktop/src/persistence.rs
+++ b/crates/app/vmux_desktop/src/persistence.rs
@@ -4,6 +4,7 @@ use bevy::window::PrimaryWindow;
 use bevy_cef::prelude::*;
 use bevy_world_serialization::WorldFilter;
 use moonshine_save::prelude::*;
+use moonshine_save::save::EntityFilter;
 use std::path::{Path, PathBuf};
 
 use vmux_browser::Browser;
@@ -67,10 +68,15 @@ impl Plugin for PersistencePlugin {
 
 fn handle_save_space_requests(
     mut requests: MessageReader<vmux_space::SaveSpaceRequest>,
+    save_entities: SpaceSaveEntities,
     mut commands: Commands,
 ) {
     for request in requests.read() {
-        save_space_to_path(&mut commands, request.path.clone());
+        save_space_to_path_excluding(
+            &mut commands,
+            request.path.clone(),
+            save_entities.excluded(),
+        );
     }
 }
 
@@ -94,6 +100,33 @@ struct AutoSave {
     debounce: Timer,
     periodic: Timer,
     dirty: bool,
+}
+
+#[derive(bevy::ecs::system::SystemParam)]
+struct SpaceSaveEntities<'w, 's> {
+    saved: Query<'w, 's, Entity, With<Save>>,
+    child_of: Query<'w, 's, &'static ChildOf>,
+    host_windows: Query<'w, 's, &'static HostWindow>,
+    windows: Query<'w, 's, (), With<Window>>,
+    primary_window: Query<'w, 's, Entity, With<PrimaryWindow>>,
+}
+
+impl SpaceSaveEntities<'_, '_> {
+    fn excluded(&self) -> Vec<Entity> {
+        let Ok(primary_window) = self.primary_window.single() else {
+            return Vec::new();
+        };
+        self.saved
+            .iter()
+            .filter(|entity| {
+                if self.windows.contains(*entity) {
+                    return *entity != primary_window;
+                }
+                vmux_layout::window::host_window_of(*entity, &self.child_of, &self.host_windows)
+                    .is_some_and(|window| window != primary_window)
+            })
+            .collect()
+    }
 }
 
 #[derive(bevy::ecs::system::SystemParam)]
@@ -198,6 +231,7 @@ fn auto_save_system(
     time: Res<Time>,
     mut auto_save: ResMut<AutoSave>,
     spaces: Query<(), With<Space>>,
+    save_entities: SpaceSaveEntities,
     mut commands: Commands,
 ) {
     auto_save.periodic.tick(time.delta());
@@ -209,17 +243,26 @@ fn auto_save_system(
     if auto_save.dirty {
         auto_save.debounce.tick(time.delta());
         if auto_save.debounce.is_finished() {
-            save_space_to_path(&mut commands, store_path());
+            save_space_to_path_excluding(&mut commands, store_path(), save_entities.excluded());
             auto_save.dirty = false;
         }
     }
 
     if auto_save.periodic.just_finished() {
-        save_space_to_path(&mut commands, store_path());
+        save_space_to_path_excluding(&mut commands, store_path(), save_entities.excluded());
     }
 }
 
+#[cfg(test)]
 pub(crate) fn save_space_to_path(commands: &mut Commands, path: PathBuf) {
+    save_space_to_path_excluding(commands, path, std::iter::empty());
+}
+
+fn save_space_to_path_excluding(
+    commands: &mut Commands,
+    path: PathBuf,
+    excluded: impl IntoIterator<Item = Entity>,
+) {
     if vmux_core::profile::is_test_session() {
         return;
     }
@@ -228,6 +271,7 @@ pub(crate) fn save_space_to_path(commands: &mut Commands, path: PathBuf) {
     }
     write_store_schema_version(&path);
     let mut save = SaveWorld::default_into_file(path);
+    save.entities = EntityFilter::block(excluded);
     save.components = WorldFilter::deny_all()
         .allow::<Save>()
         .allow::<ChildOf>()
@@ -692,6 +736,7 @@ fn sync_launch_to_stack(
 mod tests {
     use super::*;
     use bevy::ecs::entity::EntityHashMap;
+    use bevy::ecs::system::RunSystemOnce;
     use vmux_layout::settings::{
         FocusRingSettings, LayoutSettings, PaneSettings, SideSheetSettings, WindowSettings,
     };
@@ -1384,6 +1429,38 @@ mod tests {
         assert!(geom.fullscreen);
         assert_eq!(geom.position, Some(IVec2::new(11, 22)));
         assert_eq!(geom.size, Some(Vec2::new(640.0, 480.0)));
+    }
+
+    #[test]
+    fn secondary_window_views_are_excluded_from_store() {
+        let mut app = App::new();
+        let primary_window = app
+            .world_mut()
+            .spawn((Window::default(), PrimaryWindow, Save))
+            .id();
+        let secondary_window = app.world_mut().spawn((Window::default(), Save)).id();
+        let primary_root = app.world_mut().spawn(HostWindow(primary_window)).id();
+        let secondary_root = app.world_mut().spawn(HostWindow(secondary_window)).id();
+        let primary_space = app
+            .world_mut()
+            .spawn((Save, Space, ChildOf(primary_root)))
+            .id();
+        let secondary_space = app
+            .world_mut()
+            .spawn((Save, Space, ChildOf(secondary_root)))
+            .id();
+        let global = app.world_mut().spawn(Save).id();
+
+        let excluded = app
+            .world_mut()
+            .run_system_once(|entities: SpaceSaveEntities| entities.excluded())
+            .unwrap();
+
+        assert!(excluded.contains(&secondary_window));
+        assert!(excluded.contains(&secondary_space));
+        assert!(!excluded.contains(&primary_window));
+        assert!(!excluded.contains(&primary_space));
+        assert!(!excluded.contains(&global));
     }
 
     #[test]

--- a/crates/app/vmux_desktop/src/plugins.rs
+++ b/crates/app/vmux_desktop/src/plugins.rs
@@ -54,6 +54,7 @@ pub(crate) struct NativeWindowPlugin;
 impl Plugin for NativeWindowPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins((
+            crate::window_manager::WindowManagerPlugin,
             WindowStatePlugin,
             DisplayPlugin,
             crate::appearance::DesktopAppearancePlugin,

--- a/crates/app/vmux_desktop/src/recording.rs
+++ b/crates/app/vmux_desktop/src/recording.rs
@@ -1,7 +1,7 @@
 use bevy::ecs::system::NonSendMarker;
 use bevy::prelude::*;
-use bevy::window::PrimaryWindow;
 use bevy::winit::{EventLoopProxyWrapper, WinitUserEvent};
+use bevy_cef::prelude::HostWindow;
 use crossbeam_channel::{Receiver, Sender};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -228,15 +228,25 @@ fn start_recording(
     bridge: Res<RecordingBridge>,
     settings: Res<AppSettings>,
     mut status: ResMut<RecordingStatus>,
-    window_q: Query<(Entity, &Window), With<PrimaryWindow>>,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
+    window_q: Query<(Entity, &Window)>,
+    host_windows: Query<&HostWindow>,
     node_q: Query<&ComputedNode>,
     child_of_q: Query<&ChildOf>,
     proxy: Option<Res<EventLoopProxyWrapper>>,
 ) {
     let default_dir = crate::capture_output::output_dir(&settings);
     for req in start_reader.read() {
-        let Ok((window_entity, window)) = window_q.single() else {
-            start_responses.write(start_err(req.request_id, "no primary vmux window"));
+        let pane_window = req.pane.as_deref().and_then(|id| {
+            let (_, bits) = vmux_layout::protocol::parse_id(id).ok()?;
+            vmux_layout::window::host_window_of(Entity::from_bits(bits), &child_of_q, &host_windows)
+        });
+        let Some(window_entity) = pane_window.or(focused_window.0) else {
+            start_responses.write(start_err(req.request_id, "no focused vmux window"));
+            continue;
+        };
+        let Ok((_, window)) = window_q.get(window_entity) else {
+            start_responses.write(start_err(req.request_id, "focused vmux window not found"));
             continue;
         };
         let img_w = window.resolution.physical_width();

--- a/crates/app/vmux_desktop/src/remote.rs
+++ b/crates/app/vmux_desktop/src/remote.rs
@@ -200,14 +200,8 @@ fn push_remote_state_emit(
     browsers: NonSend<Browsers>,
     cef_q: Query<(Entity, Ref<PageReady>), With<LayoutCef>>,
     state: Res<RemoteState>,
-    mut last: Local<Option<RemoteStateEvent>>,
+    mut last: Local<std::collections::HashMap<Entity, RemoteStateEvent>>,
 ) {
-    let Ok((cef_e, page_ready)) = cef_q.single() else {
-        return;
-    };
-    if !browsers.can_emit_to(&cef_e) {
-        return;
-    }
     let payload = RemoteStateEvent {
         enabled: state.enabled,
         phase: state.phase,
@@ -216,15 +210,20 @@ fn push_remote_state_emit(
         paired: state.paired,
         error: state.error.clone(),
     };
-    if last.as_ref() == Some(&payload) && !page_ready.is_changed() {
-        return;
+    for (cef_e, page_ready) in &cef_q {
+        if !browsers.can_emit_to(&cef_e) {
+            continue;
+        }
+        if last.get(&cef_e) == Some(&payload) && !page_ready.is_changed() {
+            continue;
+        }
+        commands.trigger(BinHostEmitEvent::from_rkyv(
+            cef_e,
+            REMOTE_STATE_EVENT,
+            &payload,
+        ));
+        last.insert(cef_e, payload.clone());
     }
-    commands.trigger(BinHostEmitEvent::from_rkyv(
-        cef_e,
-        REMOTE_STATE_EVENT,
-        &payload,
-    ));
-    *last = Some(payload);
 }
 
 fn remote_worker(command_rx: Receiver<bool>, result_tx: Sender<RemoteWorkerResult>) {

--- a/crates/app/vmux_desktop/src/runtime/macos.rs
+++ b/crates/app/vmux_desktop/src/runtime/macos.rs
@@ -59,7 +59,8 @@ fn activate_primary_window_on_startup(
 }
 
 fn grab_key_window_on_pane_hover(
-    primary_window: Query<(Entity, &Window), With<bevy::window::PrimaryWindow>>,
+    windows: Query<(Entity, &Window)>,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
     panes: Query<
         &ComputedNode,
         (
@@ -87,7 +88,10 @@ fn grab_key_window_on_pane_hover(
     if !over_pane {
         return;
     }
-    let Ok((window_entity, window)) = primary_window.single() else {
+    let Some(window_entity) = focused_window.0 else {
+        return;
+    };
+    let Ok((_, window)) = windows.get(window_entity) else {
         return;
     };
     if !window.visible {

--- a/crates/app/vmux_desktop/src/screenshot.rs
+++ b/crates/app/vmux_desktop/src/screenshot.rs
@@ -1,8 +1,8 @@
 use bevy::ecs::relationship::Relationship;
 use bevy::ecs::system::NonSendMarker;
 use bevy::prelude::*;
-use bevy::window::PrimaryWindow;
 use bevy::winit::{EventLoopProxyWrapper, WinitUserEvent};
+use bevy_cef::prelude::HostWindow;
 use crossbeam_channel::{Receiver, Sender};
 use std::sync::Arc;
 use vmux_agent::{ScreenshotRequest, ScreenshotResponse};
@@ -74,17 +74,30 @@ fn start_screenshots(
     mut reader: MessageReader<ScreenshotRequest>,
     bridge: Res<ScreenshotBridge>,
     settings: Res<AppSettings>,
-    window_q: Query<(Entity, &Window), With<PrimaryWindow>>,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
+    window_q: Query<(Entity, &Window)>,
+    host_windows: Query<&HostWindow>,
     node_q: Query<&ComputedNode>,
     child_of_q: Query<&ChildOf>,
     proxy: Option<Res<EventLoopProxyWrapper>>,
 ) {
     let base_dir = crate::capture_output::output_dir(&settings);
     for req in reader.read() {
-        let Ok((window_entity, window)) = window_q.single() else {
+        let pane_window = req.pane.as_deref().and_then(|id| {
+            let (_, bits) = vmux_layout::protocol::parse_id(id).ok()?;
+            vmux_layout::window::host_window_of(Entity::from_bits(bits), &child_of_q, &host_windows)
+        });
+        let Some(window_entity) = pane_window.or(focused_window.0) else {
             let _ = bridge
                 .tx
-                .send(err_response(req.request_id, "no primary vmux window"));
+                .send(err_response(req.request_id, "no focused vmux window"));
+            continue;
+        };
+        let Ok((_, window)) = window_q.get(window_entity) else {
+            let _ = bridge.tx.send(err_response(
+                req.request_id,
+                "focused vmux window not found",
+            ));
             continue;
         };
         let img_w = window.resolution.physical_width();

--- a/crates/app/vmux_desktop/src/tools.rs
+++ b/crates/app/vmux_desktop/src/tools.rs
@@ -681,22 +681,25 @@ fn emit_tools_snapshot(
     browsers: NonSend<Browsers>,
     layout: Query<(Entity, Ref<PageReady>), With<LayoutCef>>,
     entities: &bevy::ecs::entity::Entities,
-    mut layout_revision: Local<u64>,
+    mut layout_revisions: Local<HashMap<Entity, u64>>,
     mut commands: Commands,
 ) {
     if !state.loaded {
         return;
     }
-    if let Ok((entity, page_ready)) = layout.single()
-        && (*layout_revision != state.revision || page_ready.is_changed())
-        && browsers.can_emit_to(&entity)
-    {
+    for (entity, page_ready) in &layout {
+        if layout_revisions.get(&entity) == Some(&state.revision) && !page_ready.is_changed() {
+            continue;
+        }
+        if !browsers.can_emit_to(&entity) {
+            continue;
+        }
         commands.trigger(BinHostEmitEvent::from_rkyv(
             entity,
             TOOLS_SNAPSHOT_EVENT,
             &state.snapshot,
         ));
-        *layout_revision = state.revision;
+        layout_revisions.insert(entity, state.revision);
     }
     let revision = state.revision;
     let snapshot = state.snapshot.clone();

--- a/crates/app/vmux_desktop/src/window_manager.rs
+++ b/crates/app/vmux_desktop/src/window_manager.rs
@@ -1,0 +1,182 @@
+use bevy::prelude::*;
+use bevy::window::PrimaryWindow;
+use bevy_cef::prelude::HostWindow;
+use vmux_command::{AppCommand, LayoutCommand, ReadAppCommands, WindowCommand};
+use vmux_layout::window::{FocusedWindow, NewWindowWorkspace, VmuxWindow};
+
+pub(crate) struct WindowManagerPlugin;
+
+impl Plugin for WindowManagerPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_message::<CloseVmuxWindow>()
+            .add_systems(
+                Update,
+                handle_window_commands
+                    .in_set(ReadAppCommands)
+                    .after(vmux_layout::window::WindowFocusSet),
+            )
+            .add_systems(Update, close_windows.after(handle_window_commands));
+    }
+}
+
+#[derive(Message, Clone, Copy)]
+pub(crate) struct CloseVmuxWindow(pub Entity);
+
+fn handle_window_commands(
+    mut reader: MessageReader<AppCommand>,
+    mut focused: ResMut<FocusedWindow>,
+    mut close: MessageWriter<CloseVmuxWindow>,
+    mut commands: Commands,
+) {
+    for command in reader.read() {
+        let AppCommand::Layout(LayoutCommand::Window(command)) = command else {
+            continue;
+        };
+        match command {
+            WindowCommand::NewWindow => {
+                let window = commands
+                    .spawn((crate::window_config(true), NewWindowWorkspace))
+                    .id();
+                focused.0 = Some(window);
+            }
+            WindowCommand::CloseWindow => {
+                if let Some(window) = focused.0 {
+                    close.write(CloseVmuxWindow(window));
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn close_windows(
+    mut requests: MessageReader<CloseVmuxWindow>,
+    windows: Query<(Entity, Has<PrimaryWindow>), With<Window>>,
+    roots: Query<(Entity, &HostWindow), With<VmuxWindow>>,
+    mut lifecycle: MessageWriter<crate::runtime::LifecycleEvent>,
+    mut commands: Commands,
+) {
+    let mut remaining: Vec<(Entity, bool)> = windows.iter().collect();
+    for request in requests.read() {
+        let Some(index) = remaining
+            .iter()
+            .position(|(window, _)| *window == request.0)
+        else {
+            continue;
+        };
+        if remaining.len() <= 1 {
+            lifecycle.write(crate::runtime::LifecycleEvent::HideAllWindows);
+            continue;
+        }
+        let (_, primary) = remaining.remove(index);
+        if primary && let Some((next, _)) = remaining.first() {
+            commands.entity(*next).insert(PrimaryWindow);
+        }
+        for (root, host) in &roots {
+            if host.0 == request.0 {
+                commands.entity(root).despawn();
+            }
+        }
+        if windows.get(request.0).is_ok() {
+            commands.entity(request.0).despawn();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::ecs::message::Messages;
+
+    #[test]
+    fn new_window_command_spawns_a_full_window_request() {
+        let mut app = App::new();
+        app.add_message::<AppCommand>()
+            .add_message::<CloseVmuxWindow>()
+            .init_resource::<FocusedWindow>()
+            .add_systems(Update, handle_window_commands);
+        app.world_mut()
+            .resource_mut::<Messages<AppCommand>>()
+            .write(AppCommand::Layout(LayoutCommand::Window(
+                WindowCommand::NewWindow,
+            )));
+
+        app.update();
+
+        let windows: Vec<Entity> = app
+            .world_mut()
+            .query_filtered::<Entity, (With<Window>, With<NewWindowWorkspace>)>()
+            .iter(app.world())
+            .collect();
+        assert_eq!(windows.len(), 1);
+        assert_eq!(app.world().resource::<FocusedWindow>().0, Some(windows[0]));
+    }
+
+    #[test]
+    fn closing_one_of_two_windows_despawns_only_its_shell() {
+        let mut app = App::new();
+        app.add_message::<crate::runtime::LifecycleEvent>()
+            .add_message::<CloseVmuxWindow>()
+            .add_systems(Update, close_windows);
+        let first = app.world_mut().spawn(Window::default()).id();
+        let second = app.world_mut().spawn(Window::default()).id();
+        let first_root = app.world_mut().spawn((VmuxWindow, HostWindow(first))).id();
+        let second_root = app.world_mut().spawn((VmuxWindow, HostWindow(second))).id();
+        app.world_mut()
+            .resource_mut::<Messages<CloseVmuxWindow>>()
+            .write(CloseVmuxWindow(second));
+
+        app.update();
+
+        assert!(app.world().get_entity(first).is_ok());
+        assert!(app.world().get_entity(first_root).is_ok());
+        assert!(app.world().get_entity(second).is_err());
+        assert!(app.world().get_entity(second_root).is_err());
+    }
+
+    #[test]
+    fn closing_every_window_in_one_update_keeps_the_last_shell() {
+        let mut app = App::new();
+        app.add_message::<crate::runtime::LifecycleEvent>()
+            .add_message::<CloseVmuxWindow>()
+            .add_systems(Update, close_windows);
+        let first = app.world_mut().spawn(Window::default()).id();
+        let second = app.world_mut().spawn(Window::default()).id();
+        app.world_mut()
+            .resource_mut::<Messages<CloseVmuxWindow>>()
+            .write(CloseVmuxWindow(first));
+        app.world_mut()
+            .resource_mut::<Messages<CloseVmuxWindow>>()
+            .write(CloseVmuxWindow(second));
+
+        app.update();
+
+        let windows: Vec<Entity> = app
+            .world_mut()
+            .query_filtered::<Entity, With<Window>>()
+            .iter(app.world())
+            .collect();
+        assert_eq!(windows, vec![second]);
+    }
+
+    #[test]
+    fn closing_the_primary_window_promotes_the_remaining_window() {
+        let mut app = App::new();
+        app.add_message::<crate::runtime::LifecycleEvent>()
+            .add_message::<CloseVmuxWindow>()
+            .add_systems(Update, close_windows);
+        let primary = app
+            .world_mut()
+            .spawn((Window::default(), PrimaryWindow))
+            .id();
+        let remaining = app.world_mut().spawn(Window::default()).id();
+        app.world_mut()
+            .resource_mut::<Messages<CloseVmuxWindow>>()
+            .write(CloseVmuxWindow(primary));
+
+        app.update();
+
+        assert!(app.world().get_entity(primary).is_err());
+        assert!(app.world().entity(remaining).contains::<PrimaryWindow>());
+    }
+}

--- a/crates/page/vmux_agent/src/host/query.rs
+++ b/crates/page/vmux_agent/src/host/query.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use bevy_cef::prelude::HostWindow;
 use vmux_command::WriteAppCommands;
 use vmux_service::client::ServiceClient;
 use vmux_service::protocol::{
@@ -45,19 +46,70 @@ impl Plugin for QueryPlugin {
     }
 }
 
+#[derive(bevy::ecs::system::SystemParam)]
+pub(super) struct ListedSpaces<'w, 's> {
+    spaces: Query<
+        'w,
+        's,
+        (
+            Entity,
+            &'static vmux_layout::space::SpaceId,
+            &'static Name,
+            Has<vmux_core::Active>,
+            Option<&'static vmux_core::Order>,
+        ),
+        With<vmux_layout::space::Space>,
+    >,
+    focused_window: Option<Res<'w, vmux_layout::window::FocusedWindow>>,
+    child_of: Query<'w, 's, &'static ChildOf>,
+    host_windows: Query<'w, 's, &'static HostWindow>,
+}
+
+impl ListedSpaces<'_, '_> {
+    fn json(&self) -> String {
+        let mut rows: Vec<(u32, String, serde_json::Value)> = Vec::new();
+        for (entity, id, name, is_active, order) in &self.spaces {
+            let local = self
+                .focused_window
+                .as_deref()
+                .and_then(|focused| focused.0)
+                .is_some_and(|focused| {
+                    vmux_layout::window::host_window_of(entity, &self.child_of, &self.host_windows)
+                        == Some(focused)
+                });
+            let order = order.map(|order| order.0).unwrap_or(u32::MAX);
+            if let Some((existing_order, _, row)) = rows
+                .iter_mut()
+                .find(|(_, existing_id, _)| existing_id == &id.0)
+            {
+                *existing_order = (*existing_order).min(order);
+                if local {
+                    row["is_active"] = serde_json::json!(is_active);
+                }
+                continue;
+            }
+            rows.push((
+                order,
+                id.0.clone(),
+                serde_json::json!({
+                    "id": id.0,
+                    "name": name.to_string(),
+                    "profile": vmux_space::model::bootstrap_profile_name(),
+                    "is_active": local && is_active,
+                }),
+            ));
+        }
+        rows.sort_by_key(|(order, _, _)| *order);
+        let rows: Vec<serde_json::Value> = rows.into_iter().map(|(_, _, row)| row).collect();
+        serde_json::to_string(&rows).unwrap_or_else(|_| "[]".to_string())
+    }
+}
+
 pub(super) fn handle_agent_queries(
     mut reader: MessageReader<AgentQueryRequest>,
     service: Option<Res<ServiceClient>>,
     settings: Res<AppSettings>,
-    spaces: Query<
-        (
-            &vmux_layout::space::SpaceId,
-            &Name,
-            Has<vmux_core::Active>,
-            Option<&vmux_core::Order>,
-        ),
-        With<vmux_layout::space::Space>,
-    >,
+    listed_spaces: ListedSpaces,
     bm_pins: Query<
         (
             &vmux_core::Uuid,
@@ -122,26 +174,9 @@ pub(super) fn handle_agent_queries(
                 });
             }
             AgentQuery::ListSpaces => {
-                let mut rows: Vec<(u32, serde_json::Value)> = spaces
-                    .iter()
-                    .map(|(id, name, is_active, order)| {
-                        (
-                            order.map(|o| o.0).unwrap_or(u32::MAX),
-                            serde_json::json!({
-                                "id": id.0,
-                                "name": name.to_string(),
-                                "profile": vmux_space::model::bootstrap_profile_name(),
-                                "is_active": is_active,
-                            }),
-                        )
-                    })
-                    .collect();
-                rows.sort_by_key(|(order, _)| *order);
-                let rows: Vec<serde_json::Value> = rows.into_iter().map(|(_, row)| row).collect();
-                let json = serde_json::to_string(&rows).unwrap_or_else(|_| "[]".to_string());
                 service.0.send(ClientMessage::AgentQueryResponse {
                     request_id: request.request_id,
-                    result: AgentQueryResult::Spaces(json),
+                    result: AgentQueryResult::Spaces(listed_spaces.json()),
                 });
             }
             AgentQuery::BookmarkList => {
@@ -439,6 +474,53 @@ fn forward_simulator_screenshot_responses(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bevy::ecs::system::RunSystemOnce;
+
+    #[test]
+    fn listed_spaces_are_global_but_active_state_is_window_local() {
+        let mut app = App::new();
+        let first_window = app.world_mut().spawn_empty().id();
+        let second_window = app.world_mut().spawn_empty().id();
+        app.insert_resource(vmux_layout::window::FocusedWindow(Some(second_window)));
+        let first_root = app.world_mut().spawn(HostWindow(first_window)).id();
+        let second_root = app.world_mut().spawn(HostWindow(second_window)).id();
+        app.world_mut().spawn((
+            vmux_layout::space::Space,
+            vmux_layout::space::SpaceId("shared".to_string()),
+            Name::new("shared"),
+            vmux_core::Active,
+            ChildOf(first_root),
+        ));
+        app.world_mut().spawn((
+            vmux_layout::space::Space,
+            vmux_layout::space::SpaceId("shared".to_string()),
+            Name::new("shared"),
+            ChildOf(second_root),
+        ));
+        app.world_mut().spawn((
+            vmux_layout::space::Space,
+            vmux_layout::space::SpaceId("local".to_string()),
+            Name::new("local"),
+            vmux_core::Active,
+            ChildOf(second_root),
+        ));
+
+        let json = app
+            .world_mut()
+            .run_system_once(|spaces: ListedSpaces| spaces.json())
+            .unwrap();
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(
+            rows.iter().find(|row| row["id"] == "shared").unwrap()["is_active"],
+            false
+        );
+        assert_eq!(
+            rows.iter().find(|row| row["id"] == "local").unwrap()["is_active"],
+            true
+        );
+    }
 
     #[test]
     pub(crate) fn screenshot_response_maps_ok_and_err() {

--- a/crates/page/vmux_command/src/host/command.rs
+++ b/crates/page/vmux_command/src/host/command.rs
@@ -603,7 +603,8 @@ pub enum ToggleLayoutCommand {
 #[derive(OsSubMenu, DefaultShortcuts, CommandBar, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum WindowCommand {
     #[default]
-    #[menu(id = "new_window", label = "New Window", hidden)]
+    #[menu(id = "new_window", label = "New Window", accel = "super+n", hidden)]
+    #[shortcut(direct = "Super+N")]
     NewWindow,
     #[menu(
         id = "close_window",

--- a/crates/page/vmux_command/src/host/command_bar/handler.rs
+++ b/crates/page/vmux_command/src/host/command_bar/handler.rs
@@ -471,7 +471,11 @@ fn command_bar_toggle_should_open(is_open: bool, picker: Option<CommandBarPicker
 
 fn handle_open_command_bar(
     mut reader: MessageReader<AppCommand>,
-    layout_q: Query<(Entity, Has<CommandBarPanelActive>), With<RendersLauncherPanel>>,
+    layout_q: Query<
+        (Entity, Has<CommandBarPanelActive>, Option<&HostWindow>),
+        With<RendersLauncherPanel>,
+    >,
+    windows: Query<&Window>,
     all_children: Query<&Children>,
     browser_meta: Query<&PageMetadata, Or<(With<WebviewSource>, With<HostsPage>)>>,
     focus: Res<CommandBarWorkspaceSnapshot>,
@@ -485,7 +489,13 @@ fn handle_open_command_bar(
     )>,
     mut commands: Commands,
 ) {
-    let Ok((layout_e, is_open)) = layout_q.single() else {
+    let Some((layout_e, is_open, _)) = layout_q
+        .iter()
+        .find(|(_, _, host)| {
+            host.is_some_and(|host| windows.get(host.0).is_ok_and(|window| window.focused))
+        })
+        .or_else(|| layout_q.iter().next())
+    else {
         return;
     };
     let active_stack_count = focus.stack_count;

--- a/crates/page/vmux_knowledge/src/host.rs
+++ b/crates/page/vmux_knowledge/src/host.rs
@@ -3,7 +3,9 @@ use std::sync::mpsc;
 use bevy::prelude::*;
 use bevy::tasks::{IoTaskPool, Task, futures_lite::future};
 use bevy::winit::{EventLoopProxyWrapper, WinitUserEvent};
-use bevy_cef::prelude::{BinEventEmitterPlugin, BinHostEmitEvent, BinReceive, Browsers};
+use bevy_cef::prelude::{
+    BinEventEmitterPlugin, BinHostEmitEvent, BinReceive, Browsers, HostWindow,
+};
 use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use vmux_core::knowledge::{
     KNOWLEDGE_CREATE_RESULT_EVENT, KNOWLEDGE_SEARCH_EVENT, KNOWLEDGE_TREE_EVENT,
@@ -256,39 +258,59 @@ impl KnowledgeExpansion<'_, '_> {
     }
 }
 
+#[derive(bevy::ecs::system::SystemParam)]
+struct KnowledgeTreeEmitter<'w, 's> {
+    browsers: NonSend<'w, Browsers>,
+    layout: Query<'w, 's, (Entity, Ref<'static, PageReady>, &'static HostWindow), With<LayoutCef>>,
+    focused_window: Res<'w, vmux_layout::window::FocusedWindow>,
+    last_revision: Local<'s, std::collections::HashMap<Entity, u64>>,
+    pending: Local<'s, std::collections::HashSet<Entity>>,
+    commands: Commands<'w, 's>,
+}
+
+impl KnowledgeTreeEmitter<'_, '_> {
+    fn emit(&mut self, state: &KnowledgeState, expansion: &KnowledgeExpansion) {
+        if !state.loaded {
+            return;
+        }
+        let Some((entity, page_ready, _)) = self
+            .focused_window
+            .0
+            .and_then(|window| self.layout.iter().find(|(_, _, host)| host.0 == window))
+            .or_else(|| self.layout.iter().next())
+        else {
+            return;
+        };
+        if self.last_revision.get(&entity) != Some(&state.revision)
+            || page_ready.is_changed()
+            || expansion.just_moved()
+        {
+            self.pending.insert(entity);
+        }
+        if !self.pending.contains(&entity) {
+            return;
+        }
+        if !self.browsers.can_emit_to(&entity) {
+            return;
+        }
+        let mut tree = state.tree.clone();
+        expansion.stamp(&mut tree);
+        self.commands.trigger(BinHostEmitEvent::from_rkyv(
+            entity,
+            KNOWLEDGE_TREE_EVENT,
+            &tree,
+        ));
+        self.pending.remove(&entity);
+        self.last_revision.insert(entity, state.revision);
+    }
+}
+
 fn emit_knowledge_tree(
     state: Res<KnowledgeState>,
-    browsers: NonSend<Browsers>,
-    layout: Query<(Entity, Ref<PageReady>), With<LayoutCef>>,
     expansion: KnowledgeExpansion,
-    mut last_revision: Local<u64>,
-    mut pending: Local<bool>,
-    mut commands: Commands,
+    mut emitter: KnowledgeTreeEmitter,
 ) {
-    if !state.loaded {
-        return;
-    }
-    let Ok((entity, page_ready)) = layout.single() else {
-        return;
-    };
-    if state.revision != *last_revision || page_ready.is_changed() || expansion.just_moved() {
-        *pending = true;
-    }
-    if !*pending {
-        return;
-    }
-    if !browsers.can_emit_to(&entity) {
-        return;
-    }
-    let mut tree = state.tree.clone();
-    expansion.stamp(&mut tree);
-    commands.trigger(BinHostEmitEvent::from_rkyv(
-        entity,
-        KNOWLEDGE_TREE_EVENT,
-        &tree,
-    ));
-    *pending = false;
-    *last_revision = state.revision;
+    emitter.emit(&state, &expansion);
 }
 
 fn on_knowledge_search(

--- a/crates/page/vmux_layout/src/host/active.rs
+++ b/crates/page/vmux_layout/src/host/active.rs
@@ -21,14 +21,19 @@ fn apply_active(entries: &[(Entity, i64, bool)], commands: &mut Commands) {
 }
 
 pub fn ensure_active_space(
+    mains: Query<&Children, With<crate::window::Main>>,
     spaces: Query<(Entity, Option<&LastActivatedAt>, Has<Active>), With<Space>>,
     mut commands: Commands,
 ) {
-    let entries: Vec<(Entity, i64, bool)> = spaces
-        .iter()
-        .map(|(entity, ts, active)| (entity, ts.map(|t| t.0).unwrap_or(0), active))
-        .collect();
-    apply_active(&entries, &mut commands);
+    for children in &mains {
+        let mut entries = Vec::new();
+        for child in children.iter() {
+            if let Ok((entity, ts, active)) = spaces.get(child) {
+                entries.push((entity, ts.map(|t| t.0).unwrap_or(0), active));
+            }
+        }
+        apply_active(&entries, &mut commands);
+    }
 }
 
 pub fn ensure_active_tab(
@@ -132,10 +137,39 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .add_systems(Update, ensure_active_space);
-        let older = app.world_mut().spawn((Space, LastActivatedAt(1))).id();
-        let newer = app.world_mut().spawn((Space, LastActivatedAt(9))).id();
+        let main = app.world_mut().spawn(crate::window::Main).id();
+        let older = app
+            .world_mut()
+            .spawn((Space, LastActivatedAt(1), ChildOf(main)))
+            .id();
+        let newer = app
+            .world_mut()
+            .spawn((Space, LastActivatedAt(9), ChildOf(main)))
+            .id();
         app.update();
         assert!(app.world().entity(newer).contains::<Active>());
         assert!(!app.world().entity(older).contains::<Active>());
+    }
+
+    #[test]
+    fn ensure_active_space_keeps_one_active_space_per_window() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_systems(Update, ensure_active_space);
+        let first_main = app.world_mut().spawn(crate::window::Main).id();
+        let second_main = app.world_mut().spawn(crate::window::Main).id();
+        let first = app
+            .world_mut()
+            .spawn((Space, LastActivatedAt(2), ChildOf(first_main)))
+            .id();
+        let second = app
+            .world_mut()
+            .spawn((Space, LastActivatedAt(1), ChildOf(second_main)))
+            .id();
+
+        app.update();
+
+        assert!(app.world().entity(first).contains::<Active>());
+        assert!(app.world().entity(second).contains::<Active>());
     }
 }

--- a/crates/page/vmux_layout/src/host/archive.rs
+++ b/crates/page/vmux_layout/src/host/archive.rs
@@ -291,6 +291,7 @@ pub(crate) struct TabArchiveLayout<'w, 's> {
     splits: Query<'w, 's, &'static PaneSplit>,
     pane_sizes: Query<'w, 's, &'static PaneSize>,
     panes: Query<'w, 's, (), With<Pane>>,
+    host_windows: Query<'w, 's, &'static HostWindow>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -300,7 +301,7 @@ pub(crate) fn handle_close_tab_requests(
     tab_data: Query<&Tab>,
     tab_q: Query<Entity, With<Tab>>,
     layout: TabArchiveLayout,
-    primary_window: Single<Entity, With<PrimaryWindow>>,
+    primary_window: Query<Entity, With<PrimaryWindow>>,
     mut layout_requests: MessageWriter<TabLayoutSpawnRequest>,
     mut last_tab_close: ResMut<LastTabCloseAt>,
     mut commands: Commands,
@@ -338,9 +339,17 @@ pub(crate) fn handle_close_tab_requests(
                 .filter(|active| siblings.contains(active) && closing.contains(active))
                 .unwrap_or(request.tab);
             if request.tab == preferred_source && !replacement_spaces.contains(&tab_space) {
+                let Some(window) = crate::window::host_window_of(
+                    request.tab,
+                    &layout.child_of,
+                    &layout.host_windows,
+                )
+                .or_else(|| primary_window.single().ok()) else {
+                    continue;
+                };
                 layout_requests.write(TabLayoutSpawnRequest {
                     space: tab_space,
-                    primary_window: *primary_window,
+                    primary_window: window,
                     name: Some("Tab 1".to_string()),
                     startup_dir: None,
                     content: TabLayoutSpawnContent::StartupUrlOrPrompt,
@@ -462,6 +471,7 @@ struct ReopenLayout<'w, 's> {
     pane_ids: Query<'w, 's, (Entity, &'static PaneId)>,
     leaf_panes: Query<'w, 's, (), (With<Pane>, Without<PaneSplit>)>,
     child_of: Query<'w, 's, &'static ChildOf>,
+    host_windows: Query<'w, 's, &'static HostWindow>,
     children_q: Query<'w, 's, &'static Children>,
     stacks_q: Query<'w, 's, (), With<Stack>>,
     tabs: Query<'w, 's, (), With<Tab>>,
@@ -484,8 +494,9 @@ fn handle_reopen_closed_page(
     any_space: Query<Entity, With<Space>>,
     layout: ReopenLayout,
     active_space: Res<ActiveSpaceEntity>,
+    focused_window: Option<Res<crate::window::FocusedWindow>>,
     settings: Res<LayoutSettings>,
-    primary_window: Single<Entity, With<PrimaryWindow>>,
+    primary_window: Query<Entity, With<PrimaryWindow>>,
     mut commands: Commands,
 ) {
     let mut reopen = false;
@@ -509,14 +520,28 @@ fn handle_reopen_closed_page(
         return;
     };
 
+    let focused_window = focused_window.as_deref().and_then(|focused| focused.0);
     let origin_space = spaces
         .iter()
-        .find(|(_, id)| id.0 == page.space_id)
+        .filter(|(_, id)| id.0 == page.space_id)
+        .find(|(space, _)| {
+            focused_window.is_some_and(|focused| {
+                crate::window::host_window_of(*space, &layout.child_of, &layout.host_windows)
+                    == Some(focused)
+            })
+        })
+        .or_else(|| spaces.iter().find(|(_, id)| id.0 == page.space_id))
         .map(|(e, _)| e);
     let target_space = origin_space
         .or_else(|| active_space.0.filter(|e| any_space.get(*e).is_ok()))
         .or_else(|| any_space.iter().next());
     let Some(space) = target_space else {
+        return;
+    };
+    let Some(window) = crate::window::host_window_of(space, &layout.child_of, &layout.host_windows)
+        .or(focused_window)
+        .or_else(|| primary_window.single().ok())
+    else {
         return;
     };
 
@@ -539,7 +564,7 @@ fn handle_reopen_closed_page(
             &tab,
             entries,
             &mut commands,
-            *primary_window,
+            window,
         );
         for (entry, stack) in restored {
             reopen_page_content(&entry.page, stack, &mut commands);
@@ -556,7 +581,7 @@ fn handle_reopen_closed_page(
         position.as_ref(),
         &layout,
         &mut commands,
-        *primary_window,
+        window,
         settings.pane.gap,
     );
     commands.entity(stack).insert(PageMetadata {
@@ -2039,6 +2064,49 @@ mod tests {
                 .iter(app.world())
                 .any(|(_, m)| m.url == "https://a.example")
         );
+    }
+
+    #[test]
+    fn reopen_prefers_the_focused_windows_view_of_the_origin_space() {
+        let mut app = reopen_app();
+        let primary_window = app
+            .world_mut()
+            .query_filtered::<Entity, With<PrimaryWindow>>()
+            .single(app.world())
+            .unwrap();
+        let secondary_window = app.world_mut().spawn(Window::default()).id();
+        app.insert_resource(crate::window::FocusedWindow(Some(secondary_window)));
+        let primary_root = app.world_mut().spawn(HostWindow(primary_window)).id();
+        let secondary_root = app.world_mut().spawn(HostWindow(secondary_window)).id();
+        let primary_space = app
+            .world_mut()
+            .spawn((Space, SpaceId("shared".to_string()), ChildOf(primary_root)))
+            .id();
+        let secondary_space = app
+            .world_mut()
+            .spawn((
+                Space,
+                SpaceId("shared".to_string()),
+                ChildOf(secondary_root),
+            ))
+            .id();
+        app.world_mut().spawn(ArchivedPage {
+            url: "https://focused.example".to_string(),
+            space_id: "shared".to_string(),
+            closed_at: 5,
+            ..default()
+        });
+
+        dispatch_reopen(&mut app);
+
+        let tab_parents: Vec<Entity> = app
+            .world_mut()
+            .query_filtered::<&ChildOf, With<Tab>>()
+            .iter(app.world())
+            .map(ChildOf::parent)
+            .collect();
+        assert!(tab_parents.contains(&secondary_space));
+        assert!(!tab_parents.contains(&primary_space));
     }
 
     #[test]

--- a/crates/page/vmux_layout/src/host/overlay_adopt.rs
+++ b/crates/page/vmux_layout/src/host/overlay_adopt.rs
@@ -1,5 +1,4 @@
 use bevy::prelude::*;
-use bevy::window::PrimaryWindow;
 use bevy_cef::prelude::HostWindow;
 use vmux_core::overlay::WindowOverlay;
 
@@ -15,21 +14,26 @@ impl Plugin for OverlayAdoptPlugin {
 }
 
 fn adopt_window_overlays(
-    orphans: Query<Entity, (With<WindowOverlay>, Without<ChildOf>)>,
-    root_q: Query<Entity, With<VmuxWindow>>,
-    primary_window: Query<Entity, With<PrimaryWindow>>,
+    overlays: Query<(Entity, Option<&HostWindow>, Option<&ChildOf>), With<WindowOverlay>>,
+    roots: Query<(Entity, &HostWindow), With<VmuxWindow>>,
+    focused_window: Res<crate::window::FocusedWindow>,
     mut commands: Commands,
 ) {
-    if orphans.is_empty() {
-        return;
-    }
-    let Ok(root) = root_q.single() else {
+    let Some(window) = focused_window.0 else {
         return;
     };
-    let Ok(window) = primary_window.single() else {
+    let Some(root) = roots
+        .iter()
+        .find_map(|(root, host)| (host.0 == window).then_some(root))
+    else {
         return;
     };
-    for overlay in orphans.iter() {
+    for (overlay, host, parent) in &overlays {
+        if host.is_some_and(|host| host.0 == window)
+            && parent.is_some_and(|parent| parent.parent() == root)
+        {
+            continue;
+        }
         commands
             .entity(overlay)
             .insert((Browser, HostWindow(window), ChildOf(root)));
@@ -44,9 +48,13 @@ mod tests {
     fn an_unparented_overlay_is_placed_in_the_window_root() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
+            .insert_resource(crate::window::FocusedWindow::default())
             .add_systems(PreUpdate, adopt_window_overlays);
-        let root = app.world_mut().spawn(VmuxWindow).id();
-        app.world_mut().spawn(PrimaryWindow);
+        let window = app.world_mut().spawn(Window::default()).id();
+        app.world_mut()
+            .resource_mut::<crate::window::FocusedWindow>()
+            .0 = Some(window);
+        let root = app.world_mut().spawn((VmuxWindow, HostWindow(window))).id();
         let overlay = app.world_mut().spawn(WindowOverlay).id();
 
         app.update();
@@ -60,26 +68,36 @@ mod tests {
     }
 
     #[test]
-    fn an_already_parented_overlay_is_left_alone() {
+    fn overlay_moves_to_the_focused_window() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
+            .insert_resource(crate::window::FocusedWindow::default())
             .add_systems(PreUpdate, adopt_window_overlays);
-        app.world_mut().spawn(VmuxWindow);
-        app.world_mut().spawn(PrimaryWindow);
+        let old_window = app.world_mut().spawn(Window::default()).id();
+        let focused_window = app.world_mut().spawn(Window::default()).id();
+        app.world_mut()
+            .resource_mut::<crate::window::FocusedWindow>()
+            .0 = Some(focused_window);
         let elsewhere = app.world_mut().spawn_empty().id();
+        let root = app
+            .world_mut()
+            .spawn((VmuxWindow, HostWindow(focused_window)))
+            .id();
         let overlay = app
             .world_mut()
-            .spawn((WindowOverlay, ChildOf(elsewhere)))
+            .spawn((WindowOverlay, HostWindow(old_window), ChildOf(elsewhere)))
             .id();
 
         app.update();
 
+        let overlay_ref = app.world().entity(overlay);
         assert_eq!(
-            app.world()
-                .entity(overlay)
-                .get::<ChildOf>()
-                .map(ChildOf::parent),
-            Some(elsewhere)
+            overlay_ref.get::<ChildOf>().map(ChildOf::parent),
+            Some(root)
+        );
+        assert_eq!(
+            overlay_ref.get::<HostWindow>(),
+            Some(&HostWindow(focused_window))
         );
     }
 }

--- a/crates/page/vmux_layout/src/host/pane.rs
+++ b/crates/page/vmux_layout/src/host/pane.rs
@@ -8,13 +8,15 @@ use crate::{
     },
     tab::Tab,
 };
+#[cfg(test)]
+use bevy::window::PrimaryWindow;
 use bevy::{
     ecs::{
         lifecycle::HookContext, message::Messages, relationship::Relationship, world::DeferredWorld,
     },
     prelude::*,
-    window::PrimaryWindow,
 };
+use bevy_cef::prelude::HostWindow;
 use moonshine_save::prelude::*;
 use std::time::Instant;
 use vmux_command::{
@@ -1958,7 +1960,10 @@ fn on_pane_select(
 
 #[cfg_attr(target_os = "macos", allow(dead_code))]
 fn poll_cursor_pane_focus(
-    windows: Query<(Entity, &Window), With<PrimaryWindow>>,
+    windows: Query<(Entity, &Window)>,
+    focused_window: Res<crate::window::FocusedWindow>,
+    child_of: Query<&ChildOf>,
+    host_windows: Query<&HostWindow>,
     leaf_panes: Query<(Entity, &ComputedNode), (With<Pane>, Without<PaneSplit>)>,
     pane_ts: Query<(Entity, &LastActivatedAt), With<Pane>>,
     pane_children: Query<&Children, With<Pane>>,
@@ -1979,7 +1984,10 @@ fn poll_cursor_pane_focus(
     {
         return;
     }
-    let Ok((window_entity, window)) = windows.single() else {
+    let Some(window_entity) = focused_window.0 else {
+        return;
+    };
+    let Ok((_, window)) = windows.get(window_entity) else {
         return;
     };
     let Some(cursor) = pane_hover_cursor_position(window_entity, window) else {
@@ -1988,7 +1996,9 @@ fn poll_cursor_pane_focus(
 
     let mut hovered_pane: Option<Entity> = None;
     for (entity, node) in &leaf_panes {
-        if node.contains(cursor) {
+        if crate::window::host_window_of(entity, &child_of, &host_windows) == Some(window_entity)
+            && node.contains(cursor)
+        {
             hovered_pane = Some(entity);
             break;
         }
@@ -2070,6 +2080,9 @@ fn native_window_cursor_position(window_entity: Entity, window: &Window) -> Opti
 
 #[cfg(target_os = "macos")]
 fn apply_pending_hover(
+    focused_window: Res<crate::window::FocusedWindow>,
+    child_of: Query<&ChildOf>,
+    host_windows: Query<&HostWindow>,
     leaf_panes: Query<(Entity, &ComputedNode), (With<Pane>, Without<PaneSplit>)>,
     pane_ts: Query<(Entity, &LastActivatedAt), With<Pane>>,
     pane_children: Query<&Children, With<Pane>>,
@@ -2084,9 +2097,14 @@ fn apply_pending_hover(
         return;
     }
     *last_motion_sequence = pointer.motion_sequence;
+    let Some(window_entity) = focused_window.0 else {
+        return;
+    };
     let mut target = None;
     for (entity, node) in leaf_panes.iter() {
-        if node.contains(pointer.position_px) {
+        if crate::window::host_window_of(entity, &child_of, &host_windows) == Some(window_entity)
+            && node.contains(pointer.position_px)
+        {
             target = Some(entity);
             break;
         }
@@ -2111,7 +2129,9 @@ fn apply_pending_hover(
 fn warp_cursor_to_active_pane(
     mut pending: ResMut<PendingCursorWarp>,
     pane_ui_q: Query<&ComputedNode, (With<Pane>, Without<PaneSplit>)>,
-    mut windows: Query<&mut Window, With<PrimaryWindow>>,
+    child_of: Query<&ChildOf>,
+    host_windows: Query<&HostWindow>,
+    mut windows: Query<&mut Window>,
 ) {
     let Some(target) = pending.target else {
         return;
@@ -2123,13 +2143,18 @@ fn warp_cursor_to_active_pane(
         return;
     }
     pending.target = None;
-    if let Ok(mut window) = windows.single_mut() {
+    let Some(window_entity) = crate::window::host_window_of(target, &child_of, &host_windows)
+    else {
+        return;
+    };
+    if let Ok(mut window) = windows.get_mut(window_entity) {
         window.set_physical_cursor_position(Some(rect.center.as_dvec2()));
     }
 }
 
 fn pane_gap_drag_resize(
-    windows: Query<&Window, With<PrimaryWindow>>,
+    windows: Query<&Window>,
+    focused_window: Res<crate::window::FocusedWindow>,
 
     splits: Query<(Entity, &PaneSplit, &Children), Without<PaneDrag>>,
     active_drags: Query<(Entity, &PaneDrag, &PaneSplit)>,
@@ -2140,7 +2165,12 @@ fn pane_gap_drag_resize(
     mouse: Res<ButtonInput<MouseButton>>,
     mut commands: Commands,
 ) {
-    let Ok(window) = windows.single() else { return };
+    let Some(window_entity) = focused_window.0 else {
+        return;
+    };
+    let Ok(window) = windows.get(window_entity) else {
+        return;
+    };
     let Some(cursor_pos) = window.physical_cursor_position() else {
         return;
     };
@@ -5075,6 +5105,8 @@ mod tests {
             .world_mut()
             .spawn((Window::default(), PrimaryWindow))
             .id();
+        app.insert_resource(crate::window::FocusedWindow(Some(window)));
+        let root = app.world_mut().spawn(HostWindow(window)).id();
         app.world_mut()
             .entity_mut(window)
             .get_mut::<Window>()
@@ -5082,7 +5114,7 @@ mod tests {
             .set_physical_cursor_position(Some(bevy::math::DVec2::new(400.0, 450.0)));
         let tab = app
             .world_mut()
-            .spawn((Tab::default(), LastActivatedAt(1)))
+            .spawn((Tab::default(), LastActivatedAt(1), ChildOf(root)))
             .id();
         let split = app
             .world_mut()

--- a/crates/page/vmux_layout/src/host/side_sheet.rs
+++ b/crates/page/vmux_layout/src/host/side_sheet.rs
@@ -3,6 +3,7 @@ use crate::settings::LayoutSettings;
 use bevy::prelude::*;
 #[cfg(target_os = "macos")]
 use bevy::{ecs::system::NonSendMarker, winit::WINIT_WINDOWS};
+#[cfg(target_os = "macos")]
 use bevy_cef::prelude::HostWindow;
 use vmux_flex::prelude::*;
 

--- a/crates/page/vmux_layout/src/host/side_sheet.rs
+++ b/crates/page/vmux_layout/src/host/side_sheet.rs
@@ -2,7 +2,8 @@ use super::Open;
 use crate::settings::LayoutSettings;
 use bevy::prelude::*;
 #[cfg(target_os = "macos")]
-use bevy::{ecs::system::NonSendMarker, window::PrimaryWindow, winit::WINIT_WINDOWS};
+use bevy::{ecs::system::NonSendMarker, winit::WINIT_WINDOWS};
+use bevy_cef::prelude::HostWindow;
 use vmux_flex::prelude::*;
 
 impl Plugin for SideSheetLayoutPlugin {
@@ -113,24 +114,6 @@ fn sync_side_sheet_visibility(
     added: Query<Entity, (With<SideSheet>, Added<Open>)>,
     mut removed: RemovedComponents<Open>,
 ) {
-    let mut left_open: Option<bool> = None;
-    for entity in &added {
-        if let Ok((_, pos, _, _)) = side_sheet_q.get(entity)
-            && *pos == SideSheetPosition::Left
-        {
-            left_open = Some(true);
-        }
-    }
-    for entity in removed.read() {
-        if let Ok((_, pos, _, _)) = side_sheet_q.get(entity)
-            && *pos == SideSheetPosition::Left
-        {
-            left_open = Some(false);
-        }
-    }
-
-    let Some(is_open) = left_open else { return };
-
     if width_res.0 <= 0.0 {
         width_res.0 = crate::event::SideSheetResizeEvent {
             width: settings.side_sheet.width,
@@ -139,16 +122,20 @@ fn sync_side_sheet_visibility(
     }
 
     let width = width_res.0;
-    for (_, pos, mut vis, mut node) in &mut side_sheet_q {
-        if *pos != SideSheetPosition::Left {
-            continue;
-        }
-        if is_open {
-            *vis = Visibility::Visible;
+    for entity in &added {
+        if let Ok((_, pos, mut visibility, mut node)) = side_sheet_q.get_mut(entity)
+            && *pos == SideSheetPosition::Left
+        {
+            *visibility = Visibility::Visible;
             node.display = Display::Flex;
             node.width = Val::Px(width);
-        } else {
-            *vis = Visibility::Hidden;
+        }
+    }
+    for entity in removed.read() {
+        if let Ok((_, pos, mut visibility, mut node)) = side_sheet_q.get_mut(entity)
+            && *pos == SideSheetPosition::Left
+        {
+            *visibility = Visibility::Hidden;
             node.display = Display::None;
         }
     }
@@ -156,75 +143,77 @@ fn sync_side_sheet_visibility(
 
 #[cfg(target_os = "macos")]
 fn sync_window_buttons_visibility(
-    side_sheet_q: Query<(&SideSheetPosition, Has<Open>), With<SideSheet>>,
-    window_q: Query<Entity, With<PrimaryWindow>>,
-    mut last_open: Local<Option<bool>>,
+    side_sheet_q: Query<(Entity, &SideSheetPosition, Has<Open>), With<SideSheet>>,
+    child_of: Query<&ChildOf>,
+    host_windows: Query<&HostWindow>,
+    window_q: Query<Entity, With<Window>>,
+    mut last_open: Local<std::collections::HashMap<Entity, bool>>,
     _non_send: NonSendMarker,
 ) {
-    let is_open = side_sheet_q
-        .iter()
-        .any(|(pos, open)| *pos == SideSheetPosition::Left && open);
+    for entity in &window_q {
+        let is_open = side_sheet_q.iter().any(|(side_sheet, pos, open)| {
+            *pos == SideSheetPosition::Left
+                && open
+                && crate::window::host_window_of(side_sheet, &child_of, &host_windows)
+                    == Some(entity)
+        });
+        if last_open.get(&entity) == Some(&is_open) {
+            continue;
+        }
 
-    if *last_open == Some(is_open) {
-        return;
-    }
+        let updated = WINIT_WINDOWS.with_borrow(|winit_windows| {
+            let Some(winit_win) = winit_windows.get_window(entity) else {
+                return false;
+            };
 
-    *last_open = Some(is_open);
+            use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+            let Ok(handle) = winit_win.window_handle() else {
+                return false;
+            };
+            let RawWindowHandle::AppKit(appkit) = handle.as_raw() else {
+                return false;
+            };
 
-    let Ok(entity) = window_q.single() else {
-        warn!("sync_window_buttons: no PrimaryWindow entity");
-        return;
-    };
+            let ns_view = appkit.ns_view.as_ptr();
+            unsafe {
+                use objc_ffi::sel;
 
-    WINIT_WINDOWS.with_borrow(|winit_windows| {
-        let Some(winit_win) = winit_windows.get_window(entity) else {
-            warn!("sync_window_buttons: winit window not found, will retry");
-            *last_open = None;
-            return;
-        };
+                type MsgSendNoArgs = unsafe extern "C" fn(
+                    *mut libc::c_void,
+                    *const libc::c_void,
+                ) -> *mut libc::c_void;
+                type MsgSendU64 = unsafe extern "C" fn(
+                    *mut libc::c_void,
+                    *const libc::c_void,
+                    u64,
+                ) -> *mut libc::c_void;
+                type MsgSendBool =
+                    unsafe extern "C" fn(*mut libc::c_void, *const libc::c_void, libc::c_schar);
 
-        use raw_window_handle::{HasWindowHandle, RawWindowHandle};
-        let Ok(handle) = winit_win.window_handle() else {
-            warn!("sync_window_buttons: no window handle");
-            return;
-        };
-        let RawWindowHandle::AppKit(appkit) = handle.as_raw() else {
-            warn!("sync_window_buttons: not AppKit handle");
-            return;
-        };
+                let send_no_args: MsgSendNoArgs =
+                    std::mem::transmute(objc_ffi::objc_msgSend as *const ());
+                let send_u64: MsgSendU64 = std::mem::transmute(objc_ffi::objc_msgSend as *const ());
+                let send_bool: MsgSendBool =
+                    std::mem::transmute(objc_ffi::objc_msgSend as *const ());
 
-        let ns_view = appkit.ns_view.as_ptr();
-        unsafe {
-            use objc_ffi::sel;
-
-            type MsgSendNoArgs =
-                unsafe extern "C" fn(*mut libc::c_void, *const libc::c_void) -> *mut libc::c_void;
-            type MsgSendU64 = unsafe extern "C" fn(
-                *mut libc::c_void,
-                *const libc::c_void,
-                u64,
-            ) -> *mut libc::c_void;
-            type MsgSendBool =
-                unsafe extern "C" fn(*mut libc::c_void, *const libc::c_void, libc::c_schar);
-
-            let send_no_args: MsgSendNoArgs =
-                std::mem::transmute(objc_ffi::objc_msgSend as *const ());
-            let send_u64: MsgSendU64 = std::mem::transmute(objc_ffi::objc_msgSend as *const ());
-            let send_bool: MsgSendBool = std::mem::transmute(objc_ffi::objc_msgSend as *const ());
-
-            let ns_window = send_no_args(ns_view, sel("window"));
-            if ns_window.is_null() {
-                return;
-            }
-            let hidden: libc::c_schar = if is_open { 0 } else { 1 };
-            for button_type in 0u64..=2 {
-                let button = send_u64(ns_window, sel("standardWindowButton:"), button_type);
-                if !button.is_null() {
-                    send_bool(button, sel("setHidden:"), hidden);
+                let ns_window = send_no_args(ns_view, sel("window"));
+                if ns_window.is_null() {
+                    return false;
+                }
+                let hidden: libc::c_schar = if is_open { 0 } else { 1 };
+                for button_type in 0u64..=2 {
+                    let button = send_u64(ns_window, sel("standardWindowButton:"), button_type);
+                    if !button.is_null() {
+                        send_bool(button, sel("setHidden:"), hidden);
+                    }
                 }
             }
+            true
+        });
+        if updated {
+            last_open.insert(entity, is_open);
         }
-    });
+    }
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -244,5 +233,68 @@ mod objc_ffi {
     pub fn sel(name: &str) -> *const libc::c_void {
         let c = std::ffi::CString::new(name).unwrap();
         unsafe { sel_registerName(c.as_ptr()) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn visibility_changes_only_for_the_side_sheet_whose_open_state_changed() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .insert_resource(LayoutSettings::default())
+            .insert_resource(SideSheetWidth(0.0))
+            .add_systems(Update, sync_side_sheet_visibility);
+        let first = app
+            .world_mut()
+            .spawn((
+                SideSheet,
+                SideSheetPosition::Left,
+                Open,
+                Visibility::Hidden,
+                Node {
+                    display: Display::None,
+                    ..default()
+                },
+            ))
+            .id();
+        let second = app
+            .world_mut()
+            .spawn((
+                SideSheet,
+                SideSheetPosition::Left,
+                Visibility::Hidden,
+                Node {
+                    display: Display::None,
+                    ..default()
+                },
+            ))
+            .id();
+
+        app.update();
+
+        assert_eq!(
+            app.world().get::<Visibility>(first),
+            Some(&Visibility::Visible)
+        );
+        assert_eq!(
+            app.world().get::<Visibility>(second),
+            Some(&Visibility::Hidden)
+        );
+
+        app.world_mut().entity_mut(first).remove::<Open>();
+        app.world_mut().entity_mut(second).insert(Open);
+        app.update();
+
+        assert_eq!(
+            app.world().get::<Visibility>(first),
+            Some(&Visibility::Hidden)
+        );
+        assert_eq!(
+            app.world().get::<Visibility>(second),
+            Some(&Visibility::Visible)
+        );
     }
 }

--- a/crates/page/vmux_layout/src/host/space.rs
+++ b/crates/page/vmux_layout/src/host/space.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use bevy_cef::prelude::HostWindow;
 use moonshine_save::prelude::*;
 use vmux_command::ReadAppCommands;
 use vmux_flex::prelude::*;
@@ -16,7 +17,8 @@ impl Plugin for SpaceLayoutPlugin {
                     sync_active_space_entity,
                     sync_active_space_id,
                 )
-                    .chain(),
+                    .chain()
+                    .after(crate::window::WindowFocusSet),
             )
             .add_systems(
                 Update,
@@ -57,9 +59,19 @@ pub struct ActiveSpaceId(pub Option<String>);
 
 pub fn sync_active_space_entity(
     tagged: Query<Entity, (With<Space>, With<vmux_core::Active>)>,
+    focused_window: Res<crate::window::FocusedWindow>,
+    child_of: Query<&ChildOf>,
+    host_windows: Query<&HostWindow>,
     mut active: ResMut<ActiveSpaceEntity>,
 ) {
-    let current = tagged.iter().next();
+    let current = focused_window
+        .0
+        .and_then(|focused| {
+            tagged.iter().find(|space| {
+                crate::window::host_window_of(*space, &child_of, &host_windows) == Some(focused)
+            })
+        })
+        .or_else(|| tagged.iter().next());
     if active.0 != current {
         active.0 = current;
     }
@@ -169,6 +181,7 @@ mod tests {
     fn active_space_entity_tracks_tagged_space() {
         let mut app = App::new();
         app.init_resource::<ActiveSpaceEntity>()
+            .init_resource::<crate::window::FocusedWindow>()
             .add_systems(Update, sync_active_space_entity);
         let space = app
             .world_mut()
@@ -182,6 +195,7 @@ mod tests {
     fn active_space_entity_clears_when_no_tag() {
         let mut app = App::new();
         app.init_resource::<ActiveSpaceEntity>()
+            .init_resource::<crate::window::FocusedWindow>()
             .add_systems(Update, sync_active_space_entity);
         app.insert_resource(ActiveSpaceEntity(Some(Entity::from_bits(42))));
         app.update();
@@ -193,6 +207,7 @@ mod tests {
         let mut app = App::new();
         app.init_resource::<ActiveSpaceEntity>()
             .init_resource::<ActiveSpaceId>()
+            .init_resource::<crate::window::FocusedWindow>()
             .add_systems(
                 Update,
                 (sync_active_space_entity, sync_active_space_id).chain(),

--- a/crates/page/vmux_layout/src/host/stack.rs
+++ b/crates/page/vmux_layout/src/host/stack.rs
@@ -332,19 +332,23 @@ pub fn active_stack_in_pane(
 pub struct ActiveTabParam<'w, 's> {
     tabs: Query<'w, 's, (Entity, &'static LastActivatedAt), With<Tab>>,
     active_tabs: Query<'w, 's, Entity, (With<Tab>, With<vmux_core::Active>)>,
-    active_spaces: Query<'w, 's, (), (With<crate::space::Space>, With<vmux_core::Active>)>,
+    active_space: Option<Res<'w, crate::space::ActiveSpaceEntity>>,
     child_of: Query<'w, 's, &'static ChildOf>,
 }
 
 impl ActiveTabParam<'_, '_> {
     pub fn get(&self) -> Option<Entity> {
-        let scoped = self.active_tabs.iter().find(|&tab| {
-            self.child_of
-                .get(tab)
-                .ok()
-                .map(|co| self.active_spaces.get(co.parent()).is_ok())
-                .unwrap_or(false)
-        });
+        let scoped = self
+            .active_space
+            .as_ref()
+            .and_then(|resource| resource.0)
+            .and_then(|active_space| {
+                self.active_tabs.iter().find(|&tab| {
+                    self.child_of
+                        .get(tab)
+                        .is_ok_and(|parent| parent.parent() == active_space)
+                })
+            });
         if scoped.is_some() {
             return scoped;
         }
@@ -1594,6 +1598,7 @@ mod tests {
                 ChildOf(space_b),
             ))
             .id();
+        app.insert_resource(crate::space::ActiveSpaceEntity(Some(space_b)));
 
         let got = app
             .world_mut()

--- a/crates/page/vmux_layout/src/host/tab.rs
+++ b/crates/page/vmux_layout/src/host/tab.rs
@@ -3,10 +3,11 @@ use crate::{
     TabLayoutSpawnContent, TabLayoutSpawnRequest,
     host::swap::{find_kind_index, resolve_next, resolve_prev, swap_siblings},
 };
+#[cfg(test)]
+use bevy::window::PrimaryWindow;
 use bevy::{
     ecs::{message::Messages, relationship::Relationship},
     prelude::*,
-    window::PrimaryWindow,
 };
 use bevy_cef::prelude::*;
 use moonshine_save::prelude::*;
@@ -26,6 +27,7 @@ impl Plugin for TabPlugin {
             .register_type::<TabWorktree>()
             .register_type::<TabDirDecided>()
             .init_resource::<LastTabCloseAt>()
+            .init_resource::<crate::window::FocusedWindow>()
             .add_message::<CloseTabRequest>()
             .add_message::<crate::NewTabRequest>()
             .add_plugins(BinEventEmitterPlugin::<(TabsCommandEvent,)>::for_hosts(&[
@@ -163,7 +165,7 @@ fn handle_tab_commands(
     tabs: Query<(Entity, &LastActivatedAt), With<Tab>>,
     active_tab_param: crate::stack::ActiveTabParam,
     tab_q: Query<Entity, With<Tab>>,
-    primary_window: Single<Entity, With<PrimaryWindow>>,
+    focused_window: Res<crate::window::FocusedWindow>,
     child_of_q: Query<&ChildOf>,
     all_children: Query<&Children>,
     effective_startup_url: Option<Res<vmux_core::EffectiveStartupUrl>>,
@@ -173,6 +175,9 @@ fn handle_tab_commands(
     mut commands: Commands,
 ) {
     for cmd in reader.read() {
+        let Some(window) = focused_window.0 else {
+            continue;
+        };
         let active_tab = active_tab_param.get();
 
         match cmd {
@@ -200,7 +205,7 @@ fn handle_tab_commands(
                 };
                 layout_requests.write(TabLayoutSpawnRequest {
                     space,
-                    primary_window: *primary_window,
+                    primary_window: window,
                     name: Some(name),
                     startup_dir: startup_dir.clone(),
                     content,
@@ -223,7 +228,7 @@ fn handle_tab_commands(
                     let name = format!("Tab {}", tabs.iter().count() + 1);
                     layout_requests.write(TabLayoutSpawnRequest {
                         space,
-                        primary_window: *primary_window,
+                        primary_window: window,
                         name: Some(name),
                         startup_dir: startup_dir.clone(),
                         content: TabLayoutSpawnContent::StartupUrlOrPrompt,
@@ -319,6 +324,9 @@ fn handle_tab_commands(
     }
 
     for request in new_tabs.read() {
+        let Some(window) = focused_window.0 else {
+            continue;
+        };
         let Some((space, startup_dir)) = effective_startup_dir
             .as_deref()
             .and_then(|effective| effective.0.clone())
@@ -328,7 +336,7 @@ fn handle_tab_commands(
         let name = format!("Tab {}", tabs.iter().count() + 1);
         layout_requests.write(TabLayoutSpawnRequest {
             space,
-            primary_window: *primary_window,
+            primary_window: window,
             name: Some(name),
             startup_dir,
             content: TabLayoutSpawnContent::Url {
@@ -702,6 +710,7 @@ mod tests {
             .add_message::<PageOpenRequest>()
             .add_message::<vmux_core::agent::SpawnAgentInStackRequest>()
             .init_resource::<crate::PendingLaunch>()
+            .init_resource::<crate::window::FocusedWindow>()
             .insert_resource(test_settings())
             .init_resource::<CollectedSpawns>()
             .add_systems(
@@ -718,6 +727,7 @@ mod tests {
 
     fn build_main_and_tab(app: &mut App) -> Entity {
         let window = app.world_mut().spawn(PrimaryWindow).id();
+        app.insert_resource(crate::window::FocusedWindow(Some(window)));
         let main = app.world_mut().spawn(MainNode).id();
         let space = app
             .world_mut()
@@ -1089,7 +1099,8 @@ mod tests {
                 .in_set(ReadAppCommands),
         );
 
-        app.world_mut().spawn(PrimaryWindow);
+        let window = app.world_mut().spawn(PrimaryWindow).id();
+        app.insert_resource(crate::window::FocusedWindow(Some(window)));
         let main = app.world_mut().spawn(MainNode).id();
         let space = app
             .world_mut()
@@ -1146,7 +1157,8 @@ mod tests {
             .add_observer(on_tabs_command_emit);
 
         let webview = app.world_mut().spawn_empty().id();
-        app.world_mut().spawn(PrimaryWindow);
+        let window = app.world_mut().spawn(PrimaryWindow).id();
+        app.insert_resource(crate::window::FocusedWindow(Some(window)));
         let main = app.world_mut().spawn(MainNode).id();
         let space = app
             .world_mut()
@@ -1210,7 +1222,8 @@ mod tests {
             sync_tab_visibility.before(LayoutSystems::Layout),
         );
 
-        app.world_mut().spawn(PrimaryWindow);
+        let window = app.world_mut().spawn(PrimaryWindow).id();
+        app.insert_resource(crate::window::FocusedWindow(Some(window)));
         let main = app.world_mut().spawn(MainNode).id();
         let space = app
             .world_mut()

--- a/crates/page/vmux_layout/src/host/toggle.rs
+++ b/crates/page/vmux_layout/src/host/toggle.rs
@@ -4,6 +4,7 @@ use crate::settings::LayoutSettings;
 use crate::side_sheet::SideSheet;
 use crate::window::VmuxWindow;
 use bevy::prelude::*;
+use bevy_cef::prelude::HostWindow;
 use vmux_command::{AppCommand, LayoutCommand, ReadAppCommands, ToggleLayoutCommand};
 use vmux_flex::prelude::*;
 
@@ -21,19 +22,34 @@ impl Plugin for TogglePlugin {
 }
 
 #[derive(Resource, Default, Debug)]
-pub struct LayoutHidden(pub bool);
+pub struct LayoutHidden(std::collections::HashSet<Entity>);
+
+impl LayoutHidden {
+    pub fn is_hidden(&self, window: Entity) -> bool {
+        self.0.contains(&window)
+    }
+
+    fn toggle(&mut self, window: Entity) -> bool {
+        if self.0.remove(&window) {
+            false
+        } else {
+            self.0.insert(window);
+            true
+        }
+    }
+}
 
 fn sync_window_padding_to_layout_hidden(
     hidden: Res<LayoutHidden>,
     settings: Res<LayoutSettings>,
-    mut window_q: Query<&mut Node, With<VmuxWindow>>,
+    mut window_q: Query<(&HostWindow, &mut Node), With<VmuxWindow>>,
 ) {
-    let (top, left) = if hidden.0 {
-        (settings.window.pad_top(), settings.window.pad_left())
-    } else {
-        (0.0, 0.0)
-    };
-    for mut node in &mut window_q {
+    for (host, mut node) in &mut window_q {
+        let (top, left) = if hidden.is_hidden(host.0) {
+            (settings.window.pad_top(), settings.window.pad_left())
+        } else {
+            (0.0, 0.0)
+        };
         let want_top = Val::Px(top);
         let want_left = Val::Px(left);
         if node.padding.top != want_top || node.padding.left != want_left {
@@ -46,8 +62,11 @@ fn sync_window_padding_to_layout_hidden(
 fn handle_toggle(
     mut reader: MessageReader<AppCommand>,
     mut hidden: ResMut<LayoutHidden>,
+    focused_window: Res<crate::window::FocusedWindow>,
     header_q: Query<Entity, With<Header>>,
     sidesheet_q: Query<Entity, With<SideSheet>>,
+    child_of: Query<&ChildOf>,
+    host_windows: Query<&HostWindow>,
     mut commands: Commands,
 ) {
     for cmd in reader.read() {
@@ -57,14 +76,21 @@ fn handle_toggle(
         ) {
             continue;
         }
-        hidden.0 = !hidden.0;
+        let Some(window) = focused_window.0 else {
+            continue;
+        };
+        let is_hidden = hidden.toggle(window);
 
-        if hidden.0 {
-            for entity in header_q.iter().chain(sidesheet_q.iter()) {
+        if is_hidden {
+            for entity in header_q.iter().chain(sidesheet_q.iter()).filter(|entity| {
+                crate::window::host_window_of(*entity, &child_of, &host_windows) == Some(window)
+            }) {
                 commands.entity(entity).remove::<Open>();
             }
         } else {
-            for entity in header_q.iter().chain(sidesheet_q.iter()) {
+            for entity in header_q.iter().chain(sidesheet_q.iter()).filter(|entity| {
+                crate::window::host_window_of(*entity, &child_of, &host_windows) == Some(window)
+            }) {
                 commands.entity(entity).insert(Open);
             }
         }
@@ -99,7 +125,7 @@ mod tests {
     fn visible_fullscreen_layout_clears_top_left_padding() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .insert_resource(LayoutHidden(false))
+            .init_resource::<LayoutHidden>()
             .insert_resource(LayoutSettings {
                 radius: 0.0,
                 window: WindowSettings { padding: 16.0 },
@@ -108,14 +134,20 @@ mod tests {
                 focus_ring: FocusRingSettings::default(),
             })
             .add_systems(Update, sync_window_padding_to_layout_hidden);
-        app.world_mut().spawn((
-            Window {
-                mode: WindowMode::BorderlessFullscreen(MonitorSelection::Current),
-                ..default()
-            },
-            PrimaryWindow,
-        ));
-        let root = app.world_mut().spawn((VmuxWindow, Node::default())).id();
+        let window = app
+            .world_mut()
+            .spawn((
+                Window {
+                    mode: WindowMode::BorderlessFullscreen(MonitorSelection::Current),
+                    ..default()
+                },
+                PrimaryWindow,
+            ))
+            .id();
+        let root = app
+            .world_mut()
+            .spawn((VmuxWindow, HostWindow(window), Node::default()))
+            .id();
 
         app.update();
 
@@ -128,7 +160,7 @@ mod tests {
     fn visible_maximized_layout_clears_top_left_padding() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .insert_resource(LayoutHidden(false))
+            .init_resource::<LayoutHidden>()
             .insert_resource(LayoutSettings {
                 radius: 0.0,
                 window: WindowSettings { padding: 16.0 },
@@ -137,13 +169,16 @@ mod tests {
                 focus_ring: FocusRingSettings::default(),
             })
             .add_systems(Update, sync_window_padding_to_layout_hidden);
-        app.world_mut().spawn((
-            Window {
-                resolution: (1200, 800).into(),
-                ..default()
-            },
-            PrimaryWindow,
-        ));
+        let window = app
+            .world_mut()
+            .spawn((
+                Window {
+                    resolution: (1200, 800).into(),
+                    ..default()
+                },
+                PrimaryWindow,
+            ))
+            .id();
         app.world_mut().spawn(Monitor {
             name: None,
             physical_width: 1200,
@@ -153,7 +188,10 @@ mod tests {
             scale_factor: 1.0,
             video_modes: Vec::new(),
         });
-        let root = app.world_mut().spawn((VmuxWindow, Node::default())).id();
+        let root = app
+            .world_mut()
+            .spawn((VmuxWindow, HostWindow(window), Node::default()))
+            .id();
 
         app.update();
 
@@ -166,7 +204,7 @@ mod tests {
     fn hidden_layout_uses_top_left_padding() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .insert_resource(LayoutHidden(true))
+            .init_resource::<LayoutHidden>()
             .insert_resource(LayoutSettings {
                 radius: 0.0,
                 window: WindowSettings { padding: 16.0 },
@@ -175,19 +213,80 @@ mod tests {
                 focus_ring: FocusRingSettings::default(),
             })
             .add_systems(Update, sync_window_padding_to_layout_hidden);
-        app.world_mut().spawn((
-            Window {
-                resolution: (1200, 800).into(),
-                ..default()
-            },
-            PrimaryWindow,
-        ));
-        let root = app.world_mut().spawn((VmuxWindow, Node::default())).id();
+        let window = app
+            .world_mut()
+            .spawn((
+                Window {
+                    resolution: (1200, 800).into(),
+                    ..default()
+                },
+                PrimaryWindow,
+            ))
+            .id();
+        app.world_mut()
+            .resource_mut::<LayoutHidden>()
+            .toggle(window);
+        let root = app
+            .world_mut()
+            .spawn((VmuxWindow, HostWindow(window), Node::default()))
+            .id();
 
         app.update();
 
         let node = app.world().get::<Node>(root).expect("window node");
         assert_eq!(node.padding.top, Val::Px(16.0));
         assert_eq!(node.padding.left, Val::Px(16.0));
+    }
+
+    #[test]
+    fn toggle_changes_only_the_focused_window() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<AppCommand>()
+            .init_resource::<LayoutHidden>()
+            .add_systems(Update, handle_toggle);
+        let first_window = app.world_mut().spawn_empty().id();
+        let second_window = app.world_mut().spawn_empty().id();
+        app.insert_resource(crate::window::FocusedWindow(Some(first_window)));
+        let first_root = app.world_mut().spawn(HostWindow(first_window)).id();
+        let second_root = app.world_mut().spawn(HostWindow(second_window)).id();
+        let first_header = app
+            .world_mut()
+            .spawn((Header, Open, ChildOf(first_root)))
+            .id();
+        let first_sheet = app
+            .world_mut()
+            .spawn((SideSheet, Open, ChildOf(first_root)))
+            .id();
+        let second_header = app
+            .world_mut()
+            .spawn((Header, Open, ChildOf(second_root)))
+            .id();
+        let second_sheet = app
+            .world_mut()
+            .spawn((SideSheet, Open, ChildOf(second_root)))
+            .id();
+        app.world_mut()
+            .resource_mut::<Messages<AppCommand>>()
+            .write(AppCommand::Layout(LayoutCommand::ToggleLayout(
+                ToggleLayoutCommand::Toggle,
+            )));
+
+        app.update();
+
+        assert!(
+            app.world()
+                .resource::<LayoutHidden>()
+                .is_hidden(first_window)
+        );
+        assert!(
+            !app.world()
+                .resource::<LayoutHidden>()
+                .is_hidden(second_window)
+        );
+        assert!(!app.world().entity(first_header).contains::<Open>());
+        assert!(!app.world().entity(first_sheet).contains::<Open>());
+        assert!(app.world().entity(second_header).contains::<Open>());
+        assert!(app.world().entity(second_sheet).contains::<Open>());
     }
 }

--- a/crates/page/vmux_layout/src/host/warm_page.rs
+++ b/crates/page/vmux_layout/src/host/warm_page.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 
 use bevy::prelude::*;
 use bevy_cef::prelude::CefSystems;
+use bevy_cef::prelude::HostWindow;
 use vmux_core::KeyboardOwner;
 use vmux_core::page::{PageReady, PrewarmPage};
 use vmux_core::{PageMetadata, PageOpenError, PageOpenHandled, PageOpenSet, PageOpenTask};
@@ -156,7 +157,8 @@ fn handle_registered_page_open(
 fn maintain_registered_page_pools(
     pages: Query<&PrewarmPage>,
     pool_nodes: Query<(Entity, &WarmPagePoolNode)>,
-    vmux_window: Query<Entity, With<VmuxWindow>>,
+    vmux_windows: Query<(Entity, &HostWindow), With<VmuxWindow>>,
+    focused_window: Res<crate::window::FocusedWindow>,
     layout_ready: Query<(), (With<LayoutCef>, With<PageReady>)>,
     spares: Query<&WarmPageSpare>,
     mut commands: Commands,
@@ -165,7 +167,15 @@ fn maintain_registered_page_pools(
     if layout_ready.is_empty() {
         return;
     }
-    let Ok(window) = vmux_window.single() else {
+    let Some(window) = focused_window
+        .0
+        .and_then(|focused| {
+            vmux_windows
+                .iter()
+                .find_map(|(root, host)| (host.0 == focused).then_some(root))
+        })
+        .or_else(|| vmux_windows.iter().next().map(|(root, _)| root))
+    else {
         return;
     };
     for page in &pages {
@@ -229,7 +239,8 @@ fn handle_warm_page_open<M: WarmPage>(
 
 fn maintain_warm_page_pool<M: WarmPage>(
     pool_nodes: Query<(Entity, &WarmPagePoolNode)>,
-    vmux_window: Query<Entity, With<VmuxWindow>>,
+    vmux_windows: Query<(Entity, &HostWindow), With<VmuxWindow>>,
+    focused_window: Res<crate::window::FocusedWindow>,
     layout_ready: Query<(), (With<LayoutCef>, With<PageReady>)>,
     spares: Query<&WarmPageSpare>,
     mut commands: Commands,
@@ -238,7 +249,15 @@ fn maintain_warm_page_pool<M: WarmPage>(
     if layout_ready.is_empty() || M::POOL_SIZE == 0 {
         return;
     }
-    let Ok(window) = vmux_window.single() else {
+    let Some(window) = focused_window
+        .0
+        .and_then(|focused| {
+            vmux_windows
+                .iter()
+                .find_map(|(root, host)| (host.0 == focused).then_some(root))
+        })
+        .or_else(|| vmux_windows.iter().next().map(|(root, _)| root))
+    else {
         return;
     };
     let node = pool_node_for(M::URL, window, &pool_nodes, &mut commands);
@@ -380,8 +399,10 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .init_resource::<WarmPageSpawnBudget>()
+            .init_resource::<crate::window::FocusedWindow>()
             .add_systems(Update, maintain_warm_page_pool::<TestPage>);
-        app.world_mut().spawn(VmuxWindow);
+        let window = app.world_mut().spawn_empty().id();
+        app.world_mut().spawn((VmuxWindow, HostWindow(window)));
 
         app.update();
         assert_eq!(
@@ -485,8 +506,10 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .init_resource::<WarmPageSpawnBudget>()
+            .init_resource::<crate::window::FocusedWindow>()
             .add_systems(Update, maintain_registered_page_pools);
-        app.world_mut().spawn(VmuxWindow);
+        let window = app.world_mut().spawn_empty().id();
+        app.world_mut().spawn((VmuxWindow, HostWindow(window)));
         app.world_mut().spawn((LayoutCef, PageReady {}));
         for (host, title) in [("history", "History"), ("lsp", "Language Servers")] {
             app.world_mut().spawn(PrewarmPage {

--- a/crates/page/vmux_layout/src/host/window.rs
+++ b/crates/page/vmux_layout/src/host/window.rs
@@ -24,9 +24,12 @@ impl Plugin for WindowLayoutPlugin {
         app.register_type::<WindowGeometry>()
             .register_type::<Option<IVec2>>()
             .register_type::<Option<Vec2>>()
+            .init_resource::<FocusedWindow>()
             .add_systems(
                 Startup,
-                setup.in_set(LayoutStartupSet::Window).after(PageEmbedSet),
+                setup_window_shells
+                    .in_set(LayoutStartupSet::Window)
+                    .after(PageEmbedSet),
             )
             .add_systems(
                 Startup,
@@ -58,11 +61,15 @@ impl Plugin for WindowLayoutPlugin {
             .add_systems(
                 Update,
                 (
+                    sync_focused_window.in_set(WindowFocusSet),
+                    setup_window_shells,
+                    bevy::ecs::schedule::ApplyDeferred,
                     crate::stack::open_startup_url_if_no_stacks.before(PageOpenSet::ResolveTarget),
                     spawn_requested_tab_layouts
                         .after(ReadAppCommands)
                         .before(PageOpenSet::ResolveTarget),
-                ),
+                )
+                    .chain(),
             )
             .add_systems(Update, handle_window_commands.in_set(ReadAppCommands));
 
@@ -70,6 +77,15 @@ impl Plugin for WindowLayoutPlugin {
             .init_resource::<WindowBackground>();
     }
 }
+
+#[derive(Resource, Default, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FocusedWindow(pub Option<Entity>);
+
+#[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct WindowFocusSet;
+
+#[derive(Component)]
+pub struct NewWindowWorkspace;
 
 pub const SIDE_SHEET_TOP_PADDING_PX: f32 = 22.0;
 
@@ -111,11 +127,13 @@ impl Default for WindowBackground {
 
 fn handle_window_commands(
     mut reader: MessageReader<AppCommand>,
-    primary_window: Single<Entity, With<PrimaryWindow>>,
+    focused_window: Res<FocusedWindow>,
 ) {
     for cmd in reader.read() {
         if let AppCommand::Layout(LayoutCommand::Window(WindowCommand::Minimize)) = cmd {
-            let entity = *primary_window;
+            let Some(entity) = focused_window.0 else {
+                continue;
+            };
             WINIT_WINDOWS.with_borrow(|winit_windows| {
                 if let Some(winit_win) = winit_windows.get_window(entity) {
                     winit_win.set_minimized(true);
@@ -128,6 +146,8 @@ fn handle_window_commands(
 #[derive(Bundle)]
 struct WindowBundle {
     marker: VmuxWindow,
+    host_window: HostWindow,
+    viewport: FlexViewport,
     surface: WindowSurface,
     transform: Transform,
     node: Node,
@@ -155,17 +175,100 @@ pub struct WindowGeometry {
     pub size: Option<Vec2>,
 }
 
-fn setup(
-    window: Single<&Window, With<PrimaryWindow>>,
-    primary_window: Single<Entity, With<PrimaryWindow>>,
+fn sync_focused_window(
+    windows: Query<(Entity, &Window, Has<PrimaryWindow>)>,
+    mut focused: ResMut<FocusedWindow>,
+) {
+    let next = windows
+        .iter()
+        .find_map(|(entity, window, _)| (window.visible && window.focused).then_some(entity))
+        .or_else(|| {
+            focused.0.filter(|entity| {
+                windows
+                    .get(*entity)
+                    .is_ok_and(|(_, window, _)| window.visible)
+            })
+        })
+        .or_else(|| {
+            windows
+                .iter()
+                .find_map(|(entity, window, primary)| (primary && window.visible).then_some(entity))
+        })
+        .or_else(|| {
+            windows
+                .iter()
+                .find_map(|(entity, window, _)| window.visible.then_some(entity))
+        })
+        .or_else(|| windows.iter().next().map(|(entity, _, _)| entity));
+    if focused.0 != next {
+        focused.0 = next;
+    }
+}
+
+pub fn host_window_of(
+    entity: Entity,
+    child_of: &Query<&ChildOf>,
+    host_windows: &Query<&HostWindow>,
+) -> Option<Entity> {
+    let mut current = entity;
+    loop {
+        if let Ok(host) = host_windows.get(current) {
+            return Some(host.0);
+        }
+        current = child_of.get(current).ok()?.parent();
+    }
+}
+
+fn setup_window_shells(
+    windows: Query<(Entity, &Window, Has<NewWindowWorkspace>)>,
+    roots: Query<&HostWindow, With<VmuxWindow>>,
+    spaces: Query<&crate::space::SpaceId, With<crate::space::Space>>,
+    effective_startup_url: Option<Res<vmux_core::EffectiveStartupUrl>>,
+    mut requests: MessageWriter<TabLayoutSpawnRequest>,
     mut commands: Commands,
     settings: Res<LayoutSettings>,
 ) {
+    let mut existing_space_ids: std::collections::HashSet<String> =
+        spaces.iter().map(|id| id.0.clone()).collect();
+    let mut next_space_number = existing_space_ids.len() + 1;
+    for (window_entity, window, new_workspace) in &windows {
+        if roots.iter().any(|root| root.0 == window_entity) {
+            continue;
+        }
+        let main = spawn_window_shell(&mut commands, window_entity, window, &settings);
+        if new_workspace {
+            while existing_space_ids.contains(&format!("space-{next_space_number}")) {
+                next_space_number += 1;
+            }
+            let id = format!("space-{next_space_number}");
+            let name = format!("Space {next_space_number}");
+            existing_space_ids.insert(id.clone());
+            next_space_number += 1;
+            spawn_new_window_workspace(
+                &mut commands,
+                &mut requests,
+                window_entity,
+                main,
+                id,
+                name,
+                effective_startup_url.as_deref(),
+            );
+        }
+    }
+}
+
+fn spawn_window_shell(
+    commands: &mut Commands,
+    window_entity: Entity,
+    window: &Window,
+    settings: &LayoutSettings,
+) -> Entity {
     let m = window.meters();
-    let pw = *primary_window;
 
     let root_commands = commands.spawn(WindowBundle {
         marker: VmuxWindow,
+        host_window: HostWindow(window_entity),
+        viewport: FlexViewport(window_entity),
         surface: WindowSurface,
         transform: Transform {
             translation: Vec3::new(0.0, m.y * 0.5, 0.0),
@@ -240,16 +343,18 @@ fn setup(
         ChildOf(main_column),
     ));
 
-    commands.spawn((
-        Main,
-        Transform::default(),
-        Node {
-            flex_grow: 1.0,
-            min_height: Val::Px(0.0),
-            ..default()
-        },
-        ChildOf(main_column),
-    ));
+    let main = commands
+        .spawn((
+            Main,
+            Transform::default(),
+            Node {
+                flex_grow: 1.0,
+                min_height: Val::Px(0.0),
+                ..default()
+            },
+            ChildOf(main_column),
+        ))
+        .id();
 
     commands.spawn((
         SideSheet,
@@ -283,12 +388,55 @@ fn setup(
         ChildOf(root),
     ));
 
-    commands.spawn((layout_cef_bundle(pw), ChildOf(root)));
+    commands.spawn((layout_cef_bundle(window_entity), ChildOf(root)));
+    main
+}
+
+fn spawn_new_window_workspace(
+    commands: &mut Commands,
+    requests: &mut MessageWriter<TabLayoutSpawnRequest>,
+    window: Entity,
+    main: Entity,
+    id: String,
+    name: String,
+    effective_startup_url: Option<&vmux_core::EffectiveStartupUrl>,
+) {
+    let space = commands
+        .spawn((
+            crate::space::Space,
+            crate::space::SpaceId(id.clone()),
+            Name::new(name),
+            vmux_core::Order(0),
+            vmux_core::Active,
+            LastActivatedAt::now(),
+            crate::space::space_view_bundle(),
+            ChildOf(main),
+        ))
+        .id();
+    requests.write(TabLayoutSpawnRequest {
+        space,
+        primary_window: window,
+        name: None,
+        startup_dir: None,
+        content: effective_startup_url
+            .map(|url| url.0.as_str())
+            .filter(|url| !url.is_empty())
+            .map(|url| TabLayoutSpawnContent::Url {
+                url: url.to_string(),
+                pending_prompt: None,
+            })
+            .unwrap_or(TabLayoutSpawnContent::StartupUrlOrPrompt),
+        clear_pending_stack: false,
+        focus: true,
+    });
+    commands.entity(window).remove::<NewWindowWorkspace>();
 }
 
 fn request_default_layout(
     tab_q: Query<(), With<Tab>>,
-    primary_window: Single<Entity, With<PrimaryWindow>>,
+    child_of: Query<&ChildOf>,
+    host_windows: Query<&HostWindow>,
+    primary_window: Query<Entity, With<PrimaryWindow>>,
     space_file: Option<Res<SpaceFilePresent>>,
     effective_startup_dir: Option<Res<crate::settings::EffectiveStartupDir>>,
     mut requests: MessageWriter<TabLayoutSpawnRequest>,
@@ -305,7 +453,9 @@ fn request_default_layout(
     };
     requests.write(TabLayoutSpawnRequest {
         space,
-        primary_window: *primary_window,
+        primary_window: host_window_of(space, &child_of, &host_windows)
+            .or_else(|| primary_window.single().ok())
+            .unwrap_or(Entity::PLACEHOLDER),
         name: None,
         startup_dir: startup_dir.clone(),
         content: TabLayoutSpawnContent::StartupUrlOrPrompt,
@@ -455,7 +605,10 @@ pub fn spawn_requested_tab_layouts(
 fn sync_window_layout_to_settings(
     settings: Res<LayoutSettings>,
     hidden: Option<Res<crate::toggle::LayoutHidden>>,
-    mut window_q: Query<&mut Node, (With<VmuxWindow>, Without<SideSheet>, Without<MainColumn>)>,
+    mut window_q: Query<
+        (&HostWindow, &mut Node),
+        (With<VmuxWindow>, Without<SideSheet>, Without<MainColumn>),
+    >,
     mut main_column_q: Query<
         &mut Node,
         (With<MainColumn>, Without<VmuxWindow>, Without<SideSheet>),
@@ -476,9 +629,10 @@ fn sync_window_layout_to_settings(
     let pad_left = settings.window.pad_left();
     let gap = crate::event::PANE_GAP_PX;
     let cfg_width = crate::event::SIDE_SHEET_WIDTH_PX;
-    let full_padding = hidden.as_deref().is_some_and(|hidden| hidden.0);
-
-    if let Ok(mut node) = window_q.single_mut() {
+    for (host, mut node) in &mut window_q {
+        let full_padding = hidden
+            .as_deref()
+            .is_some_and(|hidden| hidden.is_hidden(host.0));
         node.padding = UiRect {
             top: Val::Px(if full_padding { pad_top } else { 0.0 }),
             left: Val::Px(if full_padding { pad_left } else { 0.0 }),
@@ -488,7 +642,7 @@ fn sync_window_layout_to_settings(
         node.column_gap = Val::Px(gap);
     }
 
-    let _ = main_column_q.single_mut();
+    for _ in &mut main_column_q {}
 
     if sheet_width.0 <= 0.0 {
         sheet_width.0 = cfg_width;
@@ -545,17 +699,22 @@ fn sync_main_column_gap_to_pane_count(
 }
 
 pub fn fit_window_to_screen(
-    window: Single<&bevy::window::Window, With<PrimaryWindow>>,
-    mut last_size: Local<Vec2>,
-    mut q: Query<&mut Transform, With<VmuxWindow>>,
+    windows: Query<&bevy::window::Window>,
+    mut last_sizes: Local<std::collections::HashMap<Entity, Vec2>>,
+    mut roots: Query<(&HostWindow, &mut Transform), With<VmuxWindow>>,
 ) {
-    let m = window.meters();
-    if (m.x - last_size.x).abs() < 0.001 && (m.y - last_size.y).abs() < 0.001 {
-        return;
-    }
-    *last_size = m;
-
-    for mut transform in &mut q {
+    for (host, mut transform) in &mut roots {
+        let Ok(window) = windows.get(host.0) else {
+            continue;
+        };
+        let m = window.meters();
+        if last_sizes
+            .get(&host.0)
+            .is_some_and(|last| (m.x - last.x).abs() < 0.001 && (m.y - last.y).abs() < 0.001)
+        {
+            continue;
+        }
+        last_sizes.insert(host.0, m);
         transform.translation = Vec3::new(0.0, m.y * 0.5, 0.0);
         transform.scale = Vec3::new(m.x, m.y, 1.0);
     }
@@ -643,7 +802,8 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .insert_resource(test_settings(8.0))
-            .init_resource::<Assets<WindowMaterial>>();
+            .init_resource::<Assets<WindowMaterial>>()
+            .add_message::<TabLayoutSpawnRequest>();
         app.world_mut().spawn((
             Window {
                 resolution: (1200, 800).into(),
@@ -651,7 +811,7 @@ mod tests {
             },
             PrimaryWindow,
         ));
-        app.add_systems(Startup, setup);
+        app.add_systems(Startup, setup_window_shells);
         app
     }
 
@@ -691,6 +851,63 @@ mod tests {
             .count();
 
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn setup_spawns_one_layout_root_per_native_window() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .insert_resource(test_settings(8.0))
+            .init_resource::<Assets<WindowMaterial>>()
+            .add_message::<TabLayoutSpawnRequest>()
+            .add_systems(Update, setup_window_shells);
+        let first = app.world_mut().spawn(Window::default()).id();
+        let second = app.world_mut().spawn(Window::default()).id();
+
+        app.update();
+
+        let hosts = app
+            .world_mut()
+            .query_filtered::<(&HostWindow, &FlexViewport), With<VmuxWindow>>()
+            .iter(app.world())
+            .map(|(host, viewport)| (host.0, viewport.0))
+            .collect::<std::collections::HashSet<_>>();
+        let expected: std::collections::HashSet<_> =
+            [(first, first), (second, second)].into_iter().collect();
+        assert_eq!(hosts, expected);
+    }
+
+    #[test]
+    fn a_new_window_gets_its_own_space_and_tab_request() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .insert_resource(test_settings(8.0))
+            .init_resource::<Assets<WindowMaterial>>()
+            .add_message::<TabLayoutSpawnRequest>()
+            .add_systems(
+                Update,
+                (setup_window_shells, bevy::ecs::schedule::ApplyDeferred).chain(),
+            );
+        let window = app
+            .world_mut()
+            .spawn((Window::default(), NewWindowWorkspace))
+            .id();
+
+        app.update();
+
+        let space = app
+            .world_mut()
+            .query_filtered::<Entity, With<crate::space::Space>>()
+            .single(app.world())
+            .expect("space");
+        let request = app
+            .world_mut()
+            .resource_mut::<Messages<TabLayoutSpawnRequest>>()
+            .drain()
+            .next()
+            .expect("tab request");
+        assert_eq!(request.space, space);
+        assert_eq!(request.primary_window, window);
     }
 
     #[test]
@@ -1047,7 +1264,7 @@ mod tests {
     fn visible_fills_monitor_window_sync_clears_top_left_padding() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .insert_resource(crate::toggle::LayoutHidden(false))
+            .init_resource::<crate::toggle::LayoutHidden>()
             .insert_resource(LayoutSettings {
                 radius: 0.0,
                 window: crate::settings::WindowSettings { padding: 16.0 },
@@ -1057,13 +1274,16 @@ mod tests {
             })
             .insert_resource(SideSheetWidth(0.0))
             .add_systems(Update, sync_window_layout_to_settings);
-        app.world_mut().spawn((
-            Window {
-                resolution: (1200, 800).into(),
-                ..default()
-            },
-            PrimaryWindow,
-        ));
+        let window = app
+            .world_mut()
+            .spawn((
+                Window {
+                    resolution: (1200, 800).into(),
+                    ..default()
+                },
+                PrimaryWindow,
+            ))
+            .id();
         app.world_mut().spawn(Monitor {
             name: None,
             physical_width: 1200,
@@ -1073,7 +1293,10 @@ mod tests {
             scale_factor: 1.0,
             video_modes: Vec::new(),
         });
-        let root = app.world_mut().spawn((VmuxWindow, Node::default())).id();
+        let root = app
+            .world_mut()
+            .spawn((VmuxWindow, HostWindow(window), Node::default()))
+            .id();
 
         app.update();
 

--- a/crates/page/vmux_space/src/host/plugin.rs
+++ b/crates/page/vmux_space/src/host/plugin.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use bevy::{ecs::message::MessageReader, prelude::*, window::PrimaryWindow};
+use bevy::{ecs::message::MessageReader, prelude::*};
 use bevy_cef::prelude::*;
 use vmux_core::page::PageReady;
 use vmux_core::{PageMetadata, PageOpenRequest, PageOpenTarget};
@@ -21,6 +21,8 @@ impl Plugin for SpacePlugin {
         app.world_mut().spawn(crate::PAGE_MANIFEST);
         app.add_plugins(vmux_layout::LayoutContractPlugin)
             .init_resource::<ActiveSpace>()
+            .init_resource::<vmux_layout::space::ActiveSpaceEntity>()
+            .init_resource::<vmux_layout::window::FocusedWindow>()
             .add_message::<SaveSpaceRequest>()
             .add_message::<SpaceCommandRequest>()
             .add_systems(Update, relay_space_command_requests)
@@ -102,6 +104,7 @@ fn update_effective_startup_url(
 
 fn update_effective_startup_dir(
     settings: Option<Res<vmux_setting::AppSettings>>,
+    active: Option<Res<vmux_layout::space::ActiveSpaceEntity>>,
     spaces: Query<
         (
             Entity,
@@ -112,15 +115,17 @@ fn update_effective_startup_dir(
     >,
     mut effective: ResMut<vmux_layout::settings::EffectiveStartupDir>,
 ) {
-    let mut fallback = None;
-    let mut selected = None;
-    for (entity, id, is_active) in &spaces {
-        fallback.get_or_insert((entity, id));
-        if is_active {
-            selected = Some((entity, id));
-            break;
-        }
-    }
+    let selected = active
+        .as_deref()
+        .and_then(|active| active.0)
+        .and_then(|entity| spaces.get(entity).ok().map(|(_, id, _)| (entity, id)))
+        .or_else(|| {
+            spaces
+                .iter()
+                .find(|(_, _, is_active)| *is_active)
+                .map(|(entity, id, _)| (entity, id))
+        });
+    let fallback = spaces.iter().next().map(|(entity, id, _)| (entity, id));
     let Some((entity, id)) = selected.or(fallback) else {
         if effective.0.is_some() {
             effective.0 = None;
@@ -165,13 +170,24 @@ fn reset_spaces_sent_marker_on_page_ready(
 }
 
 fn sync_active_space_record(
-    tagged: Query<
-        (&vmux_layout::space::SpaceId, &Name),
-        (With<vmux_layout::space::Space>, With<vmux_core::Active>),
+    active_entity: Option<Res<vmux_layout::space::ActiveSpaceEntity>>,
+    spaces: Query<
+        (&vmux_layout::space::SpaceId, &Name, Has<vmux_core::Active>),
+        With<vmux_layout::space::Space>,
     >,
     mut active: ResMut<ActiveSpace>,
 ) {
-    if let Some((id, name)) = tagged.iter().next()
+    let selected = active_entity
+        .as_deref()
+        .and_then(|active| active.0)
+        .and_then(|entity| spaces.get(entity).ok().map(|(id, name, _)| (id, name)))
+        .or_else(|| {
+            spaces
+                .iter()
+                .find(|(_, _, is_active)| *is_active)
+                .map(|(id, name, _)| (id, name))
+        });
+    if let Some((id, name)) = selected
         && (active.record.id != id.0 || active.record.name != name.as_str())
     {
         active.record.id = id.0.clone();
@@ -183,11 +199,13 @@ type SpaceListQuery<'w, 's> = Query<
     'w,
     's,
     (
+        Entity,
         &'static vmux_layout::space::SpaceId,
         &'static Name,
         Has<vmux_core::Active>,
         Option<&'static vmux_core::Order>,
         Option<&'static Children>,
+        &'static ChildOf,
     ),
     With<vmux_layout::space::Space>,
 >;
@@ -205,13 +223,25 @@ fn space_rows_from_world(
     spaces: &SpaceListQuery,
     tab_q: &Query<(), With<vmux_layout::tab::Tab>>,
     settings: Option<&vmux_setting::AppSettings>,
+    main: Option<Entity>,
 ) -> Vec<SpaceRow> {
     let profile = crate::model::bootstrap_profile_name();
     let mut rows: Vec<(u32, SpaceRow)> = Vec::new();
-    for (sid, name, is_active, order, children) in spaces.iter() {
-        let tab_count = children
+    for (_, sid, name, is_active, order, children, parent) in spaces.iter() {
+        let local = main.is_none_or(|main| parent.parent() == main);
+        let local_tab_count = children
             .map(|c| c.iter().filter(|e| tab_q.contains(*e)).count())
             .unwrap_or(0) as u32;
+        if let Some((existing_order, row)) =
+            rows.iter_mut().find(|(_, existing)| existing.id == sid.0)
+        {
+            *existing_order = (*existing_order).min(order.map(|o| o.0).unwrap_or(u32::MAX));
+            if local {
+                row.is_active = is_active;
+                row.tab_count = local_tab_count;
+            }
+            continue;
+        }
         let startup_dir = settings
             .and_then(|s| s.startup_dir(&sid.0))
             .map(|path| display_dir(&path))
@@ -222,8 +252,8 @@ fn space_rows_from_world(
                 id: sid.0.clone(),
                 name: name.to_string(),
                 profile: profile.clone(),
-                is_active,
-                tab_count,
+                is_active: local && is_active,
+                tab_count: if local { local_tab_count } else { 0 },
                 startup_dir,
             },
         ));
@@ -255,7 +285,10 @@ fn broadcast_spaces_to_views(
     >,
     browsers: NonSend<Browsers>,
     settings: Option<Res<vmux_setting::AppSettings>>,
-    mut last_body: Local<Option<SpacesListEvent>>,
+    mains: Query<Entity, With<vmux_layout::window::Main>>,
+    child_of: Query<&ChildOf>,
+    host_windows: Query<&HostWindow>,
+    mut last_body: Local<std::collections::HashMap<Entity, SpacesListEvent>>,
     mut commands: Commands,
 ) {
     let pending_total = pending_spaces.iter().count() + pending_cef.iter().count();
@@ -263,11 +296,25 @@ fn broadcast_spaces_to_views(
     if pending_total == 0 && sent_total == 0 {
         return;
     }
-    let payload = SpacesListEvent {
-        spaces: space_rows_from_world(&spaces, &tab_q, settings.as_deref()),
-    };
-    let body_changed = last_body.as_ref() != Some(&payload);
-    for entity in pending_spaces.iter().chain(pending_cef.iter()) {
+    for (entity, pending) in pending_spaces
+        .iter()
+        .chain(pending_cef.iter())
+        .map(|entity| (entity, true))
+        .chain(
+            sent_spaces
+                .iter()
+                .chain(sent_cef.iter())
+                .map(|entity| (entity, false)),
+        )
+    {
+        let host = vmux_layout::window::host_window_of(entity, &child_of, &host_windows);
+        let main = host.and_then(|host| main_for_window(host, &mains, &child_of, &host_windows));
+        let payload = SpacesListEvent {
+            spaces: space_rows_from_world(&spaces, &tab_q, settings.as_deref(), main),
+        };
+        if !pending && last_body.get(&entity) == Some(&payload) {
+            continue;
+        }
         if !browsers.can_emit_to(&entity) {
             continue;
         }
@@ -277,19 +324,7 @@ fn broadcast_spaces_to_views(
             &payload,
         ));
         commands.entity(entity).insert(SpacesListSent);
-    }
-    if body_changed {
-        for entity in sent_spaces.iter().chain(sent_cef.iter()) {
-            if !browsers.can_emit_to(&entity) {
-                continue;
-            }
-            commands.trigger(BinHostEmitEvent::from_rkyv(
-                entity,
-                SPACES_LIST_EVENT,
-                &payload,
-            ));
-        }
-        *last_body = Some(payload);
+        last_body.insert(entity, payload);
     }
 }
 
@@ -346,6 +381,7 @@ type SpaceQuery<'w, 's> = Query<
         &'static vmux_layout::space::SpaceId,
         Has<vmux_core::Active>,
         Option<&'static vmux_core::Order>,
+        &'static ChildOf,
     ),
     With<vmux_layout::space::Space>,
 >;
@@ -357,15 +393,16 @@ type SpaceTabQuery<'w, 's> = Query<
         Entity,
         &'static vmux_layout::space::SpaceId,
         &'static vmux_history::LastActivatedAt,
+        &'static ChildOf,
     ),
     With<vmux_layout::tab::Tab>,
 >;
 
-fn bump_space_tab(tabs: &SpaceTabQuery, space_id: &str, commands: &mut Commands) {
-    if let Some((tab, _, _)) = tabs
+fn bump_space_tab(tabs: &SpaceTabQuery, space: Entity, commands: &mut Commands) {
+    if let Some((tab, _, _, _)) = tabs
         .iter()
-        .filter(|(_, sid, _)| sid.0 == space_id)
-        .max_by_key(|(_, _, ts)| ts.0)
+        .filter(|(_, _, _, parent)| parent.parent() == space)
+        .max_by_key(|(_, _, ts, _)| ts.0)
     {
         commands
             .entity(tab)
@@ -373,11 +410,96 @@ fn bump_space_tab(tabs: &SpaceTabQuery, space_id: &str, commands: &mut Commands)
     }
 }
 
-fn deactivate_all_spaces(spaces: &SpaceQuery, commands: &mut Commands) {
-    for (entity, _, is_active, _) in spaces.iter() {
-        if is_active {
+fn deactivate_spaces_in_main(spaces: &SpaceQuery, main: Entity, commands: &mut Commands) {
+    for (entity, _, is_active, _, parent) in spaces.iter() {
+        if parent.parent() == main && is_active {
             commands.entity(entity).remove::<vmux_core::Active>();
         }
+    }
+}
+
+fn main_for_window(
+    window: Entity,
+    mains: &Query<Entity, With<vmux_layout::window::Main>>,
+    child_of: &Query<&ChildOf>,
+    host_windows: &Query<&HostWindow>,
+) -> Option<Entity> {
+    mains.iter().find(|main| {
+        vmux_layout::window::host_window_of(*main, child_of, host_windows) == Some(window)
+    })
+}
+
+#[derive(Clone)]
+struct SpaceViewTemplate {
+    id: String,
+    name: String,
+    order: u32,
+}
+
+impl SpaceViewTemplate {
+    fn of(spaces: &SpaceListQuery, id: &str) -> Option<Self> {
+        spaces
+            .iter()
+            .filter(|(_, candidate, _, _, _, _, _)| candidate.0 == id)
+            .min_by_key(|(_, _, _, _, order, _, _)| order.map(|order| order.0).unwrap_or(u32::MAX))
+            .map(|(_, id, name, _, order, _, _)| Self {
+                id: id.0.clone(),
+                name: name.to_string(),
+                order: order.map(|order| order.0).unwrap_or(u32::MAX),
+            })
+    }
+
+    fn first_other(spaces: &SpaceListQuery, excluded: &str) -> Option<Self> {
+        spaces
+            .iter()
+            .filter(|(_, candidate, _, _, _, _, _)| candidate.0 != excluded)
+            .min_by_key(|(_, _, _, _, order, _, _)| order.map(|order| order.0).unwrap_or(u32::MAX))
+            .map(|(_, id, name, _, order, _, _)| Self {
+                id: id.0.clone(),
+                name: name.to_string(),
+                order: order.map(|order| order.0).unwrap_or(u32::MAX),
+            })
+    }
+
+    fn spawn(
+        &self,
+        main: Entity,
+        window: Entity,
+        settings: Option<&vmux_setting::AppSettings>,
+        layout_requests: &mut MessageWriter<TabLayoutSpawnRequest>,
+        commands: &mut Commands,
+    ) -> Entity {
+        let space = commands
+            .spawn((
+                vmux_layout::space::Space,
+                vmux_layout::space::SpaceId(self.id.clone()),
+                Name::new(self.name.clone()),
+                vmux_core::Order(self.order),
+                vmux_core::Active,
+                vmux_history::LastActivatedAt::now(),
+                vmux_layout::space::space_view_bundle(),
+                ChildOf(main),
+            ))
+            .id();
+        let startup_dir = settings.and_then(|settings| settings.startup_dir(&self.id));
+        let content = settings
+            .map(|settings| settings.startup_url(&self.id))
+            .filter(|url| !url.is_empty())
+            .map(|url| TabLayoutSpawnContent::Url {
+                url,
+                pending_prompt: None,
+            })
+            .unwrap_or(TabLayoutSpawnContent::StartupUrlOrPrompt);
+        layout_requests.write(TabLayoutSpawnRequest {
+            space,
+            primary_window: window,
+            name: None,
+            startup_dir,
+            content,
+            clear_pending_stack: true,
+            focus: true,
+        });
+        space
     }
 }
 
@@ -401,9 +523,11 @@ fn sync_space_name_to_id(
 fn on_space_command(
     trigger: On<BinReceive<SpaceCommandEvent>>,
     spaces: SpaceQuery,
+    space_list: SpaceListQuery,
     tabs: SpaceTabQuery,
-    main_q: Query<Entity, With<vmux_layout::window::Main>>,
-    primary_window: Single<Entity, With<PrimaryWindow>>,
+    mains: Query<Entity, With<vmux_layout::window::Main>>,
+    host_windows: Query<&HostWindow>,
+    focused_window: Option<Res<vmux_layout::window::FocusedWindow>>,
     focus: Option<Res<vmux_layout::stack::FocusedStack>>,
     mut spawn_requests: Option<MessageWriter<PageOpenRequest>>,
     mut layout_requests: MessageWriter<TabLayoutSpawnRequest>,
@@ -414,9 +538,67 @@ fn on_space_command(
     mut commands: Commands,
 ) {
     let evt = &trigger.event().payload;
+    if evt.command == "rename" {
+        let Some(id) = evt.space_id.as_deref() else {
+            return;
+        };
+        let Some(name) = evt.name.as_deref().map(str::trim).filter(|n| !n.is_empty()) else {
+            return;
+        };
+        if !spaces.iter().any(|(_, sid, _, _, _)| sid.0 == id) {
+            return;
+        }
+        let existing: std::collections::HashSet<String> = spaces
+            .iter()
+            .filter(|(_, sid, _, _, _)| sid.0 != id)
+            .map(|(_, sid, _, _, _)| sid.0.clone())
+            .collect();
+        let new_id = crate::model::unique_space_id_among(&existing, name);
+        let renamed_active = active_id.0.as_deref() == Some(id)
+            || spaces
+                .iter()
+                .any(|(_, sid, is_active, _, _)| sid.0 == id && is_active);
+        for (entity, sid, _, _, _) in spaces.iter() {
+            if sid.0 != id {
+                continue;
+            }
+            commands.entity(entity).insert((
+                Name::new(new_id.clone()),
+                vmux_layout::space::SpaceId(new_id.clone()),
+            ));
+        }
+        if new_id != id {
+            for (tab, sid, _, _) in tabs.iter() {
+                if sid.0 != id {
+                    continue;
+                }
+                commands
+                    .entity(tab)
+                    .insert(vmux_layout::space::SpaceId(new_id.clone()));
+            }
+            if renamed_active {
+                active_id.0 = Some(new_id.clone());
+            }
+        }
+        return;
+    }
+
+    let window = host_windows
+        .get(trigger.event().webview)
+        .ok()
+        .map(|host| host.0)
+        .or_else(|| focused_window.as_deref().and_then(|focused| focused.0));
+    let Some(window) = window else { return };
+    let Some(main) = main_for_window(window, &mains, &child_of_q, &host_windows) else {
+        return;
+    };
 
     if evt.command == "open_page" {
-        if let Some((existing, _)) = stack_q.iter().find(|(_, meta)| meta.url == SPACES_PAGE_URL) {
+        if let Some((existing, _)) = stack_q.iter().find(|(stack, meta)| {
+            meta.url == SPACES_PAGE_URL
+                && vmux_layout::window::host_window_of(*stack, &child_of_q, &host_windows)
+                    == Some(window)
+        }) {
             vmux_core::focus_pane_entity(existing, &mut commands, &child_of_q);
             return;
         }
@@ -444,71 +626,64 @@ fn on_space_command(
         return;
     }
 
-    if evt.command == "rename" {
-        let Some(id) = evt.space_id.as_deref() else {
-            return;
-        };
-        let Some(name) = evt.name.as_deref().map(str::trim).filter(|n| !n.is_empty()) else {
-            return;
-        };
-        let Some((entity, _, is_active, _)) = spaces.iter().find(|(_, sid, _, _)| sid.0 == id)
-        else {
-            return;
-        };
-        let existing: std::collections::HashSet<String> = spaces
-            .iter()
-            .filter(|(_, sid, _, _)| sid.0 != id)
-            .map(|(_, sid, _, _)| sid.0.clone())
-            .collect();
-        let new_id = crate::model::unique_space_id_among(&existing, name);
-        commands.entity(entity).insert(Name::new(new_id.clone()));
-        if new_id != id {
-            commands
-                .entity(entity)
-                .insert(vmux_layout::space::SpaceId(new_id.clone()));
-            for (tab, sid, _) in tabs.iter() {
-                if sid.0 == id {
-                    commands
-                        .entity(tab)
-                        .insert(vmux_layout::space::SpaceId(new_id.clone()));
-                }
-            }
-            if is_active {
-                active_id.0 = Some(new_id.clone());
-            }
-        }
-        return;
-    }
-
     if evt.command == "delete" {
         let Some(id) = evt.space_id.as_deref() else {
             return;
         };
-        if spaces.iter().count() <= 1 {
+        let logical_ids: std::collections::HashSet<&str> = spaces
+            .iter()
+            .map(|(_, id, _, _, _)| id.0.as_str())
+            .collect();
+        if logical_ids.len() <= 1 {
             return;
         }
-        let Some((entity, _, was_active, _)) = spaces.iter().find(|(_, sid, _, _)| sid.0 == id)
-        else {
+        let Some(fallback) = SpaceViewTemplate::first_other(&space_list, id) else {
             return;
         };
-        commands.entity(entity).despawn();
-        for (tab, sid, _) in tabs.iter() {
-            if sid.0 == id {
-                commands.entity(tab).despawn();
+        let mut affected_mains = Vec::new();
+        for (entity, sid, _, _, parent) in spaces.iter() {
+            if sid.0 != id {
+                continue;
             }
+            if !affected_mains.contains(&parent.parent()) {
+                affected_mains.push(parent.parent());
+            }
+            commands.entity(entity).despawn();
         }
-        if was_active
-            && let Some((target_entity, target_id)) = spaces
+        if affected_mains.is_empty() {
+            return;
+        }
+        for affected_main in affected_mains {
+            deactivate_spaces_in_main(&spaces, affected_main, &mut commands);
+            if let Some((target_entity, target_id, _, _, _)) = spaces
                 .iter()
-                .filter(|(_, sid, _, _)| sid.0 != id)
-                .min_by_key(|(_, _, _, order)| order.map(|o| o.0).unwrap_or(u32::MAX))
-                .map(|(entity, sid, _, _)| (entity, sid.0.clone()))
-        {
-            commands
-                .entity(target_entity)
-                .insert((vmux_core::Active, vmux_history::LastActivatedAt::now()));
-            active_id.0 = Some(target_id.clone());
-            bump_space_tab(&tabs, &target_id, &mut commands);
+                .filter(|(_, sid, _, _, parent)| sid.0 != id && parent.parent() == affected_main)
+                .min_by_key(|(_, _, _, order, _)| order.map(|o| o.0).unwrap_or(u32::MAX))
+            {
+                commands
+                    .entity(target_entity)
+                    .insert((vmux_core::Active, vmux_history::LastActivatedAt::now()));
+                bump_space_tab(&tabs, target_entity, &mut commands);
+                if affected_main == main {
+                    active_id.0 = Some(target_id.0.clone());
+                }
+                continue;
+            }
+            let Some(affected_window) =
+                vmux_layout::window::host_window_of(affected_main, &child_of_q, &host_windows)
+            else {
+                continue;
+            };
+            fallback.spawn(
+                affected_main,
+                affected_window,
+                settings.as_deref(),
+                &mut layout_requests,
+                &mut commands,
+            );
+            if affected_main == main {
+                active_id.0 = Some(fallback.id.clone());
+            }
         }
         return;
     }
@@ -518,38 +693,56 @@ fn on_space_command(
             let Some(id) = evt.space_id.as_deref() else {
                 return;
             };
-            let Some((entity, _, is_active, _)) = spaces.iter().find(|(_, sid, _, _)| sid.0 == id)
-            else {
+            let local = spaces
+                .iter()
+                .find(|(_, sid, _, _, parent)| sid.0 == id && parent.parent() == main);
+            let Some((entity, _, is_active, _, _)) = local else {
+                let Some(template) = SpaceViewTemplate::of(&space_list, id) else {
+                    return;
+                };
+                deactivate_spaces_in_main(&spaces, main, &mut commands);
+                template.spawn(
+                    main,
+                    window,
+                    settings.as_deref(),
+                    &mut layout_requests,
+                    &mut commands,
+                );
+                active_id.0 = Some(id.to_string());
                 return;
             };
-            if is_active {
-                return;
+            if !is_active {
+                deactivate_spaces_in_main(&spaces, main, &mut commands);
+                commands
+                    .entity(entity)
+                    .insert((vmux_core::Active, vmux_history::LastActivatedAt::now()));
+                active_id.0 = Some(id.to_string());
+                bump_space_tab(&tabs, entity, &mut commands);
             }
-            deactivate_all_spaces(&spaces, &mut commands);
-            commands
-                .entity(entity)
-                .insert((vmux_core::Active, vmux_history::LastActivatedAt::now()));
-            active_id.0 = Some(id.to_string());
-            bump_space_tab(&tabs, id, &mut commands);
         }
         "new" => {
-            let count = spaces.iter().count();
+            let count = spaces
+                .iter()
+                .filter(|(_, _, _, _, parent)| parent.parent() == main)
+                .count();
             let name = evt
                 .name
                 .clone()
                 .filter(|n| !n.trim().is_empty())
                 .unwrap_or_else(|| format!("Space {}", count + 1));
-            let existing: std::collections::HashSet<String> =
-                spaces.iter().map(|(_, sid, _, _)| sid.0.clone()).collect();
+            let existing: std::collections::HashSet<String> = spaces
+                .iter()
+                .map(|(_, sid, _, _, _)| sid.0.clone())
+                .collect();
             let id = crate::model::unique_space_id_among(&existing, &name);
             let order = spaces
                 .iter()
-                .filter_map(|(_, _, _, order)| order.map(|o| o.0))
+                .filter(|(_, _, _, _, parent)| parent.parent() == main)
+                .filter_map(|(_, _, _, order, _)| order.map(|o| o.0))
                 .max()
                 .map(|max| max + 1)
                 .unwrap_or(0);
-            let Ok(main) = main_q.single() else { return };
-            deactivate_all_spaces(&spaces, &mut commands);
+            deactivate_spaces_in_main(&spaces, main, &mut commands);
             let space = commands
                 .spawn((
                     vmux_layout::space::Space,
@@ -568,7 +761,7 @@ fn on_space_command(
                 .and_then(|settings| settings.startup_dir(&id));
             layout_requests.write(TabLayoutSpawnRequest {
                 space,
-                primary_window: *primary_window,
+                primary_window: window,
                 name: None,
                 startup_dir,
                 content: TabLayoutSpawnContent::Url {
@@ -587,8 +780,10 @@ fn on_space_command(
 fn handle_open_in_new_space(
     mut reader: MessageReader<vmux_command::AppCommand>,
     spaces: SpaceQuery,
-    main_q: Query<Entity, With<vmux_layout::window::Main>>,
-    primary_window: Single<Entity, With<PrimaryWindow>>,
+    mains: Query<Entity, With<vmux_layout::window::Main>>,
+    child_of: Query<&ChildOf>,
+    host_windows: Query<&HostWindow>,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
     effective_startup_url: Option<Res<vmux_core::EffectiveStartupUrl>>,
     settings: Option<Res<vmux_setting::AppSettings>>,
     mut active_id: ResMut<vmux_layout::space::ActiveSpaceId>,
@@ -602,20 +797,31 @@ fn handle_open_in_new_space(
         else {
             continue;
         };
+        let Some(window) = focused_window.0 else {
+            continue;
+        };
+        let Some(main) = main_for_window(window, &mains, &child_of, &host_windows) else {
+            continue;
+        };
 
-        let count = spaces.iter().count();
+        let count = spaces
+            .iter()
+            .filter(|(_, _, _, _, parent)| parent.parent() == main)
+            .count();
         let name = format!("Space {}", count + 1);
-        let existing: std::collections::HashSet<String> =
-            spaces.iter().map(|(_, sid, _, _)| sid.0.clone()).collect();
+        let existing: std::collections::HashSet<String> = spaces
+            .iter()
+            .map(|(_, sid, _, _, _)| sid.0.clone())
+            .collect();
         let id = crate::model::unique_space_id_among(&existing, &name);
         let order = spaces
             .iter()
-            .filter_map(|(_, _, _, order)| order.map(|o| o.0))
+            .filter(|(_, _, _, _, parent)| parent.parent() == main)
+            .filter_map(|(_, _, _, order, _)| order.map(|o| o.0))
             .max()
             .map(|max| max + 1)
             .unwrap_or(0);
-        let Ok(main) = main_q.single() else { continue };
-        deactivate_all_spaces(&spaces, &mut commands);
+        deactivate_spaces_in_main(&spaces, main, &mut commands);
         let space = commands
             .spawn((
                 vmux_layout::space::Space,
@@ -652,7 +858,7 @@ fn handle_open_in_new_space(
             .unwrap_or(TabLayoutSpawnContent::StartupUrlOrPrompt);
         layout_requests.write(TabLayoutSpawnRequest {
             space,
-            primary_window: *primary_window,
+            primary_window: window,
             name: None,
             startup_dir,
             content,
@@ -679,6 +885,7 @@ fn respond_spaces_spawn(
 mod tests {
     use super::*;
     use crate::model::{SpaceRecord, bootstrap_profile_name};
+    use bevy::ecs::system::RunSystemOnce;
     use vmux_layout::settings::{
         FocusRingSettings, LayoutSettings, PaneSettings, SideSheetSettings, WindowSettings,
     };
@@ -734,6 +941,31 @@ mod tests {
     }
 
     #[test]
+    fn main_for_window_walks_through_the_main_column() {
+        let mut app = App::new();
+        let window = app.world_mut().spawn_empty().id();
+        let root = app.world_mut().spawn(HostWindow(window)).id();
+        let column = app.world_mut().spawn(ChildOf(root)).id();
+        let main = app
+            .world_mut()
+            .spawn((vmux_layout::window::Main, ChildOf(column)))
+            .id();
+
+        let resolved = app
+            .world_mut()
+            .run_system_once(
+                move |mains: Query<Entity, With<vmux_layout::window::Main>>,
+                      child_of: Query<&ChildOf>,
+                      host_windows: Query<&HostWindow>| {
+                    main_for_window(window, &mains, &child_of, &host_windows)
+                },
+            )
+            .unwrap();
+
+        assert_eq!(resolved, Some(main));
+    }
+
+    #[test]
     fn effective_startup_url_reflects_active_space_override() {
         let mut settings = test_settings();
         settings.browser.startup_url = "https://global.example".into();
@@ -759,6 +991,168 @@ mod tests {
         assert_eq!(
             app.world().resource::<vmux_core::EffectiveStartupUrl>().0,
             "https://work.example"
+        );
+    }
+
+    #[test]
+    fn attaching_a_shared_space_creates_a_window_local_view() {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, vmux_layout::LayoutContractPlugin))
+            .add_message::<TabLayoutSpawnRequest>()
+            .add_observer(on_space_command);
+        let first_window = app.world_mut().spawn_empty().id();
+        let second_window = app.world_mut().spawn_empty().id();
+        app.insert_resource(vmux_layout::window::FocusedWindow(Some(second_window)));
+        let first_root = app.world_mut().spawn(HostWindow(first_window)).id();
+        let second_root = app.world_mut().spawn(HostWindow(second_window)).id();
+        let first_column = app.world_mut().spawn(ChildOf(first_root)).id();
+        let second_column = app.world_mut().spawn(ChildOf(second_root)).id();
+        let first_main = app
+            .world_mut()
+            .spawn((vmux_layout::window::Main, ChildOf(first_column)))
+            .id();
+        let second_main = app
+            .world_mut()
+            .spawn((vmux_layout::window::Main, ChildOf(second_column)))
+            .id();
+        app.world_mut().spawn((
+            vmux_layout::space::Space,
+            vmux_layout::space::SpaceId("shared".to_string()),
+            Name::new("shared"),
+            vmux_core::Order(0),
+            vmux_core::Active,
+            vmux_layout::space::space_view_bundle(),
+            ChildOf(first_main),
+        ));
+        let previous = app
+            .world_mut()
+            .spawn((
+                vmux_layout::space::Space,
+                vmux_layout::space::SpaceId("second".to_string()),
+                Name::new("second"),
+                vmux_core::Order(0),
+                vmux_core::Active,
+                vmux_layout::space::space_view_bundle(),
+                ChildOf(second_main),
+            ))
+            .id();
+        let webview = app.world_mut().spawn(HostWindow(second_window)).id();
+
+        app.world_mut().trigger(BinReceive {
+            webview,
+            payload: SpaceCommandEvent {
+                command: "attach".to_string(),
+                space_id: Some("shared".to_string()),
+                name: None,
+            },
+        });
+        app.update();
+
+        let shared_views: Vec<(Entity, Entity, bool)> = app
+            .world_mut()
+            .query_filtered::<
+                (Entity, &ChildOf, Has<vmux_core::Active>),
+                With<vmux_layout::space::Space>,
+            >()
+            .iter(app.world())
+            .filter_map(|(entity, parent, active)| {
+                let id = app
+                    .world()
+                    .get::<vmux_layout::space::SpaceId>(entity)?;
+                (id.0 == "shared").then_some((entity, parent.parent(), active))
+            })
+            .collect();
+        assert_eq!(shared_views.len(), 2);
+        assert!(
+            shared_views
+                .iter()
+                .any(|(_, parent, active)| *parent == first_main && *active)
+        );
+        assert!(
+            shared_views
+                .iter()
+                .any(|(_, parent, active)| *parent == second_main && *active)
+        );
+        assert!(!app.world().entity(previous).contains::<vmux_core::Active>());
+    }
+
+    #[test]
+    fn deleting_a_shared_space_removes_every_view_and_activates_local_fallbacks() {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, vmux_layout::LayoutContractPlugin))
+            .add_message::<TabLayoutSpawnRequest>()
+            .add_observer(on_space_command);
+        let first_window = app.world_mut().spawn_empty().id();
+        let second_window = app.world_mut().spawn_empty().id();
+        app.insert_resource(vmux_layout::window::FocusedWindow(Some(second_window)));
+        let first_root = app.world_mut().spawn(HostWindow(first_window)).id();
+        let second_root = app.world_mut().spawn(HostWindow(second_window)).id();
+        let first_main = app
+            .world_mut()
+            .spawn((vmux_layout::window::Main, ChildOf(first_root)))
+            .id();
+        let second_main = app
+            .world_mut()
+            .spawn((vmux_layout::window::Main, ChildOf(second_root)))
+            .id();
+        for main in [first_main, second_main] {
+            app.world_mut().spawn((
+                vmux_layout::space::Space,
+                vmux_layout::space::SpaceId("shared".to_string()),
+                Name::new("shared"),
+                vmux_core::Order(0),
+                vmux_core::Active,
+                vmux_layout::space::space_view_bundle(),
+                ChildOf(main),
+            ));
+        }
+        app.world_mut().spawn((
+            vmux_layout::space::Space,
+            vmux_layout::space::SpaceId("fallback".to_string()),
+            Name::new("fallback"),
+            vmux_core::Order(1),
+            vmux_layout::space::space_view_bundle(),
+            ChildOf(first_main),
+        ));
+        let webview = app.world_mut().spawn(HostWindow(second_window)).id();
+
+        app.world_mut().trigger(BinReceive {
+            webview,
+            payload: SpaceCommandEvent {
+                command: "delete".to_string(),
+                space_id: Some("shared".to_string()),
+                name: None,
+            },
+        });
+        app.update();
+
+        let views: Vec<(String, Entity, bool)> = app
+            .world_mut()
+            .query_filtered::<(
+                &vmux_layout::space::SpaceId,
+                &ChildOf,
+                Has<vmux_core::Active>,
+            ), With<vmux_layout::space::Space>>()
+            .iter(app.world())
+            .map(|(id, parent, active)| (id.0.clone(), parent.parent(), active))
+            .collect();
+        assert!(views.iter().all(|(id, _, _)| id != "shared"));
+        assert_eq!(
+            views
+                .iter()
+                .filter(|(id, _, active)| id == "fallback" && *active)
+                .count(),
+            2
+        );
+        assert!(
+            views
+                .iter()
+                .any(|(id, parent, _)| id == "fallback" && *parent == first_main)
+        );
+        assert!(
+            views
+                .iter()
+                .any(|(id, parent, _)| id == "fallback" && *parent == second_main)
         );
     }
 
@@ -1163,6 +1557,7 @@ mod tests {
             .add_message::<TabLayoutSpawnRequest>()
             .add_observer(on_space_command);
         app.world_mut().spawn(bevy::window::PrimaryWindow);
+        let main = app.world_mut().spawn(vmux_layout::window::Main).id();
         let space = app
             .world_mut()
             .spawn((
@@ -1170,6 +1565,7 @@ mod tests {
                 vmux_layout::space::SpaceId("rename-src-test".to_string()),
                 Name::new("rename-src-test"),
                 vmux_core::Active,
+                ChildOf(main),
             ))
             .id();
         let tab = app
@@ -1178,6 +1574,7 @@ mod tests {
                 vmux_layout::tab::Tab::default(),
                 vmux_layout::space::SpaceId("rename-src-test".to_string()),
                 vmux_history::LastActivatedAt::now(),
+                ChildOf(space),
             ))
             .id();
 

--- a/crates/page/vmux_space/src/host/project.rs
+++ b/crates/page/vmux_space/src/host/project.rs
@@ -145,44 +145,33 @@ const UNLISTED_DIRS: &[&str] = &[
 pub struct SpaceProjects<'w, 's> {
     settings: Option<Res<'w, vmux_setting::AppSettings>>,
     active_space: Option<Res<'w, super::spaces::ActiveSpace>>,
+    active_space_entity: Option<Res<'w, vmux_layout::space::ActiveSpaceEntity>>,
     child_of: Query<'w, 's, &'static ChildOf>,
     spaces: Query<'w, 's, (), With<vmux_layout::space::Space>>,
     space_ids: Query<'w, 's, &'static vmux_layout::space::SpaceId>,
-    expanded: Query<
-        'w,
-        's,
-        (
-            &'static vmux_layout::space::SpaceId,
-            &'static ExpandedProjectDirs,
-        ),
-        With<vmux_layout::space::Space>,
-    >,
+    expanded: Query<'w, 's, &'static ExpandedProjectDirs, With<vmux_layout::space::Space>>,
 }
 
 impl SpaceProjects<'_, '_> {
     pub fn rows(&self, entity: Entity) -> Vec<vmux_core::event::ProjectRow> {
-        let space_id =
-            vmux_layout::space::space_id_of(entity, &self.child_of, &self.spaces, &self.space_ids);
-        let Some(space_id) = space_id else {
+        let Some(space) = vmux_layout::space::space_of(entity, &self.child_of, &self.spaces) else {
             return self.active_rows();
         };
-        self.rows_of(&space_id)
+        let Ok(space_id) = self.space_ids.get(space) else {
+            return self.active_rows();
+        };
+        self.rows_of(&space_id.0, Some(space))
     }
 
     pub fn active_rows(&self) -> Vec<vmux_core::event::ProjectRow> {
         let Some(active) = self.active_space.as_deref() else {
             return Vec::new();
         };
-        self.rows_of(&active.record.id)
-    }
-
-    fn expanded_of(&self, space_id: &str) -> Option<&ExpandedProjectDirs> {
-        for (id, dirs) in &self.expanded {
-            if id.0 == space_id {
-                return Some(dirs);
-            }
-        }
-        None
+        let space = self
+            .active_space_entity
+            .as_deref()
+            .and_then(|active| active.0);
+        self.rows_of(&active.record.id, space)
     }
 
     pub fn active_projects(&self) -> Vec<vmux_core::event::ProjectRow> {
@@ -202,9 +191,9 @@ impl SpaceProjects<'_, '_> {
         overrides.project_rows()
     }
 
-    fn rows_of(&self, space_id: &str) -> Vec<vmux_core::event::ProjectRow> {
+    fn rows_of(&self, space_id: &str, space: Option<Entity>) -> Vec<vmux_core::event::ProjectRow> {
         let listed = self.projects_of(space_id);
-        let Some(expanded) = self.expanded_of(space_id) else {
+        let Some(expanded) = space.and_then(|space| self.expanded.get(space).ok()) else {
             return listed;
         };
         let mut rows = Vec::new();
@@ -307,6 +296,7 @@ fn remember_space_project(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bevy::ecs::system::RunSystemOnce;
 
     #[derive(Resource, Default)]
     struct SawSettingsChange(bool);
@@ -476,6 +466,54 @@ mod tests {
             fixture.open_dirs().is_empty(),
             "the side sheet names its pane, and the space is reached through it"
         );
+    }
+
+    #[test]
+    fn project_expansion_is_local_to_the_owning_space_view() {
+        let root = tempfile::tempdir().unwrap();
+        let project = root.path().join("project");
+        std::fs::create_dir_all(project.join("src")).unwrap();
+        let path = project.to_string_lossy().into_owned();
+        let mut settings = vmux_setting::AppSettings::embedded();
+        settings.spaces.insert(
+            "work".to_string(),
+            vmux_setting::SpaceOverrides {
+                projects: vec![vmux_setting::SpaceProject::at(path.clone())],
+                active_project: Some(path.clone()),
+                ..Default::default()
+            },
+        );
+        let mut app = App::new();
+        app.insert_resource(settings);
+        let expanded_space = app
+            .world_mut()
+            .spawn((
+                vmux_layout::space::Space,
+                vmux_layout::space::SpaceId("work".to_string()),
+                ExpandedProjectDirs(vec![path]),
+            ))
+            .id();
+        let collapsed_space = app
+            .world_mut()
+            .spawn((
+                vmux_layout::space::Space,
+                vmux_layout::space::SpaceId("work".to_string()),
+            ))
+            .id();
+        let expanded_pane = app.world_mut().spawn(ChildOf(expanded_space)).id();
+        let collapsed_pane = app.world_mut().spawn(ChildOf(collapsed_space)).id();
+
+        let (expanded, collapsed) = app
+            .world_mut()
+            .run_system_once(move |projects: SpaceProjects| {
+                (projects.rows(expanded_pane), projects.rows(collapsed_pane))
+            })
+            .unwrap();
+
+        assert!(expanded[0].expanded);
+        assert!(expanded.len() > 1);
+        assert!(!collapsed[0].expanded);
+        assert_eq!(collapsed.len(), 1);
     }
 
     #[test]

--- a/crates/page/vmux_space/src/host/snapshot_updater.rs
+++ b/crates/page/vmux_space/src/host/snapshot_updater.rs
@@ -1,7 +1,8 @@
 use bevy::prelude::*;
+use bevy_cef::prelude::HostWindow;
 use vmux_command::snapshot::{CommandBarSpacesSnapshot, SpaceSummary};
 use vmux_core::Order;
-use vmux_layout::space::{ActiveSpaceId, Space, SpaceId};
+use vmux_layout::space::{Space, SpaceId};
 
 use crate::event::SPACES_PAGE_URL;
 
@@ -17,16 +18,39 @@ impl Plugin for SpaceSnapshotPlugin {
 }
 
 fn update_spaces_snapshot(
-    spaces: Query<(&SpaceId, &Name, Option<&Order>), With<Space>>,
-    active_id: Res<ActiveSpaceId>,
-    active_name: Query<&Name, (With<Space>, With<vmux_core::Active>)>,
+    spaces: Query<
+        (
+            Entity,
+            &SpaceId,
+            &Name,
+            Has<vmux_core::Active>,
+            Option<&Order>,
+        ),
+        With<Space>,
+    >,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
+    child_of: Query<&ChildOf>,
+    host_windows: Query<&HostWindow>,
     mut snapshot: ResMut<CommandBarSpacesSnapshot>,
 ) {
     let profile = crate::model::bootstrap_profile_name();
     let mut rows: Vec<(u32, SpaceSummary)> = Vec::new();
-    for (id, name, order) in &spaces {
+    let mut active_space_id = String::new();
+    let mut active_space_name = String::new();
+    for (entity, id, name, is_active, order) in &spaces {
+        let local = vmux_layout::window::host_window_of(entity, &child_of, &host_windows)
+            == focused_window.0;
+        if local && is_active {
+            active_space_id.clone_from(&id.0);
+            active_space_name = name.to_string();
+        }
+        let order = order.map(|order| order.0).unwrap_or(u32::MAX);
+        if let Some((existing_order, _)) = rows.iter_mut().find(|(_, summary)| summary.id == id.0) {
+            *existing_order = (*existing_order).min(order);
+            continue;
+        }
         rows.push((
-            order.map(|o| o.0).unwrap_or(u32::MAX),
+            order,
             SpaceSummary {
                 id: id.0.clone(),
                 name: name.to_string(),
@@ -38,12 +62,8 @@ fn update_spaces_snapshot(
 
     snapshot.set_if_neq(CommandBarSpacesSnapshot {
         spaces: rows.into_iter().map(|(_, summary)| summary).collect(),
-        active_space_id: active_id.0.clone().unwrap_or_default(),
-        active_space_name: active_name
-            .iter()
-            .next()
-            .map(|name| name.to_string())
-            .unwrap_or_default(),
+        active_space_id,
+        active_space_name,
         spaces_page_url: SPACES_PAGE_URL.to_string(),
     });
 }
@@ -61,13 +81,17 @@ mod tests {
         fn of_one() -> Self {
             let mut app = App::new();
             app.init_resource::<CommandBarSpacesSnapshot>()
-                .insert_resource(ActiveSpaceId(Some("space-1".to_string())))
                 .add_systems(Update, update_spaces_snapshot);
+            let window = app.world_mut().spawn_empty().id();
+            app.insert_resource(vmux_layout::window::FocusedWindow(Some(window)));
+            let root = app.world_mut().spawn(HostWindow(window)).id();
+            let main = app.world_mut().spawn(ChildOf(root)).id();
             app.world_mut().spawn((
                 Space,
                 SpaceId("space-1".to_string()),
                 Name::new("Space 1"),
                 vmux_core::Active,
+                ChildOf(main),
             ));
             let published_at = Self::changed_tick(&app);
             Self { app, published_at }
@@ -135,5 +159,43 @@ mod tests {
 
         assert!(spaces.republished(), "a rename has to reach the bar");
         assert_eq!(spaces.snapshot().active_space_name, "Renamed");
+    }
+
+    #[test]
+    fn publishes_global_spaces_with_the_focused_windows_active_space() {
+        let mut app = App::new();
+        app.init_resource::<CommandBarSpacesSnapshot>()
+            .add_systems(Update, update_spaces_snapshot);
+        let first_window = app.world_mut().spawn_empty().id();
+        let second_window = app.world_mut().spawn_empty().id();
+        app.insert_resource(vmux_layout::window::FocusedWindow(Some(first_window)));
+        for (window, id) in [(first_window, "first"), (second_window, "second")] {
+            let root = app.world_mut().spawn(HostWindow(window)).id();
+            let main = app.world_mut().spawn(ChildOf(root)).id();
+            app.world_mut().spawn((
+                Space,
+                SpaceId(id.to_string()),
+                Name::new(id.to_string()),
+                vmux_core::Active,
+                ChildOf(main),
+            ));
+        }
+
+        app.update();
+
+        let snapshot = app.world().resource::<CommandBarSpacesSnapshot>();
+        assert_eq!(snapshot.active_space_id, "first");
+        assert_eq!(snapshot.spaces.len(), 2);
+        assert_eq!(snapshot.spaces[0].id, "first");
+        assert_eq!(snapshot.spaces[1].id, "second");
+
+        app.world_mut()
+            .resource_mut::<vmux_layout::window::FocusedWindow>()
+            .0 = Some(second_window);
+        app.update();
+
+        let snapshot = app.world().resource::<CommandBarSpacesSnapshot>();
+        assert_eq!(snapshot.active_space_id, "second");
+        assert_eq!(snapshot.spaces.len(), 2);
     }
 }

--- a/crates/page/vmux_team/src/host.rs
+++ b/crates/page/vmux_team/src/host.rs
@@ -139,7 +139,7 @@ fn agent_page(
 }
 
 fn build_team_members(
-    active_space: &ActiveSpaceEntity,
+    active_space: Option<Entity>,
     user_q: &Query<(Entity, &Profile), With<User>>,
     agent_q: &Query<(
         Entity,
@@ -154,8 +154,6 @@ fn build_team_members(
     meta_q: &Query<&PageMetadata>,
     children_q: &Query<&Children>,
 ) -> Vec<TeamMemberRow> {
-    let active = active_space.0;
-
     let mut members = Vec::new();
     if let Ok((entity, profile)) = user_q.single() {
         members.push(team_member_row(
@@ -170,7 +168,7 @@ fn build_team_members(
             false,
         ));
     }
-    if let Some(active) = active {
+    if let Some(active) = active_space {
         for (entity, profile, agent, run, session, done) in agent_q {
             if space_of(entity, child_of, space_marker) == Some(active) {
                 let is_running = matches!(run, Some(AgentRunState::Streaming));
@@ -232,7 +230,7 @@ fn answer_list_team(
             continue;
         };
         let members = build_team_members(
-            &active_space,
+            active_space.0,
             &user_q,
             &agent_q,
             &child_of,
@@ -258,6 +256,7 @@ fn emit_team(
     pending_team: Query<Entity, (With<Team>, With<PageReady>, Without<TeamListSent>)>,
     sent_team: Query<Entity, (With<Team>, With<PageReady>, With<TeamListSent>)>,
     active_space: Res<ActiveSpaceEntity>,
+    active_spaces: Query<Entity, (With<Space>, With<vmux_core::Active>)>,
     user_q: Query<(Entity, &Profile), With<User>>,
     agent_q: Query<(
         Entity,
@@ -268,46 +267,51 @@ fn emit_team(
         Option<&vmux_core::notify::AgentDoneUnseen>,
     )>,
     child_of: Query<&ChildOf>,
+    host_windows: Query<&HostWindow>,
     space_marker: Query<(), With<Space>>,
     meta_q: Query<&PageMetadata>,
     children_q: Query<&Children>,
-    mut last: Local<Option<TeamEvent>>,
+    mut last: Local<std::collections::HashMap<Entity, TeamEvent>>,
     mut commands: Commands,
 ) {
-    let pending_total = pending_layout.iter().count() + pending_team.iter().count();
-    let sent_total = sent_layout.iter().count() + sent_team.iter().count();
-    if pending_total == 0 && sent_total == 0 {
-        return;
-    }
-
-    let payload = TeamEvent {
-        members: build_team_members(
-            &active_space,
-            &user_q,
-            &agent_q,
-            &child_of,
-            &space_marker,
-            &meta_q,
-            &children_q,
-        ),
-    };
-    let body_changed = last.as_ref() != Some(&payload);
-
-    for entity in pending_layout.iter().chain(pending_team.iter()) {
+    for (entity, pending) in pending_layout
+        .iter()
+        .chain(pending_team.iter())
+        .map(|entity| (entity, true))
+        .chain(
+            sent_layout
+                .iter()
+                .chain(sent_team.iter())
+                .map(|entity| (entity, false)),
+        )
+    {
+        let target_space = space_of(entity, &child_of, &space_marker).or_else(|| {
+            let window = vmux_layout::window::host_window_of(entity, &child_of, &host_windows)?;
+            active_spaces.iter().find(|space| {
+                vmux_layout::window::host_window_of(*space, &child_of, &host_windows)
+                    == Some(window)
+            })
+        });
+        let payload = TeamEvent {
+            members: build_team_members(
+                target_space.or(active_space.0),
+                &user_q,
+                &agent_q,
+                &child_of,
+                &space_marker,
+                &meta_q,
+                &children_q,
+            ),
+        };
+        if !pending && last.get(&entity) == Some(&payload) {
+            continue;
+        }
         if !browsers.can_emit_to(&entity) {
             continue;
         }
         commands.trigger(BinHostEmitEvent::from_rkyv(entity, TEAM_EVENT, &payload));
         commands.entity(entity).insert(TeamListSent);
-    }
-    if body_changed {
-        for entity in sent_layout.iter().chain(sent_team.iter()) {
-            if !browsers.can_emit_to(&entity) {
-                continue;
-            }
-            commands.trigger(BinHostEmitEvent::from_rkyv(entity, TEAM_EVENT, &payload));
-        }
-        *last = Some(payload);
+        last.insert(entity, payload);
     }
 }
 
@@ -592,7 +596,7 @@ mod tests {
                  meta_q: Query<&PageMetadata>,
                  children_q: Query<&Children>| {
                     build_team_members(
-                        &active,
+                        active.0,
                         &user_q,
                         &agent_q,
                         &child_of,

--- a/crates/vmux_browser/src/command.rs
+++ b/crates/vmux_browser/src/command.rs
@@ -224,12 +224,18 @@ fn on_header_command_emit(
 
 fn on_reload_notify_header(
     _trigger: On<RequestReload>,
-    cef: Option<Single<Entity, (With<LayoutCef>, With<PageReady>)>>,
+    layouts: Query<(Entity, &HostWindow), (With<LayoutCef>, With<PageReady>)>,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
     browsers: NonSend<Browsers>,
     mut commands: Commands,
 ) {
-    let Some(cef) = cef else { return };
-    let cef_e = *cef;
+    let Some(cef_e) = focused_window.0.and_then(|window| {
+        layouts
+            .iter()
+            .find_map(|(entity, host)| (host.0 == window).then_some(entity))
+    }) else {
+        return;
+    };
     if browsers.can_emit_to(&cef_e) {
         commands.trigger(BinHostEmitEvent::from_rkyv(
             cef_e,
@@ -241,12 +247,18 @@ fn on_reload_notify_header(
 
 fn on_hard_reload_notify_header(
     _trigger: On<RequestReloadIgnoreCache>,
-    cef: Option<Single<Entity, (With<LayoutCef>, With<PageReady>)>>,
+    layouts: Query<(Entity, &HostWindow), (With<LayoutCef>, With<PageReady>)>,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
     browsers: NonSend<Browsers>,
     mut commands: Commands,
 ) {
-    let Some(cef) = cef else { return };
-    let cef_e = *cef;
+    let Some(cef_e) = focused_window.0.and_then(|window| {
+        layouts
+            .iter()
+            .find_map(|(entity, host)| (host.0 == window).then_some(entity))
+    }) else {
+        return;
+    };
     if browsers.can_emit_to(&cef_e) {
         commands.trigger(BinHostEmitEvent::from_rkyv(
             cef_e,

--- a/crates/vmux_browser/src/frame_rate.rs
+++ b/crates/vmux_browser/src/frame_rate.rs
@@ -4,7 +4,7 @@ use bevy::{
         mouse::{MouseButton, MouseButtonInput, MouseWheel},
     },
     prelude::*,
-    window::{CursorMoved, PrimaryWindow},
+    window::CursorMoved,
     winit::{EventLoopProxyWrapper, WinitUserEvent},
 };
 use bevy_cef::prelude::*;
@@ -65,18 +65,22 @@ fn keep_asset_replies_moving(
 #[cfg(target_os = "macos")]
 fn refresh_layout_cef_hover(
     windows: Query<&Window>,
-    primary_window: Query<Entity, With<PrimaryWindow>>,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
     suppress: Res<CefSuppressPointerInput>,
-    layout_q: Query<Entity, With<LayoutCef>>,
+    layout_q: Query<(Entity, &HostWindow), With<LayoutCef>>,
 ) {
-    if layout_q.single().is_err() || suppress.0 {
+    if suppress.0 {
         NATIVE_LAYOUT_POINTER_INSIDE.store(false, Ordering::Relaxed);
         return;
     }
-    let Ok(window_entity) = primary_window.single() else {
+    let Some(window_entity) = focused_window.0 else {
         NATIVE_LAYOUT_POINTER_INSIDE.store(false, Ordering::Relaxed);
         return;
     };
+    if !layout_q.iter().any(|(_, host)| host.0 == window_entity) {
+        NATIVE_LAYOUT_POINTER_INSIDE.store(false, Ordering::Relaxed);
+        return;
+    }
     let Ok(window) = windows.get(window_entity) else {
         NATIVE_LAYOUT_POINTER_INSIDE.store(false, Ordering::Relaxed);
         return;
@@ -92,14 +96,22 @@ fn refresh_layout_cef_hover(
     browsers: NonSend<Browsers>,
     buttons: Res<ButtonInput<MouseButton>>,
     windows: Query<&Window>,
-    primary_window: Query<Entity, With<PrimaryWindow>>,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
     suppress: Res<CefSuppressPointerInput>,
-    layout_q: Query<Entity, With<LayoutCef>>,
+    layout_q: Query<(Entity, &HostWindow), With<LayoutCef>>,
     pointer_capture_q: Query<(), (With<LayoutCef>, LayoutPointerCapture)>,
     cef_regions: CefPointerRegionQuery<'_, '_>,
     mut state: Local<LayoutHoverRefreshState>,
 ) {
-    let Ok(layout) = layout_q.single() else {
+    let Some(window_entity) = focused_window.0 else {
+        NATIVE_LAYOUT_POINTER_INSIDE.store(false, Ordering::Relaxed);
+        *state = LayoutHoverRefreshState::default();
+        return;
+    };
+    let Some(layout) = layout_q
+        .iter()
+        .find_map(|(entity, host)| (host.0 == window_entity).then_some(entity))
+    else {
         NATIVE_LAYOUT_POINTER_INSIDE.store(false, Ordering::Relaxed);
         *state = LayoutHoverRefreshState::default();
         return;
@@ -109,11 +121,6 @@ fn refresh_layout_cef_hover(
         reset_layout_cef_hover(&browsers, &buttons, layout, &mut state);
         return;
     }
-    let Ok(window_entity) = primary_window.single() else {
-        NATIVE_LAYOUT_POINTER_INSIDE.store(false, Ordering::Relaxed);
-        reset_layout_cef_hover(&browsers, &buttons, layout, &mut state);
-        return;
-    };
     let Ok(window) = windows.get(window_entity) else {
         NATIVE_LAYOUT_POINTER_INSIDE.store(false, Ordering::Relaxed);
         reset_layout_cef_hover(&browsers, &buttons, layout, &mut state);
@@ -155,7 +162,7 @@ fn refresh_active_windowed_hover(
     browsers: NonSend<Browsers>,
     buttons: Res<ButtonInput<MouseButton>>,
     windows: Query<&Window>,
-    primary_window: Query<Entity, With<PrimaryWindow>>,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
     overlay_q: OverlayStateQuery,
     active_q: Query<
         (Entity, &Transform, &ComputedNode, Option<&HostWindow>),
@@ -187,10 +194,7 @@ fn refresh_active_windowed_hover(
         *state = WindowedHoverRefreshState::default();
         return;
     }
-    let Some(window_entity) = host_window
-        .map(|host| host.0)
-        .or_else(|| primary_window.single().ok())
-    else {
+    let Some(window_entity) = host_window.map(|host| host.0).or(focused_window.0) else {
         *state = WindowedHoverRefreshState::default();
         return;
     };
@@ -282,11 +286,17 @@ fn sync_layout_cef_frame_rate(
     mut wheel_events: MessageReader<MouseWheel>,
     mut key_events: MessageReader<KeyboardInput>,
     buttons: Res<ButtonInput<MouseButton>>,
-    mut layout_q: Query<(&mut WebviewMaxFrameRate, Has<KeyboardOwner>), With<LayoutCef>>,
+    mut layout_q: Query<
+        (&HostWindow, &mut WebviewMaxFrameRate, Has<KeyboardOwner>),
+        With<LayoutCef>,
+    >,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
     burst: Res<LayoutFrameRateBurst>,
     mut state: Local<LayoutFrameRateState>,
 ) {
-    let owns_keyboard = layout_q.iter().any(|(_, keyboard_target)| keyboard_target);
+    let owns_keyboard = layout_q.iter().any(|(host, _, keyboard_target)| {
+        host.0 == focused_window.0.unwrap_or(Entity::PLACEHOLDER) && keyboard_target
+    });
     let inside = NativeLayout::pointer_is_inside();
     let pointer = vmux_layout::native_pointer::snapshot();
     let native_changed = pointer.is_some_and(|pointer| {
@@ -321,11 +331,15 @@ fn sync_layout_cef_frame_rate(
         state.last_input.max(burst.last_emit),
         state.dragging_layout,
     );
-    let Ok((mut cap, _)) = layout_q.single_mut() else {
-        return;
-    };
-    if cap.0 != desired {
-        cap.0 = desired;
+    for (host, mut cap, _) in &mut layout_q {
+        let target = if Some(host.0) == focused_window.0 {
+            desired
+        } else {
+            LAYOUT_IDLE_FRAME_RATE
+        };
+        if cap.0 != target {
+            cap.0 = target;
+        }
     }
 }
 

--- a/crates/vmux_browser/src/host_focus.rs
+++ b/crates/vmux_browser/src/host_focus.rs
@@ -1,6 +1,6 @@
 use bevy::ecs::relationship::Relationship;
 use bevy::prelude::*;
-use bevy_cef::prelude::{Browsers, WebviewWindowed};
+use bevy_cef::prelude::{Browsers, HostWindow, WebviewWindowed};
 use vmux_core::KeyboardOwner;
 use vmux_core::overlay::{OverlayState, OverlayStateQuery, WindowOverlay};
 use vmux_layout::Header;
@@ -86,7 +86,8 @@ pub(crate) fn compute_host_focus_intent(
         ),
         With<WindowOverlay>,
     >,
-    layout_keyboard_q: Query<(), crate::present::LayoutKeyboardHost>,
+    layout_keyboard_q: Query<(Entity, Option<&HostWindow>), crate::present::LayoutKeyboardHost>,
+    focused_window: Option<Res<vmux_layout::window::FocusedWindow>>,
     native_q: Query<(), With<vmux_core::host::page::HostsPage>>,
     mut intent: ResMut<HostFocusIntent>,
 ) {
@@ -109,7 +110,12 @@ pub(crate) fn compute_host_focus_intent(
         } else {
             HostFocusIntent::WinitHost
         }
-    } else if !layout_keyboard_q.is_empty() {
+    } else if layout_keyboard_q.iter().any(|(_, host)| match host {
+        Some(host) => focused_window
+            .as_deref()
+            .is_none_or(|focused| focused.0 == Some(host.0)),
+        None => true,
+    }) {
         HostFocusIntent::LayoutView
     } else {
         let active = focus.stack.and_then(|stack| {

--- a/crates/vmux_browser/src/host_focus/macos.rs
+++ b/crates/vmux_browser/src/host_focus/macos.rs
@@ -1,7 +1,6 @@
 use crate::host_focus::HostFocusIntent;
 use bevy::ecs::system::NonSendMarker;
 use bevy::prelude::*;
-use bevy::window::PrimaryWindow;
 
 pub(crate) struct HostFocusPlatformPlugin;
 
@@ -14,7 +13,7 @@ impl Plugin for HostFocusPlatformPlugin {
 fn apply_winit_host_focus(
     _non_send: NonSendMarker,
     intent: Res<HostFocusIntent>,
-    primary: Query<Entity, With<PrimaryWindow>>,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
     mut keys: ResMut<ButtonInput<KeyCode>>,
     mut pending_key_window: Local<bool>,
 ) {
@@ -22,7 +21,7 @@ fn apply_winit_host_focus(
         *pending_key_window = false;
         return;
     }
-    let Ok(window_entity) = primary.single() else {
+    let Some(window_entity) = focused_window.0 else {
         return;
     };
     if should_release_keys(

--- a/crates/vmux_browser/src/input.rs
+++ b/crates/vmux_browser/src/input.rs
@@ -6,7 +6,7 @@ use bevy::{
         mouse::{MouseButtonInput, MouseWheel},
     },
     prelude::*,
-    window::{CursorMoved, PrimaryWindow},
+    window::CursorMoved,
 };
 use bevy_cef::prelude::*;
 use std::sync::atomic::Ordering;
@@ -54,19 +54,27 @@ fn log_command_bar_keyboard_input(
 }
 
 fn publish_layout_pointer_inside(
-    windows: Query<&Window, With<PrimaryWindow>>,
-    layout_q: Query<(), With<LayoutCef>>,
+    windows: Query<&Window>,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
+    layout_q: Query<(Entity, &HostWindow), With<LayoutCef>>,
     pointer_capture_q: Query<(), (With<LayoutCef>, LayoutPointerCapture)>,
     cef_regions: CefPointerRegionQuery<'_, '_>,
 ) {
-    if layout_q.single().is_err() {
+    let Some(window_entity) = focused_window.0 else {
         NATIVE_LAYOUT_POINTER_INSIDE.store(false, Ordering::Relaxed);
         return;
-    }
+    };
+    let Some(layout) = layout_q
+        .iter()
+        .find_map(|(entity, host)| (host.0 == window_entity).then_some(entity))
+    else {
+        NATIVE_LAYOUT_POINTER_INSIDE.store(false, Ordering::Relaxed);
+        return;
+    };
     #[cfg(target_os = "macos")]
-    let inside = !pointer_capture_q.is_empty()
+    let inside = pointer_capture_q.contains(layout)
         || windows
-            .single()
+            .get(window_entity)
             .ok()
             .and_then(|window| {
                 let scale = window.resolution.scale_factor();
@@ -77,9 +85,9 @@ fn publish_layout_pointer_inside(
             })
             .is_some_and(|position| cef_pointer_regions_contains(position, &cef_regions));
     #[cfg(not(target_os = "macos"))]
-    let inside = !pointer_capture_q.is_empty()
+    let inside = pointer_capture_q.contains(layout)
         || windows
-            .single()
+            .get(window_entity)
             .ok()
             .and_then(Window::cursor_position)
             .is_some_and(|pos| cef_pointer_regions_contains(pos, &cef_regions));
@@ -97,7 +105,7 @@ fn forward_layout_cef_cursor_move(
     buttons: Res<ButtonInput<MouseButton>>,
     suppress: Res<CefSuppressPointerInput>,
     browsers: NonSend<Browsers>,
-    layout_q: Query<Entity, With<LayoutCef>>,
+    layout_q: Query<(Entity, &HostWindow), With<LayoutCef>>,
     pointer_capture_q: Query<(), (With<LayoutCef>, LayoutPointerCapture)>,
     cef_regions: CefPointerRegionQuery<'_, '_>,
     mut was_in_region: Local<bool>,
@@ -107,13 +115,15 @@ fn forward_layout_cef_cursor_move(
         *was_in_region = false;
         return;
     }
-    let Ok(layout) = layout_q.single() else {
-        for _ in events.read() {}
-        *was_in_region = false;
-        return;
-    };
     for event in events.read() {
-        let in_region = !pointer_capture_q.is_empty()
+        let Some(layout) = layout_q
+            .iter()
+            .find_map(|(entity, host)| (host.0 == event.window).then_some(entity))
+        else {
+            *was_in_region = false;
+            continue;
+        };
+        let in_region = pointer_capture_q.contains(layout)
             || cef_pointer_regions_contains(event.position, &cef_regions);
         if in_region {
             browsers.send_mouse_move(&layout, buttons.get_pressed(), event.position, false);
@@ -129,26 +139,27 @@ fn forward_layout_cef_mouse_button(
     windows: Query<&Window>,
     suppress: Res<CefSuppressPointerInput>,
     browsers: NonSend<Browsers>,
-    layout_q: Query<Entity, With<LayoutCef>>,
+    layout_q: Query<(Entity, &HostWindow), With<LayoutCef>>,
     pointer_capture_q: Query<(), (With<LayoutCef>, LayoutPointerCapture)>,
     cef_regions: CefPointerRegionQuery<'_, '_>,
-    mut captured: Local<bool>,
+    mut captured: Local<Option<Entity>>,
 ) {
     if suppress.0 {
         for _ in events.read() {}
-        *captured = false;
+        *captured = None;
         return;
     }
-    let Ok(layout) = layout_q.single() else {
-        for _ in events.read() {}
-        *captured = false;
-        return;
-    };
     for event in events.read() {
         let Some(button) = pointer_button_from_mouse_button(event.button) else {
             continue;
         };
         let Ok(window) = windows.get(event.window) else {
+            continue;
+        };
+        let Some(layout) = layout_q
+            .iter()
+            .find_map(|(entity, host)| (host.0 == event.window).then_some(entity))
+        else {
             continue;
         };
         #[cfg(target_os = "macos")]
@@ -162,12 +173,12 @@ fn forward_layout_cef_mouse_button(
         let Some(position) = position else {
             continue;
         };
-        let inside =
-            !pointer_capture_q.is_empty() || cef_pointer_regions_contains(position, &cef_regions);
+        let inside = pointer_capture_q.contains(layout)
+            || cef_pointer_regions_contains(position, &cef_regions);
         if event.state == ButtonState::Pressed && inside {
-            *captured = true;
+            *captured = Some(layout);
         }
-        if inside || *captured {
+        if inside || *captured == Some(layout) {
             #[cfg(target_os = "macos")]
             if let Some(pointer) = native_pointer {
                 browsers.send_native_mouse_move(&layout, pointer.buttons, position, !inside);
@@ -180,7 +191,7 @@ fn forward_layout_cef_mouse_button(
             );
         }
         if event.state == ButtonState::Released {
-            *captured = false;
+            *captured = None;
         }
     }
 }

--- a/crates/vmux_browser/src/lib.rs
+++ b/crates/vmux_browser/src/lib.rs
@@ -385,6 +385,28 @@ fn tab_of(
 }
 
 fn sync_cef_backend(world: &mut World) {
+    let mut browser_entities = world.query_filtered::<Entity, With<Browser>>();
+    let browser_entities: Vec<Entity> = browser_entities.iter(world).collect();
+    let mut moved = Vec::new();
+    for entity in browser_entities {
+        let mut current = entity;
+        let mut inherited = None;
+        while let Some(parent) = world.get::<ChildOf>(current).map(Relationship::get) {
+            if let Some(host) = world.get::<HostWindow>(parent) {
+                inherited = Some(*host);
+                break;
+            }
+            current = parent;
+        }
+        let Some(inherited) = inherited else {
+            continue;
+        };
+        if world.get::<HostWindow>(entity) != Some(&inherited) {
+            world.entity_mut(entity).insert(inherited);
+            moved.push(entity);
+        }
+    }
+
     let mut query = world.query_filtered::<(
         Entity,
         Has<WebviewNativeOverlay>,
@@ -398,7 +420,7 @@ fn sync_cef_backend(world: &mut World) {
                 .is_windowed(&entity)
                 .is_some_and(|windowed| !windowed);
             let stale_overlay = browsers.has_browser(entity) && native_overlay;
-            if stale_backend || stale_overlay {
+            if stale_backend || stale_overlay || moved.contains(&entity) {
                 recreate.push(entity);
             }
         }

--- a/crates/vmux_browser/src/native_page/macos.rs
+++ b/crates/vmux_browser/src/native_page/macos.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use bevy::ecs::relationship::Relationship;
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 use bevy::winit::{EventLoopProxy, EventLoopProxyWrapper, WINIT_WINDOWS, WinitUserEvent};
@@ -61,6 +62,7 @@ struct HostedPage {
     surface: WebView,
     placement: Placement,
     page: &'static NativePage,
+    window: Entity,
 }
 
 struct NativePageMetadata {
@@ -105,9 +107,11 @@ impl HostedPages {
         self.0.get(&page)
     }
 
-    fn layout(&self) -> Option<Entity> {
+    fn layout(&self, window: Option<Entity>) -> Option<Entity> {
         for (entity, hosted) in self.0.iter() {
-            if hosted.placement == Placement::Layout {
+            if hosted.placement == Placement::Layout
+                && window.is_none_or(|window| hosted.window == window)
+            {
                 return Some(*entity);
             }
         }
@@ -128,13 +132,10 @@ fn open_native_pages(world: &mut World) {
         return;
     }
 
-    let Ok(window_entity) = world
+    let primary_window = world
         .query_filtered::<Entity, With<PrimaryWindow>>()
         .single(world)
-    else {
-        report_waiting("no primary window entity");
-        return;
-    };
+        .ok();
     let embedder = match PageEmbedder::of(world) {
         Ok(embedder) => embedder,
         Err(reason) => {
@@ -148,18 +149,26 @@ fn open_native_pages(world: &mut World) {
     }
 
     for (entity, page, placement, read_instance) in wanted {
+        let Some(window_entity) = host_window_for(world, entity).or(primary_window) else {
+            report_waiting("page has no host window entity");
+            continue;
+        };
         let current = world
             .get_non_send::<HostedPages>()
             .and_then(|hosted| hosted.0.get(&entity))
-            .map(|hosted| hosted.page);
-        if current.is_some_and(|current| std::ptr::eq(current, page)) {
+            .map(|hosted| (hosted.page, hosted.window));
+        if current
+            .is_some_and(|(current, window)| std::ptr::eq(current, page) && window == window_entity)
+        {
             continue;
         }
         let instance = match read_instance {
             Some(read) => read(world, entity),
             None => vmux_native::Instance::default(),
         };
-        if current.is_some_and(|current| current.transparent == page.transparent) {
+        if current.is_some_and(|(current, window)| {
+            current.transparent == page.transparent && window == window_entity
+        }) {
             world
                 .entity_mut(entity)
                 .remove::<vmux_core::page::PageReady>();
@@ -215,6 +224,7 @@ fn open_native_pages(world: &mut World) {
                         surface,
                         placement,
                         page,
+                        window: window_entity,
                     },
                 );
             }
@@ -231,7 +241,7 @@ fn open_native_pages(world: &mut World) {
 fn place_native_pages(
     hosted: Option<NonSendMut<HostedPages>>,
     frames: Res<PaneFrames>,
-    window: Query<&Window, With<PrimaryWindow>>,
+    windows: Query<&Window>,
     pages: Query<(), With<HostsPage>>,
     capturing: Query<(), (With<LayoutCef>, LayoutPointerCapture)>,
     settings: Res<AppSettings>,
@@ -247,17 +257,16 @@ fn place_native_pages(
     {
         let _ = proxy.send_event(WinitUserEvent::WakeUp);
     }
-    let window = window.single().ok();
     let capturing = !capturing.is_empty();
-    let all_corners = frames.all_corners();
     for (entity, page) in hosted.0.iter() {
+        let window = windows.get(page.window).ok();
         let Some(bounds) = page.placement.bounds(*entity, window, &frames) else {
             page.surface.set_visible(false);
             continue;
         };
         page.surface.set_bounds(bounds);
         page.surface
-            .set_corner_radius(settings.layout.radius as f64, all_corners);
+            .set_corner_radius(settings.layout.radius as f64, frames.all_corners(*entity));
         let ring = frames.ring_of(*entity);
         page.surface.set_focus_ring(ring.width as f64, ring.rgb);
         page.surface.set_visible(true);
@@ -279,12 +288,13 @@ fn render_native_pages(hosted: Option<NonSend<HostedPages>>) {
 fn focus_native_page(
     hosted: Option<NonSend<HostedPages>>,
     intent: Res<crate::host_focus::HostFocusIntent>,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
 ) {
     let Some(hosted) = hosted else {
         return;
     };
     let wanted = match *intent {
-        crate::host_focus::HostFocusIntent::LayoutView => hosted.layout(),
+        crate::host_focus::HostFocusIntent::LayoutView => hosted.layout(focused_window.0),
         crate::host_focus::HostFocusIntent::NativePane(page) => Some(page),
         _ => return,
     };
@@ -292,6 +302,16 @@ fn focus_native_page(
         return;
     };
     page.surface.take_first_responder();
+}
+
+fn host_window_for(world: &World, entity: Entity) -> Option<Entity> {
+    let mut current = entity;
+    loop {
+        if let Some(host) = world.get::<bevy_cef::prelude::HostWindow>(current) {
+            return Some(host.0);
+        }
+        current = world.get::<ChildOf>(current).map(Relationship::get)?;
+    }
 }
 
 fn forward_host_emit(host_emit: On<BinHostEmitEvent>, hosted: Option<NonSend<HostedPages>>) {

--- a/crates/vmux_browser/src/page_state.rs
+++ b/crates/vmux_browser/src/page_state.rs
@@ -1,4 +1,4 @@
-use bevy::{ecs::relationship::Relationship, prelude::*, window::PrimaryWindow};
+use bevy::{ecs::relationship::Relationship, prelude::*};
 use bevy_cef::prelude::*;
 use vmux_core::{
     PageIdentity, PageMetadata,
@@ -30,6 +30,32 @@ use crate::{
 };
 use vmux_flex::prelude::*;
 
+#[derive(bevy::ecs::system::SystemParam)]
+struct FocusedLayout<'w, 's> {
+    focused: Res<'w, vmux_layout::window::FocusedWindow>,
+    layouts: Query<'w, 's, (Entity, Ref<'static, PageReady>), With<LayoutCef>>,
+    host_windows: Query<'w, 's, &'static HostWindow>,
+}
+
+impl FocusedLayout<'_, '_> {
+    fn get(&self) -> Option<(Entity, bool)> {
+        let entity = self
+            .focused
+            .0
+            .and_then(|window| {
+                self.layouts.iter().find_map(|(entity, _)| {
+                    self.host_windows
+                        .get(entity)
+                        .is_ok_and(|host| host.0 == window)
+                        .then_some(entity)
+                })
+            })
+            .or_else(|| self.layouts.iter().next().map(|(entity, _)| entity))?;
+        let (_, ready) = self.layouts.get(entity).ok()?;
+        Some((entity, ready.is_changed()))
+    }
+}
+
 pub(crate) struct PageStatePlugin;
 
 impl Plugin for PageStatePlugin {
@@ -54,41 +80,58 @@ impl Plugin for PageStatePlugin {
 fn push_layout_state_emit(
     mut commands: Commands,
     browsers: NonSend<Browsers>,
-    cef_q: Query<(Entity, Ref<PageReady>), With<LayoutCef>>,
-    header_q: Query<(Has<Open>, Option<&ComputedNode>), With<Header>>,
-    side_sheet_q: Query<(&SideSheetPosition, Has<Open>), With<SideSheet>>,
-    window_q: Query<&Node, With<VmuxWindow>>,
-    windows: Query<&Window, With<PrimaryWindow>>,
+    layout: FocusedLayout,
+    child_of: Query<&ChildOf>,
+    header_q: Query<(Entity, Has<Open>, Option<&ComputedNode>), With<Header>>,
+    side_sheet_q: Query<(Entity, &SideSheetPosition, Has<Open>), With<SideSheet>>,
+    window_q: Query<(&HostWindow, &Node), With<VmuxWindow>>,
+    windows: Query<&Window>,
     side_sheet_width: Res<SideSheetWidth>,
     settings: Res<AppSettings>,
-    mut last: Local<String>,
+    mut last: Local<std::collections::HashMap<Entity, String>>,
 ) {
-    let Ok((cef_e, page_ready)) = cef_q.single() else {
+    let Some((cef_e, page_ready_changed)) = layout.get() else {
         return;
     };
     if !browsers.can_emit_to(&cef_e) {
         return;
     }
+    let Some(host_window) = layout.host_windows.get(cef_e).ok().map(|host| host.0) else {
+        return;
+    };
     let window_padding = window_q
-        .single()
-        .ok()
+        .iter()
+        .find_map(|(host, node)| (host.0 == host_window).then_some(node))
         .map(layout_window_padding_from_node)
         .unwrap_or_else(|| layout_window_padding_from_settings(&settings));
-    let header_open = header_q.iter().any(|(is_open, _)| is_open);
+    let header_open = header_q.iter().any(|(entity, is_open, _)| {
+        is_open
+            && vmux_layout::window::host_window_of(entity, &child_of, &layout.host_windows)
+                == Some(host_window)
+    });
     let window_width_px = windows
-        .single()
+        .get(host_window)
         .ok()
         .map(|window| window.resolution.physical_width() as f32)
         .unwrap_or(0.0);
-    let header_offsets = header_q
-        .iter()
-        .find_map(|(_, computed)| LayoutFixedOffsets::of(computed?, window_width_px));
+    let header_offsets = header_q.iter().find_map(|(entity, _, computed)| {
+        if vmux_layout::window::host_window_of(entity, &child_of, &layout.host_windows)
+            == Some(host_window)
+        {
+            LayoutFixedOffsets::of(computed?, window_width_px)
+        } else {
+            None
+        }
+    });
 
     let payload = LayoutStateEvent {
         header_open,
-        side_sheet_open: side_sheet_q
-            .iter()
-            .any(|(pos, is_open)| *pos == SideSheetPosition::Left && is_open),
+        side_sheet_open: side_sheet_q.iter().any(|(entity, pos, is_open)| {
+            *pos == SideSheetPosition::Left
+                && is_open
+                && vmux_layout::window::host_window_of(entity, &child_of, &layout.host_windows)
+                    == Some(host_window)
+        }),
         header_height: header_offsets
             .map(|offsets| offsets.height)
             .unwrap_or(HEADER_HEIGHT_PX),
@@ -104,7 +147,8 @@ fn push_layout_state_emit(
         window_pad_left: window_padding.left,
     };
     let body = ron::ser::to_string(&payload).unwrap_or_default();
-    if !should_emit_cached_payload(&body, &last, page_ready.is_changed()) {
+    let previous = last.get(&cef_e).map(String::as_str).unwrap_or_default();
+    if !should_emit_cached_payload(&body, previous, page_ready_changed) {
         return;
     }
     commands.trigger(BinHostEmitEvent::from_rkyv(
@@ -112,7 +156,7 @@ fn push_layout_state_emit(
         LAYOUT_STATE_EVENT,
         &payload,
     ));
-    *last = body;
+    last.insert(cef_e, body);
 }
 
 struct AddressRoots<'a> {
@@ -152,7 +196,7 @@ impl AddressRoots<'_> {
 fn push_stacks_host_emit(
     mut commands: Commands,
     browsers: NonSend<Browsers>,
-    cef_q: Query<(Entity, Ref<PageReady>), With<LayoutCef>>,
+    layout: FocusedLayout,
     browser_q: Query<
         (
             &PageMetadata,
@@ -168,9 +212,9 @@ fn push_stacks_host_emit(
     focus: Res<vmux_layout::stack::FocusedStack>,
     child_of_q: Query<&ChildOf>,
     mut repo_info: Option<ResMut<vmux_git::RepoInfoCache>>,
-    mut last: Local<String>,
+    mut last: Local<std::collections::HashMap<Entity, String>>,
 ) {
-    let Ok((cef_e, page_ready)) = cef_q.single() else {
+    let Some((cef_e, page_ready_changed)) = layout.get() else {
         return;
     };
     if !browsers.can_emit_to(&cef_e) {
@@ -233,17 +277,18 @@ fn push_stacks_host_emit(
         is_zoomed,
     };
     let ron_body = ron::ser::to_string(&payload).unwrap_or_default();
-    if !should_emit_cached_payload(&ron_body, &last, page_ready.is_changed()) {
+    let previous = last.get(&cef_e).map(String::as_str).unwrap_or_default();
+    if !should_emit_cached_payload(&ron_body, previous, page_ready_changed) {
         return;
     }
     commands.trigger(BinHostEmitEvent::from_rkyv(cef_e, STACKS_EVENT, &payload));
-    *last = ron_body;
+    last.insert(cef_e, ron_body);
 }
 
 fn push_pane_tree_emit(
     mut commands: Commands,
     browsers: NonSend<Browsers>,
-    cef_q: Query<(Entity, Ref<PageReady>), With<LayoutCef>>,
+    layout: FocusedLayout,
     focus: Res<vmux_layout::stack::FocusedStack>,
     tab_q: Query<(), With<Tab>>,
     sections_of: vmux_layout::side_sheet::SideSheetSections,
@@ -263,9 +308,9 @@ fn push_pane_tree_emit(
         ),
         With<Browser>,
     >,
-    mut last: Local<String>,
+    mut last: Local<std::collections::HashMap<Entity, String>>,
 ) {
-    let Ok((cef_e, page_ready)) = cef_q.single() else {
+    let Some((cef_e, page_ready_changed)) = layout.get() else {
         return;
     };
     if !browsers.can_emit_to(&cef_e) {
@@ -350,7 +395,8 @@ fn push_pane_tree_emit(
     }
     let payload = PaneTreeEvent { panes };
     let ron_body = ron::ser::to_string(&payload).unwrap_or_default();
-    if !should_emit_cached_payload(&ron_body, &last, page_ready.is_changed()) {
+    let previous = last.get(&cef_e).map(String::as_str).unwrap_or_default();
+    if !should_emit_cached_payload(&ron_body, previous, page_ready_changed) {
         return;
     }
     commands.trigger(BinHostEmitEvent::from_rkyv(
@@ -358,7 +404,7 @@ fn push_pane_tree_emit(
         PANE_TREE_EVENT,
         &payload,
     ));
-    *last = ron_body;
+    last.insert(cef_e, ron_body);
 }
 
 fn abbreviate_project_path(path: &std::path::Path) -> String {
@@ -380,16 +426,16 @@ fn abbreviate_project_path(path: &std::path::Path) -> String {
 fn push_projects_host_emit(
     mut commands: Commands,
     browsers: NonSend<Browsers>,
-    cef_q: Query<(Entity, Ref<PageReady>), With<LayoutCef>>,
+    layout: FocusedLayout,
     settings: Res<AppSettings>,
     active_space: Option<Res<vmux_space::spaces::ActiveSpace>>,
     space_projects: vmux_space::SpaceProjects,
     expansion_changed: Query<(), Changed<vmux_space::ExpandedProjectDirs>>,
-    mut last: Local<String>,
+    mut last: Local<std::collections::HashMap<Entity, String>>,
     mut listed: Local<Option<Vec<vmux_core::event::ProjectRow>>>,
     mut repo_info: Option<ResMut<vmux_git::RepoInfoCache>>,
 ) {
-    let Ok((cef_e, page_ready)) = cef_q.single() else {
+    let Some((cef_e, page_ready_changed)) = layout.get() else {
         return;
     };
     if !browsers.can_emit_to(&cef_e) {
@@ -422,8 +468,9 @@ fn push_projects_host_emit(
         boundary: None,
         projects,
     };
-    let body = ron::ser::to_string(&payload).unwrap_or_default();
-    if !should_emit_cached_payload(&body, &last, page_ready.is_changed()) {
+    let ron_body = ron::ser::to_string(&payload).unwrap_or_default();
+    let previous = last.get(&cef_e).map(String::as_str).unwrap_or_default();
+    if !should_emit_cached_payload(&ron_body, previous, page_ready_changed) {
         return;
     }
     commands.trigger(BinHostEmitEvent::from_rkyv(
@@ -431,14 +478,14 @@ fn push_projects_host_emit(
         TAB_BOUNDARY_EVENT,
         &payload,
     ));
-    *last = body;
+    last.insert(cef_e, ron_body);
 }
 
 #[allow(clippy::too_many_arguments)]
 fn push_bookmarks_host_emit(
     mut commands: Commands,
     browsers: NonSend<Browsers>,
-    cef_q: Query<(Entity, Ref<PageReady>), With<LayoutCef>>,
+    layout: FocusedLayout,
     pins: Query<
         (
             &vmux_core::Uuid,
@@ -479,9 +526,9 @@ fn push_bookmarks_host_emit(
         ),
         With<vmux_core::Bookmark>,
     >,
-    mut last: Local<String>,
+    mut last: Local<std::collections::HashMap<Entity, String>>,
 ) {
-    let Ok((cef_e, page_ready)) = cef_q.single() else {
+    let Some((cef_e, page_ready_changed)) = layout.get() else {
         return;
     };
     if !browsers.can_emit_to(&cef_e) {
@@ -548,7 +595,7 @@ fn push_bookmarks_host_emit(
         roots,
     };
     let body = ron::ser::to_string(&payload).unwrap_or_default();
-    if !page_ready.is_changed() && body == *last {
+    if !page_ready_changed && last.get(&cef_e) == Some(&body) {
         return;
     }
     commands.trigger(BinHostEmitEvent::from_rkyv(
@@ -556,13 +603,13 @@ fn push_bookmarks_host_emit(
         vmux_layout::event::BOOKMARKS_EVENT,
         &payload,
     ));
-    *last = body;
+    last.insert(cef_e, body);
 }
 
 fn push_tabs_host_emit(
     mut commands: Commands,
     browsers: NonSend<Browsers>,
-    cef_q: Query<(Entity, Ref<PageReady>), With<LayoutCef>>,
+    layout: FocusedLayout,
     tabs: Query<(Entity, &Tab, &LastActivatedAt)>,
     tab_q: Query<Entity, With<Tab>>,
     active_tab_param: vmux_layout::stack::ActiveTabParam,
@@ -574,9 +621,9 @@ fn push_tabs_host_emit(
     stack_children: Query<&Children>,
     browser_meta: Query<(&PageMetadata, Option<&PageIdentity>), With<Browser>>,
     done_agents: Query<Entity, With<vmux_core::notify::AgentDoneUnseen>>,
-    mut last: Local<String>,
+    mut last: Local<std::collections::HashMap<Entity, String>>,
 ) {
-    let Ok((cef_e, page_ready)) = cef_q.single() else {
+    let Some((cef_e, page_ready_changed)) = layout.get() else {
         return;
     };
     if !browsers.can_emit_to(&cef_e) {
@@ -635,27 +682,28 @@ fn push_tabs_host_emit(
 
     let payload = TabsHostEvent { tabs: rows };
     let body = ron::ser::to_string(&payload).unwrap_or_default();
-    if !page_ready.is_changed() && body == *last {
+    if !page_ready_changed && last.get(&cef_e) == Some(&body) {
         return;
     }
     commands.trigger(BinHostEmitEvent::from_rkyv(cef_e, TABS_EVENT, &payload));
-    *last = body;
+    last.insert(cef_e, body);
 }
 
 fn push_update_notice_emit(
     mut commands: Commands,
     browsers: NonSend<Browsers>,
-    cef_q: Query<(Entity, Ref<PageReady>), With<LayoutCef>>,
+    layout: FocusedLayout,
     state: Res<UpdateState>,
-    mut last: Local<Option<UpdateState>>,
+    mut last: Local<std::collections::HashMap<Entity, UpdateState>>,
 ) {
-    let Ok((cef_e, page_ready)) = cef_q.single() else {
+    let Some((cef_e, page_ready_changed)) = layout.get() else {
         return;
     };
     if !browsers.can_emit_to(&cef_e) {
         return;
     }
-    if !should_emit_update(&state, &last, page_ready.is_changed()) {
+    let previous = last.get(&cef_e).cloned();
+    if !should_emit_update(&state, &previous, page_ready_changed) {
         return;
     }
     match &*state {
@@ -696,5 +744,5 @@ fn push_update_notice_emit(
             },
         )),
     }
-    *last = Some(state.clone());
+    last.insert(cef_e, state.clone());
 }

--- a/crates/vmux_browser/src/present.rs
+++ b/crates/vmux_browser/src/present.rs
@@ -1,7 +1,7 @@
 use bevy::{
     ecs::relationship::Relationship,
     prelude::*,
-    window::{PrimaryWindow, WindowResized},
+    window::WindowResized,
     winit::{EventLoopProxyWrapper, WinitUserEvent},
 };
 use bevy_cef::prelude::*;
@@ -67,13 +67,37 @@ pub(crate) type LayoutKeyboardCapture = Or<(
 )>;
 
 pub(crate) type LayoutKeyboardHost = (With<LayoutCef>, LayoutKeyboardCapture);
+
+#[derive(bevy::ecs::system::SystemParam)]
+struct WindowHierarchy<'w, 's> {
+    child_of: Query<'w, 's, &'static ChildOf>,
+    host_windows: Query<'w, 's, &'static HostWindow>,
+}
+
+impl WindowHierarchy<'_, '_> {
+    fn host_of(&self, entity: Entity) -> Option<Entity> {
+        vmux_layout::window::host_window_of(entity, &self.child_of, &self.host_windows)
+    }
+}
+
+#[derive(bevy::ecs::system::SystemParam)]
+pub(crate) struct WindowFrameQueries<'w, 's> {
+    hierarchy: WindowHierarchy<'w, 's>,
+    pane_rect: Query<'w, 's, &'static ComputedNode, With<Pane>>,
+    header_rect: Query<'w, 's, (Entity, &'static ComputedNode), (With<Header>, With<Open>)>,
+    tabs: Query<'w, 's, (Entity, &'static LastActivatedAt), With<Tab>>,
+    all_children: Query<'w, 's, &'static Children>,
+    leaf_panes: Query<'w, 's, Entity, (With<Pane>, Without<PaneSplit>)>,
+}
+
 fn sync_keyboard_target(
     focus: Res<vmux_layout::stack::FocusedStack>,
     child_of_q: Query<&ChildOf>,
     status_q: Query<(), With<Header>>,
     side_sheet_q: Query<(), With<SideSheet>>,
     modal_q: Query<(Entity, &Node, Has<KeyboardOwner>), With<WindowOverlay>>,
-    layout_keyboard_q: Query<Entity, LayoutKeyboardHost>,
+    layout_keyboard_q: Query<(Entity, &HostWindow), LayoutKeyboardHost>,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
     content_q: Query<(Entity, Has<KeyboardOwner>), With<Browser>>,
     mut commands: Commands,
 ) {
@@ -88,7 +112,10 @@ fn sync_keyboard_target(
         return;
     }
 
-    if layout_keyboard_q.single().is_ok() {
+    if layout_keyboard_q
+        .iter()
+        .any(|(_, host)| Some(host.0) == focused_window.0)
+    {
         for (browser_e, has_kb) in &content_q {
             if has_kb {
                 commands.entity(browser_e).try_remove::<KeyboardOwner>();
@@ -142,6 +169,7 @@ fn tab_ancestor(
 fn sync_children_to_ui(
     mut browser_q: Query<
         (
+            Entity,
             &mut Transform,
             &ComputedNode,
             &ChildOf,
@@ -158,19 +186,16 @@ fn sync_children_to_ui(
         ),
         With<Browser>,
     >,
-    child_of_q: Query<&ChildOf>,
+    hierarchy: WindowHierarchy,
     pane_rect: Query<&ComputedNode, With<Pane>>,
     pane_children: Query<&Children, With<Pane>>,
     tab_ts: Query<(Entity, &LastActivatedAt), With<Stack>>,
     tabs_q: Query<(Entity, &LastActivatedAt), With<Tab>>,
     active_tab_q: Query<(), (With<Tab>, With<vmux_core::Active>)>,
-    glass: Single<(Entity, &ComputedNode), With<VmuxWindow>>,
+    roots: Query<(Entity, &HostWindow, &ComputedNode), With<VmuxWindow>>,
 ) {
-    let &(glass_entity, glass_node) = &*glass;
-    let glass_rect = *glass_node;
-    let glass_size_px = glass_rect.padding_box();
-
     for (
+        browser,
         mut tf,
         self_computed,
         child_of,
@@ -186,8 +211,22 @@ fn sync_children_to_ui(
         is_windowed,
     ) in browser_q.iter_mut()
     {
+        let Some(host_window) = hierarchy.host_of(browser) else {
+            continue;
+        };
+        let Some((glass_entity, _, glass_node)) =
+            roots.iter().find(|(_, host, _)| host.0 == host_window)
+        else {
+            continue;
+        };
+        let glass_rect = *glass_node;
+        let glass_size_px = glass_rect.padding_box();
         let parent = child_of.get();
-        let pane_entity = child_of_q.get(parent).map(|co| co.get()).unwrap_or(parent);
+        let pane_entity = hierarchy
+            .child_of
+            .get(parent)
+            .map(|co| co.get())
+            .unwrap_or(parent);
         let computed = match pane_rect.get(pane_entity) {
             Ok(cn) => cn,
             Err(_) => self_computed,
@@ -201,7 +240,7 @@ fn sync_children_to_ui(
 
         let under_inactive_tab = parent != glass_entity
             && !is_cef_ui
-            && match tab_ancestor(parent, &child_of_q, &tabs_q) {
+            && match tab_ancestor(parent, &hierarchy.child_of, &tabs_q) {
                 Some(tab) => !active_tab_q.contains(tab),
                 None => false,
             };
@@ -353,21 +392,15 @@ pub(crate) fn sync_windowed_frames(
             Without<WindowOverlay>,
         ),
     >,
-    child_of_q: Query<&ChildOf>,
-    pane_rect: Query<&ComputedNode, With<Pane>>,
-    header_rect: Query<&ComputedNode, (With<Header>, With<Open>)>,
-    all_children: Query<&Children>,
-    leaf_panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
+    queries: WindowFrameQueries,
     mut memory: Local<FrameSyncMemory>,
     mut last_windowed_pages: Local<Vec<Entity>>,
     mut pane_frames: ResMut<PaneFrames>,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
 ) {
     pane_frames.frames.clear();
     pane_frames.rings.clear();
-    let visible_pane_count =
-        visible_pane_count_for_windowed_sync(focus.tab, &all_children, &leaf_panes);
-    pane_frames.all_corners = windowed_page_all_corners(layout_hidden.0, visible_pane_count);
-    let header_frame = header_rect.iter().find_map(WindowedFrameRect::of);
+    pane_frames.all_corners.clear();
     let force_raise = layout_hidden.is_changed();
     let mut hidden = Vec::new();
     let mut visible = Vec::new();
@@ -379,8 +412,30 @@ pub(crate) fn sync_windowed_frames(
         }
         visible.push(entity);
         let parent = child_of.get();
-        let pane_entity = child_of_q.get(parent).map(|co| co.get()).unwrap_or(parent);
-        let computed = pane_rect.get(pane_entity).unwrap_or(self_computed);
+        let pane_entity = queries
+            .hierarchy
+            .child_of
+            .get(parent)
+            .map(|co| co.get())
+            .unwrap_or(parent);
+        let computed = queries.pane_rect.get(pane_entity).unwrap_or(self_computed);
+        let host_window = queries.hierarchy.host_of(entity);
+        let layout_is_hidden = host_window.is_some_and(|window| layout_hidden.is_hidden(window));
+        let header_frame = host_window.and_then(|host_window| {
+            queries.header_rect.iter().find_map(|(header, rect)| {
+                if queries.hierarchy.host_of(header) == Some(host_window) {
+                    WindowedFrameRect::of(rect)
+                } else {
+                    None
+                }
+            })
+        });
+        let active_tab = tab_ancestor(parent, &queries.hierarchy.child_of, &queries.tabs);
+        let visible_pane_count = visible_pane_count_for_windowed_sync(
+            active_tab,
+            &queries.all_children,
+            &queries.leaf_panes,
+        );
         let Some(pane_frame) = WindowedFrameRect::of(computed) else {
             continue;
         };
@@ -388,7 +443,7 @@ pub(crate) fn sync_windowed_frames(
         let frame = windowed_page_frame_rect(
             pane_frame,
             header_frame,
-            layout_hidden.0,
+            layout_is_hidden,
             visible_pane_count,
         );
         if let Some(logical) = PaneFrame::of(frame, scale) {
@@ -406,7 +461,8 @@ pub(crate) fn sync_windowed_frames(
             frame.height,
             scale,
         );
-        let all_corners = windowed_page_all_corners(layout_hidden.0, visible_pane_count);
+        let all_corners = windowed_page_all_corners(layout_is_hidden, visible_pane_count);
+        pane_frames.all_corners.insert(entity, all_corners);
         browsers.set_windowed_corner_radius(
             &entity,
             settings.layout.radius * scale,
@@ -451,7 +507,9 @@ pub(crate) fn sync_windowed_frames(
             [cover_rgb.red, cover_rgb.green, cover_rgb.blue],
         );
         if browsers.has_browser(entity) {
-            memory.visible_frames.push(frame);
+            if host_window == focused_window.0 {
+                memory.visible_frames.push(frame);
+            }
             let key = (
                 frame.left.round() as i32,
                 frame.top.round() as i32,
@@ -501,7 +559,7 @@ pub(crate) struct FrameSyncMemory {
 pub(crate) struct PaneFrames {
     frames: std::collections::HashMap<Entity, PaneFrame>,
     rings: std::collections::HashMap<Entity, FocusRing>,
-    all_corners: bool,
+    all_corners: std::collections::HashMap<Entity, bool>,
 }
 
 impl PaneFrames {
@@ -516,8 +574,8 @@ impl PaneFrames {
     }
 
     #[cfg(target_os = "macos")]
-    pub(crate) fn all_corners(&self) -> bool {
-        self.all_corners
+    pub(crate) fn all_corners(&self, page: Entity) -> bool {
+        self.all_corners.get(&page).copied().unwrap_or_default()
     }
 }
 
@@ -643,13 +701,11 @@ fn sync_windowed_layout(
     browsers: NonSend<Browsers>,
     layout_q: Query<(Entity, Option<&HostWindow>), (With<LayoutCef>, With<WebviewWindowed>)>,
     windows: Query<&Window>,
-    primary_window: Query<Entity, With<PrimaryWindow>>,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
     mut last_raised_frame: Local<std::collections::HashMap<Entity, (i32, i32, i32, i32)>>,
 ) {
     for (entity, host_window) in &layout_q {
-        let window_entity = host_window
-            .map(|h| h.0)
-            .or_else(|| primary_window.single().ok());
+        let window_entity = host_window.map(|h| h.0).or(focused_window.0);
         let Some(window_entity) = window_entity else {
             continue;
         };
@@ -783,7 +839,7 @@ pub(crate) fn sync_windowed_command_bar(
     >,
     native_size_changed: Query<(), Changed<CommandBarNativeSize>>,
     windows: Query<&Window>,
-    primary_window: Query<Entity, With<PrimaryWindow>>,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
     mut was_open: Local<bool>,
 ) {
     let matched = modal_q.single();
@@ -819,9 +875,7 @@ pub(crate) fn sync_windowed_command_bar(
         publish_native_command_bar_route(owns_input, None, 1.0);
         return;
     }
-    let window_entity = host_window
-        .map(|h| h.0)
-        .or_else(|| primary_window.single().ok());
+    let window_entity = host_window.map(|h| h.0).or(focused_window.0);
     let Some(window_entity) = window_entity else {
         publish_native_command_bar_route(owns_input, None, 1.0);
         if is_windowed {
@@ -965,7 +1019,7 @@ fn sync_cef_webview_resize_after_ui(
     webviews: Query<(Entity, &WebviewSize), (With<Browser>, Without<WindowOverlay>)>,
     host_window: Query<&HostWindow>,
     windows: Query<&Window>,
-    primary_window: Query<Entity, With<PrimaryWindow>>,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
     proxy: Option<Res<EventLoopProxyWrapper>>,
     mut last_entries: Local<Vec<(u64, Vec2, f32)>>,
     mut window_resized: MessageReader<WindowResized>,
@@ -987,7 +1041,7 @@ fn sync_cef_webview_resize_after_ui(
             .get(entity)
             .ok()
             .map(|h| h.0)
-            .or_else(|| primary_window.single().ok());
+            .or(focused_window.0);
         let device_scale_factor = window_entity
             .and_then(|e| windows.get(e).ok())
             .map(|w| w.resolution.scale_factor())
@@ -1046,7 +1100,9 @@ fn sync_osr_webview_focus(
         ),
         With<WebviewSource>,
     >,
-    primary_window: Single<&Window, With<PrimaryWindow>>,
+    windows: Query<&Window>,
+    host_windows: Query<&HostWindow>,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
     focus: Res<vmux_layout::stack::FocusedStack>,
     leaf_panes: Query<Entity, (With<Pane>, Without<PaneSplit>)>,
     pane_children_q: Query<&Children, With<Pane>>,
@@ -1062,8 +1118,9 @@ fn sync_osr_webview_focus(
     let mut layout_shells = Vec::new();
     let mut modal_keyboard_target = None;
     let mut layout_keyboard_target = None;
-    let window_visible = primary_window.visible;
-    let window_focused = primary_window.focused;
+    let window = focused_window.0.and_then(|window| windows.get(window).ok());
+    let window_visible = window.is_some_and(|window| window.visible);
+    let window_focused = window.is_some_and(|window| window.focused);
     for (
         entity,
         visibility,
@@ -1080,6 +1137,14 @@ fn sync_osr_webview_focus(
     ) in webviews.iter()
     {
         if !browsers.has_browser(entity) {
+            continue;
+        }
+        if focused_window.0.is_some()
+            && host_windows
+                .get(entity)
+                .is_ok_and(|host| Some(host.0) != focused_window.0)
+        {
+            browsers.set_osr_hidden(&entity);
             continue;
         }
         let size = computed.map(|node| node.size).unwrap_or(Vec2::ONE);
@@ -1393,10 +1458,12 @@ mod tests {
         app.add_plugins((MinimalPlugins, vmux_layout::LayoutContractPlugin))
             .add_systems(Update, sync_children_to_ui);
 
+        let window = app.world_mut().spawn_empty().id();
         let glass = app
             .world_mut()
             .spawn((
                 VmuxWindow,
+                HostWindow(window),
                 ComputedNode {
                     size: Vec2::new(1200.0, 800.0),
                     ..default()
@@ -1419,7 +1486,7 @@ mod tests {
             .id();
         let tab = app
             .world_mut()
-            .spawn((Tab::default(), LastActivatedAt(1)))
+            .spawn((Tab::default(), LastActivatedAt(1), ChildOf(glass)))
             .id();
         let pane = app
             .world_mut()
@@ -1501,6 +1568,7 @@ mod tests {
     fn open_command_bar_is_exclusive_cef_keyboard_target() {
         let mut app = App::new();
         app.add_plugins(vmux_layout::LayoutContractPlugin)
+            .init_resource::<vmux_layout::window::FocusedWindow>()
             .add_systems(Update, sync_keyboard_target);
         let page = app.world_mut().spawn((Browser, KeyboardOwner)).id();
         let modal = app

--- a/crates/vmux_browser/src/window_drag.rs
+++ b/crates/vmux_browser/src/window_drag.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_cef::prelude::BinReceive;
+use bevy_cef::prelude::{BinReceive, HostWindow};
 use std::sync::{LazyLock, Mutex};
 use vmux_core::overlay::{OverlayState, OverlayStateQuery};
 use vmux_flex::prelude::{ComputedNode, LayoutSystems};
@@ -88,19 +88,27 @@ fn on_window_drag_region(
 
 fn publish_window_drag_region(
     reported: Res<ReportedWindowDragRegion>,
-    header_q: Query<(&ComputedNode, Has<Open>), With<Header>>,
+    header_q: Query<(Entity, &ComputedNode, Has<Open>), With<Header>>,
+    child_of: Query<&ChildOf>,
+    host_windows: Query<&HostWindow>,
+    focused_window: Res<vmux_layout::window::FocusedWindow>,
     overlay_q: OverlayStateQuery,
-    pointer_capture_q: Query<(), (With<LayoutCef>, LayoutPointerCapture)>,
+    pointer_capture_q: Query<(Entity, &HostWindow), (With<LayoutCef>, LayoutPointerCapture)>,
     mut last: Local<Option<WindowDragRegion>>,
 ) {
-    let overlay_owns_input =
-        OverlayState::of_any(&overlay_q).owns_input() || !pointer_capture_q.is_empty();
+    let overlay_owns_input = OverlayState::of_any(&overlay_q).owns_input()
+        || pointer_capture_q
+            .iter()
+            .any(|(_, host)| Some(host.0) == focused_window.0);
     let mut region = None;
     if let Some(reported) = reported.0
         && !overlay_owns_input
     {
-        for (header, open) in header_q.iter() {
-            if !open {
+        for (entity, header, open) in header_q.iter() {
+            if !open
+                || vmux_layout::window::host_window_of(entity, &child_of, &host_windows)
+                    != focused_window.0
+            {
                 continue;
             }
             region = WindowDragRegion::of(reported, *header);

--- a/crates/vmux_flex/src/lib.rs
+++ b/crates/vmux_flex/src/lib.rs
@@ -19,7 +19,7 @@ pub mod prelude {
         AlignItems, Display, FlexDirection, JustifyContent, Node, PositionType, UiRect, Val,
     };
     pub use crate::visibility::Visibility;
-    pub use crate::{FlexPlugin, LayoutSystems};
+    pub use crate::{FlexPlugin, FlexViewport, LayoutSystems};
 }
 
 use bevy::prelude::*;
@@ -40,6 +40,9 @@ impl Plugin for FlexPlugin {
     }
 }
 
+#[derive(Component, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FlexViewport(pub Entity);
+
 #[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum LayoutSystems {
     Layout,
@@ -47,35 +50,22 @@ pub enum LayoutSystems {
 }
 
 type NodeQuery<'w, 's> = Query<'w, 's, (Entity, Ref<'static, Node>)>;
+type RootQuery<'w, 's> =
+    Query<'w, 's, (Entity, Option<&'static FlexViewport>), (With<Node>, Without<ChildOf>)>;
 
 fn compute_layout(
     mut tree: ResMut<FlexTree>,
-    window: Option<Single<&Window, With<PrimaryWindow>>>,
+    windows: Query<&Window>,
+    primary_window: Query<Entity, With<PrimaryWindow>>,
     nodes: NodeQuery,
     added: Query<(), Added<Node>>,
     children_q: Query<&Children>,
     changed_children: Query<(), Changed<Children>>,
-    roots: Query<Entity, (With<Node>, Without<ChildOf>)>,
+    roots: RootQuery,
     mut removed_nodes: RemovedComponents<Node>,
     mut removed_children: RemovedComponents<Children>,
     mut out: Query<&mut ComputedNode>,
 ) {
-    let Some(window) = window else {
-        return;
-    };
-    let context = LayoutContext::of(&window);
-    if context.physical_size.x <= 0.0 || context.physical_size.y <= 0.0 {
-        return;
-    }
-    let context_changed = tree.context() != Some(context);
-    tree.set_context(context);
-
-    for (entity, node) in nodes.iter() {
-        if context_changed || node.is_changed() {
-            tree.upsert(&context, entity, &node);
-        }
-    }
-
     for entity in removed_children.read() {
         tree.set_children(entity, &[]);
     }
@@ -85,8 +75,29 @@ fn compute_layout(
         }
     }
 
-    for root in roots.iter() {
-        sync_children_recursively(&mut tree, root, &children_q, &added, &changed_children);
+    for (root, viewport) in roots.iter() {
+        let window_entity = viewport
+            .map(|viewport| viewport.0)
+            .or_else(|| primary_window.single().ok());
+        let Some(window) = window_entity.and_then(|entity| windows.get(entity).ok()) else {
+            continue;
+        };
+        let context = LayoutContext::of(window);
+        if context.physical_size.x <= 0.0 || context.physical_size.y <= 0.0 {
+            continue;
+        }
+        let context_changed = tree.context(root) != Some(context);
+        tree.set_context(root, context);
+        sync_nodes_recursively(
+            &mut tree,
+            root,
+            &context,
+            context_changed,
+            &nodes,
+            &children_q,
+            &added,
+            &changed_children,
+        );
         tree.compute(&context, root);
         let walk = GeometryWalk {
             tree: &tree,
@@ -96,16 +107,37 @@ fn compute_layout(
     }
 }
 
-fn sync_children_recursively(
+fn sync_nodes_recursively(
     tree: &mut FlexTree,
     entity: Entity,
+    context: &LayoutContext,
+    context_changed: bool,
+    nodes: &NodeQuery,
     children_q: &Query<&Children>,
     added: &Query<(), Added<Node>>,
     changed_children: &Query<(), Changed<Children>>,
 ) {
+    let Ok((_, node)) = nodes.get(entity) else {
+        return;
+    };
+    if context_changed || node.is_changed() || added.contains(entity) {
+        tree.upsert(context, entity, &node);
+    }
     let Ok(children) = children_q.get(entity) else {
         return;
     };
+    for child in children.iter() {
+        sync_nodes_recursively(
+            tree,
+            child,
+            context,
+            context_changed,
+            nodes,
+            children_q,
+            added,
+            changed_children,
+        );
+    }
     if tree.contains(entity) {
         let gained_a_child = children.iter().any(|child| added.contains(child));
         if added.contains(entity) || changed_children.contains(entity) || gained_a_child {
@@ -117,9 +149,6 @@ fn sync_children_recursively(
                 }
             }
         }
-    }
-    for child in children.iter() {
-        sync_children_recursively(tree, child, children_q, added, changed_children);
     }
 }
 
@@ -176,6 +205,45 @@ mod tests {
             app.world().resource::<FlexTree>().node_count(),
             one_root - 1,
             "despawning a node should free it"
+        );
+    }
+
+    #[test]
+    fn roots_use_their_own_window_size() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins).add_plugins(FlexPlugin);
+        let first_window = app
+            .world_mut()
+            .spawn(Window {
+                resolution: (800, 600).into(),
+                ..default()
+            })
+            .id();
+        let second_window = app
+            .world_mut()
+            .spawn(Window {
+                resolution: (1200, 900).into(),
+                ..default()
+            })
+            .id();
+        let first = app
+            .world_mut()
+            .spawn((fill(), FlexViewport(first_window)))
+            .id();
+        let second = app
+            .world_mut()
+            .spawn((fill(), FlexViewport(second_window)))
+            .id();
+
+        app.update();
+
+        assert_eq!(
+            app.world().get::<ComputedNode>(first).unwrap().size,
+            Vec2::new(800.0, 600.0)
+        );
+        assert_eq!(
+            app.world().get::<ComputedNode>(second).unwrap().size,
+            Vec2::new(1200.0, 900.0)
         );
     }
 }

--- a/crates/vmux_flex/src/tree.rs
+++ b/crates/vmux_flex/src/tree.rs
@@ -120,7 +120,7 @@ struct FlexNode {
 pub struct FlexTree {
     taffy: TaffyCell,
     entities: EntityHashMap<FlexNode>,
-    context: Option<LayoutContext>,
+    contexts: EntityHashMap<LayoutContext>,
 }
 
 impl Default for TaffyCell {
@@ -164,6 +164,7 @@ impl FlexTree {
     }
 
     pub fn remove(&mut self, entity: Entity) {
+        self.contexts.remove(&entity);
         let Some(node) = self.entities.remove(&entity) else {
             return;
         };
@@ -231,12 +232,12 @@ impl FlexTree {
         self.taffy.0.layout(node.id).ok()
     }
 
-    pub fn context(&self) -> Option<LayoutContext> {
-        self.context
+    pub fn context(&self, root: Entity) -> Option<LayoutContext> {
+        self.contexts.get(&root).copied()
     }
 
-    pub fn set_context(&mut self, context: LayoutContext) {
-        self.context = Some(context);
+    pub fn set_context(&mut self, root: Entity, context: LayoutContext) {
+        self.contexts.insert(root, context);
     }
 
     #[cfg(test)]

--- a/crates/vmux_flex/tests/layout.rs
+++ b/crates/vmux_flex/tests/layout.rs
@@ -59,14 +59,14 @@ impl Harness {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .add_plugins(bevy::asset::AssetPlugin::default())
-            .add_plugins(bevy::window::WindowPlugin {
-                primary_window: Some(Window {
-                    resolution,
-                    ..default()
-                }),
-                ..default()
-            })
             .add_plugins(FlexPlugin);
+        app.world_mut().spawn((
+            Window {
+                resolution,
+                ..default()
+            },
+            bevy::window::PrimaryWindow,
+        ));
 
         app
     }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,7 +162,25 @@ flowchart TB
     split --> p2
 ```
 
-- **Space** — a project container. Exactly one is `Active` and drawn; the rest stay alive.
+Each native Bevy `Window` owns one complete tree. Its root carries `VmuxWindow`,
+`HostWindow(window)`, and `FlexViewport(window)`; the header, side sheets, main area,
+spaces, tabs, panes, and hosted surfaces descend from that root. Descendants resolve their
+native owner through this ancestry, so sizing, visibility, and browser/native surfaces stay
+inside their window.
+
+`FocusedWindow` is the cross-tree selector. Global commands, keyboard focus, capture, and
+the single command-bar overlay follow the focused native window; `Active` selections are
+interpreted within that window's tree. Closing a window removes only its tree and promotes
+another window if the primary closes. The primary tree and geometry persist across launches;
+additional windows are runtime workspaces.
+
+Space IDs are global identities. Every window may attach its own `Space` view for the same ID;
+selecting a space that is not attached creates a fresh local tab and pane tree. Names, project
+settings, and history are shared by ID, while tabs, panes, focus, expansion, side sheets, and
+other layout state remain local to each window. Only the primary window's views persist.
+
+- **Space** — a project identity with a window-local view. Exactly one view per window is
+  `Active` and drawn; the rest stay alive.
 - **Tab** — a saved pane arrangement.
 - **Pane / PaneSplit** — a recursive row/column tree. `tmux`-style tiling.
 - **Stack** — several leaves in one pane, cycled like browser tabs.


### PR DESCRIPTION
## Context

Vmux previously treated the desktop as one native window, so opening another window could not own an independent space, layout, focus, or native surface tree. VMX-20 adds complete multi-window behavior while keeping space identities available across windows.

## Implementation

Each native window owns its full layout tree, browser/native surfaces, focus, side sheets, panes, and tabs. Space IDs remain global: selecting an existing space in another window creates an independent local view, while rename, delete, project settings, and history stay shared. Only the primary window persists across launches, and the focused window receives an additional subtle native shadow for clearer visual depth.

## Checks / QA

- Run `make vmx-20` from `vmux-cloud`.
- Press Cmd+N and confirm the new window has a complete independent layout.
- Change spaces, tabs, panes, and side-sheet state in one window; confirm the other window does not change.
- Select the same space in both windows; confirm identity/settings are shared but each window keeps independent tabs and panes.
- Rename and delete a shared space; confirm both windows update and retain valid local fallbacks.
- Focus each window and confirm only the focused window receives the stronger subtle shadow.
- Close the primary window and confirm the remaining window is promoted without losing its workspace.